### PR TITLE
fix(driver/bpf): use always-y instead of always

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -5,7 +5,9 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
-always += probe.o
+always-y += probe.o
+# kept for compatibility with kernels < 5.11
+always = $(always-y)
 
 LLC ?= llc
 CLANG ?= clang


### PR DESCRIPTION
Kbuild does not successfully compile our probe anymore with always.

This was also necessary for samples/bpf in the kernel [0]

[0] https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=5f2fb52fac15a8a8e10ce020dd532504a8abfc4e



Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug



**Any specific area of the project related to this PR?**


/area driver-ebpf



**What this PR does / why we need it**:

Compiling the probe against newer 5.11/5.12 kernels is now not working at all because the Makefile cannot pick the target. This PR fixes that.

Compiling for now only works with Clang 7 until this is fixed too https://github.com/falcosecurity/libs/issues/58

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/1696

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(driver/bpf): use always-y instead of always
```
