### PR TITLE
update(libsinsp): add k8s node name validation

### DIFF
--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -887,6 +887,7 @@ public:
 	void init_k8s_client(std::string* api_server, std::string* ssl_cert, std::string *node_name, bool verbose = false);
 	void make_k8s_client();
 	k8s* get_k8s_client() const { return m_k8s_client; }
+	void validate_k8s_node_name();
 
 	void init_mesos_client(std::string* api_server, bool verbose = false);
 	mesos* get_mesos_client() const { return m_mesos_client; }
@@ -1141,6 +1142,7 @@ public:
 	std::string* m_k8s_api_server;
 	std::string* m_k8s_api_cert;
 	std::string* m_k8s_node_name;
+	bool m_k8s_node_name_validated = false;
 #ifdef HAS_CAPTURE
 	std::shared_ptr<sinsp_ssl> m_k8s_ssl;
 	std::shared_ptr<sinsp_bearer_token> m_k8s_bt;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR tries to introduce a very simple validation check on the name of the k8s node that is used as a filter when retrieving pods metadata. As discussed [here](https://github.com/falcosecurity/libs/issues/136), autodetection of the node name may fail in some edge cases. For this reason, I followed the suggestion to just check whether the node name actually corresponds to the name of a node in the cluster. I am aware that this is not the perfect solution, but it at least helps any consumer of the `libs` to understand if Kubernetes metadata are correctly retrieved and used, instead of silently failing, in many circumstances.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/libs/issues/136

**Special notes for your reviewer**:

Since the proposed solution is intrinsically not optimal, I opted for a lazy validation approach. The idea is to let everything initialize with the node name passed. Right after, the k8s state will be filled with the vector of nodes in the cluster and that information can be used to perform the check. This also allows avoiding a new call to the API server to list the names of the nodes in the cluster, by reusing the one we already have.


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
