### PR TITLE
fix: check that extracted field is present before copying it

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -631,18 +631,20 @@ bool sinsp_plugin::extract_field(ss_plugin_event &evt, sinsp_plugin::ext_field &
 	}
 
 	field.field_present = efield.field_present;
-	switch(field.ftype)
-	{
-	case PT_CHARBUF:
-		field.res_str = str_from_alloc_charbuf(efield.res_str);
-		break;
-	case PT_UINT64:
-		field.res_u64 = efield.res_u64;
-		break;
-	default:
-		ASSERT(false);
-		throw sinsp_exception("plugin extract error: unsupported field type " + to_string(field.ftype));
-		break;
+	if (field.field_present) {
+		switch(field.ftype)
+		{
+		case PT_CHARBUF:
+			field.res_str = str_from_alloc_charbuf(efield.res_str);
+			break;
+		case PT_UINT64:
+			field.res_u64 = efield.res_u64;
+			break;
+		default:
+			ASSERT(false);
+			throw sinsp_exception("plugin extract error: unsupported field type " + to_string(field.ftype));
+			break;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:
This checks that a plugin-extracted field is present before copying its value in an internal struct. This caused spurious segmentation faults, because generally there is no guarantee that the plugin sets `res_str` to `NULL` if `field_present` is set to false.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
