### PR TITLE
cleanup sysdig references

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -95,7 +95,7 @@ static __always_inline int __bpf_##x(struct filler_data *data)		\
 
 FILLER_RAW(terminate_filler)
 {
-	struct sysdig_bpf_per_cpu_state *state;
+	struct scap_bpf_per_cpu_state *state;
 
 	state = get_local_state(bpf_get_smp_processor_id());
 	if (!state)
@@ -2598,24 +2598,24 @@ FILLER(sys_unshare_e, true)
 
 FILLER(sys_generic, true)
 {
-	long *sysdig_id;
+	long *scap_id;
 	int native_id;
 	int res;
 
 	native_id = bpf_syscall_get_nr(data->ctx);
-	sysdig_id = bpf_map_lookup_elem(&syscall_code_routing_table, &native_id);
-	if (!sysdig_id) {
+	scap_id = bpf_map_lookup_elem(&syscall_code_routing_table, &native_id);
+	if (!scap_id) {
 		bpf_printk("no routing for syscall %d\n", native_id);
 		return PPM_FAILURE_BUG;
 	}
 
-	if (*sysdig_id == PPM_SC_UNKNOWN)
+	if (*scap_id == PPM_SC_UNKNOWN)
 		bpf_printk("no syscall for id %d\n", native_id);
 
 	/*
 	 * id
 	 */
-	res = bpf_val_to_ring(data, *sysdig_id);
+	res = bpf_val_to_ring(data, *scap_id);
 	if (res != PPM_SUCCESS)
 		return res;
 

--- a/driver/bpf/maps.h
+++ b/driver/bpf/maps.h
@@ -79,14 +79,14 @@ struct bpf_map_def __bpf_section("maps") tmp_scratch_map = {
 struct bpf_map_def __bpf_section("maps") settings_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
 	.key_size = sizeof(u32),
-	.value_size = sizeof(struct sysdig_bpf_settings),
+	.value_size = sizeof(struct scap_bpf_settings),
 	.max_entries = 1,
 };
 
 struct bpf_map_def __bpf_section("maps") local_state_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
 	.key_size = sizeof(u32),
-	.value_size = sizeof(struct sysdig_bpf_per_cpu_state),
+	.value_size = sizeof(struct scap_bpf_per_cpu_state),
 	.max_entries = 0,
 };
 

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -228,9 +228,9 @@ static __always_inline const struct ppm_event_entry *get_event_filler_info(enum 
 	return e;
 }
 
-static __always_inline struct sysdig_bpf_settings *get_bpf_settings(void)
+static __always_inline struct scap_bpf_settings *get_bpf_settings(void)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	int id = 0;
 
 	settings = bpf_map_lookup_elem(&settings_map, &id);
@@ -240,9 +240,9 @@ static __always_inline struct sysdig_bpf_settings *get_bpf_settings(void)
 	return settings;
 }
 
-static __always_inline struct sysdig_bpf_per_cpu_state *get_local_state(unsigned int cpu)
+static __always_inline struct scap_bpf_per_cpu_state *get_local_state(unsigned int cpu)
 {
-	struct sysdig_bpf_per_cpu_state *state;
+	struct scap_bpf_per_cpu_state *state;
 
 	state = bpf_map_lookup_elem(&local_state_map, &cpu);
 	if (!state)
@@ -251,7 +251,7 @@ static __always_inline struct sysdig_bpf_per_cpu_state *get_local_state(unsigned
 	return state;
 }
 
-static __always_inline bool acquire_local_state(struct sysdig_bpf_per_cpu_state *state)
+static __always_inline bool acquire_local_state(struct scap_bpf_per_cpu_state *state)
 {
 	if (state->in_use) {
 		bpf_printk("acquire_local_state: already in use\n");
@@ -262,7 +262,7 @@ static __always_inline bool acquire_local_state(struct sysdig_bpf_per_cpu_state 
 	return true;
 }
 
-static __always_inline bool release_local_state(struct sysdig_bpf_per_cpu_state *state)
+static __always_inline bool release_local_state(struct scap_bpf_per_cpu_state *state)
 {
 	if (!state->in_use) {
 		bpf_printk("release_local_state: already not in use\n");
@@ -327,9 +327,9 @@ static __always_inline int bpf_test_bit(int nr, unsigned long *addr)
 }
 
 static __always_inline bool drop_event(void *ctx,
-				       struct sysdig_bpf_per_cpu_state *state,
+				       struct scap_bpf_per_cpu_state *state,
 				       enum ppm_event_type evt_type,
-				       struct sysdig_bpf_settings *settings,
+				       struct scap_bpf_settings *settings,
 				       enum syscall_flags drop_flags)
 {
 	if (!settings->dropping_mode)
@@ -422,7 +422,7 @@ static __always_inline bool drop_event(void *ctx,
 	return false;
 }
 
-static __always_inline void reset_tail_ctx(struct sysdig_bpf_per_cpu_state *state,
+static __always_inline void reset_tail_ctx(struct scap_bpf_per_cpu_state *state,
 					   enum ppm_event_type evt_type,
 					   unsigned long long ts)
 {
@@ -437,11 +437,11 @@ static __always_inline void reset_tail_ctx(struct sysdig_bpf_per_cpu_state *stat
 static __always_inline void call_filler(void *ctx,
 					void *stack_ctx,
 					enum ppm_event_type evt_type,
-					struct sysdig_bpf_settings *settings,
+					struct scap_bpf_settings *settings,
 					enum syscall_flags drop_flags)
 {
 	const struct ppm_event_entry *filler_info;
-	struct sysdig_bpf_per_cpu_state *state;
+	struct scap_bpf_per_cpu_state *state;
 	unsigned long long pid;
 	unsigned long long ts;
 	unsigned int cpu;

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -36,7 +36,7 @@ int bpf_##event(struct type *ctx)
 BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)
 {
 	const struct syscall_evt_pair *sc_evt;
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 	int drop_flags;
 	long id;
@@ -88,7 +88,7 @@ BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)
 BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 {
 	const struct syscall_evt_pair *sc_evt;
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 	int drop_flags;
 	long id;
@@ -128,7 +128,7 @@ BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 
 BPF_PROBE("sched/", sched_process_exit, sched_process_exit_args)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 	struct task_struct *task;
 	unsigned int flags;
@@ -154,7 +154,7 @@ BPF_PROBE("sched/", sched_process_exit, sched_process_exit_args)
 
 BPF_PROBE("sched/", sched_switch, sched_switch_args)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 
 	settings = get_bpf_settings();
@@ -172,7 +172,7 @@ BPF_PROBE("sched/", sched_switch, sched_switch_args)
 
 static __always_inline int bpf_page_fault(struct page_fault_args *ctx)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 
 	settings = get_bpf_settings();
@@ -203,7 +203,7 @@ BPF_PROBE("exceptions/", page_fault_kernel, page_fault_args)
 
 BPF_PROBE("signal/", signal_deliver, signal_deliver_args)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 
 	settings = get_bpf_settings();
@@ -223,7 +223,7 @@ BPF_PROBE("signal/", signal_deliver, signal_deliver_args)
 __bpf_section(TP_NAME "sched/sched_process_fork")
 int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
 {
-	struct sysdig_bpf_settings *settings;
+	struct scap_bpf_settings *settings;
 	enum ppm_event_type evt_type;
 	struct sys_stash_args args;
 	unsigned long *argsp;

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -81,7 +81,7 @@ static __always_inline int push_evt_frame(void *ctx,
 		 *
 		 * Schedule a hotplug event on CPU 0
 		 */
-		struct sysdig_bpf_per_cpu_state *state = get_local_state(0);
+		struct scap_bpf_per_cpu_state *state = get_local_state(0);
 
 		if (!state)
 			return PPM_FAILURE_BUG;

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -131,8 +131,8 @@ struct sys_stash_args {
 
 struct filler_data {
 	void *ctx;
-	struct sysdig_bpf_settings *settings;
-	struct sysdig_bpf_per_cpu_state *state;
+	struct scap_bpf_settings *settings;
+	struct scap_bpf_per_cpu_state *state;
 	char *tmp_scratch;
 	const struct ppm_event_info *evt;
 	const struct ppm_event_entry *filler_info;
@@ -171,23 +171,23 @@ struct perf_event_sample {
 
 #endif /* __KERNEL__ */
 
-enum sysdig_map_types {
-	SYSDIG_PERF_MAP = 0,
-	SYSDIG_TAIL_MAP = 1,
-	SYSDIG_SYSCALL_CODE_ROUTING_TABLE = 2,
-	SYSDIG_SYSCALL_TABLE = 3,
-	SYSDIG_EVENT_INFO_TABLE = 4,
-	SYSDIG_FILLERS_TABLE = 5,
-	SYSDIG_FRAME_SCRATCH_MAP = 6,
-	SYSDIG_TMP_SCRATCH_MAP = 7,
-	SYSDIG_SETTINGS_MAP = 8,
-	SYSDIG_LOCAL_STATE_MAP = 9,
+enum scap_map_types {
+	SCAP_PERF_MAP = 0,
+	SCAP_TAIL_MAP = 1,
+	SCAP_SYSCALL_CODE_ROUTING_TABLE = 2,
+	SCAP_SYSCALL_TABLE = 3,
+	SCAP_EVENT_INFO_TABLE = 4,
+	SCAP_FILLERS_TABLE = 5,
+	SCAP_FRAME_SCRATCH_MAP = 6,
+	SCAP_TMP_SCRATCH_MAP = 7,
+	SCAP_SETTINGS_MAP = 8,
+	SCAP_LOCAL_STATE_MAP = 9,
 #ifndef BPF_SUPPORTS_RAW_TRACEPOINTS
-	SYSDIG_STASH_MAP = 10,
+	SCAP_STASH_MAP = 10,
 #endif
 };
 
-struct sysdig_bpf_settings {
+struct scap_bpf_settings {
 	uint64_t boot_time;
 	void *socket_file_ops;
 	uint32_t snaplen;
@@ -212,7 +212,7 @@ struct tail_context {
 	int prev_res;
 } __attribute__((packed));
 
-struct sysdig_bpf_per_cpu_state {
+struct scap_bpf_per_cpu_state {
 	struct tail_context tail_ctx;
 	unsigned long long n_evts;
 	unsigned long long n_drops_buffer;

--- a/driver/main.c
+++ b/driver/main.c
@@ -2385,15 +2385,15 @@ static int do_cpu_callback(unsigned long cpu, long sd_action)
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
-static int sysdig_cpu_online(unsigned int cpu)
+static int scap_cpu_online(unsigned int cpu)
 {
-	vpr_info("sysdig_cpu_online on cpu %d\n", cpu);
+	vpr_info("scap_cpu_online on cpu %d\n", cpu);
 	return do_cpu_callback(cpu, 1);
 }
 
-static int sysdig_cpu_offline(unsigned int cpu)
+static int scap_cpu_offline(unsigned int cpu)
 {
-	vpr_info("sysdig_cpu_offline on cpu %d\n", cpu);
+	vpr_info("scap_cpu_offline on cpu %d\n", cpu);
 	return do_cpu_callback(cpu, 2);
 }
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)) */
@@ -2435,7 +2435,7 @@ static struct notifier_block cpu_notifier = {
 };
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) */
 
-int sysdig_init(void)
+int scap_init(void)
 {
 	dev_t dev;
 	unsigned int cpu;
@@ -2550,9 +2550,9 @@ int sysdig_init(void)
 	 */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0))
 	hp_ret = cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE_DYN,
-					   "sysdig/probe:online",
-					   sysdig_cpu_online,
-					   sysdig_cpu_offline);
+					   "scap/probe:online",
+					   scap_cpu_online,
+					   scap_cpu_offline);
 	if (hp_ret <= 0) {
 		pr_err("error registering cpu hotplug callback\n");
 		ret = hp_ret;
@@ -2593,7 +2593,7 @@ init_module_err:
 	return ret;
 }
 
-void sysdig_exit(void)
+void scap_exit(void)
 {
 	int j;
 
@@ -2629,8 +2629,8 @@ void sysdig_exit(void)
 #endif
 }
 
-module_init(sysdig_init);
-module_exit(sysdig_exit);
+module_init(scap_init);
+module_exit(scap_exit);
 MODULE_VERSION(PROBE_VERSION);
 
 module_param(max_consumers, uint, 0444);

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -310,10 +310,10 @@ static int32_t load_maps(scap_t *handle, struct bpf_map_data *maps, int nr_maps)
 
 	for(j = 0; j < nr_maps; ++j)
 	{
-		if(j == SYSDIG_PERF_MAP ||
-		   j == SYSDIG_LOCAL_STATE_MAP ||
-		   j == SYSDIG_FRAME_SCRATCH_MAP ||
-		   j == SYSDIG_TMP_SCRATCH_MAP)
+		if(j == SCAP_PERF_MAP ||
+		   j == SCAP_LOCAL_STATE_MAP ||
+		   j == SCAP_FRAME_SCRATCH_MAP ||
+		   j == SCAP_TMP_SCRATCH_MAP)
 		{
 			maps[j].def.max_entries = handle->m_ncpus;
 		}
@@ -756,14 +756,14 @@ static int32_t populate_syscall_routing_table_map(scap_t *handle)
 	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
 	{
 		long code = g_syscall_code_routing_table[j];
-		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SYSCALL_CODE_ROUTING_TABLE], &j, &code, BPF_ANY) != 0)
+		if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SYSCALL_CODE_ROUTING_TABLE], &j, &code, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SYSCALL_CODE_ROUTING_TABLE bpf_map_update_elem < 0");
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SYSCALL_CODE_ROUTING_TABLE bpf_map_update_elem < 0");
 			return SCAP_FAILURE;
 		}
 	}
 
-	return bpf_map_freeze(handle->m_bpf_map_fds[SYSDIG_SYSCALL_CODE_ROUTING_TABLE]);
+	return bpf_map_freeze(handle->m_bpf_map_fds[SCAP_SYSCALL_CODE_ROUTING_TABLE]);
 }
 
 static int32_t populate_syscall_table_map(scap_t *handle)
@@ -779,9 +779,9 @@ static int32_t populate_syscall_table_map(scap_t *handle)
 			p = &uninterested_pair;
 		}
 
-		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SYSCALL_TABLE], &j, p, BPF_ANY) != 0)
+		if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SYSCALL_TABLE], &j, p, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SYSCALL_TABLE bpf_map_update_elem < 0");
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SYSCALL_TABLE bpf_map_update_elem < 0");
 			return SCAP_FAILURE;
 		}
 	}
@@ -796,14 +796,14 @@ static int32_t populate_event_table_map(scap_t *handle)
 	for(j = 0; j < PPM_EVENT_MAX; ++j)
 	{
 		const struct ppm_event_info *e = &g_event_info[j];
-		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_EVENT_INFO_TABLE], &j, e, BPF_ANY) != 0)
+		if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_EVENT_INFO_TABLE], &j, e, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_EVENT_INFO_TABLE bpf_map_update_elem < 0");
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_EVENT_INFO_TABLE bpf_map_update_elem < 0");
 			return SCAP_FAILURE;
 		}
 	}
 
-	return bpf_map_freeze(handle->m_bpf_map_fds[SYSDIG_EVENT_INFO_TABLE]);
+	return bpf_map_freeze(handle->m_bpf_map_fds[SCAP_EVENT_INFO_TABLE]);
 }
 
 static int32_t populate_fillers_table_map(scap_t *handle)
@@ -813,9 +813,9 @@ static int32_t populate_fillers_table_map(scap_t *handle)
 	for(j = 0; j < PPM_EVENT_MAX; ++j)
 	{
 		const struct ppm_event_entry *e = &g_ppm_events[j];
-		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_FILLERS_TABLE], &j, e, BPF_ANY) != 0)
+		if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_FILLERS_TABLE], &j, e, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_FILLERS_TABLE bpf_map_update_elem < 0");
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_FILLERS_TABLE bpf_map_update_elem < 0");
 			return SCAP_FAILURE;
 		}
 	}
@@ -829,7 +829,7 @@ static int32_t populate_fillers_table_map(scap_t *handle)
 		}
 	}
 
-	return bpf_map_freeze(handle->m_bpf_map_fds[SYSDIG_FILLERS_TABLE]);
+	return bpf_map_freeze(handle->m_bpf_map_fds[SCAP_FILLERS_TABLE]);
 }
 
 //
@@ -852,19 +852,19 @@ static int32_t calibrate_socket_file_ops()
 
 int32_t scap_bpf_start_capture(scap_t *handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.capture_enabled = true;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -880,19 +880,19 @@ int32_t scap_bpf_start_capture(scap_t *handle)
 
 int32_t scap_bpf_stop_capture(scap_t *handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.capture_enabled = false;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -901,7 +901,7 @@ int32_t scap_bpf_stop_capture(scap_t *handle)
 
 int32_t scap_bpf_set_snaplen(scap_t* handle, uint32_t snaplen)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
 	if(snaplen > RW_MAX_SNAPLEN)
@@ -910,16 +910,16 @@ int32_t scap_bpf_set_snaplen(scap_t* handle, uint32_t snaplen)
 		return SCAP_FAILURE;
 	}
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.snaplen = snaplen;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -928,20 +928,20 @@ int32_t scap_bpf_set_snaplen(scap_t* handle, uint32_t snaplen)
 
 int32_t scap_bpf_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.fullcapture_port_range_start = range_start;
 	settings.fullcapture_port_range_end = range_end;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -950,20 +950,20 @@ int32_t scap_bpf_set_fullcapture_port_range(scap_t* handle, uint16_t range_start
 
 int32_t scap_bpf_set_statsd_port(scap_t* const handle, const uint16_t port)
 {
-	struct sysdig_bpf_settings settings = {};
+	struct scap_bpf_settings settings = {};
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.statsd_port = port;
 
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -972,19 +972,19 @@ int32_t scap_bpf_set_statsd_port(scap_t* const handle, const uint16_t port)
 
 int32_t scap_bpf_disable_dynamic_snaplen(scap_t* handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.do_dynamic_snaplen = false;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1009,20 +1009,20 @@ int32_t scap_bpf_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 			return SCAP_FAILURE;
 	}
 
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.sampling_ratio = sampling_ratio;
 	settings.dropping_mode = true;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1031,20 +1031,20 @@ int32_t scap_bpf_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 
 int32_t scap_bpf_stop_dropping_mode(scap_t* handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.sampling_ratio = 1;
 	settings.dropping_mode = false;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1053,19 +1053,19 @@ int32_t scap_bpf_stop_dropping_mode(scap_t* handle)
 
 int32_t scap_bpf_enable_dynamic_snaplen(scap_t* handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.do_dynamic_snaplen = true;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1074,19 +1074,19 @@ int32_t scap_bpf_enable_dynamic_snaplen(scap_t* handle)
 
 int32_t scap_bpf_enable_page_faults(scap_t* handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.page_faults = true;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1095,19 +1095,19 @@ int32_t scap_bpf_enable_page_faults(scap_t* handle)
 
 int32_t scap_bpf_enable_tracers_capture(scap_t* handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 	int k = 0;
 
-	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings) != 0)
+	if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_lookup_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_lookup_elem < 0");
 		return SCAP_FAILURE;
 	}
 
 	settings.tracers_enabled = true;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1274,7 +1274,7 @@ static int32_t set_runtime_params(scap_t *handle)
 
 static int32_t set_default_settings(scap_t *handle)
 {
-	struct sysdig_bpf_settings settings;
+	struct scap_bpf_settings settings;
 
 	if(set_boot_time(handle, &settings.boot_time) != SCAP_SUCCESS)
 	{
@@ -1295,9 +1295,9 @@ static int32_t set_default_settings(scap_t *handle)
 	settings.statsd_port = 8125;
 
 	int k = 0;
-	if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
+	if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings, BPF_ANY) != 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SETTINGS_MAP bpf_map_update_elem < 0");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_SETTINGS_MAP bpf_map_update_elem < 0");
 		return SCAP_FAILURE;
 	}
 
@@ -1410,9 +1410,9 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 
 		handle->m_devs[online_cpu].m_fd = pmu_fd;
 
-		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_PERF_MAP], &j, &pmu_fd, BPF_ANY) != 0)
+		if(bpf_map_update_elem(handle->m_bpf_map_fds[SCAP_PERF_MAP], &j, &pmu_fd, BPF_ANY) != 0)
 		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_PERF_MAP bpf_map_update_elem < 0: %s", scap_strerror(handle, errno));
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SCAP_PERF_MAP bpf_map_update_elem < 0: %s", scap_strerror(handle, errno));
 			return SCAP_FAILURE;
 		}
 
@@ -1455,8 +1455,8 @@ int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
 
 	for(j = 0; j < handle->m_ncpus; j++)
 	{
-		struct sysdig_bpf_per_cpu_state v;
-		if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_LOCAL_STATE_MAP], &j, &v))
+		struct scap_bpf_per_cpu_state v;
+		if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_LOCAL_STATE_MAP], &j, &v))
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Error looking up local state %d\n", j);
 			return SCAP_FAILURE;
@@ -1481,8 +1481,8 @@ int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret)
 
 	for(j = 0; j < handle->m_ncpus; j++)
 	{
-		struct sysdig_bpf_per_cpu_state v;
-		if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SYSDIG_LOCAL_STATE_MAP], &j, &v))
+		struct scap_bpf_per_cpu_state v;
+		if(bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_LOCAL_STATE_MAP], &j, &v))
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Error looking up local state %d\n", j);
 			return SCAP_FAILURE;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

/area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

**What this PR does / why we need it**:
Removing useless references to Sysdig in kernel module, bpf probe and libscap

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
