### PR TITLE
refactor(userspace/libsinsp): update filter parser and grammar to accept embedded expressions after boolean operators

### DIFF
--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -23,13 +23,19 @@ limitations under the License.
 // Context-free Grammar for Sinsp Filters
 //
 // Productions (EBNF Syntax):
-//     Expr          ::= OrExpr
-//     OrExpr        ::= AndExpr ('or' AndExpr)*
-//     AndExpr       ::= NotExpr ('and' NotExpr)*
-//     NotExpr       ::= ('not')* Check
+//     Expr                ::= OrExpr
+//     OrExpr              ::= AndExpr ('or' OrExprTail)*
+//     OrExprTail          ::= ' ' AndExpr
+//                             | '(' Expr ')'
+//     AndExpr             ::= NotExpr ('and' AndExprTail)*
+//     AndExprTail         ::= ' ' NotExpr
+//                             | '(' Expr ')'
+//     NotExpr             ::= ('not ')* NotExprTail
+//     NotExprTail         ::= 'not' '(' Expr ')'
+//                             | Check
 //     Check               ::= CheckField CheckCondition
 //                             | Identifier
-//                             | '(' OrExpr ')'
+//                             | '(' Expr ')'
 //     CheckCondition      ::= UnaryOperator
 //                             | NumOperator NumValue
 //                             | StrOperator StrValue
@@ -146,6 +152,7 @@ private:
 	ast::expr* parse_or();
 	ast::expr* parse_and();
 	ast::expr* parse_not();
+	ast::expr* parse_embedded_remainder();
 	ast::expr* parse_check();
 	ast::expr* parse_list_value();
 	ast::value_expr* parse_num_value();

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -130,11 +130,16 @@ TEST(sinsp_filter_compiler, boolean_evaluation)
 	test_filter_run(true,  "c.true=1");
 	test_filter_run(false, "c.false=1");
 	test_filter_run(false, "not c.true=1");
+	test_filter_run(false, "not(c.true=1)");
 	test_filter_run(true,  "not not c.true=1");
+	test_filter_run(true,  "not not(c.true=1)");
 	test_filter_run(true,  "not (not c.true=1)");
 	test_filter_run(false, "not not not c.true=1");
+	test_filter_run(false, "not not not(c.true=1)");
 	test_filter_run(false, "not (not (not c.true=1))");
+	test_filter_run(false, "not(not(not c.true=1))");
 	test_filter_run(true,  "not not not not c.true=1");
+	test_filter_run(true,  "not not(not not c.true=1)");
 	test_filter_run(true,  "c.true=1 and c.true=1");
 	test_filter_run(false, "c.true=1 and c.false=1");
 	test_filter_run(false, "c.false=1 and c.true=1");

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -83,20 +83,29 @@ TEST(parser, supported_operators)
 	}
 }
 
-// Inspired by Falco's parser smoke tests:
+// Based on and extended Falco's parser smoke tests:
 // https://github.com/falcosecurity/falco/blob/204f9ff875be035e620ca1affdf374dd1c610a98/userspace/engine/lua/parser-smoke.sh#L41
 TEST(parser, parse_smoke_test)
 {
 	// good
 	test_accept("  a");
-	test_accept("a and b");
 	test_accept("(a)");
+	test_accept("a and b");
+	test_accept("a and b and c");
+	test_accept("a and b and(c)");
+	test_accept("(a)and(b)and(c)");
 	test_accept("(a and b)");
+	test_accept("a or b");
+	test_accept("a or b or c");
+	test_accept("a or b or(c)");
+	test_accept("(a)or(b)or(c)");
+	test_accept("(a or b)");
 	test_accept("(a.a exists and b)");
 	test_accept("(a.a exists) and (b)");
 	test_accept("a.a exists and b");
 	test_accept("a.a=1 or b.b=2 and c");
 	test_accept("not (a)");
+	test_accept("not(a)");
 	test_accept("not (not (a))");
 	test_accept("not (a.b=1)");
 	test_accept("not (a.a exists)");
@@ -104,6 +113,9 @@ TEST(parser, parse_smoke_test)
 	test_accept("a.b = 1 and not a");
 	test_accept("not not a");
 	test_accept("(not not a)");
+	test_accept("not not(a)");
+	test_accept("not(not(a))");
+	test_accept("not(a)and(not(b))");
 	test_accept("not a.b=1");
 	test_accept("not a.a exists");
 	test_accept("a.b = bla");
@@ -121,6 +133,34 @@ TEST(parser, parse_smoke_test)
 	test_accept("evt.arg[a] contains /bin");
 
 	// bad
+	test_reject("a andb");
+	test_reject("aand b");
+	test_reject("a and b and");
+	test_reject("a and b or");
+	test_reject("a and b not");
+	test_reject("and a");
+	test_reject("or a");
+	test_reject("a or b and");
+	test_reject("a or b or");
+	test_reject("a or b not");
+	test_reject("a not b and");
+	test_reject("a not b or");
+	test_reject("a not b not");
+	test_reject("a orb");
+	test_reject("aor b");
+	test_reject("a and or b");
+	test_reject("a andor b");
+	test_reject("a not b");
+	test_reject("a notb");
+	test_reject("anot b");
+	test_reject("a andnot b");
+	test_reject("a andnotb");
+	test_reject("a and notb");
+	test_reject("(a)andnot(b)");
+	test_reject("a ornot b");
+	test_reject("a ornotb");
+	test_reject("a or notb");
+	test_reject("(a)ornot(b)");
 	test_reject("evt.arg[] contains /bin");
 	test_reject("a.b = b = 1");
 	test_reject("(a.b = 1");


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**What this PR does / why we need it**:

This updates the filter parser inside libsinsp to accept cases where embedded expressions (starting with `(`) follow a boolean operator (`and`, `or`, `not`) without leaving a whitespace. The parser is currently very strict and always requires a whitespace after boolean operators, but that's an unnecessary constraint towards the non-ambiguity of the parsing language.

With this, filters such as `evt.num > 0 and(proc.name = 'cat')` are correctly parsed and accepted. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp): update filter parser and grammar to accept embedded expressions after boolean operators
```
