### PR TITLE
ipv6net cidr filtering

### DIFF
--- a/cmake/modules/grpc.cmake
+++ b/cmake/modules/grpc.cmake
@@ -83,14 +83,13 @@ else()
 			"${GRPC_SRC}/libupb.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/hash/libabsl_hash.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/hash/libabsl_city.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/hash/libabsl_low_level_hash.a"
+			"${GRPC_SRC}/third_party/abseil-cpp/absl/hash/libabsl_wyhash.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/container/libabsl_raw_hash_set.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/container/libabsl_hashtablez_sampler.a"
+			"${GRPC_SRC}/third_party/abseil-cpp/absl/base/libabsl_exponential_biased.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/status/libabsl_statusor.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/status/libabsl_status.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_cord.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_cordz_functions.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/profiling/libabsl_exponential_biased.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/types/libabsl_bad_optional_access.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/types/libabsl_bad_variant_access.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_str_format_internal.a"
@@ -112,24 +111,13 @@ else()
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/base/libabsl_raw_logging_internal.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/base/libabsl_log_severity.a"
 			"${GRPC_SRC}/third_party/abseil-cpp/absl/time/libabsl_time_zone.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_cord_internal.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_cordz_info.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/strings/libabsl_cordz_handle.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_pool_urbg.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_randen.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_randen_hwaes.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_randen_hwaes_impl.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_platform.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_randen_slow.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_internal_seed_material.a"
-			"${GRPC_SRC}/third_party/abseil-cpp/absl/random/libabsl_random_seed_gen_exception.a"
 		)
 		
 		ExternalProject_Add(grpc
 			PREFIX "${PROJECT_BINARY_DIR}/grpc-prefix"
 			DEPENDS openssl protobuf c-ares zlib
 			GIT_REPOSITORY https://github.com/grpc/grpc.git
-			GIT_TAG v1.44.0
+			GIT_TAG v1.38.1
 			GIT_SUBMODULES "third_party/abseil-cpp third_party/re2"
 			CMAKE_CACHE_ARGS
 				-DCMAKE_INSTALL_PREFIX:PATH=${GRPC_INSTALL_DIR}
@@ -168,7 +156,6 @@ else()
 			BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB} ${GPR_LIB} ${GRPC_LIBRARIES}
 			# Keep installation files into the local ${GRPC_INSTALL_DIR} 
 			# since here is the case when we are embedding gRPC
-			UPDATE_COMMAND ""
 			INSTALL_COMMAND DESTDIR= ${CMD_MAKE} install
 		)
 	endif()

--- a/cmake/modules/luajit.cmake
+++ b/cmake/modules/luajit.cmake
@@ -42,7 +42,6 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
-					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
 				ExternalProject_Add(luajit
@@ -53,7 +52,6 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
-					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			elseif(APPLE)
 				ExternalProject_Add(luajit
@@ -74,7 +72,6 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
-					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			endif()
 		else()

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -746,10 +746,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 	curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-	{
-		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
-	}
-
+		return PPM_FAILURE_BUFFER_FULL;
 	if (dyn_idx != (u8)-1) {
 		*((u8 *)&data->buf[curoff_bounded]) = dyn_idx;
 		len_dyn = sizeof(u8);
@@ -759,9 +756,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 	curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-	{
-		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
-	}
+		return PPM_FAILURE_BUFFER_FULL;
 
 	switch (type) {
 	case PT_CHARBUF:
@@ -821,9 +816,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 				curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 				if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-				{
-					return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
-				}
+					return PPM_FAILURE_BUFFER_FULL;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (read_size)
@@ -908,9 +901,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	}
 	}
 	if (len_dyn + len > PPM_MAX_ARG_SIZE)
-	{
-		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
-	}
+		return PPM_FAILURE_BUFFER_FULL;
 
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len_dyn + len);
 	data->state->tail_ctx.curoff += len;

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -54,9 +54,7 @@ static __always_inline int push_evt_frame(void *ctx,
 	}
 
 	if (data->state->tail_ctx.len > PERF_EVENT_MAX_SIZE)
-	{
-		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
-	}
+		return PPM_FAILURE_BUFFER_FULL;
 
 	fixup_evt_len(data->buf, data->state->tail_ctx.len);
 
@@ -90,9 +88,6 @@ static __always_inline int push_evt_frame(void *ctx,
 
 		state->hotplug_cpu = bpf_get_smp_processor_id();
 		bpf_printk("detected hotplug event, cpu=%d\n", state->hotplug_cpu);
-	} else if (res == -ENOSPC) {
-		bpf_printk("bpf_perf_buffer full\n");
-		return PPM_FAILURE_BUFFER_FULL;
 	} else if (res) {
 		bpf_printk("bpf_perf_event_output failed, res=%d\n", res);
 		return PPM_FAILURE_BUG;

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -216,7 +216,6 @@ struct scap_bpf_per_cpu_state {
 	struct tail_context tail_ctx;
 	unsigned long long n_evts;
 	unsigned long long n_drops_buffer;
-	unsigned long long n_drops_scratch_map;
 	unsigned long long n_drops_pf;
 	unsigned long long n_drops_bug;
 	unsigned int hotplug_cpu;

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1331,9 +1331,7 @@ enum ppm_syscall_code {
 	PPM_SC_EXECVE = 324,
 	PPM_SC_EXECVEAT = 325,
 	PPM_SC_COPY_FILE_RANGE = 326,
-	PPM_SC_CLONE = 327,
-	PPM_SC_CLONE3 = 328,
-	PPM_SC_MAX = 329,
+	PPM_SC_MAX = 327,
 };
 
 /*
@@ -1672,7 +1670,6 @@ struct ppm_event_entry {
 #define PPM_FAILURE_INVALID_USER_MEMORY -2
 #define PPM_FAILURE_BUG -3
 #define PPM_SKIP_EVENT -4
-#define PPM_FAILURE_FRAME_SCRATCH_MAP_FULL -5	/* this is used only inside bpf, kernel module does not have a frame scratch map*/
 
 #define RW_SNAPLEN 80
 #define RW_MAX_SNAPLEN PPM_MAX_ARG_SIZE

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -1003,10 +1003,6 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_copy_file_range
 	[__NR_copy_file_range - SYSCALL_TABLE_ID0] = PPM_SC_COPY_FILE_RANGE,
 #endif
-	[__NR_clone - SYSCALL_TABLE_ID0] = PPM_SC_CLONE,
-#ifdef __NR_clone3
-	[__NR_clone3 - SYSCALL_TABLE_ID0] = PPM_SC_CLONE3,
-#endif	
 };
 
 #ifdef CONFIG_IA32_EMULATION
@@ -1826,10 +1822,6 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 #ifdef __NR_ia32_copy_file_range
 	[__NR_ia32_copy_file_range - SYSCALL_TABLE_ID0] = PPM_SC_COPY_FILE_RANGE,
 #endif
-	[__NR_ia32_clone - SYSCALL_TABLE_ID0] = PPM_SC_CLONE,
-#ifdef __NR_ia32_clone3
-	[__NR_ia32_clone3 - SYSCALL_TABLE_ID0] = PPM_SC_CLONE3,
-#endif	
 };
 
 #endif /* CONFIG_IA32_EMULATION */

--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -119,7 +119,7 @@ const static struct luaL_Reg ll_sysdig [] =
 	{"make_ts", &lua_cbacks::make_ts},
 	{"add_ts", &lua_cbacks::add_ts},
 	{"subtract_ts", &lua_cbacks::subtract_ts},
-	{"run_app", &lua_cbacks::run_app},
+	{"run_sysdig", &lua_cbacks::run_sysdig},
 	{"end_capture", &lua_cbacks::end_capture},
 	{"log", &lua_cbacks::log},
 	{"udp_setpeername", &lua_cbacks::udp_setpeername},

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -562,7 +562,7 @@ int lua_cbacks::subtract_ts(lua_State *ls)
 	return 1;
 }
 
-int lua_cbacks::run_app(lua_State *ls)
+int lua_cbacks::run_sysdig(lua_State *ls)
 {
 	lua_getglobal(ls, "sichisel");
 

--- a/userspace/chisel/chisel_api.h
+++ b/userspace/chisel/chisel_api.h
@@ -36,7 +36,7 @@ public:
 	static int make_ts(lua_State *ls);
 	static int add_ts(lua_State *ls);
 	static int subtract_ts(lua_State *ls);
-	static int run_app(lua_State *ls);
+	static int run_sysdig(lua_State *ls);
 	static int end_capture(lua_State *ls);
 	static int is_live(lua_State *ls);
 	static int is_tty(lua_State *ls);

--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -30,7 +30,6 @@ static void signal_callback(int signal)
 	printf("seen by driver: %" PRIu64 "\n", s.n_evts);
 	printf("Number of dropped events: %" PRIu64 "\n", s.n_drops);
 	printf("Number of dropped events caused by full buffer: %" PRIu64 "\n", s.n_drops_buffer);
-	printf("Number of dropped events caused by full scratch map: %" PRIu64 "\n", s.n_drops_scratch_map);
 	printf("Number of dropped events caused by invalid memory access: %" PRIu64 "\n", s.n_drops_pf);
 	printf("Number of dropped events caused by an invalid condition in the kernel instrumentation: %" PRIu64 "\n", s.n_drops_bug);
 	printf("Number of preemptions: %" PRIu64 "\n", s.n_preemptions);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -94,6 +94,11 @@ typedef struct scap_device
 			struct ppm_ring_buffer_info* m_bufinfo;
 			struct udig_ring_buffer_status* m_bufstatus; // used by udig
 		};
+		// Anonymous struct with bpf stuff
+		struct
+		{
+			uint64_t m_evt_lost;
+		};
 	};
 }scap_device;
 
@@ -149,8 +154,6 @@ struct scap
 	uint32_t m_fd_lookup_limit;
 	uint64_t m_unexpected_block_readsize;
 	uint32_t m_ncpus;
-	uint8_t m_cgroup_version;
-
 	// Abstraction layer for windows
 #if CYGWING_AGENT || _WIN32
 	wh_t* m_whh;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2098,7 +2098,6 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 	stats->n_evts = 0;
 	stats->n_drops = 0;
 	stats->n_drops_buffer = 0;
-	stats->n_drops_scratch_map = 0;
 	stats->n_drops_pf = 0;
 	stats->n_drops_bug = 0;
 	stats->n_preemptions = 0;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -112,12 +112,11 @@ typedef struct scap_stats
 	uint64_t n_evts; ///< Total number of events that were received by the driver.
 	uint64_t n_drops; ///< Number of dropped events.
 	uint64_t n_drops_buffer; ///< Number of dropped events caused by full buffer.
-	uint64_t n_drops_scratch_map; ///< Number of dropped events caused by full frame scratch map.
 	uint64_t n_drops_pf; ///< Number of dropped events caused by invalid memory access.
 	uint64_t n_drops_bug; ///< Number of dropped events caused by an invalid condition in the kernel instrumentation.
 	uint64_t n_preemptions; ///< Number of preemptions.
-	uint64_t n_suppressed; ///< Number of events skipped due to the tid being in a set of suppressed tids.
-	uint64_t n_tids_suppressed; ///< Number of threads currently being suppressed.
+	uint64_t n_suppressed; ///< Number of events skipped due to the tid being in a set of suppressed tids
+	uint64_t n_tids_suppressed; ///< Number of threads currently being suppressed
 }scap_stats;
 
 /*!

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1477,12 +1477,11 @@ int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
 		}
 
 		stats->n_evts += v.n_evts;
-		stats->n_drops_buffer += v.n_drops_buffer;
-		stats->n_drops_scratch_map += v.n_drops_scratch_map;
+		stats->n_drops_buffer += handle->m_devs[j].m_evt_lost + v.n_drops_buffer;
 		stats->n_drops_pf += v.n_drops_pf;
 		stats->n_drops_bug += v.n_drops_bug;
-		stats->n_drops += v.n_drops_buffer +
-				  v.n_drops_scratch_map +
+		stats->n_drops += handle->m_devs[j].m_evt_lost +
+				  v.n_drops_buffer +
 				  v.n_drops_pf +
 				  v.n_drops_bug;
 	}

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -124,7 +124,13 @@ static inline int32_t scap_bpf_advance_to_evt(scap_t *handle, uint16_t cpuid, bo
 				break;
 			}
 		}
-		else if(e->type != PERF_RECORD_LOST)
+		else if(e->type == PERF_RECORD_LOST)
+		{
+			struct perf_lost_sample *lost = (struct perf_lost_sample *) e;
+			ASSERT(*len >= sizeof(*lost));
+			dev->m_evt_lost += lost->lost;
+		}
+		else
 		{
 			printf("Unknown event type=%d size=%d\n",
 			       e->type, e->size);

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -356,8 +356,6 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_EXECVE*/ { EC_SYSTEM, (enum ppm_event_flags)(EF_NONE), "execve" },
 	/*PPM_SC_EXECVEAT*/ { EC_SYSTEM, (enum ppm_event_flags)(EF_NONE), "execveat" },
 	/*PPM_SC_COPY_FILE_RANGE*/ {EC_FILE, (enum ppm_event_flags)(EF_NONE), "copy_file_range" },
-	/*PPM_SC_CLONE*/ {EC_PROCESS, (enum ppm_event_flags)(EF_NONE), "clone" },
-	/*PPM_SC_CLONE3*/ {EC_PROCESS, (enum ppm_event_flags)(EF_NONE), "clone3" },
 };
 
 bool validate_info_table_size()

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -640,13 +640,6 @@ void sinsp_container_manager::set_cri_socket_path(const std::string &path)
 #endif
 }
 
-void sinsp_container_manager::add_cri_socket_path(const std::string &path)
-{
-#if !defined(MINIMAL_BUILD) && defined(HAS_CAPTURE)
-	libsinsp::container_engine::cri::add_cri_socket_path(path);
-#endif
-}
-
 void sinsp_container_manager::set_cri_timeout(int64_t timeout_ms)
 {
 #if !defined(MINIMAL_BUILD) && defined(HAS_CAPTURE)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -151,7 +151,6 @@ public:
 	void set_query_docker_image_info(bool query_image_info);
 	void set_cri_extra_queries(bool extra_queries);
 	void set_cri_socket_path(const std::string& path);
-	void add_cri_socket_path(const std::string &path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
 	void set_cri_delay(uint64_t delay_ms);

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -82,7 +82,6 @@ public:
 	void update_with_size(const std::string& container_id) override;
 	void cleanup() override;
 	static void set_cri_socket_path(const std::string& path);
-	static void add_cri_socket_path(const std::string& path);
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
 	static void set_async(bool async_limits);

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -33,11 +33,10 @@ bool pod_uses_host_netns(const runtime::v1alpha2::PodSandboxStatusResponse& resp
 
 namespace libsinsp {
 namespace cri {
-std::vector<std::string> s_cri_unix_socket_paths;
+std::string s_cri_unix_socket_path = "/run/containerd/containerd.sock";
 int64_t s_cri_timeout = 1000;
 int64_t s_cri_size_timeout = 10000;
 sinsp_container_type s_cri_runtime_type = CT_CRI;
-std::string s_cri_unix_socket_path;
 bool s_cri_extra_queries = true;
 
 cri_interface::cri_interface(const std::string& cri_path)
@@ -58,8 +57,9 @@ cri_interface::cri_interface(const std::string& cri_path)
 	if (!status.ok())
 	{
 		g_logger.format(sinsp_logger::SEV_NOTICE, "cri: CRI runtime returned an error after version check at %s: %s",
-				cri_path.c_str(), status.error_message().c_str());
+				s_cri_unix_socket_path.c_str(), status.error_message().c_str());
 		m_cri.reset(nullptr);
+		s_cri_unix_socket_path = "";
 		return;
 	}
 
@@ -78,6 +78,7 @@ cri_interface::cri_interface(const std::string& cri_path)
 	{
 		m_cri_runtime_type = CT_CRI;
 	}
+
 	s_cri_runtime_type = m_cri_runtime_type;
 }
 

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -37,10 +37,8 @@ namespace libsinsp {
 namespace cri {
 
 // these shouldn't be globals but we still need references to *the* CRI runtime
-extern std::vector<std::string> s_cri_unix_socket_paths;
-extern int64_t s_cri_timeout;
-// TODO: drop these 2 below
 extern std::string s_cri_unix_socket_path;
+extern int64_t s_cri_timeout;
 extern sinsp_container_type s_cri_runtime_type;
 extern bool s_cri_extra_queries;
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -535,6 +535,7 @@ VISIBILITY_PRIVATE
 	friend class sinsp_analyzer;
 	friend class sinsp_filter_check_event;
 	friend class sinsp_filter_check_thread;
+	friend class sinsp_evttype_filter;
 	friend class sinsp_dumper;
 	friend class sinsp_analyzer_fd_listener;
 	friend class sinsp_analyzer_parsers;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -249,7 +249,7 @@ bool flt_compare_double(cmpop op, double operand1, double operand2)
 	}
 }
 
-bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2)
+bool flt_compare_ipv4net(cmpop op, uint64_t operand1, const ipv4net* operand2)
 {
 	switch(op)
 	{
@@ -306,15 +306,15 @@ bool flt_compare_ipv6addr(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
 	}
 }
 
-bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr *operand2)
+bool flt_compare_ipv6net(cmpop op, const ipv6addr *operand1, const ipv6net *operand2)
 {
 	switch(op)
 	{
 	case CO_EQ:
 	case CO_IN:
-		return operand1->in_subnet(*operand2);
+		return operand2->in_cidr(*operand1);
 	case CO_NE:
-		return !operand1->in_subnet(*operand2);
+		return !operand2->in_cidr(*operand1);
 	case CO_CONTAINS:
 		throw sinsp_exception("'contains' not supported for ipv6 networks");
 		return false;
@@ -376,7 +376,7 @@ bool flt_compare(cmpop op, ppm_param_type type, void* operand1, void* operand2, 
 	case PT_IPV6ADDR:
 		return flt_compare_ipv6addr(op, (ipv6addr *)operand1, (ipv6addr *)operand2);
 	case PT_IPV6NET:
-		return flt_compare_ipv6net(op, (ipv6addr *)operand1, (ipv6addr*)operand2);
+		return flt_compare_ipv6net(op, (ipv6addr *)operand1, (ipv6net*)operand2);
 	case PT_IPADDR:
 		if(op1_len == sizeof(struct in_addr))
 		{

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -103,6 +103,105 @@ private:
 	friend class sinsp_evt_formatter;
 };
 
+/*!
+  \brief This class represents a filter optimized using event
+  types. It actually consists of collections of sinsp_filter objects
+  grouped by event type.
+*/
+
+class SINSP_PUBLIC sinsp_evttype_filter
+{
+public:
+	sinsp_evttype_filter();
+	virtual ~sinsp_evttype_filter();
+
+	void add(std::string &name,
+		 std::set<uint32_t> &evttypes,
+		 std::set<uint32_t> &syscalls,
+		 std::set<string> &tags,
+		 sinsp_filter* filter);
+
+	// rulesets are arbitrary numbers and should be managed by the caller.
+        // Note that rulesets are used to index into a std::vector so
+        // specifying unnecessarily large rulesets will result in
+        // unnecessarily large vectors.
+
+	// Find those rules matching the provided pattern and set
+	// their enabled status to enabled.
+	void enable(const std::string &pattern, bool enabled, uint16_t ruleset = 0);
+
+	// Find those rules that have a tag in the set of tags and set
+	// their enabled status to enabled. Note that the enabled
+	// status is on the rules, and not the tags--if a rule R has
+	// tags (a, b), and you call enable_tags([a], true) and then
+	// enable_tags([b], false), R will be disabled despite the
+	// fact it has tag a and was enabled by the first call to
+	// enable_tags.
+	void enable_tags(const std::set<string> &tags, bool enabled, uint16_t ruleset = 0);
+
+	// Match all filters against the provided event.
+	bool run(sinsp_evt *evt, uint16_t ruleset = 0);
+
+	// Populate the provided vector, indexed by event type, of the
+	// event types associated with the given ruleset id. For
+	// example, evttypes[10] = true would mean that this ruleset
+	// relates to event type 10.
+	void evttypes_for_ruleset(std::vector<bool> &evttypes, uint16_t ruleset);
+
+	// Populate the provided vector, indexed by syscall code, of the
+	// syscall codes associated with the given ruleset id. For
+	// example, syscalls[10] = true would mean that this ruleset
+	// relates to syscall code 10.
+	void syscalls_for_ruleset(std::vector<bool> &syscalls, uint16_t ruleset);
+
+private:
+
+	struct filter_wrapper {
+		sinsp_filter *filter;
+
+		// Indexes from event type to enabled/disabled.
+		std::vector<bool> evttypes;
+
+		// Indexes from syscall code to enabled/disabled.
+		std::vector<bool> syscalls;
+	};
+
+	// A group of filters all having the same ruleset
+	class ruleset_filters {
+	public:
+		ruleset_filters();
+
+		virtual ~ruleset_filters();
+
+		void add_filter(filter_wrapper *wrap);
+		void remove_filter(filter_wrapper *wrap);
+
+		bool run(sinsp_evt *evt);
+
+		void evttypes_for_ruleset(std::vector<bool> &evttypes);
+
+		void syscalls_for_ruleset(std::vector<bool> &syscalls);
+
+	private:
+		// Maps from event type to filter. There can be multiple
+		// filters per event type.
+		std::list<filter_wrapper *> *m_filter_by_evttype[PPM_EVENT_MAX];
+
+		// Maps from syscall number to filter. There can be multiple
+		// filters per syscall number
+		std::list<filter_wrapper *> *m_filter_by_syscall[PPM_SC_MAX];
+	};
+
+	std::vector<ruleset_filters *> m_rulesets;
+
+	// Maps from tag to list of filters having that tag.
+	std::map<std::string, std::list<filter_wrapper *>> m_filter_by_tag;
+
+	// This holds all the filters passed to add(), so they can
+	// be cleaned up.
+	map<std::string,filter_wrapper *> m_filters;
+};
+
 /*@}*/
 
 class sinsp_filter_factory : public gen_event_filter_factory

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1406,76 +1406,44 @@ bool sinsp_filter_check_fd::compare_ip(sinsp_evt *evt)
 
 bool sinsp_filter_check_fd::compare_net(sinsp_evt *evt)
 {
-	if(!extract_fd(evt))
+	if(!extract_fd(evt) || m_fdinfo == nullptr)
 	{
 		return false;
 	}
 
-	if(m_fdinfo != NULL)
+	bool sip_cmp = false;
+	bool dip_cmp = false;
+
+	switch (m_fdinfo->m_type)
 	{
-		scap_fd_type evt_type = m_fdinfo->m_type;
+	case SCAP_FD_IPV4_SERVSOCK:
+		return flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, (ipv4net*)filter_value_p());
 
-		if(evt_type == SCAP_FD_IPV4_SOCK)
-		{
-			if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
-			{
-				if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p()) ||
-				   flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else if(m_cmpop == CO_NE)
-			{
-				if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p()) &&
-				   flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else
-			{
-				throw sinsp_exception("filter error: IP filter only supports '=' and '!=' operators");
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV4_SERVSOCK)
-		{
+	case SCAP_FD_IPV6_SERVSOCK:
+		return flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, (ipv6net*)filter_value_p());
 
-			if(flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, (ipv4net*)filter_value_p()))
-			{
-				return true;
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV6_SOCK)
-		{
-			if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
-			{
-				if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6addr*)filter_value_p()) ||
-				   flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6addr*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else if(m_cmpop == CO_NE)
-			{
-				if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6addr*)filter_value_p()) &&
-				   flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6addr*)filter_value_p()))
-				{
-					return true;
-				}
-			}
-			else
-			{
-				throw sinsp_exception("filter error: IP filter only supports '=' and '!=' operators");
-			}
-		}
-		else if(evt_type == SCAP_FD_IPV6_SERVSOCK)
-		{
-			if(flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, (ipv6addr*)filter_value_p()))
-			{
-				return true;
-			}
-		}
+	case SCAP_FD_IPV4_SOCK:
+		sip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p());
+		dip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p());
+		break;
+
+	case SCAP_FD_IPV6_SOCK:
+		sip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6net*)filter_value_p());
+		dip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6net*)filter_value_p());
+		break;
+
+	default:
+		return false;
+	}
+
+	if(m_cmpop == CO_EQ || m_cmpop == CO_IN)
+	{
+		return sip_cmp || dip_cmp;
+	}
+
+	if(m_cmpop == CO_NE)
+	{
+		return sip_cmp && dip_cmp;
 	}
 
 	return false;

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -32,8 +32,8 @@ class sinsp_filter_check_reference;
 
 bool flt_compare(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len = 0, uint32_t op2_len = 0);
 bool flt_compare_avg(cmpop op, ppm_param_type type, void* operand1, void* operand2, uint32_t op1_len, uint32_t op2_len, uint32_t cnt1, uint32_t cnt2);
-bool flt_compare_ipv4net(cmpop op, uint64_t operand1, ipv4net* operand2);
-bool flt_compare_ipv6net(cmpop op, ipv6addr *operand1, ipv6addr* operand2);
+bool flt_compare_ipv4net(cmpop op, uint64_t operand1, const ipv4net* operand2);
+bool flt_compare_ipv6net(cmpop op, const ipv6addr *operand1, const ipv6net *operand2);
 
 char* flt_to_string(uint8_t* rawval, filtercheck_field_info* finfo);
 int32_t gmt2local(time_t t);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -179,7 +179,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 #if defined(HAS_FILTERING) && defined(HAS_CAPTURE_FILTERING)
 	bool do_filter_later = false;
 
-	if(m_inspector->m_filter)
+	if(m_inspector->m_filter || m_inspector->m_evttype_filter)
 	{
 		ppm_event_flags eflags = evt->get_info_flags();
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -366,6 +366,12 @@ public:
 	*/
 	const string get_filter();
 
+	void add_evttype_filter(std::string &name,
+				std::set<uint32_t> &evttypes,
+				std::set<uint32_t> &syscalls,
+				std::set<std::string> &tags,
+				sinsp_filter* filter);
+
 	bool run_filters_on_evt(sinsp_evt *evt);
 #endif
 
@@ -881,7 +887,6 @@ public:
 	void init_k8s_client(std::string* api_server, std::string* ssl_cert, std::string *node_name, bool verbose = false);
 	void make_k8s_client();
 	k8s* get_k8s_client() const { return m_k8s_client; }
-	void validate_k8s_node_name();
 
 	void init_mesos_client(std::string* api_server, bool verbose = false);
 	mesos* get_mesos_client() const { return m_mesos_client; }
@@ -987,14 +992,7 @@ public:
 
 	void set_statsd_port(uint16_t port);
 
-	/*!
-	  \brief Reset list of crio socket paths currently stored, and set path as the only path.
-	*/
 	void set_cri_socket_path(const std::string& path);
-	/*!
-	  \brief Pushed a new path to the list of crio socket paths
-	*/
-	void add_cri_socket_path(const std::string &path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
 	void set_cri_delay(uint64_t delay_ms);
@@ -1143,7 +1141,6 @@ public:
 	std::string* m_k8s_api_server;
 	std::string* m_k8s_api_cert;
 	std::string* m_k8s_node_name;
-	bool m_k8s_node_name_validated = false;
 #ifdef HAS_CAPTURE
 	std::shared_ptr<sinsp_ssl> m_k8s_ssl;
 	std::shared_ptr<sinsp_bearer_token> m_k8s_bt;
@@ -1181,6 +1178,7 @@ public:
 #ifdef HAS_FILTERING
 	uint64_t m_firstevent_ts;
 	sinsp_filter* m_filter;
+	sinsp_evttype_filter *m_evttype_filter;
 	std::string m_filterstring;
 #endif
 	unordered_set<uint32_t> m_ppm_sc_of_interest;

--- a/userspace/libsinsp/test/CMakeListsGtestInclude.cmake
+++ b/userspace/libsinsp/test/CMakeListsGtestInclude.cmake
@@ -27,6 +27,5 @@ ExternalProject_Add(googletest
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""
-  UPDATE_COMMAND    ""
   TEST_COMMAND      ""
 )

--- a/userspace/libsinsp/test/evttype_filter.ut.cpp
+++ b/userspace/libsinsp/test/evttype_filter.ut.cpp
@@ -91,8 +91,8 @@ protected:
 				FAIL() << "Expected event type "
 				       << etype
 				       << " not found in actual set. "
-				       << "Expected: " << testing::PrintToString(expected) << " "
-				       << " Actual: " << testing::PrintToString(actual);
+				       << "Expected: " << expected << " "
+				       << " Actual: " << actual;
 
 			}
 		}
@@ -104,8 +104,8 @@ protected:
 				FAIL() << "Actual evttypes had additional event type "
 				       << etype
 				       << " not found in expected set. "
-				       << "Expected: " << testing::PrintToString(expected) << " "
-				       << " Actual: " << testing::PrintToString(actual);
+				       << "Expected: " << expected << " "
+				       << " Actual: " << actual;
 			}
 		}
 	}

--- a/userspace/libsinsp/test/token_bucket.ut.cpp
+++ b/userspace/libsinsp/test/token_bucket.ut.cpp
@@ -1,6 +1,5 @@
 #include "token_bucket.h"
 #include <gtest.h>
-#include <memory>
 
 // token bucket default ctor
 TEST(token_bucket, constructor)

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -949,14 +949,16 @@ void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 	}
 }
 
-void sinsp_threadinfo::populate_cmdline(string &cmdline, const sinsp_threadinfo *tinfo)
+void sinsp_threadinfo::populate_cmdline(string &cmdline, sinsp_threadinfo *tinfo)
 {
 	cmdline = tinfo->get_comm();
 
-	for (const auto& arg : tinfo->m_args)
+	uint32_t j;
+	uint32_t nargs = (uint32_t)tinfo->m_args.size();
+
+	for(j = 0; j < nargs; j++)
 	{
-		cmdline += " ";
-		cmdline += arg;
+		cmdline += " " + tinfo->m_args[j];
 	}
 }
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -229,7 +229,7 @@ public:
 	typedef std::function<bool (sinsp_threadinfo *)> visitor_func_t;
 	void traverse_parent_state(visitor_func_t &visitor);
 
-	static void populate_cmdline(std::string &cmdline, const sinsp_threadinfo *tinfo);
+	static void populate_cmdline(std::string &cmdline, sinsp_threadinfo *tinfo);
 
 	// Return true if this thread is a part of a healthcheck,
 	// readiness probe, or liveness probe.

--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -16,8 +16,22 @@ limitations under the License.
 */
 
 #include <tuples.h>
+#include <string>
+#include <cstring>
+#include <arpa/inet.h>
+#include "utils.h"
+#include "sinsp_exception.h"
+#include "logger.h"
 
-ipv6addr ipv6addr::empty_address = {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+ipv6addr ipv6addr::empty_address ("0::");//= {0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+ipv6addr::ipv6addr(const std::string &str_addr)
+{
+	if(inet_pton(AF_INET6, str_addr.c_str(), m_b) != 1)
+	{
+		throw sinsp_exception("unrecognized IPv6 address " + str_addr);
+	}
+}
 
 bool ipv6addr::operator==(const ipv6addr &other) const
 {
@@ -49,4 +63,63 @@ bool ipv6addr::in_subnet(const ipv6addr &other) const
 	// bits for subnet).
 	return (m_b[0] == other.m_b[0] &&
 		m_b[1] == other.m_b[1]);
+}
+
+void ipv6net::init(const std::string &str)
+{
+	std::stringstream ss(str);
+	std::string ip, mask;
+
+	getline(ss, ip, '/');
+	getline(ss, mask);
+
+	if(inet_pton(AF_INET6, ip.c_str(), m_addr.m_b) != 1)
+	{
+		throw sinsp_exception("unrecognized IPv6 address " + std::string(str));
+	}
+
+	uint32_t prefix_len = sinsp_numparser::parseu8(mask);
+
+	if (prefix_len == 0 || prefix_len > 128)
+	{
+		throw sinsp_exception("invalid v6 netmask " + mask);
+	}
+
+	m_mask_len_bytes = prefix_len / 8;
+	m_mask_tail_bits = 8 - (prefix_len % 8);
+
+	if (m_mask_tail_bits == 8)
+	{
+		--m_mask_len_bytes;
+		m_mask_tail_bits = 0;
+	}
+}
+
+ipv6net::ipv6net(const std::string &str)
+{
+	if(strchr(str.c_str(), '/') != nullptr)
+	{
+		init(str);
+	}
+	else
+	{
+		g_logger.format(sinsp_logger::SEV_INFO, "using legacy netV6 formatting with '/64' bit prefix for '%'", str.c_str());
+		init(str + "/64");
+	}
+}
+
+bool ipv6net::in_cidr(const ipv6addr &other) const
+{
+	auto this_bytes  = (const uint8_t*)(&m_addr.m_b);
+	auto other_bytes = (const uint8_t*)(&other.m_b);
+
+	int i = 0;
+	for (; i < m_mask_len_bytes; i++)
+	{
+		if(this_bytes[i] != other_bytes[i])
+		{
+			return false;
+		}
+	}
+	return (this_bytes[i] >> m_mask_tail_bits) == (other_bytes[i] >> m_mask_tail_bits);
 }

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 /** @defgroup state State management
  *  @{
@@ -48,18 +49,31 @@ typedef struct ipv4net
 	uint32_t m_netmask; ///< Subnet mask
 }ipv4net;
 
-typedef struct _ipv6addr
+struct ipv6addr
 {
+	ipv6addr() = default;
+	ipv6addr(const std::string& str_addr);
 	uint32_t m_b[4];
 
-	bool operator==(const _ipv6addr &other) const;
-	bool operator!=(const _ipv6addr &other) const;
-	bool operator<(const _ipv6addr &other) const;
-	bool in_subnet(const _ipv6addr &other) const;
+	bool operator==(const ipv6addr &other) const;
+	bool operator!=(const ipv6addr &other) const;
+	bool operator<(const ipv6addr &other) const;
+	bool in_subnet(const ipv6addr &other) const;
 
-	static struct _ipv6addr empty_address;
-}ipv6addr;
+	static struct ipv6addr empty_address;
+};
 
+class ipv6net
+{
+private:
+	ipv6addr m_addr;
+	uint32_t m_mask_len_bytes;
+	uint32_t m_mask_tail_bits;
+	void init(const std::string &str);
+public:
+	ipv6net(const std::string &str);
+	bool in_cidr(const ipv6addr &other) const;
+};
 
 /*!
 	\brief An IPv6 tuple. 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -898,7 +898,7 @@ void sinsp_utils::bt(void)
 
 bool sinsp_utils::find_first_env(std::string &out, const vector<std::string> &env, const vector<std::string> &keys)
 {
-	for (const auto& key : keys)
+	for (const string key : keys)
 	{
 		for(const auto& env_var : env)
 		{

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -160,13 +160,8 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			parsed_len = sizeof(struct in_addr);
 			break;
 	        case PT_IPV6ADDR:
-	        case PT_IPV6NET:
 		{
-			ipv6addr *addr = (ipv6addr*) storage;
-			if(inet_pton(AF_INET6, str, addr->m_b) != 1)
-			{
-				throw sinsp_exception("unrecognized IPv6 address " + string(str));
-			}
+			new (storage) ipv6addr(str);
 			parsed_len = sizeof(ipv6addr);
 			break;
 		}
@@ -218,6 +213,12 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			net->m_netmask = htonl(net->m_netmask);
 
 			parsed_len = sizeof(ipv4net);
+			break;
+		}
+		case PT_IPV6NET:
+		{
+			new (storage) ipv6net(str);
+			parsed_len = sizeof(ipv6net);
 			break;
 		}
 		default:


### PR DESCRIPTION
Signed-off-by: vadim.zyarko <vadim.zyarko@sysdig.com>
Co-authored-by: Angelo Puglisi <angelo.puglisi@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

What type of PR is this?

/kind feature

Any specific area of the project related to this PR?

/area libsinsp

What this PR does / why we need it:

We are extending existing behavior when ipv6net was accepting subnet resolution for the fixed prefix of 48 bits only.

Now we are allowing flexible and standard CIDR notation to be specified in rules conditions. like ` BFD0::/32`
A bit of code cleanup was done as well.
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: allow ipv6 filtering with normalized CIDR notation BFD0::/32
```

