### PR TITLE
build: update deps upstream URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,8 +299,8 @@ if(NOT WIN32)
 		set(TBB_INCLUDE_DIR "${TBB_SRC}/include/")
 		set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
 		ExternalProject_Add(tbb
-			URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
-			URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
+			URL "https://github.com/oneapi-src/oneTBB/archive/2018_U5.tar.gz"
+			URL_HASH "SHA256=b8dbab5aea2b70cf07844f86fa413e549e099aa3205b6a04059ca92ead93a372"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc
 			BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,8 +392,8 @@ if(NOT WIN32 AND NOT APPLE)
 		set(B64_INCLUDE "${B64_SRC}/include")
 		set(B64_LIB "${B64_SRC}/src/libb64.a")
 		ExternalProject_Add(b64
-			URL "http://download.draios.com/dependencies/libb64-1.2.src.zip"
-			URL_MD5 "a609809408327117e2c643bed91b76c5"
+			URL "https://github.com/libb64/libb64/archive/v1.2.1.tar.gz"
+			URL_HASH "SHA256=d620e7caf3ed5f9c28d727fa799918ad3ef69c80975905646bb549a6019cdcbd"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,8 +454,8 @@ if(NOT WIN32 AND NOT MINIMAL_BUILD)
 
 		ExternalProject_Add(curl
 			DEPENDS openssl
-			URL "http://download.draios.com/dependencies/curl-7.61.0.tar.bz2"
-			URL_MD5 "31d0a9f48dc796a7db351898a1e5058a"
+			URL "https://github.com/curl/curl/releases/download/curl-7_61_0/curl-7.61.0.tar.bz2"
+			URL_HASH "SHA256=5f6f336921cf5b84de56afbd08dfb70adeef2303751ffb3e570c936c6d656c9c"
 			CONFIGURE_COMMAND ./configure ${CURL_SSL_OPTION} --disable-threaded-resolver --disable-shared --enable-optimize --disable-curldebug --disable-rt --enable-http --disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-winssl --without-darwinssl --without-polarssl --without-cyassl --without-nss --without-axtls --without-ca-path --without-ca-bundle --without-libmetalink --without-librtmp --without-winidn --without-libidn --without-libidn2 --without-nghttp2 --without-libssh2  --without-libpsl
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,8 +421,8 @@ if(NOT WIN32 AND NOT MINIMAL_BUILD)
 		message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")
 
 		ExternalProject_Add(openssl
-			URL "http://download.draios.com/dependencies/openssl-1.0.2n.tar.gz"
-			URL_MD5 "13bdc1b1d1ff39b6fd42a255e74676a4"
+			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_0_2n.tar.gz"
+			URL_HASH "SHA256=4f4bc907caff1fee6ff8593729e5729891adcee412049153a3bb4db7625e8364"
 			CONFIGURE_COMMAND ./config shared --prefix=${OPENSSL_INSTALL_DIR}
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,9 +332,24 @@ if(NOT WIN32 AND NOT APPLE)
 		set(ONIGURUMA_LIB "${JQ_INSTALL_DIR}/lib/libonig.a")
 		message(STATUS "Bundled jq: include: ${JQ_INCLUDE}, lib: ${JQ_LIB}")
 
+		# Why we mirror jq here?
+		#
+		# In their readme, jq claims that you don't have
+		# to do autoreconf -fi when downloading a released tarball.
+		#
+		# However, they forgot to push the released makefiles
+		# into their release tarbal.
+		#
+		# For this reason, we have to mirror their release after
+		# doing the configuration ourselves.
+		#
+		# This is needed because many distros do not ship the right
+		# version of autoreconf, making virtually impossible to build Falco on them.
+		# Read more about it here:
+		#   https://github.com/stedolan/jq/issues/2061#issuecomment-593445920
 		ExternalProject_Add(
 			jq
-			URL "http://download.draios.com/dependencies/jq-1.6.tar.gz"
+			URL "https://download.falco.org/dependencies/jq-1.6.tar.gz"
 			URL_HASH "SHA256=787518068c35e244334cc79b8e56b60dbab352dff175b7f04a94f662b540bfd9"
 			CONFIGURE_COMMAND ./configure --disable-maintainer-mode --enable-all-static --disable-dependency-tracking --with-oniguruma=builtin --prefix=${JQ_INSTALL_DIR}
 			BUILD_COMMAND ${CMD_MAKE} LDFLAGS=-all-static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,8 +257,8 @@ if(WIN32 OR NOT MINIMAL_BUILD)
 		if(NOT WIN32)
 			set(ZLIB_LIB "${ZLIB_SRC}/libz.a")
 			ExternalProject_Add(zlib
-				URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
-				URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
+				URL "https://github.com/madler/zlib/archive/v1.2.11.tar.gz"
+				URL_HASH "SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff"
 				CONFIGURE_COMMAND "./configure"
 				BUILD_COMMAND ${CMD_MAKE}
 				BUILD_IN_SOURCE 1
@@ -267,8 +267,8 @@ if(WIN32 OR NOT MINIMAL_BUILD)
 		else()
 			set(ZLIB_LIB "${ZLIB_SRC}/zdll.lib")
 			ExternalProject_Add(zlib
-				URL "http://download.draios.com/dependencies/zlib-1.2.11.tar.gz"
-				URL_MD5 "1c9f62f0778697a09d36121ead88e08e"
+				URL "https://github.com/madler/zlib/archive/v1.2.11.tar.gz"
+				URL_HASH "SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff"
 				CONFIGURE_COMMAND ""
 				BUILD_COMMAND nmake -f win32/Makefile.msc
 				BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,8 +194,8 @@ else()
                         INSTALL_COMMAND "")
 		else()
 		ExternalProject_Add(luajit
-			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
-			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
+			URL "https://github.com/LuaJIT/LuaJIT/archive/v2.0.3.tar.gz"
+			URL_HASH "SHA256=8da3d984495a11ba1bce9a833ba60e18b532ca0641e7d90d97fafe85ff014baa"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1
@@ -205,8 +205,8 @@ else()
 	else()
 		set(LUAJIT_LIB "${LUAJIT_SRC}/lua51.lib")
 		ExternalProject_Add(luajit
-			URL "http://download.draios.com/dependencies/LuaJIT-2.0.3.tar.gz"
-			URL_MD5 "f14e9104be513913810cd59c8c658dc0"
+			URL "https://github.com/LuaJIT/LuaJIT/archive/v2.0.3.tar.gz"
+			URL_HASH "SHA256=8da3d984495a11ba1bce9a833ba60e18b532ca0641e7d90d97fafe85ff014baa"
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND msvcbuild.bat
 			BUILD_BYPRODUCTS ${LUAJIT_LIB}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,7 @@ if(NOT WIN32 AND NOT APPLE)
 		# doing the configuration ourselves.
 		#
 		# This is needed because many distros do not ship the right
-		# version of autoreconf, making virtually impossible to build Falco on them.
+		# version of autoreconf, making virtually impossible to build libs on them.
 		# Read more about it here:
 		#   https://github.com/stedolan/jq/issues/2061#issuecomment-593445920
 		ExternalProject_Add(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR trivially changes the download URLs of some dependencies so that the build system can fetch them from their original repositories. 

This PR also renames to `common/sysdig_types.h` to `common/types.h` since the sysdig prefix is not needed anymore.

N.B.
This PR will not address all dependencies since some need care (see above, under the "special note" section).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

- `gRPC` and related dependencies (protobuf, cares, zlib) will be updated in a subsequent PR, since we need to refactor a bit the way they are included (and possibly upgraded, see #12) cc @leodido 
- `ncurses` is left for the moment since it will be removed by #14
- `jq` needed to be mirrored since the package has to be adjusted before it can be used (a detailed explanation can be found here: https://github.com/falcosecurity/falco/blob/b3693a0b7594da8a0d3a7615992929dbca091c76/cmake/modules/jq.cmake#L31)


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
