### PR TITLE
Treat plugin fields like other sinsp fields (all evt types)

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -48,8 +48,6 @@ using namespace std;
 // plugin simplified field extraction implementations
 ///////////////////////////////////////////////////////////////////////////////
 
-static std::set<uint16_t> s_all_plugin_event_types = {PPME_PLUGINEVENT_E};
-
 class sinsp_filter_check_plugin : public sinsp_filter_check
 {
 public:
@@ -80,11 +78,6 @@ public:
 
 	virtual ~sinsp_filter_check_plugin()
 	{
-	}
-
-	const std::set<uint16_t> &evttypes()
-	{
-		return s_all_plugin_event_types;
 	}
 
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)


### PR DESCRIPTION
In #74 we pushed down some code from falco that determines the sinsp
event types that are applicable for a given filter. The set of event
types starts with "all events", and as the filter condition is parsed,
including logical operators like "and", "or", "not", etc, the set of
event types is changed, honoring the logical operators.

For example, for a condition proc.name=nginx, the filter is applicable
for all event types, as the condition does not include any evt.type
field. For a more complicated condition like evt.type=openat and
proc.name=nginx, the first field restricts the event types to openat,
which is logical anded against all event types from proc.name,
resulting in only the event type openat.

With the introduction of plugins, there's also a need to segregate
plugin-related filterchecks from non-plugin-related filterchecks by
event source, but that's handled at a higher level, using a notion of
filter factories and formatter factories (falcosecurity/libs#77).

The bug is that plugin filtercheck fields like ct.name, json.value
were mistakenly being restricted to only the plugin event
PPME_PLUGINEVENT_E. This was being mistakenly inverted when conditions
had a "not" operator, with the result being that they did not run on
any event types at all.

The fix is to treat plugin fields as working with all event types,
just like almost all other fields like proc.name, etc. are. This
allows the logical operators to combine event type sets properly.

This, along with other small changes in falco + plugins, fixes
https://github.com/falcosecurity/plugins/issues/56.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note

```
