### PR TITLE
Don't define strlcpy on musl libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,3 +69,9 @@ if(CREATE_TEST_TARGETS AND NOT WIN32)
 			COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
 		)
 endif()
+
+include(CheckSymbolExists)
+check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
+if(HAVE_STRLCPY)
+	add_definitions(-DHAVE_STRLCPY)
+endif()

--- a/userspace/common/strlcpy.h
+++ b/userspace/common/strlcpy.h
@@ -17,12 +17,15 @@ limitations under the License.
 #include <sys/types.h>
 #include <string.h>
 
+#pragma once
 
 /*!
   \brief Copy up to size - 1 characters from the NUL-terminated string src to dst, NUL-terminating the result.
 
   \return The length of the source string.
 */
+
+#ifndef HAVE_STRLCPY
 static inline size_t strlcpy(char *dst, const char *src, size_t size) {
     size_t srcsize = strlen(src);
     if (size == 0) {
@@ -40,3 +43,4 @@ static inline size_t strlcpy(char *dst, const char *src, size_t size) {
 
     return srcsize;
 }
+#endif


### PR DESCRIPTION
Falco has a build variant that uses musl libc, and musl libc already
defines strlcpy, so we don't want strlcpy when compiling with musl
libc.

Unfortunately, musl doesn't have a define like _MUSL_SOURCE that we
could use to detect when compiling with musl libc. So instead, use
MINIMAL_BUILD, which when set always means compiling with musl libc.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Don't redefine strlcpy when using musl libc, which is true when building with MINIMAL_BUILD.
```
