### PR TITLE
Add std:: namespace to stl classes, add string include

### DIFF
--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include <set>
+#include <string>
 #include <vector>
 
 
@@ -49,7 +50,7 @@ private:
 /*!
   \brief This is the class that compiles the filters.
 */
-class SINSP_PUBLIC sinsp_filter_compiler: 
+class SINSP_PUBLIC sinsp_filter_compiler:
 	private libsinsp::filter::ast::expr_visitor
 {
 public:
@@ -66,7 +67,7 @@ public:
 	*/
 	sinsp_filter_compiler(
 		sinsp* inspector,
-		const string& fltstr,
+		const std::string& fltstr,
 		bool ttable_only=false);
 
 	/*!
@@ -79,7 +80,7 @@ public:
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<gen_event_filter_factory> factory,
-		const string& fltstr,
+		const std::string& fltstr,
 		bool ttable_only=false);
 
 	/*!
@@ -116,20 +117,20 @@ private:
 	void visit(libsinsp::filter::ast::list_expr*) override;
 	void visit(libsinsp::filter::ast::unary_check_expr*) override;
 	void visit(libsinsp::filter::ast::binary_check_expr*) override;
-	void check_ttable_only(string& field, gen_event_filter_check *check);
+	void check_ttable_only(std::string& field, gen_event_filter_check *check);
 	void check_op_value_compatibility(cmpop op, std::string& value);
-	cmpop str_to_cmpop(string& str);
-	string create_filtercheck_name(string& name, string& arg);
-	gen_event_filter_check* create_filtercheck(string& field);
+	cmpop str_to_cmpop(std::string& str);
+	std::string create_filtercheck_name(std::string& name, std::string& arg);
+	gen_event_filter_check* create_filtercheck(std::string& field);
 
 	int32_t m_check_id;
 	bool m_ttable_only;
 	bool m_internal_parsing;
 	bool m_expect_values;
 	boolop m_last_boolop;
-	string m_flt_str;
+	std::string m_flt_str;
 	sinsp_filter* m_filter;
-	vector<string> m_field_values;
+	std::vector<std::string> m_field_values;
 	libsinsp::filter::ast::expr* m_flt_ast;
 	std::shared_ptr<gen_event_filter_factory> m_factory;
 
@@ -156,7 +157,7 @@ public:
 	// filter_fieldclass_infos. This is useful for programs that
 	// use filterchecks but not factories.
 	static std::list<filter_fieldclass_info> check_infos_to_fieldclass_infos(
-		const vector<const filter_check_info*> &fc_plugins);
+		const std::vector<const filter_check_info*> &fc_plugins);
 
 protected:
 	sinsp *m_inspector;


### PR DESCRIPTION
This header file had a bunch of bare references to stl classes without
a std:: prefix. Until recently, some other header file must have had a
"using namespace std" that allowed this to compile. Bad practice to
put using namespace in header files, but it masked this problem.

Looks like the "using namespace" has been cleaned up, which causes a
compile error for some toolchains, at least.

Fix this by adding std:: to any stl classes.

Also include <string> as this header file uses std::string.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
