### PR TITLE
Skip cgroup lookups in podman if no api socket

### DIFF
--- a/userspace/libsinsp/container_engine/docker/podman.h
+++ b/userspace/libsinsp/container_engine/docker/podman.h
@@ -12,7 +12,16 @@ public:
 
 private:
 	static std::string m_api_sock;
+	static std::string m_user_api_sock_pattern;
 
+	// true if any file matching any possible api socket pattern
+	// exists. Is set at the first call to resolve()
+	std::unique_ptr<bool> m_api_sock_can_exist;
+
+	// Return true if any possible api socket pattern exists.
+	bool can_api_sock_exist();
+
+	// Return whether or not any possible api socket exists. (The actual socket is
 	// implement container_engine_base
 	bool resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info) override;
 };


### PR DESCRIPTION
As a part of looking at the event processing path and trying to speed
it up, I started looking for all reads below /proc that are inline
with event processing.

I noticed that the podman container engine does a read of
`/proc/<pid>/cgroup` for every new process (in a container or not) as a
part of detecting new containers. I think we can eliminate those opens
by first checking to see if any podman api socket exists. It is
possible to have podman containers without the api part, but the
podman engine needs the api socket to actually look up any container
info, so there's no point in validating anything unless the socket is
there.

So track and remember whether any default or user-specific socket
exists. If neither exists, simply skip resolving potential podman
containers.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update: avoid unnecessary cgroup lookups from /proc when no podman api socket is available.
```
