### PR TITLE
Users and groups loading code fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ driver/driver_config.h
 .vscode
 .cache.mk
 build*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ driver/driver_config.h
 .vscode
 .cache.mk
 build*
-.idea

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2162,10 +2162,9 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 			snprintf(&m_paramstr_storage[0],
 					 m_paramstr_storage.size(),
 					 "%d", val);
-			auto find_it = m_inspector->get_userlist()->find(val);
-			if (find_it != m_inspector->get_userlist()->end())
+			auto user_info = m_inspector->get_user(val);
+			if (user_info != NULL)
 			{
-				scap_userinfo* user_info = find_it->second;
 				strcpy_sanitized(&m_resolved_paramstr_storage[0], user_info->name,
 								(uint32_t)m_resolved_paramstr_storage.size());
 			}
@@ -2195,10 +2194,9 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 			snprintf(&m_paramstr_storage[0],
 					 m_paramstr_storage.size(),
 					 "%d", val);
-			auto find_it = m_inspector->get_grouplist()->find(val);
-			if (find_it != m_inspector->get_grouplist()->end())
+			auto group_info = m_inspector->get_group(val);
+			if (group_info != NULL)
 			{
-				scap_groupinfo* group_info = find_it->second;
 				strcpy_sanitized(&m_resolved_paramstr_storage[0], group_info->name,
 								(uint32_t)m_resolved_paramstr_storage.size());
 			}

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4777,7 +4777,6 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	case TYPE_LOGINNAME:
 		ASSERT(m_inspector != NULL);
 		uinfo = m_inspector->get_user(tinfo->m_loginuid);
-		ASSERT(uinfo != NULL);
 		if(uinfo == NULL)
 		{
 			return NULL;
@@ -4834,8 +4833,10 @@ uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			ASSERT(m_inspector != NULL);
 			auto ginfo = m_inspector->get_group(tinfo->m_gid);
-			ASSERT(ginfo != NULL);
-
+			if (ginfo == NULL)
+			{
+				return NULL;
+			}
 			RETURN_EXTRACT_CSTR(ginfo->name);
 		}
 	default:

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4755,6 +4755,7 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	{
 		ASSERT(m_inspector != NULL);
 		uinfo = m_inspector->get_user(tinfo->m_uid);
+		ASSERT(uinfo != NULL);
 		if(uinfo == NULL)
 		{
 			return NULL;
@@ -4776,6 +4777,7 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	case TYPE_LOGINNAME:
 		ASSERT(m_inspector != NULL);
 		uinfo = m_inspector->get_user(tinfo->m_loginuid);
+		ASSERT(uinfo != NULL);
 		if(uinfo == NULL)
 		{
 			return NULL;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4755,7 +4755,6 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	{
 		ASSERT(m_inspector != NULL);
 		uinfo = m_inspector->get_user(tinfo->m_uid);
-		ASSERT(uinfo != NULL);
 		if(uinfo == NULL)
 		{
 			return NULL;
@@ -4832,23 +4831,7 @@ uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			unordered_map<uint32_t, scap_groupinfo*>::iterator it;
 
 			ASSERT(m_inspector != NULL);
-			unordered_map<uint32_t, scap_groupinfo*>* grouplist =
-				(unordered_map<uint32_t, scap_groupinfo*>*)m_inspector->get_grouplist();
-			ASSERT(grouplist->size() != 0);
-
-			if(tinfo->m_gid == 0xffffffff)
-			{
-				return NULL;
-			}
-
-			it = grouplist->find(tinfo->m_gid);
-			if(it == grouplist->end())
-			{
-				ASSERT(false);
-				return NULL;
-			}
-
-			scap_groupinfo* ginfo = it->second;
+			auto ginfo = m_inspector->get_group(tinfo->m_gid);
 			ASSERT(ginfo != NULL);
 
 			RETURN_EXTRACT_CSTR(ginfo->name);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1799,13 +1799,12 @@ const unordered_map<uint32_t, scap_userinfo*>* sinsp::get_userlist()
 
 scap_userinfo* sinsp::get_user(uint32_t uid)
 {
-	unordered_map<uint32_t, scap_userinfo*>::const_iterator it;
 	if(uid == 0xffffffff)
 	{
 		return NULL;
 	}
 
-	it = m_userlist.find(uid);
+	auto it = m_userlist.find(uid);
 	if(it == m_userlist.end())
 	{
 		return NULL;
@@ -1817,6 +1816,22 @@ scap_userinfo* sinsp::get_user(uint32_t uid)
 const unordered_map<uint32_t, scap_groupinfo*>* sinsp::get_grouplist()
 {
 	return &m_grouplist;
+}
+
+scap_groupinfo* sinsp::get_group(uint32_t gid)
+{
+	if(gid == 0xffffffff)
+	{
+		return NULL;
+	}
+
+	auto it = m_grouplist.find(gid);
+	if(it == m_grouplist.end())
+	{
+		return NULL;
+	}
+
+	return it->second;
 }
 
 #ifdef HAS_FILTERING

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -491,7 +491,7 @@ public:
 	threadinfo_map_t::ptr_t get_thread_ref(int64_t tid, bool query_os_if_not_found = false, bool lookup_only = true, bool main_thread = false);
 
 	/*!
-	  \brief Return the table with all the machine users.
+  	  \brief Return the table with all the machine users.
 
 	  \return a hash table with the user ID (UID) as the key and the user
 	   information as the data.
@@ -525,6 +525,18 @@ public:
 	   user table is the one of the machine where the capture happened.
 	*/
 	const unordered_map<uint32_t, scap_groupinfo*>* get_grouplist();
+
+	/*!
+	  \brief Lookup for group in the group table.
+
+	  \return the \ref scap_groupinfo object containing full group information,
+	   if group not found, returns NULL.
+
+ 	  \note this call works with file captures as well, because the group
+	   table is stored in the trace files. In that case, the returned
+	   group list is the one of the machine where the capture happened.
+	*/
+	scap_groupinfo* get_group(uint32_t gid);
 
 	/*!
 	  \brief Fill the given structure with statistics about the currently

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -491,7 +491,7 @@ public:
 	threadinfo_map_t::ptr_t get_thread_ref(int64_t tid, bool query_os_if_not_found = false, bool lookup_only = true, bool main_thread = false);
 
 	/*!
-  	  \brief Return the table with all the machine users.
+	  \brief Return the table with all the machine users.
 
 	  \return a hash table with the user ID (UID) as the key and the user
 	   information as the data.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap
/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix weird edge cases where users/groups where added while libscap was loading them, potentially causing a segfault.
Moreover, a sinsp::get_group() api is added, following  sinsp::get_user(), and used where needed. 

Interesting fact: libscap only loads the list of users once, during startup; thus the list of users is static, and not dynamically updated. 
This means that when filtering on a user {name,homedir,shell,loginname} (and the same goes for a group name), events for new users won't be actually managed.

Steps to reproduce the abort in #19: 

* build libs in debug mode
* using sysdig tool linking debug-mode-libs, start with an user filter, eg: `sudo ./userspace/sysdig/sysdig "user.name=foo"`
* on another shell, add a new user (name does not matter): `sudo useradd bar` 
* now let's run eg: `sudo -u bar echo test`
* see sysdig aborting with `sysdig: libs/userspace/libsinsp/filterchecks.cpp:4619: virtual uint8_t* sinsp_filter_check_user::extract(sinsp_evt*, uint32_t*, bool): Assertion `uinfo != __null' failed.`
 
In release mode, the crash is not triggered, but the filter is doing nothing for newly created users, eg running:
`sudo ./userspace/sysdig/sysdig "user.name=foo"`
and then creating a foo user and let it doing stuff, won't trigger any output.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #19 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
