### PR TITLE
fix(driver-ebpf): fix a verifier issue in `sys_autofill` filler

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -5379,8 +5379,11 @@ FILLER(sys_autofill, true)
 	unsigned long ret = 0;
 	unsigned long val = 0;
 
-	/* We are interested in the return value only in the exit events.
-	 * Please note: all exit events have an odd `PPM`code.
+	/* Please note: we have to perform this action outside the `for` loop
+	 * in order to avoid verifier issues on aarch64.
+	 *
+	 * We are interested in the return value only inside the exit events.
+	 * Remember that all exit events have an odd `PPM`code.
 	 */
 	if(data->state->tail_ctx.evt_type % 2 != 0)
 	{


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Loading our BPF probe on **5.11.0-1022-aws 20.04.1-Ubuntu aarch64 GNU/Linux** I faced the following verifier issue:

```
311: (bf) r2 = r6
312: (07) r2 += 16
313: (79) r5 = *(u64 *)(r2 +0)
dereference of modified ctx ptr R2 off=16 disallowed
processed 8486 insns (limit 1000000) max_states_per_insn 5 total_states 151 peak_states 143 mark_read 13
-- END PROG LOAD LOG --
libscap: bpf_load_program() err=13 event=filler/sys_autofill
```
I used `clang-13` as a compiler.
In a nutshell, the problem is that for some reason clang tries to modify the `ctx` ptr, saved in `R2` when we access the syscall return value thought  `bpf_syscall_get_retval()`. If we move this function outside the `for` loop we are able to solve this problem.
I tested it on other two machines and it works:

* Amazon linux Kenrel 4.14/clang-11 (x86)
* Ubuntu 21.04 5.11/clang-14 (x86)

I know it's not a great fix but it's the least bad I've managed to do. If you have any suggestions, I'm all ears.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
