### PR TITLE
fix(libsinsp,libscap): fix compilation warnings

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -57,6 +57,8 @@ struct bpf_map_data {
 	struct bpf_map_def def;
 };
 
+#ifndef MINIMAL_BUILD
+
 static const int BUF_SIZE_PAGES = 2048;
 
 static const int BPF_LOG_SIZE = 1 << 18;
@@ -197,7 +199,6 @@ static int bpf_raw_tracepoint_open(const char *name, int prog_fd)
 	return sys_bpf(BPF_RAW_TRACEPOINT_OPEN, &attr, sizeof(attr));
 }
 
-#ifndef MINIMAL_BUILD
 static int32_t get_elf_section(Elf *elf, int i, GElf_Ehdr *ehdr, char **shname, GElf_Shdr *shdr, Elf_Data **data)
 {
 	Elf_Scn *scn = elf_getscn(elf, i);
@@ -302,7 +303,6 @@ static int32_t load_elf_maps_section(scap_t *handle, struct bpf_map_data *maps,
 	free(sym);
 	return SCAP_SUCCESS;
 }
-#endif // MINIMAL_BUILD
 
 static int32_t load_maps(scap_t *handle, struct bpf_map_data *maps, int nr_maps)
 {
@@ -341,7 +341,6 @@ static int32_t load_maps(scap_t *handle, struct bpf_map_data *maps, int nr_maps)
 	return SCAP_SUCCESS;
 }
 
-#ifndef MINIMAL_BUILD
 static int32_t parse_relocations(scap_t *handle, Elf_Data *data, Elf_Data *symbols,
 				 GElf_Shdr *shdr, struct bpf_insn *insn,
 				 struct bpf_map_data *maps, int nr_maps)
@@ -395,7 +394,6 @@ static int32_t parse_relocations(scap_t *handle, Elf_Data *data, Elf_Data *symbo
 
 	return SCAP_SUCCESS;
 }
-#endif // MINIMAL_BUILD
 
 static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_insn *prog, int size)
 {
@@ -547,7 +545,6 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 	return SCAP_SUCCESS;
 }
 
-#ifndef MINIMAL_BUILD
 static int32_t load_bpf_file(scap_t *handle, const char *path)
 {
 	int j;
@@ -718,7 +715,6 @@ cleanup:
 	close(program_fd);
 	return res;
 }
-#endif // MINIMAL_BUILD
 
 static void *perf_event_mmap(scap_t *handle, int fd)
 {
@@ -863,6 +859,10 @@ static int32_t calibrate_socket_file_ops()
 	close(fd);
 	return SCAP_SUCCESS;
 }
+
+#endif // MINIMAL_BUILD
+
+#ifndef MINIMAL_BUILD
 
 int32_t scap_bpf_start_capture(scap_t *handle)
 {
@@ -1189,6 +1189,83 @@ int32_t scap_bpf_close(scap_t *handle)
 	return SCAP_SUCCESS;
 }
 
+#else // MINIMAL_BUILD
+
+int32_t scap_bpf_start_capture(scap_t *handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_stop_capture(scap_t *handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_set_snaplen(scap_t* handle, uint32_t snaplen)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_set_statsd_port(scap_t* const handle, const uint16_t port)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_disable_dynamic_snaplen(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_stop_dropping_mode(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_enable_dynamic_snaplen(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_enable_page_faults(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_enable_tracers_capture(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_close(scap_t *handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+#endif // MINIMAL_BUILD
+
+#ifndef MINIMAL_BUILD
 //
 // This is completely horrible, revisit this shameful code
 // with a proper solution
@@ -1319,13 +1396,11 @@ static int32_t set_default_settings(scap_t *handle)
 
 	return SCAP_SUCCESS;
 }
+#endif // MINIMAL_BUILD
 
+#ifndef MINIMAL_BUILD
 int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 {
-#ifdef MINIMAL_BUILD
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
-	return SCAP_FAILURE;
-#else
 	int online_cpu;
 	int j;
 
@@ -1462,7 +1537,6 @@ int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
 	}
 
 	return SCAP_SUCCESS;
-#endif // MINIMAL_BUILD
 }
 
 int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
@@ -1559,3 +1633,38 @@ int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_i
 	}
 	return populate_syscall_table_map(handle);
 }
+
+#else // MINIMAL_BUILD
+
+int32_t scap_bpf_load(scap_t *handle, const char *bpf_probe)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_set_simple_mode(scap_t* handle)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_id)
+{
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "The eBPF probe driver is not supported when using a minimal build");
+	return SCAP_FAILURE;
+}
+
+#endif // MINIMAL_BUILD
+

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -1290,11 +1290,13 @@ static int32_t set_default_settings(scap_t *handle)
 {
 	struct scap_bpf_settings settings;
 
-	if(set_boot_time(handle, &settings.boot_time) != SCAP_SUCCESS)
+	uint64_t boot_time = 0;
+	if(set_boot_time(handle, &boot_time) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
 
+	settings.boot_time = boot_time;
 	settings.socket_file_ops = NULL;
 	settings.snaplen = RW_SNAPLEN;
 	settings.sampling_ratio = 1;

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1024,24 +1024,21 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress, bool skip_proc_scan)
 {
 	gzFile f = NULL;
-	const char* mode;
 
 	switch(compress)
 	{
 	case SCAP_COMPRESSION_GZIP:
-		mode = "wb";
+		f = gzdopen(fd, "wb");
 		break;
 	case SCAP_COMPRESSION_NONE:
-		mode = "wbT";
+		f = gzdopen(fd, "wbT");
 		break;
 	default:
 		ASSERT(false);
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
 		return NULL;
 	}
-
-	f = gzdopen(fd, mode);
-
+	
 	if(f == NULL)
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open fd %d", fd);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2127,7 +2127,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	string sdir;
 	uint16_t etype = evt->get_type();
 	uint32_t dev = 0;
-	bool lastevent_retrieved;
+	bool lastevent_retrieved = false;
 
 	ASSERT(evt->m_tinfo);
 	if(evt->m_tinfo == nullptr)
@@ -2135,16 +2135,12 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		return;
 	}
 
-
 	if(etype != PPME_SYSCALL_OPEN_BY_HANDLE_AT_X)
 	{
 		//
 		// Load the enter event so we can access its arguments
 		//
-		if(!retrieve_enter_event(enter_evt, evt))
-		{
-			return;
-		}
+		lastevent_retrieved = retrieve_enter_event(enter_evt, evt);
 	}
 
 	//


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area libscap

/area libsinsp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR removes a bunch of warnings that prevents the libraries to be compiled with the `BUILD_WARNINGS_AS_ERRORS` flag set to ON. This is required by Falco, which has some CI jobs using that flag. At the same time, this PR fixes a variable-initialization bug inside `parsers.cpp`.

**Special notes for your reviewer**:

As for now, compilation seems to fail when both `BUILD_WARNINGS_AS_ERRORS` and `MINIMAL_BUILD` are set to ON.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update: build with warnings as errors by default
```