### PR TITLE
read BPF license from ELF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ driver/driver_config.h
 *.ll
 .vscode
 .cache.mk
-build-*
-
+build*

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -12,8 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -60,6 +60,8 @@ struct bpf_map_data {
 static const int BUF_SIZE_PAGES = 2048;
 
 static const int BPF_LOG_SIZE = 1 << 18;
+
+static char* license;
 
 #define FILLER_NAME_FN(x) #x,
 static const char *g_filler_names[PPM_FILLER_MAX] = {
@@ -152,6 +154,7 @@ static int bpf_load_program(const struct bpf_insn *insns,
 	attr.prog_type = type;
 	attr.insn_cnt = (uint32_t) insns_cnt;
 	attr.insns = (unsigned long) insns;
+	attr.license = (unsigned long) license;
 	attr.log_buf = (unsigned long) NULL;
 	attr.log_size = 0;
 	attr.log_level = 0;
@@ -613,6 +616,11 @@ static int32_t load_bpf_file(scap_t *handle, const char *path)
 					 (char *) data->d_buf, PROBE_VERSION);
 				goto cleanup;
 			}
+		}
+		else if(strcmp(shname, "license") == 0)
+		{
+			license = data->d_buf;
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "BPF probe license is %s", license);
 		}
 	}
 

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -12,8 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
+
 #ifndef _SCAP_BPF_H
 #define _SCAP_BPF_H
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**


/area driver-ebpf

/area libscap


**What this PR does / why we need it**:

While it is indeed correct that the license section is in the BPF probe source code (see https://github.com/falcosecurity/libs/commit/8918b9579cd5a3828df6c57652dd38ea92875b11), 
our custom BPF loader should read it by parsing the ELF and then accordingly use the read value in the `bpf_attr` instance.

**Which issue(s) this PR fixes**:

Rather than always enforcing the license in the libscap loader - like the #37 attempt does - this PR reads the actual value from the ELF and then uses it in our custom loading phases (see `load_tracepoint` > `bpf_load_program`) 

**Special notes for your reviewer**:

Supersedes #37 

- [x] rebase on master as soon #30 gets merged in.

**Does this PR introduce a user-facing change?**:


```release-note
fix(userspace/libscap): read the license section for the BPF ELF
fix(userspace/libscap): pass the read license to the `bpf` syscall via `bpf_attr`
```
