### PR TITLE
fix(userspace/libscap): fixed cgroups v2 support in scap_proc_fill_cgroups()

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -154,6 +154,8 @@ struct scap
 	uint32_t m_fd_lookup_limit;
 	uint64_t m_unexpected_block_readsize;
 	uint32_t m_ncpus;
+	uint8_t m_cgroup_version;
+
 	// Abstraction layer for windows
 #if CYGWING_AGENT || _WIN32
 	wh_t* m_whh;

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -378,6 +378,8 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 		char* subsys_list;
 		char* cgroup;
 		char* scratch;
+		// Default subsys list for cgroups v2 unified hierarchy.
+		// These are the ones we actually use in cri container engine.
 		char default_subsys_list[] = "cpu,memory,cpuset";
 
 		// id
@@ -684,6 +686,8 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procd
 		{
 			while(fgets(line, sizeof(line), f) != NULL)
 			{
+				// NOTE: we do not support mixing cgroups v1 v2 controllers.
+				// Neither docker nor podman support this: https://github.com/docker/for-linux/issues/1256
 				if (strstr(line, "cgroup2"))
 				{
 					handle->m_cgroup_version = 2;

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -378,6 +378,7 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 		char* subsys_list;
 		char* cgroup;
 		char* scratch;
+		char default_subsys_list[] = "cpu,memory,cpuset";
 
 		// id
 		token = strtok_r(line, ":", &scratch);
@@ -406,20 +407,52 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 		// on CentOS 6 (has been added from Glibc 2.19)
 		if(subsys_list-token-strlen(token) > 1)
 		{
-			// skip cgroups like this:
-			// 0::/init.scope
-			continue;
-		}
-
-		// cgroup should be the only thing remaining so use newline as the delimiter.
-		cgroup = strtok_r(NULL, "\n", &scratch);
-		if(cgroup == NULL)
+			// Subsys list empty (ie: it contains cgroup path instead)!
+			//
+			// See https://man7.org/linux/man-pages/man7/cgroups.7.html:
+			// 5:cpuacct,cpu,cpuset:/daemons
+			//
+			//              The colon-separated fields are, from left to right:
+			//
+			//              1. For cgroups version 1 hierarchies, this field contains
+			//                 a unique hierarchy ID number that can be matched to a
+			//                 hierarchy ID in /proc/cgroups.  For the cgroups version
+			//                 2 hierarchy, this field contains the value 0.
+			//
+			//              2. For cgroups version 1 hierarchies, this field contains
+			//                 a comma-separated list of the controllers bound to the
+			//                 hierarchy.  For the cgroups version 2 hierarchy, this
+			//                 field is empty.
+			//
+			//              3. This field contains the pathname of the control group
+			//                 in the hierarchy to which the process belongs.  This
+			//                 pathname is relative to the mount point of the
+			//                 hierarchy.
+			//
+			// -> for cgroup2: id is always 0 and subsys list is always empty (single unified hierarchy)
+			// -> for cgroup1: skip subsys empty because it means controller is not mounted on any hierarchy
+			if (handle->m_cgroup_version == 2 && strcmp(token, "0") == 0)
+			{
+				cgroup = subsys_list;
+				subsys_list = default_subsys_list; // force-set a default subsys list
+			} else
+			{
+				// skip cgroups like this:
+				// 0::/init.scope
+				continue;
+			}
+		} else
 		{
-			ASSERT(false);
-			fclose(f);
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Did not find cgroup in cgroup file %s",
-				 filename);
-			return SCAP_FAILURE;
+			// cgroup should be the only thing remaining so use newline as the delimiter.
+			cgroup = strtok_r(NULL, "\n", &scratch);
+			if(cgroup == NULL)
+			{
+				ASSERT(false);
+				fclose(f);
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Did not find cgroup in cgroup file %s",
+					 filename);
+				return SCAP_FAILURE;
+			}
 		}
 
 		while((token = strtok_r(subsys_list, ",", &scratch)) != NULL)
@@ -641,6 +674,34 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procd
 	bool free_tinfo = false;
 	int32_t res = SCAP_SUCCESS;
 	struct stat dirstat;
+
+
+	if (handle->m_cgroup_version == 0)
+	{
+		snprintf(dir_name, sizeof(dir_name), "%s/filesystems", procdirname);
+		f = fopen(dir_name, "r");
+		if (f)
+		{
+			while(fgets(line, sizeof(line), f) != NULL)
+			{
+				if (strstr(line, "cgroup2"))
+				{
+					handle->m_cgroup_version = 2;
+					break;
+				}
+				if (strstr(line, "cgroup"))
+				{
+					handle->m_cgroup_version = 1;
+				}
+			}
+			fclose(f);
+		} else
+		{
+			ASSERT(false);
+			snprintf(error, SCAP_LASTERR_SIZE, "failed to fetch cgroup version information");
+			return SCAP_FAILURE;
+		}
+	}
 
 	snprintf(dir_name, sizeof(dir_name), "%s/%u/", procdirname, tid);
 	snprintf(filename, sizeof(filename), "%sexe", dir_name);
@@ -1071,16 +1132,16 @@ static int32_t _scap_proc_scan_proc_dir_impl(scap_t* handle, char* procdirname, 
 		if(res != SCAP_SUCCESS)
 		{
 			//
-			// When a /proc lookup fails (while scanning the whole directory, 
-			// not just while looking up a single tid), 
-			// we should drop this thread/process completely. 
-			// We will fill the gap later, when the first event 
+			// When a /proc lookup fails (while scanning the whole directory,
+			// not just while looking up a single tid),
+			// we should drop this thread/process completely.
+			// We will fill the gap later, when the first event
 			// for that process arrives.
 			//
 			//
 			res = SCAP_SUCCESS;
 			//
-			// Continue because if we failed to read details of pid=1234, 
+			// Continue because if we failed to read details of pid=1234,
 			// it doesn’t say anything about pid=1235
 			//
 			continue;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes a bug in scap procs initialization: running containers before Falco booted, were ignored until a new process spawned on them; instead, their running process were thought to be running on the host.  

Basically, cgroups v2 uses the "Unified hierarchy" for subsystems, thus the subsys list string is always empty in /proc/pid/cgroup file.
Workaround this by forcing a default set of subsystems <cpu,cpuset,memory>.

For cgroups v1 instead everything is kept the same.

See [cgroups](https://man7.org/linux/man-pages/man7/cgroups.7.html) man:

> 
>                   5:cpuacct,cpu,cpuset:/daemons
> 
>               The colon-separated fields are, from left to right:
> 
>               1. For cgroups version 1 hierarchies, this field contains
>                  a unique hierarchy ID number that can be matched to a
>                  hierarchy ID in /proc/cgroups.  For the cgroups version
>                  2 hierarchy, this field contains the value 0.
> 
>               2. For cgroups version 1 hierarchies, this field contains
>                  a comma-separated list of the controllers bound to the
>                  hierarchy.  For the cgroups version 2 hierarchy, this
>                  field is empty.
> 
>               3. This field contains the pathname of the control group
>                  in the hierarchy to which the process belongs.  This
>                  pathname is relative to the mount point of the
>                  hierarchy.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libscap): containers running prior to Falco boot are now correctly populated upon Falco start.
```
