### PR TITLE
fix(libsinsp): overwrite fd destination address when safe to do so

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2822,12 +2822,12 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt *evt, uint8_t *packe
             if(!(sinsp_utils::is_ipv4_mapped_ipv6(sip) && sinsp_utils::is_ipv4_mapped_ipv6(dip)))
             {
                 evt->m_fdinfo->m_type = SCAP_FD_IPV6_SOCK;
-                changed = m_inspector->m_parser->set_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data);
+                changed = m_inspector->m_parser->set_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data, false);
             }
             else
             {
                 evt->m_fdinfo->m_type = SCAP_FD_IPV4_SOCK;
-                changed = m_inspector->m_parser->set_ipv4_mapped_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data);
+                changed = m_inspector->m_parser->set_ipv4_mapped_ipv6_addresses_and_ports(evt->m_fdinfo, packed_data, false);
             }
         }
         else
@@ -2837,7 +2837,7 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt *evt, uint8_t *packe
             //
             // Update the FD info with this tuple
             //
-            changed = m_inspector->m_parser->set_ipv4_addresses_and_ports(evt->m_fdinfo, packed_data);
+            changed = m_inspector->m_parser->set_ipv4_addresses_and_ports(evt->m_fdinfo, packed_data, false);
         }
 
         if(changed && evt->m_fdinfo->is_role_server() && evt->m_fdinfo->is_udp_socket())
@@ -3334,7 +3334,7 @@ void sinsp_parser::parse_thread_exit(sinsp_evt *evt)
 }
 
 inline bool sinsp_parser::update_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, 
-	uint32_t tsip, uint16_t tsport, uint32_t tdip, uint16_t tdport)
+	uint32_t tsip, uint16_t tsport, uint32_t tdip, uint16_t tdport, bool overwrite_dest)
 {
 	if(fdinfo->m_type == SCAP_FD_IPV4_SOCK)
 	{
@@ -3364,12 +3364,14 @@ inline bool sinsp_parser::update_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo
 		changed = true;
 	}
 
-	if(fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip == 0) {
+	if(fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip == 0 || 
+		(overwrite_dest && fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip != tdip)) {
 		fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip = tdip;
 		changed = true;
 	}
 
-	if(fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport == 0) {
+	if(fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport == 0 ||
+		(overwrite_dest && fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport != tdport)) {
 		fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport = tdport;
 		changed = true;
 	}
@@ -3377,7 +3379,7 @@ inline bool sinsp_parser::update_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo
 	return changed;
 }
 
-bool sinsp_parser::set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data)
+bool sinsp_parser::set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest)
 {
 	uint32_t tsip, tdip;
 	uint16_t tsport, tdport;
@@ -3387,10 +3389,10 @@ bool sinsp_parser::set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t*
 	memcpy(&tdip, packed_data + 7, sizeof(uint32_t));
 	memcpy(&tdport, packed_data + 11, sizeof(uint16_t));
 
-	return update_ipv4_addresses_and_ports(fdinfo, tsip, tsport, tdip, tdport);
+	return update_ipv4_addresses_and_ports(fdinfo, tsip, tsport, tdip, tdport, overwrite_dest);
 }
 
-bool sinsp_parser::set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data)
+bool sinsp_parser::set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest)
 {
 	uint32_t tsip, tdip;
 	uint16_t tsport, tdport;
@@ -3400,10 +3402,10 @@ bool sinsp_parser::set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdin
 	tdip = *(uint32_t *)(packed_data + 31);
 	tdport = *(uint16_t *)(packed_data + 35);
 
-	return update_ipv4_addresses_and_ports(fdinfo, tsip, tsport, tdip, tdport);
+	return update_ipv4_addresses_and_ports(fdinfo, tsip, tsport, tdip, tdport, overwrite_dest);
 }
 
-bool sinsp_parser::set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data)
+bool sinsp_parser::set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest)
 {
 	ipv6addr tsip, tdip;
 	uint16_t tsport, tdport;
@@ -3442,12 +3444,14 @@ bool sinsp_parser::set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t*
 		changed = true;
 	}
 
-	if(fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip == ipv6addr::empty_address) {
+	if(fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip == ipv6addr::empty_address ||
+		(overwrite_dest && fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip != tdip)) {
 		fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip = tdip;
 		changed = true;
 	}
 
-	if(fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport == 0) {
+	if(fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport == 0 ||
+		(overwrite_dest && fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport != tdport)) {
 		fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport = tdport;
 		changed = true;
 	}

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -146,7 +146,7 @@ private:
 	void parse_getsockopt_exit(sinsp_evt *evt);
 
 	inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo,
-		uint32_t tsip, uint16_t tsport, uint32_t tdip, uint16_t tdport);
+		uint32_t tsip, uint16_t tsport, uint32_t tdip, uint16_t tdport, bool overwrite_dest=true);
 	inline void fill_client_socket_info(sinsp_evt* evt, uint8_t* packed_data);
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
 	inline void infer_sendto_fdinfo(sinsp_evt *evt);
@@ -155,9 +155,9 @@ private:
 	bool update_fd(sinsp_evt *evt, sinsp_evt_param* parinfo);
 
 	// Next 4 return false if the update didn't happen because the tuple is identical to the given address
-	bool set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data);
-	bool set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data);
-	bool set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data);
+	bool set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
+	bool set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
+	bool set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
 	bool set_unix_info(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data);
 
 	void swap_addresses(sinsp_fdinfo_t* fdinfo);


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When updating libsinsp to make sure we correctly update the fd on `connect()` events we were a bit overzealous and changed the functions to always prioritize the content that was already stored in the fdinfo object. However, this shouldn't be done in all cases. If an UDP socket issues several `sendto()`s to different addresses, the fd needs to be updated regardless at each `sendto()` and it is safe to do so since it's correctly captured by the corresponding enter event.

This PR fixes the issue by setting a parameter to indicate when destination override is safe and required.

Related to issue #260

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): overwrite fd destination address when safe to do so
```
