### PR TITLE
new: add support for kernel side simple consumers

### DIFF
--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -59,6 +59,9 @@ BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)
 	if (!sc_evt)
 		return 0;
 
+	if (sc_evt->flags & UF_UNINTERESTING)
+		return 0;
+
 	if (sc_evt->flags & UF_USED) {
 		evt_type = sc_evt->enter_event_type;
 		drop_flags = sc_evt->flags;
@@ -106,6 +109,9 @@ BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 
 	sc_evt = get_syscall_info(id);
 	if (!sc_evt)
+		return 0;
+
+	if (sc_evt->flags & UF_UNINTERESTING)
 		return 0;
 
 	if (sc_evt->flags & UF_USED) {

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -87,6 +87,7 @@ struct ppm_consumer_t {
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
 	uint16_t statsd_port;
+	DECLARE_BITMAP(events_mask, PPM_EVENT_MAX);
 };
 #endif // UDIG
 

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1571,8 +1571,10 @@ enum syscall_flags {
 	UF_USED = (1 << 0),
 	UF_NEVER_DROP = (1 << 1),
 	UF_ALWAYS_DROP = (1 << 2),
-	UF_SIMPLEDRIVER_KEEP = (1 << 3),
+	UF_SIMPLEDRIVER_KEEP = (1 << 3), ///< Mark a syscall to be kept in simpledriver mode, see scap_enable_simpledriver_mode()
 	UF_ATOMIC = (1 << 4), ///< The handler should not block (interrupt context)
+	UF_UNINTERESTING = (1 << 5), ///< Marks a syscall as not interesting. Currently only used by BPF probe to avoid tracing uninteresting syscalls.
+				     ///< Kmod uses a different logic path as we communicate with it through ioctls
 };
 
 struct syscall_evt_pair {

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -185,6 +185,8 @@ struct scap
 	// matching an entry in m_suppressed_comms.
 	uint64_t m_num_suppressed_evts;
 
+	bool syscalls_of_interest[SYSCALL_TABLE_SIZE];
+
 	//
 	// Plugin-related state
 	//

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2726,9 +2726,12 @@ int32_t scap_enable_simpledriver_mode(scap_t* handle)
 
 	if(handle->m_bpf)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "setting simpledriver mode not supported on bpf");
-		ASSERT(false);
-		return SCAP_FAILURE;
+		if (scap_bpf_set_simple_mode(handle))
+		{
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_enable_simpledriver_mode failed");
+			ASSERT(false);
+			return SCAP_FAILURE;
+		}
 	}
 	else
 	{

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2446,9 +2446,7 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t event
 
 	if(handle->m_bpf)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on bpf");
-		ASSERT(false);
-		return SCAP_FAILURE;
+		return scap_bpf_handle_event_mask(handle, op, event_id);
 	}
 	else
 	{

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -296,6 +296,15 @@ typedef enum {
 	SCAP_MODE_PLUGIN,
 } scap_mode_t;
 
+/*!
+  \brief Argument for scap_open
+  Set any PPM_SC syscall idx to true to enable its tracing at driver level,
+  otherwise syscalls are not traced (so called "uninteresting syscalls").
+*/
+typedef struct {
+	bool ppm_sc[PPM_SC_MAX];
+} interesting_ppm_sc_set;
+
 typedef struct scap_open_args
 {
 	scap_mode_t mode;
@@ -311,6 +320,8 @@ typedef struct scap_open_args
 	                                                         // You can provide additional comm
 	                                                         // values via scap_suppress_events_comm().
 	bool udig; ///< If true, UDIG will be used for event capture. Otherwise, the kernel driver will be used.
+	interesting_ppm_sc_set ppm_sc_of_interest;
+	
 	source_plugin_info* input_plugin; ///< use this to configure a source plugin that will produce the events for this capture
 	char* input_plugin_params; ///< optional parameters string for the source plugin pointed by src_plugin
 }scap_open_args;

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -778,6 +778,7 @@ static int32_t populate_syscall_table_map(scap_t *handle)
 		{
 			p = &uninterested_pair;
 		}
+
 		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SYSCALL_TABLE], &j, p, BPF_ANY) != 0)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SYSCALL_TABLE bpf_map_update_elem < 0");
@@ -1491,4 +1492,18 @@ int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret)
 	}
 
 	return SCAP_SUCCESS;
+}
+
+int32_t scap_bpf_set_simple_mode(scap_t* handle)
+{
+	int j;
+	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
+	{
+		const struct syscall_evt_pair *p = &g_syscall_table[j];
+		if(!(p->flags & UF_SIMPLEDRIVER_KEEP))
+		{
+			handle->syscalls_of_interest[j] = false;
+		}
+	}
+	return populate_syscall_table_map(handle);
 }

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -768,11 +768,16 @@ static int32_t populate_syscall_routing_table_map(scap_t *handle)
 
 static int32_t populate_syscall_table_map(scap_t *handle)
 {
+	static const struct syscall_evt_pair uninterested_pair = { .flags = UF_UNINTERESTING };
 	int j;
 
 	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
 	{
 		const struct syscall_evt_pair *p = &g_syscall_table[j];
+		if (!handle->syscalls_of_interest[j])
+		{
+			p = &uninterested_pair;
+		}
 		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SYSCALL_TABLE], &j, p, BPF_ANY) != 0)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SYSCALL_TABLE bpf_map_update_elem < 0");

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -47,6 +47,7 @@ int32_t scap_bpf_enable_tracers_capture(scap_t* handle);
 int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats);
 int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret);
 int32_t scap_bpf_set_simple_mode(scap_t* handle);
+int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_id);
 
 static inline scap_evt *scap_bpf_evt_from_perf_sample(void *evt)
 {

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -46,6 +46,7 @@ int32_t scap_bpf_stop_dropping_mode(scap_t* handle);
 int32_t scap_bpf_enable_tracers_capture(scap_t* handle);
 int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats);
 int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret);
+int32_t scap_bpf_set_simple_mode(scap_t* handle);
 
 static inline scap_evt *scap_bpf_evt_from_perf_sample(void *evt)
 {

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1895,7 +1895,6 @@ sinsp_filter* sinsp_filter_compiler::compile()
 sinsp_filter* sinsp_filter_compiler::compile_()
 {
 	m_scansize = (uint32_t)m_fltstr.size();
-
 	while(true)
 	{
 		char a = next();
@@ -2027,8 +2026,6 @@ sinsp_filter* sinsp_filter_compiler::compile_()
 			break;
 		}
 	}
-
-	vector<string> components = sinsp_split(m_fltstr, ' ');
 	return m_filter;
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -37,7 +37,6 @@ limitations under the License.
 #include "dns_manager.h"
 #include "plugin.h"
 
-
 #ifndef CYGWING_AGENT
 #ifndef MINIMAL_BUILD
 #include "k8s_api_handler.h"
@@ -66,9 +65,11 @@ void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_thr
 ///////////////////////////////////////////////////////////////////////////////
 sinsp::sinsp(bool static_container, const std::string static_id, const std::string static_name, const std::string static_image) :
 	m_external_event_processor(),
+	m_simpleconsumer(false),
 	m_evt(this),
 	m_lastevent_ts(0),
 	m_container_manager(this, static_container, static_id, static_name, static_image),
+	m_ppm_sc_of_interest(),
 	m_suppressed_comms()
 {
 #if !defined(MINIMAL_BUILD) && !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
@@ -438,6 +439,39 @@ void sinsp::set_import_users(bool import_users)
 	m_import_users = import_users;
 }
 
+void sinsp::fill_syscalls_of_interest(scap_open_args *oargs)
+{
+	// Fallback to set all events as interesting
+	if (m_mode != SCAP_MODE_LIVE  || m_ppm_sc_of_interest.empty())
+	{
+		for(int i = 0; i < PPM_SC_MAX; i++)
+		{
+			m_ppm_sc_of_interest.insert(i);
+		}
+	}
+
+	/*
+	 * in case of simple consumer (driver side)
+	 * set all droppable events as non interesting (if they are syscall driven)
+	 */
+	if (m_simpleconsumer)
+	{
+		for (int i = 0; i < PPM_SC_MAX; i++)
+		{
+			if (g_infotables.m_syscall_info_table[i].flags & EF_DROP_SIMPLE_CONS)
+			{
+				m_ppm_sc_of_interest.erase(i);
+			}
+		}
+	}
+
+	// Finally, set scap_open_args syscalls_of_interest
+	for (int i = 0; i < PPM_SC_MAX; i++)
+	{
+		oargs->ppm_sc_of_interest.ppm_sc[i] = m_ppm_sc_of_interest.find(i) != m_ppm_sc_of_interest.end();
+	}
+}
+
 void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 {
 	char error[SCAP_LASTERR_SIZE];
@@ -454,11 +488,14 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 	//
 	m_mode = mode;
 	scap_open_args oargs;
+
 	oargs.mode = mode;
 	oargs.fname = NULL;
 	oargs.proc_callback = NULL;
 	oargs.proc_callback_context = NULL;
 	oargs.udig = m_udig;
+
+	fill_syscalls_of_interest(&oargs);
 
 	if(!m_filter_proc_table_when_saving)
 	{
@@ -543,6 +580,7 @@ void sinsp::open_nodriver()
 		oargs.proc_callback_context = this;
 	}
 	oargs.import_users = m_import_users;
+	fill_syscalls_of_interest(&oargs);
 
 	int32_t scap_rc;
 	m_h = scap_open(oargs, error, &scap_rc);
@@ -555,6 +593,11 @@ void sinsp::open_nodriver()
 	scap_set_refresh_proc_table_when_saving(m_h, !m_filter_proc_table_when_saving);
 
 	init();
+}
+
+void sinsp::set_simple_consumer()
+{
+	m_simpleconsumer = true;
 }
 
 int64_t sinsp::get_file_size(const std::string& fname, char *error)
@@ -675,10 +718,12 @@ void sinsp::open_int()
 	oargs.proc_callback_context = NULL;
 	oargs.import_users = m_import_users;
 	oargs.start_offset = 0;
+	fill_syscalls_of_interest(&oargs);
 
 	add_suppressed_comms(oargs);
 
 	int32_t scap_rc;
+
 	m_h = scap_open(oargs, error, &scap_rc);
 
 	if(m_h == NULL)
@@ -759,6 +804,8 @@ void sinsp::close()
 		m_evttype_filter = NULL;
 	}
 #endif
+
+	m_ppm_sc_of_interest.clear();
 }
 
 //

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -61,7 +61,7 @@ limitations under the License.
 #include <map>
 #include <queue>
 #include <vector>
-#include <set>
+#include <unordered_set>
 #include <list>
 #include <memory>
 
@@ -880,6 +880,13 @@ public:
 
 	sinsp_parser* get_parser();
 
+	/*!
+	  \brief Enables simple_consumer mode on sinsp, at driver level.
+	  This will avoid tracing syscalls flagged with EF_DROP_SIMPLE_CONS.
+	  Must be called before sinsp opening.
+	*/
+	void set_simple_consumer();
+
 	bool setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 	void add_meta_event(sinsp_evt *metaevt);
@@ -984,7 +991,7 @@ private:
 	void import_ifaddr_list();
 	void import_user_list();
 	void add_protodecoders();
-
+	void fill_syscalls_of_interest(scap_open_args *oargs);
 	void remove_thread(int64_t tid, bool force);
 
 	//
@@ -1036,6 +1043,8 @@ private:
 	scap_t* m_h;
 	uint64_t m_nevts;
 	int64_t m_filesize;
+
+	bool m_simpleconsumer;
 
 	scap_mode_t m_mode = SCAP_MODE_NONE;
 
@@ -1128,8 +1137,8 @@ public:
 	sinsp_filter* m_filter;
 	sinsp_evttype_filter *m_evttype_filter;
 	std::string m_filterstring;
-
 #endif
+	unordered_set<uint32_t> m_ppm_sc_of_interest;
 
 	//
 	// Internal stats


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

/area driver-kmod

/area driver-ebpf

/area libscap

/area libsinsp

**What this PR does / why we need it**:

The PR introduces kernel side support (both kmod and eBPF) for filtering syscalls; right now, simple consumer mode can be enabled directly kernel side, instead of filtering in userspace.  
In details:
* a new dep was added for linux builds: libaudit. It is needed to fetch syscall number given syscall name
* kmod g_events_mask is now per-consumer
* eBPF will mark syscalls as uninteresting while building the shared syscall map
* libsinsp expose a new API `sinsp::set_simple_consumer()` to enable kernel side simple consumer
* falco will be updated using the new api

The changes should help falco users to reduce number of drops in syscalls-intensive environment; 
some benchmarks using stress-ng.  

_Note that baseline (ie: abscissa) means "same benchmark run without falco"_, and benchmark values are intended as performance hit from baseline; thus **the lower the better**!

### Falco with kmod:

![kmod](https://user-images.githubusercontent.com/5837210/139814050-5c4ac98f-c764-4d6d-bc55-dc9e56b7d76c.png)

**Drops**:
![immagine](https://user-images.githubusercontent.com/5837210/139813512-e9061e2b-9ae3-40b6-8719-d309bea0e22b.png)

### Falco with eBPF:

![ebpf](https://user-images.githubusercontent.com/5837210/139813943-da81793f-1213-47a3-b55c-0f2821157d7e.png)

**Drops**:
![immagine](https://user-images.githubusercontent.com/5837210/139813534-bfddf1a1-7d6d-4b10-b295-e7151c9850e1.png)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: added a simple consumer mode with kernel side filtering.
```
