### PR TITLE
chore(libsinsp): improve UX of plugin init schema validation

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -811,17 +811,8 @@ void sinsp_plugin::validate_init_config(const char* config)
 	}
 }
 
-void sinsp_plugin::validate_init_config_json_schema(std::string &config, std::string &schema)
+void sinsp_plugin::validate_init_config_json_schema(std::string config, std::string &schema)
 {
-	Json::Value configJson;
-	if(!Json::Reader().parse(config, configJson))
-	{
-		throw sinsp_exception(
-			string("error in plugin ")
-			+ name()
-			+ ": init config is not a valid json");
-	}
-
 	Json::Value schemaJson;
 	if(!Json::Reader().parse(schema, schemaJson) || schemaJson.type() != Json::objectValue)
 	{
@@ -829,6 +820,20 @@ void sinsp_plugin::validate_init_config_json_schema(std::string &config, std::st
 			string("error in plugin ")
 			+ name()
 			+ ": get_init_schema did not return a json object");
+	}
+
+	// stub empty configs to an empty json object
+	if (config.size() == 0)
+	{
+		config = "{}";
+	}
+	Json::Value configJson;
+	if(!Json::Reader().parse(config, configJson))
+	{
+		throw sinsp_exception(
+			string("error in plugin ")
+			+ name()
+			+ ": init config is not a valid json");
 	}
 	
 	// validate config with json schema

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -164,7 +164,7 @@ private:
 
 	common_plugin_info m_plugin_info;
 
-	void validate_init_config_json_schema(std::string &config, std::string &schema);
+	void validate_init_config_json_schema(std::string config, std::string &schema);
 };
 
 // Note that this doesn't have a next_batch() method, as event generation is


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This improve the UX of the init config schema automatic validation as follows:
- Parse the schema before the config string. This way, users will not get confused
  about errors coming from their configuration if the plugin has development issues.
- Stubbing empty configurations as empty json objects. This way, a default JSON value
  is always provided, and is possible to pass empty configs to plugins with all-optional
  schemas.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
