### PR TITLE
fix(driver-ebpf): fixes verifier error for sys_open_by_handle_at

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3098,7 +3098,8 @@ FILLER(sys_open_by_handle_at_x, true)
 		}
 	} 
 
-	res = bpf_val_to_ring(data, (unsigned long)"<NA>");
+	char na[] = "<NA>";
+	res = bpf_val_to_ring(data, (unsigned long)na);
 	return res;
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

Fixes a verifier error on some kernels due to passing of `"<NA>"` marker directly to bpf helpers. The verifier error I've seen is somewhat confusing: `filler/sys_open_by_handle_at_x message=fd 0 is not pointing to valid bpf_map`

By putting the marker into a stack variable and then passing that through to the helper, the verifier is happy with the program. This matches other uses of the marker throughout the other filler programs.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
