### PR TITLE
chore(libscap): change missed int32_t to ss_plugin_rc

### DIFF
--- a/userspace/libscap/plugin_info.h
+++ b/userspace/libscap/plugin_info.h
@@ -201,8 +201,7 @@ typedef struct
 	// Arguments:
 	// - config: a string with the plugin configuration. The format of the
 	//   string is chosen by the plugin itself.
-	// - rc: pointer to a ss_plugin_rc that will contain the initialization result,
-	//   as a SS_PLUGIN_* value (e.g. SS_PLUGIN_SUCCESS=0, SS_PLUGIN_FAILURE=1)
+	// - rc: pointer to a ss_plugin_rc that will contain the initialization result
 	// Return value: pointer to the plugin state that will be treated as opaque
 	//   by the engine and passed to the other plugin functions.
 	//   If rc is SS_PLUGIN_FAILURE, this function should return NULL.
@@ -297,8 +296,7 @@ typedef struct
 	// - s: the plugin state returned by init()
 	// - params: the open parameters, as a string. The format is defined by the plugin
 	//   itsef
-	// - rc: pointer to a ss_plugin_rc that will contain the open result,
-	//   as a SS_PLUGIN_* value (e.g. SS_PLUGIN_SUCCESS=0, SS_PLUGIN_FAILURE=1)
+	// - rc: pointer to a ss_plugin_rc that will contain the open result
 	// Return value: a pointer to the open context that will be passed to next_batch(),
 	//   close(), event_to_string() and extract_fields.
 	//
@@ -359,7 +357,7 @@ typedef struct
 	//   by the plugin and must not be deallocated or modified until the next
 	//   extract_fields() call.
 	//
-	// Return value: An ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
+	// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
 	//
 	ss_plugin_rc (*extract_fields)(ss_plugin_t *s, const ss_plugin_event *evt, uint32_t num_fields, ss_plugin_extract_field *fields);
 	//
@@ -415,12 +413,11 @@ typedef struct
 	// Arguments:
 	// - config: a string with the plugin configuration. The format of the
 	//   string is chosen by the plugin itself.
-	// - rc: pointer to an integer that will contain the initialization result,
-	//   as a SS_PLUGIN_* value (e.g. SS_PLUGIN_SUCCESS=0, SS_PLUGIN_FAILURE=1)
+	// - rc: pointer to a ss_plugin_rc that will contain the initialization result
 	// Return value: pointer to the plugin state that will be treated as opaque
 	//   by the engine and passed to the other plugin functions.
 	//
-	ss_plugin_t* (*init)(const char* config, int32_t* rc);
+	ss_plugin_t* (*init)(const char* config, ss_plugin_rc* rc);
 	//
 	// Destroy the plugin and, if plugin state was allocated, free it.
 	// Required: yes
@@ -498,7 +495,7 @@ typedef struct
 	//   by the plugin and must not be deallocated or modified until the next
 	//   extract_fields() call.
 	//
-	// Return value: An integer with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
+	// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
 	//
 	ss_plugin_rc (*extract_fields)(ss_plugin_t *s, const ss_plugin_event *evt, uint32_t num_fields, ss_plugin_extract_field *fields);
 	//


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Change missed int32_t (f48b7bd) to ss_plugin_rc
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
