### PR TITLE
fix(driver): fix bpf probe verifier on linux 5.14 and llvm 12.0.1

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -724,7 +724,6 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 		return PPM_FAILURE_BUFFER_FULL;
-	
 	if (dyn_idx != (u8)-1) {
 		*((u8 *)&data->buf[curoff_bounded]) = dyn_idx;
 		len_dyn = sizeof(u8);
@@ -874,7 +873,6 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		return PPM_FAILURE_BUG;
 	}
 	}
-	
 	if (len_dyn + len > PPM_MAX_ARG_SIZE)
 		return PPM_FAILURE_BUFFER_FULL;
 

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -770,7 +770,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 					if (read_size)
-						if (bpf_probe_read(&data->buf[curoff],
+						if (bpf_probe_read(&data->buf[curoff_bounded],
 								   ((read_size - 1) & SCRATCH_SIZE_HALF) + 1,
 								   (void *)val))
 #else
@@ -794,7 +794,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (read_size)
-					if (bpf_probe_read(&data->buf[curoff],
+					if (bpf_probe_read(&data->buf[curoff_bounded],
 							   ((read_size - 1) & SCRATCH_SIZE_HALF) + 1,
 							   (void *)val))
 #else

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -415,7 +415,7 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 	for (j = 0; j < MAX_IOVCNT; ++j) {
 		if (j == iovcnt)
 			break;
-		// BPF seems to require an hard limit to avoid overflows
+		// BPF seems to require a hard limit to avoid overflows
 		if (size == LONG_MAX)
 			break;
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -435,6 +435,7 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 	if (flags & PRB_FLAG_PUSH_DATA) {
 		if (size > 0) {
 			unsigned long off = _READ(data->state->tail_ctx.curoff);
+			unsigned long off_bounded;
 			unsigned long remaining = size;
 			int j;
 
@@ -445,6 +446,7 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 				if (j == iovcnt)
 					break;
 
+				off_bounded = off & SCRATCH_SIZE_HALF;
 				if (off > SCRATCH_SIZE_HALF)
 					break;
 
@@ -458,11 +460,11 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (to_read)
-					if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
+					if (bpf_probe_read(&data->buf[off_bounded],
 							   ((to_read - 1) & SCRATCH_SIZE_HALF) + 1,
 							   iov[j].iov_base))
 #else
-				if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
+				if (bpf_probe_read(&data->buf[off_bounded],
 						   to_read & SCRATCH_SIZE_HALF,
 						   iov[j].iov_base))
 #endif


### PR DESCRIPTION
```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>
Co-authored-by: Jason Dellaluce <jasondellaluce@gmail.com>
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

So far, the eBPF probe needs to be compiled with clang 7. Although newer versions of clang can successfully compile the probe, it then gets rejected by the kernel verifier. This has been an open issue for a while.

This PR applies a small set of fixes that allow our eBPF probe to be accepted by the kernel verifier even when compiled with recent versions of clang.  
So far, we tested this on various versions of the linux kernel and of clang.  
These are the results of our test grid, which we ran on amd64 architecture:

|  Kernel Ver.  | 5.14 | 5.11 | 5.8 | 5.4 | 4.19 | 4.17 | 4.15 |
|:------------:|:----:|:----:|:---:|:---:|:----:|:----:|:----:|
| **clang-7**  |  --  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-8**  |  --  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-9**  |  --  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-10** |  --  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-11** |  --  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-12** |  OK  |  OK  | OK  | OK  |  OK  |  OK  | OK |
| **clang-14** |  --  |  OK  | OK  | OK  |  OK  |  OK  | **KO** |

### Additional context
At a high level, the kernel verifier rejects the eBPF for three main reasons:

1. **Unclear exit conditions in bounded loops**. In some cases where the exit condition of a unrolled loop is a little ambiguous, the verifier is not able to predict if some memory accesses can go out of bounds. An example is visible [here](https://github.com/falcosecurity/libs/pull/81/files#diff-a8b6fc07077f8fcef2f22e51392da619a5e68b7c603c62b3ab93ce5b6be22d6bR311). In this case, a check on the `off` variable is required because it is used to access memory inside `data->buf[off & ...]`. We solved the error by checking the value of `off` at the beginning of the loop.
2. **Unprotected memory accesses**. Accessing memory with patterns like `&buf[off & SCRATCH_SIZE_HALF]`, visible [here](https://github.com/falcosecurity/libs/pull/81/files#diff-a8b6fc07077f8fcef2f22e51392da619a5e68b7c603c62b3ab93ce5b6be22d6bR1514), is often rejected if compiled with newest clang versions. This is due to an optimization applied during the compilation. If a check such as `if (off > SCRATCH_SIZE_HALF) /* fail /*` appears before a memory access such as `&buf[off & SCRATCH_SIZE_HALF]`, the compiler avoids performing the `& SCRATCH_SIZE_HALF` operation by assuming that the value of `off` is already bounded because it is checked inside the if statement. However, the compiled eBPF bytecode gets then rejected by the kernel verifier because it has no way to predict the value of `off` when accessing the memory buffer. We fixed this by storing the result of `off & SCRATCH_SIZE_HALF` in an additional variable, so that the compiler is forced to perform the bitwise bounding operation.
3. **Passing long integers to eBPF helpers**. Helpers such as `bpf_probe_read`, accept a `size` argument that is defined as a `signed integer`. However, in multiple instances (such as [here](https://github.com/falcosecurity/libs/pull/81/files#diff-c8f0685e0b19ed879c6a46c5570ae4e960346c349f9e477f2127542d6daa6c85R769)) we pass `unsigned long` variables as `size` arguments. We assume the safety of this operation by checking that the value does not go beyond a certain threshold, or by bouding its value through a bitwise and operation, but this is not sufficient. The kernel verifier recognizes an attempt of converting an `u64` to a `s32`, and predicts the possibility of the value to become negative due to the potential bit overflow. We solved this problem by defining the passed value as `u16`, which was quite sufficient to cover our use cases (our max value fits in 16 bits comfortably).

**Which issue(s) this PR fixes**:
Fixes #58 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
