### PR TITLE
fix(userspace/libsinsp): remote data fetching with openssl 1.1.1 

### DIFF
--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -14,6 +14,7 @@ else()
 	set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include")
 	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl.a")
 	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a")
+ 	set(OPENSSL_LIBRARIES "${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO}")
 
 	if(NOT TARGET openssl)
 		message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")

--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -20,8 +20,8 @@ else()
 
 		ExternalProject_Add(openssl
 			PREFIX "${PROJECT_BINARY_DIR}/openssl-prefix"
-			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_0_2u.tar.gz"
-			URL_HASH "SHA256=82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
+			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1k.tar.gz"
+			URL_HASH "SHA256=b92f9d3d12043c02860e5e602e50a73ed21a69947bcc74d391f41148e9f6aa95"
 			CONFIGURE_COMMAND ./config no-shared --prefix=${OPENSSL_INSTALL_DIR}
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1

--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -14,7 +14,7 @@ else()
 	set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include")
 	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl.a")
 	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a")
- 	set(OPENSSL_LIBRARIES "${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO}")
+ 	set(OPENSSL_LIBRARIES ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO})
 
 	if(NOT TARGET openssl)
 		message(STATUS "Using bundled openssl in '${OPENSSL_BUNDLE_DIR}'")

--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -20,8 +20,8 @@ else()
 
 		ExternalProject_Add(openssl
 			PREFIX "${PROJECT_BINARY_DIR}/openssl-prefix"
-			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1k.tar.gz"
-			URL_HASH "SHA256=b92f9d3d12043c02860e5e602e50a73ed21a69947bcc74d391f41148e9f6aa95"
+			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1l.tar.gz"
+			URL_HASH "SHA256=dac036669576e83e8523afdb3971582f8b5d33993a2d6a5af87daa035f529b4f"
 			CONFIGURE_COMMAND ./config no-shared --prefix=${OPENSSL_INSTALL_DIR}
 			BUILD_COMMAND ${CMD_MAKE}
 			BUILD_IN_SOURCE 1

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -249,23 +249,17 @@ if(NOT WIN32)
 		endif()
 	endif() # NOT APPLE
 
-        if(USE_BUNDLED_OPENSSL AND NOT MINIMAL_BUILD)
-		list(APPEND SINSP_LIBRARIES
-			"${OPENSSL_LIBRARY_SSL}"
-			"${OPENSSL_LIBRARY_CRYPTO}")
-        else()
-		list(APPEND SINSP_LIBRARIES
-                    "${OPENSSL_LIBRARIES}")
-        endif()
+	list(APPEND SINSP_LIBRARIES
+        	"${OPENSSL_LIBRARIES}")
 
-		if(WITH_CHISEL)
+	if(WITH_CHISEL)
 		list(APPEND SINSP_LIBRARIES
 			"${LUAJIT_LIB}")
-		endif()
+	endif()
 
-		list(APPEND SINSP_LIBRARIES
-			dl
-			pthread)
+	list(APPEND SINSP_LIBRARIES
+		dl
+		pthread)
 else()
 	if(WITH_CHISEL)
 		list(APPEND SINSP_LIBRARIES

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -387,7 +387,7 @@ public:
 			if(processed > m_data_max_b)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-										  "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
+						      "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
 						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
 						      " bytes, " + std::to_string(counter) + " reads). Giving up");
 			} else {

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -433,7 +433,7 @@ public:
 			if(processed > m_data_max_b)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-										  "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
+						      "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
 						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
 						      " bytes, " + std::to_string(counter) + " reads). Giving up");
 			}

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -353,15 +353,55 @@ public:
 		}
 	}
 
-	int get_all_data()
+	int get_all_data_secure()
 	{
-		g_logger.log("Socket handler (" + m_id + ") Retrieving all data in blocking mode ...",
-					 sinsp_logger::SEV_TRACE);
-		ssize_t rec = 0;
+		int rec = 0;
+		int processed = 0;
+		int counter = 0;
+		std::vector<char> buf(1024, 0);
+		do {
+			rec = SSL_read(m_ssl_connection, &buf[0], buf.size());
+			counter++;
+			if (rec > 0)
+			{
+				processed += rec;
+			}
+			int err = SSL_get_error(m_ssl_connection, rec);
+			switch (err) {
+			case SSL_ERROR_NONE:
+				process(&buf[0], rec, false);
+				break;
+			case SSL_ERROR_ZERO_RETURN:
+				throw sinsp_exception("Socket handler (" + m_id + "): Connection closed.");
+				break;
+			case SSL_ERROR_WANT_READ:
+			case SSL_ERROR_WANT_WRITE:
+				break;
+			default:
+				g_logger.log("Socket handler (" + m_id + ") received=" + std::to_string(err) + " SSL error.",  sinsp_logger::SEV_TRACE);
+				break;
+			}
+
+			// To prevent reads from entirely stalling (like in gigantic k8s environments),
+			// give up after reading a certain size (by default, 100MB, but configurable).
+			if(processed > m_data_max_b)
+			{
+				throw sinsp_exception("Socket handler (" + m_id + "): "
+										  "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
+						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
+						      " bytes, " + std::to_string(counter) + " reads). Giving up");
+			} else {
+				usleep(m_data_chunk_wait_us);
+			}
+		} while (!m_msg_completed);
+		return processed;
+	}
+
+	int get_all_data_unsecure() {
+		int rec = 0;
 		std::vector<char> buf(1024, 0);
 		int counter = 0;
-		uint32_t processed = 0;
-		init_http_parser();
+		int processed = 0;
 		do
 		{
 			int count = 0;
@@ -369,18 +409,11 @@ public:
 			if(ioret >= 0 && count > 0)
 			{
 				buf.resize(count);
-				if(m_url.is_secure())
-				{
-					rec = SSL_read(m_ssl_connection, &buf[0], buf.size());
-				}
-				else
-				{
-					rec = recv(m_socket, &buf[0], buf.size(), 0);
-				}
+				rec = recv(m_socket, &buf[0], count, 0);
 				if(rec > 0)
 				{
 					process(&buf[0], rec, false);
-					processed += (uint32_t)rec;
+					processed += rec;
 				}
 				else if(rec == 0)
 				{
@@ -394,18 +427,32 @@ public:
 				//			 "\n\n" + data + "\n\n", sinsp_logger::SEV_TRACE);
 			}
 
-			// To prevent reads from entirely stalling (like in gigantic k8s environments), 
+			// To prevent reads from entirely stalling (like in gigantic k8s environments),
 			// give up after reading a certain size (by default, 100MB, but configurable).
 			++counter;
 			if(processed > m_data_max_b)
 			{
 				throw sinsp_exception("Socket handler (" + m_id + "): "
-						      "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
+										  "read more than " + to_string(m_data_max_b / 1024 / 1024) + " MB of data from " +
 						      m_url.to_string(false) + m_path + " (" + std::to_string(processed) +
 						      " bytes, " + std::to_string(counter) + " reads). Giving up");
 			}
 			else { usleep(m_data_chunk_wait_us); }
 		} while(!m_msg_completed);
+		return processed;
+	}
+
+	int get_all_data()
+	{
+		g_logger.log("Socket handler (" + m_id + ") Retrieving all data in blocking mode ...",
+					 sinsp_logger::SEV_TRACE);
+		int processed = 0;
+		init_http_parser();
+		if (m_url.is_secure()) {
+			processed = get_all_data_secure();
+		} else {
+			processed = get_all_data_unsecure();
+		}
 		init_http_parser();
 		return processed;
 	}


### PR DESCRIPTION
```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

Co-authored-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
Co-authored-by: lucklypse <lucklypse@gmail.com>
```

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR fixes a bug introduced with the openssl version bump from 1.0.2 to 1.1.1, that broke socket_handler::get_all_data() https path.

**Which issue(s) this PR fixes**:

Fixes #89 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
build: upgrade openssl to 1.1.1l
```
