### PR TITLE
Include linux/compat.h before net/compat.h

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -9,6 +9,7 @@ or GPL2.txt for full copies of the license.
 #ifndef __SYSDIGBPF_HELPERS_H
 #define __SYSDIGBPF_HELPERS_H
 
+#include <linux/compat.h>
 #include <net/compat.h>
 #include <net/sock.h>
 #include <net/inet_sock.h>


### PR DESCRIPTION
When attempting to build the eBPF probe in a kernel development
environment with the config parameter CONFIG_COMPAT=no, the compile
of filler_helpers.h fails due to unknown types in net/compat.h
There is a kernel patch available to fix this problem:
- https://patches.linaro.org/project/netdev/patch/20201121214844.1488283-1-kuba@kernel.org/

But for environments where this patch is not available (such as
RHEL8 on ARM processors), we can work around this problem by
explicitly including linux/compat.h before net/compat.h, where
it is needed.

Signed-off-by: Joseph Pittman <joseph.pittman@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

/area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Allows eBPF probe to be built on systems with CONFIG_COMPAT=no, and without
a recent kernel patch.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
