### PR TITLE
new(libscap): add scap_event_encode_params()

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -57,6 +57,7 @@ struct iovec;
 // Core types
 //
 #include <time.h>
+#include <stdarg.h>
 #include "uthash.h"
 #include "../common/types.h"
 #include "../../driver/ppm_api_version.h"
@@ -569,6 +570,16 @@ struct scap_sized_buffer {
 	void* buf;
 	size_t size;
 };
+typedef struct scap_sized_buffer scap_sized_buffer;
+
+/*!
+  \brief Structure used to pass a read-only buffer and its size.
+*/
+struct scap_const_sized_buffer {
+	const void* buf;
+	size_t size;
+};
+typedef struct scap_const_sized_buffer scap_const_sized_buffer;
 
 /*@}*/
 
@@ -763,7 +774,7 @@ void scap_event_reset_count(scap_t* handle);
 
   \return The pointer to the the event table entry for the given event.
 */
-const struct ppm_event_info* scap_event_getinfo(scap_evt* e);
+const struct ppm_event_info* scap_event_getinfo(const scap_evt* e);
 
 /*!
   \brief Return the dump flags for the last event received from this handle
@@ -1070,6 +1081,32 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid);
   \param params An array large enough to contain n entries.
  */
 uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *params);
+
+/*!
+  \brief Create an event from the parameters given as arguments.
+
+  Create any event from the event_table passing the type, n and the parameters as variadic arguments as follows:
+   - Any integer type is passed from the correct type
+   - String types (including PT_FSPATH, PT_FSRELPATH) are passed via a null-terminated char*
+   - Buffer types, variable size types and similar, including PT_BYTEBUF, PT_SOCKTUPLE are passed with
+     a struct scap_const_sized_buffer
+  
+  If the event was written successfully, SCAP_SUCCESS is returned. If the supplied buffer is not large enough to contain
+  the event, SCAP_INPUT_TOO_SMALL is returned and event_size is set with the required size to contain the entire event.
+
+  \param event_buf The buffer where to store the encoded event.
+  \param event_size Output value that will be filled with the size of the event.
+  \param error A pointer to a scap error string to be filled in case of error.
+  \param event_type The event type (normally PPME_*)
+  \param n The number of parameters for this event. This is required as the number of parameters used for each event can change between versions.
+  \param ...
+  \return int32_t The error value. If the event was written successfully, SCAP_SUCCESS is returned.
+  If the supplied buffer is not large enough for the event SCAP_INPUT_TOO_SMALL is returned and event_size
+  is set with the required size to contain the entire event. In other error cases, SCAP_FAILURE is returned.
+
+ */
+int32_t scap_event_encode_params(struct scap_sized_buffer event_buf, size_t *event_size, char *error, enum ppm_event_type event_type, uint32_t n, ...);
+int32_t scap_event_encode_params_v(struct scap_sized_buffer event_buf, size_t *event_size, char *error, enum ppm_event_type event_type, uint32_t n, va_list args);
 
 /*@}*/
 

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -72,7 +72,7 @@ uint32_t scap_event_get_sentinel_begin(scap_evt* e)
 }
 #endif
 
-const struct ppm_event_info* scap_event_getinfo(scap_evt* e)
+const struct ppm_event_info* scap_event_getinfo(const scap_evt* e)
 {
 	return &(g_event_info[e->type]);
 }
@@ -124,4 +124,217 @@ uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *p
 	}
 
 	return n;
+}
+
+void scap_event_set_param_length_regular(scap_evt *event, uint32_t n, uint16_t len)
+{
+	memcpy((char *)event + sizeof(struct ppm_evt_hdr) + sizeof(uint16_t) * n, &len, sizeof(uint16_t));
+}
+
+void scap_event_set_param_length_large(scap_evt *event, uint32_t n, uint32_t len)
+{
+	memcpy((char *)event + sizeof(struct ppm_evt_hdr) + sizeof(uint32_t) * n, &len, sizeof(uint32_t));
+}
+
+static inline int32_t scap_buffer_can_fit(struct scap_sized_buffer buf, size_t len)
+{
+	return (buf.size >= len);
+}
+
+int32_t scap_event_encode_params(struct scap_sized_buffer event_buf, size_t *event_size, char *error, enum ppm_event_type event_type, uint32_t n, ...)
+{
+    va_list args;
+    va_start(args, n);
+    int32_t ret = scap_event_encode_params_v(event_buf, event_size, error, event_type, n, args);
+    va_end(args);
+
+	return ret;
+}
+
+int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf, size_t *event_size, char *error, enum ppm_event_type event_type, uint32_t n, va_list args)
+{
+	scap_evt *event = NULL;
+
+	const struct ppm_event_info *event_info = &g_event_info[event_type];
+
+	// len_size is the size in bytes of an entry of the parameter length array
+	size_t len_size = sizeof(uint16_t);
+	if((event_info->flags & EF_LARGE_PAYLOAD) != 0)
+	{
+		len_size = sizeof(uint32_t);
+	}
+
+	n = event_info->nparams < n ? event_info->nparams : n;
+
+	size_t len = sizeof(struct ppm_evt_hdr) + len_size * n;
+
+	// every buffer write access needs to be guarded by a scap_buffer_can_fit call to check if it's large enough
+	if (scap_buffer_can_fit(event_buf, len))
+	{
+		event = event_buf.buf;
+		event->type = event_type;
+		event->nparams = n;
+		event->len = len;
+	}
+
+	for(int i = 0; i < n; i++)
+	{
+		const struct ppm_param_info *pi = &event_info->params[i];
+		struct scap_const_sized_buffer param = {0};
+
+        uint8_t u8_arg;
+        uint16_t u16_arg;
+        uint32_t u32_arg;
+        uint64_t u64_arg;
+
+		switch(pi->type)
+		{
+		case PT_INT8:
+		case PT_UINT8:
+		case PT_FLAGS8:
+		case PT_SIGTYPE:
+		case PT_L4PROTO:
+		case PT_SOCKFAMILY:
+			u8_arg = (uint8_t) (va_arg(args, int) & 0xff);
+			param.buf = &u8_arg;
+			param.size = sizeof(uint8_t);
+			break;
+
+		case PT_INT16:
+		case PT_UINT16:
+		case PT_SYSCALLID:
+		case PT_PORT:
+		case PT_FLAGS16:
+			u16_arg = (uint16_t) (va_arg(args, int) & 0xffff);
+			param.buf = &u16_arg;
+			param.size = sizeof(uint16_t);
+			break;
+
+		case PT_INT32:
+		case PT_UINT32:
+		case PT_BOOL:
+		case PT_IPV4ADDR:
+		case PT_UID:
+		case PT_GID:
+		case PT_FLAGS32:
+		case PT_SIGSET:
+		case PT_MODE:
+            u32_arg = va_arg(args, uint32_t);
+            param.buf = &u32_arg;
+            param.size = sizeof(uint32_t);
+			break;
+
+		case PT_INT64:
+		case PT_UINT64:
+		case PT_ERRNO:
+		case PT_FD:
+		case PT_PID:
+		case PT_RELTIME:
+		case PT_ABSTIME:
+		case PT_DOUBLE:
+            u64_arg = va_arg(args, uint64_t);
+            param.buf = &u64_arg;
+            param.size = sizeof(uint64_t);
+			break;
+
+		case PT_CHARBUF:
+		case PT_FSPATH:
+		case PT_FSRELPATH:
+            param.buf = va_arg(args, char*);
+            param.size = strlen(param.buf) + 1;
+			break;
+
+		case PT_BYTEBUF: /* A raw buffer of bytes not suitable for printing */
+		case PT_SOCKTUPLE:  /* A sockaddr tuple,1byte family + 12byte data + 12byte data */
+		case PT_FDLIST:		    /* A list of fds, 16bit count + count * (64bit fd + 16bit flags) */
+		case PT_DYN:		    /* Type can vary depending on the context. Used for filter fields like evt.rawarg. */
+		case PT_CHARBUFARRAY:	    /* Pointer to an array of strings, exported by the user events decoder. 64bit. For internal use only. */
+		case PT_CHARBUF_PAIR_ARRAY: /* Pointer to an array of string pairs, exported by the user events decoder. 64bit. For internal use only. */
+		case PT_IPV4NET:	    /* An IPv4 network. */
+		case PT_IPV6ADDR:	    /* A 16 byte raw IPv6 address. */
+		case PT_IPV6NET:	    /* An IPv6 network. */
+		case PT_IPADDR:		    /* Either an IPv4 or IPv6 address. The length indicates which one it is. */
+		case PT_IPNET:		    /* Either an IPv4 or IPv6 network. The length indicates which one it is. */
+		case PT_SOCKADDR:
+            param = va_arg(args, struct scap_const_sized_buffer);
+			break;
+			
+		case PT_NONE:
+        case PT_MAX:
+			break; // Nothing to do 
+		default: // Unsupported event
+			snprintf(error, SCAP_LASTERR_SIZE, "event param %d (param type %d) is unsupported", i, pi->type);
+			return SCAP_FAILURE;
+		}
+
+        // don't do anything if we couldn't correctly parse the argument (or if it's unsupported)
+        if(param.size == 0)
+        {
+            continue;
+        }
+
+		uint16_t param_size_16;
+		uint32_t param_size_32;
+
+		switch(len_size)
+		{
+			case sizeof(uint16_t):
+				param_size_16 = (uint16_t) (param.size & 0xffff);
+				if (param_size_16 != param.size)
+				{
+					snprintf(error, SCAP_LASTERR_SIZE, "could not fit event param %d size %zu for event with type %d in %zu bytes",
+							i, param.size, event->type, len_size);
+					return SCAP_FAILURE;
+				}
+				if (scap_buffer_can_fit(event_buf, len))
+				{
+					scap_event_set_param_length_regular(event, i, param_size_16);
+				}
+				break;
+			case sizeof(uint32_t):
+				param_size_32 = (uint32_t) (param.size & 0xffffffff);
+				if (param_size_32 != param.size)
+				{
+					snprintf(error, SCAP_LASTERR_SIZE, "could not fit event param %d size %zu for event with type %d in %zu bytes",
+							i, param.size, event->type, len_size);
+					return SCAP_FAILURE;
+				}
+				if (scap_buffer_can_fit(event_buf, len))
+				{
+					scap_event_set_param_length_large(event, i, param_size_32);
+				}
+				break;
+			default:
+				snprintf(error, SCAP_LASTERR_SIZE, "unexpected param %d length %zu for event with type %d",
+						i, len_size, event->type);
+				return SCAP_FAILURE;
+		}
+
+		if (scap_buffer_can_fit(event_buf, len + param.size))
+		{
+        	memcpy(((char*)event_buf.buf + len), param.buf, param.size);
+		}
+        len = len + param.size;
+	}
+
+#ifdef PPM_ENABLE_SENTINEL
+	if (scap_buffer_can_fit(event_buf, len + sizeof(uint32_t)))
+	{
+		event->sentinel_begin = 0x01020304;
+		memcpy(((char*)event_buf.buf + len), &event->sentinel_begin, sizeof(uint32_t));
+	}
+	len = len + sizeof(uint32_t);
+#endif
+
+	*event_size = len;
+
+	// we were not able to write the event to the buffer
+	if (!scap_buffer_can_fit(event_buf, len))
+	{
+		return SCAP_INPUT_TOO_SMALL;
+	}
+
+	event->len = len;
+
+	return SCAP_SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a function to libscap to generate a scap event given the arguments. The event will be generated from userspace but doesn't come from any ringbuffer. This is necessary to allow syscall generators that do not use a ringbuffer such as the upcoming gvisor support.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libscap): add event_encode
```
