### PR TITLE
fix(bpf): avoid to discard useful events

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -822,16 +822,24 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_CHARBUF:
 	case PT_FSPATH:
 	case PT_FSRELPATH: {
-		if (!data->curarg_already_on_frame) {
+		if (!data->curarg_already_on_frame) 
+		{
 			int res;
-
-			res = bpf_probe_read_str(&data->buf[curoff_bounded],
-						 PPM_MAX_ARG_SIZE,
-						 (const void *)val);
-			if (res == -EFAULT)
-				return PPM_FAILURE_INVALID_USER_MEMORY;
+			res = bpf_probe_read_str(&data->buf[curoff_bounded], 
+						PPM_MAX_ARG_SIZE,
+						(const void *)val);
+			
+			if (res <= 0)
+			{
+				char not_available[] = "<NA>";
+				res = bpf_probe_read_str(&data->buf[curoff_bounded],
+							PPM_MAX_ARG_SIZE,
+							(const void *)not_available);
+			}
 			len = res;
-		} else {
+		} 
+		else 
+		{
 			len = val_len;
 		}
 		break;


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Today when we are not able to catch a parameter of type  `PT_CHARBUF`, `PT_FSPATH` or `PT_FSRELPATH` we discard the entire event, counting it as a `PPM_FAILURE_INVALID_USER_MEMORY`.  For example, on my machine, some `open_e` and `openat_e` events are discarded because the instrumentation cannot correctly get the `pathname`. IMHO this is a loss of useful information, we could send to userspace just a not-available (`<NA>`) param without discarding the entire event. Let me know what do you think about this idea :smile: 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: return also partial events with not-available params without losing the entire information.
```
