### PR TITLE
update(libsinsp): Enable position-independent code.

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -1,5 +1,10 @@
 option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
 
+option(ENABLE_PIC "Build position independent libraries and executables" OFF)
+if(ENABLE_PIC)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
 	set(CMD_MAKE gmake)
 else()


### PR DESCRIPTION
Set CMAKE_POSITION_INDEPENDENT_CODE in CompilerFlags.cmake. This fixes

/usr/bin/ld: libsinsp/libsinsp.a(logger.cpp.o): relocation R_X86_64_TPOFF32 against `_ZN12_GLOBAL__N_16s_tbufE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: libsinsp/libsinsp.a(sinsp.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTV15sinsp_exception' can not be used when making a shared object; recompile with -fPIC

when linking a PIC-enabled shared library with libsinsp here on Ubuntu.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It fixes an error when linking with position-independent code on Linux and possibly other platforms.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
