### PR TITLE
Update lua parser to be short-lived for a single filter

### DIFF
--- a/userspace/chisel/lua_parser.cpp
+++ b/userspace/chisel/lua_parser.cpp
@@ -16,9 +16,8 @@ limitations under the License.
 */
 #include <iostream>
 #include <fstream>
-#include "sinsp.h"
-#include "filter.h"
-#include "sinsp_int.h"
+#include <memory>
+#include "gen_filter.h"
 
 #include "lua_parser.h"
 #include "lua_parser_api.h"
@@ -39,50 +38,29 @@ const static struct luaL_reg ll_filter [] =
 	{NULL,NULL}
 };
 
-lua_parser::lua_parser(gen_event_filter_factory &factory, lua_State *ls, const char *lua_library_name)
-	: m_factory(factory)
+lua_parser::lua_parser(std::shared_ptr<gen_event_filter_factory> factory)
+	: m_factory(factory), m_filter(m_factory->new_filter()),
+	  m_last_boolop(BO_NONE), m_have_rel_expr(false),
+	  m_nest_level(0)
 {
-	m_filter = NULL;
-
-	m_ls = ls;
-	reset();
-
-	// Register our c++ defined functions
-	luaL_openlib(m_ls, lua_library_name, ll_filter, 0);
 }
 
-void lua_parser::reset()
-{
-	m_have_rel_expr = false;
-	m_last_boolop = BO_NONE;
-	m_nest_level = 0;
-
-	m_filter = m_factory.new_filter();
-}
-
-gen_event_filter* lua_parser::get_filter(bool reset_filter)
-{
-	if (m_nest_level != 0)
-	{
-		throw sinsp_exception("Error in configured filter: unbalanced nesting");
-	}
-
-	gen_event_filter *ret = m_filter;
-
-	if (reset_filter)
-	{
-		reset();
-	}
-
-	return ret;
-}
 lua_parser::~lua_parser()
 {
-	// The lua state is not considered owned by this object, so
-	// not freeing it.
-
-	delete m_filter;
-	m_filter = NULL;
 }
 
+void lua_parser::register_callbacks(lua_State *ls, const char *lua_library_name)
+{
+	// Register our c++ defined functions
+	luaL_openlib(ls, lua_library_name, ll_filter, 0);
+}
 
+std::shared_ptr<gen_event_filter> lua_parser::filter()
+{
+	return m_filter;
+}
+
+std::shared_ptr<gen_event_filter_factory> lua_parser::factory()
+{
+	return m_factory;
+}

--- a/userspace/chisel/lua_parser.h
+++ b/userspace/chisel/lua_parser.h
@@ -24,22 +24,21 @@ typedef struct lua_State lua_State;
 class lua_parser
 {
 public:
-	lua_parser(gen_event_filter_factory &factory, lua_State *ls, const char *lua_library_name);
+	lua_parser(std::shared_ptr<gen_event_filter_factory> factory);
 	virtual ~lua_parser();
-	gen_event_filter* get_filter(bool reset_filter = false);
+
+	std::shared_ptr<gen_event_filter> filter();
+	std::shared_ptr<gen_event_filter_factory> factory();
+
+	static void register_callbacks(lua_State *ls, const char *lua_library_name);
 
  private:
-
-	void reset();
-	gen_event_filter_factory &m_factory;
-
-	gen_event_filter* m_filter;
+	std::shared_ptr<gen_event_filter_factory> m_factory;
+	std::shared_ptr<gen_event_filter> m_filter;
 
 	boolop m_last_boolop;
 	bool m_have_rel_expr;
 	int32_t m_nest_level;
-
-	lua_State* m_ls;
 
 	friend class lua_parser_cbacks;
 };

--- a/userspace/chisel/lua_parser_api.cpp
+++ b/userspace/chisel/lua_parser_api.cpp
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+
+#include <memory>
+
 #include "sinsp.h"
 #include "sinsp_int.h"
 
@@ -131,9 +134,7 @@ int lua_parser_cbacks::nest(lua_State *ls)
 			throw sinsp_exception(err);
 		}
 
-		gen_event_filter* filter = parser->m_filter;
-
-		filter->push_expression(parser->m_last_boolop);
+		parser->filter()->push_expression(parser->m_last_boolop);
 		parser->m_nest_level++;
 
 		parser->m_last_boolop = BO_NONE;
@@ -160,9 +161,7 @@ int lua_parser_cbacks::unnest(lua_State *ls)
 			throw sinsp_exception(err);
 		}
 
-		gen_event_filter* filter = parser->m_filter;
-
-		filter->pop_expression();
+		parser->filter()->pop_expression();
 		parser->m_nest_level--;
 	}
 	catch (const std::exception& e)
@@ -231,10 +230,9 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 		}
 
 		parser->m_have_rel_expr = true;
-		gen_event_filter* filter = parser->m_filter;
 
 		const char* fld = luaL_checkstring(ls, 2);
-		gen_event_filter_check *chk = parser->m_factory.new_filtercheck(fld);
+		gen_event_filter_check *chk = parser->factory()->new_filtercheck(fld);
 		if(chk == NULL)
 		{
 			string err = "filter_check called with nonexistent field " + string(fld);
@@ -297,7 +295,7 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 			chk->set_check_id(rule_index);
 		}
 
-		filter->add_check(chk);
+		parser->filter()->add_check(chk);
 
 	}
 	catch (const std::exception& e)


### PR DESCRIPTION
Clean up the interface for lua_parser/lua_parser_api so it doesn't
rely on a single object.

Context--the lua_parser object simply holds some intermediate
state (e.g. nesting level) and builds up a gen_filter as the lua side
traverses the ast of a filter expression. The lua_parser_api class
just has static methods that are registered into lua.

lua_parser used to be a single object that was reset for each
filter. Now, it's an object that is created as a single filter is
parsed and deleted afterward. The callbacks always pass the lua_parser
object as a first argument and the state/filter in the object is
updated.

Also, registering the lua callbacks is now done via a static method
instead of in the constructor.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update: update LUA parser to be short-lived for a single filter
```
