### PR TITLE
fix(driver): silence drop enter/exit event delayed insert messages

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1427,7 +1427,9 @@ static inline void record_drop_e(struct ppm_consumer_t *consumer,
 		consumer->need_to_insert_drop_e = 1;
 	} else {
 		if (consumer->need_to_insert_drop_e == 1 && !(drop_flags & UF_ATOMIC)) {
-			pr_err("drop enter event delayed insert\n");
+			if (verbose) {
+				pr_err("consumer:%p drop enter event delayed insert\n", consumer->consumer_id);
+			}
 		}
 
 		consumer->need_to_insert_drop_e = 0;
@@ -1444,7 +1446,9 @@ static inline void record_drop_x(struct ppm_consumer_t *consumer,
 		consumer->need_to_insert_drop_x = 1;
 	} else {
 		if (consumer->need_to_insert_drop_x == 1 && !(drop_flags & UF_ATOMIC)) {
-			pr_err("drop exit event delayed insert\n");
+			if (verbose) {
+				pr_err("consumer:%p drop exit event delayed insert\n", consumer->consumer_id);
+			}
 		}
 
 		consumer->need_to_insert_drop_x = 0;


### PR DESCRIPTION
such messages might end up flooding kernel logs.
Silence them unless the "verbose" module parameter is enabled.
Also, add information about the consumer.

Signed-off-by: Gerlando Falauto <gerlando.falauto@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Removes noisy messages from kernel logs
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Drop enter/exit event delayed messages are now only logged when in verbose mode
```
