### PR TITLE
Do not overwrite imageID if it's already set

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -145,7 +145,10 @@ bool cri_async_source::parse_cri(sinsp_container_info& container, const libsinsp
 		{
 			container.m_container_ip = m_cri->get_container_ip(container.m_id);
 		}
-		container.m_imageid = m_cri->get_container_image_id(resp_container.image_ref());
+		if(container.m_imageid.empty())
+		{
+			container.m_imageid = m_cri->get_container_image_id(resp_container.image_ref());
+		}
 	}
 
 	return true;


### PR DESCRIPTION
In environments using CRI imageID can be recovered in 2 ways,
by reading it from the container info or by doing an extra query.

Due to the extra query not working in gke environments, it's safer
to check whether imageID has already been found instead of
unconditionally overwrite it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
imageID is not reported in GKE.

**Which issue(s) this PR fixes**:
None
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): imageID was not being reported on GKE
```
