### PR TITLE
fix(driver): remove unused filler identifiers

### DIFF
--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -131,13 +131,9 @@ or GPL2.txt for full copies of the license.
 	FN(sys_io_uring_setup_x)		\
 	FN(sys_io_uring_enter_x)		\
 	FN(sys_io_uring_register_x)		\
-	FN(sys_mlock_e)				\
 	FN(sys_mlock_x)                 	\
-	FN(sys_munlock_e)			\
 	FN(sys_munlock_x)              		\
-	FN(sys_mlockall_e)			\
 	FN(sys_mlockall_x)			\
-	FN(sys_munlockall_e)           		\
 	FN(sys_munlockall_x)			\
 	FN(sys_capset_x)			\
 	FN(terminate_filler)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Adding filler identifiers like `sys_mlock_e`, `sys_munlock_e`, and the others in this PR, we deny the bpf probe to be loaded. Every filler identifier must have a corresponding elf section with its implementation. We have an explicit check in our `libscap` code here https://github.com/falcosecurity/libs/blob/2043b949aebbc59eb34e824ea97695ce2d68675c/userspace/libscap/scap_bpf.c#L835
In this case, `sys_mlock_e` is only defined as an identifier but it has no implementation since the `PPME_SYSCALL_MLOCK_E` event use `sys_empty` as filler! Same problem for the other identifiers in this PR. 

I added some comments in the `libscap` loading code to make this issue more explicit. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
