### PR TITLE
fix(driver): fix a wrong flag-check

### DIFF
--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1042,7 +1042,7 @@ static __always_inline u16 poll_events_to_scap(short revents)
 	if (revents & POLLIN)
 		res |= PPM_POLLIN;
 
-	if (revents & PPM_POLLPRI)
+	if (revents & POLLPRI)
 		res |= PPM_POLLPRI;
 
 	if (revents & POLLOUT)


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**What this PR does / why we need it**:

This PR corrects an oversight in the `poll_events_to_scap` function. We have to compare the input flags with the kernel-defined `POLLPRI` instead of using our internal `PPM` representation.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
