### PR TITLE
fix(libscap): add defines in userspace_flags_helpers.h for alpine-musl/centos7 builds that don't have them

### DIFF
--- a/userspace/libscap/userspace_flag_helpers.h
+++ b/userspace/libscap/userspace_flag_helpers.h
@@ -9,9 +9,17 @@
 #include <sys/quota.h>
 #include <sys/ptrace.h>
 #include <sys/resource.h>
+#include <sys/file.h>
 
 #define ASSERT assert
 #define F_CANCELLK 1024 + 5
+
+#ifndef QFMT_VFS_OLD
+#define	QFMT_VFS_OLD 1
+#define	QFMT_VFS_V0 2
+#define QFMT_OCFS2 3
+#define	QFMT_VFS_V1 4
+#endif
 
 #define u8 uint8_t
 #define u16 uint16_t


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR aims to fix the following build errors, with musl for alpine:
```
/build-static/release/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libscap/../../driver/ppm_flag_helpers.h:1279:14: error: 'LOCK_EX' was not declared in this scope
 1279 |  if (flags & LOCK_EX)
      |              ^~~~~~~
```
and similar

and with CentOS 7:
```
/build/release/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libscap/../../driver/ppm_flag_helpers.h:1369:7: error: 'QFMT_VFS_OLD' was not declared in this scope
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
