### PR TITLE
update(userspace/libsinsp): add 'separator' field in plugin open param list

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -1111,6 +1111,7 @@ std::vector<sinsp_plugin_cap_sourcing::open_param> sinsp_plugin::list_open_param
 					throw sinsp_exception(string("error in plugin ") + name() + ": list_open_params has entry with no value");
 				}
 				param.desc = root[i]["desc"].asString();
+				param.separator = root[i]["separator"].asString();
 				list.push_back(param);
 			}
 		}

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -54,6 +54,7 @@ public:
 	struct open_param {
 		std::string value;
 		std::string desc;
+		std::string separator;
 	};
 
 	// Return a struct to be used as scap source plugin


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This adds a `separator` field in the open param list of plugins. This can be used by plugins to specify an open param that represents more than one source, in which case they can be separated by the `separator` substring. It's a plugin responsibility to specify the separator string.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): add `separator` field in plugin open param list
```
