### PR TITLE
update(libsinsp): drop also untracked syscalls in kernel-side simple consumer mode

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -456,7 +456,9 @@ void sinsp::fill_syscalls_of_interest(scap_open_args *oargs)
 	 */
 	if (m_simpleconsumer)
 	{
-		for (int i = 0; i < PPM_SC_MAX; i++)
+		m_ppm_sc_of_interest.erase(PPM_SC_UNKNOWN);
+
+		for (int i = 1; i < PPM_SC_MAX; i++)
 		{
 			if (g_infotables.m_syscall_info_table[i].flags & EF_DROP_SIMPLE_CONS)
 			{


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Today, in the kernel-side simple consumer mode, all the events related to syscalls marked with the flag `EF_DROP_SIMPLE_CONS` are not pushed to the ringbuffer unless they are marked with the flag `UF_NEVER_DROP`. The idea here is to drop also all events related to untracked syscalls (`PPM_SC_UNKNOWN` enum) since they don't seem to particularly enrich the capture with useful information. 

To do that, we could simply change the flag of the `PPM_SC_UNKNOWN` enum, from `EF_NONE` to `EF_DROP_SIMPLE_CONS` [here](https://github.com/falcosecurity/libs/blob/423235173187cd4629f1e1fd6409a013a9a3fb84/userspace/libscap/syscall_info_table.c#L26). This however would lead to dropping these events also in userspace-side simple consumer mode and this behavior does not seem to be desired since the flag `EF_DROP_SIMPLE_CONS` was not set at the time. So to not alter the behavior, I suggest adding the right line directly in the `for` loop.

In my opinion, these events do not carry important information and therefore can be truncated together with the other events already neglected by the kernel-side simple consumer approach, but this is just my opinion, I am obviously open to suggestions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
