### PR TITLE
Support LARGE block type to allow for 4B len header

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -284,7 +284,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_TRACER_X */{ "tracer", EC_OTHER, EF_NONE, 3, { { "id", PT_INT64, PF_DEC }, { "tags", PT_CHARBUFARRAY, PF_NA }, { "args", PT_CHARBUF_PAIR_ARRAY, PF_NA } } },
 	/* PPME_MESOS_E */{"mesos", EC_INTERNAL, EF_SKIPPARSERESET | EF_MODIFIES_STATE, 1, {{"json", PT_CHARBUF, PF_NA} } },
 	/* PPME_MESOS_X */{"NA4", EC_SYSTEM, EF_UNUSED, 0},
-	/* PPME_CONTAINER_JSON_E */{"container", EC_PROCESS, EF_MODIFIES_STATE, 1, {{"json", PT_CHARBUF, PF_NA} } },
+	/* PPME_CONTAINER_JSON_E */{"container", EC_PROCESS, EF_MODIFIES_STATE | EF_LARGE_PAYLOAD, 1, {{"json", PT_CHARBUF, PF_NA} } },
 	/* PPME_CONTAINER_JSON_X */{"container", EC_PROCESS, EF_UNUSED, 0},
 	/* PPME_SYSCALL_SETSID_E */{"setsid", EC_PROCESS, EF_MODIFIES_STATE, 0},
 	/* PPME_SYSCALL_SETSID_X */{"setsid", EC_PROCESS, EF_MODIFIES_STATE, 1, {{"res", PT_PID, PF_DEC} } },
@@ -334,7 +334,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_RENAMEAT2_X */{"renameat2", EC_FILE, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"olddirfd", PT_FD, PF_DEC}, {"oldpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)}, {"newdirfd", PT_FD, PF_DEC}, {"newpath", PT_FSRELPATH, PF_NA, DIRFD_PARAM(3)}, {"flags", PT_FLAGS32, PF_HEX, renameat2_flags} } },
 	/* PPME_SYSCALL_USERFAULTFD_E */{"userfaultfd", EC_FILE, EF_CREATES_FD | EF_MODIFIES_STATE, 0},
 	/* PPME_SYSCALL_USERFAULTFD_X */{"userfaultfd", EC_FILE, EF_CREATES_FD | EF_MODIFIES_STATE, 2, {{"res", PT_ERRNO, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX, file_flags} } },
-	/* PPME_PLUGINEVENT_E */{"pluginevent", EC_OTHER, EF_NONE, 2, {{"plugin ID", PT_UINT32, PF_DEC}, {"event_data", PT_BYTEBUF, PF_NA} } },
+	/* PPME_PLUGINEVENT_E */{"pluginevent", EC_OTHER, EF_LARGE_PAYLOAD, 2, {{"plugin ID", PT_UINT32, PF_DEC}, {"event_data", PT_BYTEBUF, PF_NA} } },
 	/* PPME_NA1 */{"pluginevent", EC_OTHER, EF_UNUSED, 0}
 	/* NB: Starting from scap version 1.2, event types will no longer be changed when an event is modified, and the only kind of change permitted for pre-existent events is adding parameters.
 	 *     New event types are allowed only for new syscalls or new internal events.

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1334,7 +1334,8 @@ enum ppm_event_flags {
 	EF_WAITS = (1 << 7), /* This event reads data from an FD. */
 	EF_SKIPPARSERESET = (1 << 8), /* This event shouldn't pollute the parser lastevent state tracker. */
 	EF_OLD_VERSION = (1 << 9), /* This event is kept for backward compatibility */
-	EF_DROP_SIMPLE_CONS = (1 << 10) /* This event can be skipped by consumers that privilege low overhead to full event capture */
+	EF_DROP_SIMPLE_CONS = (1 << 10), /* This event can be skipped by consumers that privilege low overhead to full event capture */
+	EF_LARGE_PAYLOAD = (1 << 11), /* This event has a large payload, ie: up to UINT32_MAX bytes. DO NOT USE ON syscalls-driven events!!! */
 };
 
 /*

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -124,6 +124,8 @@ struct scap
 	FILE* m_file;
 #endif
 	char* m_file_evt_buf;
+	size_t m_file_evt_buf_size;
+
 	uint32_t m_last_evt_dump_flags;
 	char m_lasterr[SCAP_LASTERR_SIZE];
 
@@ -225,7 +227,7 @@ struct scap_ns_socket_list
 // Misc stuff
 //
 #define MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
-#define FILE_READ_BUF_SIZE 65536
+#define FILE_READ_BUF_SIZE (1 << 16) // UINT16_MAX + 1, ie: 65536
 
 //
 // Internal library functions

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -511,7 +511,8 @@ typedef enum scap_dump_flags
 	SCAP_DF_NONE = 0,
 	SCAP_DF_STATE_ONLY = 1,		///< The event should be used for state update but it should
 								///< not be shown to the user
-	SCAP_DF_TRACER = (1 << 1)	///< This event is a tracer
+	SCAP_DF_TRACER = (1 << 1),	///< This event is a tracer
+	SCAP_DF_LARGE = (1 << 2)	///< This event has large payload (up to UINT_MAX Bytes, ie 4GB)
 }scap_dump_flags;
 
 typedef struct scap_dumper scap_dumper_t;

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -123,6 +123,8 @@ typedef struct _section_header_block
 											// backward compatibility
 #define EV_BLOCK_TYPE_V2		0x216
 
+#define EV_BLOCK_TYPE_V2_LARGE		0x221
+
 ///////////////////////////////////////////////////////////////////////////////
 // INTERFACE LIST BLOCK
 ///////////////////////////////////////////////////////////////////////////////
@@ -147,6 +149,8 @@ typedef struct _section_header_block
 #define EVF_BLOCK_TYPE		0x208
 
 #define EVF_BLOCK_TYPE_V2	0x217
+
+#define EVF_BLOCK_TYPE_V2_LARGE		0x222
 
 #if defined __sun
 #pragma pack()

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -245,7 +245,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 
 bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp_evt* evt, shared_ptr<sinsp_threadinfo> tinfo)
 {
-	size_t totlen = sizeof(scap_evt) +  sizeof(uint16_t) + json.length() + 1;
+	size_t totlen = sizeof(scap_evt) + sizeof(uint32_t) + json.length() + 1;
 
 	ASSERT(evt->m_pevt_storage == nullptr);
 	evt->m_pevt_storage = new char[totlen];
@@ -273,10 +273,10 @@ bool sinsp_container_manager::container_to_sinsp_event(const string& json, sinsp
 	scapevt->type = PPME_CONTAINER_JSON_E;
 	scapevt->nparams = 1;
 
-	uint16_t* lens = (uint16_t*)((char *)scapevt + sizeof(struct ppm_evt_hdr));
-	char* valptr = (char*)lens + sizeof(uint16_t);
+	uint32_t* lens = (uint32_t*)((char *)scapevt + sizeof(struct ppm_evt_hdr));
+	char* valptr = (char*)lens + sizeof(uint32_t);
 
-	*lens = (uint16_t)json.length() + 1;
+	*lens = (uint32_t)json.length() + 1;
 	memcpy(valptr, json.c_str(), *lens);
 
 	evt->init();
@@ -345,7 +345,7 @@ void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
 		sinsp_evt evt;
 		if(container_to_sinsp_event(container_to_json(*it.second), &evt, it.second->get_tinfo(m_inspector)))
 		{
-			int32_t res = scap_dump(m_inspector->m_h, dumper, evt.m_pevt, evt.m_cpuid, 0);
+			int32_t res = scap_dump(m_inspector->m_h, dumper, evt.m_pevt, evt.m_cpuid, SCAP_DF_LARGE);
 			if(res != SCAP_SUCCESS)
 			{
 				throw sinsp_exception(scap_getlasterr(m_inspector->m_h));

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -742,7 +742,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 {
 	const ppm_param_info* param_info;
 	char* payload;
-	uint16_t payload_len;
+	uint32_t payload_len;
 	Json::Value ret;
 
 	//
@@ -1457,7 +1457,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	const ppm_param_info* param_info;
 	char* payload;
 	uint32_t j;
-	uint16_t payload_len;
+	uint32_t payload_len;
 
 	//
 	// Make sure the params are actually loaded
@@ -2628,6 +2628,11 @@ scap_dump_flags sinsp_evt::get_dump_flags(OUT bool* should_drop)
 	if(m_flags & sinsp_evt::SINSP_EF_IS_TRACER)
 	{
 		dflags |= SCAP_DF_TRACER;
+	}
+
+	if(get_info_flags() & EF_LARGE_PAYLOAD)
+	{
+		dflags |= SCAP_DF_LARGE;
 	}
 
 	return (scap_dump_flags)dflags;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**What this PR does / why we need it**:

With this PR, 2 new block types are added: EV_BLOCK_TYPE_V2_LARGE and EVF_BLOCK_TYPE_V2_LARGE.  
These types will be used for events marked with EF_LARGE_PAYLOAD flag in event_table.c; their lens headers will be then read as uint32_t values, removing the hard limit of 64KB we previously had (up to 4GB).  
I decided to avoid using a 4B len size block type for all events to avoid any possible performance impact.  

For now, EF_LARGE_PAYLOAD is only used for containers json and plugin events.

Here below, you can see a patched wireshark that will properly load a PPME_CONTAINER_JSON_E event with a payload larger that 64KB (89298B):  
![Screenshot_20211021_155031](https://user-images.githubusercontent.com/5837210/138414571-34ab2a11-5c0e-4dde-96f2-8f21e45138cd.png)

**Which issue(s) this PR fixes**:

Fixes #103 

**Special notes for your reviewer**:

What do i do with the wireshark patch? Should i already open a PR, or wait until this PR is merged?
@ldegio 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
