### PR TITLE
disallow-ipv6net-without-prefix

### DIFF
--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -115,8 +115,7 @@ ipv6net::ipv6net(const std::string &str)
 	}
 	else
 	{
-		g_logger.format(sinsp_logger::SEV_INFO, "using legacy netV6 formatting with '/64' bit prefix for '%'", str.c_str());
-		init(str + "/64");
+		throw sinsp_exception("invalid v6 netmask: " + str);
 	}
 }
 


### PR DESCRIPTION
The current implementation of the libs allows specifying naked ipv6 address in place of ipv6 net: like "FD80::" while prohibiting using of naked ipv4 in place of ipv4 net.

This PR prohibits such notation for ipv6 net in favor of explicitly specifying the prefix: "FD80::/64".
Providing that this PR will make IP vs NET consistent across both ipv4 and ipv6.

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

The current implementation of the libs allows specifying naked ipv6 address in place of ipv6 net: like "FD80::" while prohibiting using of naked ipv4 in place of ipv4 net.

This PR prohibits such notation for ipv6 net in favor of explicitly specifying the prefix: "FD80::/64".
Providing that this PR will make IP vs NET consistent across both ipv4 and ipv6.

**Which issue(s) this PR fixes**:

The current implementation of the libs allows specifying naked ipv6 address in place of ipv6 net: like "FD80::" while prohibiting using of naked ipv4 in place of ipv4 net.

```release-note
update: make ipv6net validation consistent with ipv4net when using a simple address in place of the net with prefix notation
```