### PR TITLE
fix(userspace/libsinsp): restore capture mode with proper checks in is_initialstate_event()

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -266,8 +266,8 @@ bool sinsp::is_initialstate_event(scap_evt* pevent)
 			pevent->type == PPME_CONTAINER_JSON_2_E ||
 			pevent->type == PPME_USER_ADDED_E ||
 			pevent->type == PPME_USER_DELETED_E ||
-			pevent->type != PPME_GROUP_ADDED_E ||
-			pevent->type != PPME_GROUP_DELETED_E;
+			pevent->type == PPME_GROUP_ADDED_E ||
+			pevent->type == PPME_GROUP_DELETED_E;
 }
 
 void sinsp::consume_initialstate_events()


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR fixes the boolean check inside `sinsp::is_initialstate_event()`. This currently causes capture mode to fail due to the `sinsp::consume_initialstate_events()` method consuming all the event blocks. This is also the reason why the CI integration tests fail in https://github.com/falcosecurity/falco/pull/1982 (see: https://circleci.com/gh/falcosecurity/falco/22719?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): restore capture mode with proper checks in is_initialstate_event()
```
