### PR TITLE
fix(cmake): downgrade openssl to 1.0.2u

### DIFF
--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -20,8 +20,8 @@ else()
 
 		ExternalProject_Add(openssl
 			PREFIX "${PROJECT_BINARY_DIR}/openssl-prefix"
-			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1k.tar.gz"
-			URL_HASH "SHA256=b92f9d3d12043c02860e5e602e50a73ed21a69947bcc74d391f41148e9f6aa95"
+			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_0_2u.tar.gz"
+			URL_HASH "SHA256=82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
 			CONFIGURE_COMMAND ./config no-shared --prefix=${OPENSSL_INSTALL_DIR}
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

This PR aims to work around the problem described by #89 so that we can unblock the release process of the [upcoming Falco version](https://github.com/falcosecurity/falco/issues/1741).

**Which issue(s) this PR fixes**:
This PR addresses the problem described by #89 but does not solve the issue with OpenSSL 1.1.x. 
A separate fix will be needed to fix the issue definitively.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
build: downgrade openssl to 1.0.2u
```
