### PR TITLE
Support PT_FD param types when converting to json/string

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -682,6 +682,7 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 
 		case PT_INT64:
 		case PT_PID:
+		case PT_FD:
 			if(print_format == PF_DEC ||
 			   print_format == PF_ID)
 			{
@@ -784,7 +785,7 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 			return rawval_to_string(rawval, ptype, print_format, len);
 		default:
 			ASSERT(false);
-			throw sinsp_exception("wrong event type " + to_string((long long) ptype));
+			throw sinsp_exception("wrong param type " + to_string((long long) ptype));
 	}
 }
 
@@ -874,6 +875,7 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		case PT_INT64:
 		case PT_PID:
 		case PT_ERRNO:
+		case PT_FD:
 			if(print_format == PF_OCT)
 			{
 				prfmt = (char*)"%" PRIo64;
@@ -1084,7 +1086,7 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			return m_getpropertystr_storage;
 		default:
 			ASSERT(false);
-			throw sinsp_exception("wrong event type " + to_string((long long) ptype));
+			throw sinsp_exception("wrong param type " + to_string((long long) ptype));
 	}
 }
 


### PR DESCRIPTION
No filterchecks have PT_FD params, but it's possible to have an
evt.arg.fd param for many syscalls and that could be printed in output
fields.

It's a 64 bit int so just add it to the sections that work with that
underlying type.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
