### PR TITLE
refactor: move async key value source into libsinsp

### DIFF
--- a/userspace/libsinsp/async/async_key_value_source.h
+++ b/userspace/libsinsp/async/async_key_value_source.h
@@ -27,7 +27,7 @@ limitations under the License.
 #include <unordered_map>
 #include <stdint.h>
 
-namespace sysdig
+namespace libsinsp
 {
 
 /**
@@ -338,6 +338,6 @@ private:
 };
 
 
-} // end namespace sysdig
+} // end namespace libsinsp
 
 #include "async_key_value_source.tpp"

--- a/userspace/libsinsp/async/async_key_value_source.tpp
+++ b/userspace/libsinsp/async/async_key_value_source.tpp
@@ -25,7 +25,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-namespace sysdig
+namespace libsinsp
 {
 
 template<typename key_type, typename value_type>
@@ -382,5 +382,5 @@ std::chrono::steady_clock::time_point async_key_value_source<key_type, value_typ
 	return next_request.first;
 }
 
-} // end namespace sysdig
+} // end namespace libsinsp
 

--- a/userspace/libsinsp/cgroup_limits.h
+++ b/userspace/libsinsp/cgroup_limits.h
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <utility>
-#include "async_key_value_source.h"
+#include "async/async_key_value_source.h"
 
 namespace {
 bool less_than(const std::string& lhs, const std::string& rhs, bool if_equal=false)

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -46,7 +46,7 @@ namespace container_engine {
  * 2. Apparently CRI can fail to find a freshly created container
  * for a short while, so we should delay the query a bit.
  */
-class cri_async_source : public sysdig::async_key_value_source<
+class cri_async_source : public libsinsp::async_key_value_source<
         libsinsp::cgroup_limits::cgroup_limits_key,
         sinsp_container_info>
 {

--- a/userspace/libsinsp/container_engine/docker/async_source.h
+++ b/userspace/libsinsp/container_engine/docker/async_source.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "async_key_value_source.h"
+#include "async/async_key_value_source.h"
 #include "container_info.h"
 
 #include "container_engine/docker/connection.h"
@@ -11,7 +11,7 @@ namespace container_engine {
 
 class container_cache_interface;
 
-class docker_async_source : public sysdig::async_key_value_source<docker_lookup_request, sinsp_container_info>
+class docker_async_source : public libsinsp::async_key_value_source<docker_lookup_request, sinsp_container_info>
 {
 public:
 	docker_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface *cache);


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

The `async_key_value_source` class used to reside in its own `async` base level directory. However, such a class is only used in the scope of libsinsp, and having an extra directory inside `userspace` makes the overall design of the libraries repo more confusing.

This PR cleans this up by moving the `async` directory inside `userspace/libsinsp` and by putting the `async_key_value_source` class under the `libsinsp` namespace.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor: move async key value source into libsinsp
```
