### PR TITLE
Use error value over lua_error() in lua callbacks

### DIFF
--- a/userspace/chisel/lua_parser_api.cpp
+++ b/userspace/chisel/lua_parser_api.cpp
@@ -143,10 +143,11 @@ int lua_parser_cbacks::nest(lua_State *ls)
 	catch (const std::exception& e)
 	{
 		lua_pushstring(ls, e.what());
-		lua_error(ls);
+		return 1;
 	}
 
-	return 0;
+	lua_pushnil(ls);
+	return 1;
 }
 
 int lua_parser_cbacks::unnest(lua_State *ls)
@@ -167,10 +168,11 @@ int lua_parser_cbacks::unnest(lua_State *ls)
 	catch (const std::exception& e)
 	{
 		lua_pushstring(ls, e.what());
-		lua_error(ls);
+		return 1;
 	}
 
-	return 0;
+	lua_pushnil(ls);
+	return 1;
 }
 
 int lua_parser_cbacks::bool_op(lua_State *ls)
@@ -211,9 +213,11 @@ int lua_parser_cbacks::bool_op(lua_State *ls)
 	catch (const std::exception& e)
 	{
 		lua_pushstring(ls, e.what());
-		lua_error(ls);
+		return 1;
 	}
-	return 0;
+
+	lua_pushnil(ls);
+	return 1;
 
 }
 
@@ -301,9 +305,10 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 	catch (const std::exception& e)
 	{
 		lua_pushstring(ls, e.what());
-		lua_error(ls);
+		return 1;
 	}
 
-	return 0;
+	lua_pushnil(ls);
+	return 1;
 }
 


### PR DESCRIPTION
Instead of returning errors in lua callbacks via lua_error(), which
stops the lua interpreter, return the error explicitly as a string
error or nil.

This allows for more graceful error handling on the lua side.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
