### PR TITLE
chore(userspace/libsinsp): print field argument flags in filtercheck format

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1929,12 +1929,21 @@ std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory
 
 			if(fld->m_flags & EPF_FILTER_ONLY)
 			{
-				info.tags.insert("FILTER ONLY");
+				info.tags.insert("FILTER_ONLY");
 			}
 
 			if(fld->m_flags & EPF_TABLE_ONLY)
 			{
 				info.tags.insert("EPF_TABLE_ONLY");
+			}
+
+			if(fld->m_flags & EPF_ARG_REQUIRED)
+			{
+				info.tags.insert("ARG_REQUIRED");
+			}
+			else if(fld->m_flags & EPF_ARG_ALLOWED)
+			{
+				info.tags.insert("ARG_ALLOWED");
 			}
 
 			cinfo.fields.emplace_back(std::move(info));


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR adds the ARG_ALLOWED and ARG_REQUIRED flags in the filtercheck output info format, to expand to all fields the output that Falco has for filterchecks related to k8s_audit (e.g. IDX_ALLOWED, IDX_REQUIRED).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
chore(userspace/libsinsp): print field argument flags in filtercheck format
```
