### PR TITLE
refactor(libsinsp): renovate the filter grammar, parser, and compiler

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -248,6 +248,7 @@ if(NOT WIN32)
 			list(APPEND SINSP_LIBRARIES
 			"${ONIGURUMA_LIB}")
 			add_dependencies(sinsp jq)
+			add_definitions(-DUSE_BUNDLED_ONIGURUMA)
 		endif()
 
 		if(USE_BUNDLED_B64)

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -53,6 +53,7 @@ if(NOT WIN32)
 endif()
 
 set(SINSP_SOURCES
+	filter/parser.cpp
 	container.cpp
 	container_engine/container_engine_base.cpp
 	container_engine/static_container.cpp

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -53,6 +53,7 @@ if(NOT WIN32)
 endif()
 
 set(SINSP_SOURCES
+	filter/ast.cpp
 	filter/parser.cpp
 	container.cpp
 	container_engine/container_engine_base.cpp

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1519,6 +1519,7 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = true;
+	m_check_id = 0;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1532,6 +1533,7 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = true;
+	m_check_id = 0;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1544,6 +1546,7 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = fltast;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = false;
+	m_check_id = 0;
 }
 
 sinsp_filter_compiler::~sinsp_filter_compiler()
@@ -1553,6 +1556,11 @@ sinsp_filter_compiler::~sinsp_filter_compiler()
 	{
 		delete m_flt_ast;
 	}
+}
+
+void sinsp_filter_compiler::set_check_id(int32_t id)
+{
+	m_check_id = id;
 }
 
 sinsp_filter* sinsp_filter_compiler::compile()
@@ -1658,6 +1666,7 @@ void sinsp_filter_compiler::visit(libsinsp::filter::ast::unary_check_expr& e)
 	check->m_cmpop = str_to_cmpop(e.op);
 	check->m_boolop = m_last_boolop;
 	check->parse_field_name(field.c_str(), true, true);
+	check->set_check_id(m_check_id);
 }
 
 void sinsp_filter_compiler::visit(libsinsp::filter::ast::binary_check_expr& e)
@@ -1669,6 +1678,7 @@ void sinsp_filter_compiler::visit(libsinsp::filter::ast::binary_check_expr& e)
 	check->m_cmpop = str_to_cmpop(e.op);
 	check->m_boolop = m_last_boolop;
 	check->parse_field_name(field.c_str(), true, true);
+	check->set_check_id(m_check_id);
 
 	// Read the the the right-hand values of the filtercheck. 
 	// For list-related operators ('in', 'intersects', 'pmatch'), the vector
@@ -1726,7 +1736,7 @@ gen_event_filter_check* sinsp_filter_compiler::create_filtercheck(string& field)
 	gen_event_filter_check *chk = m_factory->new_filtercheck(field.c_str());
 	if(chk == NULL)
 	{
-		throw sinsp_exception("filter error: unrecognized field '" + field + "'");
+		throw sinsp_exception("filter_check called with nonexistent field " + field);
 	}
 	return chk;
 }

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -106,6 +106,8 @@ public:
 	*/
 	sinsp_filter* compile();
 
+	void set_check_id(int32_t id);
+
 private:
 	void visit(libsinsp::filter::ast::and_expr&) override;
 	void visit(libsinsp::filter::ast::or_expr&) override;
@@ -119,6 +121,7 @@ private:
 	string create_filtercheck_name(string& name, string& arg);
 	gen_event_filter_check* create_filtercheck(string& field);
 
+	int32_t m_check_id;
 	bool m_ttable_only;
 	bool m_internal_parsing;
 	bool m_expect_values;

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -109,13 +109,13 @@ public:
 	void set_check_id(int32_t id);
 
 private:
-	void visit(libsinsp::filter::ast::and_expr&) override;
-	void visit(libsinsp::filter::ast::or_expr&) override;
-	void visit(libsinsp::filter::ast::not_expr&) override;
-	void visit(libsinsp::filter::ast::value_expr&) override;
-	void visit(libsinsp::filter::ast::list_expr&) override;
-	void visit(libsinsp::filter::ast::unary_check_expr&) override;
-	void visit(libsinsp::filter::ast::binary_check_expr&) override;
+	void visit(libsinsp::filter::ast::and_expr*) override;
+	void visit(libsinsp::filter::ast::or_expr*) override;
+	void visit(libsinsp::filter::ast::not_expr*) override;
+	void visit(libsinsp::filter::ast::value_expr*) override;
+	void visit(libsinsp::filter::ast::list_expr*) override;
+	void visit(libsinsp::filter::ast::unary_check_expr*) override;
+	void visit(libsinsp::filter::ast::binary_check_expr*) override;
 	void check_ttable_only(string& field, gen_event_filter_check *check);
 	cmpop str_to_cmpop(string& str);
 	string create_filtercheck_name(string& name, string& arg);

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -117,6 +117,7 @@ private:
 	void visit(libsinsp::filter::ast::unary_check_expr*) override;
 	void visit(libsinsp::filter::ast::binary_check_expr*) override;
 	void check_ttable_only(string& field, gen_event_filter_check *check);
+	void check_op_value_compatibility(cmpop op, std::string& value);
 	cmpop str_to_cmpop(string& str);
 	string create_filtercheck_name(string& name, string& arg);
 	gen_event_filter_check* create_filtercheck(string& field);

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "ast.h"
+
+using namespace std;
+using namespace libsinsp::filter::ast;
+
+void base_expr_visitor::visit(and_expr& e)
+{
+    for(auto &c: e .children)
+    {
+        if (m_should_stop_visit)
+        {
+            return;
+        }
+        c->accept(*this);
+    }
+}
+
+void base_expr_visitor::visit(or_expr& e)
+{
+    for(auto &c: e .children)
+    {
+        if (m_should_stop_visit)
+        {
+            return;
+        }
+        c->accept(*this);
+    }
+}
+
+void base_expr_visitor::visit(not_expr& e)
+{
+    if (!m_should_stop_visit)
+    {
+        e.child->accept(*this);
+    }
+}
+
+void base_expr_visitor::visit(binary_check_expr& e)
+{
+    if (!m_should_stop_visit)
+    {
+        e.value->accept(*this);
+    }
+}
+
+void base_expr_visitor::visit(value_expr& e) { }
+
+void base_expr_visitor::visit(list_expr& e) { }
+
+void base_expr_visitor::visit(unary_check_expr& e){ }
+
+expr* libsinsp::filter::ast::clone(expr* e)
+{  
+    struct clone_visitor: public expr_visitor
+    {   
+        expr* m_last_node;
+
+        inline void visit(and_expr& e) 
+        {
+            vector<expr*> children;
+            for (auto &c: e.children)
+            {
+                c->accept(*this);
+                children.push_back(m_last_node);
+            }
+            m_last_node = new and_expr(children);
+        }
+
+        inline void visit(or_expr& e)
+        {
+            vector<expr*> children;
+            for (auto &c: e.children)
+            {
+                c->accept(*this);
+                children.push_back(m_last_node);
+            }
+            m_last_node = new or_expr(children);
+        }
+
+        inline void visit(not_expr& e)
+        {
+            e.child->accept(*this);
+            m_last_node = new not_expr(m_last_node);
+        }
+
+        inline void visit(binary_check_expr& e)
+        {
+            e.value->accept(*this);
+            m_last_node = new binary_check_expr(e.field, e.arg, e.op, m_last_node);
+        }
+
+        inline void visit(unary_check_expr& e)
+        {
+            m_last_node = new unary_check_expr(e.field, e.arg, e.op);
+        }
+
+        inline void visit(value_expr& e)
+        {
+            m_last_node = new value_expr(e.value);
+        }
+
+        inline void visit(list_expr& e)
+        {
+            m_last_node = new list_expr(e.values);
+        }
+    } visitor;
+
+    visitor.m_last_node = NULL;
+    e->accept(visitor);
+    return visitor.m_last_node;
+}

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -20,51 +20,51 @@ limitations under the License.
 using namespace std;
 using namespace libsinsp::filter::ast;
 
-void base_expr_visitor::visit(and_expr& e)
+void base_expr_visitor::visit(and_expr* e)
 {
-    for(auto &c: e .children)
+    for(auto &c: e->children)
     {
         if (m_should_stop_visit)
         {
             return;
         }
-        c->accept(*this);
+        c->accept(this);
     }
 }
 
-void base_expr_visitor::visit(or_expr& e)
+void base_expr_visitor::visit(or_expr* e)
 {
-    for(auto &c: e .children)
+    for(auto &c: e->children)
     {
         if (m_should_stop_visit)
         {
             return;
         }
-        c->accept(*this);
+        c->accept(this);
     }
 }
 
-void base_expr_visitor::visit(not_expr& e)
+void base_expr_visitor::visit(not_expr* e)
 {
     if (!m_should_stop_visit)
     {
-        e.child->accept(*this);
+        e->child->accept(this);
     }
 }
 
-void base_expr_visitor::visit(binary_check_expr& e)
+void base_expr_visitor::visit(binary_check_expr* e)
 {
     if (!m_should_stop_visit)
     {
-        e.value->accept(*this);
+        e->value->accept(this);
     }
 }
 
-void base_expr_visitor::visit(value_expr& e) { }
+void base_expr_visitor::visit(value_expr* e) { }
 
-void base_expr_visitor::visit(list_expr& e) { }
+void base_expr_visitor::visit(list_expr* e) { }
 
-void base_expr_visitor::visit(unary_check_expr& e){ }
+void base_expr_visitor::visit(unary_check_expr* e){ }
 
 expr* libsinsp::filter::ast::clone(expr* e)
 {  
@@ -72,57 +72,57 @@ expr* libsinsp::filter::ast::clone(expr* e)
     {   
         expr* m_last_node;
 
-        inline void visit(and_expr& e) 
+        inline void visit(and_expr* e) 
         {
             vector<expr*> children;
-            for (auto &c: e.children)
+            for (auto &c: e->children)
             {
-                c->accept(*this);
+                c->accept(this);
                 children.push_back(m_last_node);
             }
             m_last_node = new and_expr(children);
         }
 
-        inline void visit(or_expr& e)
+        inline void visit(or_expr* e)
         {
             vector<expr*> children;
-            for (auto &c: e.children)
+            for (auto &c: e->children)
             {
-                c->accept(*this);
+                c->accept(this);
                 children.push_back(m_last_node);
             }
             m_last_node = new or_expr(children);
         }
 
-        inline void visit(not_expr& e)
+        inline void visit(not_expr* e)
         {
-            e.child->accept(*this);
+            e->child->accept(this);
             m_last_node = new not_expr(m_last_node);
         }
 
-        inline void visit(binary_check_expr& e)
+        inline void visit(binary_check_expr* e)
         {
-            e.value->accept(*this);
-            m_last_node = new binary_check_expr(e.field, e.arg, e.op, m_last_node);
+            e->value->accept(this);
+            m_last_node = new binary_check_expr(e->field, e->arg, e->op, m_last_node);
         }
 
-        inline void visit(unary_check_expr& e)
+        inline void visit(unary_check_expr* e)
         {
-            m_last_node = new unary_check_expr(e.field, e.arg, e.op);
+            m_last_node = new unary_check_expr(e->field, e->arg, e->op);
         }
 
-        inline void visit(value_expr& e)
+        inline void visit(value_expr* e)
         {
-            m_last_node = new value_expr(e.value);
+            m_last_node = new value_expr(e->value);
         }
 
-        inline void visit(list_expr& e)
+        inline void visit(list_expr* e)
         {
-            m_last_node = new list_expr(e.values);
+            m_last_node = new list_expr(e->values);
         }
     } visitor;
 
     visitor.m_last_node = NULL;
-    e->accept(visitor);
+    e->accept(&visitor);
     return visitor.m_last_node;
 }

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -24,9 +24,6 @@ limitations under the License.
 
 namespace libsinsp {
 namespace filter {
-
-using namespace std;
-
 namespace ast {
 
 struct expr;
@@ -100,7 +97,7 @@ struct SINSP_PUBLIC and_expr: expr
 {
     inline and_expr() { }
 
-    inline and_expr(vector<expr*> c): children(c) { }
+    inline and_expr(std::vector<expr*> c): children(c) { }
 
     inline ~and_expr()
     {
@@ -118,19 +115,19 @@ struct SINSP_PUBLIC and_expr: expr
     inline bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const and_expr*>(other);
-        return o != nullptr && equal(
+        return o != nullptr && std::equal(
             children.begin(), children.end(), 
             o->children.begin(), compare);
     }
 
-    vector<expr*> children;
+    std::vector<expr*> children;
 };
 
 struct SINSP_PUBLIC or_expr: expr
 {
     inline or_expr() { }
 
-    inline or_expr(vector<expr*> c): children(c) { }
+    inline or_expr(std::vector<expr*> c): children(c) { }
 
     inline ~or_expr()
     {
@@ -148,12 +145,12 @@ struct SINSP_PUBLIC or_expr: expr
     inline bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const or_expr*>(other);
-        return o != nullptr && equal(
+        return o != nullptr && std::equal(
             children.begin(), children.end(), 
             o->children.begin(), compare);
     }
 
-    vector<expr*> children;
+    std::vector<expr*> children;
 };
 
 struct SINSP_PUBLIC not_expr: expr
@@ -185,7 +182,7 @@ struct SINSP_PUBLIC value_expr: expr
 {
     inline value_expr() { }
 
-    inline value_expr(string v): value(v) { }
+    inline value_expr(std::string v): value(v) { }
 
     inline void accept(expr_visitor& v) override
     {
@@ -198,14 +195,14 @@ struct SINSP_PUBLIC value_expr: expr
         return o != nullptr && value == o->value;
     }
 
-    string value;
+    std::string value;
 };
 
 struct SINSP_PUBLIC list_expr: expr
 {
     inline list_expr() { }
 
-    inline list_expr(vector<string>v): values(v) { }
+    inline list_expr(std::vector<std::string>v): values(v) { }
 
     inline void accept(expr_visitor& v) override
     {
@@ -218,7 +215,7 @@ struct SINSP_PUBLIC list_expr: expr
         return o != nullptr && values == o->values;
     }
 
-    vector<string> values;
+    std::vector<std::string> values;
 };
 
 struct SINSP_PUBLIC unary_check_expr: expr
@@ -226,9 +223,9 @@ struct SINSP_PUBLIC unary_check_expr: expr
     inline unary_check_expr() { }
 
     inline unary_check_expr(
-        string f,
-        string a,
-        string o): field(f), arg(a), op(o) { }
+        std::string f,
+        std::string a,
+        std::string o): field(f), arg(a), op(o) { }
 
     inline void accept(expr_visitor& v) override
     {
@@ -242,9 +239,9 @@ struct SINSP_PUBLIC unary_check_expr: expr
             && arg == o->arg && op == o->op;
     }
 
-    string field;
-    string arg;
-    string op;
+    std::string field;
+    std::string arg;
+    std::string op;
 };
 
 struct SINSP_PUBLIC binary_check_expr: expr
@@ -252,9 +249,9 @@ struct SINSP_PUBLIC binary_check_expr: expr
     inline binary_check_expr() { }
 
     inline binary_check_expr(
-        string f,
-        string a,
-        string o,
+        std::string f,
+        std::string a,
+        std::string o,
         expr* v): field(f), arg(a), op(o), value(v) { }
 
     inline ~binary_check_expr()
@@ -274,9 +271,9 @@ struct SINSP_PUBLIC binary_check_expr: expr
             && arg == o->arg && op == o->op && value->is_equal(o->value);
     }
 
-    string field;
-    string arg;
-    string op;
+    std::string field;
+    std::string arg;
+    std::string op;
     expr* value;
 };
 

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 #include <string>
 #include <algorithm>
+#include "../sinsp_public.h"
 
 namespace libsinsp {
 namespace filter {
@@ -40,7 +41,7 @@ struct binary_check_expr;
 /*!
     \brief Base interface of AST visitors
 */
-struct expr_visitor
+struct SINSP_PUBLIC expr_visitor
 {
     virtual void visit(and_expr&) = 0;
     virtual void visit(or_expr&) = 0;
@@ -54,8 +55,9 @@ struct expr_visitor
 /*!
     \brief Base interface of AST hierarchy
 */
-struct expr
+struct SINSP_PUBLIC expr
 {
+    virtual ~expr() { }
     virtual void accept(expr_visitor&) = 0;
     virtual bool is_equal(const expr* other) const = 0;
 };
@@ -68,7 +70,7 @@ inline bool compare(const expr* left, const expr* right)
     return left->is_equal(right);
 };
 
-struct and_expr: expr
+struct SINSP_PUBLIC and_expr: expr
 {
     inline and_expr() { }
 
@@ -98,7 +100,7 @@ struct and_expr: expr
     vector<expr*> children;
 };
 
-struct or_expr: expr
+struct SINSP_PUBLIC or_expr: expr
 {
     inline or_expr() { }
 
@@ -128,7 +130,7 @@ struct or_expr: expr
     vector<expr*> children;
 };
 
-struct not_expr: expr
+struct SINSP_PUBLIC not_expr: expr
 {
     inline not_expr() { }
 
@@ -153,7 +155,7 @@ struct not_expr: expr
     expr* child;
 };
 
-struct value_expr: expr
+struct SINSP_PUBLIC value_expr: expr
 {
     inline value_expr() { }
 
@@ -173,7 +175,7 @@ struct value_expr: expr
     string value;
 };
 
-struct list_expr: expr
+struct SINSP_PUBLIC list_expr: expr
 {
     inline list_expr() { }
 
@@ -193,7 +195,7 @@ struct list_expr: expr
     vector<string> values;
 };
 
-struct unary_check_expr: expr
+struct SINSP_PUBLIC unary_check_expr: expr
 {
     inline unary_check_expr() { }
 
@@ -219,7 +221,7 @@ struct unary_check_expr: expr
     string op;
 };
 
-struct binary_check_expr: expr
+struct SINSP_PUBLIC binary_check_expr: expr
 {
     inline binary_check_expr() { }
 

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -1,0 +1,257 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <algorithm>
+
+namespace libsinsp {
+namespace filter {
+
+using namespace std;
+
+namespace ast {
+
+struct expr;
+struct and_expr;
+struct or_expr;
+struct not_expr;
+struct value_expr;
+struct list_expr;
+struct unary_check_expr;
+struct binary_check_expr;
+
+/*!
+    \brief Base interface of AST visitors
+*/
+struct expr_visitor
+{
+    virtual void visit(and_expr&) = 0;
+    virtual void visit(or_expr&) = 0;
+    virtual void visit(not_expr&) = 0;
+    virtual void visit(value_expr&) = 0;
+    virtual void visit(list_expr&) = 0;
+    virtual void visit(unary_check_expr&) = 0;
+    virtual void visit(binary_check_expr&) = 0;
+};
+
+/*!
+    \brief Base interface of AST hierarchy
+*/
+struct expr
+{
+    virtual void accept(expr_visitor&) = 0;
+    virtual bool is_equal(const expr* other) const = 0;
+};
+
+/*!
+    \brief Comparator for AST hierarchy
+*/
+inline bool compare(const expr* left, const expr* right)
+{
+    return left->is_equal(right);
+};
+
+struct and_expr: expr
+{
+    inline and_expr() { }
+
+    inline and_expr(vector<expr*> c): children(c) { }
+
+    inline ~and_expr()
+    {
+        for (auto &c : children)
+        {
+            delete c;
+        }
+    }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const and_expr*>(other);
+        return o != nullptr && equal(
+            children.begin(), children.end(), 
+            o->children.begin(), compare);
+    }
+
+    vector<expr*> children;
+};
+
+struct or_expr: expr
+{
+    inline or_expr() { }
+
+    inline or_expr(vector<expr*> c): children(c) { }
+
+    inline ~or_expr()
+    {
+        for (auto &c : children)
+        {
+            delete c;
+        }
+    }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const or_expr*>(other);
+        return o != nullptr && equal(
+            children.begin(), children.end(), 
+            o->children.begin(), compare);
+    }
+
+    vector<expr*> children;
+};
+
+struct not_expr: expr
+{
+    inline not_expr() { }
+
+    inline not_expr(expr* c): child(c) { }
+
+    inline ~not_expr()
+    {
+        delete child;
+    }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const not_expr*>(other);
+        return o != nullptr && child->is_equal(o->child);
+    }
+
+    expr* child;
+};
+
+struct value_expr: expr
+{
+    inline value_expr() { }
+
+    inline value_expr(string v): value(v) { }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const value_expr*>(other);
+        return o != nullptr && value == o->value;
+    }
+
+    string value;
+};
+
+struct list_expr: expr
+{
+    inline list_expr() { }
+
+    inline list_expr(vector<string>v): values(v) { }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const list_expr*>(other);
+        return o != nullptr && values == o->values;
+    }
+
+    vector<string> values;
+};
+
+struct unary_check_expr: expr
+{
+    inline unary_check_expr() { }
+
+    inline unary_check_expr(
+        string f,
+        string a,
+        string o): field(f), arg(a), op(o) { }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const unary_check_expr*>(other);
+        return o != nullptr && field == o->field
+            && arg == o->arg && op == o->op;
+    }
+
+    string field;
+    string arg;
+    string op;
+};
+
+struct binary_check_expr: expr
+{
+    inline binary_check_expr() { }
+
+    inline binary_check_expr(
+        string f,
+        string a,
+        string o,
+        expr* v): field(f), arg(a), op(o), value(v) { }
+
+    inline ~binary_check_expr()
+    {
+        delete value;
+    }
+
+    inline void accept(expr_visitor& v) override
+    {
+        v.visit(*this);
+    };
+
+    inline bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const binary_check_expr*>(other);
+        return o != nullptr && field == o->field
+            && arg == o->arg && op == o->op && value->is_equal(o->value);
+    }
+
+    string field;
+    string arg;
+    string op;
+    expr* value;
+};
+
+}
+}
+}

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -40,13 +40,13 @@ struct binary_check_expr;
 */
 struct SINSP_PUBLIC expr_visitor
 {
-    virtual void visit(and_expr&) = 0;
-    virtual void visit(or_expr&) = 0;
-    virtual void visit(not_expr&) = 0;
-    virtual void visit(value_expr&) = 0;
-    virtual void visit(list_expr&) = 0;
-    virtual void visit(unary_check_expr&) = 0;
-    virtual void visit(binary_check_expr&) = 0;
+    virtual void visit(and_expr*) = 0;
+    virtual void visit(or_expr*) = 0;
+    virtual void visit(not_expr*) = 0;
+    virtual void visit(value_expr*) = 0;
+    virtual void visit(list_expr*) = 0;
+    virtual void visit(unary_check_expr*) = 0;
+    virtual void visit(binary_check_expr*) = 0;
 };
 
 /*!
@@ -58,13 +58,13 @@ struct SINSP_PUBLIC expr_visitor
 struct SINSP_PUBLIC base_expr_visitor: public expr_visitor
 {
 public:
-    virtual void visit(and_expr&) override;
-    virtual void visit(or_expr&) override;
-    virtual void visit(not_expr&) override;
-    virtual void visit(value_expr&) override;
-    virtual void visit(list_expr&) override;
-    virtual void visit(unary_check_expr&) override;
-    virtual void visit(binary_check_expr&) override;
+    virtual void visit(and_expr*) override;
+    virtual void visit(or_expr*) override;
+    virtual void visit(not_expr*) override;
+    virtual void visit(value_expr*) override;
+    virtual void visit(list_expr*) override;
+    virtual void visit(unary_check_expr*) override;
+    virtual void visit(binary_check_expr*) override;
 
     /*!
         \brief Can be set to true by subclasses to instruct the
@@ -81,7 +81,7 @@ public:
 struct SINSP_PUBLIC expr
 {
     virtual ~expr() { }
-    virtual void accept(expr_visitor&) = 0;
+    virtual void accept(expr_visitor*) = 0;
     virtual bool is_equal(const expr* other) const = 0;
 };
 
@@ -107,9 +107,9 @@ struct SINSP_PUBLIC and_expr: expr
         }
     }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -137,9 +137,9 @@ struct SINSP_PUBLIC or_expr: expr
         }
     }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -164,9 +164,9 @@ struct SINSP_PUBLIC not_expr: expr
         delete child;
     }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -184,9 +184,9 @@ struct SINSP_PUBLIC value_expr: expr
 
     inline value_expr(std::string v): value(v) { }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -204,9 +204,9 @@ struct SINSP_PUBLIC list_expr: expr
 
     inline list_expr(std::vector<std::string>v): values(v) { }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -227,9 +227,9 @@ struct SINSP_PUBLIC unary_check_expr: expr
         std::string a,
         std::string o): field(f), arg(a), op(o) { }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override
@@ -259,9 +259,9 @@ struct SINSP_PUBLIC binary_check_expr: expr
         delete value;
     }
 
-    inline void accept(expr_visitor& v) override
+    inline void accept(expr_visitor* v) override
     {
-        v.visit(*this);
+        v->visit(this);
     };
 
     inline bool is_equal(const expr* other) const override

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -39,7 +39,7 @@ struct unary_check_expr;
 struct binary_check_expr;
 
 /*!
-    \brief Base interface of AST visitors
+    \brief Interface of AST visitors
 */
 struct SINSP_PUBLIC expr_visitor
 {
@@ -53,6 +53,32 @@ struct SINSP_PUBLIC expr_visitor
 };
 
 /*!
+    \brief Base implementation for AST visitors, that traverses
+    the tree without doing anything. This way, subclasses can
+    avoid overriding empty methods if they are not interested
+    in a specific type of AST node
+*/
+struct SINSP_PUBLIC base_expr_visitor: public expr_visitor
+{
+public:
+    virtual void visit(and_expr&) override;
+    virtual void visit(or_expr&) override;
+    virtual void visit(not_expr&) override;
+    virtual void visit(value_expr&) override;
+    virtual void visit(list_expr&) override;
+    virtual void visit(unary_check_expr&) override;
+    virtual void visit(binary_check_expr&) override;
+
+    /*!
+        \brief Can be set to true by subclasses to instruct the
+        visitor that the exploration can be stopped, so
+        that the recursion gets rewinded and no more nodes
+        are explored.
+    */
+    bool m_should_stop_visit = false;
+};
+
+/*!
     \brief Base interface of AST hierarchy
 */
 struct SINSP_PUBLIC expr
@@ -63,7 +89,7 @@ struct SINSP_PUBLIC expr
 };
 
 /*!
-    \brief Comparator for AST hierarchy
+    \brief Compares two ASTs, returns true if they are deep equal
 */
 inline bool compare(const expr* left, const expr* right)
 {
@@ -253,6 +279,13 @@ struct SINSP_PUBLIC binary_check_expr: expr
     string op;
     expr* value;
 };
+
+/*!
+	\brief Creates a deep clone of a filter AST
+	\return The newly created cloned AST. Comparing the return value
+    with the input parameter returns true
+*/
+expr* clone(expr* e);
 
 }
 }

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -72,8 +72,8 @@ static const vector<string> binary_num_ops =
 
 static const vector<string> binary_str_ops =
 {
-	"==", "=", "!=", "glob ", "contains ", "icontains ",
-	"startswith ", "endswith ",
+	"==", "=", "!=", "glob ", "contains ", "icontains ", "bcontains ",
+	"startswith ", "bstartswith ", "endswith ",
 };
 
 static const vector<string> binary_list_ops =

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstring>
 #include <regex>
 #include "parser.h"
+#include "../utils.h"
 #include "../sinsp_exception.h"
 
 using namespace libsinsp::filter;
@@ -34,8 +35,8 @@ static const vector<string> binary_num_ops =
 
 static const vector<string> binary_str_ops =
 {
-	"==", "=", "!=", "glob", "contains", "icontains",
-	"startswith", "endswith",
+	"==", "=", "!=", "glob ", "contains ", "icontains ",
+	"startswith ", "endswith ",
 };
 
 static const vector<string> binary_list_ops =
@@ -210,7 +211,7 @@ ast::expr* parser::parse_check()
 		{
 			lex_blank();
 			depth_pop();
-			return new ast::unary_check_expr(field, field_arg, m_last_token);
+			return new ast::unary_check_expr(field, field_arg, trim_str(m_last_token));
 		}
 
 		string op = "";
@@ -238,25 +239,25 @@ ast::expr* parser::parse_check()
 			string ops = "";
 			for (auto &o: unary_ops)
 			{
-				ops += "'" + o + "', ";
+				ops += "'" + trim_str(o) + "', ";
 			}
 			for (auto &o: binary_num_ops)
 			{
-				ops += "'" + o + "', ";
+				ops += "'" + trim_str(o) + "', ";
 			}
 			for (auto &o: binary_str_ops)
 			{
-				ops += "'" + o + "', ";
+				ops += "'" + trim_str(o) + "', ";
 			}
 			for (auto &o: binary_list_ops)
 			{
-				ops += "'" + o + "', ";
+				ops += "'" + trim_str(o) + "', ";
 			}
 			ops.erase(ops.size() - 2, 2);
 			throw sinsp_exception("expected a valid check operator: one of " + ops);
 		}
 		depth_pop();
-		return new ast::binary_check_expr(field, field_arg, op, value);
+		return new ast::binary_check_expr(field, field_arg, trim_str(op), value);
 	}
 
 	if (lex_identifier())
@@ -547,6 +548,13 @@ string parser::escape_str(string& str)
 		}
 	}
 	return res;
+}
+
+inline string parser::trim_str(const string& str)
+{
+	string val = str;
+	trim(val);
+	return val;
 }
 
 inline void parser::depth_push()

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -232,9 +232,9 @@ ast::expr* parser::parse_check()
 		string field_arg = "";
 		if (lex_helper_str("["))
 		{
-			if (!lex_num() && !lex_quoted_str() && !lex_field_arg_bare_str())
+			if (!lex_quoted_str() && !lex_field_arg_bare_str())
 			{
-				throw sinsp_exception("expected a valid field argument: a number, quoted string, or a bare string");
+				throw sinsp_exception("expected a valid field argument: a quoted string or a bare string");
 			}
 			field_arg = m_last_token;
 			if (!lex_helper_str("]"))

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "../utils.h"
 #include "../sinsp_exception.h"
 
+using namespace std;
 using namespace libsinsp::filter;
 
 static const vector<string> unary_ops =

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -1,0 +1,548 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <cstring>
+#include <regex>
+#include "parser.h"
+#include "../sinsp_exception.h"
+
+using namespace libsinsp::filter;
+
+static const vector<string> unary_ops =
+{ 
+	"exists"
+};
+
+static const vector<string> binary_num_ops = 
+{ 
+	"<=", "<", ">=", ">"
+};
+
+static const vector<string> binary_str_ops =
+{
+	"==", "=", "!=", "glob", "contains", "icontains",
+	"startswith", "endswith",
+};
+
+static const vector<string> binary_list_ops =
+{
+	"intersects", "in", "pmatch"
+};
+
+parser::parser(const string& input)
+{
+	m_input = input;
+	m_pos.reset();
+	m_depth = 0;
+	m_max_depth = 100;
+	m_parse_partial = false;
+}
+
+void parser::get_pos(pos_info& pos)
+{
+	pos.idx = m_pos.idx - m_last_token.size();
+	pos.col = m_pos.col - m_last_token.size();
+	pos.line = m_pos.line;
+}
+
+parser::pos_info parser::get_pos()
+{
+	pos_info info;
+	get_pos(info);
+	return info;
+}
+
+void parser::set_parse_partial(bool parse_partial)
+{
+	m_parse_partial = parse_partial;
+}
+
+void parser::set_max_depth(uint32_t max_depth)
+{
+	m_max_depth = max_depth;
+}
+
+ast::expr* parser::parse()
+{
+	if (m_input.size() == 0)
+	{
+		throw sinsp_exception("filter input string is empty");
+	}
+	m_pos.reset();
+	m_last_token = "";
+	m_depth = 0;
+	auto res = parse_or();
+	if (m_depth > 0)
+	{
+		ASSERT(false);
+		throw sinsp_exception("parser recursion is unbalanced");
+	}
+	if (!m_parse_partial && m_pos.idx != m_input.size())
+	{
+		throw sinsp_exception("filter input was parsed partially");
+	}
+	return res;
+}
+
+ast::expr* parser::parse_or()
+{
+	depth_push();
+	vector<ast::expr*> children;
+	lex_blank();
+	children.push_back(parse_and());
+	lex_blank();
+	while (lex_helper_str("or"))
+	{
+		if (!lex_blank())
+		{
+			throw sinsp_exception("expected blank after 'or'");
+		}
+		children.push_back(parse_and());
+		lex_blank();
+	}
+	depth_pop();
+	if (children.size() > 1)
+	{
+		return new ast::or_expr(children);
+	}
+	return children[0];
+}
+
+ast::expr* parser::parse_and()
+{
+	depth_push();
+	vector<ast::expr*> children;
+	lex_blank();
+	children.push_back(parse_not());
+	lex_blank();
+	while (lex_helper_str("and"))
+	{
+		if (!lex_blank())
+		{
+			throw sinsp_exception("expected blank after 'and'");
+		}
+		children.push_back(parse_not());
+		lex_blank();
+	}
+	depth_pop();
+	if (children.size() > 1)
+	{
+		return new ast::and_expr(children);
+	}
+	return children[0];
+}
+
+ast::expr* parser::parse_not()
+{
+	depth_push();
+	bool is_not = false;
+	lex_blank();
+	while (lex_helper_str("not"))
+	{
+		if (!lex_blank())
+		{
+			throw sinsp_exception("expected blank after 'not'");
+		}
+		is_not = !is_not;
+	}
+	auto child = parse_check();
+	lex_blank();
+	depth_pop();
+	if (is_not)
+	{
+		return new ast::not_expr(child);
+	}
+	return child;
+}
+
+ast::expr* parser::parse_check()
+{
+	depth_push();
+	lex_blank();
+	if (lex_helper_str("("))
+	{
+		lex_blank();
+		auto child = parse_or();
+		lex_blank();
+		if (!lex_helper_str(")"))
+		{
+			delete child;
+			throw sinsp_exception("expected a ')' token");
+		}
+		lex_blank();
+		depth_pop();
+		return child;
+	}
+
+	if (lex_field_name())
+	{
+		string field = m_last_token;
+		string field_arg = "";
+		if (lex_helper_str("["))
+		{
+			if (!lex_num() && !lex_quoted_str() && !lex_field_arg_bare_str())
+			{
+				throw sinsp_exception("expected a valid field argument: a number, quoted string, or a bare string");
+			}
+			field_arg = m_last_token;
+			if (!lex_helper_str("]"))
+			{
+				throw sinsp_exception("expected a ']' token");
+			}
+		}
+		lex_blank();
+
+		if (lex_unary_op())
+		{
+			lex_blank();
+			depth_pop();
+			return new ast::unary_check_expr(field, field_arg, m_last_token);
+		}
+
+		string op = "";
+		ast::expr* value = NULL;
+		if (lex_num_op())
+		{
+			lex_blank();
+			op = m_last_token;
+			value = parse_num_value();
+		}
+		else if (lex_str_op())
+		{
+			lex_blank();
+			op = m_last_token;
+			value = parse_str_value();
+		}
+		else if (lex_list_op())
+		{
+			lex_blank();
+			op = m_last_token;
+			value = parse_list_value();
+		} 
+		else
+		{
+			string ops = "";
+			for (auto &o: unary_ops)
+			{
+				ops += "'" + o + "', ";
+			}
+			for (auto &o: binary_num_ops)
+			{
+				ops += "'" + o + "', ";
+			}
+			for (auto &o: binary_str_ops)
+			{
+				ops += "'" + o + "', ";
+			}
+			for (auto &o: binary_list_ops)
+			{
+				ops += "'" + o + "', ";
+			}
+			ops.erase(ops.size() - 2, 2);
+			throw sinsp_exception("expected a valid check operator: one of " + ops);
+		}
+		depth_pop();
+		return new ast::binary_check_expr(field, field_arg, op, value);
+	}
+
+	if (lex_identifier())
+	{
+		lex_blank();
+		depth_pop();
+		return new ast::value_expr(m_last_token);
+	}
+
+	throw sinsp_exception("expected a '(' token, a field check, or an identifier");
+}
+
+ast::value_expr* parser::parse_num_value()
+{
+	depth_push();
+	lex_blank();
+	if (lex_hex_num() || lex_num())
+	{
+		lex_blank();
+		depth_pop();
+		return new ast::value_expr(m_last_token);
+	}
+	throw sinsp_exception("expected a number value");
+}
+
+ast::value_expr* parser::parse_str_value()
+{
+	depth_push();
+	lex_blank();
+	if (lex_quoted_str() || lex_bare_str())
+	{
+		lex_blank();
+		depth_pop();
+		return new ast::value_expr(m_last_token);
+	}
+	throw sinsp_exception("expected a string value");
+}
+
+ast::expr* parser::parse_list_value()
+{
+	depth_push();
+	lex_blank();
+	if (lex_helper_str("("))
+	{
+		vector<string> values;
+		lex_blank();
+		auto child = parse_str_value();
+		values.push_back(child->value);
+		delete child;
+		lex_blank();
+		while (lex_helper_str(","))
+		{
+			lex_blank();
+			child = parse_str_value();
+			values.push_back(child->value);
+			delete child;
+			lex_blank();
+		}
+		if (!lex_helper_str(")"))
+		{
+			throw sinsp_exception("expected a ')' token");
+		}
+		lex_blank();
+		depth_pop();
+		return new ast::list_expr(values);
+	}
+
+	if (lex_identifier())
+	{
+		lex_blank();
+		depth_pop();
+		return new ast::value_expr(m_last_token);
+	}
+
+	throw sinsp_exception("expected a list or an identifier");
+}
+
+// note: lex_blank is the only lex method that does not update m_last_token.
+bool parser::lex_blank()
+{
+	bool found = false;
+	while(*cursor() == ' ' || *cursor() == '\t' || *cursor() == '\b'
+			|| *cursor() == '\r' || *cursor() == '\n')
+	{
+		found = true;
+		m_pos.col++;
+		if (*cursor() == '\r' || *cursor() == '\n')
+		{
+			m_pos.col = 1;
+			m_pos.line++;
+		}
+		m_pos.idx++;
+	}
+	return found;
+}
+
+inline bool parser::lex_identifier()
+{
+	return lex_helper_rgx("[a-zA-Z]+[a-zA-Z0-9_]*");
+}
+
+inline bool parser::lex_field_name()
+{
+	return lex_helper_rgx("[a-zA-Z]+[a-zA-Z0-9_]*(\\.[a-zA-Z]+[a-zA-Z0-9_]*)+");
+}
+
+inline bool parser::lex_field_arg_bare_str()
+{
+	return lex_helper_rgx("[^ \\b\\t\\n\\r\\[\\]\"']+");
+}
+
+inline bool parser::lex_hex_num()
+{
+	return lex_helper_rgx("0[xX][0-9a-zA-Z]+");
+}
+
+inline bool parser::lex_num()
+{
+	return lex_helper_rgx("[+\\-]?[0-9]+[\\.]?[0-9]*([eE][+\\-][0-9]+)?");
+}
+
+inline bool parser::lex_quoted_str()
+{
+	if(lex_helper_rgx("\"(?:\\\\\"|.)*?\"|'(?:\\\\'|.)*?'"))
+	{
+		m_last_token = escape_str(m_last_token);
+		return true;
+	}
+	return false;
+}
+
+inline bool parser::lex_bare_str()
+{
+	return lex_helper_rgx("[^ \\b\\t\\n\\r\\(\\),=\"']+");
+}
+
+inline bool parser::lex_unary_op()
+{
+	return lex_helper_str_list(unary_ops);
+}
+
+inline bool parser::lex_num_op()
+{
+	return lex_helper_str_list(binary_num_ops);
+}
+
+inline bool parser::lex_str_op()
+{
+	return lex_helper_str_list(binary_str_ops);
+}
+
+inline bool parser::lex_list_op()
+{
+	return lex_helper_str_list(binary_list_ops);
+}
+
+bool parser::lex_helper_rgx(string rgx)
+{
+	cmatch match;
+	auto r = regex("^(" + rgx + ")");
+	if (regex_search (cursor(), match, r))
+	{
+		size_t group_idx = 0;
+		if (match.size() > group_idx && match[group_idx].matched)
+		{
+			m_last_token = match[group_idx].str();
+			m_pos.idx += m_last_token.size();
+			m_pos.col += m_last_token.size();
+			return true;
+		}
+	}
+	return false;
+}
+
+bool parser::lex_helper_str(string str)
+{
+	if (strncmp(cursor(), str.c_str(), str.size()) == 0)
+	{
+		m_last_token = str;
+		m_pos.idx += m_last_token.size();
+		m_pos.col += m_last_token.size();
+		return true;
+	}
+	return false;
+}
+
+bool parser::lex_helper_str_list(vector<string> list)
+{
+	for (auto &op : list)
+	{
+		if (lex_helper_str(op))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+inline const char* parser::cursor()
+{
+	return m_input.c_str() + m_pos.idx;
+}
+
+string parser::escape_str(string& str)
+{
+	string res = "";
+	size_t len = str.size() - 1;
+	bool escaped = false;
+	for (size_t i = 1; i < len; i++)
+	{
+		if (!escaped)
+		{
+			if (str[i] == '\\')
+			{
+				escaped = true;
+			}
+			else 
+			{
+				res += str[i];
+			}
+		}
+		else
+		{
+			switch(str[i])
+			{
+				case 'b':
+					res += '\b';
+					break;
+				case 'f':
+					res += '\f';
+					break;
+				case 'n':
+					res += '\n';
+					break;
+				case 'r':
+					res += '\r';
+					break;
+				case 't':
+					res += '\t';
+					break;
+				case ' ':
+					// NOTE: we may need to initially support this to not create breaking changes with
+					// some existing wrongly-escaped rules. So far, I only found one, in Falco:
+					// https://github.com/falcosecurity/falco/blob/204f9ff875be035e620ca1affdf374dd1c610a98/rules/falco_rules.yaml#L3046
+					// todo(jasondellaluce): remove this once rules are rewritten with correct escaping
+				case '\\':
+					res += '\\';
+					break;
+				case '/':
+					res += '/';
+					break;
+				case '"':
+					if (str[0] != str[i]) 
+					{
+						throw sinsp_exception("invalid \\\" escape in '-quoted string");
+					}
+					res += '\"';
+					break;
+				case '\'':
+					if (str[0] != str[i]) 
+					{
+						throw sinsp_exception("invalid \\' escape in \"-quoted string");
+					}
+					res += '\'';
+					break;
+				case 'x':
+					// todo(jasondellaluce): support hex num escaping (not needed for now)
+				default:
+					throw sinsp_exception("unsupported string escape sequence: \\" + str[i]);
+			}
+			escaped = false;
+		}
+	}
+	return res;
+}
+
+inline void parser::depth_push()
+{
+	m_depth++;
+	if (m_depth >= m_max_depth)
+	{
+		throw sinsp_exception("exceeded max depth limit of " + to_string(m_max_depth));
+	}
+}
+
+inline void parser::depth_pop()
+{
+	m_depth--;
+}

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -1,0 +1,177 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "ast.h"
+
+//
+// Context-free Grammar for Sinsp Filters
+//
+// Productions (EBNF Syntax):
+//     Expr          ::= OrExpr
+//     OrExpr        ::= AndExpr ('or' AndExpr)*
+//     AndExpr       ::= NotExpr ('and' NotExpr)*
+//     NotExpr       ::= ('not')* Check
+//     Check               ::= CheckField CheckCondition
+//                             | Identifier
+//                             | '(' OrExpr ')'
+//     CheckCondition      ::= UnaryOperator
+//                             | NumOperator NumValue
+//                             | StrOperator StrValue
+//                             | ListOperator ListValue
+//     ListValue           ::= '(' StrValue (',' StrValue)* ')'
+//                             | Identifier
+//     CheckField          ::= FieldName('[' FieldArg ']')?
+//     FieldArg            ::= Number | QuotedStr | FieldArgBareStr 
+//     NumValue            ::= HexNumber | Number
+//     StrValue            ::= QuotedStr | BareStr
+// 
+// Supported Check Operators (EBNF Syntax):
+//     UnaryOperator       ::= 'exists'
+//     NumOperator         ::= '<=' | '<' | '>=' | '>' 
+//     StrOperator         ::= '==' | '=' | '!=' | 'glob' | 'contains'
+//                             | 'icontains' | 'startswith' | 'endswith'
+//     ListOperator        ::= 'intersects' | 'in' | 'pmatch' 
+// 
+// Tokens (Regular Expressions):
+//     Identifier          ::= [a-zA-Z]+[a-zA-Z0-9_]*
+//     FieldName           ::= [a-zA-Z]+[a-zA-Z0-9_]*(\.[a-zA-Z]+[a-zA-Z0-9_]*)+
+//     FieldArgBareStr     ::= [^ \b\t\n\r\[\]"']+
+//     HexNumber           ::= 0[xX][0-9a-zA-Z]+
+//     Number              ::= [+\-]?[0-9]+[\.]?[0-9]*([eE][+\-][0-9]+)?
+//     QuotedStr           ::= "(?:\\"|.)*?"|'(?:\\'|.)*?'
+//     BareStr             ::= [^ \b\t\n\r\(\),="']+
+//
+
+namespace libsinsp {
+namespace filter {
+
+/*!
+	\brief This class parses a sinsp filter string with a context-free
+	formal grammar and generates an AST.
+*/
+class SINSP_PUBLIC parser
+{
+public:
+	/*!
+		\brief A struct containing info about the position of the parser
+		relatively to the string input. For example, this can either be used
+		to retrieve context information when an exception is thrown.
+	*/
+	struct pos_info
+	{
+		inline void reset() 
+		{
+			idx = 0;
+			line = 1;
+			col = 1;
+		}
+		
+		inline string as_string()
+		{
+			return "index " + to_string(idx) 
+				+ ", line " + to_string(line) 
+				+ ", column " + to_string(col);
+		}
+
+		uint32_t idx;
+		uint32_t line;
+		uint32_t col;
+	};
+
+	/*!
+		\brief Constructs the parser with a given filter string input
+		\param input The filter string to parse.
+	*/
+	parser(const string& input);
+
+	/*!
+		\brief Retrieves the parser position info.
+		\param pos pos_info struct in which the info is written.
+	*/
+	void get_pos(pos_info& pos);
+
+	/*!
+		\brief Retrieves the parser position info.
+		\return pos_info struct in which the info is written.
+	*/
+	pos_info get_pos();
+
+	/*!
+		\brief Sets the partial parsing option. Default is true.
+		\note Parsing the input partially means that the parsing can succeed
+		without reaching the end of the input. In other word, this allows
+		parsing strings that have a valid filter as their prefix.
+	*/
+	void set_parse_partial(bool parse_partial);
+
+	/*!
+		\brief Sets the max depth of the recursion. Default is 100.
+		\note The parser is implemented as a recursive descent parser, so the
+		depth of the recursion is capped to a max level to prevent stack abuse.
+	*/
+	void set_max_depth(uint32_t max_depth);
+
+	/*!
+		\brief Parses the input and returns an AST.
+		\note Throws a sinsp_exception in case of parsing errors.
+		\return Pointer to a expr struct representing the the parsed
+		AST. The resulting pointer is owned by the caller and must be deleted
+		by it. The pointer is automatically deleted in case of exception.
+		On delete, each node of the AST deletes all its subnodes.
+	*/
+	ast::expr* parse();
+
+private:
+	ast::expr* parse_or();
+	ast::expr* parse_and();
+	ast::expr* parse_not();
+	ast::expr* parse_check();
+	ast::expr* parse_list_value();
+	ast::value_expr* parse_num_value();
+	ast::value_expr* parse_str_value();
+	bool lex_blank();
+	bool lex_identifier();
+	bool lex_field_name();
+	bool lex_field_arg_bare_str();
+	bool lex_hex_num();
+	bool lex_num();
+	bool lex_quoted_str();
+	bool lex_bare_str();
+	bool lex_unary_op();
+	bool lex_num_op();
+	bool lex_str_op();
+	bool lex_list_op();
+	bool lex_helper_rgx(string rgx);
+	bool lex_helper_str(string str);
+	bool lex_helper_str_list(vector<string> list);
+	void depth_push();
+	void depth_pop();
+	const char* cursor();
+	string escape_str(string& str);
+
+	bool m_parse_partial;
+	uint32_t m_depth;
+	uint32_t m_max_depth;
+	pos_info m_pos;
+	string m_input;
+	string m_last_token;
+};
+
+}
+}

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -37,7 +37,7 @@ limitations under the License.
 //     ListValue           ::= '(' (StrValue (',' StrValue)*)* ')'
 //                             | Identifier
 //     CheckField          ::= FieldName('[' FieldArg ']')?
-//     FieldArg            ::= Number | QuotedStr | FieldArgBareStr 
+//     FieldArg            ::= QuotedStr | FieldArgBareStr 
 //     NumValue            ::= HexNumber | Number
 //     StrValue            ::= QuotedStr | BareStr
 // 

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -34,7 +34,7 @@ limitations under the License.
 //                             | NumOperator NumValue
 //                             | StrOperator StrValue
 //                             | ListOperator ListValue
-//     ListValue           ::= '(' StrValue (',' StrValue)* ')'
+//     ListValue           ::= '(' (StrValue (',' StrValue)*)* ')'
 //                             | Identifier
 //     CheckField          ::= FieldName('[' FieldArg ']')?
 //     FieldArg            ::= Number | QuotedStr | FieldArgBareStr 

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -82,11 +82,11 @@ public:
 			col = 1;
 		}
 		
-		inline string as_string()
+		inline std::string as_string()
 		{
-			return "index " + to_string(idx) 
-				+ ", line " + to_string(line) 
-				+ ", column " + to_string(col);
+			return "index " + std::to_string(idx) 
+				+ ", line " + std::to_string(line) 
+				+ ", column " + std::to_string(col);
 		}
 
 		uint32_t idx;
@@ -98,7 +98,7 @@ public:
 		\brief Constructs the parser with a given filter string input
 		\param input The filter string to parse.
 	*/
-	parser(const string& input);
+	parser(const std::string& input);
 
 	/*!
 		\brief Retrieves the parser position info.
@@ -157,21 +157,21 @@ private:
 	bool lex_num_op();
 	bool lex_str_op();
 	bool lex_list_op();
-	bool lex_helper_rgx(string rgx);
-	bool lex_helper_str(string str);
-	bool lex_helper_str_list(vector<string> list);
+	bool lex_helper_rgx(std::string rgx);
+	bool lex_helper_str(std::string str);
+	bool lex_helper_str_list(std::vector<std::string> list);
 	void depth_push();
 	void depth_pop();
 	const char* cursor();
-	string escape_str(string& str);
-	string trim_str(const string& str);
+	std::string escape_str(std::string& str);
+	std::string trim_str(const std::string& str);
 
 	bool m_parse_partial;
 	uint32_t m_depth;
 	uint32_t m_max_depth;
 	pos_info m_pos;
-	string m_input;
-	string m_last_token;
+	std::string m_input;
+	std::string m_last_token;
 };
 
 }

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -44,8 +44,8 @@ limitations under the License.
 // Supported Check Operators (EBNF Syntax):
 //     UnaryOperator       ::= 'exists'
 //     NumOperator         ::= '<=' | '<' | '>=' | '>' 
-//     StrOperator         ::= '==' | '=' | '!=' | 'glob' | 'contains'
-//                             | 'icontains' | 'startswith' | 'endswith'
+//     StrOperator         ::= '==' | '=' | '!=' | 'glob ' | 'contains '
+//                             | 'icontains ' | 'startswith ' | 'endswith '
 //     ListOperator        ::= 'intersects' | 'in' | 'pmatch' 
 // 
 // Tokens (Regular Expressions):
@@ -164,6 +164,7 @@ private:
 	void depth_pop();
 	const char* cursor();
 	string escape_str(string& str);
+	string trim_str(const string& str);
 
 	bool m_parse_partial;
 	uint32_t m_depth;

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	token_bucket.ut.cpp
 	ppm_api_version.ut.cpp
 	filter_parser.ut.cpp
+	filter_compiler.ut.cpp
 )
 
 if(NOT MINIMAL_BUILD)

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	evttype_filter.ut.cpp
 	token_bucket.ut.cpp
 	ppm_api_version.ut.cpp
+	filter_parser.ut.cpp
 )
 
 if(NOT MINIMAL_BUILD)

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -1,0 +1,110 @@
+#include <sinsp.h>
+#include <filter.h>
+#include <gtest.h>
+#include <list>
+
+using namespace std;
+
+// A mock filtercheck that returns always true or false depending on
+// the passed-in field name. The operation is ignored.
+class mock_compiler_filter_check: public gen_event_filter_check
+{
+public:
+	inline int32_t parse_field_name(const char* str, bool a, bool n) override
+	{
+		m_name = string(str);
+		return 0;
+	}
+
+	inline bool compare(gen_event *evt) override
+	{
+		return m_name == "c.true";
+	}
+
+	inline void add_filter_value(const char* str, uint32_t l, uint32_t i) override { }
+
+	inline uint8_t* extract(gen_event *e, uint32_t* l, bool s) override { return NULL; }
+
+	string m_name;
+};
+
+// A factory that creates mock filterchecks
+class mock_compiler_filter_factory: public gen_event_filter_factory
+{
+public:
+	inline gen_event_filter *new_filter() override
+	{
+		return new sinsp_filter(NULL);
+	}
+
+	inline gen_event_filter_check *new_filtercheck(const char *fldname) override
+	{
+		return new mock_compiler_filter_check();
+	}
+
+	inline list<gen_event_filter_factory::filter_fieldclass_info> get_fields() override
+	{
+		return m_list;
+	}
+
+	list<gen_event_filter_factory::filter_fieldclass_info> m_list;
+};
+
+// Compile a filter, pass a mock event to it, and
+// check that the result of the boolean evaluation is
+// the expected one
+void test_filter_run(bool result, string filter_str)
+{
+	std::shared_ptr<gen_event_filter_factory> factory;
+	factory.reset(new mock_compiler_filter_factory());
+	sinsp_filter_compiler compiler(factory, filter_str);
+	try
+	{
+		auto filter = compiler.compile();
+		if (filter->run(NULL) != result)
+		{
+			FAIL() << filter_str << " -> unexpected '" << (result ? "false" : "true") << "' result";
+		}
+		delete filter;
+	}
+	catch(const sinsp_exception& e)
+	{
+		FAIL() << filter_str << " -> " << e.what();
+	}
+}
+
+// In each of these test cases, we compile filter expression
+// of which we can control the truth state of each filtercheck,
+// so that we can deterministically check the result of running
+// a mock event in the compiled filters. The purpose is verifying
+// that the compiler constructs valid boolean expressions.
+TEST(sinsp_filter_compiler, smoke_filter_run)
+{
+	test_filter_run(true,  "c.true=1");
+	test_filter_run(false, "c.false=1");
+	test_filter_run(false, "not c.true=1");
+	test_filter_run(true,  "not not c.true=1");
+	test_filter_run(true,  "not (not c.true=1)");
+	test_filter_run(false, "not not not c.true=1");
+	test_filter_run(false, "not (not (not c.true=1))");
+	test_filter_run(true,  "not not not not c.true=1");
+	test_filter_run(true,  "c.true=1 and c.true=1");
+	test_filter_run(false, "c.true=1 and c.false=1");
+	test_filter_run(false, "c.false=1 and c.true=1");
+	test_filter_run(false, "c.false=1 and c.false=1");
+	test_filter_run(false, "c.true=1 and not c.true=1");
+	test_filter_run(false, "not c.true=1 and c.true=1");
+	test_filter_run(true,  "c.true=1 or c.true=1");
+	test_filter_run(true,  "c.true=1 or c.false=1");
+	test_filter_run(true,  "c.false=1 or c.true=1");
+	test_filter_run(false, "c.false=1 or c.false=1");
+	test_filter_run(true,  "c.false=1 or not c.false=1");
+	test_filter_run(true,  "not c.false=1 or c.false=1");
+	test_filter_run(true,  "c.true=1 or c.true=1 and c.false=1");
+	test_filter_run(false, "(c.true=1 or c.true=1) and c.false=1");
+	test_filter_run(true,  "not (not (c.true=1 or c.true=1) and c.false=1)");
+	test_filter_run(false, "not (c.false=1 or c.false=1 or c.true=1)");
+	test_filter_run(true,  "not (c.false=1 or c.false=1 and not c.true=1)");
+	test_filter_run(false, "not (c.false=1 or not c.false=1 and c.true=1)");
+	test_filter_run(false, "not ((c.false=1 or not (c.false=1 and not c.true=1)) and c.true=1)");
+}

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -18,14 +18,34 @@ public:
 
 	inline bool compare(gen_event *evt) override
 	{
-		return m_name == "c.true";
+		if (m_name == "c.true")
+		{
+			return true;
+		}
+		if (m_name == "c.false")
+		{
+			return false;
+		}
+		if (m_name == "c.doublequote")
+		{
+			return m_value == "hello \"quoted\"";
+		}
+		if (m_name == "c.singlequote")
+		{
+			return m_value == "hello 'quoted'";
+		}
+		return false;
 	}
 
-	inline void add_filter_value(const char* str, uint32_t l, uint32_t i) override { }
+	inline void add_filter_value(const char* str, uint32_t l, uint32_t i) override
+	{ 
+		m_value = string(str);
+	}
 
 	inline uint8_t* extract(gen_event *e, uint32_t* l, bool s) override { return NULL; }
 
 	string m_name;
+	string m_value;
 };
 
 // A factory that creates mock filterchecks
@@ -73,12 +93,28 @@ void test_filter_run(bool result, string filter_str)
 	}
 }
 
+void test_filter_compile(string filter_str)
+{
+	std::shared_ptr<gen_event_filter_factory> factory;
+	factory.reset(new mock_compiler_filter_factory());
+	sinsp_filter_compiler compiler(factory, filter_str);
+	try
+	{
+		auto filter = compiler.compile();
+		delete filter;
+	}
+	catch(const sinsp_exception& e)
+	{
+		FAIL() << filter_str << " -> " << e.what();
+	}
+}
+
 // In each of these test cases, we compile filter expression
 // of which we can control the truth state of each filtercheck,
 // so that we can deterministically check the result of running
 // a mock event in the compiled filters. The purpose is verifying
 // that the compiler constructs valid boolean expressions.
-TEST(sinsp_filter_compiler, smoke_filter_run)
+TEST(sinsp_filter_compiler, boolean_evaluation)
 {
 	test_filter_run(true,  "c.true=1");
 	test_filter_run(false, "c.false=1");
@@ -107,4 +143,39 @@ TEST(sinsp_filter_compiler, smoke_filter_run)
 	test_filter_run(true,  "not (c.false=1 or c.false=1 and not c.true=1)");
 	test_filter_run(false, "not (c.false=1 or not c.false=1 and c.true=1)");
 	test_filter_run(false, "not ((c.false=1 or not (c.false=1 and not c.true=1)) and c.true=1)");
+}
+
+TEST(sinsp_filter_compiler, str_escape)
+{
+	test_filter_run(true, "c.singlequote = 'hello \\'quoted\\''");
+	test_filter_run(true, "c.singlequote = \"hello 'quoted'\"");
+	test_filter_run(true, "c.doublequote = 'hello \"quoted\"'");
+	test_filter_run(true, "c.doublequote = \"hello \\\"quoted\\\"\"");
+
+	test_filter_run(false, "c.singlequote = 'hello \\\\'quoted\\\\''");
+	test_filter_run(false, "c.singlequote = \"hello ''quoted''\"");
+	test_filter_run(false, "c.doublequote = \"hello \\\\\"quoted\\\\\"\"");
+	test_filter_run(false, "c.doublequote = 'hello \"\"quoted\"\"'");
+}
+
+TEST(sinsp_filter_compiler, supported_operators)
+{
+	// valid operators
+	test_filter_compile("c.true exists");
+	test_filter_compile("c.true = value");
+	test_filter_compile("c.true == value");
+	test_filter_compile("c.true != value");
+	test_filter_compile("c.true glob value");
+	test_filter_compile("c.true contains value");
+	test_filter_compile("c.true icontains value");
+	test_filter_compile("c.true startswith value");
+	test_filter_compile("c.true endswith value");
+	test_filter_compile("c.true > 1");
+	test_filter_compile("c.true < 1");
+	test_filter_compile("c.true >= 1");
+	test_filter_compile("c.true <= 1");
+	test_filter_compile("c.true in ()");
+	test_filter_compile("c.true intersects ()");
+	test_filter_compile("c.true pmatch ()");
+	test_filter_compile("c.true in()");
 }

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -42,7 +42,10 @@ public:
 		m_value = string(str);
 	}
 
-	inline uint8_t* extract(gen_event *e, uint32_t* l, bool s) override { return NULL; }
+	inline bool extract(gen_event *e, OUT vector<extract_value_t>& v, bool) override
+	{
+		return false;
+	}
 
 	string m_name;
 	string m_value;

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -118,6 +118,15 @@ TEST(parser, parse_str)
 	test_accept("test.str = \"test value\"");
 	test_accept("test.str = 'test value'");
 
+	// valid field args
+	test_accept("test.str[0a!@#456:/\\.;!$%^&*(){}|] = testval");
+	test_accept("test.str[aaaa1] = a");
+	test_accept("test.str[1234] = a");
+	test_accept("test.str[+0.25e+10] = a");
+	test_accept("test.str[\"\"] = empty");
+	test_accept("test.str['a aa'] = a");
+	test_accept("test.str[\"test \\\"with\\\"escaping\"] = a");
+
 	// valid string escaping
 	test_accept("test.str = \"escape double quote \\\" \"");
 	test_accept("test.str = \"escape double quote \\\" \"");
@@ -145,6 +154,17 @@ TEST(parser, parse_str)
 	test_reject("test.str = 'broken escape single quote''");
 	test_reject("test.str = \"mixed \\\'\"");
 	test_reject("test.str = 'mixed \\\"'");
+
+	// invalid field args
+	test_reject("test.str[0a!@#456:/\\.;!$%^&*[]{}] = testval");
+	test_reject("test.str[] = testval");
+	test_reject("test.str[[] = testval");
+	test_reject("test.str[]] = testval");
+	test_reject("test.str['''] = a");
+	test_reject("test.str[aaa\"] = a");
+	test_reject("test.str[   test   ] = testval");
+	test_reject("test.str[ = testval");
+	test_reject("test.str] = testval");
 }
 
 TEST(parser, parse_numbers)

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -1,0 +1,158 @@
+#include <filter/parser.h>
+#include <gtest.h>
+
+using namespace libsinsp::filter;
+using namespace libsinsp::filter::ast;
+
+static void test_equal_ast(string in, expr* ast)
+{
+	parser parser(in);
+	try
+	{
+		auto res = parser.parse();
+		if (!res->is_equal(ast))
+		{
+			FAIL() << "parsed ast is not equal to the expected one -> " << in;
+		}
+		delete res;
+	}
+	catch (runtime_error& e)
+	{
+		auto pos = parser.get_pos();
+		FAIL() << "at " << pos.as_string() << ": " << e.what() << " -> " << in;
+	}
+	delete ast;
+};
+
+static void test_accept(string in)
+{
+	parser parser(in);
+	try
+	{
+	   	delete parser.parse();
+	}
+	catch (runtime_error& e)
+	{
+		auto pos = parser.get_pos();
+		FAIL() << "at " << pos.as_string() << ": " << e.what() << " -> " << in;
+	}
+}
+
+static void test_reject(string in)
+{
+	parser parser(in);
+	try
+	{
+		delete parser.parse();
+		FAIL() << "error expected but not received";
+	}
+	catch (runtime_error& e)
+	{
+		// all good
+	}
+}
+
+// Inspired by Falco's parser smoke tests:
+// https://github.com/falcosecurity/falco/blob/204f9ff875be035e620ca1affdf374dd1c610a98/userspace/engine/lua/parser-smoke.sh#L41
+TEST(parser, smoke_accept_reject)
+{
+	// good
+	test_accept("  a");
+	test_accept("a and b");
+	test_accept("(a)");
+	test_accept("(a and b)");
+	test_accept("(a.a exists and b)");
+	test_accept("(a.a exists) and (b)");
+	test_accept("a.a exists and b");
+	test_accept("a.a=1 or b.b=2 and c");
+	test_accept("not (a)");
+	test_accept("not (not (a))");
+	test_accept("not (a.b=1)");
+	test_accept("not (a.a exists)");
+	test_accept("not a");
+	test_accept("a.b = 1 and not a");
+	test_accept("not not a");
+	test_accept("(not not a)");
+	test_accept("not a.b=1");
+	test_accept("not a.a exists");
+	test_accept("a.b = bla");
+	test_accept("a.b = 'bla'");
+	test_accept("a.b = not");
+	test_accept("a.b contains bla");
+	test_accept("a.b icontains 'bla'");
+	test_accept("a.g in (1, 'a', b)");
+	test_accept("evt.dir=> and fd.name=*.log");
+	test_accept("a.g in (1, 'a', b.c)");
+	test_accept("a.b = a.a");
+
+	// marked as bad in Falco smoke checks, but they should be good instead
+	test_accept("evt.arg[0] contains /bin");
+	test_accept("evt.arg[a] contains /bin");
+
+	// bad
+	test_reject("evt.arg[] contains /bin");
+	test_reject("a.b = b = 1");
+	test_reject("(a.b = 1");
+	test_reject("a.a invalidoperator xxx");
+
+	// marked as good in Falco smoke checks, but they should be bad instead
+	test_reject("a.g in ( 1 ,, , b)");
+	test_reject("#a and b; a and b");
+	test_reject("#a and b; # ; ; a and b");
+	test_reject("evt.dir=> and fd.name=/var/lo);g/httpd.log");
+	test_reject("notz and a and b");
+}
+
+// complex test case with all supported node types
+TEST(parser, expr_all_node_types)
+{
+	test_equal_ast(
+		"evt.name exists and evt.type in (a, b) and not evt.dir=< or proc.name=cat",
+		new or_expr({
+			new and_expr({
+				new unary_check_expr("evt.name", "", "exists"), 
+				new binary_check_expr("evt.type", "", "in", new list_expr({"a", "b"})),
+				new not_expr(
+					new binary_check_expr("evt.dir", "", "=", new value_expr("<"))
+				),
+			}),
+			new binary_check_expr("proc.name", "", "=", new value_expr("cat")),
+		})
+	);
+}
+
+// complex example with parenthesis
+TEST(parser, expr_parenthesis)
+{
+	test_equal_ast(
+		"evt.name exists and evt.type in (a, b) and not evt.dir=< or proc.name=cat",
+		new or_expr({
+			new and_expr({
+				new unary_check_expr("evt.name", "", "exists"), 
+				new binary_check_expr("evt.type", "", "in", new list_expr({"a", "b"})),
+				new not_expr(
+					new binary_check_expr("evt.dir", "", "=", new value_expr("<"))
+				),
+			}),
+			new binary_check_expr("proc.name", "", "=", new value_expr("cat")),
+		})
+	);
+}
+
+// stressing nested negation and identifiers
+TEST(parser, expr_multi_negation)
+{
+	test_equal_ast(
+		"evt.name exists and evt.type in (a, b) and not evt.dir=< or proc.name=cat",
+		new or_expr({
+			new and_expr({
+				new unary_check_expr("evt.name", "", "exists"), 
+				new binary_check_expr("evt.type", "", "in", new list_expr({"a", "b"})),
+				new not_expr(
+					new binary_check_expr("evt.dir", "", "=", new value_expr("<"))
+				),
+			}),
+			new binary_check_expr("proc.name", "", "=", new value_expr("cat")),
+		})
+	);
+}

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -222,7 +222,9 @@ TEST(parser, parse_lists)
 	test_reject("test.list = (value)");
 	test_reject("test.list < (value)");
 	test_reject("test.list startswith (value)");
+	test_reject("test.list bstartswith (value)");
 	test_reject("test.list contains (value)");
+	test_reject("test.list icontains (value)");
 }
 
 TEST(parser, parse_operators)
@@ -236,7 +238,9 @@ TEST(parser, parse_operators)
 	test_accept("test.op glob value");
 	test_accept("test.op contains value");
 	test_accept("test.op icontains value");
+	test_accept("test.op bcontains 48545450");
 	test_accept("test.op startswith value");
+	test_accept("test.op bstartswith 12ab001fc5");
 	test_accept("test.op endswith value");
 	test_accept("test.op > 1");
 	test_accept("test.op < 1");
@@ -254,8 +258,11 @@ TEST(parser, parse_operators)
 	test_reject("test.op ===");
 	test_reject("test.op !==");
 	test_reject("test.op startswithvalue");
+	test_reject("test.op bstartswithvalue");
 	test_reject("test.op endswithvalue");
 	test_reject("test.op containsvalue");
+	test_reject("test.op icontainsvalue");
+	test_reject("test.op bcontainsvalue");
 	test_reject("test.op globvalue");
 }
 

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -1,6 +1,7 @@
 #include <filter/parser.h>
 #include <gtest.h>
 
+using namespace std;
 using namespace libsinsp::filter;
 using namespace libsinsp::filter::ast;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

/kind design

/kind documentation

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**What this PR does / why we need it**:

This PR attempts to **solve all the points** of #216. The approach that I tried to undertake is to **not introduce any breaking changes** and **keep supporting the legacy public interfaces** of `sinsp_filter_compiler`. As such, this **PR is a big no-op** from a user-facing point of view, **but addresses most of the problems** we have in the libsinsp filter parser. Briefly, the core changes are the following:
- **Definition of a context-free formal grammar** that regulates the filtering language
- Explicit **separation of textual filter parsing from filterchecks** compilation:
  - Definition of ad-hoc AST text-only classes, explorable with through the visitor pattern
  - Implementation of a filter parser that generates an AST. The parser is a simple top-down recursive descent manual implementation (**no new dependencies or code generators**)
- Re-implementation of `sinsp_filter_compiler`:
  - Legacy constructor and interfaces are maintained to not create breaking changes
  - Support for filtercheck factories has been added
  - The compiler works on AST classes and build filtercheck expressions using the visitor pattern
- **Unit tests for the filter parser** have been added
- **Unit tests for the filter compiler** have been added

The proposed grammar is proposed below. It supports the notion of _identifers_, which are non-resolved expression that need to be substituted/expanded on the ASTs before being compiled to filterchecks. This allows implementing things like macros in Falco.
```
Context-free Grammar for Sinsp Filters
Productions (EBNF Syntax):
    Expr                ::= OrExpr
    OrExpr              ::= AndExpr ('or' AndExpr)*
    AndExpr             ::= NotExpr ('and' NotExpr)*
    NotExpr             ::= ('not')* Check
    Check               ::= CheckField CheckCondition
                            | Identifier
                            | '(' OrExpr ')'
    CheckCondition      ::= UnaryOperator
                            | NumOperator NumValue
                            | StrOperator StrValue
                            | ListOperator ListValue
    ListValue           ::= '(' (StrValue (',' StrValue)*)* ')'
                            | Identifier
    CheckField          ::= FieldName('[' FieldArg ']')?
    FieldArg            ::= QuotedStr | FieldArgBareStr 
    NumValue            ::= HexNumber | Number
    StrValue            ::= QuotedStr | BareStr

Supported Check Operators (EBNF Syntax):
    UnaryOperator       ::= 'exists'
    NumOperator         ::= '<=' | '<' | '>=' | '>' 
    StrOperator         ::= '==' | '=' | '!=' | 'glob ' | 'contains '
                            | 'icontains ' | 'startswith ' | 'endswith '
    ListOperator        ::= 'intersects' | 'in' | 'pmatch' 

Tokens (Regular Expressions):
    Identifier          ::= [a-zA-Z]+[a-zA-Z0-9_]*
    FieldName           ::= [a-zA-Z]+[a-zA-Z0-9_]*(\.[a-zA-Z]+[a-zA-Z0-9_]*)+
    FieldArgBareStr     ::= [^ \b\t\n\r\[\]"']+
    HexNumber           ::= 0[xX][0-9a-zA-Z]+
    Number              ::= [+\-]?[0-9]+[\.]?[0-9]*([eE][+\-][0-9]+)?
    QuotedStr           ::= "(?:\\"|.)*?"|'(?:\\'|.)*?'
    BareStr             ::= [^ \b\t\n\r\(\),="']+
```

**Which issue(s) this PR fixes**:

Fixes #216

**Special notes for your reviewer**:

- The proposed formal grammar aims to be the **official** one, to be respected among all tools using the libsinsp filtering language
- I apologize for the PR to be very large in lines of code. This was necessary to implement the new parser, and many lines are spent in comments/pseudo-documentation. Plus, almost all the lines are additions, and the only changing code is the one in `sinsp_filter_compiler`.
- The newly-introduced unit tests for `sinsp_filter_compiler` have been experimentally backported to the current implementation, and I had confirmation that the following test cases happened to fail (see [filter_compiler.ut.cpp](https://github.com/falcosecurity/libs/pull/217/files#diff-d3f04509a3305c563a33169154b1398959751b24ab940394f99f671f6fa135d4R81) for more details):
  - `not not <true>` 👉🏼  should evaluate as `true`, but is `false` instead
  - `not not not not <true>`  👉🏼  should evaluate as `true`, but is `false` instead
  - `<true> or <true> and <false>`  👉🏼  compilation fails because of mixed `and`-`or`s
  - `not (<false> or <false> and not <true>)`   👉🏼  compilation fails because of mixed `and`-`or`s
  - `not (<false> or not <false> and <true>)`  👉🏼  compilation fails because of mixed `and`-`or`s

**Does this PR introduce a user-facing change?**:

```release-note
refactor(libsinsp): renovate the filter grammar, parser, and compiler
```
