### PR TITLE
fix(libscap): perform seteuid/setegid only for the current thread

### DIFF
--- a/userspace/libscap/unixid.h
+++ b/userspace/libscap/unixid.h
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <sys/types.h>
+#include <errno.h>
+#include <unistd.h>
+
+#pragma once
+
+/*!
+    \brief Set the Effective User ID only for the current thread
+
+    \return On success, zero is returned.  On error, -1 is returned, and
+       errno is set to indicate the error.
+ */
+static inline int thread_seteuid(uid_t uid)
+{
+	int result;
+
+	if (uid == (uid_t) ~0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+#ifdef __NR_setresuid32
+	result = syscall(SYS_setresuid32, -1, uid, -1);
+#else
+	result = syscall(SYS_setresuid, -1, uid, -1);
+#endif
+
+	return result;
+}
+
+/*!
+    \brief Set the Effective Group ID only for the current thread
+
+    \return On success, zero is returned.  On error, -1 is returned, and
+       errno is set to indicate the error.
+ */
+static inline int thread_setegid(gid_t gid)
+{
+	int result;
+
+	if (gid == (gid_t) ~0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+#ifdef __NR_setresgid32
+	result = syscall(SYS_setresgid32, -1, gid, -1);
+#else
+	result = syscall(SYS_setresgid, -1, gid, -1);
+#endif
+
+	return result;
+}


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

During computation of `is_exe_writable` via scap we need to perform access checks with the user that is running the program. Using the standard seteuid/setegid functions would affect all the threads in the current application, which would generate signals, change permissions and do bad things to everything else that may be running. According to the [manual](https://man7.org/linux/man-pages/man2/setresuid.2.html) , the raw syscalls operate per-thread, while the NPTL wrappers operate on the whole process, so we're going to use raw syscalls for this function.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
