### PR TITLE
Parametrize the metadata download

### DIFF
--- a/userspace/libsinsp/k8s_api_handler.cpp
+++ b/userspace/libsinsp/k8s_api_handler.cpp
@@ -37,7 +37,7 @@ k8s_api_handler::k8s_api_handler(collector_ptr_t collector,
 	,ssl_ptr_t ssl
 	,bt_ptr_t bt
 	,bool blocking_socket
-	,uint32_t data_max_mb
+	,uint32_t data_max_b
 	,uint32_t data_chunk_wait_us
 #endif // HAS_CAPTURE
 ):
@@ -46,7 +46,7 @@ k8s_api_handler::k8s_api_handler(collector_ptr_t collector,
 					url, path, filter, ".", "", collector, http_version, 1000L, ssl, bt,
 					false, true, std::make_shared<k8s_dummy_handler>(), blocking_socket,
 #endif // HAS_CAPTURE
-					 ~0, nullptr, data_max_mb, data_chunk_wait_us)
+					 ~0, nullptr, data_max_b, data_chunk_wait_us)
 {
 }
 

--- a/userspace/libsinsp/k8s_api_handler.cpp
+++ b/userspace/libsinsp/k8s_api_handler.cpp
@@ -37,6 +37,8 @@ k8s_api_handler::k8s_api_handler(collector_ptr_t collector,
 	,ssl_ptr_t ssl
 	,bt_ptr_t bt
 	,bool blocking_socket
+	,uint32_t data_max_mb
+	,uint32_t data_chunk_wait_us
 #endif // HAS_CAPTURE
 ):
 		k8s_handler("k8s_api_handler", false,
@@ -44,7 +46,7 @@ k8s_api_handler::k8s_api_handler(collector_ptr_t collector,
 					url, path, filter, ".", "", collector, http_version, 1000L, ssl, bt,
 					false, true, std::make_shared<k8s_dummy_handler>(), blocking_socket,
 #endif // HAS_CAPTURE
-					 ~0, nullptr)
+					 ~0, nullptr, data_max_mb, data_chunk_wait_us)
 {
 }
 

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -37,7 +37,10 @@ public:
 		const std::string& http_version = "1.1",
 		ssl_ptr_t ssl = 0,
 		bt_ptr_t bt = 0,
-		bool blocking_socket = false);
+		bool blocking_socket = false,
+		uint32_t data_max_mb = K8S_DATA_MAX_MB,
+		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US
+		);
 
 	~k8s_api_handler();
 

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -38,7 +38,7 @@ public:
 		ssl_ptr_t ssl = 0,
 		bt_ptr_t bt = 0,
 		bool blocking_socket = false,
-		uint32_t data_max_mb = K8S_DATA_MAX_MB,
+		uint32_t data_max_mb = K8S_DATA_MAX_B,
 		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US
 		);
 

--- a/userspace/libsinsp/k8s_api_handler.h
+++ b/userspace/libsinsp/k8s_api_handler.h
@@ -38,7 +38,7 @@ public:
 		ssl_ptr_t ssl = 0,
 		bt_ptr_t bt = 0,
 		bool blocking_socket = false,
-		uint32_t data_max_mb = K8S_DATA_MAX_B,
+		uint32_t data_max_b = K8S_DATA_MAX_B,
 		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US
 		);
 

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -97,7 +97,7 @@ k8s_handler::k8s_handler(const std::string& id,
 							 uri(m_url).to_string(false) + m_path), sinsp_logger::SEV_DEBUG);
 		m_handler = std::make_shared<handler_t>(*this, m_id, m_url, m_path, m_http_version,
 											 m_timeout_ms, m_ssl, m_bt, !m_blocking_socket, m_blocking_socket,
-											 524288u, true, data_max_mb, data_chunk_wait_us);
+											 SOCKET_HANDLER_DATA_LIMIT, true, data_max_mb, data_chunk_wait_us);
 		m_handler->set_json_callback(&k8s_handler::set_event_json);
 
 		// filter order is important; there are four kinds of filters:

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -64,7 +64,7 @@ k8s_handler::k8s_handler(const std::string& id,
 #endif // HAS_CAPTURE
 	unsigned max_messages,
 	k8s_state_t* state,
-	uint32_t data_max_mb,
+	uint32_t data_max_b,
 	uint32_t data_chunk_wait_us): m_state(state),
 		m_id(id + "_state"),
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
@@ -97,7 +97,7 @@ k8s_handler::k8s_handler(const std::string& id,
 							 uri(m_url).to_string(false) + m_path), sinsp_logger::SEV_DEBUG);
 		m_handler = std::make_shared<handler_t>(*this, m_id, m_url, m_path, m_http_version,
 											 m_timeout_ms, m_ssl, m_bt, !m_blocking_socket, m_blocking_socket,
-											 SOCKET_HANDLER_DATA_LIMIT, true, data_max_mb, data_chunk_wait_us);
+											 SOCKET_HANDLER_DATA_LIMIT, true, data_max_b, data_chunk_wait_us);
 		m_handler->set_json_callback(&k8s_handler::set_event_json);
 
 		// filter order is important; there are four kinds of filters:

--- a/userspace/libsinsp/k8s_handler.cpp
+++ b/userspace/libsinsp/k8s_handler.cpp
@@ -63,7 +63,9 @@ k8s_handler::k8s_handler(const std::string& id,
 	bool blocking_socket,
 #endif // HAS_CAPTURE
 	unsigned max_messages,
-	k8s_state_t* state): m_state(state),
+	k8s_state_t* state,
+	uint32_t data_max_mb,
+	uint32_t data_chunk_wait_us): m_state(state),
 		m_id(id + "_state"),
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
 		m_collector(collector),
@@ -94,7 +96,8 @@ k8s_handler::k8s_handler(const std::string& id,
 		g_logger.log(std::string("K8s (" + m_id + ") creating handler for " +
 							 uri(m_url).to_string(false) + m_path), sinsp_logger::SEV_DEBUG);
 		m_handler = std::make_shared<handler_t>(*this, m_id, m_url, m_path, m_http_version,
-											 m_timeout_ms, m_ssl, m_bt, !m_blocking_socket, m_blocking_socket);
+											 m_timeout_ms, m_ssl, m_bt, !m_blocking_socket, m_blocking_socket,
+											 524288u, true, data_max_mb, data_chunk_wait_us);
 		m_handler->set_json_callback(&k8s_handler::set_event_json);
 
 		// filter order is important; there are four kinds of filters:

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -69,7 +69,9 @@ public:
 		bool blocking_socket = false,
 #endif // HAS_CAPTURE
 		unsigned max_messages = ~0,
-		k8s_state_t* state = nullptr);
+		k8s_state_t* state = nullptr,
+		uint32_t data_max_mb = K8S_DATA_MAX_MB,
+		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US);
 
 	virtual ~k8s_handler();
 

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -70,7 +70,7 @@ public:
 #endif // HAS_CAPTURE
 		unsigned max_messages = ~0,
 		k8s_state_t* state = nullptr,
-		uint32_t data_max_mb = K8S_DATA_MAX_B,
+		uint32_t data_max_b = K8S_DATA_MAX_B,
 		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US);
 
 	virtual ~k8s_handler();

--- a/userspace/libsinsp/k8s_handler.h
+++ b/userspace/libsinsp/k8s_handler.h
@@ -70,7 +70,7 @@ public:
 #endif // HAS_CAPTURE
 		unsigned max_messages = ~0,
 		k8s_state_t* state = nullptr,
-		uint32_t data_max_mb = K8S_DATA_MAX_MB,
+		uint32_t data_max_mb = K8S_DATA_MAX_B,
 		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US);
 
 	virtual ~k8s_handler();

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -105,3 +105,9 @@ typedef sinsp_fdinfo<int> sinsp_fdinfo_t;
 // very big JSONs returned by container inspect call
 static const unsigned MAX_JSON_SIZE_B = 500 * 1024; // 500 kiB
 
+//
+// Default metadata download settings
+//
+#define K8S_DATA_MAX_MB 100 * 1024 * 1024
+#define K8S_DATA_CHUNK_WAIT_US 1000
+#define METADATA_DATA_WATCH_FREQ_SEC 1

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -108,6 +108,6 @@ static const unsigned MAX_JSON_SIZE_B = 500 * 1024; // 500 kiB
 //
 // Default metadata download settings
 //
-#define K8S_DATA_MAX_MB 100 * 1024 * 1024
+#define K8S_DATA_MAX_B 100 * 1024 * 1024
 #define K8S_DATA_CHUNK_WAIT_US 1000
 #define METADATA_DATA_WATCH_FREQ_SEC 1

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1947,6 +1947,15 @@ double sinsp::get_read_progress()
 	return (double)fpos * 100 / m_filesize;
 }
 
+void sinsp::set_metadata_download_params(uint32_t data_max_b,
+	uint32_t data_chunk_wait_us,
+	uint32_t data_watch_freq_sec)
+{
+	m_metadata_download_params.m_data_max_b = data_max_b;
+	m_metadata_download_params.m_data_chunk_wait_us = data_chunk_wait_us;
+	m_metadata_download_params.m_data_watch_freq_sec = data_watch_freq_sec;
+}
+
 bool sinsp::remove_inactive_threads()
 {
 	return m_thread_manager->remove_inactive_threads();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1947,15 +1947,6 @@ double sinsp::get_read_progress()
 	return (double)fpos * 100 / m_filesize;
 }
 
-void sinsp::set_metadata_download_params(uint32_t data_max_mb,
-	uint32_t data_chunk_wait_us,
-	uint32_t data_watch_freq_sec)
-{
-	m_metadata_download_params.m_data_max_mb = data_max_mb;
-	m_metadata_download_params.m_data_chunk_wait_us = data_chunk_wait_us;
-	m_metadata_download_params.m_data_watch_freq_sec = data_watch_freq_sec;
-}
-
 bool sinsp::remove_inactive_threads()
 {
 	return m_thread_manager->remove_inactive_threads();
@@ -2221,7 +2212,7 @@ void sinsp::update_k8s_state()
 					m_k8s_api_handler.reset(new k8s_api_handler(m_k8s_collector, *m_k8s_api_server,
 										    "/api", ".versions", "1.1",
 										    m_k8s_ssl, m_k8s_bt, true,
-										    m_metadata_download_params.m_data_max_mb,
+										    m_metadata_download_params.m_data_max_b,
 										    m_metadata_download_params.m_data_chunk_wait_us));
 				}
 				else

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -782,6 +782,14 @@ public:
 		}
 	}
 
+	/*!
+	  \brief Set the parameters that control metadata fetching from orchestrators
+	  like Kuberneted and mesos.
+	*/
+	void set_metadata_download_params(uint32_t data_max_b,
+		uint32_t data_chunk_wait_us,
+		uint32_t data_watch_freq_sec);
+
 
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	void init_k8s_ssl(const std::string *ssl_cert);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -144,6 +144,22 @@ public:
 	uint32_t m_flags;
 };
 
+#define K8S_DATA_MAX_MB 100 * 1024 * 1024
+#define K8S_DATA_CHUNK_WAIT_US 1000
+#define METADATA_DATA_WATCH_FREQ_SEC 1
+
+/*!
+  \brief Parameters to configure the download behavior when connected to an
+  orchestrator like Kubernetes or mesos.
+*/
+class metadata_download_params
+{
+public:
+	uint32_t m_data_max_mb = K8S_DATA_MAX_MB;
+	uint32_t m_data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US;
+	uint32_t m_data_watch_freq_sec = METADATA_DATA_WATCH_FREQ_SEC;
+};
+
 /*!
   \brief The default way an event is converted to string by the library
 */
@@ -770,6 +786,15 @@ public:
 		}
 	}
 
+	/*!
+	  \brief Se the parameters that control metadata fetching from orchestrators
+	  like Kuberneted and mesos.
+	*/
+	void set_metadata_download_params(uint32_t data_max_mb,
+		uint32_t data_chunk_wait_us,
+		uint32_t data_watch_freq_sec);
+
+
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	void init_k8s_ssl(const std::string *ssl_cert);
 	void init_k8s_client(std::string* api_server, std::string* ssl_cert, bool verbose = false);
@@ -1001,6 +1026,8 @@ public:
 	sinsp_thread_manager* m_thread_manager;
 
 	sinsp_container_manager m_container_manager;
+
+	metadata_download_params m_metadata_download_params;
 
 	//
 	// Kubernetes

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -144,10 +144,6 @@ public:
 	uint32_t m_flags;
 };
 
-#define K8S_DATA_MAX_MB 100 * 1024 * 1024
-#define K8S_DATA_CHUNK_WAIT_US 1000
-#define METADATA_DATA_WATCH_FREQ_SEC 1
-
 /*!
   \brief Parameters to configure the download behavior when connected to an
   orchestrator like Kubernetes or mesos.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -151,7 +151,7 @@ public:
 class metadata_download_params
 {
 public:
-	uint32_t m_data_max_mb = K8S_DATA_MAX_MB;
+	uint32_t m_data_max_b = K8S_DATA_MAX_B;
 	uint32_t m_data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US;
 	uint32_t m_data_watch_freq_sec = METADATA_DATA_WATCH_FREQ_SEC;
 };
@@ -781,14 +781,6 @@ public:
 			return scap_disable_dynamic_snaplen(m_h);
 		}
 	}
-
-	/*!
-	  \brief Se the parameters that control metadata fetching from orchestrators
-	  like Kuberneted and mesos.
-	*/
-	void set_metadata_download_params(uint32_t data_max_mb,
-		uint32_t data_chunk_wait_us,
-		uint32_t data_watch_freq_sec);
 
 
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -398,8 +398,9 @@ public:
 			if(processed > m_data_max_mb)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-						      "read more than 30MB of data from " + m_url.to_string(false) + m_path +
-						      " (" + std::to_string(processed) + " bytes, " + std::to_string(counter) + " reads). Giving up");
+						      "read more than " + to_string(m_data_max_mb / 1024 / 1024) + " MB of data from " +
+						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
+						      " bytes, " + std::to_string(counter) + " reads). Giving up");
 			}
 			else { usleep(m_data_chunk_wait_us); }
 		} while(!m_msg_completed);

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -57,6 +57,8 @@ limitations under the License.
 #define SOCK_NONBLOCK 0
 #endif
 
+#define SOCKET_HANDLER_DATA_LIMIT 524288u
+
 template <typename T>
 class socket_data_handler
 {
@@ -81,9 +83,9 @@ public:
 		bt_ptr_t bt = nullptr,
 		bool keep_alive = true,
 		bool blocking = false,
-		unsigned data_limit = 524288u,
+		unsigned data_limit = SOCKET_HANDLER_DATA_LIMIT,
 		bool fetching_state = true,
-		uint32_t data_max_mb = K8S_DATA_MAX_MB,
+		uint32_t data_max_b = K8S_DATA_MAX_B,
 		uint32_t data_chunk_wait_us = K8S_DATA_CHUNK_WAIT_US): m_obj(obj),
 			m_id(id),
 			m_url(url),
@@ -97,7 +99,7 @@ public:
 			m_http_version(http_version),
 			m_data_limit(data_limit),
 			m_fetching_state(fetching_state),
-			m_data_max_mb(data_max_mb),
+			m_data_max_b(data_max_b),
 			m_data_chunk_wait_us(data_chunk_wait_us)
 
 	{
@@ -392,13 +394,13 @@ public:
 				//			 "\n\n" + data + "\n\n", sinsp_logger::SEV_TRACE);
 			}
 
-			// To prevent reads from entirely stalling (like in gigantic k8s
-			// environments), give up after reading 30mb.
+			// To prevent reads from entirely stalling (like in gigantic k8s environments), 
+			// give up after reading a certain size (by default, 100MB, but configurable).
 			++counter;
-			if(processed > m_data_max_mb)
+			if(processed > m_data_max_b)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-						      "read more than " + to_string(m_data_max_mb / 1024 / 1024) + " MB of data from " +
+						      "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
 						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
 						      " bytes, " + std::to_string(counter) + " reads). Giving up");
 			}
@@ -1617,7 +1619,7 @@ private:
 	http_parser_settings     m_http_parser_settings;
 	http_parser*             m_http_parser = nullptr;
 	http_parser_data         m_http_parser_data;
-	unsigned                 m_data_limit = 524288; // bytes
+	unsigned                 m_data_limit = SOCKET_HANDLER_DATA_LIMIT; // bytes
 
 	ares_channel             m_ares_channel = nullptr;
 	ares_options             m_ares_opts;
@@ -1634,7 +1636,7 @@ private:
 	// from the string and the purged buffer is posted for further processing
 	bool                     m_fetching_state = true;
 
-	uint32_t m_data_max_mb;
+	uint32_t m_data_max_b;
 	uint32_t m_data_chunk_wait_us;
 
 };


### PR DESCRIPTION
This commit adds a new sinsp public API (set_metadata_download_params), allowing the user modify some of the key parameters that determine the behavior of metadata download from orchestrators like Kubernetes or Mesos.

The commit also changes the default value of some of the metadata download parameters. Specifically, the maximum startup download size goes from 30MB to 100MB, and the chunck wait delay goes from 10ms to 1ms.

Signed-off-by: Loris Degioanni <loris@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: sinsp public API method `set_metadata_download_params` allows the user to modify some of the key parameters that determine the behavior of metadata download from orchestrators like Kubernetes or Mesos.
```
