### PR TITLE
update: build with warnings as errors by default

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -1,4 +1,4 @@
-option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
+option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags" ON)
 
 if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
 	set(CMD_MAKE gmake)

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#ifndef MINIMAL_BUILD
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,9 +25,7 @@ limitations under the License.
 #include <sys/socket.h>
 #include <sys/syscall.h>
 #include <sys/utsname.h>
-#ifndef MINIMAL_BUILD
 #include <gelf.h>
-#endif // MINIMAL_BUILD
 #include <fcntl.h>
 #include <errno.h>
 #include <ctype.h>
@@ -1559,3 +1558,5 @@ int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_i
 	}
 	return populate_syscall_table_map(handle);
 }
+
+#endif // MINIMAL_BUILD

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1290,11 +1290,13 @@ static int32_t set_default_settings(scap_t *handle)
 {
 	struct scap_bpf_settings settings;
 
-	if(set_boot_time(handle, &settings.boot_time) != SCAP_SUCCESS)
+	uint64_t boot_time = 0;
+	if(set_boot_time(handle, &boot_time) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
 
+	settings.boot_time = boot_time;
 	settings.socket_file_ops = NULL;
 	settings.snaplen = RW_SNAPLEN;
 	settings.sampling_ratio = 1;

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1024,24 +1024,21 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress, bool skip_proc_scan)
 {
 	gzFile f = NULL;
-	const char* mode;
 
 	switch(compress)
 	{
 	case SCAP_COMPRESSION_GZIP:
-		mode = "wb";
+		f = gzdopen(fd, "wb");
 		break;
 	case SCAP_COMPRESSION_NONE:
-		mode = "wbT";
+		f = gzdopen(fd, "wbT");
 		break;
 	default:
 		ASSERT(false);
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
 		return NULL;
 	}
-
-	f = gzdopen(fd, mode);
-
+	
 	if(f == NULL)
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open fd %d", fd);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2127,7 +2127,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	string sdir;
 	uint16_t etype = evt->get_type();
 	uint32_t dev = 0;
-	bool lastevent_retrieved;
+	bool lastevent_retrieved = false;
 
 	ASSERT(evt->m_tinfo);
 	if(evt->m_tinfo == nullptr)
@@ -2135,16 +2135,12 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		return;
 	}
 
-
 	if(etype != PPME_SYSCALL_OPEN_BY_HANDLE_AT_X)
 	{
 		//
 		// Load the enter event so we can access its arguments
 		//
-		if(!retrieve_enter_event(enter_evt, evt))
-		{
-			return;
-		}
+		lastevent_retrieved = retrieve_enter_event(enter_evt, evt);
 	}
 
 	//


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area libscap

/area libsinsp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR proposes setting the cmake `BUILD_WARNINGS_AS_ERRORS` build flag as `ON` by default. This implies a more strict building process that potentially helps spotting tedious bugs. This is also already done in Falco (not enabled by default, but used in some jobs of our CI), which can occasionally cause the side-effect of having Falco build failing after some libs PRs got merged without prior noticeable build errors. Accordingly, this brings two bug fixes of issues spotted as simple warnings.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update: build with warnings as errors by default
```
