### PR TITLE
fix: correct close cleanup

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1207,7 +1207,7 @@ void scap_close(scap_t* handle)
 	{
 		handle->m_input_plugin->close(handle->m_input_plugin->state, handle->m_input_plugin->handle);
 		scap_free_plugin_batch_state(handle);
-		handle->m_input_plugin->state = NULL;
+		handle->m_input_plugin->handle = NULL;
 		// name was allocated
 		handle->m_input_plugin->free_mem(handle->m_input_plugin->name);
 	}

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -859,7 +859,7 @@ void sinsp_source_plugin::close()
 	}
 
 	m_source_plugin_info.close(plugin_state(), m_source_plugin_info.handle);
-	m_source_plugin_info.state = NULL;
+	m_source_plugin_info.handle = NULL;
 }
 
 std::string sinsp_source_plugin::get_progress(uint32_t &progress_pct)


### PR DESCRIPTION
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**What this PR does / why we need it**:
This bug prevented `destroy` from being called in `libsinsp` due to `state` being set to NULL after closing.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
