### PR TITLE
update: in nodriver mode, avoid loading proc, users and interfaces related informations

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -541,14 +541,6 @@ void sinsp::open_nodriver()
 	scap_open_args oargs;
 	oargs.mode = SCAP_MODE_NODRIVER;
 	oargs.fname = NULL;
-	oargs.proc_callback = NULL;
-	oargs.proc_callback_context = NULL;
-	if(!m_filter_proc_table_when_saving)
-	{
-		oargs.proc_callback = ::on_new_entry_from_proc;
-		oargs.proc_callback_context = this;
-	}
-	oargs.import_users = m_import_users;
 
 	int32_t scap_rc;
 	m_h = scap_open(oargs, error, &scap_rc);
@@ -558,7 +550,7 @@ void sinsp::open_nodriver()
 		throw scap_open_exception(error, scap_rc);
 	}
 
-	scap_set_refresh_proc_table_when_saving(m_h, !m_filter_proc_table_when_saving);
+	m_filter_proc_table_when_saving = false;
 
 	init();
 }


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**What this PR does / why we need it**:

In nodriver mode, skip loading proc, users and interfaces related informations as all event sources will be system-external.

**Which issue(s) this PR fixes**:

Possibly: https://github.com/falcosecurity/falco/issues/1757

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
