### PR TITLE
fix(userspace/libscap): do not return any value from void scap_fseek() function

### DIFF
--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -2949,7 +2949,8 @@ void scap_fseek(scap_t *handle, uint64_t off)
 	switch (scap_reader_type(handle->m_reader))
 	{
 		case RT_FILE:
-			return scap_reader_seek(handle->m_reader, off, SEEK_SET);
+			scap_reader_seek(handle->m_reader, off, SEEK_SET);
+			return;
 		default:
 			ASSERT(false);
 			return;


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:
The PR fixes a small bug in scap_fseek() that breaks the build on old gcc (centos7 on Falco CI).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
