### PR TITLE
Add ability to return event types used by a filter

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -651,6 +651,18 @@ sinsp_filter_check::sinsp_filter_check()
 	m_val_storages = vector<vector<uint8_t>> (1, vector<uint8_t>(256));
 	m_val_storages_min_size = (numeric_limits<uint32_t>::max)();
 	m_val_storages_max_size = (numeric_limits<uint32_t>::min)();
+
+	// Do this once
+	if(s_all_event_types.size() == 0)
+	{
+		//
+		// Fill in from 2 to PPM_EVENT_MAX-1. 0 and 1 are excluded as
+		// those are PPM_GENERIC_E/PPME_GENERIC_X.
+		for(uint16_t i = 2; i < PPM_EVENT_MAX; i++)
+		{
+			s_all_event_types.insert(i);
+		}
+	}
 }
 
 void sinsp_filter_check::set_inspector(sinsp* inspector)
@@ -1363,6 +1375,18 @@ uint8_t* sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT uint32_t* len, b
 	{
 		return extract(evt, len, sanitize_strings);
 	}
+}
+
+const std::set<uint16_t> &sinsp_filter_check::evttypes()
+{
+	// By default a check should be considered for all event types
+	// so use the default.
+	return s_all_event_types;
+}
+
+const std::set<uint16_t> &sinsp_filter_check::possible_evttypes()
+{
+	return s_all_event_types;
 }
 
 bool sinsp_filter_check::compare(gen_event *evt)

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4524,6 +4524,73 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	return NULL;
 }
 
+const std::set<uint16_t> &sinsp_filter_check_event::evttypes()
+{
+	bool should_match = true;
+
+	if(m_field_id == TYPE_TYPE)
+	{
+		// The only meaningful comparison operators for this
+		// filter check should be direct comparisons and not
+		// LT/GE/CONTAINS/etc.
+		if(!(m_cmpop == CO_EQ || m_cmpop == CO_NE || m_cmpop == CO_IN))
+		{
+			m_event_types = possible_evttypes();
+			return m_event_types;
+		}
+
+		// If the comparison operator is !=, we need to invert
+		// the set. "not" is handled in
+		// gen_event_filter_expression::evttypes().
+		if(m_cmpop == CO_NE)
+		{
+			should_match = false;
+		}
+	}
+	else
+	{
+		// Should run for all event types
+		m_event_types = possible_evttypes();
+		return m_event_types;
+	}
+
+	// If here, we know we can find a more specific set of event types.
+	m_event_types.clear();
+
+	sinsp_evttables* einfo = m_inspector->get_event_info_tables();
+	const struct ppm_event_info* etable = einfo->m_event_info;
+
+	// This skips PPME_EVENT_GENERIC_{E,X} as the logical
+	// operators/inverse don't work for these values.
+	for(uint32_t i = 2; i < PPM_EVENT_MAX; i++)
+	{
+		// The values are held as strings, so we need to
+		// convert them back to numbers.
+		bool found = false;
+		for (uint16_t j=0; j < m_val_storages.size(); j++)
+		{
+			std::string evttype_str((char *) filter_value_p(j));
+
+			if(etable[i].name == evttype_str)
+			{
+				found = true;
+				break;
+			}
+		}
+
+		// We add to m_event_types if:
+		//  - was found and should_match == true, or
+		//  - was not found and should_match == false
+		// so found == should_match
+		if(found == should_match)
+		{
+			m_event_types.insert(i);
+		}
+	}
+
+	return m_event_types;
+}
+
 bool sinsp_filter_check_event::compare(sinsp_evt *evt)
 {
 	bool res;

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -136,6 +136,9 @@ public:
 		return Json::nullValue;
 	}
 
+	virtual const std::set<uint16_t> &evttypes() override;
+	const std::set<uint16_t> &possible_evttypes() override;
+
 	//
 	// Compare the field with the constant value obtained from parse_filter_value()
 	//
@@ -192,6 +195,8 @@ protected:
 
 private:
 	void set_inspector(sinsp* inspector);
+
+	std::set<uint16_t> s_all_event_types;
 
 friend class sinsp_filter_check_list;
 friend class sinsp_filter_optimizer;
@@ -482,6 +487,8 @@ public:
 	Json::Value extract_as_js(sinsp_evt *evt, OUT uint32_t* len);
 	bool compare(sinsp_evt *evt);
 
+	const std::set<uint16_t> &evttypes() override;
+
 	uint64_t m_u64val;
 	uint64_t m_tsdelta;
 	uint32_t m_u32val;
@@ -510,6 +517,8 @@ private:
 	uint32_t m_storage_size;
 	const char* m_cargname;
 	sinsp_filter_check_reference* m_converter;
+
+	std::set<uint16_t> m_event_types;
 };
 
 //

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories(${LIBSCAP_INCLUDE_DIR})
 add_executable(unit-test-libsinsp
 	cgroup_list_counter.ut.cpp
 	sinsp.ut.cpp
+	evttype_filter.ut.cpp
 )
 
 target_link_libraries(unit-test-libsinsp

--- a/userspace/libsinsp/test/evttype_filter.ut.cpp
+++ b/userspace/libsinsp/test/evttype_filter.ut.cpp
@@ -1,0 +1,285 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest.h>
+#include <sinsp.h>
+#include <filter.h>
+
+std::stringstream & operator<<(std::stringstream &out, set<uint16_t> s)
+{
+	out << "[ ";
+	for(auto &val : s)
+	{
+		out << val;
+		out << " ";
+	}
+	out << "]";
+
+	return out;
+}
+
+class evttype_filter_test : public testing::Test
+{
+
+protected:
+
+	void SetUp()
+	{
+		for(uint32_t i = 2; i < PPM_EVENT_MAX; i++)
+		{
+			all_events.insert(i);
+
+			if(openat_only.find(i) == openat_only.end())
+			{
+				not_openat.insert(i);
+			}
+
+			if(openat_close.find(i) == openat_close.end())
+			{
+				not_openat_close.insert(i);
+			}
+
+			if (close_only.find(i) == close_only.end())
+			{
+				not_close.insert(i);
+			}
+		}
+	}
+
+	void TearDown()
+	{
+	}
+
+	sinsp_filter *compile(const string &fltstr)
+	{
+		sinsp_filter_compiler compiler(NULL, fltstr);
+
+		return compiler.compile();
+	}
+
+	void compare_evttypes(sinsp_filter *f, std::set<uint16_t> &expected)
+	{
+		std::set<uint16_t> actual = f->evttypes();
+
+		for(auto &etype : expected)
+		{
+			if(actual.find(etype) == actual.end())
+			{
+				FAIL() << "Expected event type "
+				       << etype
+				       << " not found in actual set. "
+				       << "Expected: " << expected << " "
+				       << " Actual: " << actual;
+
+			}
+		}
+
+		for(auto &etype : actual)
+		{
+			if(expected.find(etype) == expected.end())
+			{
+				FAIL() << "Actual evttypes had additional event type "
+				       << etype
+				       << " not found in expected set. "
+				       << "Expected: " << expected << " "
+				       << " Actual: " << actual;
+			}
+		}
+	}
+
+	std::set<uint16_t> openat_only{
+		PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
+		PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X
+	};
+
+	std::set<uint16_t> close_only{
+		PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X
+	};
+
+	std::set<uint16_t> openat_close{
+		PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
+		 PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X,
+		 PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X
+	};
+
+	std::set<uint16_t> not_openat;
+	std::set<uint16_t> not_openat_close;
+	std::set<uint16_t> not_close;
+	std::set<uint16_t> all_events;
+	std::set<uint16_t> no_events;
+};
+
+TEST_F(evttype_filter_test, evt_type_eq)
+{
+	sinsp_filter *f = compile("evt.type=openat");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, evt_type_in)
+{
+	sinsp_filter *f = compile("evt.type in (openat, close)");
+
+	compare_evttypes(f, openat_close);
+}
+
+TEST_F(evttype_filter_test, evt_type_ne)
+{
+	sinsp_filter *f = compile("evt.type!=openat");
+
+	compare_evttypes(f, not_openat);
+}
+
+TEST_F(evttype_filter_test, not_evt_type_eq)
+{
+	sinsp_filter *f = compile("not evt.type=openat");
+
+	compare_evttypes(f, not_openat);
+}
+
+TEST_F(evttype_filter_test, not_evt_type_in)
+{
+	sinsp_filter *f = compile("not evt.type in (openat, close)");
+
+	compare_evttypes(f, not_openat_close);
+}
+
+TEST_F(evttype_filter_test, not_evt_type_ne)
+{
+	sinsp_filter *f = compile("not evt.type != openat");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, evt_type_or)
+{
+	sinsp_filter *f = compile("evt.type=openat or evt.type=close");
+
+	compare_evttypes(f, openat_close);
+}
+
+TEST_F(evttype_filter_test, not_evt_type_or)
+{
+	sinsp_filter *f = compile("evt.type!=openat or evt.type!=close");
+
+	compare_evttypes(f, all_events);
+}
+
+TEST_F(evttype_filter_test, evt_type_or_ne)
+{
+	sinsp_filter *f = compile("evt.type=close or evt.type!=openat");
+
+	compare_evttypes(f, not_openat);
+}
+
+TEST_F(evttype_filter_test, evt_type_and)
+{
+	sinsp_filter *f = compile("evt.type=close and evt.type=openat");
+
+	compare_evttypes(f, no_events);
+}
+
+TEST_F(evttype_filter_test, evt_type_and_non_evt_type)
+{
+	sinsp_filter *f = compile("evt.type=openat and proc.name=nginx");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, evt_type_and_non_evt_type_not)
+{
+	sinsp_filter *f = compile("evt.type=openat and not proc.name=nginx");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, evt_type_and_nested)
+{
+	sinsp_filter *f = compile("evt.type=openat and (proc.name=nginx)");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, evt_type_and_nested_multi)
+{
+	sinsp_filter *f = compile("evt.type=openat and (evt.type=close and proc.name=nginx)");
+
+	compare_evttypes(f, no_events);
+}
+
+TEST_F(evttype_filter_test, non_evt_type)
+{
+	sinsp_filter *f = compile("proc.name=nginx");
+
+	compare_evttypes(f, all_events);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_or)
+{
+	sinsp_filter *f = compile("evt.type=openat or proc.name=nginx");
+
+	compare_evttypes(f, all_events);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_or_nested_first)
+{
+	sinsp_filter *f = compile("(evt.type=openat) or proc.name=nginx");
+
+	compare_evttypes(f, all_events);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_or_nested_second)
+{
+	sinsp_filter *f = compile("evt.type=openat or (proc.name=nginx)");
+
+	compare_evttypes(f, all_events);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_or_nested_multi)
+{
+	sinsp_filter *f = compile("evt.type=openat or (evt.type=close and proc.name=nginx)");
+
+	compare_evttypes(f, openat_close);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_or_nested_multi_not)
+{
+	sinsp_filter *f = compile("evt.type=openat or not (evt.type=close and proc.name=nginx)");
+
+	compare_evttypes(f, not_close);
+}
+
+TEST_F(evttype_filter_test, non_evt_type_and_nested_multi_not)
+{
+	sinsp_filter *f = compile("evt.type=openat and not (evt.type=close and proc.name=nginx)");
+
+	compare_evttypes(f, openat_only);
+}
+
+TEST_F(evttype_filter_test, ne_and_and)
+{
+	sinsp_filter *f = compile("evt.type!=openat and evt.type!=close");
+
+	compare_evttypes(f, not_openat_close);
+}
+
+TEST_F(evttype_filter_test, not_not)
+{
+	sinsp_filter *f = compile("not (not evt.type=openat)");
+
+	compare_evttypes(f, openat_only);
+}


### PR DESCRIPTION
Add ability to return event types used by a filter

Add the ability to return the event types used by a filter. For
example, if a filter was "evt.type=open and fd.name=/tmp/foo", the
event types would be PPME_SYSCALL_OPEN*_{E,X}.

By default, an empty set is returned, meaning no specific events are
used.

Event types PPME_GENERIC_{E,X} are not included and it's assumed the
code using this will handle those event types directly.

This is used in programs like falco to provide a quick external test
against an event to see if it makes sense to evaluate the filter at
all. This can speed up event processing when falco has a large number
of loaded rules. Prior to this change, this was handled solely in
falco's lua code for loading rules. Moving responsibility to the
filter significantly simplifies the falco side of rule loading.

In the base classes, new methods
gen_event_filter_check::evttypes/possible_evttypes return a set of
event types. The base class implementation just returns a single event
type "1".

gen_event_filter_expression::evttypes() does all the work of iterating
over the filterchecks that make up an expression and combining sets of
event types. possible_evttypes is used for "not" operators, which
invert a set of event types to include everything outside the set.

The sinsp "base" class sinsp_filter_check just returns all event types
from 2 to PPM_EVENT_MAX.

The only actual implementation of evttypes() that does something is in
sinsp_filter_check_event for the field "evt.type". The method handles
=, in, and != as comparison operators.

Also add a unit test that compiles various filters and double-checks
the resulting set of event types.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: add the ability to report the event types that are relevant for a given filter. This is used by programs like Falco to speed up rule evaluation.
```
