### PR TITLE
Detect containerd containers when SystemdCgroup is not configured

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -410,8 +410,8 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 			continue;
 		}
 
-		// cgroup
-		cgroup = strtok_r(NULL, ":", &scratch);
+		// cgroup should be the only thing remaining so use newline as the delimiter.
+		cgroup = strtok_r(NULL, "\n", &scratch);
 		if(cgroup == NULL)
 		{
 			ASSERT(false);
@@ -420,9 +420,6 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 				 filename);
 			return SCAP_FAILURE;
 		}
-
-		// remove the \n
-		cgroup[strlen(cgroup) - 1] = 0;
 
 		while((token = strtok_r(subsys_list, ",", &scratch)) != NULL)
 		{

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -50,6 +50,7 @@ constexpr const cgroup_layout CRI_CGROUP_LAYOUT[] = {
 	{"/crio-", ""}, // non-systemd cri-o
 	{"/cri-containerd-", ".scope"}, // systemd containerd
 	{"/crio-", ".scope"}, // systemd cri-o
+	{":cri-containerd:", ""}, // containerd without "SystemdCgroup = true"
 	{nullptr, nullptr}
 };
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In the linked issue, there was a cgroup layout in `/proc/[pid]/cgroup` which was not supported in libscap and libsinsp. It took the form `/system.slice/containerd.service/kubepods-burstable-podb4f3dfaf_f987_499d_a04c_2c60eb01958c.slice:cri-containerd:f659de946112140fd722cddfd24015a8c9fce51b7ab7f007ac30612b6f9acfc9` and was only observed when `SystemdCgroup` is not configured in containerd.

The libscap change makes it so we always read the cgroup to the end of the line when reading from `/proc/[pid]/cgroup`. With the cgroup layout observed in the issue, the previous behavior would only read up to the first `:` and drop the rest, including the container ID which libsinsp requires in order to detect the container.

The libsinsp change adds the cgroup layout observed in the issue to the CRI cgroup layout array. This allows for libsinsp to detect and parse the container ID from the cgroup string.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #63

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libscap, libsinsp): Detect containerd containers when SystemdCgroup is not configured
```

