### PR TITLE
Add ability to return all fields exported by a factory

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -2442,5 +2442,50 @@ gen_event_filter_check *sinsp_filter_factory::new_filtercheck(const char *fldnam
 							  true);
 }
 
+std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory::get_fields()
+{
+	std::list<gen_event_filter_factory::filter_fieldclass_info> ret;
+
+	vector<const filter_check_info*> fc_plugins;
+	sinsp::get_filtercheck_fields_info(&fc_plugins);
+
+	for(auto &fci : fc_plugins)
+	{
+		if(fci->m_flags & filter_check_info::FL_HIDDEN)
+		{
+			continue;
+		}
+
+		gen_event_filter_factory::filter_fieldclass_info cinfo;
+		cinfo.name = fci->m_name;
+		cinfo.desc = "";
+		cinfo.class_info = "";
+
+		for(int32_t k = 0; k < fci->m_nfields; k++)
+		{
+			const filtercheck_field_info* fld = &fci->m_fields[k];
+
+			// If a field can't be used to filter events,
+			// or if a field is only used for stuff like
+			// chisels to organize events, we don't want
+			// to print it and don't return it here.
+			if(fld->m_flags & EPF_TABLE_ONLY ||
+			   fld->m_flags & EPF_PRINT_ONLY)
+			{
+				continue;
+			}
+
+			gen_event_filter_factory::filter_field_info info;
+			info.name = fld->m_name;
+			info.desc = fld->m_description;
+
+			cinfo.fields.emplace_back(std::move(info));
+		}
+
+		ret.emplace_back(std::move(cinfo));
+	}
+
+	return ret;
+}
 
 #endif // HAS_FILTERING

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -213,6 +213,8 @@ public:
 
 	gen_event_filter_check *new_filtercheck(const char *fldname);
 
+	std::list<gen_event_filter_factory::filter_fieldclass_info> get_fields() override;
+
 protected:
 	sinsp *m_inspector;
 };

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -17,6 +17,8 @@ along with Falco.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <set>
+#include <list>
+#include <string>
 #include <vector>
 
 /*
@@ -166,7 +168,7 @@ public:
 	//
 	// An expression is consistent if all its checks are of the same type (or/and).
 	//
-	// This method returns the expression operator (BO_AND/BO_OR/BO_NONE) if the 
+	// This method returns the expression operator (BO_AND/BO_OR/BO_NONE) if the
 	// expression is consistent. It returns -1 if the expression is not consistent.
 	//
 	int32_t get_expr_boolop();
@@ -234,6 +236,31 @@ class gen_event_filter_factory
 {
 public:
 
+	// A struct describing a single filtercheck field ("ka.user")
+	struct filter_field_info
+	{
+		// The name of the field
+		std::string name;
+
+		// A description of the field
+		std::string desc;
+	};
+
+	// A struct describing a group of filtercheck fields ("ka")
+	struct filter_fieldclass_info
+	{
+		// The name of the group of fields
+		std::string name;
+
+		// A short description for the fields
+		std::string desc;
+
+		// Additional information about proper use of the fields
+		std::string class_info;
+
+		std::list<filter_field_info> fields;
+	};
+
 	gen_event_filter_factory() {};
 	virtual ~gen_event_filter_factory() {};
 
@@ -242,4 +269,7 @@ public:
 
 	// Create a new filtercheck
 	virtual gen_event_filter_check *new_filtercheck(const char *fldname) = 0;
+
+	// Return the set of fields supported by this factory
+	virtual std::list<filter_fieldclass_info> get_fields() = 0;
 };


### PR DESCRIPTION
Add the ability to return all fields exported by a factory. This is
important for programs like falco that need to validate rule filter
expressions for various event sources, as well as print out sets of
supported fields.

Previously, falco did direct calls to
sinsp::get_filtercheck_fields_info but we're trying to standardize
everything to work through factories, to make it easier to support new
event sources. This PR supports that work.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: add ability to return all fields exported by a filter factory. This will be used by Falco to support multiple event sources.
```
