### PR TITLE
update(userspace/libscap): Makes BPF_PROGS_MAX configurable at compile time

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -62,6 +62,10 @@ if(NOT DEFINED SCAP_HOST_ROOT_ENV_VAR_NAME)
 endif()
 add_definitions(-DSCAP_HOST_ROOT_ENV_VAR_NAME="${SCAP_HOST_ROOT_ENV_VAR_NAME}")
 
+if (DEFINED SCAP_BPF_PROGS_MAX)
+	add_definitions(-DBPF_PROGS_MAX=${SCAP_BPF_PROGS_MAX})
+endif()
+
 if(CYGWIN)
 include_directories("${WIN_HAL_INCLUDE}")
 endif()

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -71,7 +71,10 @@ inline const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error readi
 //
 // ebpf defs
 //
+#ifndef BPF_PROGS_MAX
 #define BPF_PROGS_MAX 128
+#endif
+
 #define BPF_MAPS_MAX 32
 
 //


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**
/area libscap

**What this PR does / why we need it**:

This is a very small change that makes BPF_PROGS_MAX configurable at compile time. I'm currently building a custom probe that works with Falco (as outlined in #267 ) and it has more programs than libscap can currently work with. This change will allow me to define a larger limit.

As an aside, accesses to the various arrays that use BPF_PROGS_MAX as their size are not bounds-checked and whilst I have not added these checks here they might also make sense for a bit more robustness in the libs. (I am happy to add them if desired!) 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
