### PR TITLE
Add notion of generic formatters/formatter factories

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -27,10 +27,27 @@ limitations under the License.
 #ifdef HAS_FILTERING
 extern sinsp_filter_check_list g_filterlist;
 
+sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector)
+	: m_inspector(inspector)
+{
+}
+
 sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector, const string& fmt)
 {
 	m_inspector = inspector;
-	set_format(fmt);
+
+	gen_event_formatter::output_format of = gen_event_formatter::OF_NORMAL;
+
+	if(m_inspector->get_buffer_format() == sinsp_evt::PF_JSON
+	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONEOLS
+	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEX
+	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEXASCII
+	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONBASE64)
+	{
+		of = gen_event_formatter::OF_JSON;
+	}
+
+	set_format(of, fmt);
 }
 
 sinsp_evt_formatter::~sinsp_evt_formatter()
@@ -43,11 +60,13 @@ sinsp_evt_formatter::~sinsp_evt_formatter()
 	}
 }
 
-void sinsp_evt_formatter::set_format(const string& fmt)
+void sinsp_evt_formatter::set_format(gen_event_formatter::output_format of, const string& fmt)
 {
 	uint32_t j;
 	uint32_t last_nontoken_str_start = 0;
 	string lfmt(fmt);
+
+	m_output_format = of;
 
 	if(lfmt == "")
 	{
@@ -200,25 +219,33 @@ bool sinsp_evt_formatter::resolve_tokens(sinsp_evt *evt, map<string,string>& val
 	return retval;
 }
 
+bool sinsp_evt_formatter::get_field_values(gen_event *gevt, std::map<std::string, std::string> &fields)
+{
+	sinsp_evt *evt = static_cast<sinsp_evt *>(gevt);
 
-bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
+	return resolve_tokens(evt, fields);
+}
+
+gen_event_formatter::output_format sinsp_evt_formatter::get_output_format()
+{
+	return m_output_format;
+}
+
+bool sinsp_evt_formatter::tostring_withformat(gen_event* gevt, std::string &output, gen_event_formatter::output_format of)
 {
 	bool retval = true;
 	const filtercheck_field_info* fi;
 
+	sinsp_evt *evt = static_cast<sinsp_evt *>(gevt);
+
 	uint32_t j = 0;
-	vector<sinsp_filter_check*>::iterator it;
-	res->clear();
+	output.clear();
 
 	ASSERT(m_tokenlens.size() == m_tokens.size());
 
 	for(j = 0; j < m_tokens.size(); j++)
 	{
-		if(m_inspector->get_buffer_format() == sinsp_evt::PF_JSON
-		   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONEOLS
-		   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEX
-		   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEXASCII
-		   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONBASE64)
+		if(of == OF_JSON)
 		{
 			Json::Value json_value = m_tokens[j].second->tojson(evt);
 
@@ -268,35 +295,41 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 			{
 				string sstr(str);
 				sstr.resize(tks, ' ');
-				(*res) += sstr;
+				output += sstr;
 			}
 			else
 			{
-				(*res) += str;
+				output += str;
 			}
 		}
 	}
 
-	if(m_inspector->get_buffer_format() == sinsp_evt::PF_JSON
-	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONEOLS
-	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEX
-	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONHEXASCII
-	   || m_inspector->get_buffer_format() == sinsp_evt::PF_JSONBASE64)
+	if(of == OF_JSON)
 	{
-		(*res) = m_writer.write(m_root);
-		(*res) = res->substr(0, res->size() - 1);
+		output = m_writer.write(m_root);
+		output = output.substr(0, output.size() - 1);
 	}
 
 	return retval;
 }
 
+bool sinsp_evt_formatter::tostring(gen_event* gevt, std::string &output)
+{
+	return tostring_withformat(gevt, output, m_output_format);
+}
+
+bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
+{
+	return tostring_withformat(evt, *res, m_output_format);
+}
+
 #else  // HAS_FILTERING
 
-sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector, const string& fmt)
+sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector)
 {
 }
 
-void sinsp_evt_formatter::set_format(const string& fmt)
+void sinsp_evt_formatter::set_format(gen_event_formatter::output_format of, const std::string &format) = 0;
 {
 	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
 }
@@ -306,7 +339,12 @@ bool sinsp_evt_formatter::resolve_tokens(sinsp_evt *evt, map<string,string>& val
 	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
 }
 
-bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
+bool sinsp_evt_formatter::tostring(gen_event* gevt, std::string &output)
+{
+	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
+}
+
+bool sinsp_evt_formatter::tostring_withformat(gen_event* gevt, std::string &output, gen_event_formatter::output_format of)
 {
 	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
 }
@@ -342,5 +380,40 @@ bool sinsp_evt_formatter_cache::resolve_tokens(sinsp_evt *evt, string &format, m
 
 bool sinsp_evt_formatter_cache::tostring(sinsp_evt *evt, string &format, OUT string *res)
 {
-	return get_cached_formatter(format)->tostring(evt, res);
+	return get_cached_formatter(format)->tostring(evt, *res);
+}
+
+sinsp_evt_formatter_factory::sinsp_evt_formatter_factory(sinsp *inspector)
+	: m_inspector(inspector), m_output_format(gen_event_formatter::OF_NORMAL)
+{
+}
+
+sinsp_evt_formatter_factory::~sinsp_evt_formatter_factory()
+{
+}
+
+void sinsp_evt_formatter_factory::set_output_format(gen_event_formatter::output_format of)
+{
+	m_formatters.clear();
+
+	m_output_format = of;
+}
+
+std::shared_ptr<gen_event_formatter> sinsp_evt_formatter_factory::create_formatter(const std::string &format)
+{
+	auto it = m_formatters.find(format);
+
+	if (it != m_formatters.end())
+	{
+		return it->second;
+	}
+
+	std::shared_ptr<gen_event_formatter> ret;
+
+	ret.reset(new sinsp_evt_formatter(m_inspector));
+
+	ret->set_format(m_output_format, format);
+	m_formatters[format] = ret;
+
+	return ret;
 }

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -361,3 +361,18 @@ std::set<uint16_t> gen_event_filter::evttypes()
 {
 	return m_filter->evttypes();
 }
+gen_event_formatter::gen_event_formatter()
+{
+}
+
+gen_event_formatter::~gen_event_formatter()
+{
+}
+
+gen_event_formatter_factory::gen_event_formatter_factory()
+{
+}
+
+gen_event_formatter_factory::~gen_event_formatter_factory()
+{
+}

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -18,6 +18,8 @@ along with Falco.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <set>
 #include <list>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -272,4 +274,46 @@ public:
 
 	// Return the set of fields supported by this factory
 	virtual std::list<filter_fieldclass_info> get_fields() = 0;
+};
+
+class gen_event_formatter
+{
+public:
+	enum output_format {
+		OF_NORMAL = 0,
+		OF_JSON   = 1
+	};
+
+	gen_event_formatter();
+	virtual ~gen_event_formatter();
+
+	virtual void set_format(output_format of, const std::string &format) = 0;
+
+	// Format the output string with the configured format
+	virtual bool tostring(gen_event *evt, std::string &output) = 0;
+
+	// In some cases, it may be useful to format an output string
+	// with a custom format.
+	virtual bool tostring_withformat(gen_event *evt, std::string &output, output_format of) = 0;
+
+	// The map should map from field name, without the '%'
+	// (e.g. "proc.name"), to field value (e.g. "nginx")
+	virtual bool get_field_values(gen_event *evt, std::map<std::string, std::string> &fields) = 0;
+
+	virtual output_format get_output_format() = 0;
+};
+
+
+class gen_event_formatter_factory
+{
+public:
+	gen_event_formatter_factory();
+	virtual ~gen_event_formatter_factory();
+
+	// This should be called before any calls to
+	// create_formatter(), and changes the output format of new
+	// formatters.
+	virtual void set_output_format(gen_event_formatter::output_format of) = 0;
+
+	virtual std::shared_ptr<gen_event_formatter> create_formatter(const std::string &format) = 0;
 };


### PR DESCRIPTION
Add the notion of "generic" event formatters and formatter factories
that can create a formatter for a given format string:

- gen_filter.h defines two new classes: gen_event_formatter provides
  the interface to format events:
    - set_format(): set the output format and format string
    - tostring(): resolve the format with info from a gen_event,
      populating a resolved string.
    - tostring_withformat(): like tostring() but with a one-off output
      format.
    - get_field_values(): return all templated field names and values
      from the configured format string.
    - get_output_format(): get the current output format.
- gen_event_formatter_factory performs a similar role as the existing
  sinsp_evt_formatter_cache, in that it maintains a cache of previously
  used format strings/formatters, to avoid the overhead of creating
  formatters. It simply returns a formatter, though, rather than
  duplicating the format methods like sinsp_evt_formatter_cache does.

This can be used in programs like falco to format general purpose
events without having a direct connection to an
inspector/filterchecks/etc.

- The eventformatter changes simply add gen_event_formatter as a
  parent class and implements the interfaces. To aid in backwards
  compatibility with other parts of libsinsp, this only adds new
  methods as needed to conform to the gen_event_formatter
  interface. In some cases, the new methods just call existing methods
  that did the same thing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): add notion of generic event formatters/formatter factories, similar to how filters have generic filters/factories
```
