### PR TITLE
Make the `scap-driver` component name configurable

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -7,6 +7,9 @@
 
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
+if(NOT DEFINED DRIVER_COMPONENT_NAME)
+    set(DRIVER_COMPONENT_NAME "scap-driver")
+endif()
 
 # The driver build process is somewhat involved because we use the same
 # sources for building the driver locally and for shipping as a DKMS module.
@@ -104,7 +107,7 @@ if(ENABLE_DKMS)
 		${CMAKE_CURRENT_BINARY_DIR}/src/driver_config.h
 		${DRIVER_SOURCES}
 		DESTINATION "src/${DRIVER_PACKAGE_NAME}-${PROBE_VERSION}"
-		COMPONENT scap-driver)
+		COMPONENT ${DRIVER_COMPONENT_NAME})
 
 endif()
 

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -30,4 +30,4 @@ install(FILES
 	ring_helpers.h
 	types.h
 	DESTINATION "src/${DRIVER_PACKAGE_NAME}-${PROBE_VERSION}/bpf"
-	COMPONENT scap-driver)
+	COMPONENT ${DRIVER_COMPONENT_NAME})


### PR DESCRIPTION
This affects downstream packaging (the cmake component name
ends up in package names) so make this configurable instead
of forcing `scap-driver`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Have scap-driver cmake component configurable as other scap-driver related stuff.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
