### PR TITLE
filters optimizer PT_IPNET

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -780,6 +780,7 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 		case PT_IPV4ADDR:
 		case PT_IPV6ADDR:
 		case PT_IPADDR:
+		case PT_IPNET:
 		case PT_FSRELPATH:
 			return rawval_to_string(rawval, ptype, print_format, len);
 		default:
@@ -1081,6 +1082,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			snprintf(m_getpropertystr_storage,
 					 sizeof(m_getpropertystr_storage),
 					 "%.1lf", *(double*)rawval);
+			return m_getpropertystr_storage;
+		case PT_IPNET:
+			snprintf(m_getpropertystr_storage,
+				 sizeof(m_getpropertystr_storage),
+				 "<IPNET>");
 			return m_getpropertystr_storage;
 		default:
 			ASSERT(false);


### PR DESCRIPTION
Signed-off-by: vadim.zyarko <vadim.zyarko@sysdig.com>

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:
the change is to allow enough support for PT_INET param types so they can be serialized as strings. In debug builds, this results in a false assertion as it drops to the end of the switch in sinsp_filter_check::rawval_to_{json,string}


```release-note
update: added formatting support for PT_IPNET
```