### PR TITLE
fix(driver,libscap): add `PPM_SC_CLONE` and `PPM_SC_CLONE3`

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1331,7 +1331,9 @@ enum ppm_syscall_code {
 	PPM_SC_EXECVE = 324,
 	PPM_SC_EXECVEAT = 325,
 	PPM_SC_COPY_FILE_RANGE = 326,
-	PPM_SC_MAX = 327,
+	PPM_SC_CLONE = 327,
+	PPM_SC_CLONE3 = 328,
+	PPM_SC_MAX = 329,
 };
 
 /*

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -1003,6 +1003,10 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_copy_file_range
 	[__NR_copy_file_range - SYSCALL_TABLE_ID0] = PPM_SC_COPY_FILE_RANGE,
 #endif
+	[__NR_clone - SYSCALL_TABLE_ID0] = PPM_SC_CLONE,
+#ifdef __NR_clone3
+	[__NR_clone3 - SYSCALL_TABLE_ID0] = PPM_SC_CLONE3,
+#endif	
 };
 
 #ifdef CONFIG_IA32_EMULATION
@@ -1822,6 +1826,10 @@ const enum ppm_syscall_code g_syscall_ia32_code_routing_table[SYSCALL_TABLE_SIZE
 #ifdef __NR_ia32_copy_file_range
 	[__NR_ia32_copy_file_range - SYSCALL_TABLE_ID0] = PPM_SC_COPY_FILE_RANGE,
 #endif
+	[__NR_ia32_clone - SYSCALL_TABLE_ID0] = PPM_SC_CLONE,
+#ifdef __NR_ia32_clone3
+	[__NR_ia32_clone3 - SYSCALL_TABLE_ID0] = PPM_SC_CLONE3,
+#endif	
 };
 
 #endif /* CONFIG_IA32_EMULATION */

--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -356,6 +356,8 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_EXECVE*/ { EC_SYSTEM, (enum ppm_event_flags)(EF_NONE), "execve" },
 	/*PPM_SC_EXECVEAT*/ { EC_SYSTEM, (enum ppm_event_flags)(EF_NONE), "execveat" },
 	/*PPM_SC_COPY_FILE_RANGE*/ {EC_FILE, (enum ppm_event_flags)(EF_NONE), "copy_file_range" },
+	/*PPM_SC_CLONE*/ {EC_PROCESS, (enum ppm_event_flags)(EF_NONE), "clone" },
+	/*PPM_SC_CLONE3*/ {EC_PROCESS, (enum ppm_event_flags)(EF_NONE), "clone3" },
 };
 
 bool validate_info_table_size()


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

/area libscap

**What this PR does / why we need it**:

This PR adds `PPM_SC_CLONE` and `PPM_SC_CLONE3` enums. They are necessary to have correct driver instrumentation in `simpleconsumer` mode. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

