### PR TITLE
new(chisel): Allow chisels to be loaded from memory

### DIFF
--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -1173,8 +1173,8 @@ bool sinsp_chisel::openfile(string filename, OUT ifstream* is)
 void sinsp_chisel::load(string cmdstr, bool is_file)
 {
 	if (is_file) {
-		m_filename = cmdstr;
 		trim(cmdstr);
+		m_filename = cmdstr;
 	} else {
 		m_filename = "<in-memory-string>";
 	}
@@ -1201,7 +1201,7 @@ void sinsp_chisel::load(string cmdstr, bool is_file)
 		// Load the file
 		//
 		std::istreambuf_iterator<char> eos;
-		std::string scriptstr(std::istreambuf_iterator<char>(is), eos);
+		scriptstr.assign(std::istreambuf_iterator<char>(is), eos);
 	} else {
 		scriptstr = cmdstr;
 	}

--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -245,7 +245,7 @@ void chiselinfo::set_callback_precise_interval(uint64_t interval)
 ///////////////////////////////////////////////////////////////////////////////
 // chisel implementation
 ///////////////////////////////////////////////////////////////////////////////
-sinsp_chisel::sinsp_chisel(sinsp* inspector, string filename)
+sinsp_chisel::sinsp_chisel(sinsp* inspector, string filename, bool is_file)
 {
 	m_inspector = inspector;
 	m_ls = NULL;
@@ -256,7 +256,7 @@ sinsp_chisel::sinsp_chisel(sinsp* inspector, string filename)
 	m_lua_last_interval_ts = 0;
 	m_udp_socket = 0;
 
-	load(filename);
+	load(filename, is_file);
 }
 
 sinsp_chisel::~sinsp_chisel()
@@ -1170,33 +1170,42 @@ bool sinsp_chisel::openfile(string filename, OUT ifstream* is)
 	return false;
 }
 
-void sinsp_chisel::load(string cmdstr)
+void sinsp_chisel::load(string cmdstr, bool is_file)
 {
-	m_filename = cmdstr;
-	trim(cmdstr);
-
-	ifstream is;
-
-	//
-	// Try to open the file with lua extension
-	//
-	if(!openfile(m_filename + ".lua", &is))
-	{
-		//
-		// Try to open the file as is
-		//
-		if(!openfile(m_filename, &is))
-		{
-			throw sinsp_exception("can't open file " + m_filename);
-		}
+	if (is_file) {
+		m_filename = cmdstr;
+		trim(cmdstr);
+	} else {
+		m_filename = "<in-memory-string>";
 	}
 
+	ifstream is;
+	std::string scriptstr;
+
+	if (is_file) {
+		//
+		// Try to open the file with lua extension
+		//
+		if(!openfile(m_filename + ".lua", &is))
+		{
+			//
+			// Try to open the file as is
+			//
+			if(!openfile(m_filename, &is))
+			{
+				throw sinsp_exception("can't open file " + m_filename);
+			}
+		}
+
+		//
+		// Load the file
+		//
+		std::istreambuf_iterator<char> eos;
+		std::string scriptstr(std::istreambuf_iterator<char>(is), eos);
+	} else {
+		scriptstr = cmdstr;
+	}
 #ifdef HAS_LUA_CHISELS
-	//
-	// Load the file
-	//
-	std::istreambuf_iterator<char> eos;
-	std::string scriptstr(std::istreambuf_iterator<char>(is), eos);
 
 	//
 	// Open the script

--- a/userspace/chisel/chisel.h
+++ b/userspace/chisel/chisel.h
@@ -110,11 +110,11 @@ private:
 class SINSP_PUBLIC sinsp_chisel
 {
 public:
-	sinsp_chisel(sinsp* inspector, string filename);
+	sinsp_chisel(sinsp* inspector, string filename, bool is_file = true);
 	~sinsp_chisel();
 	static void add_lua_package_path(lua_State* ls, const char* path);
 	static void get_chisel_list(vector<chisel_desc>* chisel_descs);
-	void load(string cmdstr);
+	void load(string cmdstr, bool is_file = true);
 	string get_name()
 	{
 		return m_filename;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

These changes allow for simple chisels to be loaded directly from a string stored in memory. For complicated use cases, this might make much sense, but imaging your chisel looks as follows:

```lua
args = {}
function on_event()
    return true
end
function on_init()
    filter = "not container.id = 'host'\n"
    chisel.set_filter(filter)
    return true
end
```

You could create a file, store the script, then distribute the file along your application for it to be loaded at runtime, or you could define a string and pass it directly:
```c++
static constexpr char chisel[] = R"(
args = {}
function on_event()
    return true
end
function on_init()
    filter = "not container.id = 'host'\n"
    chisel.set_filter(filter)
    return true
end
)";

sinsp_chisel(inspector, chisel, true);
```

As is, the change should not introduce any changes in behavior to existing code, but would allow adopters to use this functionality if needed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
