### PR TITLE
fix(driver): use file_inode() for file inode operations

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1149,14 +1149,16 @@ cgroups_error:
 
 		exe_file = ppm_get_mm_exe_file(mm);
 
-		if (exe_file != NULL && exe_file->f_inode != NULL) {
+		if (exe_file != NULL) {
+			if (file_inode(exe_file) != NULL) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
-			exe_writable |= (inode_permission(current_user_ns(), exe_file->f_inode, MAY_WRITE) == 0);
-			exe_writable |= inode_owner_or_capable(current_user_ns(), exe_file->f_inode);
+				exe_writable |= (inode_permission(current_user_ns(), file_inode(exe_file), MAY_WRITE) == 0);
+				exe_writable |= inode_owner_or_capable(current_user_ns(), file_inode(exe_file));
 #else
-			exe_writable |= (inode_permission(exe_file->f_inode, MAY_WRITE) == 0);
-			exe_writable |= inode_owner_or_capable(exe_file->f_inode);
+				exe_writable |= (inode_permission(file_inode(exe_file), MAY_WRITE) == 0);
+				exe_writable |= inode_owner_or_capable(file_inode(exe_file));
 #endif
+			}
 			fput(exe_file);
 		}
 


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When looking up a file inode it is tempting to just write `->f_inode` because that's how it's done in current Linux kernel versions. However, older versions have a slightly different way to do this. Fortunately we already have a function that we use to deal with this difference. Remove `f_inode` uses and use `file_inode()` instead.

In addition, this adds a double check on NULL for the inode to make sure we always `fput()`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
