### PR TITLE
fix(driver): properly support AF_UNIX abstract socket addresses

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -406,6 +406,28 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 	return res;
 }
 
+static __always_inline int unix_socket_path(char *dest, const char *user_ptr) {
+	int res = bpf_probe_read_str(dest,
+				     UNIX_PATH_MAX,
+				     user_ptr);
+	/*
+  	 * Extract from: https://man7.org/linux/man-pages/man7/unix.7.html
+	 * an abstract socket address is distinguished (from a
+	 * pathname socket) by the fact that sun_path[0] is a null byte
+	 * ('\0').  The socket's address in this namespace is given by
+	 * the additional bytes in sun_path that are covered by the
+	 * specified length of the address structure.
+	 */
+	if (res == 1) {
+		dest[0] = '@';
+		res = bpf_probe_read_str(dest + 1,
+					 UNIX_PATH_MAX,
+					 user_ptr + 1);
+		res++; // account for '@'
+	}
+	return res;
+}
+
 static __always_inline u16 bpf_pack_addr(struct filler_data *data,
 					 struct sockaddr *usrsockaddr,
 					 int ulen)
@@ -487,9 +509,7 @@ static __always_inline u16 bpf_pack_addr(struct filler_data *data,
 
 		data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF] = socket_family_to_scap(family);
 
-		res = bpf_probe_read_str(&data->buf[(data->state->tail_ctx.curoff + 1) & SCRATCH_SIZE_HALF],
-					 UNIX_PATH_MAX,
-					 usrsockaddr_un->sun_path);
+		res = unix_socket_path(&data->buf[(data->state->tail_ctx.curoff + 1) & SCRATCH_SIZE_HALF], usrsockaddr_un->sun_path);
 
 		size += res;
 
@@ -697,9 +717,7 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 				us_name = usrsockaddr_un->sun_path;
 		}
 
-		int res = bpf_probe_read_str(&data->buf[(data->state->tail_ctx.curoff + 1 + 8 + 8) & SCRATCH_SIZE_HALF],
-					     UNIX_PATH_MAX,
-					     us_name);
+		int res = unix_socket_path(&data->buf[(data->state->tail_ctx.curoff + 1 + 8 + 8) & SCRATCH_SIZE_HALF], us_name);
 
 		size += res;
 

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -901,10 +901,10 @@ static void unix_socket_path(char *dest, const char *path, size_t size)
 			 "@%s",
 			 path + 1);
 	} else {
-		dest = strncpy(dest,
-			       path,
-			       size - 1); /* we assume this will be smaller than (targetbufsize - (1 + 8 + 8)) */
-		dest[size - 1] = 0;
+		snprintf(dest,
+			size,
+			 "%s",
+			 path); /* we assume this will be smaller than (targetbufsize - (1 + 8 + 8)) */
 	}
 }
 

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -996,7 +996,9 @@ u16 pack_addr(struct sockaddr *usrsockaddr,
 		size = 1;
 
 		*targetbuf = socket_family_to_scap((u8)family);
-		unix_socket_path(targetbuf + 1, usrsockaddr_un->sun_path);
+
+		dest = targetbuf + 1;
+		unix_socket_path(dest, usrsockaddr_un->sun_path);
 
 		dest[UNIX_PATH_MAX - 1] = 0;
 		size += (u16)strlen(dest) + 1;
@@ -1253,6 +1255,7 @@ u16 fd_to_socktuple(int fd,
 		}
 
 		ASSERT(us_name);
+
 		dest = targetbuf + 1 + 8 + 8;
 		unix_socket_path(dest, us_name);
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area driver-kmod

/area driver-ebpf

**What this PR does / why we need it**:

This PR adds support for AF_UNIX abstract socket addresses path, as specified https://man7.org/linux/man-pages/man7/unix.7.html:
>  abstract: an abstract socket address is distinguished (from a
>          pathname socket) by the fact that sun_path[0] is a null byte
>          ('\0').  The socket's address in this namespace is given by
>          the additional bytes in sun_path that are covered by the
>          specified length of the address structure.  (Null bytes in the
>          name have no special significance.)  The name has no
>          connection with filesystem pathnames.

Example new output:
```
sudo ./userspace/sysdig/sysdig  "proc.name=xwd and evt.type=connect" --bpf=./driver/bpf/probe.o
30158 12:50:18.595356241 6 xwd (74819) > connect fd=3(<u>)
30159 12:50:18.595379936 6 xwd (74819) < connect res=0 tuple=ffff9018e813dd80->ffff9018e813f700 @/tmp/.X11-unix/X0
```

**Which issue(s) this PR fixes**:
Fixes #47 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
abstract socket addresses path will now be properly parsed with a (conventionally used) '@' as first char
```
