### PR TITLE
fix(bpf_probe): check null buffer pointer in `PPME_SOCKET_RECVFROM_X` event

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -777,7 +777,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		break;
 	}
 	case PT_BYTEBUF: {
-		if (val!=0) {
+		if (val!=0 && val_len) {
 			len = val_len;
 
 			if (enforce_snaplen) {

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -777,7 +777,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		break;
 	}
 	case PT_BYTEBUF: {
-		if (val_len) {
+		if (val!=0) {
 			len = val_len;
 
 			if (enforce_snaplen) {
@@ -830,7 +830,12 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 #endif
 					return PPM_FAILURE_INVALID_USER_MEMORY;
 			}
-		} else {
+		} 
+		else 
+		{
+			/*
+			 * Handle NULL pointers
+			 */
 			len = 0;
 		}
 		break;

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -650,7 +650,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 
 		break;
 	case PT_BYTEBUF:
-		if (likely(val != 0)) {
+		if (likely(val != 0 && val_len)) {
 			if (fromuser) {
 				/*
 				 * Copy the lookahead portion of the buffer that we will use DPI-based

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -2160,10 +2160,8 @@ int f_sys_recv_x_common(struct event_filler_arguments *args, int64_t *retval)
 
 	args->enforce_snaplen = true;
 	res = val_to_ring(args, val, bufsize, true, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
 
-	return PPM_SUCCESS;
+	return res;
 }
 
 int f_sys_recv_x(struct event_filler_arguments *args)


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Testing the [scap-open example](https://github.com/falcosecurity/libs/blob/master/userspace/libscap/examples/01-open/test.c) on my machine I noticed this:

```
❯ sudo BPF_PROBE=driver/bpf/probe.o ./libscap/examples/01-open/scap-open
events captured: 11086030
seen by driver: 11087536
Number of dropped events: 13
Number of dropped events caused by full buffer: 0
Number of dropped events caused by invalid memory access: 13
Number of dropped events caused by an invalid condition in the kernel instrumentation: 0
Number of preemptions: 0
Number of events skipped due to the tid being in a set of suppressed tids: 0
Number of threads currently being suppressed: 0
```

These `invalid memory access` seem to be related to `PPME_SOCKET_RECVFROM_X` events. More in detail my `systemd-resolve` process performs `recvfrom()` calls like this:

```
recvfrom(12, NULL, 0, MSG_PEEK|MSG_TRUNC, NULL, NULL) = 39  
```

Thanks to the `MSG_TRUNC` flag, the call returns the real length of the packet or datagram, even when it was longer than the passed buffer (here the buffer pointer is `NULL`, 2° parameter in the call above). Today we only check the return value, if it is positive we assume that the buffer contains data and then we read a pointer to NULL obtaining `invalid memory access`. To be more robust I would propose a check on the pointer making sure not to read anything when the pointer is null.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
