### PR TITLE
Add sinsp_extractor_plugin::id

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -891,6 +891,11 @@ sinsp_extractor_plugin::~sinsp_extractor_plugin()
 	destroy();
 }
 
+uint32_t sinsp_extractor_plugin::id()
+{
+	return m_id;
+}
+
 const std::set<std::string> &sinsp_extractor_plugin::extract_event_sources()
 {
 	return m_extract_event_sources;
@@ -942,6 +947,7 @@ bool sinsp_extractor_plugin::resolve_dylib_symbols(void *handle, std::string &er
 
 	// Others are not.
 	(*(void **) (&m_extractor_plugin_info.get_extract_event_sources)) = getsym(handle, "plugin_get_extract_event_sources", errstr);
+	(*(void **) (&(m_extractor_plugin_info.get_id)) = getsym(handle, "plugin_get_id", errstr);
 
 	if (m_extractor_plugin_info.get_extract_event_sources != NULL)
 	{
@@ -967,6 +973,15 @@ bool sinsp_extractor_plugin::resolve_dylib_symbols(void *handle, std::string &er
 
 			m_extract_event_sources.insert(root[j].asString());
 		}
+	}
+
+	if (m_extractor_plugin_info.get_id != NULL)
+	{
+		m_id = m_extractor_plugin_info.get_id();
+	}
+	else
+	{
+		m_id = 0;
 	}
 
 	return true;

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -206,7 +206,7 @@ public:
 	bool resolve_dylib_symbols(void *handle, std::string &errstr) override;
 
 	ss_plugin_type type() override { return TYPE_EXTRACTOR_PLUGIN; };
-
+	uint32_t id();
 	const std::set<std::string> &extract_event_sources();
 
 	// Return true if the provided source is compatible with this
@@ -222,4 +222,5 @@ protected:
 private:
 	extractor_plugin_info m_extractor_plugin_info;
 	std::set<std::string> m_extract_event_sources;
+	uint32_t m_id;
 };


### PR DESCRIPTION
Return the result of plugin_get_id if that symbol is present, or 0 if
not.

Signed-off-by: Gerald Combs <gerald@wireshark.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Makes extractor plugin IDs available to sinsp consumers.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
