### PR TITLE
fix(libsinsp): correct `MINIMAL_BUILD` gate for docker

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -43,7 +43,9 @@ bool should_drop(sinsp_evt *evt);
 #endif
 #include "sinsp_int.h"
 
+#if !defined(MINIMAL_BUILD)
 #include "container_engine/docker/async_source.h"
+#endif
 
 extern sinsp_protodecoder_list g_decoderlist;
 extern sinsp_evttables g_infotables;


### PR DESCRIPTION
`container_engine/docker/async_source.h` includes curl, which is not included in the minimal build.

Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The issue was introduced by https://github.com/falcosecurity/libs/pull/66 and we noticed it when added a specific CI check (see https://github.com/falcosecurity/test-infra/pull/555) for testing the minimal build of libs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
