### PR TITLE
fix(udig): add fourth argument placeholder for PPME_PROCEXIT_1_E

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4377,6 +4377,9 @@ int f_sys_procexit_e(struct event_filler_arguments *args)
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	res = val_to_ring(args, 0, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+	res = val_to_ring(args, 0, 0, false, 0);
 #endif
 	if (unlikely(res != PPM_SUCCESS))
 		return res;


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>
Co-authored-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

`PPME_PROCEXIT_1_E` requires four params ( https://github.com/falcosecurity/libs/blob/5f457a366916a96aff816b809eb0b8e8a5e4961e/driver/event_table.c#L201
 ). UDIG does not really require/use them yet and so is using placeholders, but it had only 3 of them instead of the required four. At runtime this mismatch is detected and makes `pdig` crash as indicated in the corresponding issue. This PR fixes that crash.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

https://github.com/falcosecurity/pdig/issues/24

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
