### PR TITLE
fix(probe): fix clang optimization problem

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1736,14 +1736,12 @@ bpf_map_id_up_base(unsigned extents, struct uid_gid_map *map, u32 id)
 
 	#pragma unroll UID_GID_MAP_MAX_BASE_EXTENTS
 	for (idx = 0; idx < UID_GID_MAP_MAX_BASE_EXTENTS; idx++) {
-		if (idx >= extents) {
-			break;
+		if (idx < extents) {
+			first = _READ(map->extent[idx].lower_first);
+			last = first + _READ(map->extent[idx].count) - 1;
+			if (id >= first && id <= last)
+				return &map->extent[idx];
 		}
-
-		first = _READ(map->extent[idx].lower_first);
-		last = first + _READ(map->extent[idx].count) - 1;
-		if (id >= first && id <= last)
-			return &map->extent[idx];
 	}
 	return NULL;
 }


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Compiling our probe with `clang11` on `Kernel 5.8` we noticed that compiler optimizations introduce a back-edge. The back-edge is the result of the clang compilation, it can never be executed, however, the verifier detects the back-edge and rejects the probe. The change proposed in this PR prevents the compiler from generating this back-edge. 

**Future steps**

Understand which clang optimizations can cause verifier problems and remove them.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE 
```
