### PR TITLE
update(userspace/libsinsp): improve filter AST and parser classes and interfaces

### DIFF
--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "ast.h"
 
-using namespace std;
 using namespace libsinsp::filter::ast;
 
 void base_expr_visitor::visit(and_expr* e)
@@ -64,7 +63,7 @@ void base_expr_visitor::visit(value_expr* e) { }
 
 void base_expr_visitor::visit(list_expr* e) { }
 
-void base_expr_visitor::visit(unary_check_expr* e){ }
+void base_expr_visitor::visit(unary_check_expr* e) { }
 
 expr* libsinsp::filter::ast::clone(expr* e)
 {  
@@ -72,9 +71,9 @@ expr* libsinsp::filter::ast::clone(expr* e)
     {   
         expr* m_last_node;
 
-        inline void visit(and_expr* e) 
+        void visit(and_expr* e) override
         {
-            vector<expr*> children;
+            std::vector<expr*> children;
             for (auto &c: e->children)
             {
                 c->accept(this);
@@ -83,9 +82,9 @@ expr* libsinsp::filter::ast::clone(expr* e)
             m_last_node = new and_expr(children);
         }
 
-        inline void visit(or_expr* e)
+        void visit(or_expr* e) override
         {
-            vector<expr*> children;
+            std::vector<expr*> children;
             for (auto &c: e->children)
             {
                 c->accept(this);
@@ -94,29 +93,30 @@ expr* libsinsp::filter::ast::clone(expr* e)
             m_last_node = new or_expr(children);
         }
 
-        inline void visit(not_expr* e)
+        void visit(not_expr* e) override
         {
             e->child->accept(this);
             m_last_node = new not_expr(m_last_node);
         }
 
-        inline void visit(binary_check_expr* e)
+        void visit(binary_check_expr* e) override
         {
             e->value->accept(this);
-            m_last_node = new binary_check_expr(e->field, e->arg, e->op, m_last_node);
+            m_last_node = new binary_check_expr(
+                e->field, e->arg, e->op, m_last_node);
         }
 
-        inline void visit(unary_check_expr* e)
+        void visit(unary_check_expr* e) override
         {
             m_last_node = new unary_check_expr(e->field, e->arg, e->op);
         }
 
-        inline void visit(value_expr* e)
+        void visit(value_expr* e) override
         {
             m_last_node = new value_expr(e->value);
         }
 
-        inline void visit(list_expr* e)
+        void visit(list_expr* e) override
         {
             m_last_node = new list_expr(e->values);
         }

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -105,14 +105,14 @@ parser::parser(const string& input)
 	m_parse_partial = false;
 }
 
-void parser::get_pos(pos_info& pos)
+void parser::get_pos(pos_info& pos) const
 {
 	pos.idx = m_pos.idx;
 	pos.col = m_pos.col;
 	pos.line = m_pos.line;
 }
 
-parser::pos_info parser::get_pos()
+parser::pos_info parser::get_pos() const
 {
 	pos_info info;
 	get_pos(info);
@@ -539,7 +539,7 @@ bool parser::lex_helper_rgx(string rgx)
 	return false;
 }
 
-bool parser::lex_helper_str(string str)
+bool parser::lex_helper_str(const string& str)
 {
 	if (strncmp(cursor(), str.c_str(), str.size()) == 0)
 	{
@@ -551,7 +551,7 @@ bool parser::lex_helper_str(string str)
 	return false;
 }
 
-bool parser::lex_helper_str_list(vector<string> list)
+bool parser::lex_helper_str_list(const std::vector<std::string>& list)
 {
 	for (auto &op : list)
 	{
@@ -568,7 +568,7 @@ inline const char* parser::cursor()
 	return m_input.c_str() + m_pos.idx;
 }
 
-string parser::escape_str(string& str)
+string parser::escape_str(const string& str)
 {
 	string res = "";
 	size_t len = str.size() - 1;
@@ -641,11 +641,10 @@ string parser::escape_str(string& str)
 	return res;
 }
 
-inline string parser::trim_str(const string& str)
+inline string parser::trim_str(string str)
 {
-	string val = str;
-	trim(val);
-	return val;
+	trim(str);
+	return str;
 }
 
 inline void parser::depth_push()

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -81,6 +81,21 @@ static const vector<string> binary_list_ops =
 	"intersects", "in", "pmatch"
 };
 
+vector<string> parser::supported_operators(bool list_only)
+{
+	if (list_only)
+	{
+		return binary_list_ops;
+	}
+	vector<string> ops;
+	ops.insert(ops.end(), unary_ops.begin(), unary_ops.end());
+	ops.insert(ops.end(), binary_num_ops.begin(), binary_num_ops.end());
+	ops.insert(ops.end(), binary_str_ops.begin(), binary_str_ops.end());
+	ops.insert(ops.end(), binary_list_ops.begin(), binary_list_ops.end());
+	transform(ops.begin(), ops.end(), ops.begin(), ::trim);
+	return ops;
+}
+
 parser::parser(const string& input)
 {
 	m_input = input;

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -82,7 +82,7 @@ public:
 			col = 1;
 		}
 		
-		inline std::string as_string()
+		inline std::string as_string() const
 		{
 			return "index " + std::to_string(idx) 
 				+ ", line " + std::to_string(line) 
@@ -103,19 +103,19 @@ public:
 		\brief Constructs the parser with a given filter string input
 		\param input The filter string to parse.
 	*/
-	parser(const std::string& input);
+	explicit parser(const std::string& input);
 
 	/*!
 		\brief Retrieves the parser position info.
 		\param pos pos_info struct in which the info is written.
 	*/
-	void get_pos(pos_info& pos);
+	void get_pos(pos_info& pos) const;
 
 	/*!
 		\brief Retrieves the parser position info.
 		\return pos_info struct in which the info is written.
 	*/
-	pos_info get_pos();
+	pos_info get_pos() const;
 
 	/*!
 		\brief Sets the partial parsing option. Default is true.
@@ -163,13 +163,13 @@ private:
 	bool lex_str_op();
 	bool lex_list_op();
 	bool lex_helper_rgx(std::string rgx);
-	bool lex_helper_str(std::string str);
-	bool lex_helper_str_list(std::vector<std::string> list);
+	bool lex_helper_str(const std::string& str);
+	bool lex_helper_str_list(const std::vector<std::string>& list);
 	void depth_push();
 	void depth_pop();
 	const char* cursor();
-	std::string escape_str(std::string& str);
-	std::string trim_str(const std::string& str);
+	std::string escape_str(const std::string& str);
+	std::string trim_str(std::string str);
 
 	bool m_parse_partial;
 	uint32_t m_depth;

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -95,6 +95,11 @@ public:
 	};
 
 	/*!
+		\brief Returns the set of filtering operators supported by libsinsp
+	*/
+	static std::vector<std::string> supported_operators(bool list_only=false);
+
+	/*!
 		\brief Constructs the parser with a given filter string input
 		\param input The filter string to parse.
 	*/

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -53,6 +53,36 @@ static void test_reject(string in)
 	}
 }
 
+TEST(parser, supported_operators)
+{
+	static vector<string> expected_all = {
+		"=", "==", "!=", "<=", ">=", "<", ">", "exists",
+		"contains", "icontains", "bcontains", "glob", "bstartswith",
+		"startswith", "endswith", "in", "intersects", "pmatch"};
+	static vector<string> expected_list_only = {
+		"in", "intersects", "pmatch"};
+	
+	auto actual_all = parser::supported_operators();
+	ASSERT_EQ(actual_all.size(), expected_all.size());
+	for (auto &op : expected_all)
+	{
+		if (count(actual_all.begin(), actual_all.end(), op) != 1)
+		{
+			FAIL() << "expected support for operator: " << op;
+		}
+	}
+
+	auto actual_list_only = parser::supported_operators(true);
+	ASSERT_EQ(actual_list_only.size(), actual_list_only.size());
+	for (auto &op : expected_list_only)
+	{
+		if (count(actual_list_only.begin(), actual_list_only.end(), op) != 1)
+		{
+			FAIL() << "expected support for list operator: " << op;
+		}
+	}
+}
+
 // Inspired by Falco's parser smoke tests:
 // https://github.com/falcosecurity/falco/blob/204f9ff875be035e620ca1affdf374dd1c610a98/userspace/engine/lua/parser-smoke.sh#L41
 TEST(parser, parse_smoke_test)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**What this PR does / why we need it**:

This adds a new static method to `libsinsp::filter::parser` to return all the filtering operators supported by libsinp. This is meant to be the single source of truth for sinsp clients, so that we don't have to replicate this list anywhere else (like we did in Falco so far). On top of that, this also polishes the methods definitions of the filter parser and AST classes by using better C++ practices.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): improve filter AST and parser classes and interfaces
```
