### PR TITLE
update(build): allow gvisor compilation toggle -DBUILD_LIBSCAP_GVISOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mkdir build && cd build
 The easiest way to build the project is to use `BUNDLED_DEPS` option, 
 meaning that most of the dependencies will be fetched and compiled during the process:
 ```bash
-cmake -DUSE_BUNDLED_DEPS=true ../
+cmake -DUSE_BUNDLED_DEPS=true -DCREATE_TEST_TARGETS=OFF ../
 make sinsp
 ```
 > **NOTE:** take a break as this will take quite a bit of time (around 15 mins, dependent on the hardware obviously).
@@ -89,6 +89,11 @@ Then, issue:
 cmake -DBUILD_BPF=true ../
 make bpf
 ```
+
+### gVisor support
+
+Libscap contains additional library functions to allow integration with system call events coming from [gVisor](https://gvisor.dev).
+Compilation of this functionality can be disabled with `-DBUILD_LIBSCAP_GVISOR=Off`.
 
 >__WARNING__: **clang-7** is the oldest supported version to build our BPF probe, since it is the one used by our infrastructure.
 

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -142,11 +142,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	include(FindMakedev)
 endif()
 
-if(NOT MINIMAL_BUILD AND NOT WIN32 AND NOT APPLE) # gVisor is currently only supported on Linux
-	set(ENGINE_GVISOR TRUE)
-	add_definitions(-DHAS_ENGINE_GVISOR)
-	add_subdirectory(engine/gvisor)
-	target_link_libraries(scap scap_engine_gvisor)
+
+# gVisor is currently only supported on Linux
+if(NOT MINIMAL_BUILD AND NOT WIN32 AND NOT APPLE)
+	option(BUILD_LIBSCAP_GVISOR "Build gVisor support" ON)
+	if (BUILD_LIBSCAP_GVISOR)
+		add_definitions(-DHAS_ENGINE_GVISOR)
+		add_subdirectory(engine/gvisor)
+		target_link_libraries(scap scap_engine_gvisor)
+	endif()
 endif()
 
 option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)

--- a/userspace/libscap/test/CMakeLists.txt
+++ b/userspace/libscap/test/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LIBSCAP_UNIT_TESTS_SOURCES
     scap_event.ut.cpp
 )
 
-if (ENGINE_GVISOR)
+if (BUILD_LIBSCAP_GVISOR)
 	list(APPEND LIBSCAP_UNIT_TESTS_SOURCES scap_gvisor_parsers.ut.cpp)
 	include_directories(../engine/gvisor)
 	include_directories(${CMAKE_CURRENT_BINARY_DIR}/../engine/gvisor)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test
/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently, libscap includes library functions useful for gVisor message ingestion by default that depend on libraries that might take a long time to compile such as protobuf (which is also required by libsinsp). For some use cases, it is not necessary to build this support, for example when only a lightweight version of libscap is necessary that only interfaces with the ebpf probe or kernel module, such as the `scap-open` example.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
