### PR TITLE
fix(userspace/libsinsp): fix evttype_filter.ut test build

### DIFF
--- a/userspace/libsinsp/test/evttype_filter.ut.cpp
+++ b/userspace/libsinsp/test/evttype_filter.ut.cpp
@@ -91,8 +91,8 @@ protected:
 				FAIL() << "Expected event type "
 				       << etype
 				       << " not found in actual set. "
-				       << "Expected: " << expected << " "
-				       << " Actual: " << actual;
+				       << "Expected: " << testing::PrintToString(expected) << " "
+				       << " Actual: " << testing::PrintToString(actual);
 
 			}
 		}
@@ -104,8 +104,8 @@ protected:
 				FAIL() << "Actual evttypes had additional event type "
 				       << etype
 				       << " not found in expected set. "
-				       << "Expected: " << expected << " "
-				       << " Actual: " << actual;
+				       << "Expected: " << testing::PrintToString(expected) << " "
+				       << " Actual: " << testing::PrintToString(actual);
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes evttype_filter_ut test build:
```
/home/federico/Work/libs/userspace/libsinsp/test/evttype_filter.ut.cpp:94:31:   required from here
/usr/include/gtest/gtest-message.h:129:10: error: no match for ‘operator<<’ (operand types are ‘std::__cxx11::basic_stringstream<char>’ and ‘const std::set<short unsigned int>’)
129 |     *ss_ << val;
```

std::set has no `<<` operator: https://en.cppreference.com/w/cpp/container/set
As @deepskyblue86 noted, gtest framework ships the code to print the set: https://github.com/google/googletest/blob/main/docs/advanced.md#teaching-googletest-how-to-print-your-values.  
Perhaps some gtest version are somewhat bugged and their `GTEST_FAIL` macro is not actually expanding passed values using `testing::PrintToString`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
