### PR TITLE
fix(driver): use fput in kmod when handling open_by_handle_at

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4928,14 +4928,18 @@ int f_sys_open_by_handle_at_x(struct event_filler_arguments *args)
 		pathname = d_path(&file->f_path, buf, PAGE_SIZE);
 		if (unlikely(!pathname))
 		{
+			fput(file);
 			goto empty_pathname;
 		}
 
 		res = val_to_ring(args, (unsigned long)pathname, 0, false, 0);
 		if (likely(res == PPM_SUCCESS))
 		{
+			fput(file);
 			return add_sentinel(args);
-		}		
+		}
+
+		fput(file);		
 	}
 
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I have noticed that when handling the `open_by_handle_at` syscall we retrieve a pointer to `struct file` using `fget`. 
See here:
https://github.com/falcosecurity/libs/blob/master/driver/ppm_fillers.c#L4921
Since a reference counter is involved in this operation, we should decrement it using the `fput` function when we are done. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
