### PR TITLE
new: add support for bcontains and bstartswith operators

### DIFF
--- a/userspace/chisel/lua_parser_api.cpp
+++ b/userspace/chisel/lua_parser_api.cpp
@@ -76,6 +76,10 @@ static cmpop string_to_cmpop(const char* str)
 	{
 		return CO_STARTSWITH;
 	}
+	else if(strcmp(str, "bstartswith") == 0)
+	{
+		return CO_BSTARTSWITH;
+	}
 	else if(strcmp(str, "endswith") == 0)
 	{
 		return CO_ENDSWITH;

--- a/userspace/chisel/lua_parser_api.cpp
+++ b/userspace/chisel/lua_parser_api.cpp
@@ -68,6 +68,10 @@ static cmpop string_to_cmpop(const char* str)
 	{
 		return CO_ICONTAINS;
 	}
+	else if(strcmp(str, "bcontains") == 0)
+	{
+		return CO_BCONTAINS;
+	}
 	else if(strcmp(str, "startswith") == 0)
 	{
 		return CO_STARTSWITH;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -90,6 +90,9 @@ bool flt_compare_uint64(cmpop op, uint64_t operand1, uint64_t operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for numeric filters");
+		return false;
 	case CO_ENDSWITH:
 		throw sinsp_exception("'endswith' not supported for numeric filters");
 		return false;
@@ -130,9 +133,12 @@ bool flt_compare_int64(cmpop op, int64_t operand1, int64_t operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
-        case CO_ENDSWITH:
-                throw sinsp_exception("'endswith' not supported for numeric filters");
-                return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for numeric filters");
+		return false;
+	case CO_ENDSWITH:
+		throw sinsp_exception("'endswith' not supported for numeric filters");
+		return false;
 	case CO_GLOB:
 		throw sinsp_exception("'glob' not supported for numeric filters");
 		return false;
@@ -168,6 +174,8 @@ bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 		throw sinsp_exception("'bcontains' not supported for string filters");
 	case CO_STARTSWITH:
 		return (strncmp(operand1, operand2, strlen(operand2)) == 0);
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for string filters");
 	case CO_ENDSWITH: 
 		return (sinsp_utils::endswith(operand1, operand2));
 	case CO_GLOB:
@@ -210,7 +218,17 @@ bool flt_compare_buffer(cmpop op, char* operand1, char* operand2, uint32_t op1_l
 		return (memmem(operand1, op1_len, &hex_bytes[0], hex_bytes.size()) != NULL);
 	}
 	case CO_STARTSWITH:
-		return (memcmp(operand1, operand2, op2_len) == 0);
+		return op2_len <= op1_len && (memcmp(operand1, operand2, op2_len) == 0);
+	case CO_BSTARTSWITH:
+	{
+		std::vector<char> hex_chars(operand2, operand2 + op2_len);
+		std::vector<char> hex_bytes;
+		if(!sinsp_utils::unhex(hex_chars, hex_bytes))
+		{
+			return false;
+		}
+		return hex_bytes.size() <= op1_len && (memcmp(operand1, &hex_bytes[0], hex_bytes.size()) == 0);
+	}
 	case CO_ENDSWITH: 
 		return (sinsp_utils::endswith(operand1, operand2, op1_len, op2_len));
 	case CO_GLOB:
@@ -258,6 +276,9 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for numeric filters");
+		return false;
 	case CO_ENDSWITH:
 		throw sinsp_exception("'endswith' not supported for numeric filters");
 		return false;
@@ -293,6 +314,9 @@ bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for numeric filters");
+		return false;
 	case CO_ENDSWITH:
 		throw sinsp_exception("'endswith' not supported for numeric filters");
 		return false;
@@ -325,6 +349,9 @@ bool flt_compare_ipv6addr(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for ipv6 addresses");
 		return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for ipv6 addresses");
+		return false;
 	case CO_GLOB:
 		throw sinsp_exception("'glob' not supported for ipv6 addresses");
 		return false;
@@ -353,6 +380,9 @@ bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for ipv6 networks");
+		return false;
+	case CO_BSTARTSWITH:
+		throw sinsp_exception("'bstartswith' not supported for ipv6 networks");
 		return false;
 	case CO_GLOB:
 		throw sinsp_exception("'glob' not supported for ipv6 networks");
@@ -1684,6 +1714,11 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 	{
 		m_scanpos += 10;
 		return CO_STARTSWITH;
+	}
+	else if(compare_no_consume("bstartswith"))
+	{
+		m_scanpos += 11;
+		return CO_BSTARTSWITH;
 	}
 	else if(compare_no_consume("endswith"))
 	{

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -84,6 +84,9 @@ bool flt_compare_uint64(cmpop op, uint64_t operand1, uint64_t operand2)
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for numeric filters");
 		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for numeric filters");
+		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
@@ -120,6 +123,9 @@ bool flt_compare_int64(cmpop op, int64_t operand1, int64_t operand2)
 		return false;
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for numeric filters");
+		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for numeric filters");
 		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
@@ -158,6 +164,8 @@ bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 #else
 		return (strcasestr(operand1, operand2) != NULL);
 #endif
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for string filters");
 	case CO_STARTSWITH:
 		return (strncmp(operand1, operand2, strlen(operand2)) == 0);
 	case CO_ENDSWITH: 
@@ -191,6 +199,16 @@ bool flt_compare_buffer(cmpop op, char* operand1, char* operand2, uint32_t op1_l
 		return (memmem(operand1, op1_len, operand2, op2_len) != NULL);
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for buffer filters");
+	case CO_BCONTAINS:
+	{
+		std::vector<char> hex_chars(operand2, operand2 + op2_len);
+		std::vector<char> hex_bytes;
+		if(!sinsp_utils::unhex(hex_chars, hex_bytes))
+		{
+			return false;
+		}
+		return (memmem(operand1, op1_len, &hex_bytes[0], hex_bytes.size()) != NULL);
+	}
 	case CO_STARTSWITH:
 		return (memcmp(operand1, operand2, op2_len) == 0);
 	case CO_ENDSWITH: 
@@ -234,6 +252,9 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for numeric filters");
 		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for numeric filters");
+		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
@@ -266,6 +287,9 @@ bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for numeric filters");
 		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for numeric filters");
+		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for numeric filters");
 		return false;
@@ -295,6 +319,9 @@ bool flt_compare_ipv6addr(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for ipv6 addresses");
 		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for ipv6 addresses");
+		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for ipv6 addresses");
 		return false;
@@ -320,6 +347,9 @@ bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 		return false;
 	case CO_ICONTAINS:
 		throw sinsp_exception("'icontains' not supported for ipv6 networks");
+		return false;
+	case CO_BCONTAINS:
+		throw sinsp_exception("'bcontains' not supported for ipv6 networks");
 		return false;
 	case CO_STARTSWITH:
 		throw sinsp_exception("'startswith' not supported for ipv6 networks");
@@ -1604,6 +1634,7 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 	//
 	start = m_scanpos;
 
+	// Maybe you can use sizeof - 1 here 
 	if(compare_no_consume("="))
 	{
 		m_scanpos += 1;
@@ -1643,6 +1674,11 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 	{
 		m_scanpos += 9;
 		return CO_ICONTAINS;
+	}
+	else if(compare_no_consume("bcontains"))
+	{
+		m_scanpos += 9;
+		return CO_BCONTAINS;
 	}
 	else if(compare_no_consume("startswith"))
 	{

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -43,6 +43,7 @@ enum cmpop {
 	CO_PMATCH = 13,
 	CO_ENDSWITH = 14,
 	CO_INTERSECTS = 15,
+	CO_BCONTAINS = 16,
 };
 
 enum boolop

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -44,6 +44,7 @@ enum cmpop {
 	CO_ENDSWITH = 14,
 	CO_INTERSECTS = 15,
 	CO_BCONTAINS = 16,
+	CO_BSTARTSWITH = 17,
 };
 
 enum boolop

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1537,6 +1537,27 @@ bool sinsp_utils::startswith(const std::string& s, const std::string& prefix)
 	return strncmp(s.c_str(), prefix.c_str(), prefix_len) == 0;
 }
 
+bool sinsp_utils::unhex(const std::vector<char> &hex_chars, std::vector<char> &hex_bytes)
+{
+	if(hex_chars.size() % 2 != 0 || 
+		!std::all_of(hex_chars.begin(), hex_chars.end(), [](unsigned char c){ return std::isxdigit(c); }))
+	{
+		return false;
+	}
+
+	std::stringstream ss;
+	for(size_t i = 0; i < hex_chars.size(); i += 2)
+	{
+		int byte;
+		ss << std::hex << hex_chars.at(i) << hex_chars.at(i + 1);
+		ss >> byte;
+		hex_bytes.push_back(byte & 0xff);
+		ss.str(std::string());
+		ss.clear();
+	}
+	
+	return true;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_numparser implementation

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -82,6 +82,11 @@ public:
 	static bool startswith(const std::string& s, const std::string& prefix);
 
 	//
+	// Transform a hex string into bytes 
+	//
+	static bool unhex(const std::vector<char> &hex_chars, std::vector<char> &hex_bytes);
+
+	//
 	// Concatenate two paths and puts the result in "target".
 	// If path2 is relative, the concatenation happens and the result is true.
 	// If path2 is absolute, the concatenation does not happen, target contains path2 and the result is false.


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR introduces two new operators called `bcontains` and `bstartswith`. They allow performing byte matching, accepting as input a hexadecimal string. 
I have tested them with variations of these rules: 
```
- rule: ELF magic 
  desc: Detect if ELF file is being sent or received through a socket by matching on the ELF magic bytes
  condition: fd.type=ipv4 and evt.type in (read, write, send, recv, sendto, recvfrom) and evt.buffer bcontains 7f454c46
  output: elf magic!!!!! %proc.name, %evt.type. %evt.buffer
  priority: WARNING 

- rule: bcontains test
  desc: test
  condition: evt.type=write and (evt.buffer bcontains 12ab001fc5 or evt.buffer bcontains 48545450)
  output:  bcontains!!!! %fd.name
  priority: WARNING 
# HTTP=48545450
# launch with sudo ./userspace/falco/falco -A -r /path/to/this/rule -S 4096
```
this little C program: 
```
int main(){
        int fd;
        const unsigned char arr[] = {0xaa,0xbb,0xcc,0x12,0xab,0x00,0x1f,0xc5};
        fd = open("A.txt", O_WRONLY);
        write(fd, arr, sizeof(arr));
        return 0;
}
```
and some HTTP requests crafted with Burpsuite and its hexadecimal editor. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/falco/issues/1837

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: introduce the bcontains and bstartswith operators for byte matching, using hex string as input
```
