### PR TITLE
fix(probe): extend support for execve flags in old kernels

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1861,7 +1861,10 @@ static __always_inline u32 bpf_map_id_up(struct uid_gid_map *map, u32 id)
 
 	if (extents <= UID_GID_MAP_MAX_BASE_EXTENTS) {
 		extent = bpf_map_id_up_base(extents, map, id);
-	} 
+	}
+	/* Kernel 4.15 increased the number of extents to `340` while all the previous kernels have 
+	 * the limit set to `5`. So the `if` case should be enough.
+	 */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))			
 	else {
 		extent = bpf_map_id_up_max(extents, map, id);

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -119,6 +119,7 @@ or GPL2.txt for full copies of the license.
 	FN(sys_mprotect_e)			\
 	FN(sys_mprotect_x)			\
 	FN(sys_execveat_e)			\
+	FN(execve_family_flags)		\
 	FN(terminate_filler)
 
 #define FILLER_ENUM_FN(x) PPM_FILLER_##x,


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Extracting the `exe_writable` flag requires several inline functions and a number of loops unrolling which lead to a bpf stack overflow in old kernels (like 4.14). The scap loader gives us this error message:

```
bpf_load_program() err=7
```  

`err 7` corresponds to the errno `E2BIG`, i.e. the bpf program is too large to be loaded, as confirmed [here](https://man7.org/linux/man-pages/man2/bpf.2.html#ERRORS) 

To solve the problem, a new bpf program `execve_family_flags` has been introduced. This is called in tail call by `proc_startupdate_3` when we need to extract flags from syscalls of the `execve` family.

 **Testing**

I have tested this new bpf feature on the following Vagrant environments:

1. Image = bento/amazonlinux-2

- Kernel = 4.14.198-152.320.amzn2.x86_64
- clang = clang version 11.1.0

2. Image = generic/debian10

- Kernel = 4.19.0-18-amd64
- clang = clang version 7.0.1-8+deb10u2

3. Image = generic/centos8

- Kernel = 4.18.0-348.2.1.el8_5.x86_64
- clang = clang version 12.0.1



**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE 
```
