### PR TITLE
libsinsp: Add support for plugin "info" and "conversation" properties.

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -48,6 +48,8 @@ typedef enum filtercheck_field_flags
 	EPF_PRINT_ONLY        = 1 << 1, ///< this field can only be printed.
 	EPF_REQUIRES_ARGUMENT = 1 << 2, ///< this field includes an argument, under the form 'property.argument'.
 	EPF_TABLE_ONLY        = 1 << 3, ///< this field is designed to be used in a table and won't appear in the field listing.
+	EPF_INFO              = 1 << 4, ///< this field contains summary information about the event.
+	EPF_CONVERSATION      = 1 << 5, ///< this field can be used to identify conversations.
 }filtercheck_field_flags;
 
 /*!

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -763,11 +763,18 @@ bool sinsp_plugin::resolve_dylib_symbols(void *handle, std::string &errstr)
 
 					const std::string &str = prop.asString();
 
-					// There might be other properties (e.g. "conversation" and "info", which are used by wireshark),
-					// but the only one that is relevant to libs is "hidden".
+					// "hidden" is used inside and outside libs. "info" and "conversation" are used outside libs.
 					if(str == "hidden")
 					{
 						tf.m_flags = (filtercheck_field_flags) ((int) tf.m_flags | (int) filtercheck_field_flags::EPF_TABLE_ONLY);
+					}
+					else if(str == "info")
+					{
+						tf.m_flags = (filtercheck_field_flags) ((int) tf.m_flags | (int) filtercheck_field_flags::EPF_INFO);
+					}
+					else if(str == "conversation")
+					{
+						tf.m_flags = (filtercheck_field_flags) ((int) tf.m_flags | (int) filtercheck_field_flags::EPF_CONVERSATION);
 					}
 				}
 			}


### PR DESCRIPTION
Add EPF_INFO and EPF_CONVERSATION to filtercheck_field_flags so that
they can be exposed via sinsp_plugin::fields().

Signed-off-by: Gerald Combs <gerald@wireshark.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Plugins might have "info" or "conversation" properties set. This exposes them via sinsp_plugin::fields().

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
