### PR TITLE
Fix threadinfo leaks when threaded programs exec

### DIFF
--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -96,6 +96,7 @@ private:
 	// Parsers
 	//
 	void parse_clone_exit(sinsp_evt* evt);
+	void parse_execve_enter(sinsp_evt* evt);
 	void parse_execve_exit(sinsp_evt* evt);
 	void proc_schedule_removal(sinsp_evt* evt);
 	void parse_open_openat_creat_exit(sinsp_evt* evt);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1042,6 +1042,28 @@ void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 	}
 }
 
+void sinsp_threadinfo::set_exec_enter_tid(int64_t tid)
+{
+	m_exec_enter_tid.reset(new int64_t(tid));
+}
+
+bool sinsp_threadinfo::get_exec_enter_tid(int64_t* tid)
+{
+	if(m_exec_enter_tid == NULL)
+	{
+		return false;
+	}
+
+	*tid = *(m_exec_enter_tid.get());
+
+	return true;
+}
+
+void sinsp_threadinfo::clear_exec_enter_tid()
+{
+	m_exec_enter_tid = NULL;
+}
+
 void sinsp_threadinfo::populate_cmdline(string &cmdline, const sinsp_threadinfo *tinfo)
 {
 	cmdline = tinfo->get_comm();
@@ -1421,6 +1443,15 @@ void sinsp_thread_manager::remove_thread(int64_t tid, bool force)
 				else
 				{
 					ASSERT(false);
+				}
+
+				// If the main thread has already been
+				// closed and now has no children,
+				// remove it now.
+				if((main_thread->m_flags & PPM_CL_CLOSED) &&
+				   main_thread->m_nchilds == 0)
+				{
+					m_inspector->m_tid_to_remove = main_thread->m_tid;
 				}
 			}
 			else


### PR DESCRIPTION
It's fairly uncommon to do an exec() from a multithreaded program, but
while doing some performance tests using "stress-ng -exec N", I
noticed that stress-ng does exactly that:
https://github.com/ColinIanKing/stress-ng/blob/master/stress-exec.c#L160.

This exposes some problems in event parsing that we need to fix:

- When the thread that does the exec is the main thread, the pid/tid
  remain the same, but all child threads are killed and you may not see
  procexit events for those threads. In the threadinfo for the main
  thread, we need to reset the child thread count so when the main
  thread exits it is properly removed.

- When the thread that does the exec is a non-main thread, the tid
  changes back to the main process pid in the exec exit event. The
  threadinfo for the tid in the enter event would otherwise be lost.
  Handle this by adding a parser for the exec enter event that tracks
  when the exec was done by a non-main thread. In the exit event,
  remove the threadinfo for that non-main thread.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Fix potential threadinfo leaks when non-main threads perform an exec().
```
