### PR TITLE
fix(libsinsp): Zero-initializes m_sockinfo in sinsp_fdinfo.

### DIFF
--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -332,9 +332,9 @@ public:
 	
 	/*!
 	  \brief Socket-specific state.
-	  This is uninitialized for non-socket FDs.
+	  This is uninitialized (zero) for non-socket FDs.
 	*/
-	sinsp_sockinfo m_sockinfo;
+	sinsp_sockinfo m_sockinfo = {};
 
 	std::string m_name; ///< Human readable rendering of this FD. For files, this is the full file name. For sockets, this is the tuple. And so on.
 	std::string m_oldname; // The name of this fd at the beginning of event parsing. Used to detect name changes that result from parsing an event.


### PR DESCRIPTION
This fixes a bug where invalid results appeared in parsed fdinfos,
due to random stack values for the contents of m_sockinfo.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

**What this PR does / why we need it**:

This PR fixes a bug where `sinsp_fdinfo::m_sockinfo` is uninitialized, which means that it is populated with random stack data, and can make it appear that the socket information is populated when it isn't.

In particular, this corruption can mean that values aren't overwritten when they should be:
https://github.com/falcosecurity/libs/blob/75ac8c97459919b696c23481b860927fb638da07/userspace/libsinsp/parsers.cpp#L3366-L3379

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
