### PR TITLE
cleanup(libsinsp): make user agent string parametrized

### DIFF
--- a/cmake/modules/libsinsp.cmake
+++ b/cmake/modules/libsinsp.cmake
@@ -9,6 +9,10 @@ option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system
 
 option(WITH_CHISEL "Include chisel implementation" OFF)
 
+if(DEFINED LIBSINSP_USER_AGENT)
+	add_definitions(-DLIBSINSP_USER_AGENT="${LIBSINSP_USER_AGENT}")
+endif()
+
 include(ExternalProject)
 include(libscap)
 include(tbb)

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -391,7 +391,7 @@ std::string mesos_http::make_request(uri url, curl_version_info_data* curl_versi
 	{
 		request << '?' << query;
 	}
-	request << " HTTP/1.1\r\nConnection: Keep-Alive\r\nUser-Agent: sysdig";
+	request << " HTTP/1.1\r\nConnection: Keep-Alive\r\nUser-Agent: " LIBSINSP_USER_AGENT;
 	if(curl_version && curl_version->version)
 	{
 		request << " (curl " << curl_version->version << ')';

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -157,6 +157,14 @@ public:
 };
 
 /*!
+  \brief The user agent string to use for any libsinsp connection, can be changed at compile time
+*/
+
+#if !defined(LIBSINSP_USER_AGENT)
+#define LIBSINSP_USER_AGENT "falcosecurity-libs"
+#endif // LIBSINSP_USER_AGENT
+
+/*!
   \brief The default way an event is converted to string by the library
 */
 #define DEFAULT_OUTPUT_STR "*%evt.num %evt.time %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.args"

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -181,7 +181,7 @@ public:
 		{
 			request << '?' << query;
 		}
-		request << " HTTP/" << http_version << "\r\n" << m_keep_alive << "User-Agent: sysdig\r\n";
+		request << " HTTP/" << http_version << "\r\n" << m_keep_alive << "User-Agent: " LIBSINSP_USER_AGENT "\r\n";
 		if(!host_and_port.empty())
 		{
 			request << "Host: " << host_and_port << "\r\n";


### PR DESCRIPTION
Signed-off-by: lucklypse <lucklypse@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Add a compile-time option to define the user agent that will be used in requests issued by libsinsp.

**Which issue(s) this PR fixes**:

Fixes #60

**Special notes for your reviewer**:

We could also hard-code the user-agent, or better yet, add the library version as well to it. I'm not sure about the cases where we would need to change it.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
