### PR TITLE
fix(libsinsp): fix formatter for bytebuf types

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1055,9 +1055,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			{
 				ASSERT(len < 1024 * 1024);
 
-				if(len >= filter_value().size())
+				if(len >= filter_value()->size())
 				{
-					filter_value().resize(len + 1);
+					filter_value()->resize(len + 1);
 				}
 
 				memcpy(filter_value_p(), rawval, len);
@@ -1209,7 +1209,7 @@ void sinsp_filter_check::add_filter_value(const char* str, uint32_t len, uint32_
 		m_val_storages.push_back(vector<uint8_t>(256));
 	}
 
-	parsed_len = parse_filter_value(str, len, filter_value_p(i), filter_value(i).size());
+	parsed_len = parse_filter_value(str, len, filter_value_p(i), filter_value(i)->size());
 
 	// XXX/mstemm this doesn't work if someone called
 	// add_filter_value more than once for a given index.
@@ -1287,7 +1287,7 @@ bool sinsp_filter_check::flt_compare(cmpop op, ppm_param_type type, void* operan
 						  operand1,
 						  filter_value_p(i),
 						  op1_len,
-						  filter_value(i).size()))
+						  filter_value(i)->size()))
 				{
 					return true;
 				}

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3082,7 +3082,7 @@ size_t sinsp_filter_check_event::parse_filter_value(const char* str, uint32_t le
 	if(m_field_id == sinsp_filter_check_event::TYPE_ARGRAW)
 	{
 		ASSERT(m_arginfo != NULL);
-		parsed_len = sinsp_filter_value_parser::string_to_rawval(str, len, filter_value_p(), filter_value().size(), m_arginfo->type);
+		parsed_len = sinsp_filter_value_parser::string_to_rawval(str, len, filter_value_p(), filter_value()->size(), m_arginfo->type);
 	}
 	else
 	{

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -173,7 +173,7 @@ protected:
 	char m_getpropertystr_storage[1024];
 	vector<vector<uint8_t>> m_val_storages;
 	inline uint8_t* filter_value_p(uint16_t i = 0) { return &m_val_storages[i][0]; }
-	inline vector<uint8_t> filter_value(uint16_t i = 0) { return m_val_storages[i]; }
+	inline vector<uint8_t>* filter_value(uint16_t i = 0) { return &m_val_storages[i]; }
 
 	unordered_set<filter_value_t,
 		g_hash_membuf,


### PR DESCRIPTION
Signed-off-by: lucklypse <lucklypse@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix variable passing when attempting to format rawarg type values. This is in general not a very smart thing to do and is not really used in Falco but could be used in other clients, (if they tried they would incur in a segfault, this pr fixes that).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): segfault in rawarg formatter
```
