### PR TITLE
update: add source plugin symbol to list suggested open parameters

### DIFF
--- a/userspace/libscap/plugin_info.h
+++ b/userspace/libscap/plugin_info.h
@@ -318,6 +318,21 @@ typedef struct
 	//
 	void (*close)(ss_plugin_t* s, ss_instance_t* h);
 	//
+	// Return a list of suggested open parameters supported by this plugin.
+	// Any of the values in the returned list are valid parameters for open().
+	// Required: no
+	// Return value: a string with the list of open params encoded as
+	//   a json array.
+	//   Each field entry is a json object with the following properties:
+	//     "value": a string usable as an open() parameter.
+	//     "desc": (optional) a string with a description of the parameter.
+	//   Example return value:
+	//   [
+	//      {"value": "resource1", "desc": "An example of openable resource"},
+	//      {"value": "resource2", "desc": "Another example of openable resource"}
+	//   ]
+	const char* (*list_open_params)(ss_plugin_t* s, ss_plugin_rc* rc);
+	//
 	// Return the read progress.
 	// Required: no
 	// Arguments:

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -166,6 +166,12 @@ private:
 class sinsp_source_plugin : public sinsp_plugin
 {
 public:
+	// Describes a valid parameter for the open() function.
+	struct open_param {
+		std::string value;
+		std::string desc;
+	};
+
 	sinsp_source_plugin();
 	virtual ~sinsp_source_plugin();
 
@@ -185,6 +191,8 @@ public:
 	std::string get_progress(uint32_t &progress_pct);
 
 	std::string event_to_string(const uint8_t *data, uint32_t datalen);
+
+	std::vector<open_param> list_open_params();
 
 protected:
 	void set_plugin_state(ss_plugin_t *state) override;


### PR DESCRIPTION
**What type of PR is this?**

/kind design

/kind documentation

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**What this PR does / why we need it**:

This adds support to an optional function symbol for source plugins named `list_open_params`. Its purpose is to allow source plugins to return a list of suggested parameters that would be accepted as valid arguments to `open()`.

An example use case might be to list the resources openable by the plugin. This can also act as a self-documentation measure to improve the UX of plugin users. Moreover, this can make the plugin more suitable for automatic tooling by obtaining valid `open()` parameters from the plugin itself without requiring human intervention.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: add source plugin symbol to list suggested open parameters
```
