### PR TITLE
wip: update: extend PT_CHARBUFARRAY param type and support it in plugins

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1410,7 +1410,7 @@ enum ppm_param_type {
 	PT_GID = 32, /* this is an UINT32, MAX_UINT32 will be interpreted as no value. */
 	PT_DOUBLE = 33, /* this is a double precision floating point number. */
 	PT_SIGSET = 34, /* sigset_t. I only store the lower UINT32 of it */
-	PT_CHARBUFARRAY = 35,	/* Pointer to an array of strings, exported by the user events decoder. 64bit. For internal use only. */
+	PT_CHARBUFARRAY = 35,	/* Pointer to an array of strings. 64bit. Used internally and in plugins filterchecks. */
 	PT_CHARBUF_PAIR_ARRAY = 36,	/* Pointer to an array of string pairs, exported by the user events decoder. 64bit. For internal use only. */
 	PT_IPV4NET = 37, /* An IPv4 network. */
 	PT_IPV6ADDR = 38, /* A 16 byte raw IPv6 address. */

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -194,6 +194,9 @@ uint32_t lua_cbacks::rawval_to_lua_stack(lua_State *ls, uint8_t* rawval, ppm_par
 				}
 			}
 			break;
+		case PT_CHARBUFARRAY:
+			ASSERT(false);
+			return 0;
 		default:
 			ASSERT(false);
 			string err = "wrong event type " + to_string((long long) ptype);

--- a/userspace/libscap/plugin_info.h
+++ b/userspace/libscap/plugin_info.h
@@ -134,7 +134,12 @@ typedef struct ss_plugin_event
 //   by the plugin.
 // - res_u64: if the corresponding field was type==uint64, this should be
 //   filled in with the uint64 value.
-
+// - res_str_list/res_str_list_len: if the corresponding field was
+//   type==string[], res_str_list should be filled with a pointer to an array
+//   of char pointers, each of them containing a string value.
+//   res_str_list_len sould be filled with the length of the array.
+//   The memory referenced by the pointers must be allocated and owned by
+//   the plugin.
 typedef struct ss_plugin_extract_field
 {
 	uint32_t field_id;
@@ -145,6 +150,8 @@ typedef struct ss_plugin_extract_field
 	bool field_present;
 	const char* res_str;
 	uint64_t res_u64;
+	const char** res_str_list;
+	uint32_t res_str_list_len;
 } ss_plugin_extract_field;
 
 //

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1659,15 +1659,15 @@ cmpop sinsp_filter_compiler::next_comparison_operator()
 		m_scanpos += 4;
 		return CO_GLOB;
 	}
-	else if(compare_no_consume("in"))
-	{
-		m_scanpos += 2;
-		return CO_IN;
-	}
 	else if(compare_no_consume("intersects"))
 	{
 		m_scanpos += 10;
 		return CO_INTERSECTS;
+	}
+	else if(compare_no_consume("in"))
+	{
+		m_scanpos += 2;
+		return CO_IN;
 	}
 	else if(compare_no_consume("pmatch"))
 	{

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -81,6 +81,8 @@ public:
 		bool field_present;
 		std::string res_str;
 		uint64_t res_u64;
+		const char** res_str_list;
+		uint32_t res_str_list_len;
 	};
 
 	// Create and register a plugin from a shared library pointed

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -109,6 +109,9 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			parsed_len = sizeof(uint64_t);
 			break;
 		case PT_CHARBUF:
+		// this function is invoked for each element of a list,
+		// so this is the same as a charbuf
+		case PT_CHARBUFARRAY:
 		case PT_SOCKADDR:
 		case PT_SOCKFAMILY:
 		case PT_FSPATH:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**What this PR does / why we need it**:

The event parameter type `PT_CHARBUFARRAY` was defined but only used internally. Now, code it has been changed to be fully supported like the other parameter types.

`PT_CHARBUFARRAY` represents a list of one or more strings. Although not fully documented, this was already supported by Falco with the k8s audit log filter checks. Now, this needs to be supported natively in libsinsp in order to allow plugins to use list filtercheck types too. Morover, libsinp is also the right place as it bundles the logic for all the other
event parameter types.

Filterchecks of type `PT_CHARBUFARRAY` only support list-based operators: `in`, `intersects`, and `pmatch`. Using it with other operators leads to an error.

If formatted as a string, the output is a list such as `"(item1,item2,...,itemN)"`. This is not safe for
string escaping, and creates an ambiguity on the `,` separator character. However, this is how Falco implemented
this already, and I reported it faithfully for backward compatibility. If formatted as a json, the output is a json-formatted list.

The plugin API has been updated to support a new `string[]` extraction field type.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: extend PT_CHARBUFARRAY param type and support it in plugins
```
