### PR TITLE
fix(libsinsp): Reset destination IP on old connect enter event

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2767,6 +2767,25 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
 
 	if(evt->get_num_params() < 2)
 	{
+		switch(evt->m_fdinfo->m_type)
+		{
+		case SCAP_FD_IPV4_SOCK:
+			evt->m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip = 0;
+			evt->m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport = 0;
+			break;
+		case SCAP_FD_IPV6_SOCK:
+			evt->m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip = ipv6addr::empty_address;
+			evt->m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport = 0;
+			break;
+		default:
+			break;
+		}
+		sinsp_utils::sockinfo_to_str(&evt->m_fdinfo->m_sockinfo,
+					     evt->m_fdinfo->m_type, &evt->m_paramstr_storage[0],
+					     (uint32_t)evt->m_paramstr_storage.size(),
+					     m_inspector->m_hostname_and_port_resolution_enabled);
+
+		evt->m_fdinfo->m_name = &evt->m_paramstr_storage[0];
 		return;
 	}
 


### PR DESCRIPTION
When a connect enter event comes from a driver that does not
report the connection tuple argument, reset the destination
address to zero. We know the old destination is no longer valid
but don't know the new one until the exit event arrives
so a buch of zeros is the best we can have.

Signed-off-by: Grzegorz Nosek <grzegorz.nosek@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Fix a regression introduced by PR 235
```
