### PR TITLE
chore(libsinsp): remove unused macros HAS_FILTERING and HAS_CAPTURE_FILTERING

### DIFF
--- a/userspace/libsinsp/doxygen/conf.dox
+++ b/userspace/libsinsp/doxygen/conf.dox
@@ -270,7 +270,7 @@ EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = 
 INCLUDE_FILE_PATTERNS  = 
-PREDEFINED             = HAS_FILTERING _DOXYGEN
+PREDEFINED             = _DOXYGEN
 EXPAND_AS_DEFINED      = 
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2587,7 +2587,6 @@ bool sinsp_evt::is_filtered_out()
 	return m_filtered_out;
 }
 
-#ifdef HAS_FILTERING
 scap_dump_flags sinsp_evt::get_dump_flags(OUT bool* should_drop)
 {
 	uint32_t dflags = SCAP_DF_NONE;
@@ -2635,7 +2634,6 @@ scap_dump_flags sinsp_evt::get_dump_flags(OUT bool* should_drop)
 
 	return (scap_dump_flags)dflags;
 }
-#endif
 
 bool sinsp_evt::simple_consumer_consider()
 {

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -330,13 +330,11 @@ public:
 	*/
 	void get_category(OUT sinsp_evt::category* cat);
 
-#ifdef HAS_FILTERING
 	/*!
 	  \brief Return true if the event has been rejected by the filtering system.
 	*/
 	bool is_filtered_out();
 	scap_dump_flags get_dump_flags(OUT bool* should_drop);
-#endif
 
 	/*!
 	  \brief Return whether or not a simple consumer that privileges low overhead to
@@ -524,9 +522,7 @@ VISIBILITY_PRIVATE
 	uint32_t m_iosize;
 	int32_t m_errorcode;
 	int32_t m_rawbuf_str_len;
-#ifdef HAS_FILTERING
 	bool m_filtered_out;
-#endif
 	const struct ppm_event_info* m_event_info_table;
 
 	friend class sinsp;

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 ///////////////////////////////////////////////////////////////////////////////
 // rawstring_check implementation
 ///////////////////////////////////////////////////////////////////////////////
-#ifdef HAS_FILTERING
 
 sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector,
 					 filter_check_list &available_checks)
@@ -325,33 +324,6 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT string* res)
 {
 	return tostring_withformat(evt, *res, m_output_format);
 }
-
-#else  // HAS_FILTERING
-
-sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector)
-{
-}
-
-void sinsp_evt_formatter::set_format(gen_event_formatter::output_format of, const std::string &format) = 0;
-{
-	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
-}
-
-bool sinsp_evt_formatter::resolve_tokens(sinsp_evt *evt, map<string,string>& values)
-{
-	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
-}
-
-bool sinsp_evt_formatter::tostring(gen_event* gevt, std::string &output)
-{
-	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
-}
-
-bool sinsp_evt_formatter::tostring_withformat(gen_event* gevt, std::string &output, gen_event_formatter::output_format of)
-{
-	throw sinsp_exception("sinsp_evt_formatter unavailable because it was not compiled in the library");
-}
-#endif // HAS_FILTERING
 
 sinsp_evt_formatter_cache::sinsp_evt_formatter_cache(sinsp *inspector)
 	: m_inspector(inspector)

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -36,7 +36,6 @@ limitations under the License.
 #include "sinsp_int.h"
 #include "utils.h"
 
-#ifdef HAS_FILTERING
 #include "filter.h"
 #include "filterchecks.h"
 #include "value_parser.h"
@@ -2113,4 +2112,3 @@ std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory
 	return ret;
 }
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include <set>
 #include <vector>
 
-#ifdef HAS_FILTERING
 
 #include "filter_check_list.h"
 #include "gen_filter.h"
@@ -130,4 +129,3 @@ protected:
 	filter_check_list &m_available_checks;
 };
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 
 #include "sinsp.h"
 
-#ifdef HAS_FILTERING
 #include "filter_check_list.h"
 #include "filterchecks.h"
 
@@ -145,4 +144,3 @@ sinsp_filter_check_list::~sinsp_filter_check_list()
 {
 }
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#ifdef HAS_FILTERING
 class sinsp_filter_check;
 class filter_check_info;
 class sinsp;
@@ -55,4 +54,3 @@ public:
 // This is the "default" filter check list
 extern sinsp_filter_check_list g_filterlist;
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include "sinsp_int.h"
 #include "dns_manager.h"
 
-#ifdef HAS_FILTERING
 #include "filter.h"
 #include "filterchecks.h"
 #include "plugin.h"
@@ -8226,4 +8225,3 @@ uint8_t* sinsp_filter_check_mesos::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 }
 #endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -25,7 +25,6 @@ limitations under the License.
 #include "mesos.h"
 #endif
 
-#ifdef HAS_FILTERING
 #include "gen_filter.h"
 
 class sinsp_filter_check_reference;
@@ -968,4 +967,3 @@ private:
 
 #endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 
-#endif // HAS_FILTERING

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -176,7 +176,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	//
 	// Filtering
 	//
-#ifdef HAS_CAPTURE_FILTERING
 	bool do_filter_later = false;
 
 	if(m_inspector->m_filter)
@@ -236,7 +235,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	}
 
 	evt->m_filtered_out = false;
-#endif // HAS_CAPTURE_FILTERING
 
 	//
 	// Route the event to the proper function
@@ -486,7 +484,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	// With some state-changing events like clone, execve and open, we do the
 	// filtering after having updated the state
 	//
-#ifdef HAS_CAPTURE_FILTERING
 	if(do_filter_later)
 	{
 		if(m_inspector->run_filters_on_evt(evt) == false)
@@ -496,7 +493,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 		}
 		evt->m_filtered_out = false;
 	}
-#endif // HAS_CAPTURE_FILTERING
 	//
 	// Offline captures can produce events with the SCAP_DF_STATE_ONLY. They are
 	// supposed to go through the engine, but they must be filtered out before

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -176,7 +176,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	//
 	// Filtering
 	//
-#if defined(HAS_FILTERING) && defined(HAS_CAPTURE_FILTERING)
+#ifdef HAS_CAPTURE_FILTERING
 	bool do_filter_later = false;
 
 	if(m_inspector->m_filter)
@@ -236,7 +236,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	}
 
 	evt->m_filtered_out = false;
-#endif
+#endif // HAS_CAPTURE_FILTERING
 
 	//
 	// Route the event to the proper function
@@ -486,7 +486,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	// With some state-changing events like clone, execve and open, we do the
 	// filtering after having updated the state
 	//
-#if defined(HAS_FILTERING) && defined(HAS_CAPTURE_FILTERING)
+#ifdef HAS_CAPTURE_FILTERING
 	if(do_filter_later)
 	{
 		if(m_inspector->run_filters_on_evt(evt) == false)
@@ -496,7 +496,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 		}
 		evt->m_filtered_out = false;
 	}
-#endif
+#endif // HAS_CAPTURE_FILTERING
 	//
 	// Offline captures can produce events with the SCAP_DF_STATE_ONLY. They are
 	// supposed to go through the engine, but they must be filtered out before

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -29,11 +29,6 @@ limitations under the License.
 #define SP_EVT_BUF_SIZE 4096
 
 //
-// If defined, the filtering system is compiled
-//
-#define HAS_CAPTURE_FILTERING
-
-//
 // Controls if assertions break execution or if they are just printed to the
 // log
 //

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -31,7 +31,6 @@ limitations under the License.
 //
 // If defined, the filtering system is compiled
 //
-#define HAS_FILTERING
 #define HAS_CAPTURE_FILTERING
 
 //

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1390,8 +1390,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	//
 	if(NULL != m_dumper)
 	{
-
-#ifdef HAS_CAPTURE_FILTERING
 		scap_dump_flags dflags;
 
 		bool do_drop;
@@ -1401,7 +1399,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			*puevt = evt;
 			return SCAP_TIMEOUT;
 		}
-#endif // HAS_CAPTURE_FILTERING
 
 		if(m_write_cycling)
 		{
@@ -1432,7 +1429,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		}
 	}
 
-#ifdef HAS_CAPTURE_FILTERING
 	if(evt->m_filtered_out)
 	{
 		ppm_event_category cat = evt->get_info_category();
@@ -1445,7 +1441,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			return SCAP_TIMEOUT;
 		}
 	}
-#endif
 
 	//
 	// Run the analysis engine

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -89,11 +89,7 @@ sinsp::sinsp(bool static_container, const std::string static_id, const std::stri
 	m_inactive_container_scan_time_ns = DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S * ONE_SECOND_IN_NS;
 	m_cycle_writer = NULL;
 	m_write_cycling = false;
-
-#ifdef HAS_FILTERING
 	m_filter = NULL;
-#endif
-
 	m_fds_to_remove = new vector<int64_t>;
 	m_machine_info = NULL;
 #ifdef SIMULATE_DROP_MODE
@@ -311,9 +307,7 @@ void sinsp::init()
 	m_nevts = 0;
 	m_tid_to_remove = -1;
 	m_lastevent_ts = 0;
-#ifdef HAS_FILTERING
 	m_firstevent_ts = 0;
-#endif
 	m_fds_to_remove->clear();
 
 	//
@@ -790,14 +784,11 @@ void sinsp::close()
 
 	deinit_state();
 
-#ifdef HAS_FILTERING
 	if(m_filter != NULL)
 	{
 		delete m_filter;
 		m_filter = NULL;
 	}
-
-#endif
 
 	m_ppm_sc_of_interest.clear();
 }
@@ -1400,7 +1391,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	if(NULL != m_dumper)
 	{
 
-#if defined(HAS_FILTERING) && defined(HAS_CAPTURE_FILTERING)
+#ifdef HAS_CAPTURE_FILTERING
 		scap_dump_flags dflags;
 
 		bool do_drop;
@@ -1410,7 +1401,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			*puevt = evt;
 			return SCAP_TIMEOUT;
 		}
-#endif
+#endif // HAS_CAPTURE_FILTERING
 
 		if(m_write_cycling)
 		{
@@ -1441,7 +1432,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		}
 	}
 
-#if defined(HAS_FILTERING) && defined(HAS_CAPTURE_FILTERING)
+#ifdef HAS_CAPTURE_FILTERING
 	if(evt->m_filtered_out)
 	{
 		ppm_event_category cat = evt->get_info_category();
@@ -1805,7 +1796,6 @@ void sinsp::start_dropping_mode(uint32_t sampling_ratio)
 }
 #endif // _WIN32
 
-#ifdef HAS_FILTERING
 void sinsp::set_filter(sinsp_filter* filter)
 {
 	if(m_filter != NULL)
@@ -1847,7 +1837,6 @@ bool sinsp::run_filters_on_evt(sinsp_evt *evt)
 
 	return false;
 }
-#endif
 
 const scap_machine_info* sinsp::get_machine_info()
 {
@@ -1896,16 +1885,10 @@ scap_groupinfo* sinsp::get_group(uint32_t gid)
 	return it->second;
 }
 
-#ifdef HAS_FILTERING
 void sinsp::get_filtercheck_fields_info(OUT vector<const filter_check_info*>& list)
 {
 	sinsp_utils::get_filtercheck_fields_info(list);
 }
-#else
-void sinsp::get_filtercheck_fields_info(OUT vector<const filter_check_info*>& list)
-{
-}
-#endif
 
 uint32_t sinsp::reserve_thread_memory(uint32_t size)
 {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -338,7 +338,6 @@ public:
 	*/
 	void start_capture();
 
-#ifdef HAS_FILTERING
 	/*!
 	  \brief Compiles and installs the given capture filter.
 
@@ -367,7 +366,6 @@ public:
 	const string get_filter();
 
 	bool run_filters_on_evt(sinsp_evt *evt);
-#endif
 
 	/*!
 	  \brief This method can be used to specify a function to collect the library
@@ -1178,11 +1176,9 @@ public:
 	//
 	bool m_print_container_data;
 
-#ifdef HAS_FILTERING
 	uint64_t m_firstevent_ts;
 	sinsp_filter* m_filter;
 	std::string m_filterstring;
-#endif
 	unordered_set<uint32_t> m_ppm_sc_of_interest;
 
 	//

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -76,10 +76,8 @@ void sinsp_threadinfo::init()
 	m_vpid = -1;
 	m_main_thread.reset();
 	m_lastevent_fd = 0;
-#ifdef HAS_FILTERING
 	m_last_latency_entertime = 0;
 	m_latency = 0;
-#endif
 	m_program_hash = 0;
 	m_program_hash_scripts = 0;
 	m_lastevent_data = NULL;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -321,13 +321,11 @@ public:
 	void cgroups_to_iovec(struct iovec **iov, int *iovcnt,
 			      std::string &rem) const;
 
-#ifdef HAS_FILTERING
 	//
 	// State for filtering
 	//
 	uint64_t m_last_latency_entertime;
 	uint64_t m_latency;
-#endif
 
 	//
 	// Global state

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -67,9 +67,7 @@ limitations under the License.
 sinsp_evttables g_infotables;
 sinsp_logger g_logger;
 sinsp_initializer g_initializer;
-#ifdef HAS_FILTERING
 sinsp_filter_check_list g_filterlist;
-#endif
 sinsp_protodecoder_list g_decoderlist;
 
 //
@@ -843,12 +841,10 @@ const struct ppm_param_info* sinsp_utils::find_longest_matching_evt_param(string
 	return res;
 }
 
-#ifdef HAS_FILTERING
 void sinsp_utils::get_filtercheck_fields_info(OUT vector<const filter_check_info*>& list)
 {
 	g_filterlist.get_all_fields(list);
 }
-#endif
 
 uint64_t sinsp_utils::get_current_time_ns()
 {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This removes the `HAS_FILTERING` and `HAS_CAPTURE_FILTERING` macros from libsinsp, which are legacy code and are not used anymore.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
