### PR TITLE
fix(libsinsp): use `at` instead of `operator []` for bound checking

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -173,7 +173,7 @@ sinsp_evt_param *sinsp_evt::get_param(uint32_t id)
 		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
 	}
 
-	return &(m_params[id]);
+	return &(m_params.at(id));
 }
 
 const char *sinsp_evt::get_param_name(uint32_t id)
@@ -754,8 +754,6 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
 	}
 
-	ASSERT(id < get_num_params());
-
 	//
 	// Reset the resolved string
 	//
@@ -764,7 +762,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 	//
 	// Get the parameter
 	//
-	sinsp_evt_param *param = &(m_params[id]);
+	sinsp_evt_param *param = get_param(id);
 	payload = param->m_val;
 	payload_len = param->m_len;
 	param_info = &(m_info->params[id]);
@@ -1430,7 +1428,7 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo)
 		return cwd;
 	}
 
-	const sinsp_evt_param* dir_param = &m_params[dirfd_id];
+	const sinsp_evt_param* dir_param = get_param(dirfd_id);
 	const int64_t dirfd = *(int64_t*)dir_param->m_val;
 
 	// If the FD is special value PPM_AT_FDCWD, just use CWD
@@ -1478,7 +1476,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	//
 	// Get the parameter
 	//
-	sinsp_evt_param *param = &(m_params[id]);
+	sinsp_evt_param *param = get_param(id);
 	payload = param->m_val;
 	payload_len = param->m_len;
 	param_info = &(m_info->params[id]);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The `std::vector::at` function is bound checked and it is much safer to use it instead of operator `[]`, which is not. I'd like to use this function, especially when we pass indexes around like in `sinsp_evt::get_param`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
