### PR TITLE
fix(userspace/libsinsp): always import users and groups from scap to retain backward compatibility with existent scap files for host users/groups

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -391,6 +391,8 @@ void sinsp::init()
 
 	import_ifaddr_list();
 
+	import_user_list();
+
 	//
 	// Scan the list to create the proper parent/child dependencies
 	//
@@ -998,6 +1000,25 @@ void sinsp::import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo)
 {
 	ASSERT(m_network_interfaces);
 	m_network_interfaces->import_ipv4_interface(ifinfo);
+}
+
+void sinsp::import_user_list()
+{
+	uint32_t j;
+	scap_userlist* ul = scap_get_user_list(m_h);
+
+	if(ul)
+	{
+		for(j = 0; j < ul->nusers; j++)
+		{
+			m_usergroup_manager.add_user("", ul->users[j].uid, ul->users[j].gid, ul->users[j].name, ul->users[j].homedir, ul->users[j].shell);
+		}
+
+		for(j = 0; j < ul->ngroups; j++)
+		{
+			m_usergroup_manager.add_group("", ul->groups[j].gid, ul->groups[j].name);
+		}
+	}
 }
 
 void sinsp::refresh_ifaddr_list()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -995,6 +995,7 @@ private:
 	bool is_initialstate_event(scap_evt* pevent);
 	void import_thread_table();
 	void import_ifaddr_list();
+	void import_user_list();
 	void add_protodecoders();
 	void fill_syscalls_of_interest(scap_open_args *oargs);
 	void remove_thread(int64_t tid, bool force);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
