### PR TITLE
perf(sinsp): optimize sinsp_threadinfo::populate_cmdline

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -953,12 +953,10 @@ void sinsp_threadinfo::populate_cmdline(string &cmdline, const sinsp_threadinfo 
 {
 	cmdline = tinfo->get_comm();
 
-	uint32_t j;
-	uint32_t nargs = (uint32_t)tinfo->m_args.size();
-
-	for(j = 0; j < nargs; j++)
+	for (const auto& arg : tinfo->m_args)
 	{
-		cmdline += " " + tinfo->m_args[j];
+		cmdline += " ";
+		cmdline += arg;
 	}
 }
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -949,7 +949,7 @@ void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 	}
 }
 
-void sinsp_threadinfo::populate_cmdline(string &cmdline, sinsp_threadinfo *tinfo)
+void sinsp_threadinfo::populate_cmdline(string &cmdline, const sinsp_threadinfo *tinfo)
 {
 	cmdline = tinfo->get_comm();
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -229,7 +229,7 @@ public:
 	typedef std::function<bool (sinsp_threadinfo *)> visitor_func_t;
 	void traverse_parent_state(visitor_func_t &visitor);
 
-	static void populate_cmdline(std::string &cmdline, sinsp_threadinfo *tinfo);
+	static void populate_cmdline(std::string &cmdline, const sinsp_threadinfo *tinfo);
 
 	// Return true if this thread is a part of a healthcheck,
 	// readiness probe, or liveness probe.


### PR DESCRIPTION
Prefer += over +
Tested with callgrind, ~2x improvement

Signed-off-by: Angelo Puglisi <angelopuglisi86@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
Performance enhancement
> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
About 60% of the load on `falco_engine::process_event` is `sinsp_threadinfo::populate_cmdline`, improving it is definitely beneficial.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
sinsp_threadinfo::populate_cmdline performance improvement
```
