### PR TITLE
Always skip update command for git based external projects

### DIFF
--- a/cmake/modules/grpc.cmake
+++ b/cmake/modules/grpc.cmake
@@ -156,6 +156,7 @@ else()
 			BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB} ${GPR_LIB} ${GRPC_LIBRARIES}
 			# Keep installation files into the local ${GRPC_INSTALL_DIR} 
 			# since here is the case when we are embedding gRPC
+			UPDATE_COMMAND ""
 			INSTALL_COMMAND DESTDIR= ${CMD_MAKE} install
 		)
 	endif()

--- a/cmake/modules/luajit.cmake
+++ b/cmake/modules/luajit.cmake
@@ -42,6 +42,7 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
+					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
 				ExternalProject_Add(luajit
@@ -52,6 +53,7 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
+					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			elseif(APPLE)
 				ExternalProject_Add(luajit
@@ -72,6 +74,7 @@ else()
 					BUILD_COMMAND ${CMD_MAKE}
 					BUILD_IN_SOURCE 1
 					BUILD_BYPRODUCTS ${LUAJIT_LIB}
+					UPDATE_COMMAND ""
 					INSTALL_COMMAND "")
 			endif()
 		else()

--- a/userspace/libsinsp/test/CMakeListsGtestInclude.cmake
+++ b/userspace/libsinsp/test/CMakeListsGtestInclude.cmake
@@ -27,5 +27,6 @@ ExternalProject_Add(googletest
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""
+  UPDATE_COMMAND    ""
   TEST_COMMAND      ""
 )


### PR DESCRIPTION
I noticed that some external projects were being reconfigured/built
with every make, even though no files in the external project had been
updated.

With some debugging I noticed that git based external projects were
re-running their "update" step every time, and that in turn caused the
configure/build/install steps to re-run as well. (Generally the build
step is a no-op as the Makefile/etc. in the external project is well
formed and doesn't do anything, but the configure/install steps still
run).

It seems related to this cmake bug:
https://gitlab.kitware.com/cmake/cmake/-/issues/19703. In short, the
git update step for an external project does not create any "done"
file that denotes that the files are still up-to-date. Without that
"done" file, the update step is always run, and that in turn causes
the other steps for the external project to re-run as well.

The best way to fix this seems to be to skip the update step by
defining an empty UPDATE_COMMAND. As long as the downloaded code for a
given hash/tag/etc does not change, the update step is unnecessary.

And if we *really* wanted to ensure unchanged dependencies, we would
download our own copies anyway.

Making this change significantly cleans up the falco build to avoid
rebuilding git based external dependencies.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cmake improvements to avoid redundant configure/install steps for external projects using git.
```
