### PR TITLE
fix(driver/bpf): catch pushed on frame data when `val=0`

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -845,7 +845,8 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		break;
 	}
 	case PT_BYTEBUF: {
-		if (val!=0 && val_len) {
+		if (data->curarg_already_on_frame || (val && val_len))  
+		{
 			len = val_len;
 
 			if (enforce_snaplen) {


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>
Co-authored-by: Jie Lin <jie.lin.fj@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-ebpf

**What this PR does / why we need it**:

First of all, I would thank @jie-lin for having spotted the following bug. This PR replace the #342  that now could be closed.

When a syscall has to manage a parameter of type `PT_BYTEBUF` that is already pushed on frame (`curarg_already_on_frame`) it usually calls the `__bpf_val_to_ring` function in this way: 

```     
data->curarg_already_on_frame = true;
res = __bpf_val_to_ring(data, 0, len, PT_BYTEBUF, -1, false);
```

The second parameter is `val`, so here `val=0`. If we check the `__bpf_val_to_ring` function we can notice that:

```
case PT_BYTEBUF: {
    if (val!=0 && val_len) 
    {
        ...
    }
    else
    {
        /*
         * Handle NULL pointers
         */
        len = 0;
    }
```

Since `val` is equal to `0` in this case we will take the `else` branch, and so we will set `len=0` thinking that `val=0` means an invalid kernel pointer. Setting `len` equal to `0` means pushing an empty parameter to userspace because we are unable to extract the correct parameter from the kernel. But this is not the case, the parameter is already in our auxiliary map, and we have only to set `len` equal to `val_len`. 

Please note that we have to follow the `if` branch since we have to apply the `snaplen` on the parameter if it is necessary.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(driver/bpf): catch pushed on frame data when `val=0`
```
