### PR TITLE
fix(driver): initialize event_filler_arguments to fix is_socketcall on aarch64

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1589,7 +1589,7 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	u32 freespace;
 	u32 usedspace;
 	u32 delta_from_end;
-	struct event_filler_arguments args;
+	struct event_filler_arguments args = {};
 	u32 ttail;
 	u32 head;
 	struct ppm_ring_buffer_context *ring;


### PR DESCRIPTION
struct event_filler_arguments has a .is_socketcall member for
compatibility with those architectures having a single syscall
for all socket functions (bind, connect...).
When the architecture does NOT _HAS_SOCKETCALL though (e.g. arm64),
this field takes the value from whatever happens to be in the stack
(so likely non-zero), leading to fillers assuming it IS a socketcall
-- where in reality it is not -- and therefore exposing bogus
argument values.

The issue can be triggered by running the following on ARM:

```
telnet 127.0.0.1 8080
```

which results in sysdig reporting something like:

```
1187851 20:45:11.730173066 3 bash (1999317) > connect fd=1368509440 addr=NULL
```

Initialize the whole structure to all-zeroes so to have deterministic
behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
