### PR TITLE
Driver API versioning fixes

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -783,10 +783,16 @@ cleanup_ioctl_procinfo:
 		ret = 0;
 		goto cleanup_ioctl_nolock;
 	} else if (cmd == PPM_IOCTL_GET_API_VERSION) {
-		ret = PPM_API_CURRENT_VERSION;
+		unsigned long long __user *out = (unsigned long long __user *) arg;
+		ret = 0;
+		if(put_user(PPM_API_CURRENT_VERSION, out))
+			ret = -EINVAL;
 		goto cleanup_ioctl_nolock;
 	} else if (cmd == PPM_IOCTL_GET_SCHEMA_VERSION) {
-		ret = PPM_SCHEMA_CURRENT_VERSION;
+		unsigned long long __user *out = (unsigned long long __user *) arg;
+		ret = 0;
+		if(put_user(PPM_SCHEMA_CURRENT_VERSION, out))
+			ret = -EINVAL;
 		goto cleanup_ioctl_nolock;
 	}
 

--- a/driver/ppm_api_version.h
+++ b/driver/ppm_api_version.h
@@ -11,16 +11,19 @@
  * bits 0-23: patch version
  */
 
+#define PPM_VERSION_PACK(val, bits, shift) ((((unsigned long long)(val)) & ((1ULL << (bits)) - 1)) << (shift))
+#define PPM_VERSION_UNPACK(val, bits, shift) ((((unsigned long long)(val)) >> (shift)) & ((1ULL << (bits)) - 1))
+
 /* extract components from an API version number */
-#define PPM_API_VERSION_MAJOR(ver) ((((ver) >> 44)) & (((1 << 19) - 1)))
-#define PPM_API_VERSION_MINOR(ver) (((ver) >> 24) & (((1 << 20) - 1)))
-#define PPM_API_VERSION_PATCH(ver) (((ver) & ((1 << 24) - 1)))
+#define PPM_API_VERSION_MAJOR(ver) PPM_VERSION_UNPACK(ver, 19, 44)
+#define PPM_API_VERSION_MINOR(ver) PPM_VERSION_UNPACK(ver, 20, 24)
+#define PPM_API_VERSION_PATCH(ver) PPM_VERSION_UNPACK(ver, 24, 0)
 
 /* build an API version number from components */
 #define PPM_API_VERSION(major, minor, patch) \
-	(((major) & (((1ULL << 19) - 1) << 44)) | \
-	((minor) & (((1ULL << 20) - 1) << 24)) | \
-	((major) & (((1ULL << 24) - 1))))
+	PPM_VERSION_PACK(major, 19, 44) | \
+	PPM_VERSION_PACK(minor, 20, 24) | \
+	PPM_VERSION_PACK(patch, 24, 0)
 
 #define PPM_API_CURRENT_VERSION PPM_API_VERSION( \
 	PPM_API_CURRENT_VERSION_MAJOR, \

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -431,8 +431,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 			}
 
 			// Check the API version reported
-			api_version = ioctl(handle->m_devs[j].m_fd, PPM_IOCTL_GET_API_VERSION, 0);
-			if ((int64_t)api_version < 0)
+			if (ioctl(handle->m_devs[j].m_fd, PPM_IOCTL_GET_API_VERSION, &api_version) < 0)
 			{
 				snprintf(error, SCAP_LASTERR_SIZE, "Kernel module does not support PPM_IOCTL_GET_API_VERSION");
 				close(handle->m_devs[j].m_fd);
@@ -462,8 +461,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 			handle->m_api_version = api_version;
 
 			// Check the schema version reported
-			schema_version = ioctl(handle->m_devs[j].m_fd, PPM_IOCTL_GET_SCHEMA_VERSION, 0);
-			if ((int64_t)schema_version < 0)
+			if (ioctl(handle->m_devs[j].m_fd, PPM_IOCTL_GET_SCHEMA_VERSION, &schema_version) < 0)
 			{
 				snprintf(error, SCAP_LASTERR_SIZE, "Kernel module does not support PPM_IOCTL_GET_SCHEMA_VERSION");
 				close(handle->m_devs[j].m_fd);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -443,7 +443,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 			// Make sure all devices report the same API version
 			if (handle->m_api_version != 0 && handle->m_api_version != api_version)
 			{
-				snprintf(error, SCAP_LASTERR_SIZE, "API version mismatch: device %s reports API version %lu.%lu.%lu, expected %lu.%lu.%lu",
+				snprintf(error, SCAP_LASTERR_SIZE, "API version mismatch: device %s reports API version %llu.%llu.%llu, expected %llu.%llu.%llu",
 					filename,
 					PPM_API_VERSION_MAJOR(api_version),
 					PPM_API_VERSION_MINOR(api_version),
@@ -474,7 +474,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 			// Make sure all devices report the same schema version
 			if (handle->m_schema_version != 0 && handle->m_schema_version != schema_version)
 			{
-				snprintf(error, SCAP_LASTERR_SIZE, "Schema version mismatch: device %s reports schema version %lu.%lu.%lu, expected %lu.%lu.%lu",
+				snprintf(error, SCAP_LASTERR_SIZE, "Schema version mismatch: device %s reports schema version %llu.%llu.%llu, expected %llu.%llu.%llu",
 					filename,
 					PPM_API_VERSION_MAJOR(schema_version),
 					PPM_API_VERSION_MINOR(schema_version),
@@ -557,7 +557,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 
 	if(!scap_is_api_compatible(handle->m_api_version, SCAP_MINIMUM_DRIVER_API_VERSION))
 	{
-		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports API version %lu.%lu.%lu, but running version needs %d.%d.%d",
+		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports API version %llu.%llu.%llu, but running version needs %d.%d.%d",
 			PPM_API_VERSION_MAJOR(handle->m_api_version),
 			PPM_API_VERSION_MINOR(handle->m_api_version),
 			PPM_API_VERSION_PATCH(handle->m_api_version),
@@ -571,7 +571,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 
 	if(!scap_is_api_compatible(handle->m_schema_version, SCAP_MINIMUM_DRIVER_SCHEMA_VERSION))
 	{
-		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports schema version %lu.%lu.%lu, but running version needs %d.%d.%d",
+		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports schema version %llu.%llu.%llu, but running version needs %d.%d.%d",
 			PPM_API_VERSION_MAJOR(handle->m_schema_version),
 			PPM_API_VERSION_MINOR(handle->m_schema_version),
 			PPM_API_VERSION_PATCH(handle->m_schema_version),

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -22,13 +22,14 @@ if(NOT MINIMAL_BUILD)
 endif() # MINIMAL_BUILD
 
 include_directories("..")
-include_directories(${LIBSCAP_INCLUDE_DIR})
+include_directories(${LIBSCAP_INCLUDE_DIR} ${LIBSCAP_DIR}/driver)
 
 set(LIBSINSP_UNIT_TESTS_SOURCES
 	cgroup_list_counter.ut.cpp
 	sinsp.ut.cpp
 	evttype_filter.ut.cpp
 	token_bucket.ut.cpp
+	ppm_api_version.ut.cpp
 )
 
 if(NOT MINIMAL_BUILD)

--- a/userspace/libsinsp/test/ppm_api_version.ut.cpp
+++ b/userspace/libsinsp/test/ppm_api_version.ut.cpp
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest.h>
+#include <ppm_api_version.h>
+
+TEST(api_version, unpack)
+{
+	uint64_t ver1_2_3 = (1ULL << 44) | (2ULL << 24) | 3;
+	ASSERT_EQ(ver1_2_3, PPM_API_VERSION(1, 2, 3));
+}
+
+TEST(api_version, pack)
+{
+	uint64_t ver1_2_3 = (1ULL << 44) | (2ULL << 24) | 3;
+	EXPECT_EQ(1u, PPM_API_VERSION_MAJOR(ver1_2_3));
+	EXPECT_EQ(2u, PPM_API_VERSION_MINOR(ver1_2_3));
+	EXPECT_EQ(3u, PPM_API_VERSION_PATCH(ver1_2_3));
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The driver API versioning PR (https://github.com/falcosecurity/libs/pull/39) got a few important things wrong:
* the bit-twiddling calculations were completely wrong and also had a copy-paste error
* the value returned from the new ioctls in kmod was truncated to 32 bits and effectively useless
 
 This PR fixes them.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
