### PR TITLE
fix(driver): small fix for eBPF probe on amznlinux2 kernels

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -813,6 +813,10 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 			if (!data->curarg_already_on_frame) {
 				volatile u16 read_size = len;
 
+				curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
+				if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+					return PPM_FAILURE_BUFFER_FULL;
+
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (read_size)
 					if (bpf_probe_read(&data->buf[curoff_bounded],


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Most probably, amznlinux2 kernels are somewhat patched, and the verifier rejects our eBPF probe.  
I could reproduce the issue using the amznlinux2 vbox image.  
Together with @leogr and @jasondellaluce we made sure that it was not a clang/llvm issue (we built the kernel using https://github.com/falcosecurity/driverkit, thus using the clang/llvm on the builder image); it still failed.  

In the end, it seems like kernel verifier **is** patched.  

This PR addresses the issue on these kernels.

**Which issue(s) this PR fixes**:

Fixes #130 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
