### PR TITLE
fix(userspace/libsinsp): fixed podman as user detection

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -288,9 +288,9 @@ void cri::set_cri_delay(uint64_t delay_ms)
 bool cri::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	container_cache_interface *cache = &container_cache();
-	std::string container_id;
+	std::string container_id, cgroup;
 
-	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_id))
+	if(!matches_runc_cgroups(tinfo, CRI_CGROUP_LAYOUT, container_id, cgroup))
 	{
 		return false;
 	}

--- a/userspace/libsinsp/container_engine/docker/base.cpp
+++ b/userspace/libsinsp/container_engine/docker/base.cpp
@@ -18,7 +18,7 @@ docker_base::resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& 
 		g_logger.log("docker_async: Creating docker async source",
 			     sinsp_logger::SEV_DEBUG);
 		uint64_t max_wait_ms = 10000;
-		docker_async_source *src = new docker_async_source(docker_async_source::NO_WAIT_LOOKUP, max_wait_ms, cache);
+		auto src = new docker_async_source(docker_async_source::NO_WAIT_LOOKUP, max_wait_ms, cache);
 		m_docker_info_source.reset(src);
 	}
 
@@ -31,21 +31,21 @@ docker_base::resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& 
 		if(!query_os_for_missing_info)
 		{
 			auto container = std::make_shared<sinsp_container_info>();
-			container->m_type = CT_DOCKER;
+			container->m_type = request.container_type;
 			container->m_id = request.container_id;
 			cache->notify_new_container(*container);
 			return true;
 		}
 
 #ifdef HAS_CAPTURE
-		if(cache->should_lookup(request.container_id, CT_DOCKER))
+		if(cache->should_lookup(request.container_id, request.container_type))
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"docker_async (%s): No existing container info",
 					request.container_id.c_str());
 
 			// give docker a chance to return metadata for this container
-			cache->set_lookup_status(request.container_id, CT_DOCKER, sinsp_container_lookup_state::STARTED);
+			cache->set_lookup_status(request.container_id, request.container_type, sinsp_container_lookup_state::STARTED);
 			parse_docker_async(request, cache);
 		}
 #endif

--- a/userspace/libsinsp/container_engine/docker/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker/docker_linux.cpp
@@ -35,9 +35,9 @@ std::string docker_linux::m_docker_sock = "/var/run/docker.sock";
 
 bool docker_linux::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
-	std::string container_id;
+	std::string container_id, cgroup;
 
-	if(!matches_runc_cgroups(tinfo, DOCKER_CGROUP_LAYOUT, container_id))
+	if(!matches_runc_cgroups(tinfo, DOCKER_CGROUP_LAYOUT, container_id, cgroup))
 	{
 		return false;
 	}

--- a/userspace/libsinsp/runc.cpp
+++ b/userspace/libsinsp/runc.cpp
@@ -81,12 +81,13 @@ bool match_container_id(const std::string &cgroup, const libsinsp::runc::cgroup_
 
 	return false;
 }
-bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id)
+bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id, std::string &matching_cgroup)
 {
 	for(const auto &it : tinfo->m_cgroups)
 	{
 		if(match_container_id(it.second, layout, container_id))
 		{
+			matching_cgroup = it.second;
 			return true;
 		}
 	}

--- a/userspace/libsinsp/runc.h
+++ b/userspace/libsinsp/runc.h
@@ -72,12 +72,13 @@ bool match_container_id(const std::string &cgroup, const libsinsp::runc::cgroup_
  * @brief Match all the cgroups of `tinfo` against a list of cgroup layouts
  * @param layout an array of (prefix, suffix) pairs
  * @param container_id output parameter
+ * @param matching_cgroup output parameter
  * @return true if any of `tinfo`'s cgroups match any of the patterns
  *
  * If this function returns true, `container_id` will be set to
  * the truncated hex string (first 12 digits). Otherwise, it will remain
  * unchanged.
  */
-bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id);
+bool matches_runc_cgroups(const sinsp_threadinfo *tinfo, const cgroup_layout *layout, std::string &container_id, std::string &matching_cgroup);
 }
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The PR fixes a problem in podman as user detection; basically, in podman we have 2 runc matching cgroups layouts:

```
/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-$ID.scope/container
/machine.slice/libpod-$ID.scope/container
```

While we were able to parse the container ID just fine, we did not checked if the cgroup belonged to an user or root.
This behavior broke podman as user detection.

Moreover, fixed some inconsistencies in docker/base.cpp that was still using CT_DOCKER in various calls.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

(Falco: https://github.com/falcosecurity/falco/issues/1912)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): fixed podman as user detection
```
