### PR TITLE
create evtcpy method to clone sinsp_evt

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2732,3 +2732,83 @@ uint64_t sinsp_evt::get_lastevent_ts() const
 {
 	return m_tinfo->m_lastevent_ts;
 }
+
+bool sinsp_evt::evtcpy(sinsp_evt& dest, const sinsp_evt& src)
+{
+	dest.m_inspector = src.m_inspector;
+
+	if (src.m_pevt != nullptr)
+	{
+		dest.m_pevt_storage = new char[src.m_pevt->len];
+		memcpy(dest.m_pevt_storage, src.m_pevt, src.m_pevt->len);
+		dest.m_pevt = (scap_evt*)dest.m_pevt_storage;
+	}
+	else
+	{
+		dest.m_pevt_storage = nullptr;
+		dest.m_pevt = nullptr;
+	}
+
+	dest.m_poriginal_evt = nullptr;
+
+	// tinfo
+	if (src.m_tinfo_ref && src.m_tinfo && src.m_tinfo_ref.get() != src.m_tinfo)
+	{
+		// both not null and not equal: bad data
+		return false;
+	}
+
+	dest.m_tinfo_ref = src.m_tinfo_ref;
+	dest.m_tinfo = src.m_tinfo;
+	// safely copy tinfo only if it's available as shared_ptr
+	// otherwise no guaranty to have it alive when the event replayed
+	if(src.m_tinfo_ref)
+	{
+		dest.m_tinfo_ref = src.m_tinfo_ref;
+		dest.m_tinfo = dest.m_tinfo_ref.get();
+	}
+	else if (src.m_tinfo)
+	{
+		dest.m_tinfo_ref = dest.m_inspector->get_thread_ref(src.m_tinfo->m_tid , false, false)		;
+		if (dest.m_tinfo_ref == nullptr)
+		{
+			// no tinfo
+			return false;
+		}
+		dest.m_tinfo = dest.m_tinfo_ref.get();
+	}
+
+	// scalars
+	dest.m_cpuid = src.m_cpuid;
+	// m_evtnum is used in cached filters and that is safe for reuse
+	dest.m_evtnum = src.m_evtnum;
+	dest.m_flags = src.m_flags;
+	dest.m_params_loaded = src.m_params_loaded;
+
+	dest.m_iosize = src.m_iosize;
+	dest.m_errorcode = src.m_errorcode;
+	dest.m_rawbuf_str_len = src.m_rawbuf_str_len;
+	dest.m_filtered_out = src.m_filtered_out;
+
+	// vectors
+	dest.m_params = src.m_params;
+	dest.m_paramstr_storage = src.m_paramstr_storage;
+	dest.m_resolved_paramstr_storage = src.m_resolved_paramstr_storage;
+
+	// pointer to an entry in global static table
+	// safe to copy naked ptr
+	dest.m_info = src.m_info;
+
+	// fd info
+	dest.m_fdinfo = nullptr;
+	if (src.m_fdinfo != nullptr)
+	{
+		//m_fdinfo_ref is only used to keep a handle to this
+		// copy of the fdinfo which was copied from the global fdinfo table
+		dest.m_fdinfo_ref.reset(new sinsp_fdinfo_t(*src.m_fdinfo));
+		dest.m_fdinfo = dest.m_fdinfo_ref.get();
+	}
+	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;
+
+	return true;
+}

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -463,6 +463,8 @@ private:
 	int render_fd_json(Json::Value *ret, int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
 	uint32_t get_dump_flags();
 
+	static bool evtcpy(sinsp_evt& dest, const sinsp_evt& src);
+
 VISIBILITY_PRIVATE
 	enum flags
 	{
@@ -500,6 +502,8 @@ VISIBILITY_PRIVATE
 	int32_t m_rawbuf_str_len;
 	bool m_filtered_out;
 	const struct ppm_event_info* m_event_info_table;
+
+	std::shared_ptr<sinsp_fdinfo_t> m_fdinfo_ref;
 
 	friend class sinsp;
 	friend class sinsp_parser;


### PR DESCRIPTION
Signed-off-by: vadim.zyarko <vadim.zyarko@sysdig.com>


**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:
Create a convenient routine to facilitate creating a shallow copy of the sinsp event.
It's useful when a client needs to delay processing for certain events. 

**Does this PR introduce a user-facing change?**:
yes

```release-note
Create a convenient routine to facilitate creating a shallow copy of the sinsp event.
It's useful when a client needs to delay processing for certain events. 

```
