### PR TITLE
Reintroducing the token_bucket unit test adapted to gtest

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(unit-test-libsinsp
 	cgroup_list_counter.ut.cpp
 	sinsp.ut.cpp
 	evttype_filter.ut.cpp
+	token_bucket.ut.cpp
 )
 
 target_link_libraries(unit-test-libsinsp

--- a/userspace/libsinsp/test/token_bucket.ut.cpp
+++ b/userspace/libsinsp/test/token_bucket.ut.cpp
@@ -1,0 +1,66 @@
+#include "token_bucket.h"
+#include <gtest.h>
+
+// token bucket default ctor
+TEST(token_bucket, constructor)
+{
+	auto tb = std::make_shared<token_bucket>();
+
+	EXPECT_EQ(tb->get_tokens(), 1);
+
+	// initialising with specific time, rate 2 tokens/sec
+	auto max = 2.0;
+	uint64_t now = 1;
+	tb->init(1.0, max, now);
+	EXPECT_EQ(tb->get_last_seen(), now);
+	EXPECT_EQ(tb->get_tokens(), max);
+	
+}
+
+// token bucket ctor with custom timer
+TEST(token_bucket, constructor_custom_timer)
+{
+	auto t = []() -> uint64_t { return 22; };
+	auto tb = std::make_shared<token_bucket>(t);
+
+	EXPECT_EQ(tb->get_tokens(), 1);
+	EXPECT_EQ(tb->get_last_seen(), 22);
+}
+
+// token bucket with 2 tokens/sec rate, max 10 tokens
+TEST(token_bucket, two_token_per_sec_ten_max)
+{
+	auto tb = std::make_shared<token_bucket>();
+	tb->init(2.0, 10, 1);
+
+	// claiming 5 tokens
+	{
+		bool claimed = tb->claim(5, 1000000001);
+		EXPECT_EQ(tb->get_last_seen(), 1000000001);
+		EXPECT_EQ(tb->get_tokens(), 5.0);
+		EXPECT_TRUE(claimed);
+	}
+
+	// claiming all the 7 remaining tokens	
+	{ 
+		bool claimed = tb->claim(7, 2000000001);
+		EXPECT_EQ(tb->get_last_seen(), 2000000001);
+		EXPECT_EQ(tb->get_tokens(), 0.0);
+		EXPECT_TRUE(claimed);
+	}
+
+	// claiming 1 token more than the 2 available fails		
+	{
+		bool claimed = tb->claim(3, 3000000001);
+		EXPECT_EQ(tb->get_last_seen(),3000000001);
+		EXPECT_EQ(tb->get_tokens(), 2.0);
+		EXPECT_FALSE(claimed);
+	}
+}
+
+// token bucket default initialization
+TEST(token_bucket, default_init)
+{
+	token_bucket tb;
+	EXPECT_EQ(tb.get_tokens(), 1);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR reintroduces the `token_bucket` unit test that previously belonged to the `falco` repository. As `token_bucket` was moved from there to this repository, its unit tests must be adapted to use `gtest`, since this is the testing framework that `libs` uses. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/libs/issues/137

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
