### PR TITLE
fix(libsinsp): check param num on connect/open/openat parsing

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2173,7 +2173,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		//
 		// Compare with enter event parameters
 		//
-		if(lastevent_retrieved)
+		if(lastevent_retrieved && enter_evt->get_num_params() >= 2)
 		{
 			parinfo = enter_evt->get_param(0);
 			enter_evt_name = parinfo->m_val;
@@ -2208,7 +2208,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			dev = *(uint32_t *)parinfo->m_val;
 		}
 
-		if(lastevent_retrieved)
+		if(lastevent_retrieved && enter_evt->get_num_params() >= 1)
 		{
 			parinfo = enter_evt->get_param(0);
 			enter_evt_name = parinfo->m_val;
@@ -2266,7 +2266,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		//
 		// Compare with enter event parameters
 		//
-		if(lastevent_retrieved)
+		if(lastevent_retrieved && enter_evt->get_num_params() >= 3)
 		{
 			parinfo = enter_evt->get_param(1);
 			enter_evt_name = parinfo->m_val;
@@ -2703,6 +2703,11 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
 
 	if (m_track_connection_status) {
 		evt->m_fdinfo->set_socket_pending();
+	}
+
+	if(evt->get_num_params() < 2)
+	{
+		return;
 	}
 
     parinfo = evt->get_param(1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Following the recent addition to extra parameters and their parsing to connect/open/openat (https://github.com/falcosecurity/libs/pull/235) we still want to be compatible with drivers and scap files that didn't have those params. This PR adds the relevant check.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
