### PR TITLE
Track container user info and expose via user.name

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -189,6 +189,8 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 
 	container["Mounts"] = mounts;
 
+	container["User"] = container_info.m_container_user;
+
 	sinsp_container_info::container_health_probe::add_health_probes(container_info.m_health_probes, container);
 
 	char addrbuff[100];

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -54,9 +54,12 @@ constexpr const cgroup_layout CRI_CGROUP_LAYOUT[] = {
 
 bool cri_async_source::parse_containerd(const runtime::v1alpha2::ContainerStatusResponse& status, sinsp_container_info &container)
 {
+	g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s) in parse_containerd", container.m_id.c_str());
+
 	const auto &info_it = status.info().find("info");
 	if(info_it == status.info().end())
 	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s) no info property, returning", container.m_id.c_str());
 		return false;
 	}
 
@@ -64,13 +67,19 @@ bool cri_async_source::parse_containerd(const runtime::v1alpha2::ContainerStatus
 	Json::Reader reader;
 	if(!reader.parse(info_it->second, root))
 	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s) could not json parse info, returning", container.m_id.c_str());
 		ASSERT(false);
 		return false;
 	}
 
+	g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): will parse info json: %s",
+			container.m_id.c_str(),
+			info_it->second.c_str());
+
 	m_cri->parse_cri_env(root, container);
 	m_cri->parse_cri_json_image(root, container);
 	bool ret = m_cri->parse_cri_ext_container_info(root, container);
+	m_cri->parse_cri_user_info(root, container);
 
 	if(root.isMember("sandboxID") && root["sandboxID"].isString())
 	{
@@ -105,6 +114,7 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 
 	if(!resp.has_status())
 	{
+		g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s) no status, returning", container.m_id.c_str());
 		ASSERT(false);
 		return false;
 	}
@@ -136,6 +146,11 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 		container.m_cpu_quota = limits.m_cpu_quota;
 		container.m_cpu_period = limits.m_cpu_period;
 		container.m_cpuset_cpu_count = limits.m_cpuset_cpu_count;
+
+		// In some cases (e.g. openshift), the cri-o response
+		// may not have an info property, which is used to set
+		// the container user. In those cases, the container
+		// name stays at its default "<NA>" value.
 	}
 
 	if(s_cri_extra_queries)

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -677,6 +677,12 @@ bool docker_async_source::parse(const docker_lookup_request& request, sinsp_cont
 	get_image_info(request, container, root);
 
 	const Json::Value& config_obj = root["Config"];
+	const Json::Value& user = config_obj["User"];
+	if(!user.isNull())
+	{
+		container.m_container_user = user.asString();
+	}
+
 	parse_health_probes(config_obj, container);
 
 	container.m_full_id = root["Id"].asString();

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -155,6 +155,7 @@ std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspect
 	tinfo->m_vtid = -2;
 	tinfo->m_vpid = -2;
 	tinfo->m_comm = "container:" + m_id;
+	tinfo->m_exe = "container:" + m_id;
 	tinfo->m_container_id = m_id;
 
 	return tinfo;

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -252,6 +252,7 @@ public:
 		m_cpu_period(100000),
 		m_cpuset_cpu_count(0),
 		m_is_pod_sandbox(false),
+		m_container_user("<NA>"),
 		m_metadata_deadline(0),
 		m_size_rw_bytes(-1)
 	{
@@ -316,6 +317,9 @@ public:
 	bool m_is_pod_sandbox;
 
 	sinsp_container_lookup m_lookup;
+
+	std::string m_container_user;
+
 #ifdef HAS_ANALYZER
 	std::string m_sysdig_agent_conf;
 #endif

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -324,6 +324,18 @@ bool cri_interface::parse_cri_ext_container_info(const Json::Value &info, sinsp_
 	return true;
 }
 
+bool cri_interface::parse_cri_user_info(const Json::Value &info, sinsp_container_info &container)
+{
+	const Json::Value *uid = nullptr;
+	if(!walk_down_json(info, &uid, "runtimeSpec", "process", "user", "uid") || !uid->isInt())
+	{
+		return false;
+	}
+
+	container.m_container_user = std::to_string(uid->asInt());
+	return true;
+}
+
 bool cri_interface::is_pod_sandbox(const std::string &container_id)
 {
 	runtime::v1alpha2::PodSandboxStatusRequest req;

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -126,6 +126,16 @@ public:
 	bool parse_cri_ext_container_info(const Json::Value &info, sinsp_container_info &container);
 
 	/**
+	 * @brief fill out extra container user info (e.g. configured uid) based on CRI response
+	 * @param info the `info` key of the `info` field of the ContainerStatusResponse
+	 * @param container the container info to fill out
+	 * @return true if successful
+	 *
+	 * Note: only containerd exposes this data
+	 */
+	bool parse_cri_user_info(const Json::Value &info, sinsp_container_info &container);
+
+	/**
 	 * @brief check if the passed container ID is a pod sandbox (pause container)
 	 * @param container_id the container ID to check
 	 * @return true if it's a pod sandbox

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4819,6 +4819,21 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 		return NULL;
 	}
 
+	// For container events, use the user from the container metadata instead.
+	if(m_field_id == TYPE_NAME &&
+	   (evt->get_type() == PPME_CONTAINER_JSON_E || evt->get_type() == PPME_CONTAINER_JSON_2_E))
+	{
+		const sinsp_container_info::ptr_t container_info =
+			m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+
+		if(!container_info)
+		{
+			return NULL;
+		}
+
+		RETURN_EXTRACT_STRING(container_info->m_container_user);
+	}
+
 	switch(m_field_id)
 	{
 	case TYPE_UID:

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5108,6 +5108,12 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		libsinsp::container_engine::docker_async_source::parse_json_mounts(container["Mounts"], container_info->m_mounts);
 #endif
 
+		const Json::Value& user = container["User"];
+		if(check_json_val_is_convertible(user, Json::stringValue, "User"))
+		{
+			container_info->m_container_user = user.asString();
+		}
+
 		sinsp_container_info::container_health_probe::parse_health_probes(container, container_info->m_health_probes);
 
 		const Json::Value& contip = container["ip"];


### PR DESCRIPTION
Changes to support tracking how a container was configured with an
initial user and make that info available as user.name for
CONTAINER_JSON events:

1. Add a "container user" field m_container_user to container_info. By
   default, the value is "<NA>".
2. In the docker and cri container engine resolvers, parse any
   configured user info out of the json response and set
   m_container_user.
3. Serialize the parsed username to the json blob that comprises a
   CONTAINER_JSON event, and parse it out of the json blob when parsing a
   CONTAINER_JSON event.
4. When creating the fake threadinfo that is attached to a container
   event, also set m_exe to "container:<id>".
5. For the proc.name filtercheck, if the event type is container_json,
   return not the thread uid but the container user.

This ends up being more robust in the face of containers where the
initial process might exec and then setuid than a different user. This
tracks the configured user rather than the uids of processes in the
container, which might change.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Track the configured user when containers are created and make that info available as the field user.name for container events.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Track the configured user when containers are created and make that info available as the field user.name for container events.
```
