### PR TITLE
fix(userspace/libsinsp): fix checks on PT_BYTEBUF fields and optimize bcontains/bstartswith

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1464,7 +1464,8 @@ bool sinsp_filter_check::compare(sinsp_evt *evt)
 
 	return flt_compare(m_cmpop,
 		m_info.m_fields[m_field_id].m_type,
-		extracted_values);
+		extracted_values,
+		m_val_storage_len);
 }
 
 sinsp_filter::sinsp_filter(sinsp *inspector)

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -118,7 +118,6 @@ private:
 	void visit(libsinsp::filter::ast::unary_check_expr*) override;
 	void visit(libsinsp::filter::ast::binary_check_expr*) override;
 	void check_ttable_only(std::string& field, gen_event_filter_check *check);
-	void check_op_value_compatibility(cmpop op, std::string& value);
 	cmpop str_to_cmpop(std::string& str);
 	std::string create_filtercheck_name(std::string& name, std::string& arg);
 	gen_event_filter_check* create_filtercheck(std::string& field);

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	ppm_api_version.ut.cpp
 	plugin_manager.ut.cpp
 	filter_parser.ut.cpp
+	filter_op_bcontains.ut.cpp
 	filter_compiler.ut.cpp
 )
 

--- a/userspace/libsinsp/test/filter_op_bcontains.ut.cpp
+++ b/userspace/libsinsp/test/filter_op_bcontains.ut.cpp
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <sinsp.h>
+#include <gtest/gtest.h>
+
+// passing a NULL out pointer means expecting a failure
+static void filter_compile(sinsp_filter **out, std::string filter)
+{
+	std::shared_ptr<gen_event_filter_factory> factory(new sinsp_filter_factory(NULL));
+	sinsp_filter_compiler compiler(factory, filter);
+	try
+	{
+		auto f = compiler.compile();
+		if (!out)
+		{
+			delete f;
+			FAIL() << "Unexpected successful compilation for: " << filter;
+		}
+		else
+		{
+			*out = compiler.compile();
+		}
+	}
+	catch(const sinsp_exception& e)
+	{
+		if (out)
+		{
+			FAIL() << "Can't compile: " << filter << " -> " << e.what();
+		}
+	}
+}
+
+static void filter_run(sinsp_evt* evt, bool result, std::string filter_str)
+{
+	sinsp_filter *filter = NULL;
+	filter_compile(&filter, filter_str);
+	if (filter->run(evt) != result)
+	{
+		FAIL() << filter_str
+			<< " -> unexpected '"
+			<< (result ? "false" : "true") << "' result";
+	}
+	delete filter;
+}
+
+TEST(sinsp_filter_check, bcontains_bstartswith)
+{
+	// craft a fake read exit event containing the "hello" string
+	char scap_evt_err[2048];
+	uint8_t read_buf[] = {'h', 'e', 'l', 'l', 'o'};
+	uint8_t scap_evt_buf[2048];
+	size_t evt_size;
+	scap_sized_buffer scap_evt;
+	scap_evt.buf = (void*) &scap_evt_buf[0];
+	scap_evt.size = (size_t) sizeof(scap_evt_buf);
+	if (scap_event_encode_params(
+		scap_evt, &evt_size, scap_evt_err, PPME_SYSCALL_READ_X, 3, 0,
+		scap_const_sized_buffer{&read_buf[0],sizeof(read_buf)}) != SCAP_SUCCESS)
+	{
+		FAIL() << "could not create scap event";
+	}
+	sinsp_evt evt;
+	evt.init((uint8_t*) scap_evt.buf, 0); // 68656c6c6f
+
+	// test filters with bcontains
+	filter_compile(NULL, "evt.buffer bcontains");
+	filter_compile(NULL, "evt.buffer bcontains 2");
+	filter_compile(NULL, "evt.buffer bcontains 2g");
+	filter_run(&evt, true, "evt.buffer bcontains 68656c6c6f");
+	filter_run(&evt, true, "evt.buffer bcontains 656c6C");
+	filter_run(&evt, false, "evt.buffer bcontains 20");
+	filter_run(&evt, false, "evt.buffer bcontains 656c6cAA");
+
+	// test filters with bstartswith
+	filter_compile(NULL, "evt.buffer bstartswith");
+	filter_compile(NULL, "evt.buffer bstartswith 2");
+	filter_compile(NULL, "evt.buffer bstartswith 2g");
+	filter_run(&evt, true, "evt.buffer bstartswith 68");
+	filter_run(&evt, true, "evt.buffer bstartswith 68656c6c6f");
+	filter_run(&evt, false, "evt.buffer bstartswith 65");
+	filter_run(&evt, false, "evt.buffer bstartswith 656c6C");
+	filter_run(&evt, false, "evt.buffer bstartswith 20");
+	filter_run(&evt, false, "evt.buffer bstartswith 656c6cAA");
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR brings 3 contributions:
1. Fix a regression in filterchecks involving fields of type PT_BYTEBUF. After the recent refactorings of #201, the length of the right-hand bytebuf values was not passed-down in `sinsp_filter_check::compare`, which inherently ended up making all checks on bytebufs return true due to a `memcmp` being performed with length = 0.
2. Optimizes the performance of `bcontains` and `bstartswith` operators. Previously, the operator performed the hexstr <->  bytebuf conversion at each check, which is not performant and should instead be done at initialization time. Now, the hex string is converted to a bytebuf right at the filter compilation level
3. Add a first attempt of unit testing for filtercheck operators, starting with the `bcontains` operator (and `bstartswith`, since they are similar). We didn't have unit tests for filterchecks and operators so far, and perhaps the class designs involved are not much testable, but we can use this first attempt as a base to do more of these in the future.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
