### PR TITLE
new(userspace/libsinsp): introduce sinsp_dns_manager.clear_cache method, improve performance, fix concurrency issue

### DIFF
--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -15,62 +15,322 @@ limitations under the License.
 
 */
 
+#include <iostream>
 #include "dns_manager.h"
+
+#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
+
+template <int> class af_converter{};
+
+template <> class af_converter<AF_INET>
+{
+public:
+	typedef int32_t type;
+
+	static type value(void *addr){ return *(uint32_t *)addr; }
+};
+
+template <> class af_converter<AF_INET6>
+{
+public:
+	typedef std::string type;
+	static type value(void *addr)
+	{
+		char str[INET6_ADDRSTRLEN];
+		if (inet_ntop(AF_INET6, addr, str, INET6_ADDRSTRLEN) == nullptr)
+		{
+			SINSP_ERROR("error converting INET6 = %p", addr);
+		}
+		return str;
+	}
+};
+
+struct dns_info
+{
+public:
+	uint64_t m_timeout=0;
+	uint64_t m_last_resolve_ts =0;
+	uint64_t m_last_used_ts = 0;
+
+	std::set<uint32_t> m_v4_addrs;
+	std::set<ipv6addr> m_v6_addrs;
+
+	bool operator==(const dns_info &other) const
+	{
+		return m_v4_addrs == other.m_v4_addrs && m_v6_addrs == other.m_v6_addrs;
+	};
+	bool operator!=(const dns_info &other) const
+	{
+		return !operator==(other);
+	};
+
+	void refresh(const string &name)
+	{
+		addrinfo hints{}, *result, *rp;
+		memset(&hints, 0, sizeof(struct addrinfo));
+
+		// Allow IPv4 or IPv6, all socket types, all protocols
+		hints.ai_family = AF_UNSPEC;
+
+		m_v4_addrs.clear();
+		m_v6_addrs.clear();
+
+		int s = getaddrinfo(name.c_str(), nullptr, &hints, &result);
+		if (!s && result)
+		{
+			for (rp = result; rp != nullptr; rp = rp->ai_next)
+			{
+				if(rp->ai_family == AF_INET)
+				{
+					m_v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
+				}
+				else // AF_INET6
+				{
+					ipv6addr v6;
+					memcpy(v6.m_b, ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
+					m_v6_addrs.insert(v6);
+				}
+			}
+			freeaddrinfo(result);
+		}
+	}
+};
+
+using dns_info_table_t = tbb::concurrent_unordered_map<std::string, std::shared_ptr<dns_info>>;
+
+template<typename First, typename Second>
+class dns_map
+{
+private:
+	typedef tbb::concurrent_unordered_map<Second, dns_info *> inner_map_t;
+	typedef tbb::concurrent_unordered_map<First, inner_map_t> outer_map_t;
+	outer_map_t m_map;
+public:
+	Second get_sindex(First fidx, uint64_t ts)
+	{
+		const auto fit = m_map.find(fidx);
+		if(fit == m_map.end() || fit->second.empty())
+		{
+			return {};
+		}
+
+		auto sit = fit->second.begin();
+		sit->second->m_last_used_ts = ts;
+		return sit->first;
+	}
+
+	bool has_value(First fidx, Second sidx, uint64_t ts)
+	{
+		const auto fit = m_map.find(fidx);
+		if(fit == m_map.end() || fit->second.empty())
+		{
+			return false;
+		}
+
+		auto sit = fit->second.find(sidx);
+		if(sit == fit->second.end())
+		{
+			return false;
+		}
+
+		sit->second->m_last_used_ts = ts;
+		return true;
+	}
+
+	void insert (First fidx, Second sidx, dns_info * info, uint64_t ts)
+	{
+		//info->m_last_used_ts = ts;
+		m_map[fidx][sidx] = info;
+	}
+};
+
+template <int AF> class dns_addr_map
+{
+private:
+	typedef af_converter<AF> af_converter_t;
+	typedef typename af_converter_t::type addr_t;
+	dns_map<addr_t, std::string> m_addr_to_name_map;
+public:
+	void insert (std::string name, addr_t addr, dns_info * info, uint64_t ts)
+	{
+		m_addr_to_name_map.insert(addr, name, info, ts);
+	}
+	std::string name_of(void *addr, uint64_t ts)
+	{
+		return m_addr_to_name_map.get_sindex(af_converter_t::value(addr), ts);
+	}
+	bool match(std::string name, void* addr, uint64_t ts)
+	{
+		return m_addr_to_name_map.has_value(af_converter_t::value(addr), name, ts);
+	}
+};
+
+class dns_af_cache
+{
+private:
+	dns_addr_map<AF_INET>  m_v4_cache;
+	dns_addr_map<AF_INET6> m_v6_cache;
+public:
+	dns_info_table_t m_info_table;
+
+	void print_stats()
+	{
+		//SINSP_DEBUG("v4_size=%lu, v6_size=%lu", m_v4_cache.size(), m_v6_cache.size() );
+	}
+
+	std::string name_of(int af, void *addr, uint64_t ts)
+	{
+		if (af == AF_INET)
+		{
+			return m_v4_cache.name_of(addr, ts);
+		}
+		else if (af == AF_INET6)
+		{
+			return m_v6_cache.name_of(addr, ts);
+		}
+		return {};
+	}
+
+	bool match(int af, std::string name, void* addr, uint64_t ts)
+	{
+		if (af == AF_INET)
+		{
+			return m_v4_cache.match(name, addr, ts);
+		}
+		else if (af == AF_INET6)
+		{
+			return m_v6_cache.match(name, addr, ts);
+		}
+		return false;
+	}
+
+	void insert(std::string name, std::shared_ptr<dns_info> info, uint64_t ts)
+	{
+		for (auto addr : info->m_v4_addrs)
+		{
+			m_v4_cache.insert(name, addr, info.get(), ts);
+		}
+
+		for (auto addr : info->m_v6_addrs)
+		{
+			m_v6_cache.insert(name, af_converter<AF_INET6>::value(&addr.m_b[0]), info.get(), ts);
+		}
+		m_info_table[name] = info;
+	}
+};
+
+class sinsp_dns_manager::dns_cache
+{
+private:
+	tbb::concurrent_vector<std::shared_ptr<dns_af_cache>> m_cashes;
+	tbb::queuing_rw_mutex m_cache_swap_mtx;
+	using scoped_lock = typename tbb::queuing_rw_mutex::scoped_lock;
+public:
+	dns_cache()
+	{
+		m_cashes.emplace_back(new dns_af_cache());
+		m_cashes.emplace_back(new dns_af_cache());
+	}
+
+	std::shared_ptr<dns_af_cache> get_work()
+	{
+		scoped_lock lk(m_cache_swap_mtx, false);
+		return m_cashes[0];
+	}
+
+	std::shared_ptr<dns_af_cache> get_shadow()
+	{
+		scoped_lock lk(m_cache_swap_mtx, false);
+		m_cashes[1] = std::make_shared<dns_af_cache>();
+		return m_cashes[1];
+	}
+
+	void swap()
+	{
+		//std::cout << "swap\n";
+
+		scoped_lock lk(m_cache_swap_mtx);
+		m_cashes[0] = m_cashes[1];
+		m_cashes[1] = std::make_shared<dns_af_cache>();
+	}
+
+	void insert(std::string name, std::shared_ptr<dns_info> info, uint64_t ts)
+	{
+		scoped_lock lk(m_cache_swap_mtx);
+		m_cashes[0]->insert(name, info, ts);
+		m_cashes[1]->insert(name, info, ts);
+	}
+
+	void clear()
+	{
+		scoped_lock lk(m_cache_swap_mtx);
+		m_cashes[0] = std::make_shared<dns_af_cache>();
+		m_cashes[1] = std::make_shared<dns_af_cache>();
+	}
+};
 
 void sinsp_dns_manager::refresh(std::future<void> f_exit)
 {
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	sinsp_dns_manager &manager = sinsp_dns_manager::get();
-
 	while(true)
 	{
 		uint64_t base_refresh_timeout = manager.m_base_refresh_timeout;
 		uint64_t max_refresh_timeout = manager.m_max_refresh_timeout;
 		uint64_t erase_timeout = manager.m_erase_timeout;
 
-		if(!manager.m_cache.empty())
-		{
-			std::list<std::string> to_delete;
+		auto shadow_cache = manager.m_dns_cache->get_shadow();
+		auto work_cache = manager.m_dns_cache->get_work();
 
+		if(!work_cache->m_info_table.empty())
+		{
 			uint64_t ts = sinsp_utils::get_current_time_ns();
 
-			for(auto &it: manager.m_cache)
+			for(auto &it: work_cache->m_info_table)
 			{
 				const std::string &name = it.first;
 				auto info = it.second;
+//				auto prt= [&](const std::string& act, dns_info *i) {
+//					std::cout << "\nacction: " << act << " info{ name:" << name
+//						  << " last_used:" << i->m_last_used_ts/ONE_SECOND_IN_NS
+//						  << " last_resolved:" << i->m_last_resolve_ts/ONE_SECOND_IN_NS
+//						  << " timeout:" << i->m_timeout/ONE_SECOND_IN_NS
+//						  << "\n";
+//				};
 
 				if((ts > info->m_last_used_ts) &&
 				   (ts - info->m_last_used_ts) > erase_timeout)
 				{
+					//prt("erase", info.get());
 					// remove the entry if it's hasn't been used for a whole hour
-					to_delete.push_back(name);
 				}
-				else if(ts > (info->m_last_resolve_ts + info->m_timeout))
+				else
 				{
-					// dns_info::operator!= will check if some
-					// v4 or v6 addresses are changed from the
-					// last resolution
-					if(info->refresh(name))
+					auto n_info = new dns_info();
+					n_info->m_last_used_ts = info->m_last_used_ts;
+					n_info->m_last_resolve_ts = info->m_last_resolve_ts;
+					n_info->m_timeout = info->m_timeout;
+
+					if(ts > n_info->m_last_resolve_ts + n_info->m_timeout && *n_info != *info)
 					{
-						info->m_timeout = base_refresh_timeout;
-						info->m_last_resolve_ts = info->m_last_resolve_ts = ts;
+						n_info->refresh(name);
+						n_info->m_timeout = base_refresh_timeout;
+						n_info->m_last_resolve_ts  = ts;
+						//prt("refresh", n_info);
 					}
-					else if(info->m_timeout < max_refresh_timeout)
+					else if(n_info->m_timeout < max_refresh_timeout)
 					{
 						// double the timeout until 320 secs
-						info->m_timeout <<= 1;
+						n_info->m_timeout <<= 1;
+						//prt("copy timeout", n_info);
 					}
+					else
+					{
+						//prt("copy", n_info);
+					}
+					shadow_cache->insert(name, std::shared_ptr<dns_info>(n_info), ts);
 				}
 			}
-			if(!to_delete.empty())
-			{
-				manager.m_erase_mutex.lock();
-				for(const auto &name : to_delete)
-				{
-					manager.m_cache.unsafe_erase(name);
-				}
-				manager.m_erase_mutex.unlock();
-			}
+			manager.m_dns_cache->swap();
 		}
 
 		if(f_exit.wait_for(std::chrono::nanoseconds(base_refresh_timeout)) == std::future_status::ready)
@@ -78,130 +338,33 @@ void sinsp_dns_manager::refresh(std::future<void> f_exit)
 			break;
 		}
 	}
-#endif
 }
-
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-bool sinsp_dns_manager::dns_info::refresh(const string &name)
-{
-	std::set<uint32_t> v4_addrs;
-	std::set<ipv6addr> v6_addrs;
-
-	addrinfo hints{}, *result, *rp;
-	memset(&hints, 0, sizeof(struct addrinfo));
-
-	// Allow IPv4 or IPv6, all socket types, all protocols
-	hints.ai_family = AF_UNSPEC;
-
-	int s = getaddrinfo(name.c_str(), nullptr, &hints, &result);
-	if (!s && result)
-	{
-		for (rp = result; rp != nullptr; rp = rp->ai_next)
-		{
-			if(rp->ai_family == AF_INET)
-			{
-				v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
-			}
-			else // AF_INET6
-			{
-				ipv6addr v6;
-				memcpy(v6.m_b, ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
-				v6_addrs.insert(v6);
-			}
-		}
-		freeaddrinfo(result);
-	}
-
-	std::lock_guard<std::mutex> lk(m_mtx);
-	if (m_v4_addrs == v4_addrs && m_v6_addrs == v6_addrs)
-	{
-		return false;
-	}
-	m_v4_addrs = std::move(v4_addrs);
-	m_v6_addrs = std::move(v6_addrs);
-	return true;
-}
-#endif
 
 bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
 {
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	if(!m_resolver)
 	{
 		m_resolver = new thread(sinsp_dns_manager::refresh, m_exit_signal.get_future());
 	}
 
-	std::shared_ptr<dns_info> dinfo;
+	if( m_dns_cache->get_work()->match(af, name, addr, ts))
+	{
+		return true;
+	}
+
 	string sname = string(name);
-
-	{
-		std::lock_guard<std::mutex> lk(m_erase_mutex);
-
-		const auto &it = m_cache.find(sname);
-		if(it == m_cache.end())
-		{
-			dinfo = std::make_shared<dns_info>();
-			dinfo->refresh(name);
-			dinfo->m_timeout = m_base_refresh_timeout;
-			dinfo->m_last_resolve_ts = ts;
-			m_cache.emplace(name, dinfo);
-		}
-		else
-		{
-			dinfo = it->second;
-			dinfo->m_last_used_ts = ts;
-		}
-	}
-
-	if(af == AF_INET6)
-	{
-		ipv6addr v6;
-		memcpy(v6.m_b, addr, sizeof(ipv6addr));
-		return dinfo->contains(v6);
-	}
-	else if(af == AF_INET)
-	{
-		return dinfo->contains(*(uint32_t *)addr);
-	}
-#endif
-	return false;
+	auto dinfo = make_shared<dns_info>();
+	dinfo->refresh(sname);
+	dinfo->m_last_used_ts = ts;
+	dinfo->m_timeout = sinsp_dns_manager::get().m_base_refresh_timeout;
+	dinfo->m_last_resolve_ts = ts;
+	m_dns_cache->insert(sname, dinfo, ts);
+	return m_dns_cache->get_work()->match(af, name, addr, ts);
 }
 
 string sinsp_dns_manager::name_of(int af, void *addr, uint64_t ts)
 {
-	string ret;
-
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-	std::lock_guard<std::mutex> lk (m_erase_mutex);
-	if(!m_cache.empty())
-	{
-		if(af == AF_INET6)
-		{
-			ipv6addr v6;
-			memcpy(v6.m_b, addr, sizeof(ipv6addr));
-			for(auto &it: m_cache)
-			{
-				if (it.second->contains(v6))
-				{
-					it.second->m_last_used_ts = ts;
-					return it.first;
-				}
-			}
-		}
-		else if(af == AF_INET)
-		{
-			for(auto &it: m_cache)
-			{
-				if(it.second->contains(*(uint32_t *)addr))
-				{
-					it.second->m_last_used_ts = ts;
-					return it.first;
-				}
-			}
-		}
-	}
-#endif
-	return ret;
+	return m_dns_cache->get_work()->name_of(af, addr, ts);
 }
 
 void sinsp_dns_manager::cleanup()
@@ -214,3 +377,69 @@ void sinsp_dns_manager::cleanup()
 		m_exit_signal = std::promise<void>();
 	}
 }
+
+
+size_t sinsp_dns_manager::size()
+{
+	return m_dns_cache->get_work()-> m_info_table.size();
+}
+
+void sinsp_dns_manager::clear_cache()
+{
+	m_dns_cache->clear();
+}
+
+sinsp_dns_manager::sinsp_dns_manager():
+	m_dns_cache(new sinsp_dns_manager::dns_cache()),
+	m_resolver(nullptr),
+	m_erase_timeout(3600 * ONE_SECOND_IN_NS),
+	m_base_refresh_timeout(10 * ONE_SECOND_IN_NS),
+	m_max_refresh_timeout(320 * ONE_SECOND_IN_NS)
+{
+}
+
+#else
+
+void sinsp_dns_manager::refresh(std::future<void> f_exit)
+{
+}
+
+void sinsp_dns_manager::clear_cache()
+{
+}
+
+size_t sinsp_dns_manager::size()
+{
+	return 0;
+}
+
+sinsp_dns_manager::sinsp_dns_manager():
+	m_resolver(nullptr),
+	m_erase_timeout(3600 * ONE_SECOND_IN_NS),
+	m_base_refresh_timeout(10 * ONE_SECOND_IN_NS),
+	m_max_refresh_timeout(320 * ONE_SECOND_IN_NS)
+{
+}
+
+bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
+{
+	return false;
+}
+
+string sinsp_dns_manager::name_of(int af, void *addr, uint64_t ts)
+{
+	return {};
+}
+
+void sinsp_dns_manager::cleanup()
+{
+}
+
+#endif
+
+sinsp_dns_manager &sinsp_dns_manager::get()
+{
+	static sinsp_dns_manager instance;
+	return instance;
+}
+

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -17,12 +17,17 @@ limitations under the License.
 
 #include "dns_manager.h"
 
-void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_timeout, uint64_t max_refresh_timeout, std::future<void> f_exit)
+void sinsp_dns_manager::refresh(std::future<void> f_exit)
 {
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	sinsp_dns_manager &manager = sinsp_dns_manager::get();
+
 	while(true)
 	{
+		uint64_t base_refresh_timeout = manager.m_base_refresh_timeout;
+		uint64_t max_refresh_timeout = manager.m_max_refresh_timeout;
+		uint64_t erase_timeout = manager.m_erase_timeout;
+
 		if(!manager.m_cache.empty())
 		{
 			std::list<std::string> to_delete;
@@ -32,31 +37,28 @@ void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_t
 			for(auto &it: manager.m_cache)
 			{
 				const std::string &name = it.first;
-				sinsp_dns_manager::dns_info &info = it.second;
+				auto info = it.second;
 
-				if((ts > info.m_last_used_ts) &&
-				   (ts - info.m_last_used_ts) > erase_timeout)
+				if((ts > info->m_last_used_ts) &&
+				   (ts - info->m_last_used_ts) > erase_timeout)
 				{
 					// remove the entry if it's hasn't been used for a whole hour
 					to_delete.push_back(name);
 				}
-				else if(ts > (info.m_last_resolve_ts + info.m_timeout))
+				else if(ts > (info->m_last_resolve_ts + info->m_timeout))
 				{
-					sinsp_dns_manager::dns_info refreshed_info = manager.resolve(name, ts);
-					refreshed_info.m_timeout = base_refresh_timeout;
-					refreshed_info.m_last_resolve_ts = info.m_last_resolve_ts = ts;
-
 					// dns_info::operator!= will check if some
 					// v4 or v6 addresses are changed from the
 					// last resolution
-					if(refreshed_info != info)
+					if(info->refresh(name))
 					{
-						info = refreshed_info;
+						info->m_timeout = base_refresh_timeout;
+						info->m_last_resolve_ts = info->m_last_resolve_ts = ts;
 					}
-					else if(info.m_timeout < max_refresh_timeout)
+					else if(info->m_timeout < max_refresh_timeout)
 					{
 						// double the timeout until 320 secs
-						info.m_timeout <<= 1;
+						info->m_timeout <<= 1;
 					}
 				}
 			}
@@ -80,35 +82,44 @@ void sinsp_dns_resolver::refresh(uint64_t erase_timeout, uint64_t base_refresh_t
 }
 
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string &name, uint64_t ts)
+bool sinsp_dns_manager::dns_info::refresh(const string &name)
 {
-	dns_info dinfo;
+	std::set<uint32_t> v4_addrs;
+	std::set<ipv6addr> v6_addrs;
 
-	struct addrinfo hints, *result, *rp;
+	addrinfo hints{}, *result, *rp;
 	memset(&hints, 0, sizeof(struct addrinfo));
 
 	// Allow IPv4 or IPv6, all socket types, all protocols
 	hints.ai_family = AF_UNSPEC;
 
-	int s = getaddrinfo(name.c_str(), NULL, &hints, &result);
+	int s = getaddrinfo(name.c_str(), nullptr, &hints, &result);
 	if (!s && result)
 	{
-		for (rp = result; rp != NULL; rp = rp->ai_next)
+		for (rp = result; rp != nullptr; rp = rp->ai_next)
 		{
 			if(rp->ai_family == AF_INET)
 			{
-				dinfo.m_v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
+				v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
 			}
 			else // AF_INET6
 			{
 				ipv6addr v6;
 				memcpy(v6.m_b, ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
-				dinfo.m_v6_addrs.insert(v6);
+				v6_addrs.insert(v6);
 			}
 		}
 		freeaddrinfo(result);
 	}
-	return dinfo;
+
+	std::lock_guard<std::mutex> lk(m_mtx);
+	if (m_v4_addrs == v4_addrs && m_v6_addrs == m_v6_addrs)
+	{
+		return false;
+	}
+	m_v4_addrs = std::move(v4_addrs);
+	m_v6_addrs = std::move(v6_addrs);
+	return true;
 }
 #endif
 
@@ -117,35 +128,40 @@ bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	if(!m_resolver)
 	{
-		m_resolver = new thread(sinsp_dns_resolver::refresh, m_erase_timeout, m_base_refresh_timeout, m_max_refresh_timeout, m_exit_signal.get_future());
+		m_resolver = new thread(sinsp_dns_manager::refresh, m_exit_signal.get_future());
 	}
 
+	std::shared_ptr<dns_info> dinfo;
 	string sname = string(name);
 
-	m_erase_mutex.lock();
-
-	if(m_cache.find(sname) == m_cache.end())
 	{
-		dns_info dinfo = resolve(sname, ts);
-		dinfo.m_timeout = m_base_refresh_timeout;
-		dinfo.m_last_resolve_ts = ts;
-		m_cache[sname] = dinfo;
+		std::lock_guard<std::mutex> lk(m_erase_mutex);
+
+		const auto &it = m_cache.find(sname);
+		if(it == m_cache.end())
+		{
+			dinfo = std::make_shared<dns_info>();
+			dinfo->refresh(name);
+			dinfo->m_timeout = m_base_refresh_timeout;
+			dinfo->m_last_resolve_ts = ts;
+			m_cache.emplace(name, dinfo);
+		}
+		else
+		{
+			dinfo = it->second;
+			dinfo->m_last_used_ts = ts;
+		}
 	}
-
-	m_cache[sname].m_last_used_ts = ts;
-	dns_info &dinfo = m_cache[sname];
-
-	m_erase_mutex.unlock();
 
 	if(af == AF_INET6)
 	{
 		ipv6addr v6;
 		memcpy(v6.m_b, addr, sizeof(ipv6addr));
-		return dinfo.m_v6_addrs.find(v6) != dinfo.m_v6_addrs.end();
+		return dinfo->contains(v6);
 	}
 	else if(af == AF_INET)
 	{
-		return dinfo.m_v4_addrs.find(*(uint32_t *)addr) != dinfo.m_v4_addrs.end();
+		return dinfo->contains(*(uint32_t *)addr);
 	}
 #endif
 	return false;
@@ -156,33 +172,33 @@ string sinsp_dns_manager::name_of(int af, void *addr, uint64_t ts)
 	string ret;
 
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
+	std::lock_guard<std::mutex> lk (m_erase_mutex);
 	if(!m_cache.empty())
 	{
-		m_erase_mutex.lock();
-		for(auto &it: m_cache)
+		if(af == AF_INET6)
 		{
-			const std::string &name = it.first;
-			sinsp_dns_manager::dns_info &info = it.second;
-
-			if(af == AF_INET6)
+			ipv6addr v6;
+			memcpy(v6.m_b, addr, sizeof(ipv6addr));
+			for(auto &it: m_cache)
 			{
-				ipv6addr v6;
-				memcpy(v6.m_b, addr, sizeof(ipv6addr));
-				if (info.m_v6_addrs.find(v6) != info.m_v6_addrs.end())
+				if (it.second->contains(v6))
 				{
-					info.m_last_used_ts = ts;
-					ret = name;
-					break;
+					it.second->m_last_used_ts = ts;
+					return it.first;
 				}
 			}
-			else if(af == AF_INET && info.m_v4_addrs.find(*(uint32_t *)addr) != info.m_v4_addrs.end())
+		}
+		else if(af == AF_INET)
+		{
+			for(auto &it: m_cache)
 			{
-				info.m_last_used_ts = ts;
-				ret = name;
-				break;
+				if(it.second->contains(*(uint32_t *)addr))
+				{
+					it.second->m_last_used_ts = ts;
+					return it.first;
+				}
 			}
 		}
-		m_erase_mutex.unlock();
 	}
 #endif
 	return ret;
@@ -194,7 +210,7 @@ void sinsp_dns_manager::cleanup()
 	{
 		m_exit_signal.set_value();
 		m_resolver->join();
-		m_resolver = NULL;
+		m_resolver = nullptr;
 		m_exit_signal = std::promise<void>();
 	}
 }

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -113,7 +113,7 @@ bool sinsp_dns_manager::dns_info::refresh(const string &name)
 	}
 
 	std::lock_guard<std::mutex> lk(m_mtx);
-	if (m_v4_addrs == v4_addrs && m_v6_addrs == m_v6_addrs)
+	if (m_v4_addrs == v4_addrs && m_v6_addrs == v6_addrs)
 	{
 		return false;
 	}

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -27,27 +27,23 @@ limitations under the License.
 #include <chrono>
 #include <future>
 #include <mutex>
+#include <utility>
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-#include "tbb/concurrent_unordered_map.h"
+#include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/queuing_rw_mutex.h>
 #endif
 #include "sinsp.h"
-
-
 
 class sinsp_dns_manager
 {
 public:
-
 	bool match(const char *name, int af, void *addr, uint64_t ts);
 	string name_of(int af, void *addr, uint64_t ts);
 
 	void cleanup();
 
-        static sinsp_dns_manager& get()
-        {
-            static sinsp_dns_manager instance;
-            return instance;
-        };
+	static sinsp_dns_manager &get();
 
 	void set_erase_timeout(uint64_t ns)
 	{
@@ -61,72 +57,23 @@ public:
 	{
 		m_max_refresh_timeout = ns;
 	};
-	void clear_cache()
-	{
-		std::lock_guard<std::mutex> lk(m_erase_mutex);
-		m_cache.clear();
-	}
 
-	size_t size()
-	{
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-		return m_cache.size();
-#else
-		return 0;
-#endif
-	};
+	void clear_cache();
+	size_t size();
+
+	sinsp_dns_manager(sinsp_dns_manager const &) = delete;
+	void operator=(sinsp_dns_manager const &) = delete;
 
 private:
-
-	static void refresh(std::future<void> f_exit);
-
-	sinsp_dns_manager() :
-		m_erase_timeout(3600 * ONE_SECOND_IN_NS),
-		m_base_refresh_timeout(10 * ONE_SECOND_IN_NS),
-		m_max_refresh_timeout(320 * ONE_SECOND_IN_NS)
-	{};
-        sinsp_dns_manager(sinsp_dns_manager const&) = delete;
-        void operator=(sinsp_dns_manager const&) = delete;
+	sinsp_dns_manager();
 
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-	class dns_info
-	{
-	public:
-		uint64_t m_timeout;
-		uint64_t m_last_resolve_ts =0;
-		uint64_t m_last_used_ts = 0;
-		bool refresh (const std::string &name);
-
-		bool contains(const ipv6addr& v6)
-		{
-			std::lock_guard<std::mutex> lk(m_mtx);
-			return m_v6_addrs.find(v6) != m_v6_addrs.end();
-		}
-
-		bool contains(const uint32_t & v4)
-		{
-			std::lock_guard<std::mutex> lk(m_mtx);
-			return m_v4_addrs.find(v4) != m_v4_addrs.end();
-		}
-	private:
-		std::mutex m_mtx;
-		std::set<uint32_t> m_v4_addrs;
-		std::set<ipv6addr> m_v6_addrs;
-	};
-
-	typedef tbb::concurrent_unordered_map<std::string, std::shared_ptr<dns_info>> c_dns_table;
-	c_dns_table m_cache;
-#endif
-
-	// tbb concurrent unordered map is not thread-safe for deletions,
-	// so we still need a mutex, but the chances of waiting are really
-	// low, since we will almost never do an erase.
-	std::mutex m_erase_mutex;
-
-	// used to let m_resolver know when to terminate
+	class dns_cache;
+	std::unique_ptr<dns_cache> m_dns_cache;
+	static void refresh(std::future<void> f_exit);
 	std::promise<void> m_exit_signal;
-
-	std::thread *m_resolver;
+	std::thread *m_resolver{};
+#endif
 
 	uint64_t m_erase_timeout;
 	uint64_t m_base_refresh_timeout;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -59,7 +59,6 @@ public:
 	sinsp_dns_manager(sinsp_dns_manager const &) = delete;
 	void operator=(sinsp_dns_manager const &) = delete;
 
-
 private:
 	sinsp_dns_manager();
 	friend class dns_manager_test;
@@ -69,7 +68,9 @@ private:
 	std::unique_ptr<dns_cache> m_dns_cache;
 	static void refresh(std::future<void> f_exit);
 	std::promise<void> m_exit_signal;
-	std::thread *m_resolver{};
+	std::atomic<bool> m_resolver_flag;
+	std::thread *m_resolver = nullptr;
+
 #endif
 
 	uint64_t m_erase_timeout;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -61,7 +61,6 @@ public:
 
 private:
 	sinsp_dns_manager();
-	friend class dns_manager_test;
 
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	class dns_cache;
@@ -70,7 +69,6 @@ private:
 	std::promise<void> m_exit_signal;
 	std::atomic<bool> m_resolver_flag;
 	std::thread *m_resolver = nullptr;
-
 #endif
 
 	uint64_t m_erase_timeout;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -28,11 +28,6 @@ limitations under the License.
 #include <future>
 #include <mutex>
 #include <utility>
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/queuing_rw_mutex.h>
-#endif
 #include "sinsp.h"
 
 class sinsp_dns_manager
@@ -64,8 +59,10 @@ public:
 	sinsp_dns_manager(sinsp_dns_manager const &) = delete;
 	void operator=(sinsp_dns_manager const &) = delete;
 
+
 private:
 	sinsp_dns_manager();
+	friend class dns_manager_test;
 
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32)
 	class dns_cache;


### PR DESCRIPTION

**What type of PR is this?**

> /kind bug

> /kind feature

**Any specific area of the project related to this PR?**

> /area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
when reloading Falco policies we need to clear DNS lookup cache, otherwise, the refresher will refresh-lookup names for disabled rules up to 1 hour - the cache TTL.
In particular: 
> Customer is looking to stop receiving AWS GuardDuty alarms after disabling the Cryptomining rule in the Secure UI which executes DNS lookups

**Which issue(s) this PR fixes**:

In the current implementation, there is a thread-unsafe assignment:
```
if(refreshed_info != info)
{
        info = refreshed_info;
}
```
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Does this PR introduce a user-facing change?**:
new method:
```
sinsp_dns_manager::clear_cache() 
```

