### PR TITLE
Support the Podman container engine

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -149,11 +149,13 @@ if(NOT MINIMAL_BUILD)
 	list(APPEND SINSP_SOURCES
 		container_engine/docker/docker_linux.cpp
 		container_engine/docker/connection_linux.cpp
+		container_engine/docker/podman.cpp
 		container_engine/libvirt_lxc.cpp
 		container_engine/lxc.cpp
 		container_engine/mesos.cpp
 		container_engine/rkt.cpp
 		container_engine/bpm.cpp
+		procfs_utils.cpp
 		runc.cpp)
 	endif()
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include "container_engine/docker/docker_win.h"
 #else
 #include "container_engine/docker/docker_linux.h"
+#include "container_engine/docker/podman.h"
 #endif
 #include "container_engine/rkt.h"
 #include "container_engine/libvirt_lxc.h"
@@ -534,6 +535,11 @@ void sinsp_container_manager::create_engines()
 	}
 #else
 #ifndef _WIN32
+	{
+		auto podman_engine = std::make_shared<container_engine::podman>(*this);
+		m_container_engines.push_back(podman_engine);
+		m_container_engine_by_type[CT_PODMAN] = podman_engine;
+	}
 	{
 		auto docker_engine = std::make_shared<container_engine::docker_linux>(*this);
 		m_container_engines.push_back(docker_engine);

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -610,7 +610,7 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 	{
 		// a '/' is present in the Image field. Parse it into parts
 		std::string hostname, port;
-		sinsp_utils::split_container_image(container.m_image,
+		sinsp_utils::split_container_image(imgstr,
 						   hostname,
 						   port,
 						   container.m_imagerepo,

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -391,7 +391,7 @@ void docker_async_source::fetch_image_info(const docker_lookup_request& request,
 			"docker_async url: %s",
 			url.c_str());
 
-	if(!(m_connection.get_docker(request, url, img_json) == docker_connection::RESP_OK))
+	if(m_connection.get_docker(request, url, img_json) != docker_connection::RESP_OK)
 	{
 		g_logger.format(sinsp_logger::SEV_ERROR,
 				"docker_async (%s) image (%s): Could not fetch image info",

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -420,44 +420,121 @@ void docker_async_source::fetch_image_info(const docker_lookup_request& request,
 	parse_image_info(container, img_root);
 }
 
-void docker_async_source::parse_image_info(sinsp_container_info& container, const Json::Value& img)
+void docker_async_source::fetch_image_info_from_list(const docker_lookup_request& request, sinsp_container_info& container)
 {
-	// img_root["RepoDigests"] contains only digests for images pulled from registries.
-	// If an image gets retagged and is never pushed to any registry, we will not find
-	// that entry in container.m_imagerepo. Also, for locally built images we have the
-	// same issue. This leads to container.m_imagedigest being empty as well.
-	//
-	// Each individual digest looks like e.g.
-	// "docker.io/library/redis@sha256:b6a9fc3535388a6fc04f3bdb83fb4d9d0b4ffd85e7609a6ff2f0f731427823e3"
-	// so we need to split it at the `@` (the part before is the repo,
-	// the part after is the digest)
-	std::unordered_set<std::string> imageDigestSet;
-	for(const auto& rdig : img["RepoDigests"])
+	Json::Reader reader;
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"docker_async (%s): Fetching image list",
+			request.container_id.c_str());
+
+	std::string img_json;
+	std::string url = "/images/json?digests=1";
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"docker_async url: %s",
+			url.c_str());
+
+	if(!(m_connection.get_docker(request, url, img_json) == docker_connection::RESP_OK))
 	{
-		if(rdig.isString())
+		g_logger.format(sinsp_logger::SEV_ERROR,
+				"docker_async (%s): Could not fetch image list",
+				request.container_id.c_str());
+		return;
+	}
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"docker_async (%s): Image list fetch returned \"%s\"",
+			request.container_id.c_str(),
+			img_json.c_str());
+
+	Json::Value img_root;
+	if(!reader.parse(img_json, img_root))
+	{
+		g_logger.format(sinsp_logger::SEV_ERROR,
+				"docker_async (%s): Could not parse json image list \"%s\"",
+				request.container_id.c_str(),
+				img_json.c_str());
+		return;
+	}
+
+	for(const auto& img : img_root)
+	{
+		// the "Names" field is podman specific. we could parse repotags
+		// twice but this is less effort and we only call this function
+		// for podman anyway
+		const auto& names = img["Names"];
+		if(!names.isArray())
 		{
-			std::string repodigest = rdig.asString();
-			std::string digest = repodigest.substr(repodigest.find('@')+1);
-			imageDigestSet.insert(digest);
-			if(container.m_imagerepo.empty())
+			return;
+		}
+
+		for(const auto& name : names)
+		{
+			if(name == container.m_image)
 			{
-				container.m_imagerepo = repodigest.substr(0, repodigest.find('@'));
-			}
-			if(repodigest.find(container.m_imagerepo) != std::string::npos)
-			{
-				container.m_imagedigest = digest;
-				break;
+				std::string imgstr = img["Id"].asString();
+				size_t cpos = imgstr.find(':');
+				if(cpos != std::string::npos)
+				{
+					imgstr = imgstr.substr(cpos + 1);
+				}
+				container.m_imageid = std::move(imgstr);
+
+				parse_image_info(container, img);
+				return;
 			}
 		}
 	}
+}
 
-	// fix image digest for locally tagged images or multiple repo digests.
-	// Case 1: One repo digest with many tags.
-	// Case 2: Many repo digests with the same digest value.
-	if(container.m_imagedigest.empty() && imageDigestSet.size() == 1) {
-		container.m_imagedigest = *imageDigestSet.begin();
+void docker_async_source::parse_image_info(sinsp_container_info& container, const Json::Value& img)
+{
+	const auto& podman_digest = img["Digest"];
+	if(podman_digest.isString())
+	{
+		// img["Digest"] if present is the digest in the form we need it
+		// e.g. "sha256:b6a9fc3535388a6fc04f3bdb83fb4d9d0b4ffd85e7609a6ff2f0f731427823e3"
+		// so just use it directly
+		container.m_imagedigest = podman_digest.asString();
 	}
-
+	else
+	{
+		// img_root["RepoDigests"] contains only digests for images pulled from registries.
+		// If an image gets retagged and is never pushed to any registry, we will not find
+		// that entry in container.m_imagerepo. Also, for locally built images we have the
+		// same issue. This leads to container.m_imagedigest being empty as well.
+		//
+		// Each individual digest looks like e.g.
+		// "docker.io/library/redis@sha256:b6a9fc3535388a6fc04f3bdb83fb4d9d0b4ffd85e7609a6ff2f0f731427823e3"
+		// so we need to split it at the `@` (the part before is the repo,
+		// the part after is the digest)
+		std::unordered_set<std::string> imageDigestSet;
+		for(const auto& rdig : img["RepoDigests"])
+		{
+			if(rdig.isString())
+			{
+				std::string repodigest = rdig.asString();
+				std::string digest = repodigest.substr(repodigest.find('@')+1);
+				imageDigestSet.insert(digest);
+				if(container.m_imagerepo.empty())
+				{
+					container.m_imagerepo = repodigest.substr(0, repodigest.find('@'));
+				}
+				if(repodigest.find(container.m_imagerepo) != std::string::npos)
+				{
+					container.m_imagedigest = digest;
+					break;
+				}
+			}
+		}
+		// fix image digest for locally tagged images or multiple repo digests.
+		// Case 1: One repo digest with many tags.
+		// Case 2: Many repo digests with the same digest value.
+		if(container.m_imagedigest.empty() && imageDigestSet.size() == 1) {
+			container.m_imagedigest = *imageDigestSet.begin();
+		}
+	}
 	for(const auto& rtag : img["RepoTags"])
 	{
 		if(rtag.isString())
@@ -480,34 +557,58 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 {
 	container.m_image = root["Config"]["Image"].asString();
 
+	// podman has the image *name*, not the *id* in the Image field
+	// detect that with the presence of '/' in the field
 	std::string imgstr = root["Image"].asString();
-	size_t cpos = imgstr.find(':');
-	if(cpos != std::string::npos)
+	if(imgstr.find('/') == std::string::npos)
 	{
-		container.m_imageid = imgstr.substr(cpos + 1);
+		// no '/' in the Image field, assume it's a Docker image id
+		size_t cpos = imgstr.find(':');
+		if(cpos != std::string::npos)
+		{
+			container.m_imageid = imgstr.substr(cpos + 1);
+		}
+
+		// containers can be spawned using just the imageID as image name,
+		// with or without the hash prefix (e.g. sha256:)
+		//
+		// e.g. an image with the id `sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347`
+		// can be used to run a container as:
+		// - docker run sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
+		// - docker run ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
+		// - docker run sha256:ddcca4
+		// - docker run ddcca4
+		//
+		// in all these cases we need to determine the image repo/tag
+		// via the API (in `fetch_image_info()`)
+		//
+		// otherwise we assume the name passed to `docker run`
+		// (available in container.m_image) is the repo name like `redis`
+		// and use that to determine the name and tag
+		bool no_name = sinsp_utils::startswith(container.m_imageid, container.m_image) ||
+				   sinsp_utils::startswith(imgstr, container.m_image);
+
+		if(!no_name || !m_query_image_info)
+		{
+			std::string hostname, port;
+			sinsp_utils::split_container_image(container.m_image,
+							   hostname,
+							   port,
+							   container.m_imagerepo,
+							   container.m_imagetag,
+							   container.m_imagedigest,
+							   false);
+		}
+
+		if(m_query_image_info && !container.m_imageid.empty() &&
+		   (no_name || container.m_imagedigest.empty() || container.m_imagetag.empty()))
+		{
+			fetch_image_info(request, container);
+		}
 	}
-
-	// containers can be spawned using just the imageID as image name,
-	// with or without the hash prefix (e.g. sha256:)
-	//
-	// e.g. an image with the id `sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347`
-	// can be used to run a container as:
-	// - docker run sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
-	// - docker run ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
-	// - docker run sha256:ddcca4
-	// - docker run ddcca4
-	//
-	// in all these cases we need to determine the image repo/tag
-	// via the API (in `fetch_image_info()`)
-	//
-	// otherwise we assume the name passed to `docker run`
-	// (available in container.m_image) is the repo name like `redis`
-	// and use that to determine the name and tag
-	bool no_name = sinsp_utils::startswith(container.m_imageid, container.m_image) ||
-			   sinsp_utils::startswith(imgstr, container.m_image);
-
-	if(!no_name || !m_query_image_info)
+	else
 	{
+		// a '/' is present in the Image field. Parse it into parts
 		std::string hostname, port;
 		sinsp_utils::split_container_image(container.m_image,
 						   hostname,
@@ -516,12 +617,13 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 						   container.m_imagetag,
 						   container.m_imagedigest,
 						   false);
-	}
 
-	if(m_query_image_info && !container.m_imageid.empty() &&
-	   (no_name || container.m_imagedigest.empty() || container.m_imagetag.empty()))
-	{
-		fetch_image_info(request, container);
+		// we don't have the image id so we need to list all images
+		// and find the matching one by comparing the repo names
+		if(m_query_image_info)
+		{
+			fetch_image_info_from_list(request, container);
+		}
 	}
 
 	if(container.m_imagetag.empty())

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -835,6 +835,18 @@ bool docker_async_source::parse_docker(const docker_lookup_request& request, sin
 		}
 	}
 
+	if(request.container_type == sinsp_container_type::CT_PODMAN)
+	{
+		if(request.uid == 0)
+		{
+			container.m_labels.erase("podman_owner_uid");
+		}
+		else
+		{
+			container.m_labels["podman_owner_uid"] = to_string(request.uid);
+		}
+	}
+
 	const Json::Value& env_vars = config_obj["Env"];
 
 	for(const auto& env_var : env_vars)

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -660,8 +660,8 @@ bool docker_async_source::parse_docker(const docker_lookup_request& request, sin
 	string json;
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
-			"docker_async (%s): Looking up info for container",
-			request.container_id.c_str());
+			"docker_async (%s): Looking up info for container via socket %s",
+			request.container_id.c_str(), request.docker_socket.c_str());
 
 	std::string api_request = "/containers/" + request.container_id + "/json";
 	if(request.request_rw_size)

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -55,7 +55,7 @@ void docker_async_source::run_impl()
 		sinsp_container_info res;
 
 		res.m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
-		res.m_type = CT_DOCKER;
+		res.m_type = request.container_type;
 		res.m_id = request.container_id;
 
 		if(!parse_docker(request, res))
@@ -762,6 +762,8 @@ bool docker_async_source::parse_docker(const docker_lookup_request& request, sin
 
 			if(parse_docker(docker_lookup_request(secondary_container_id,
 							      request.docker_socket,
+							      request.container_type,
+							      request.uid,
 							      false /*don't request size since we just need the IP*/),
 					pcnt))
 			{

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -458,6 +458,7 @@ void docker_async_source::fetch_image_info_from_list(const docker_lookup_request
 		return;
 	}
 
+	const std::string match_name = container.m_imagerepo + ':' + container.m_imagetag;
 	for(const auto& img : img_root)
 	{
 		// the "Names" field is podman specific. we could parse repotags
@@ -471,7 +472,7 @@ void docker_async_source::fetch_image_info_from_list(const docker_lookup_request
 
 		for(const auto& name : names)
 		{
-			if(name == container.m_image)
+			if(name == match_name)
 			{
 				std::string imgstr = img["Id"].asString();
 				size_t cpos = imgstr.find(':');
@@ -605,6 +606,11 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 		{
 			fetch_image_info(request, container);
 		}
+
+		if(container.m_imagetag.empty())
+		{
+			container.m_imagetag = "latest";
+		}
 	}
 	else
 	{
@@ -618,6 +624,13 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 						   container.m_imagedigest,
 						   false);
 
+		// we need the tag set in the call to `fetch_image_from_list`
+		// so set it here instead of after the if/else
+		if(container.m_imagetag.empty())
+		{
+			container.m_imagetag = "latest";
+		}
+
 		// we don't have the image id so we need to list all images
 		// and find the matching one by comparing the repo names
 		if(m_query_image_info)
@@ -626,10 +639,6 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 		}
 	}
 
-	if(container.m_imagetag.empty())
-	{
-		container.m_imagetag = "latest";
-	}
 }
 void docker_async_source::parse_json_mounts(const Json::Value &mnt_obj, vector<sinsp_container_info::container_mount_info> &mounts)
 {

--- a/userspace/libsinsp/container_engine/docker/async_source.h
+++ b/userspace/libsinsp/container_engine/docker/async_source.h
@@ -74,6 +74,11 @@ private:
 	// Fetch the image info for the current container's m_imageid
 	void fetch_image_info(const docker_lookup_request& request, sinsp_container_info& container);
 
+	// Podman reports image repository/tag instead of the image id,
+	// so to fetch the image digest we need to list all the images,
+	// find one with matching repository/tag and get the digest from there
+	void fetch_image_info_from_list(const docker_lookup_request& request, sinsp_container_info& container);
+
 	container_cache_interface *m_cache;
 	docker_connection m_connection;
 	static bool m_query_image_info;

--- a/userspace/libsinsp/container_engine/docker/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker/docker_linux.cpp
@@ -45,6 +45,8 @@ bool docker_linux::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_in
 	return resolve_impl(tinfo, docker_lookup_request(
 		container_id,
 		m_docker_sock,
+		CT_DOCKER,
+		0,
 		false), query_os_for_missing_info);
 }
 
@@ -65,6 +67,6 @@ void docker_linux::update_with_size(const std::string &container_id)
 			container_id.c_str());
 
 	sinsp_container_info result;
-	docker_lookup_request instruction(container_id, m_docker_sock, true /*request rw size*/);
+	docker_lookup_request instruction(container_id, m_docker_sock, CT_DOCKER, 0, true /*request rw size*/);
 	(void)m_docker_info_source->lookup(instruction, result, cb);
 }

--- a/userspace/libsinsp/container_engine/docker/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker/docker_win.cpp
@@ -42,6 +42,8 @@ bool docker_win::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info
 	return resolve_impl(tinfo, docker_async_instruction(
 		container_id,
 		"",
+		CT_DOCKER,
+		0,
 		false), query_os_for_missing_info);
 }
 

--- a/userspace/libsinsp/container_engine/docker/docker_win.cpp
+++ b/userspace/libsinsp/container_engine/docker/docker_win.cpp
@@ -47,9 +47,4 @@ bool docker_win::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info
 		false), query_os_for_missing_info);
 }
 
-void docker_win::update_with_size(const std::string &container_id)
-{
-	// not supported
-}
-
 #endif // CYGWING_AGENT

--- a/userspace/libsinsp/container_engine/docker/docker_win.h
+++ b/userspace/libsinsp/container_engine/docker/docker_win.h
@@ -13,7 +13,6 @@ public:
 
 	// implement container_engine_base
 	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
-	void update_with_size(const std::string& container_id) override;
 
 private:
 	static std::string s_incomplete_info_name;

--- a/userspace/libsinsp/container_engine/docker/lookup_request.h
+++ b/userspace/libsinsp/container_engine/docker/lookup_request.h
@@ -1,19 +1,27 @@
 #pragma once
 
+#include "container_engine/sinsp_container_type.h"
+
 namespace libsinsp {
 namespace container_engine {
 
 struct docker_lookup_request
 {
 	docker_lookup_request() :
+		container_type(CT_DOCKER),
+		uid(0),
 		request_rw_size(false)
 	{}
 
 	docker_lookup_request(const std::string& container_id_value,
 			      const std::string& docker_socket_value,
+			      sinsp_container_type container_type_value,
+			      unsigned long uid_value,
 			      bool rw_size_value) :
 		container_id(container_id_value),
 		docker_socket(docker_socket_value),
+		container_type(container_type_value),
+		uid(uid_value),
 		request_rw_size(rw_size_value)
 	{}
 
@@ -29,6 +37,16 @@ struct docker_lookup_request
 			return docker_socket < rhs.docker_socket;
 		}
 
+		if(container_type != rhs.container_type)
+		{
+			return container_type < rhs.container_type;
+		}
+
+		if(uid != rhs.uid)
+		{
+			return uid < rhs.uid;
+		}
+
 		return request_rw_size < rhs.request_rw_size;
 	}
 
@@ -36,11 +54,15 @@ struct docker_lookup_request
 	{
 		return container_id == rhs.container_id &&
 		       docker_socket == rhs.docker_socket &&
+		       container_type == rhs.container_type &&
+		       uid == rhs.uid &&
 		       request_rw_size == rhs.request_rw_size;
 	}
 
 	std::string container_id;
 	std::string docker_socket;
+	sinsp_container_type container_type;
+	unsigned long uid;
 	bool request_rw_size;
 };
 

--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -1,0 +1,140 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#include "podman.h"
+
+#include "container_engine/docker/lookup_request.h"
+#include "procfs_utils.h"
+#include "runc.h"
+#include "sinsp.h"
+
+#include <fstream>
+
+using namespace libsinsp::container_engine;
+using namespace libsinsp::runc;
+
+std::string podman::m_api_sock = "/run/podman/podman.sock";
+
+namespace {
+constexpr const cgroup_layout ROOT_PODMAN_CGROUP_LAYOUT[] = {
+	{"/libpod-", ".scope"}, // podman
+	{nullptr,    nullptr}
+};
+
+std::string get_systemd_cgroup(const sinsp_threadinfo *tinfo)
+{
+	// the kernel driver does not return cgroups without subsystems (e.g. name=systemd)
+	// in the cgroups field, so we have to do a check here, and load /proc/pid/cgroups
+	// ourselves if needed
+
+	for(const auto& it : tinfo->m_cgroups)
+	{
+		if(it.first == "name=systemd")
+		{
+			return it.second;
+		}
+	}
+
+	std::stringstream cgroups_file;
+	cgroups_file << scap_get_host_root() << "/proc/" << tinfo->m_tid << "/cgroup";
+
+	std::ifstream cgroups(cgroups_file.str());
+	return libsinsp::procfs_utils::get_systemd_cgroup(cgroups);
+}
+
+int get_userns_root_uid(const sinsp_threadinfo *tinfo)
+{
+	std::stringstream uid_map_file;
+	uid_map_file << scap_get_host_root() << "/proc/" << tinfo->m_tid << "/uid_map";
+
+	std::ifstream uid_map(uid_map_file.str());
+	return libsinsp::procfs_utils::get_userns_root_uid(uid_map);
+}
+
+// Check whether `tinfo` belongs to a podman container
+//
+// Returns the uid of the container owner:
+//  0 for root containers,
+//  >0 for rootless containers,
+//  NO_MATCH if the process is not in a podman container
+int detect_podman(const sinsp_threadinfo *tinfo, std::string& container_id)
+{
+	if(matches_runc_cgroups(tinfo, ROOT_PODMAN_CGROUP_LAYOUT, container_id))
+	{
+		return 0; // root
+	}
+
+	std::string systemd_cgroup = get_systemd_cgroup(tinfo);
+	if(systemd_cgroup.empty())
+	{
+		// can't get the cgroup name
+		return libsinsp::procfs_utils::NO_MATCH;
+	}
+
+	size_t pos = systemd_cgroup.find("podman-");
+	if(pos == std::string::npos)
+	{
+		return libsinsp::procfs_utils::NO_MATCH;
+	}
+
+	int podman_pid; // unused except to set the sscanf return value
+	char c;         // ^ same
+	if(sscanf(systemd_cgroup.c_str() + pos, "podman-%d.scope/%c", &podman_pid, &c) != 2)
+	{
+		// cgroup doesn't match the expected pattern
+		return libsinsp::procfs_utils::NO_MATCH;
+	}
+
+	if(!match_one_container_id(systemd_cgroup, ".scope/", "", container_id))
+	{
+		return libsinsp::procfs_utils::NO_MATCH;
+	}
+
+	int uid = get_userns_root_uid(tinfo);
+	if(uid == 0)
+	{
+		// root doesn't spawn rootless containers
+		return libsinsp::procfs_utils::NO_MATCH;
+	}
+
+	return uid;
+}
+}
+
+bool podman::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
+{
+	std::string container_id, container_name, api_sock;
+	int uid = detect_podman(tinfo, container_id);
+
+	switch(uid)
+	{
+	case 0: // root, use the default socket
+		api_sock = m_api_sock;
+		break;
+	case libsinsp::procfs_utils::NO_MATCH:
+		return false;
+	default: // rootless container, use the user's socket
+		api_sock = "/run/user/" + std::to_string(uid) + "/podman/podman.sock";
+	}
+
+	docker_lookup_request request(container_id, api_sock, CT_PODMAN, uid, false);
+	return resolve_impl(tinfo, request, query_os_for_missing_info);
+}
+
+void podman::update_with_size(const std::string& container_id)
+{
+	// not supported
+}

--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -133,8 +133,3 @@ bool podman::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	docker_lookup_request request(container_id, api_sock, CT_PODMAN, uid, false);
 	return resolve_impl(tinfo, request, query_os_for_missing_info);
 }
-
-void podman::update_with_size(const std::string& container_id)
-{
-	// not supported
-}

--- a/userspace/libsinsp/container_engine/docker/podman.h
+++ b/userspace/libsinsp/container_engine/docker/podman.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "container_engine/docker/base.h"
+
+namespace libsinsp {
+namespace container_engine {
+
+class podman : public docker_base
+{
+public:
+	podman(container_cache_interface& cache): docker_base(cache) {}
+
+private:
+	static std::string m_api_sock;
+
+	// implement container_engine_base
+	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
+	void update_with_size(const std::string& container_id) override;
+};
+
+}
+}

--- a/userspace/libsinsp/container_engine/docker/podman.h
+++ b/userspace/libsinsp/container_engine/docker/podman.h
@@ -15,7 +15,6 @@ private:
 
 	// implement container_engine_base
 	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
-	void update_with_size(const std::string& container_id) override;
 };
 
 }

--- a/userspace/libsinsp/container_engine/sinsp_container_type.h
+++ b/userspace/libsinsp/container_engine/sinsp_container_type.h
@@ -30,4 +30,5 @@ enum sinsp_container_type
 	CT_CRIO = 8,
 	CT_BPM = 9,
 	CT_STATIC = 10,
+	CT_PODMAN = 11,
 };

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -45,7 +45,8 @@ static inline bool is_docker_compatible(sinsp_container_type t)
 	return t == CT_DOCKER ||
 		t == CT_CRI ||
 		t == CT_CONTAINERD ||
-		t == CT_CRIO;
+		t == CT_CRIO ||
+		t == CT_PODMAN;
 }
 
 /**

--- a/userspace/libsinsp/procfs_utils.cpp
+++ b/userspace/libsinsp/procfs_utils.cpp
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#include "procfs_utils.h"
+
+#include <string>
+#include "sinsp.h"
+
+int libsinsp::procfs_utils::get_userns_root_uid(std::istream& uid_map)
+{
+	std::string uid_map_line;
+
+	while(std::getline(uid_map, uid_map_line))
+	{
+		int src_uid, target_uid;
+		std::stringstream mapping(uid_map_line);
+		mapping >> src_uid;
+
+		// if the target uid we're looking for was anything other than 0,
+		// we'd have to check the length of the range as well, but since
+		// 0 is the lowest, we're good
+		if(src_uid != 0)
+		{
+			continue;
+		}
+		mapping >> target_uid;
+
+		return target_uid;
+	}
+
+	return libsinsp::procfs_utils::NO_MATCH;
+}
+
+
+std::string libsinsp::procfs_utils::get_systemd_cgroup(std::istream& cgroups)
+{
+	std::string cgroups_line;
+
+	while(std::getline(cgroups, cgroups_line))
+	{
+		size_t cgpos = cgroups_line.find(":name=systemd:");
+		if(cgpos == std::string::npos)
+		{
+			continue;
+		}
+
+		std::string systemd_cgroup = cgroups_line.substr(cgpos + strlen(":name=systemd:"), std::string::npos);
+		return systemd_cgroup;
+	}
+
+	return "";
+}

--- a/userspace/libsinsp/procfs_utils.h
+++ b/userspace/libsinsp/procfs_utils.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <istream>
+#include <string>
+
+namespace libsinsp {
+namespace procfs_utils {
+
+constexpr const int NO_MATCH = -1;
+
+/**
+ * @brief Parse /proc/<pid>/uid_map to find the uid that root in the userns maps to
+ * @param uid_map a stream with the contents of /proc/<pid>/uid_map
+ * @return the uid of the userns owner
+ *
+ * For unprivileged Podman containers at least, all processes are created
+ * in a child user namespace which maps uids inside the container to uids
+ * outside. The root user in the container is mapped to the uid that created
+ * the container (in the parent user namespace)
+ */
+int get_userns_root_uid(std::istream& uid_map);
+
+/**
+ * @brief Get the path of the `name=systemd` cgroup
+ * @param cgroups a stream with the contents of /proc/<pid>/cgroup
+ * @return the path of the `name=systemd` cgroup
+ */
+std::string get_systemd_cgroup(std::istream& cgroups);
+
+}
+}

--- a/userspace/libsinsp/runc.cpp
+++ b/userspace/libsinsp/runc.cpp
@@ -30,6 +30,11 @@ const char* CONTAINER_ID_VALID_CHARACTERS = "0123456789abcdefABCDEF";
 
 static_assert(REPORTED_CONTAINER_ID_LENGTH <= CONTAINER_ID_LENGTH, "Reported container ID length cannot be longer than actual length");
 
+}
+
+namespace libsinsp {
+namespace runc {
+
 // check if cgroup ends with <prefix><container_id><suffix>
 // If true, set <container_id> to a truncated version of the id and return true.
 // Otherwise return false and leave container_id unchanged
@@ -76,11 +81,6 @@ bool match_container_id(const std::string &cgroup, const libsinsp::runc::cgroup_
 
 	return false;
 }
-}
-
-namespace libsinsp {
-namespace runc {
-
 bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id)
 {
 	for(const auto &it : tinfo->m_cgroups)

--- a/userspace/libsinsp/runc.h
+++ b/userspace/libsinsp/runc.h
@@ -24,22 +24,60 @@ class sinsp_threadinfo;
 namespace libsinsp {
 namespace runc {
 
-/// runc-based runtimes (Docker, containerd, CRI-O, probably others) use the same two cgroup layouts
-/// with slight variations:
-/// - non-systemd layout uses cgroups ending with .../<prefix><container id>
-/// - systemd layout uses .../<prefix><container id>.scope
-/// where <container id> is always 64 hex digits (we report the first 12 as the container id).
-/// For non-systemd only CRI-O seems to use /crio-<container id>, while for systemd layout
-/// while all known container engines use a prefix like "docker-", "crio-" or "containerd-cri-".
-/// We can encode all these variants with a simple list of (prefix, suffix) pairs
-/// (the last one must be a pair of null pointers to mark the end of the array)
+/**
+ * @brief A pattern to match cgroup paths against
+ *
+ *  runc-based runtimes (Docker, containerd, CRI-O, probably others) use the same two cgroup layouts
+ *  with slight variations:
+ *  - non-systemd layout uses cgroups ending with .../<prefix><container id>
+ *  - systemd layout uses .../<prefix><container id>.scope
+ *  where <container id> is always 64 hex digits (we report the first 12 as the container id).
+ *  For non-systemd only CRI-O seems to use /crio-<container id>, while for systemd layout
+ *  while all known container engines use a prefix like "docker-", "crio-" or "containerd-cri-".
+ *  We can encode all these variants with a simple list of (prefix, suffix) pairs
+ *  (the last one must be a pair of null pointers to mark the end of the array)
+ */
 struct cgroup_layout {
 	const char* prefix;
 	const char* suffix;
 };
 
-/// If any of the cgroups of the thread in `tinfo` matches the `layout`, set `container_id` to the found id
-/// and return true. Otherwise, return false and leave `container_id` unchanged
+/**
+ * @brief Check if `cgroup` ends with <prefix><64_hex_digits><suffix>
+ * @param container_id output parameter
+ * @return true if `cgroup` matches the pattern
+ *
+ * If this function returns true, `container_id` will be set to
+ * the truncated hex string (first 12 digits). Otherwise, it will remain
+ * unchanged.
+ */
+bool match_one_container_id(const std::string &cgroup, const std::string &prefix, const std::string &suffix, std::string &container_id);
+
+/**
+ * @brief Match `cgroup` against a list of layouts using `match_one_container_id()`
+ * @param layout an array of (prefix, suffix) pairs
+ * @param container_id output parameter
+ * @return true if `cgroup` matches any of the patterns
+ *
+ * `layout` is an array terminated by an empty entry (prefix, suffix both empty)
+ *
+ * If this function returns true, `container_id` will be set to
+ * the truncated hex string (first 12 digits). Otherwise, it will remain
+ * unchanged.
+ */
+bool match_container_id(const std::string &cgroup, const libsinsp::runc::cgroup_layout *layout,
+			std::string &container_id);
+
+/**
+ * @brief Match all the cgroups of `tinfo` against a list of cgroup layouts
+ * @param layout an array of (prefix, suffix) pairs
+ * @param container_id output parameter
+ * @return true if any of `tinfo`'s cgroups match any of the patterns
+ *
+ * If this function returns true, `container_id` will be set to
+ * the truncated hex string (first 12 digits). Otherwise, it will remain
+ * unchanged.
+ */
 bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id);
 }
 }

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -24,12 +24,18 @@ endif() # MINIMAL_BUILD
 include_directories("..")
 include_directories(${LIBSCAP_INCLUDE_DIR})
 
-add_executable(unit-test-libsinsp
+set(LIBSINSP_UNIT_TESTS_SOURCES
 	cgroup_list_counter.ut.cpp
 	sinsp.ut.cpp
 	evttype_filter.ut.cpp
 	token_bucket.ut.cpp
 )
+
+if(NOT MINIMAL_BUILD)
+	list(APPEND LIBSINSP_UNIT_TESTS_SOURCES procfs_utils.ut.cpp)
+endif()
+
+add_executable(unit-test-libsinsp ${LIBSINSP_UNIT_TESTS_SOURCES})
 
 target_link_libraries(unit-test-libsinsp
 	"${GTEST_LIB}"

--- a/userspace/libsinsp/test/procfs_utils.ut.cpp
+++ b/userspace/libsinsp/test/procfs_utils.ut.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest.h>
+#include <procfs_utils.h>
+#include <sstream>
+
+using namespace libsinsp::procfs_utils;
+
+TEST(procfs_utils_test, get_userns_uid)
+{
+	std::string uidmap = "         0      1000         0\n         1   1000000      1000\n";
+	std::stringstream s(uidmap);
+
+	ASSERT_EQ(get_userns_root_uid(s), 1000);
+}
+
+
+TEST(procfs_utils_test, get_userns_uid_root)
+{
+	std::string uidmap = "         0         0         0\n";
+	std::stringstream s(uidmap);
+
+	ASSERT_EQ(get_userns_root_uid(s), 0);
+}
+
+TEST(procfs_utils_test, get_systemd_cgroup)
+{
+	std::string cgroups = "12:perf_event:/\n"
+			      "11:memory:/user.slice/user-0.slice/session-10697.scope\n"
+			      "10:cpuset:/\n"
+			      "9:cpu,cpuacct:/user.slice/user-0.slice/session-10697.scope\n"
+			      "8:hugetlb:/\n"
+			      "7:freezer:/\n"
+			      "6:rdma:/\n"
+			      "5:devices:/user.slice/user-0.slice/session-10697.scope\n"
+			      "4:pids:/user.slice/user-0.slice/session-10697.scope\n"
+			      "3:blkio:/user.slice/user-0.slice/session-10697.scope\n"
+			      "2:net_cls,net_prio:/\n"
+			      "1:name=systemd:/user.slice/user-0.slice/session-10697.scope";
+	std::stringstream s(cgroups);
+
+	ASSERT_EQ(get_systemd_cgroup(s), "/user.slice/user-0.slice/session-10697.scope");
+}
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces support for the Podman container engine. It builds on top of the support for Docker, as the APIs are very similar. This PR adds support for all the known and relevant differences.

To retrieve metadata about a container, it requires the Podman API to be enabled for the user that started the container (`/run/podman/podman.sock` for root containers, `/run/user/<uid>/podman/podman.sock` for rootless containers). The API socket for the root user can usually be started on demand with `systemctl start podman.socket` (and/or `systemctl enable podman.socket`). The API for non-root users can be started e.g. by executing `podman system service -t 0 &` as each individual user.

Non-root containers have an extra label added (`podman_owner_uid`), set to the numeric uid of the user who started the container.

**Special notes for your reviewer**:

This PR includes https://github.com/falcosecurity/libs/pull/66 inside. To see just the changes specific to this PR, go to https://github.com/draios/agent-libs/compare/podman-upstream-prepare...draios:podman-upstream?expand=1

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Containers started using `podman` are now recognized by libsinsp, as long as the API service for the user running the container is available.
```
