### PR TITLE
refactor(libsinsp): update format for events and fields self-documentation

### DIFF
--- a/userspace/libsinsp/fields_info.cpp
+++ b/userspace/libsinsp/fields_info.cpp
@@ -61,12 +61,16 @@ void list_fields(bool verbose, bool markdown, bool names_only)
 		{
 			if(markdown)
 			{
-				printf("## Filter Class: %s\n\n", fci->m_name.c_str());
+				printf("\n## Field Class: %s\n\n", fci->m_name.c_str());
+				printf("%s\n\n", fci->m_desc.c_str());
+				printf("Name | Type | Description\n");
+				printf(":----|:-----|:-----------\n");
 			}
 			else
 			{
 				printf("\n----------------------\n");
 				printf("Field Class: %s\n\n", fci->m_name.c_str());
+				printf("%s\n\n", fci->m_desc.c_str());
 			}
 		}
 
@@ -85,9 +89,7 @@ void list_fields(bool verbose, bool markdown, bool names_only)
 			}
 			else if(markdown)
 			{
-				printf("**Name**: %s  \n", fld->m_name);
-				printf("**Description**: %s  \n", fld->m_description);
-				printf("**Type**: %s  \n\n", param_type_to_string(fld->m_type));
+				printf("`%s` | %s | %s\n", fld->m_name, param_type_to_string(fld->m_type), fld->m_description);
 			}
 			else
 			{
@@ -140,13 +142,19 @@ void list_fields(bool verbose, bool markdown, bool names_only)
 	}
 }
 
-void list_events(sinsp* inspector)
+void list_events(sinsp* inspector, bool markdown)
 {
 	uint32_t j, k;
 	string tstr;
 
 	sinsp_evttables* einfo = inspector->get_event_info_tables();
 	const struct ppm_event_info* etable = einfo->m_event_info;
+
+	if(markdown)
+	{
+		printf("Falco | Dir | Event\n");
+		printf(":-----|:----|:-----\n");
+	}
 
 	for(j = 0; j < PPM_EVENT_MAX; j++)
 	{
@@ -158,19 +166,45 @@ void list_events(sinsp* inspector)
 			continue;
 		}
 
-		printf("%c %s(", dir, ei.name);
-
-		for(k = 0; k < ei.nparams; k++)
+		if(markdown)
 		{
-			if(k != 0)
+			if(sinsp::simple_consumer_consider_evtnum(j))
 			{
-				printf(", ");
+				printf("Yes");
+			} else {
+				printf("No");
 			}
 
-			printf("%s %s", param_type_to_string(ei.params[k].type),
-				ei.params[k].name);
-		}
+			printf(" | %c | **%s**(", dir, ei.name);
 
-		printf(")\n");
+			for(k = 0; k < ei.nparams; k++)
+			{
+				if(k != 0)
+				{
+					printf(", ");
+				}
+
+				printf("%s %s", param_type_to_string(ei.params[k].type),
+					ei.params[k].name);
+			}
+
+			printf(")\n");
+		} else
+		{
+			printf("%c %s(", dir, ei.name);
+
+			for(k = 0; k < ei.nparams; k++)
+			{
+				if(k != 0)
+				{
+					printf(", ");
+				}
+
+				printf("%s %s", param_type_to_string(ei.params[k].type),
+					ei.params[k].name);
+			}
+
+			printf(")\n");
+		}
 	}
 }

--- a/userspace/libsinsp/fields_info.cpp
+++ b/userspace/libsinsp/fields_info.cpp
@@ -39,12 +39,6 @@ void list_fields(bool verbose, bool markdown, bool names_only)
 {
 	uint32_t j, l, m;
 	int32_t k;
-
-	if(markdown && !names_only)
-	{
-		printf("# Filter Fields List\n\n");
-	}
-
 	vector<const filter_check_info*> fc_plugins;
 	sinsp::get_filtercheck_fields_info(fc_plugins);
 

--- a/userspace/libsinsp/fields_info.h
+++ b/userspace/libsinsp/fields_info.h
@@ -25,4 +25,4 @@ class sinsp;
 // Printer functions
 //
 void list_fields(bool verbose, bool markdown, bool names_only=false);
-void list_events(sinsp* inspector);
+void list_events(sinsp* inspector, bool markdown=false);

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -108,14 +108,13 @@ sinsp_filter_check_list::sinsp_filter_check_list()
 	//////////////////////////////////////////////////////////////////////////////
 	// ADD NEW FILTER CHECK CLASSES HERE
 	//////////////////////////////////////////////////////////////////////////////
-	add_filter_check(new sinsp_filter_check_fd());
-	add_filter_check(new sinsp_filter_check_thread());
-	add_filter_check(new sinsp_filter_check_gen_event());
 	add_filter_check(new sinsp_filter_check_event());
+	add_filter_check(new sinsp_filter_check_thread());
 	add_filter_check(new sinsp_filter_check_user());
 	add_filter_check(new sinsp_filter_check_group());
-	add_filter_check(new sinsp_filter_check_syslog());
 	add_filter_check(new sinsp_filter_check_container());
+	add_filter_check(new sinsp_filter_check_fd());
+	add_filter_check(new sinsp_filter_check_syslog());
 	add_filter_check(new sinsp_filter_check_utils());
 	add_filter_check(new sinsp_filter_check_fdlist());
 #if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
@@ -124,6 +123,7 @@ sinsp_filter_check_list::sinsp_filter_check_list()
 #endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	add_filter_check(new sinsp_filter_check_tracer());
 	add_filter_check(new sinsp_filter_check_evtin());
+	add_filter_check(new sinsp_filter_check_gen_event());
 }
 
 sinsp_filter_check_list::~sinsp_filter_check_list()

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -143,6 +143,7 @@ sinsp_filter_check_fd::sinsp_filter_check_fd()
 	m_fdinfo = NULL;
 
 	m_info.m_name = "fd";
+	m_info.m_desc = "Every syscall that has a file descriptor in its arguments has these fields set with information related to the file.";
 	m_info.m_fields = sinsp_filter_check_fd_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_fd_fields) / sizeof(sinsp_filter_check_fd_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -1859,6 +1860,7 @@ const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 sinsp_filter_check_thread::sinsp_filter_check_thread()
 {
 	m_info.m_name = "process";
+	m_info.m_desc = "Additional information about the process and thread executing the syscall event.";
 	m_info.m_fields = sinsp_filter_check_thread_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_thread_fields) / sizeof(sinsp_filter_check_thread_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -2965,6 +2967,7 @@ sinsp_filter_check_event::sinsp_filter_check_event()
 {
 	m_is_compare = false;
 	m_info.m_name = "evt";
+	m_info.m_desc = "Generic event fields. Note that for syscall events you can access the individual arguments/parameters of each syscall via evt.arg, e.g. evt.arg.filename.";
 	m_info.m_fields = sinsp_filter_check_event_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_event_fields) / sizeof(sinsp_filter_check_event_fields[0]);
 	m_u64val = 0;
@@ -4719,6 +4722,7 @@ const filtercheck_field_info sinsp_filter_check_user_fields[] =
 sinsp_filter_check_user::sinsp_filter_check_user()
 {
 	m_info.m_name = "user";
+	m_info.m_desc = "Information about the user executing the specific event.";
 	m_info.m_fields = sinsp_filter_check_user_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_user_fields) / sizeof(sinsp_filter_check_user_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -4791,6 +4795,7 @@ const filtercheck_field_info sinsp_filter_check_group_fields[] =
 sinsp_filter_check_group::sinsp_filter_check_group()
 {
 	m_info.m_name = "group";
+	m_info.m_desc = "Information about the user group.";
 	m_info.m_fields = sinsp_filter_check_group_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_group_fields) / sizeof(sinsp_filter_check_group_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -4880,6 +4885,7 @@ sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 {
 	m_storage = NULL;
 	m_info.m_name = "span";
+	m_info.m_desc = "Fields used if information about distributed tracing is available.";
 	m_info.m_fields = sinsp_filter_check_tracer_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_tracer_fields) / sizeof(sinsp_filter_check_tracer_fields[0]);
 	m_converter = new sinsp_filter_check_reference();
@@ -5482,6 +5488,7 @@ sinsp_filter_check_evtin::sinsp_filter_check_evtin()
 {
 	m_is_compare = false;
 	m_info.m_name = "evtin";
+	m_info.m_desc = "Fields used if information about distributed tracing is available.";
 	m_info.m_fields = sinsp_filter_check_evtin_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_evtin_fields) / sizeof(sinsp_filter_check_evtin_fields[0]);
 	m_u64val = 0;
@@ -6051,6 +6058,7 @@ const filtercheck_field_info sinsp_filter_check_syslog_fields[] =
 sinsp_filter_check_syslog::sinsp_filter_check_syslog()
 {
 	m_info.m_name = "syslog";
+	m_info.m_desc = "Content of Syslog messages.";
 	m_info.m_fields = sinsp_filter_check_syslog_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_syslog_fields) / sizeof(sinsp_filter_check_syslog_fields[0]);
 	m_decoder = NULL;
@@ -6131,6 +6139,7 @@ const filtercheck_field_info sinsp_filter_check_container_fields[] =
 sinsp_filter_check_container::sinsp_filter_check_container()
 {
 	m_info.m_name = "container";
+	m_info.m_desc = "Container information. If the event is not happening inside a container, both id and name will be set to 'host'.";
 	m_info.m_fields = sinsp_filter_check_container_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_container_fields) / sizeof(sinsp_filter_check_container_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -6614,6 +6623,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 sinsp_filter_check_reference::sinsp_filter_check_reference()
 {
 	m_info.m_name = "<NA>";
+	m_info.m_desc = "";
 	m_info.m_fields = &m_finfo;
 	m_info.m_nfields = 1;
 	m_info.m_flags = 0;
@@ -7008,6 +7018,7 @@ const filtercheck_field_info sinsp_filter_check_utils_fields[] =
 sinsp_filter_check_utils::sinsp_filter_check_utils()
 {
 	m_info.m_name = "util";
+	m_info.m_desc = "";
 	m_info.m_fields = sinsp_filter_check_utils_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_utils_fields) / sizeof(sinsp_filter_check_utils_fields[0]);
 	m_info.m_flags = filter_check_info::FL_HIDDEN;
@@ -7051,6 +7062,7 @@ const filtercheck_field_info sinsp_filter_check_fdlist_fields[] =
 sinsp_filter_check_fdlist::sinsp_filter_check_fdlist()
 {
 	m_info.m_name = "fdlist";
+	m_info.m_desc = "Poll event related fields.";
 	m_info.m_fields = sinsp_filter_check_fdlist_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_fdlist_fields) / sizeof(sinsp_filter_check_fdlist_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -7277,6 +7289,7 @@ const filtercheck_field_info sinsp_filter_check_k8s_fields[] =
 sinsp_filter_check_k8s::sinsp_filter_check_k8s()
 {
 	m_info.m_name = "k8s";
+	m_info.m_desc = "Kubernetes related context.";
 	m_info.m_fields = sinsp_filter_check_k8s_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_k8s_fields) / sizeof(sinsp_filter_check_k8s_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
@@ -7930,6 +7943,7 @@ const filtercheck_field_info sinsp_filter_check_mesos_fields[] =
 sinsp_filter_check_mesos::sinsp_filter_check_mesos()
 {
 	m_info.m_name = "mesos";
+	m_info.m_desc = "Mesos related context.";
 	m_info.m_fields = sinsp_filter_check_mesos_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_mesos_fields) / sizeof(sinsp_filter_check_mesos_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2916,7 +2916,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] =
 	{PT_CHARBUF, EPF_NONE, PF_DIR, "evt.dir", "event direction can be either '>' for enter events or '<' for exit events."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.type", "The name of the event (e.g. 'open')."},
 	{PT_UINT32, EPF_REQUIRES_ARGUMENT, PF_NA, "evt.type.is", "allows one to specify an event type, and returns 1 for events that are of that type. For example, evt.type.is.open returns 1 for open events, 0 for any other event."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "syscall.type", "For system call events, the name of the system call (e.g. 'open'). Unset for other events (e.g. switch or sysdig internal events). Use this field instead of evt.type if you need to make sure that the filtered/printed value is actually a system call."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "syscall.type", "For system call events, the name of the system call (e.g. 'open'). Unset for other events (e.g. switch or internal events). Use this field instead of evt.type if you need to make sure that the filtered/printed value is actually a system call."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.category", "The event category. Example values are 'file' (for file operations like open and close), 'net' (for network operations like socket and bind), memory (for things like brk or mmap), and so on."},
 	{PT_INT16, EPF_NONE, PF_ID, "evt.cpu", "number of the CPU where this event happened."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.args", "all the event arguments, aggregated into a single string."},
@@ -4876,9 +4876,9 @@ const filtercheck_field_info sinsp_filter_check_tracer_fields[] =
 	{PT_UINT64, EPF_TABLE_ONLY, PF_DEC, "span.count", "1 for span exit events."},
 	{PT_UINT64, (filtercheck_field_flags) (EPF_TABLE_ONLY | EPF_REQUIRES_ARGUMENT), PF_DEC, "span.count.fortag", "1 if the span's number of tags matches the field argument, and zero for all the other ones."},
 	{PT_UINT64, (filtercheck_field_flags) (EPF_TABLE_ONLY | EPF_REQUIRES_ARGUMENT), PF_DEC, "span.childcount.fortag", "1 if the span's number of tags is greater than the field argument, and zero for all the other ones."},
-	{PT_CHARBUF, (filtercheck_field_flags) (EPF_TABLE_ONLY | EPF_REQUIRES_ARGUMENT), PF_NA, "span.idtag", "id used by the span list csysdig view."},
-	{PT_CHARBUF, EPF_TABLE_ONLY, PF_NA, "span.rawtime", "id used by the span list csysdig view."},
-	{PT_CHARBUF, EPF_TABLE_ONLY, PF_NA, "span.rawparenttime", "id used by the span list csysdig view."},
+	{PT_CHARBUF, (filtercheck_field_flags) (EPF_TABLE_ONLY | EPF_REQUIRES_ARGUMENT), PF_NA, "span.idtag", "id used by the span list view."},
+	{PT_CHARBUF, EPF_TABLE_ONLY, PF_NA, "span.rawtime", "id used by the span list view."},
+	{PT_CHARBUF, EPF_TABLE_ONLY, PF_NA, "span.rawparenttime", "id used by the span list view."},
 };
 
 sinsp_filter_check_tracer::sinsp_filter_check_tracer()
@@ -6117,7 +6117,7 @@ const filtercheck_field_info sinsp_filter_check_container_fields[] =
 {
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.id", "the container id."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.name", "the container name."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image", "the container image name (e.g. sysdig/sysdig:latest for docker, )."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image", "the container image name (e.g. falcosecurity/falco:latest for docker)."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image.id", "the container image id (e.g. 6f7e2741b66b)."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.type", "the container type, eg: docker or rkt"},
 	{PT_BOOL, EPF_NONE, PF_NA, "container.privileged", "true for containers running as privileged, false otherwise"},
@@ -6128,7 +6128,7 @@ const filtercheck_field_info sinsp_filter_check_container_fields[] =
 	{PT_CHARBUF, EPF_REQUIRES_ARGUMENT, PF_NA, "container.mount.mode", "the mount mode, specified by number (e.g. container.mount.mode[0]) or mount source (container.mount.mode[/usr/local]). The pathname can be a glob."},
 	{PT_CHARBUF, EPF_REQUIRES_ARGUMENT, PF_NA, "container.mount.rdwr", "the mount rdwr value, specified by number (e.g. container.mount.rdwr[0]) or mount source (container.mount.rdwr[/usr/local]). The pathname can be a glob."},
 	{PT_CHARBUF, EPF_REQUIRES_ARGUMENT, PF_NA, "container.mount.propagation", "the mount propagation value, specified by number (e.g. container.mount.propagation[0]) or mount source (container.mount.propagation[/usr/local]). The pathname can be a glob."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image.repository", "the container image repository (e.g. sysdig/sysdig)."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image.repository", "the container image repository (e.g. falcosecurity/falco)."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image.tag", "the container image tag (e.g. stable, latest)."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.image.digest", "the container image registry digest (e.g. sha256:d977378f890d445c15e51795296e4e5062f109ce6da83e0a355fc4ad8699d27)."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "container.healthcheck", "The container's health check. Will be the null value (\"N/A\") if no healthcheck configured, \"NONE\" if configured but explicitly not created, and the healthcheck command line otherwise"},

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -144,6 +144,7 @@ public:
 	}
 
 	string m_name; ///< Field class name.
+	string m_desc; ///< Field class description.
 	int32_t m_nfields; ///< Number of fields in this field group.
 	const filtercheck_field_info* m_fields; ///< Array containing m_nfields field descriptions.
 	uint32_t m_flags;

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1374,6 +1374,10 @@ const char* param_type_to_string(ppm_param_type pt)
 		return "BOOL";
 	case PT_IPV4ADDR:
 		return "IPV4ADDR";
+	case PT_IPADDR:
+		return "IPADDR";
+	case PT_IPNET:
+		return "IPNET";
 	case PT_DYN:
 		return "DYNAMIC";
 	case PT_FLAGS8:


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

- Change the way falco libs automatically document their supported events and fields in Markdown format
- Add a description field for field classes so they can be documented
- Change the order of addition of the field classes so they're displayed in the right order upon documentation request

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Please read the comment on the change of order as I'm not completely sure it can be done

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
