### PR TITLE
new(build): sets FALCOSECURITY_LIBS_VERSION on the checked-out git ref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,28 @@ option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
 list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+include(GetGitRevisionDescription)
+
 if(NOT DEFINED FALCOSECURITY_LIBS_VERSION)
-	set(FALCOSECURITY_LIBS_VERSION "0.1.1dev")
+	# Try to obtain the exact git tag
+	git_get_exact_tag(LIBS_TAG)
+	if(NOT LIBS_TAG)
+		# Obtain the closest tag
+		git_describe(FALCOSECURITY_LIBS_VERSION "--always" "--tags" "--abbrev=7")
+		# Fallback version
+		if(FALCOSECURITY_LIBS_VERSION MATCHES "NOTFOUND$")
+			set(FALCOSECURITY_LIBS_VERSION "0.1.1dev")
+		endif()
+		# Format FALCOSECURITY_LIBS_VERSION to be semver with prerelease and build part
+		string(REPLACE "-g" "+" FALCOSECURITY_LIBS_VERSION "${FALCOSECURITY_LIBS_VERSION}")
+	else()
+		# A tag has been found: use it as the Falco version
+		set(FALCOSECURITY_LIBS_VERSION "${LIBS_TAG}")
+	endif()
 endif()
+
+# Remove the starting "v" in case there is one
+string(REGEX REPLACE "^v(.*)" "\\1" FALCOSECURITY_LIBS_VERSION "${FALCOSECURITY_LIBS_VERSION}")
 
 if(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE Release)

--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -1,0 +1,170 @@
+
+# * Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can trust the values of the variables in your
+# build system.
+#
+# get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+# git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting the output so that it tests false if an error
+# occurs.
+#
+# git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree, and adjusting the output so that it tests false
+# if there was no exact matching tag.
+#
+# git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes. Uses the return code of "git diff-index --quiet
+# HEAD --". Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author: 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net> http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010. Distributed under the Boost Software License, Version 1.0. (See
+# accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+    return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time, to find the path to this module rather than
+# the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+    set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+    while(NOT EXISTS "${GIT_DIR}") # .git dir not found, search parent directories
+        set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+        get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+        if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+            # We have reached the root directory, we are not in git
+            set(${_refspecvar}
+                    "GITDIR-NOTFOUND"
+                    PARENT_SCOPE)
+            set(${_hashvar}
+                    "GITDIR-NOTFOUND"
+                    PARENT_SCOPE)
+            return()
+        endif()
+        set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+    endwhile()
+    # check if this is a submodule
+    if(NOT IS_DIRECTORY ${GIT_DIR})
+        file(READ ${GIT_DIR} submodule)
+        string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+        get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+        get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+    endif()
+    set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+    if(NOT EXISTS "${GIT_DATA}")
+        file(MAKE_DIRECTORY "${GIT_DATA}")
+    endif()
+
+    if(NOT EXISTS "${GIT_DIR}/HEAD")
+        return()
+    endif()
+    set(HEAD_FILE "${GIT_DATA}/HEAD")
+    configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+    configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in" "${GIT_DATA}/grabRef.cmake" @ONLY)
+    include("${GIT_DATA}/grabRef.cmake")
+
+    set(${_refspecvar}
+            "${HEAD_REF}"
+            PARENT_SCOPE)
+    set(${_hashvar}
+            "${HEAD_HASH}"
+            PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+                "GIT-NOTFOUND"
+                PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+                "HEAD-HASH-NOTFOUND"
+                PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(COMMAND
+            "${GIT_EXECUTABLE}"
+            describe
+            ${hash}
+            ${ARGN}
+            WORKING_DIRECTORY
+            "${CMAKE_CURRENT_SOURCE_DIR}"
+            RESULT_VARIABLE
+            res
+            OUTPUT_VARIABLE
+            out
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var}
+            "${out}"
+            PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+    git_describe(out --exact-match ${ARGN})
+    set(${_var}
+            "${out}"
+            PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+                "GIT-NOTFOUND"
+                PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+                "HEAD-HASH-NOTFOUND"
+                PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+            COMMAND "${GIT_EXECUTABLE}" diff-index --quiet HEAD --
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            RESULT_VARIABLE res
+            OUTPUT_VARIABLE out
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(res EQUAL 0)
+        set(${_var}
+                "CLEAN"
+                PARENT_SCOPE)
+    else()
+        set(${_var}
+                "DIRTY"
+                PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/modules/GetGitRevisionDescription.cmake.in
+++ b/cmake/modules/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()


### PR DESCRIPTION
Signed-off-by: Andrea Bonanno <andrea@bonanno.cloud>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently, FALCOSECURITY_LIBS_VERSION defaults to a "fake" version.
Considering the possibility to start applying versioning to libs, this features automatically populate FALCOSECURITY_LIBS_VERSION based on the checked-out git ref (commit or tag).

**Which issue(s) this PR fixes**:
Fixes #139 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

This feature leverages on the sam the [same cmake modules ](https://github.com/falcosecurity/falco/blob/master/cmake/modules/GetFalcoVersion.cmake) already used for Falco.

Test has been run via the creation of git tags on a local repo, and the script correctly populate FALCOSCURITY_LIBS_VERSION with the tag (or twith the commit abbreviated hash if a tag cannot be found).

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
