### PR TITLE
new(libsinsp,libscap): add scap_event_decode_params() in libscap and use it in libsinsp

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -562,6 +562,14 @@ struct ppm_syscall_desc {
 	char *name; /**< System call name, e.g. 'open'. */
 };
 
+/*!
+  \brief Structure used to pass a buffer and its size.
+*/
+struct scap_sized_buffer {
+	void* buf;
+	size_t size;
+};
+
 /*@}*/
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1054,6 +1062,14 @@ int32_t scap_suppress_events_comm(scap_t* handle, const char *comm);
 */
 
 bool scap_check_suppressed_tid(scap_t *handle, int64_t tid);
+
+/*!
+  \brief Get (at most) n parameters for this event.
+ 
+  \param e The scap event.
+  \param params An array large enough to contain n entries.
+ */
+uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *params);
 
 /*@}*/
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -441,44 +441,16 @@ private:
 	inline void load_params()
 	{
 		uint32_t j;
-		uint32_t nparams;
 		sinsp_evt_param par;
+		struct scap_sized_buffer params[PPM_MAX_EVENT_PARAMS];
 
-		// If we're reading a capture created with a newer version, it may contain
-		// new parameters. If instead we're reading an older version, the current
-		// event table entry may contain new parameters.
-		// Use the minimum between the two values.
-		nparams = m_info->nparams < m_pevt->nparams ? m_info->nparams : m_pevt->nparams;
-
-		char *valptr;
-		union {
-			uint16_t* lens16;
-			uint32_t* lens32;
-		} lens;
-
-		const bool large_payload = get_info_flags() & EF_LARGE_PAYLOAD;
-
-		if (large_payload) {
-			lens.lens32 = (uint32_t *)((char *)m_pevt + sizeof(struct ppm_evt_hdr));
-			// The offset in the block is instead always based on the capture value.
-			valptr = (char *)lens.lens32 + m_pevt->nparams * sizeof(uint32_t);
-		} else
-		{
-			lens.lens16 = (uint16_t*)((char*)m_pevt + sizeof(struct ppm_evt_hdr));
-			// The offset in the block is instead always based on the capture value.
-			valptr = (char *)lens.lens16 + m_pevt->nparams * sizeof(uint16_t);
-		}
 		m_params.clear();
+
+		uint32_t nparams = scap_event_decode_params(m_pevt, params);
 
 		for(j = 0; j < nparams; j++)
 		{
-			if (large_payload) {
-				par.init(valptr, lens.lens32[j]);
-				valptr += lens.lens32[j];
-			} else {
-				par.init(valptr, lens.lens16[j]);
-				valptr += lens.lens16[j];
-			}
+			par.init((char*)params[j].buf, params[j].size);
 			m_params.push_back(par);
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a function to libscap to decode a scap event. The PR is made out of two parts (two commits):
1. adding the function itself `scap_event_decode_params()`
2. replacing the logic inside the libsinsp function `load_params()` to use `scap_event_decode_params()`

I think this is valuable because it should be libscap's responsbility to decode an event that it generates. In addition, this could allow us to build tests for event generation code.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

One issue I have with this is whether there is performance impact since this function is in the hot path. The only difference I see at first glance is that the function itself is not inlined. I wonder if it's possible to make it more inlining-friendly.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
