### PR TITLE
fix(libscap): increase the BPF verifier's log buffer size

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -464,7 +464,7 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 	fd = bpf_load_program(prog, program_type, insns_cnt, error, BPF_LOG_SIZE);
 	if(fd < 0)
 	{
-		fprintf(stderr, "-- BEGIN PROG LOAD LOG --\n%s-- END PROG LOAD LOG --\n", error);
+		fprintf(stderr, "-- BEGIN PROG LOAD LOG --\n%s\n-- END PROG LOAD LOG --\n", error);
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "libscap: bpf_load_program() err=%d event=%s", errno, event);
 		free(error);
 		return SCAP_FAILURE;


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

/area libscap

**What this PR does / why we need it**:

When we load a BPF program we pass also a tmp buffer to collect the verifier logs in case of failure. If the size of the buffer is not large enough to store all verifier messages, `-1` is returned and `errno` is set to `ENOSPC`.  This is what happens on my machine (**5.11.0-1022-aws 20.04.1-Ubuntu aarch64 GNU/Linux**): 

```
bpf_load_program() err=28 event=filler/sys_autofill message=0
```
Where `28` is exactly `ENOSPC`.
This PR aligns the log buffer size to the one used by `libbpf` library, avoiding this problem. Moreover, I tried to improve our debug prints in case of verifier issues, the new output should be something like this (very similar to `libbpf`):

```
dereference of modified ctx ptr R2 off=16 disallowed
processed 8486 insns (limit 1000000) max_states_per_insn 5 total_states 151 peak_states 143 mark_read 13
-- END PROG LOAD LOG --
libscap: bpf_load_program() err=13 event=filler/sys_autofill
```
 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
