### PR TITLE
new: introduce `is_exe_upper_layer`

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2252,7 +2252,7 @@ static __always_inline bool get_exe_upper_layer(struct inode *inode)
 	struct super_block *sb = _READ(inode->i_sb);
 	unsigned long sb_magic = _READ(sb->s_magic);
 
-	if(sb_magic == OVERLAYFS_SUPER_MAGIC)
+	if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 	{
 		struct dentry *upper_dentry;
 		struct inode *lower_inode;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2153,16 +2153,8 @@ static __always_inline bool bpf_kgid_has_mapping(struct user_namespace *targ, kg
 
 static __always_inline struct inode *get_exe_inode(struct task_struct *task)
 {
-	struct file *exe_file;
-	struct mm_struct *mm;
-	
-	mm = _READ(task->mm);
-	exe_file = _READ(mm->exe_file);
-	if (!exe_file) 
-	{
-		return NULL;
-	}
-
+	struct mm_struct *mm = _READ(task->mm);
+	struct file *exe_file = _READ(mm->exe_file);
 	return _READ(exe_file->f_inode);
 }
 
@@ -2171,10 +2163,6 @@ static __always_inline bool get_exe_writable(struct inode *inode, struct cred *c
 	umode_t i_mode = _READ(inode->i_mode);
 	unsigned i_flags = _READ(inode->i_flags);
 	struct super_block *sb = _READ(inode->i_sb);
-	if(sb == NULL)
-	{
-		return false;
-	}
 	kuid_t i_uid = _READ(inode->i_uid);
 	kgid_t i_gid = _READ(inode->i_gid);
 
@@ -2251,11 +2239,6 @@ static __always_inline bool get_exe_writable(struct inode *inode, struct cred *c
 static __always_inline bool get_exe_upper_layer(struct inode *inode)
 {
 	struct super_block *sb = _READ(inode->i_sb);
-	if(sb == NULL)
-	{
-		return false;
-	}
-
 	unsigned long sb_magic = _READ(sb->s_magic);
 	if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 	{
@@ -2263,6 +2246,7 @@ static __always_inline bool get_exe_upper_layer(struct inode *inode)
 		char *vfs_inode = (char *)inode;
 		
 		// Pointer arithmetics due to unexported ovl_inode struct
+		// warning: this works if and only if the dentry pointer is placed right after the inode struct
 		bpf_probe_read(&upper_dentry, sizeof(upper_dentry), vfs_inode + sizeof(struct inode));
 
 		if(upper_dentry)
@@ -6466,14 +6450,14 @@ FILLER(sched_prog_exec_4, false)
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	struct cred *cred = (struct cred *)_READ(task->cred);
 
-
 	/* `exe_writable` and `exe_upper_layer` flag logic */
 	bool exe_writable = false;
 	bool exe_upper_layer = false;
 	struct inode *inode = get_exe_inode(task);
+
 	if(inode)
 	{
-		exe_writable = get_exe_writable(task, inode);
+		exe_writable = get_exe_writable(inode, cred);
 		if(exe_writable)
 		{
 			flags |= PPM_EXE_WRITABLE;

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -538,6 +538,7 @@ const struct ppm_name_value openat2_flags[] = {
 
 const struct ppm_name_value execve_flags[] = {
 	{"EXE_WRITABLE", PPM_EXE_WRITABLE},
+	{"EXE_UPPER_LAYER", PPM_EXE_UPPER_LAYER},
 	{0, 0},
 };
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -177,6 +177,10 @@ int BPF_PROG(t1_sched_p_exec,
 	/* Parameter 20: flags (type: PT_FLAGS32) */
 	/// TODO: still to implement! See what we do in the old probe.
 	u32 flags = 0;
+	if(extract__exe_upper_layer(task))
+	{
+		flags |= PPM_EXE_UPPER_LAYER;
+	}
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -241,6 +241,10 @@ int BPF_PROG(t1_execve_x,
 	/* Parameter 20: flags (type: PT_FLAGS32) */
 	/// TODO: still to implement! See what we do in the old probe.
 	u32 flags = 0;
+	if(extract__exe_upper_layer(task))
+	{
+		flags |= PPM_EXE_UPPER_LAYER;
+	}
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -258,6 +258,10 @@ int BPF_PROG(t1_execveat_x,
 	/* Parameter 20: flags (type: PT_FLAGS32) */
 	/// TODO: we still have to manage `exe_writable` flag.
 	u32 flags = 0;
+	if(extract__exe_upper_layer(task))
+	{
+		flags |= PPM_EXE_UPPER_LAYER;
+	}
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -613,6 +613,7 @@ or GPL2.txt for full copies of the license.
  * Execve family additional flags.
  */
 #define PPM_EXE_WRITABLE		(1 << 0)
+#define PPM_EXE_UPPER_LAYER 	(1 << 1)
   
 /*
  * Execveat flags

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1283,12 +1283,11 @@ cgroups_error:
 						if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 						{
 							struct dentry **upper_dentry;
-							struct inode **lower_inode;
 
+							// Pointer arithmetics due to unexported ovl_inode struct
 							upper_dentry = (struct dentry **)((char *)exe_file->f_inode + sizeof(struct inode));
-							lower_inode = (struct inode **)((char *)upper_dentry + sizeof(struct dentry *));
 
-							if(!*lower_inode && *upper_dentry)
+							if(*upper_dentry)
 							{
 								exe_upper_layer = true;
 							}
@@ -6807,12 +6806,11 @@ cgroups_error:
 					if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 					{
 						struct dentry **upper_dentry;
-						struct inode **lower_inode;
 
+						// Pointer arithmetics due to unexported ovl_inode struct
 						upper_dentry = (struct dentry **)((char *)exe_file->f_inode + sizeof(struct inode));
-						lower_inode = (struct inode **)((char *)upper_dentry + sizeof(struct dentry *));
 
-						if(!*lower_inode && *upper_dentry)
+						if(*upper_dentry)
 						{
 							exe_upper_layer = true;
 						}

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1278,7 +1278,7 @@ cgroups_error:
 
 					sb = exe_file->f_inode->i_sb;
 					sb_magic = sb->s_magic;
-					if(sb_magic == OVERLAYFS_SUPER_MAGIC)
+					if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 					{
 						struct dentry **upper_dentry;
 						struct inode **lower_inode;

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1273,8 +1273,8 @@ cgroups_error:
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
 				{
-					struct super_block *sb;
-					unsigned long sb_magic;
+					struct super_block *sb = NULL;
+					unsigned long sb_magic = 0;
 
 					sb = exe_file->f_inode->i_sb;
 					if(sb)
@@ -1282,9 +1282,10 @@ cgroups_error:
 						sb_magic = sb->s_magic;
 						if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 						{
-							struct dentry **upper_dentry;
+							struct dentry **upper_dentry = NULL;
 
 							// Pointer arithmetics due to unexported ovl_inode struct
+							// warning: this works if and only if the dentry pointer is placed right after the inode struct
 							upper_dentry = (struct dentry **)((char *)exe_file->f_inode + sizeof(struct inode));
 
 							if(*upper_dentry)
@@ -6796,8 +6797,8 @@ cgroups_error:
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
 			{
-				struct super_block *sb;
-				unsigned long sb_magic;
+				struct super_block *sb = NULL;
+				unsigned long sb_magic = 0;
 
 				sb = exe_file->f_inode->i_sb;
 				if(sb)
@@ -6805,9 +6806,10 @@ cgroups_error:
 					sb_magic = sb->s_magic;
 					if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 					{
-						struct dentry **upper_dentry;
+						struct dentry **upper_dentry = NULL;
 
 						// Pointer arithmetics due to unexported ovl_inode struct
+						// warning: this works if and only if the dentry pointer is placed right after the inode struct
 						upper_dentry = (struct dentry **)((char *)exe_file->f_inode + sizeof(struct inode));
 
 						if(*upper_dentry)

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1891,6 +1891,12 @@ static __always_inline uint32_t epoll_create1_flags_to_scap(uint32_t flags)
 	return res;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#define PPM_OVERLAYFS_SUPER_MAGIC OVERLAYFS_SUPER_MAGIC
+#else
+#define PPM_OVERLAYFS_SUPER_MAGIC 0x794c7630
+#endif
+
 #endif // !WDIG
 
 #endif /* PPM_FLAG_HELPERS_H_ */

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1891,7 +1891,7 @@ static __always_inline uint32_t epoll_create1_flags_to_scap(uint32_t flags)
 	return res;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#ifdef OVERLAYFS_SUPER_MAGIC
 #define PPM_OVERLAYFS_SUPER_MAGIC OVERLAYFS_SUPER_MAGIC
 #else
 #define PPM_OVERLAYFS_SUPER_MAGIC 0x794c7630

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -276,6 +276,7 @@ typedef struct scap_threadinfo
 	char exe[SCAP_MAX_PATH_SIZE+1]; ///< argv[0] (e.g. "sshd: user@pts/4")
 	char exepath[SCAP_MAX_PATH_SIZE+1]; ///< full executable path
 	bool exe_writable; ///< true if the original executable is writable by the same user that spawned it.
+	bool exe_upper_layer; //< True if the original executable belongs to upper layer in overlayfs
 	char args[SCAP_MAX_ARGS_SIZE+1]; ///< Command line arguments (e.g. "-d1")
 	uint16_t args_len; ///< Command line arguments length
 	char env[SCAP_MAX_ENV_SIZE+1]; ///< Environment

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -468,8 +468,8 @@ int32_t scap_write_proclist_entry_bufs(scap_t *handle, scap_dumper_t *d, struct 
 			  sizeof(uint8_t) +  // exe_writable
 			  sizeof(uint64_t) + // cap_inheritable
 			  sizeof(uint64_t) + // cap_permitted
-			  sizeof(uint64_t)); // cap_effective
-
+			  sizeof(uint64_t) + // cap_effective
+			  sizeof(uint8_t)); // exe_upper_layer
 	if(scap_dump_write(d, len, sizeof(uint32_t)) != sizeof(uint32_t) ||
 		    scap_dump_write(d, &(tinfo->tid), sizeof(uint64_t)) != sizeof(uint64_t) ||
 		    scap_dump_write(d, &(tinfo->pid), sizeof(uint64_t)) != sizeof(uint64_t) ||
@@ -507,7 +507,8 @@ int32_t scap_write_proclist_entry_bufs(scap_t *handle, scap_dumper_t *d, struct 
 			scap_dump_write(d, &(tinfo->exe_writable), sizeof(uint8_t)) != sizeof(uint8_t) ||
 			scap_dump_write(d, &(tinfo->cap_inheritable), sizeof(uint64_t)) != sizeof(uint64_t) ||
 			scap_dump_write(d, &(tinfo->cap_permitted), sizeof(uint64_t)) != sizeof(uint64_t) ||
-			scap_dump_write(d, &(tinfo->cap_effective), sizeof(uint64_t)) != sizeof(uint64_t))
+			scap_dump_write(d, &(tinfo->cap_effective), sizeof(uint64_t)) != sizeof(uint64_t) || 
+			scap_dump_write(d, &(tinfo->exe_upper_layer), sizeof(uint8_t)) != sizeof(uint8_t))
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error writing to file (2)");
 		return SCAP_FAILURE;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1907,6 +1907,7 @@ const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.cmdnargs", "Number of cmd args", "The number of cmd args."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.cmdlenargs", "Total Count of Chars in cmd args", "The total count of characters / length of all cmd args combined excluding whitespaces."},
 	{PT_INT64, EPF_NONE, PF_ID, "proc.pvpid", "Parent Virtual Process ID", "the id of the parent process generating the event as seen from its current PID namespace."},
+	{PT_BOOL, EPF_NONE, PF_NA, "proc.is_exe_upper_layer", "Process Executable Is In Upper Layer", "true if this process' executable file is in upper layer in overlayfs. This field value can only be trusted if the underlying kernel version is greater or equal than 3.18.0, since overlayfs was introduced at that time."},
 };
 
 sinsp_filter_check_thread::sinsp_filter_check_thread()
@@ -2737,6 +2738,9 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 		RETURN_EXTRACT_VAR(m_tbool);
 	case TYPE_IS_EXE_WRITABLE:
 		m_tbool = tinfo->m_exe_writable;
+		RETURN_EXTRACT_VAR(m_tbool);
+	case TYPE_IS_EXE_UPPER_LAYER:
+		m_tbool = tinfo->m_exe_upper_layer;
 		RETURN_EXTRACT_VAR(m_tbool);
 	case TYPE_CAP_PERMITTED:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_permitted);

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -384,6 +384,7 @@ public:
 		TYPE_CMDNARGS = 53,
 		TYPE_CMDLENARGS = 54,
 		TYPE_PVPID = 55,
+		TYPE_IS_EXE_UPPER_LAYER = 56,
 	};
 
 	sinsp_filter_check_thread();

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1261,6 +1261,9 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		// Copy the exe writable metadata from the parent
 		tinfo->m_exe_writable = ptinfo->m_exe_writable;
 
+		// Copy the exe upper layer metadata from the parent
+		tinfo->m_exe_upper_layer = ptinfo->m_exe_upper_layer;
+
 		// Copy the command arguments from the parent
 		tinfo->m_args = ptinfo->m_args;
 
@@ -2082,6 +2085,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 		uint32_t flags = *(uint32_t *) parinfo->m_val;
 
 		evt->m_tinfo->m_exe_writable = ((flags & PPM_EXE_WRITABLE) != 0);
+		evt->m_tinfo->m_exe_upper_layer = ((flags & PPM_EXE_UPPER_LAYER) != 0);
 	}
 
 	// Get capabilities

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -401,7 +401,8 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_exe = pi->exe;
 	m_exepath = pi->exepath;
 	m_exe_writable = pi->exe_writable;
-
+	m_exe_upper_layer = pi->exe_upper_layer;
+	
 	set_args(pi->args, pi->args_len);
 	if(is_main_thread())
 	{

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -293,6 +293,7 @@ public:
 	std::string m_exe; ///< argv[0] (e.g. "sshd: user@pts/4")
 	std::string m_exepath; ///< full executable path
 	bool m_exe_writable;
+	bool m_exe_upper_layer; ///< True if the executable file belongs to upper layer in overlayfs
 	std::vector<std::string> m_args; ///< Command line arguments (e.g. "-d1")
 	std::vector<std::string> m_env; ///< Environment variables
 	std::unique_ptr<cgroups_t> m_cgroups; ///< subsystem-cgroup pairs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

/area driver-ebpf

/area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR tries to deal with `overlayfs`, a union mount filesystem often used by container runtimes, to understand if a process is executing something that is part of the base image of a container or not. Monitoring this could be relevant from a security standpoint since best practices state that containers should be immutable. For this reason, in many use cases, we don't expect processes in the container to execute something that is not part of the base image, whether that file was created in the container or an existing one was modified. 
To do so, the PR aims at identifying the layer of the file being executed by a process: if the file belongs to the lower layer, it means that it was part of the base image of the container. Otherwise, the process executed something that is part of the upper layer, and a flag is set upon the `execve` event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

To better understand the code, I'd like to give reviewers some useful pointers. First, we must check if the file being executed is part of an overlayfs. We can do that by retrieving the superblock magic of the file and comparing it with the `OVERLAYFS_SUPER_MAGIC`.  You can see [here](https://elixir.bootlin.com/linux/latest/source/fs/overlayfs/super.c#L2129) that this constant is used when an overlayfs is mounted. 
Then, to check the layer of the executable file, we can do some pointer arithmetics, having in mind that the pointer to the inode that we can retrieve form `struct file` is pointing to the `vfs_inode` member of the `ovl_inode` struct, as you can see [here](https://elixir.bootlin.com/linux/latest/source/fs/overlayfs/ovl_entry.h#L122).

The last thing that I wanted to discuss is that for now I didn't find a way to retrieve the upper_layer information when scanning the proc filesystem. One possible way to do it could be by inspecting the `/proc/<pid>/mounts` file and checking if there is an overlayfs entry, which in case we can use to retrieve the upperdir directory and look for the `exe` file there. However, this would easily work when Falco is installed on the host, but could be a problem when it is running as a container. This is because most of the time the upperdir directory is placed in `/var/lib/docker`, `/var/lib/containerd` directories. This means we would need to give the Falco container access to those directories. I would like to know what do you think, and if you like it, I can implement it. Also, I am open to any other possible solution on this!

EDIT: I have implemented this approach

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: introduce is_exe_upper_layer
```