### PR TITLE
build(driver) automatic COS workaround & clang fixes in BPF driver build

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -22,7 +22,7 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 # 
 # This enables the workaround for this divergence.
 #
-NEEDS_COS_73_WORKAROUND = $(shell expr `grep -sq "^\s*struct\s\+audit_task_info\s\+\*audit;\s*$$" $(KERNELDIR)/include/linux/sched.h` = 0)
+NEEDS_COS_73_WORKAROUND = $(shell expr `grep -sc "^\s*struct\s\+audit_task_info\s\+\*audit;\s*$$" $(KERNELDIR)/include/linux/sched.h` = 1)
 ifeq ($(NEEDS_COS_73_WORKAROUND), 1)
 	KBUILD_CPPFLAGS += -DCOS_73_WORKAROUND
 endif

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -27,6 +27,13 @@ ifeq ($(NEEDS_WORKAROUND), 1)
 	KBUILD_CPPFLAGS += -DCOS_73_WORKAROUND
 endif
 
+# -fmacro-prefix-map is not supported on version of clang older than 10
+# so remove it if necessary.
+IS_CLANG_OLDER_THAN_10 := $(shell expr `$(CLANG) -dumpversion | cut -f1 -d.` \<= 10)
+ifeq ($(IS_CLANG_OLDER_THAN_10), 1)
+	KBUILD_CPPFLAGS := $(filter-out -fmacro-prefix-map=%,$(KBUILD_CPPFLAGS))
+endif
+
 all:
 	$(MAKE) -C $(KERNELDIR) M=$$PWD
 

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -22,8 +22,8 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 # 
 # This enables the workaround for this divergence.
 #
-NEEDS_WORKAROUND = $(shell expr `grep -sq "^\s*struct\s\+audit_task_info\s\+\*audit;\s*$$" $(KERNELDIR)/include/linux/sched.h` = 0)
-ifeq ($(NEEDS_WORKAROUND), 1)
+NEEDS_COS_73_WORKAROUND = $(shell expr `grep -sq "^\s*struct\s\+audit_task_info\s\+\*audit;\s*$$" $(KERNELDIR)/include/linux/sched.h` = 0)
+ifeq ($(NEEDS_COS_73_WORKAROUND), 1)
 	KBUILD_CPPFLAGS += -DCOS_73_WORKAROUND
 endif
 

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -16,6 +16,17 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 # DEBUG = -DBPF_DEBUG
 
+#
+# https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
+# This commit diverged the ChromiumOS kernel from stock in the area of audit information, which this probe accesses.
+# 
+# This enables the workaround for this divergence.
+#
+NEEDS_WORKAROUND = $(shell expr `grep -sq "^\s*struct\s\+audit_task_info\s\+\*audit;\s*$$" $(KERNELDIR)/include/linux/sched.h` = 0)
+ifeq ($(NEEDS_WORKAROUND), 1)
+	KBUILD_CPPFLAGS += -DCOS_73_WORKAROUND
+endif
+
 all:
 	$(MAKE) -C $(KERNELDIR) M=$$PWD
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -9,15 +9,6 @@ or GPL2.txt for full copies of the license.
 #ifndef __FILLERS_H
 #define __FILLERS_H
 
-/*
- * https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
- * This commit diverged the ChromiumOS kernel from stock in the area of audit
- * information, which this probe accesses.
- *
- * If running on a patched version of COS, enable this #define to get the
- * probe to build.
- */
-//#define COS_73_WORKAROUND
 #include "../systype_compat.h"
 #include "../ppm_flag_helpers.h"
 #include "../ppm_version.h"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**Any specific area of the project related to this PR?**

/area build
/area driver-ebpf

**What this PR does / why we need it**:

This is just a couple of small fixes / additions to the BPF driver makefile:
- Fixes compilation when using clang versions older than 10, which do not support the `-fmacro-prefix-map` arg
- Automatic identification of COS builds, to enable `-DCOS_73_WORKAROUND`, rather than the current manual approach.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
