### PR TITLE
feature(sinsp-example): Add JSON format output

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -33,9 +33,9 @@ sinsp_evt* get_event(sinsp& inspector);
 #define PROCESS_DEFAULTS "*%evt.num %evt.time %evt.category %container.id %proc.ppid %proc.pid %evt.type %proc.exe %proc.cmdline %evt.args"
 
 // Formatters used with JSON output
-sinsp_evt_formatter* default_formatter = nullptr;
-sinsp_evt_formatter* process_formatter = nullptr;
-sinsp_evt_formatter* net_formatter = nullptr;
+static sinsp_evt_formatter* default_formatter = nullptr;
+static sinsp_evt_formatter* process_formatter = nullptr;
+static sinsp_evt_formatter* net_formatter = nullptr;
 
 // Functions used for dumping to stdout
 void plaintext_dump(sinsp& inspector);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Following up on #271, this PR adds a `-j` option to `sinsp-example` that should make it a lot easier to write tests based on it, since any major language has the ability of parsing JSON directly without too much extra effort.

The issue itself didn't have a very big response, but I'm a firm believer of automating tests so I'm not letting it die too easy. Would love to hear any thoughts/opinions on this. if the community feels like this is not useful, feel free to close the PR.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
