### PR TITLE
fix(driver/bpf): probe compilation fixes

### DIFF
--- a/driver/bpf/builtins.h
+++ b/driver/bpf/builtins.h
@@ -1,0 +1,30 @@
+/*
+
+Copyright (c) 2021 The Falco Authors
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+#ifndef __BUILTINS_H
+#define __BUILTINS_H
+
+/*
+ * Make sure to always use the inline LLVM built-ins.
+ * This is done to avoid using any different implementation at all costs
+ * since we always want to use the specific LLVM builtins in this context
+ * and nothing else.
+ */
+
+#ifdef memset
+#undef memset
+#endif
+#define memset __builtin_memset
+
+#ifdef memcpy
+#undef memcpy
+#endif
+#define memcpy __builtin_memcpy
+
+#endif // __BUILTINS_H

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -18,6 +18,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/net.h>
 
 #include "../ppm_flag_helpers.h"
+#include "builtins.h"
 
 static __always_inline bool in_port_range(uint16_t port, uint16_t min, uint16_t max)
 {

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -217,7 +217,6 @@ static __always_inline int bpf_addr_to_kernel(void *uaddr, int ulen,
 {
 	if (ulen < 0 || ulen > sizeof(struct sockaddr_storage))
 		return -EINVAL;
-
 	if (ulen == 0)
 		return 0;
 
@@ -778,7 +777,6 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 				}
 
 				sl = bpf_compute_snaplen(data, dpi_lookahead_size);
-
 				if (len > sl)
 					len = sl;
 			}

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -216,15 +216,16 @@ static __always_inline bool bpf_getsockname(struct socket *sock,
 static __always_inline int bpf_addr_to_kernel(void *uaddr, int ulen,
 					      struct sockaddr *kaddr)
 {
-	if (ulen < 0 || ulen > sizeof(struct sockaddr_storage))
+	int len = _READ(ulen);
+	if (len < 0 || len > sizeof(struct sockaddr_storage))
 		return -EINVAL;
-	if (ulen == 0)
+	if (len == 0)
 		return 0;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-	if (bpf_probe_read(kaddr, ((ulen - 1) & 0xff) + 1, uaddr))
+	if (bpf_probe_read(kaddr, ((len - 1) & 0xff) + 1, uaddr))
 #else
-	if (bpf_probe_read(kaddr, ulen & 0xff, uaddr))
+	if (bpf_probe_read(kaddr, len & 0xff, uaddr))
 #endif
 		return -EFAULT;
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -435,7 +435,7 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 	if (flags & PRB_FLAG_PUSH_DATA) {
 		if (size > 0) {
-			unsigned long off = data->state->tail_ctx.curoff;
+			unsigned long off = _READ(data->state->tail_ctx.curoff);
 			unsigned long remaining = size;
 			int j;
 

--- a/driver/bpf/maps.h
+++ b/driver/bpf/maps.h
@@ -9,8 +9,17 @@ or GPL2.txt for full copies of the license.
 #ifndef __MAPS_H
 #define __MAPS_H
 
-#include "types.h"
+struct bpf_map_def {
+	unsigned int type;
+	unsigned int key_size;
+	unsigned int value_size;
+	unsigned int max_entries;
+	unsigned int map_flags;
+	unsigned int inner_map_idx;
+	unsigned int numa_node;
+};
 
+#ifdef __KERNEL__
 struct bpf_map_def __bpf_section("maps") perf_map = {
 	.type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
 	.key_size = sizeof(u32),
@@ -89,5 +98,7 @@ struct bpf_map_def __bpf_section("maps") stash_map = {
 	.max_entries = 65535,
 };
 #endif
+
+#endif // __KERNEL__
 
 #endif

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -14,6 +14,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/fdtable.h>
 
 #include "types.h"
+#include "builtins.h"
 
 #define _READ(P) ({ typeof(P) _val;				\
 		    memset(&_val, 0, sizeof(_val));		\

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -242,4 +242,6 @@ int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
 
 char kernel_ver[] __bpf_section("kernel_version") = UTS_RELEASE;
 
+char __license[] __bpf_section("license") = "GPL";
+
 char probe_ver[] __bpf_section("probe_version") = PROBE_VERSION;

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -21,6 +21,7 @@ or GPL2.txt for full copies of the license.
 #include "ring_helpers.h"
 #include "filler_helpers.h"
 #include "fillers.h"
+#include "builtins.h"
 
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
 #define BPF_PROBE(prefix, event, type)			\

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -171,16 +171,6 @@ struct perf_event_sample {
 
 #endif /* __KERNEL__ */
 
-struct bpf_map_def {
-	unsigned int type;
-	unsigned int key_size;
-	unsigned int value_size;
-	unsigned int max_entries;
-	unsigned int map_flags;
-	unsigned int inner_map_idx;
-	unsigned int numa_node;
-};
-
 enum sysdig_map_types {
 	SYSDIG_PERF_MAP = 0,
 	SYSDIG_TAIL_MAP = 1,

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -154,7 +154,6 @@ static int bpf_load_program(const struct bpf_insn *insns,
 	attr.prog_type = type;
 	attr.insn_cnt = (uint32_t) insns_cnt;
 	attr.insns = (unsigned long) insns;
-	attr.license = (unsigned long) "GPL";
 	attr.log_buf = (unsigned long) NULL;
 	attr.log_size = 0;
 	attr.log_level = 0;

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -40,6 +40,7 @@ limitations under the License.
 #include "scap_bpf.h"
 #include "driver_config.h"
 #include "../../driver/bpf/types.h"
+#include "../../driver/bpf/maps.h"
 #include "compat/misc.h"
 #include "compat/bpf.h"
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**


/kind bug


**Any specific area of the project related to this PR?**


/area driver-ebpf



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #4

This is another attempt to fix the issue reported by many users on Falco where you can't have a working BPF probe when compiling with Clang >= 10.0.0

Systems where to test before merging

- [x] COS (esp with 73 workaround)
- [x] Longterm Kernel 4.19.182
- [x] Longterm Kernel 5.10.25
- [x] Stable Kernel 5.11.8
- [x] Ubuntu 20.04
- [x] CentOS 8

In particular, we want to make sure the probe still works under systems where it was working before the changes made here.

For faster iteration with newer kernels I created a bpf-harness test suite for our probe. You can find it here https://github.com/fntlnz/bpf-harness






**Special notes for your reviewer**:

If you can, please test this under your environment and report.

**Does this PR introduce a user-facing change?**:


```release-note
fix(driver/bpf): probe compatibility with clang >= 10.0.0
```
