### PR TITLE
new(userspace/libsinsp): added a is_plugin_loaded() API to check if desired library object is currently loaded

### DIFF
--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -102,7 +102,7 @@ public:
 	static std::list<sinsp_plugin::info> plugin_infos(sinsp *inspector);
 
 	// Return whether a filesystem object is loaded
-	static bool is_plugin_loaded(sinsp* inspector, std::string &filepath);
+	static bool is_plugin_loaded(std::string &filepath);
 
 	sinsp_plugin(sinsp_plugin_handle handle);
 	virtual ~sinsp_plugin();


### PR DESCRIPTION
`Signed-off-by: Federico Di Pierro <nierro92@gmail.com>`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

A new `is_plugin_loaded` API is exposed to check if a library object is currently loaded.  
Moreover, plugins' library handles are now dlclosed during dtor.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(userspace/libsinsp): added a is_plugin_loaded() API.
```
