### PR TITLE
fix(userspace/libsinsp): properly use dlerror() instead of errno when catching dlopen errors

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -411,7 +411,7 @@ std::shared_ptr<sinsp_plugin> sinsp_plugin::create_plugin(string &filepath, cons
 #endif
 	if(handle == NULL)
 	{
-		errstr = "error loading plugin " + filepath + ": " + strerror(errno);
+		errstr = "error loading plugin " + filepath + ": " + dlerror();
 		return ret;
 	}
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Use dlerror() in place of strerror(errno) when catching dlopen errors.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
