### PR TITLE
fix: report the correct number of drops from bpf side

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -746,7 +746,10 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 	curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-		return PPM_FAILURE_BUFFER_FULL;
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+
 	if (dyn_idx != (u8)-1) {
 		*((u8 *)&data->buf[curoff_bounded]) = dyn_idx;
 		len_dyn = sizeof(u8);
@@ -756,7 +759,9 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 	curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-		return PPM_FAILURE_BUFFER_FULL;
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
 
 	switch (type) {
 	case PT_CHARBUF:
@@ -816,7 +821,9 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 				curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 				if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-					return PPM_FAILURE_BUFFER_FULL;
+				{
+					return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+				}
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (read_size)
@@ -901,7 +908,9 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	}
 	}
 	if (len_dyn + len > PPM_MAX_ARG_SIZE)
-		return PPM_FAILURE_BUFFER_FULL;
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
 
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len_dyn + len);
 	data->state->tail_ctx.curoff += len;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -134,6 +134,9 @@ FILLER_RAW(terminate_filler)
 		bpf_printk("PPM_FAILURE_FRAME_SCRATCH_MAP_FULL event=%d curarg=%d\n",
 			   state->tail_ctx.evt_type,
 			   state->tail_ctx.curarg);
+		if (state->n_drops_scratch_map != ULLONG_MAX) {
+			++state->n_drops_scratch_map;
+		}
 		break;	
 	default:
 		bpf_printk("Unknown filler res=%d event=%d curarg=%d\n",

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -54,7 +54,9 @@ static __always_inline int push_evt_frame(void *ctx,
 	}
 
 	if (data->state->tail_ctx.len > PERF_EVENT_MAX_SIZE)
-		return PPM_FAILURE_BUFFER_FULL;
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
 
 	fixup_evt_len(data->buf, data->state->tail_ctx.len);
 

--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -90,6 +90,9 @@ static __always_inline int push_evt_frame(void *ctx,
 
 		state->hotplug_cpu = bpf_get_smp_processor_id();
 		bpf_printk("detected hotplug event, cpu=%d\n", state->hotplug_cpu);
+	} else if (res == -ENOSPC) {
+		bpf_printk("bpf_perf_buffer full\n");
+		return PPM_FAILURE_BUFFER_FULL;
 	} else if (res) {
 		bpf_printk("bpf_perf_event_output failed, res=%d\n", res);
 		return PPM_FAILURE_BUG;

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -216,6 +216,7 @@ struct scap_bpf_per_cpu_state {
 	struct tail_context tail_ctx;
 	unsigned long long n_evts;
 	unsigned long long n_drops_buffer;
+	unsigned long long n_drops_scratch_map;
 	unsigned long long n_drops_pf;
 	unsigned long long n_drops_bug;
 	unsigned int hotplug_cpu;

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1670,6 +1670,7 @@ struct ppm_event_entry {
 #define PPM_FAILURE_INVALID_USER_MEMORY -2
 #define PPM_FAILURE_BUG -3
 #define PPM_SKIP_EVENT -4
+#define PPM_FAILURE_FRAME_SCRATCH_MAP_FULL -5	/* this is used only inside bpf, kernel module does not have a frame scratch map*/
 
 #define RW_SNAPLEN 80
 #define RW_MAX_SNAPLEN PPM_MAX_ARG_SIZE

--- a/userspace/libscap/examples/01-open/test.c
+++ b/userspace/libscap/examples/01-open/test.c
@@ -30,6 +30,7 @@ static void signal_callback(int signal)
 	printf("seen by driver: %" PRIu64 "\n", s.n_evts);
 	printf("Number of dropped events: %" PRIu64 "\n", s.n_drops);
 	printf("Number of dropped events caused by full buffer: %" PRIu64 "\n", s.n_drops_buffer);
+	printf("Number of dropped events caused by full scratch map: %" PRIu64 "\n", s.n_drops_scratch_map);
 	printf("Number of dropped events caused by invalid memory access: %" PRIu64 "\n", s.n_drops_pf);
 	printf("Number of dropped events caused by an invalid condition in the kernel instrumentation: %" PRIu64 "\n", s.n_drops_bug);
 	printf("Number of preemptions: %" PRIu64 "\n", s.n_preemptions);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -94,11 +94,6 @@ typedef struct scap_device
 			struct ppm_ring_buffer_info* m_bufinfo;
 			struct udig_ring_buffer_status* m_bufstatus; // used by udig
 		};
-		// Anonymous struct with bpf stuff
-		struct
-		{
-			uint64_t m_evt_lost;
-		};
 	};
 }scap_device;
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -2098,6 +2098,7 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 	stats->n_evts = 0;
 	stats->n_drops = 0;
 	stats->n_drops_buffer = 0;
+	stats->n_drops_scratch_map = 0;
 	stats->n_drops_pf = 0;
 	stats->n_drops_bug = 0;
 	stats->n_preemptions = 0;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -112,11 +112,12 @@ typedef struct scap_stats
 	uint64_t n_evts; ///< Total number of events that were received by the driver.
 	uint64_t n_drops; ///< Number of dropped events.
 	uint64_t n_drops_buffer; ///< Number of dropped events caused by full buffer.
+	uint64_t n_drops_scratch_map; ///< Number of dropped events caused by full frame scratch map.
 	uint64_t n_drops_pf; ///< Number of dropped events caused by invalid memory access.
 	uint64_t n_drops_bug; ///< Number of dropped events caused by an invalid condition in the kernel instrumentation.
 	uint64_t n_preemptions; ///< Number of preemptions.
-	uint64_t n_suppressed; ///< Number of events skipped due to the tid being in a set of suppressed tids
-	uint64_t n_tids_suppressed; ///< Number of threads currently being suppressed
+	uint64_t n_suppressed; ///< Number of events skipped due to the tid being in a set of suppressed tids.
+	uint64_t n_tids_suppressed; ///< Number of threads currently being suppressed.
 }scap_stats;
 
 /*!

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1478,10 +1478,12 @@ int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
 
 		stats->n_evts += v.n_evts;
 		stats->n_drops_buffer += handle->m_devs[j].m_evt_lost + v.n_drops_buffer;
+		stats->n_drops_scratch_map += v.n_drops_scratch_map;
 		stats->n_drops_pf += v.n_drops_pf;
 		stats->n_drops_bug += v.n_drops_bug;
 		stats->n_drops += handle->m_devs[j].m_evt_lost +
 				  v.n_drops_buffer +
+				  v.n_drops_scratch_map +
 				  v.n_drops_pf +
 				  v.n_drops_bug;
 	}

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1477,12 +1477,11 @@ int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
 		}
 
 		stats->n_evts += v.n_evts;
-		stats->n_drops_buffer += handle->m_devs[j].m_evt_lost + v.n_drops_buffer;
+		stats->n_drops_buffer += v.n_drops_buffer;
 		stats->n_drops_scratch_map += v.n_drops_scratch_map;
 		stats->n_drops_pf += v.n_drops_pf;
 		stats->n_drops_bug += v.n_drops_bug;
-		stats->n_drops += handle->m_devs[j].m_evt_lost +
-				  v.n_drops_buffer +
+		stats->n_drops += v.n_drops_buffer +
 				  v.n_drops_scratch_map +
 				  v.n_drops_pf +
 				  v.n_drops_bug;

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -124,13 +124,7 @@ static inline int32_t scap_bpf_advance_to_evt(scap_t *handle, uint16_t cpuid, bo
 				break;
 			}
 		}
-		else if(e->type == PERF_RECORD_LOST)
-		{
-			struct perf_lost_sample *lost = (struct perf_lost_sample *) e;
-			ASSERT(*len >= sizeof(*lost));
-			dev->m_evt_lost += lost->lost;
-		}
-		else
+		else if(e->type != PERF_RECORD_LOST)
 		{
 			printf("Unknown event type=%d size=%d\n",
 			       e->type, e->size);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1308,11 +1308,13 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 					"n_evts:%" PRIu64
 					" n_drops:%" PRIu64
 					" n_drops_buffer:%" PRIu64
+					" n_drops_scratch_map:%" PRIu64
 					" n_drops_pf:%" PRIu64
 					" n_drops_bug:%" PRIu64,
 					stats.n_evts,
 					stats.n_drops,
 					stats.n_drops_buffer,
+					stats.n_drops_scratch_map,
 					stats.n_drops_pf,
 					stats.n_drops_bug);
 			}


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo andrea.terzolo@polito.it

**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-ebpf

/area libscap

/area libsinsp

**What this PR does / why we need it**:

This PR addresses the following points:

1. Add a new return code `PPM_FAILURE_FRAME_SCRATCH_MAP_FULL` to indicate all problems related to an event that exceeds the maximum expected size, and therefore cannot be inserted in the `frame_scratch` bpf map. Today these types of problems are marked with the slightly misleading `PPM_FAILURE_BUFFER_FULL` return code.

2. Add a new field `n_drops_scratch_map` in `scap_bpf_per_cpu_state` struct to capture drop stats due to `PPM_FAILURE_FRAME_SCRATCH_MAP_FULL` errors.

3. Use the `PPM_FAILURE_BUFFER_FULL` return code, only when the perf buffer between the bpf_probe and the userspace is full, as it is already done in the kernel module.

4. Fix how `scap_bpf_get_stats` collects the number of drops. Today `n_drops_buffer` are collected two times: 

- by reading the perf buffer header directly 
- by reading the bpf map `local_state_map`. 

  This fix uses only the bpf map `local_state_map` to obtain `n_drops_buffer`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: correct the total number of drops returned by the bpf probe
```
