### PR TITLE
ipv6net cidr filtering

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -249,7 +249,7 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 	}
 }
 
-bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
+bool flt_compare_ipv4net(cmpop op, uint64_t operand1, const ipv4net* operand2)
 {
 	switch(op)
 	{
@@ -306,15 +306,15 @@ bool flt_compare_ipv6addr(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 	}
 }
 
-bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
+bool flt_compare_ipv6net(cmpop op, const ipv6addr *operand1, const ipv6net *operand2)
 {
 	switch(op)
 	{
 	case CO_EQ:
 	case CO_IN:
-		return operand1->in_subnet(*operand2);
+		return operand2->in_cidr(*operand1);
 	case CO_NE:
-		return !operand1->in_subnet(*operand2);
+		return !operand2->in_cidr(*operand1);
 	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for ipv6 networks");
 		return false;
@@ -376,7 +376,7 @@ bool flt_compare(cmpop op, ppm_param_type type, void* operand1, void* operand2, 
 	case PT_IPV6ADDR:
 		return flt_compare_ipv6addr(op, (ipv6addr *)operand1, (ipv6addr *)operand2);
 	case PT_IPV6NET:
-		return flt_compare_ipv6net(op, (ipv6addr *)operand1, (ipv6addr*)operand2);
+		return flt_compare_ipv6net(op, (ipv6addr *)operand1, (ipv6net*)operand2);
 	case PT_IPADDR:
 		if(op1_len == sizeof(struct in_addr))
 		{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1406,76 +1406,44 @@ bool sinsp_filter_check_fd::compare_ip(sinsp_evt *evt)
 
 bool sinsp_filter_check_fd::compare_net(sinsp_evt *evt)
 {
-	if(!extract_fd(evt))
+	if(!extract_fd(evt) || m_fdinfo == nullptr)
 	{
 		return false;
 	}
 
-	if(m_fdinfo != NULL)
+	bool sip_cmp = false;
+	bool dip_cmp = false;
+
+	switch (m_fdinfo->m_type)
 	{
-		scap_fd_type evt_type = m_fdinfo->m_type;
+	case SCAP_FD_IPV4_SERVSOCK:
+		return flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, (ipv4net*)filter_value_p());
 
-		if(evt_type == SCAP_FD_IPV4_SOCK)
-		{
-			if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
-			{
-				if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p()) ||
-				   flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else if(m_cmpop == CO_NE)
-			{
-				if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p()) &&
-				   flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else
-			{
-				throw sinsp_exception("filter error: IP filter only supports '=' and '!=' operators");
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV4_SERVSOCK)
-		{
+	case SCAP_FD_IPV6_SERVSOCK:
+		return flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, (ipv6net*)filter_value_p());
 
-			if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, (ipv4net*)filter_value_p()))
-			{
-				return true;
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV6_SOCK)
-		{
-			if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
-			{
-				if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6addr*)filter_value_p()) ||
-				   flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6addr*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else if(m_cmpop == CO_NE)
-			{
-				if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6addr*)filter_value_p()) &&
-				   flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6addr*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else
-			{
-				throw sinsp_exception("filter error: IP filter only supports '=' and '!=' operators");
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV6_SERVSOCK)
-		{
-			if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, (ipv6addr*)filter_value_p()))
-			{
-				return true;
-			}
-		}
+	case SCAP_FD_IPV4_SOCK:
+		sip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p());
+		dip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p());
+		break;
+
+	case SCAP_FD_IPV6_SOCK:
+		sip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6net*)filter_value_p());
+		dip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6net*)filter_value_p());
+		break;
+
+	default:
+		return false;
+	}
+
+	if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
+	{
+		return sip_cmp || dip_cmp;
+	}
+
+	if(m_cmpop == CO_NE)
+	{
+		return sip_cmp && dip_cmp;
 	}
 
 	return false;

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -32,8 +32,8 @@ class sinsp_filter_check_reference;
 
 bool flt_compare(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len = 0, uint32_t op2_len = 0);
 bool flt_compare_avg(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len, uint32_t op2_len, uint32_t cnt1, uint32_t cnt2);
-bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2);
-bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr* operand2);
+bool flt_compare_ipv4net(cmpop op, uint64_t operand1, const ipv4net* operand2);
+bool flt_compare_ipv6net(cmpop op, const ipv6addr *operand1, const ipv6net *operand2);
 
 char* flt_to_string(uint8_t* rawval, filtercheck_field_info* finfo);
 int32_t gmt2local(time_t t);

--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -16,8 +16,22 @@ limitations under the License.
 */
 
 #include <tuples.h>
+#include <string>
+#include <cstring>
+#include <arpa/inet.h>
+#include "utils.h"
+#include "sinsp_exception.h"
+#include "logger.h"
 
-ipv6addr ipv6addr::empty_address = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+ipv6addr ipv6addr::empty_address ("0::");//= {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+ipv6addr::ipv6addr(const std::string &str_addr)
+{
+	if(inet_pton(AF_INET6, str_addr.c_str(), m_b) != 1)
+	{
+		throw sinsp_exception("unrecognized IPv6 address " + str_addr);
+	}
+}
 
 bool ipv6addr::operator==(const ipv6addr &other) const
 {
@@ -49,4 +63,63 @@ bool ipv6addr::in_subnet(const ipv6addr &other) const
 	// bits for subnet).
 	return (m_b[0] == other.m_b[0] &&
 		m_b[1] == other.m_b[1]);
+}
+
+void ipv6net::init(const std::string &str)
+{
+	std::stringstream ss(str);
+	std::string ip, mask;
+
+	getline(ss, ip, '/');
+	getline(ss, mask);
+
+	if(inet_pton(AF_INET6, ip.c_str(), m_addr.m_b) != 1)
+	{
+		throw sinsp_exception("unrecognized IPv6 address " + std::string(str));
+	}
+
+	uint32_t prefix_len = sinsp_numparser::parseu8(mask);
+
+	if (prefix_len == 0 || prefix_len > 128)
+	{
+		throw sinsp_exception("invalid v6 netmask " + mask);
+	}
+
+	m_mask_len_bytes = prefix_len / 8;
+	m_mask_tail_bits = 8 - (prefix_len % 8);
+
+	if (m_mask_tail_bits == 8)
+	{
+		--m_mask_len_bytes;
+		m_mask_tail_bits = 0;
+	}
+}
+
+ipv6net::ipv6net(const std::string &str)
+{
+	if(strchr(str.c_str(), '/') != nullptr)
+	{
+		init(str);
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_INFO, "using legacy netV6 formatting with '/64' bit prefix for '%'", str.c_str());
+		init(str + "/64");
+	}
+}
+
+bool ipv6net::in_cidr(const ipv6addr &other) const
+{
+	auto this_bytes  = (const uint8_t*)(&m_addr.m_b);
+	auto other_bytes = (const uint8_t*)(&other.m_b);
+
+	int i = 0;
+	for (; i < m_mask_len_bytes; i++)
+	{
+		if(this_bytes[i] != other_bytes[i])
+		{
+			return false;
+		}
+	}
+	return (this_bytes[i] >> m_mask_tail_bits) == (other_bytes[i] >> m_mask_tail_bits);
 }

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 /** @defgroup state State management
  *  @{
@@ -48,18 +49,31 @@ typedef struct ipv4net
 	uint32_t m_netmask; ///< Subnet mask
 }ipv4net;
 
-typedef struct _ipv6addr
+struct ipv6addr
 {
+	ipv6addr() = default;
+	ipv6addr(const std::string& str_addr);
 	uint32_t m_b[4];
 
-	bool operator==(const _ipv6addr &other) const;
-	bool operator!=(const _ipv6addr &other) const;
-	bool operator<(const _ipv6addr &other) const;
-	bool in_subnet(const _ipv6addr &other) const;
+	bool operator==(const ipv6addr &other) const;
+	bool operator!=(const ipv6addr &other) const;
+	bool operator<(const ipv6addr &other) const;
+	bool in_subnet(const ipv6addr &other) const;
 
-	static struct _ipv6addr empty_address;
-}ipv6addr;
+	static struct ipv6addr empty_address;
+};
 
+class ipv6net
+{
+private:
+	ipv6addr m_addr;
+	uint32_t m_mask_len_bytes;
+	uint32_t m_mask_tail_bits;
+	void init(const std::string &str);
+public:
+	ipv6net(const std::string &str);
+	bool in_cidr(const ipv6addr &other) const;
+};
 
 /*!
 	\brief An IPv6 tuple. 

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -160,13 +160,8 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			parsed_len = sizeof(struct in_addr);
 			break;
 	        case PT_IPV6ADDR:
-	        case PT_IPV6NET:
 		{
-			ipv6addr *addr = (ipv6addr*) storage;
-			if(inet_pton(AF_INET6, str, addr->m_b) != 1)
-			{
-				throw sinsp_exception("unrecognized IPv6 address " + string(str));
-			}
+			new (storage) ipv6addr(str);
 			parsed_len = sizeof(ipv6addr);
 			break;
 		}
@@ -218,6 +213,12 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			net->m_netmask = htonl(net->m_netmask);
 
 			parsed_len = sizeof(ipv4net);
+			break;
+		}
+		case PT_IPV6NET:
+		{
+			new (storage) ipv6net(str);
+			parsed_len = sizeof(ipv6net);
 			break;
 		}
 		default:


### PR DESCRIPTION
Co-authored-by: Angelo Puglisi <angelo.puglisi@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

allow ipv6 filtering with normalized cidr notation `BFD0::/32`


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
