### PR TITLE
filtercheck-container args string

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6132,6 +6132,11 @@ int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t base
 	return end+1;
 }
 
+const std::string &sinsp_filter_check_container::get_argstr()
+{
+	return m_argstr;
+}
+
 int32_t sinsp_filter_check_container::parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)
 {
 	string val(str);

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -783,6 +783,7 @@ public:
 	sinsp_filter_check* allocate_new();
 	uint8_t* extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings = true);
 
+	const std::string &get_argstr();
 private:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering);
 	int32_t extract_arg(const string& val, size_t basename);


### PR DESCRIPTION
/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

the change adds a method to print a container's arguments as a string when debug prints filters

```release-note
chore(libsinsp): method to print a container's arguments as a string when debug prints filters
```
