### PR TITLE
new(gen_filters): port markdown function to generic filters

### DIFF
--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -399,6 +399,47 @@ void gen_event_filter_factory::filter_fieldclass_info::wrapstring(const std::str
 	}
 }
 
+std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const std::set<std::string>& event_sources)
+{
+	std::ostringstream os;
+
+	os << "## Field Class: " << name << std::endl << std::endl;
+
+	if(desc != "")
+	{
+		os << desc << std::endl << std::endl;
+	}
+
+	if(!event_sources.empty())
+	{
+		os << "Event Sources: ";
+
+		for(const auto &src : event_sources)
+		{
+			os << src << " ";
+		}
+
+		os << std::endl << std::endl;
+	}
+
+	os << "Name | Type | Description" << std::endl;
+	os << ":----|:-----|:-----------" << std::endl;
+
+	for(auto &fld_info : fields)
+	{
+		// Skip fields that should not be included
+		// (e.g. hidden fields)
+		if(fld_info.is_skippable())
+		{
+			continue;
+		}
+
+		os << "`" << fld_info.name << "` | " << fld_info.data_type << " | " << fld_info.desc << std::endl;
+	}
+
+	return os.str();
+}
+
 std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool verbose, const std::set<std::string>& event_sources)
 {
 	std::ostringstream os;

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -280,6 +280,11 @@ public:
 		// event sources, and the name and description of each field.
 		std::string as_string(bool verbose, const std::set<std::string>& event_sources = std::set<std::string>());
 
+		// Print a markdown representation of this
+		// field class, suitable for publication on the documentation
+		// website.
+		std::string as_markdown(const std::set<std::string>& event_sources = std::set<std::string>());
+
 		// How far to right-justify the name/description/etc block.
 		static uint32_t s_rightblock_start;
 


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces a replacement for `void list_fields()` with markdown format, that in turn is used to format the documentation website ( https://falco.org/docs/rules/supported-fields/ ). After merging this PR we can completely remove `list_fields()` I believe since all the relevant functionality lives in `gen_event_*` and so we can remove duplicated code.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
