### PR TITLE
More flexible thread table management

### DIFF
--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -53,12 +53,6 @@ limitations under the License.
 #define SCAP_TIMEOUT_MS 30
 
 //
-// Max size that the thread table can reach
-//
-#define MAX_THREAD_TABLE_SIZE 131072
-#define DEFAULT_THREAD_TABLE_SIZE 65536
-
-//
 // Max size that the FD table of a process can reach
 //
 #define MAX_FD_TABLE_SIZE 4096

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -58,16 +58,6 @@ limitations under the License.
 #define MAX_FD_TABLE_SIZE 4096
 
 //
-// The time after an inactive thread is removed.
-//
-#define DEFAULT_THREAD_TIMEOUT_S 1800
-
-//
-// How often the thread table is scanned for inactive threads
-//
-#define DEFAULT_INACTIVE_THREAD_SCAN_TIME_S 1200
-
-//
 // How often the container table is scanned for inactive containers
 //
 #define DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S 30

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1754,11 +1754,6 @@ void sinsp::get_capture_stats(scap_stats* stats) const
 	}
 }
 
-void sinsp::set_max_thread_table_size(uint32_t value)
-{
-	m_thread_manager->set_max_thread_table_size(value);
-}
-
 #ifdef GATHER_INTERNAL_STATS
 sinsp_stats sinsp::get_stats()
 {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -497,8 +497,6 @@ public:
 	*/
 	void get_capture_stats(scap_stats* stats) const override;
 
-	void set_max_thread_table_size(uint32_t value);
-
 #ifdef GATHER_INTERNAL_STATS
 	sinsp_stats get_stats();
 #endif

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -384,6 +384,29 @@ public:
 	void set_min_log_severity(sinsp_logger::severity sev);
 
 	/*!
+	 * \brief set whether the library will automatically purge the threadtable
+	 *        at specific times. If not, client is responsible for thread lifetime
+	 *        management. If invoked, then the purge interval and thread timeout change
+	 *        defaults, but have no observable effect.
+	 */
+	void disable_automatic_threadtable_purging();
+
+	/*!
+	 * \brief sets the interval at which the thread purge code runs. This does
+	 *        not run every event as it's mildly expensive if there are lots of threads
+	 */
+	void set_thread_purge_interval_s(uint32_t val);
+
+	/*!
+	 * \brief sets the amount of time after which a thread which has seen no events
+	 *        can be purged. As the purging happens only every m_thread_purge_interval_s,
+	 *        the max time a thread may linger is actually m_thread_purge_interval +
+	 *        m_thread_timeout_s
+	 */
+	void set_thread_timeout_s(uint32_t val);
+
+
+	/*!
 	  \brief Start writing the captured events to file.
 
 	  \param dump_filename the destination trace file.
@@ -993,6 +1016,7 @@ private:
 	bool m_large_envs_enabled;
 
 	sinsp_network_interfaces* m_network_interfaces;
+
 public:
 	sinsp_thread_manager* m_thread_manager;
 
@@ -1076,8 +1100,9 @@ public:
 	// Some thread table limits
 	//
 	uint32_t m_max_fdtable_size;
-	uint64_t m_thread_timeout_ns;
-	uint64_t m_inactive_thread_scan_time_ns;
+	bool m_automatic_threadtable_purging = true;
+	uint64_t m_thread_timeout_ns = (uint64_t)1800 * ONE_SECOND_IN_NS;
+	uint64_t m_inactive_thread_scan_time_ns = (uint64_t)1200 * ONE_SECOND_IN_NS;
 
 	//
 	// Container limits

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1212,7 +1212,7 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 // sinsp_thread_manager implementation
 ///////////////////////////////////////////////////////////////////////////////
 sinsp_thread_manager::sinsp_thread_manager(sinsp* inspector)
-	: m_max_thread_table_size(uint32_t(MAX_THREAD_TABLE_SIZE))
+	: m_max_thread_table_size(m_thread_table_absolute_max_size)
 {
 	m_inspector = inspector;
 	clear();
@@ -1822,6 +1822,5 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::find_thread(int64_t tid, bool look
 
 void sinsp_thread_manager::set_max_thread_table_size(uint32_t value)
 {
-    uint32_t max_size = uint32_t(MAX_THREAD_TABLE_SIZE);
-    m_max_thread_table_size = (value < max_size ? value : max_size);
+    m_max_thread_table_size = std::min(value, m_thread_table_absolute_max_size);
 }

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -646,6 +646,7 @@ private:
 	std::weak_ptr<sinsp_threadinfo> m_last_tinfo;
 	uint64_t m_last_flush_time_ns;
 	uint32_t m_n_drops;
+	const uint32_t m_thread_table_absolute_max_size = 131072;
 	uint32_t m_max_thread_table_size;
 	int32_t m_n_proc_lookups = 0;
 	uint64_t m_n_proc_lookups_duration_ns = 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR exposes two aspects of libsinsp thread table management to libsinsp consumers:
* Make thread table size configurable at runtime
    
    API change: sinsp::set_max_thread_table_size() is removed, use
    m_thread_manager->set_max_thread_table_size() directly.
    
    A build-time absolute maximum is still maintained and respected.

* Configurable thread table purging

    Exited threads are not removed immediately, because we want the thread
    to be present in the table for handling e.g. exit() events after
    sinsp_parser::process_event() finishes but before the next call
    to sinsp::next().

    The delayed removal of an exited thread can either happen in sinsp::next()
    itself, or can be handled by the sinsp consumer (if the consumer wants
    to hold on to the exited threads even longer).

    Originally, switching between these two behaviors was switched at build
    time, using `#define HAS_ANALYZER`. This patch makes it configurable
    at runtime.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

Removing `-DHAS_ANALYZER`, one piece at a time :)

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
action required: sinsp::set_max_thread_table_size() is removed, use m_thread_manager->set_max_thread_table_size() directly.```
