### PR TITLE
new: ability to filter by a node when fetching K8S metadata

### DIFF
--- a/userspace/libsinsp/k8s.cpp
+++ b/userspace/libsinsp/k8s.cpp
@@ -38,12 +38,16 @@ k8s::k8s(const std::string& uri, bool is_captured,
 #endif // HAS_CAPTURE
 		filter_ptr_t event_filter,
 		ext_list_ptr_t extensions,
-		bool events_only) :
+		bool events_only
+#ifdef HAS_CAPTURE
+		,const std::string& node_selector
+#endif // HAS_CAPTURE
+		) :
 		m_state(is_captured),
 		m_event_filter(event_filter)
 #ifdef HAS_CAPTURE
 		,m_net(uri.empty() ?
-			   nullptr : new k8s_net(*this, m_state, uri, ssl, bt, event_filter, block))
+			   nullptr : new k8s_net(*this, m_state, uri, ssl, bt, event_filter, block, node_selector))
 #endif
 {
 	g_logger.log(std::string("Creating K8s object for [" +

--- a/userspace/libsinsp/k8s.h
+++ b/userspace/libsinsp/k8s.h
@@ -53,7 +53,11 @@ public:
 #endif // HAS_CAPTURE
 		filter_ptr_t event_filter = nullptr,
 		ext_list_ptr_t extensions = nullptr,
-		bool events_only = false);
+		bool events_only = false
+#ifdef HAS_CAPTURE
+		,const std::string& node_selector = ""
+#endif // HAS_CAPTURE
+		);
 
 	~k8s();
 

--- a/userspace/libsinsp/k8s_net.cpp
+++ b/userspace/libsinsp/k8s_net.cpp
@@ -44,14 +44,16 @@ k8s_net::k8s_net(k8s& kube, k8s_state_t& state, const std::string& uri,
 	ssl_ptr_t ssl,
 	bt_ptr_t bt,
 	filter_ptr_t event_filter,
-	bool blocking_sockets) : m_state(state),
+	bool blocking_sockets,
+	const std::string& node_selector) : m_state(state),
 		m_collector(std::make_shared<collector_t>()),
 		m_uri(uri),
 		m_ssl(ssl),
 		m_bt(bt),
 		m_stopped(true),
 		m_blocking_sockets(blocking_sockets),
-		m_event_filter(event_filter)
+		m_event_filter(event_filter),
+		m_node_selector(node_selector)
 {
 }
 
@@ -157,7 +159,8 @@ bool k8s_net::has_dependency(const k8s_component::type_map::value_type& componen
 
 k8s_net::handler_ptr_t k8s_net::make_handler(k8s_state_t& state, const k8s_component::type component, bool connect,
 											handler_ptr_t dep, collector_ptr_t collector, const std::string& urlstr,
-											ssl_ptr_t ssl, bt_ptr_t bt, bool blocking, filter_ptr_t event_filter)
+											ssl_ptr_t ssl, bt_ptr_t bt, bool blocking, filter_ptr_t event_filter,
+											const std::string& node_selector)
 {
 	switch(component)
 	{
@@ -166,7 +169,7 @@ k8s_net::handler_ptr_t k8s_net::make_handler(k8s_state_t& state, const k8s_compo
 		case k8s_component::K8S_NAMESPACES:
 			return std::make_shared<k8s_namespace_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_PODS:
-			return std::make_shared<k8s_pod_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
+			return std::make_shared<k8s_pod_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking, node_selector);
 		case k8s_component::K8S_REPLICATIONCONTROLLERS:
 			return std::make_shared<k8s_replicationcontroller_handler>(state, dep, collector, urlstr, "1.1", ssl, bt, connect, blocking);
 		case k8s_component::K8S_REPLICASETS:
@@ -193,7 +196,7 @@ void k8s_net::add_handler(const k8s_component::type_map::value_type& component)
 	{
 		handler_ptr_t handler =
 			make_handler(m_state, component.first, true, get_dependency_handler(m_handlers, component),
-						 m_collector, m_uri.to_string(), m_ssl, m_bt, m_blocking_sockets, m_event_filter);
+						 m_collector, m_uri.to_string(), m_ssl, m_bt, m_blocking_sockets, m_event_filter, m_node_selector);
 		if(handler)
 		{
 			if(!m_machine_id.empty())

--- a/userspace/libsinsp/k8s_net.h
+++ b/userspace/libsinsp/k8s_net.h
@@ -50,7 +50,8 @@ public:
 		ssl_ptr_t ssl = nullptr,
 		bt_ptr_t bt = nullptr,
 		filter_ptr_t event_filter = nullptr,
-		bool blocking_sockets = false);
+		bool blocking_sockets = false,
+		const std::string& node_selector = "");
 
 	~k8s_net();
 
@@ -58,7 +59,7 @@ public:
 									 handler_ptr_t dep = std::make_shared<k8s_dummy_handler>(),
 									 collector_ptr_t collector = nullptr, const std::string& urlstr = "",
 									 ssl_ptr_t ssl = nullptr, bt_ptr_t bt = nullptr, bool blocking = false,
-									 filter_ptr_t event_filter = nullptr);
+									 filter_ptr_t event_filter = nullptr, const std::string& node_selector = "");
 	void add_handler(const k8s_component::type_map::value_type& component);
 	bool has_handler(const k8s_component::type_map::value_type& component);
 	bool has_dependency(const k8s_component::type_map::value_type& component);
@@ -96,6 +97,7 @@ private:
 	bool            m_blocking_sockets = false;
 	filter_ptr_t    m_event_filter;
 	std::string     m_machine_id;
+	std::string     m_node_selector;
 };
 
 inline bool k8s_net::is_secure()

--- a/userspace/libsinsp/k8s_pod_handler.cpp
+++ b/userspace/libsinsp/k8s_pod_handler.cpp
@@ -86,11 +86,14 @@ k8s_pod_handler::k8s_pod_handler(k8s_state_t& state
 	,bt_ptr_t bt
 	,bool connect
 	,bool blocking_socket
+	,std::string node_selector
 #endif // HAS_CAPTURE
 	):
 		k8s_handler("k8s_pod_handler", true,
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
-					url, "/api/v1/pods?fieldSelector=status.phase!=Failed,status.phase!=Unknown,status.phase!=Succeeded",
+					url, 
+					"/api/v1/pods?fieldSelector=status.phase!=Failed,status.phase!=Unknown,status.phase!=Succeeded"
+					+ (node_selector.size() == 0 ? "" : ",spec.nodeName=" + node_selector),
 					STATE_FILTER, EVENT_FILTER, "", collector,
 					http_version, 1000L, ssl, bt, true,
 					connect, dependency_handler, blocking_socket,

--- a/userspace/libsinsp/k8s_pod_handler.h
+++ b/userspace/libsinsp/k8s_pod_handler.h
@@ -40,6 +40,7 @@ public:
 		,bt_ptr_t bt = 0
 		,bool connect = true
 		,bool blocking_socket = false
+		,std::string node_selector = ""
 #endif // HAS_CAPTURE
 		);
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2059,16 +2059,20 @@ void sinsp::make_k8s_client()
 #else
 		,nullptr
 #endif // HAS_CAPTURE
+		,false // events_only
+#ifdef HAS_CAPTURE
+		,m_k8s_node_name ? *m_k8s_node_name : std::string() // node_selector
+#endif // HAS_CAPTURE
 	);
 }
 
-void sinsp::init_k8s_client(string* api_server, string* ssl_cert, bool verbose)
+void sinsp::init_k8s_client(string* api_server, string* ssl_cert, string* node_name, bool verbose)
 {
 	ASSERT(api_server);
 	m_verbose_json = verbose;
 	m_k8s_api_server = api_server;
 	m_k8s_api_cert = ssl_cert;
-
+	m_k8s_node_name = node_name;
 
 #ifdef HAS_CAPTURE
 	if(m_k8s_api_detected && m_k8s_ext_detect_done)
@@ -2092,7 +2096,7 @@ void sinsp::collect_k8s()
 		{
 			if(!m_k8s_client)
 			{
-				init_k8s_client(m_k8s_api_server, m_k8s_api_cert, m_verbose_json);
+				init_k8s_client(m_k8s_api_server, m_k8s_api_cert, m_k8s_node_name, m_verbose_json);
 				if(m_k8s_client)
 				{
 					g_logger.log("K8s client created.", sinsp_logger::SEV_DEBUG);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -772,7 +772,15 @@ public:
 
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	void init_k8s_ssl(const std::string *ssl_cert);
-	void init_k8s_client(std::string* api_server, std::string* ssl_cert, bool verbose = false);
+
+	/*!
+	  \brief Initialize the Kubernetes client.
+	  \param api_server Kubernetes API server URI
+	  \param ssl_cert use the provided file name to authenticate with the Kubernetes API server
+	  \param node_name the node name is used as a filter when requesting metadata of pods 
+	  to the API server; if empty, no filter is set
+	*/
+	void init_k8s_client(std::string* api_server, std::string* ssl_cert, std::string *node_name, bool verbose = false);
 	void make_k8s_client();
 	k8s* get_k8s_client() const { return m_k8s_client; }
 
@@ -1008,6 +1016,7 @@ public:
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	std::string* m_k8s_api_server;
 	std::string* m_k8s_api_cert;
+	std::string* m_k8s_node_name;
 #ifdef HAS_CAPTURE
 	std::shared_ptr<sinsp_ssl> m_k8s_ssl;
 	std::shared_ptr<sinsp_bearer_token> m_k8s_bt;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

See #43

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #43 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: ability to filter by a node when fetching K8S metadata
BREAKING CHANGE: `sinsp::init_k8s_client()` signature has changed since the new argument `node_name` has been introduced
```
