### PR TITLE
update len variable of case PT_BYTEBUF

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -903,10 +903,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		} 
 		else 
 		{
-			/*
-			 * Handle NULL pointers
-			 */
-			len = 0;
+			len = val_len;
 		}
 		break;
 	}


### PR DESCRIPTION
if val == 0, len should be assigned to val_len

**What type of PR is this?**
/kind bug
/area driver-ebpf

**What this PR does / why we need it**:
When configure rule %proc.args  in yaml file, the result has no value.

**Which issue(s) this PR fixes**:
This PR fixes the problem for no output of %proc.args configured in yaml file.

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Fixes problem for no output of %proc.args rule.
```

Signed-off-by: Jie Lin <jie.lin.fj@gmail.com>