### PR TITLE
fix(userspace/libsinsp): remove usage of designated initializer

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -1053,12 +1053,11 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt)
 	auto data = (const uint8_t *) evt->get_param(1)->m_val;
 	if (m_state && m_api.event_to_string)
 	{
-		ss_plugin_event pevt = {
-			.evtnum = evt->get_num(),
-			.data = data,
-			.datalen = datalen,
-			.ts = evt->get_ts(),
-		};
+		ss_plugin_event pevt;
+		pevt.evtnum = evt->get_num();
+		pevt.data = data;
+		pevt.datalen = datalen;
+		pevt.ts = evt->get_ts();
 		ret = str_from_alloc_charbuf(m_api.event_to_string(m_state, &pevt));
 	}
 	if (ret.empty())


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR fixes `plugin.cpp` to avoid using a designated initializer, which unnecessarily increased the C++ standard of the project up to C++20.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): remove usage of designated initializer
```
