### PR TITLE
chore(userspace/libsinsp): expose plugin schema in sinsp_plugin::info vector returned by plugin_infos()

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -441,6 +441,8 @@ std::list<sinsp_plugin::info> sinsp_plugin::plugin_infos(sinsp* inspector)
 		info.plugin_version = p->plugin_version();
 		info.required_api_version = p->required_api_version();
 		info.type = p->type();
+		info.init_schema = p->m_init_schema;
+		info.init_schema_type = p->m_init_schema_type;
 
 		if(info.type == TYPE_SOURCE_PLUGIN)
 		{
@@ -830,15 +832,14 @@ std::string sinsp_plugin::get_init_schema(ss_plugin_schema_type& schema_type)
 
 void sinsp_plugin::validate_init_config(const char* config)
 {
-	ss_plugin_schema_type schema_type;
 	std::string conf = str_from_alloc_charbuf(config);
-	std::string schema = get_init_schema(schema_type);
-	if (schema.size() > 0 && schema_type != SS_PLUGIN_SCHEMA_NONE)
+	m_init_schema = get_init_schema(m_init_schema_type);
+	if (!m_init_schema.empty() && m_init_schema_type != SS_PLUGIN_SCHEMA_NONE)
 	{
-		switch (schema_type)
+		switch (m_init_schema_type)
 		{
 			case SS_PLUGIN_SCHEMA_JSON:
-				validate_init_config_json_schema(conf, schema);
+				validate_init_config_json_schema(conf, m_init_schema);
 				break;
 			default:
 				ASSERT(false);
@@ -846,7 +847,7 @@ void sinsp_plugin::validate_init_config(const char* config)
 					string("error in plugin ")
 					+ name()
 					+ ": get_init_schema returned an unknown schema type "
-					+ to_string(schema_type));
+					+ to_string(m_init_schema_type));
 		}
 	}
 }

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -66,6 +66,9 @@ public:
 		version plugin_version;
 		version required_api_version;
 
+		ss_plugin_schema_type init_schema_type;
+		std::string init_schema;
+
 		// Only filled in for source plugins
 		uint32_t id;
 	};
@@ -169,6 +172,9 @@ private:
 	std::string m_contact;
 	version m_plugin_version;
 	version m_required_api_version;
+
+	ss_plugin_schema_type m_init_schema_type;
+	std::string m_init_schema;
 
 	// Allocated instead of vector to match how it will be held in filter_check_info
 	std::unique_ptr<filtercheck_field_info[]> m_fields;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This allows consumers to also print plugin schema when eg: listing plugins. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
