### PR TITLE
update(cmake): Update libcurl to 7.83.1

### DIFF
--- a/cmake/modules/curl.cmake
+++ b/cmake/modules/curl.cmake
@@ -28,10 +28,8 @@ else()
 			curl
 			PREFIX "${PROJECT_BINARY_DIR}/curl-prefix"
 			DEPENDS openssl zlib
-			# START CHANGE for CVE-2017-8816, CVE-2017-8817, CVE-2017-8818, CVE-2018-1000007
-			URL "https://github.com/curl/curl/releases/download/curl-7_77_0/curl-7.77.0.tar.bz2"
-			URL_HASH "SHA256=6c0c28868cb82593859fc43b9c8fdb769314c855c05cf1b56b023acf855df8ea"
-			# END CHANGE for CVE-2017-8816, CVE-2017-8817, CVE-2017-8818, CVE-2018-1000007
+			URL "https://github.com/curl/curl/releases/download/curl-7_83_1/curl-7.83.1.tar.bz2"
+			URL_HASH "SHA256=f539a36fb44a8260ec5d977e4e0dbdd2eee29ed90fcedaa9bc3c9f78a113bff0"
 			CONFIGURE_COMMAND
 			./configure
 			${CURL_SSL_OPTION}
@@ -56,14 +54,12 @@ else()
 			--disable-ntlm-wb
 			--disable-tls-srp
 			--without-winssl
-			--without-darwinssl
 			--without-polarssl
 			--without-cyassl
 			--without-nss
 			--without-axtls
 			--without-ca-path
 			--without-ca-bundle
-			--without-libmetalink
 			--without-librtmp
 			--without-winidn
 			--without-libidn2


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-ebpf

/area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Bump the libcurl version to 7.83.1. This includes the latest features, performance fixes and fixes for the following vulnerabliities:
* CVE-2018-1000007
* CVE-2022-27776
* CVE-2021-22898
* CVE-2021-22925
* CVE-2021-22924
* CVE-2021-22926
* CVE-2021-22923
* CVE-2021-22922
* CVE-2021-22945
* CVE-2021-22946
* CVE-2021-22947
* CVE-2022-22576
* CVE-2022-27775
* CVE-2022-27774
* CVE-2022-27782
* CVE-2022-27781

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update(cmake): update libcurl to 7.83.1
```
