### PR TITLE
fix(libsinsp): catch errors during plugin initialization

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -411,7 +411,7 @@ std::shared_ptr<sinsp_plugin> sinsp_plugin::create_plugin(string &filepath, cons
 	// Initialize the plugin
 	if (!ret->init(config))
 	{
-		errstr = string("Could not initialize plugin");
+		errstr = string("Could not initialize plugin: " + ret->get_last_error());
 		ret = NULL;
 	}
 
@@ -462,16 +462,15 @@ bool sinsp_plugin::init(const char *config)
 	ss_plugin_rc rc;
 
 	ss_plugin_t *state = m_plugin_info.init(config, &rc);
-	if(rc != SS_PLUGIN_SUCCESS)
+	if (state != NULL)
 	{
-		// Not calling get_last_error here because there was
-		// no valid ss_plugin_t struct returned from init.
-		return false;
+		// Plugins can return a state even if the result code is
+		// SS_PLUGIN_FAILURE, which can be useful to set an init
+		// error that can later be retrieved through get_last_error().
+		set_plugin_state(state);
 	}
 
-	set_plugin_state(state);
-
-	return true;
+	return rc == SS_PLUGIN_SUCCESS;
 }
 
 void sinsp_plugin::destroy()


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Currently, errors arising during plugins initialization are lost. This can become troublesome for debugging and development purposes. The reason is that, if initialization fails, the framework assumes that an invalid state is returned.

This PR fixes this by allowing plugins to return a non-NULL state in case of failure. If so, the initialization error could later be retrived through the `get_last_error` symbol. The state is then disposed with `destroy` as usual.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): catch errors during plugin initialization
```
