### PR TITLE
chore(userspace/libsisnp): addresses is_pod deprecation in C++20

### DIFF
--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -31,7 +31,8 @@ template <bool T> class mem_layout_test;
 template <> class mem_layout_test<true>{}; // empty struct take 1 byte of mem
 
 static auto check_size   = mem_layout_test<sizeof (ipv6addr) == 16>();
-static auto check_layout = mem_layout_test<std::is_pod<ipv6addr>::value>();
+// is_pod check split into is_standard_layout && is_trivial to be C++20 future proof
+static auto check_layout = mem_layout_test<std::is_standard_layout<ipv6addr>::value && std::is_trivial<ipv6addr>::value>();
 // end layout checks
 
 ipv6addr ipv6addr::empty_address ("0::");//= {0x00000000, 0x00000000, 0x00000000, 0x00000000};


### PR DESCRIPTION
Signed-off-by: Andrea Bonanno <andrea@bonanno.cloud>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Addresses `is_pod` deprecation in C++20

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
