### PR TITLE
feat(filterchecks): add optional metrics struct for caching

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1410,6 +1410,11 @@ uint8_t* sinsp_filter_check::extract(sinsp_evt *evt, OUT uint32_t* len, bool san
 
 bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT vector<extract_value_t>& values, bool sanitize_strings)
 {
+	if(m_cache_metrics != NULL)
+	{
+		m_cache_metrics->m_num_extract++;
+	}
+
 	if(m_extraction_cache_entry != NULL)
 	{
 		uint64_t en = ((sinsp_evt *)evt)->get_num();
@@ -1418,6 +1423,13 @@ bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT vector<extract_value
 		{
 			m_extraction_cache_entry->m_evtnum = en;
 			extract(evt, m_extraction_cache_entry->m_res, sanitize_strings);
+		}
+		else
+		{
+			if(m_cache_metrics != NULL)
+			{
+				m_cache_metrics->m_num_extract_cache++;
+			}
 		}
 
 		// Shallow-copy the cached values to values
@@ -1433,6 +1445,11 @@ bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT vector<extract_value
 
 bool sinsp_filter_check::compare(gen_event *evt)
 {
+	if(m_cache_metrics != NULL)
+	{
+		m_cache_metrics->m_num_eval++;
+	}
+
 	if(m_eval_cache_entry != NULL)
 	{
 		uint64_t en = ((sinsp_evt *)evt)->get_num();
@@ -1442,6 +1459,14 @@ bool sinsp_filter_check::compare(gen_event *evt)
 			m_eval_cache_entry->m_evtnum = en;
 			m_eval_cache_entry->m_res = compare((sinsp_evt *) evt);
 		}
+		else
+		{
+			if(m_cache_metrics != NULL)
+			{
+				m_cache_metrics->m_num_eval_cache++;
+			}
+		}
+
 
 		return m_eval_cache_entry->m_res;
 	}

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -60,6 +60,22 @@ public:
 	bool m_res;
 };
 
+class check_cache_metrics
+{
+public:
+	// The number of times extract_cached() was called
+	uint64_t m_num_extract;
+
+	// The number of times extract_cached() could use a cached value
+	uint64_t m_num_extract_cache;
+
+	// The number of times compare() was called
+	uint64_t m_num_eval;
+
+	// The number of times compare() could use a cached value
+	uint64_t m_num_eval_cache;
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // The filter check interface
 // NOTE: in order to add a new type of filter check, you need to add a class for
@@ -163,6 +179,7 @@ public:
 	check_eval_cache_entry* m_eval_cache_entry = NULL;
 	check_extraction_cache_entry* m_extraction_cache_entry = NULL;
 	std::vector<extract_value_t> m_extracted_values;
+	check_cache_metrics *m_cache_metrics = NULL;
 
 protected:
 	// This is a single-value version of extract for subclasses non supporting extracting


### PR DESCRIPTION
Add an optional metrics struct that if present, keeps track of the
efficacy of the extraction cache/evaluation cache.

The metrics count the number of times extract_cached() was called and
when it could use the cache, and the number of times comapre() was
called and when it could use the cache.

Like the caches, the memory for the pointer is assumed to be owned by
something else.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Add ability to track metrics on filtercheck cache efficacy. 
```
