### PR TITLE
fix(libscap/engine/gvisor): fix cmake without USE_BUNDLED_DEPS

### DIFF
--- a/userspace/libscap/engine/gvisor/CMakeLists.txt
+++ b/userspace/libscap/engine/gvisor/CMakeLists.txt
@@ -10,7 +10,10 @@ add_library(scap_engine_gvisor STATIC
     parsers.cpp
 )
 
-add_dependencies(scap_engine_gvisor protobuf)
+if(USE_BUNDLED_PROTOBUF)
+    add_dependencies(scap_engine_gvisor protobuf)
+endif()
+
 target_link_libraries(scap_engine_gvisor ${PROTOBUF_LIB} scap)
 
 add_custom_command(


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In some cmake versions trying to include protobuf without a guard on bundled libs might generate the following warning:
```
CMake Warning (dev) at userspace/libscap/engine/gvisor/CMakeLists.txt:13 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "protobuf" of target "scap_engine_gvisor" does not
  exist.
```
which is an error in some other cmake versions.

This adds the necessary `if()` to make it work correctly.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
