### PR TITLE
fix(libsinsp/plugins): fix init schema config string passing

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -418,8 +418,9 @@ std::shared_ptr<sinsp_plugin> sinsp_plugin::create_plugin(string &filepath, cons
 	errstr = "";
 
 	// Initialize the plugin
-	ret->validate_init_config(config);
-	if (!ret->init(config))
+	std::string conf = ret->str_from_alloc_charbuf(config);
+	ret->validate_init_config(conf);
+	if (!ret->init(conf.c_str()))
 	{
 		errstr = string("Could not initialize plugin: " + ret->get_last_error());
 		ret = NULL;
@@ -828,17 +829,16 @@ std::string sinsp_plugin::get_init_schema(ss_plugin_schema_type& schema_type)
 	return std::string("");
 }
 
-void sinsp_plugin::validate_init_config(const char* config)
+void sinsp_plugin::validate_init_config(std::string& config)
 {
 	ss_plugin_schema_type schema_type;
-	std::string conf = str_from_alloc_charbuf(config);
 	std::string schema = get_init_schema(schema_type);
 	if (schema.size() > 0 && schema_type != SS_PLUGIN_SCHEMA_NONE)
 	{
 		switch (schema_type)
 		{
 			case SS_PLUGIN_SCHEMA_JSON:
-				validate_init_config_json_schema(conf, schema);
+				validate_init_config_json_schema(config, schema);
 				break;
 			default:
 				ASSERT(false);
@@ -851,7 +851,7 @@ void sinsp_plugin::validate_init_config(const char* config)
 	}
 }
 
-void sinsp_plugin::validate_init_config_json_schema(std::string config, std::string &schema)
+void sinsp_plugin::validate_init_config_json_schema(std::string& config, std::string &schema)
 {
 	Json::Value schemaJson;
 	if(!Json::Reader().parse(schema, schemaJson) || schemaJson.type() != Json::objectValue)

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -131,7 +131,7 @@ public:
 	bool extract_field(ss_plugin_event &evt, sinsp_plugin::ext_field &field);
 
 	std::string get_init_schema(ss_plugin_schema_type& schema_type);
-	void validate_init_config(const char* config);
+	void validate_init_config(std::string& config);
 
 	sinsp_plugin_handle m_handle;
 
@@ -176,7 +176,7 @@ private:
 
 	common_plugin_info m_plugin_info;
 
-	void validate_init_config_json_schema(std::string config, std::string &schema);
+	void validate_init_config_json_schema(std::string& config, std::string &schema);
 
 	static void destroy_handle(sinsp_plugin_handle handle);
 };


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Andrea Bonanno <andrea@bonanno.cloud>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This fixes the init config feature of the plugin system. When an init schema is defined, the framework takes care of automatically validating the contents to match the provided schema. To improve the UX, empty config strings are turned into an empty json string `{}` when a json schema is defined.

However, the framework doesn't pass the fixed config string to the framework. As such, plugins still ended up receiving an empty string even if a json schema was defined, which is a flaw in the validator logic.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp/plugins): fix init schema config string passing
```