### PR TITLE
cleanup(libsinsp): add PT_IPNET and PT_IPADDR strings

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1373,6 +1373,10 @@ const char* param_type_to_string(ppm_param_type pt)
 		return "BOOL";
 	case PT_IPV4ADDR:
 		return "IPV4ADDR";
+	case PT_IPADDR:
+		return "IPADDR";
+	case PT_IPNET:
+		return "IPNET";
 	case PT_DYN:
 		return "DYNAMIC";
 	case PT_FLAGS8:


### PR DESCRIPTION
Signed-off-by: lucklypse <lucklypse@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Prevent `list_fields` from triggering an ASSERT when compiled in debug mode.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
