### PR TITLE
do not clear dns cache until last sinsp instance

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -63,7 +63,9 @@ void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_thr
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp implementation
 ///////////////////////////////////////////////////////////////////////////////
-sinsp::sinsp(bool static_container, const std::string static_id, const std::string static_name, const std::string static_image) :
+std::atomic<int> sinsp::instance_count{0};
+
+sinsp::sinsp(bool static_container, const std::string &static_id, const std::string &static_name, const std::string &static_image) :
 	m_external_event_processor(),
 	m_simpleconsumer(false),
 	m_evt(this),
@@ -73,6 +75,7 @@ sinsp::sinsp(bool static_container, const std::string static_id, const std::stri
 	m_suppressed_comms(),
 	m_inited(false)
 {
+	++instance_count;
 #if !defined(MINIMAL_BUILD) && !defined(CYGWING_AGENT) && defined(HAS_CAPTURE)
 	// used by mesos and container_manager
 	curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -206,7 +209,10 @@ sinsp::~sinsp()
 	delete m_mesos_client;
 #ifdef HAS_CAPTURE
 	curl_global_cleanup();
-	sinsp_dns_manager::get().cleanup();
+	if (--instance_count == 0)
+	{
+		sinsp_dns_manager::get().cleanup();
+	}
 #endif
 #endif
 	m_plugins_list.clear();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -212,10 +212,11 @@ public:
 	typedef std::shared_ptr<k8s_ext_list_t> k8s_ext_list_ptr_t;
 
 	sinsp(bool static_container = false,
-		  const std::string static_id = "",
-		  const std::string static_name = "",
-		  const std::string static_image = "");
-	virtual ~sinsp();
+		  const std::string &static_id = "",
+		  const std::string &static_name = "",
+		  const std::string &static_image = "");
+
+	~sinsp() override;
 
 	/*!
 	  \brief Start a live event capture.
@@ -1316,6 +1317,7 @@ public:
 	uint16_t m_replay_scap_cpuid;
 
 	bool m_inited;
+	static std::atomic<int> instance_count;
 
 	friend class sinsp_parser;
 	friend class sinsp_analyzer;


### PR DESCRIPTION
as sinsp is not a singleton there are cases when multiple instances of sinsp with diff lifetimes exist. Currently, each instance of sinsp destructor will kill the DNS manager refresher thread and invalidate the DNS cache, this PR introduces the instance counter to prohibit unintended and premature DNS cache destruction. 

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

**What this PR does / why we need it**:
Fix DNS cache unintended clearing

**Which issue(s) this PR fixes**:
Fix DNS cache unintended clearing

```release-note
fix: correct DNS cache unintended clearing
```