### PR TITLE
fix: move definitions to inner CMakeLists.txt(s) and correct add_user/add_group

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -5,6 +5,8 @@ if(ENABLE_PIC)
 	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
+# NOTE: do not add `add_definition` in this file because consumers project won't import it.
+
 if(CMAKE_SYSTEM_NAME MATCHES "SunOS")
 	set(CMD_MAKE gmake)
 else()
@@ -62,19 +64,6 @@ else() # MSVC
 	add_definitions(-DHAS_CAPTURE)
 
 endif()
-
-include(CheckIncludeFile)
-
-check_include_file("pwd.h" HAVE_PWD_H)
-if (HAVE_PWD_H)
-	add_definitions(-DHAVE_PWD_H)
-endif()
-
-check_include_file("grp.h" HAVE_GRP_H)
-if (HAVE_GRP_H)
-	add_definitions(-DHAVE_GRP_H)
-endif()
-
 
 if(APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -17,6 +17,15 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../common")
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
+if(NOT MSVC)
+	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+		add_definitions(-DHAS_CAPTURE)
+	endif()
+else() # MSVC
+	# todo(leogr): this should be removed - double check
+	add_definitions(-DHAS_CAPTURE)
+endif()
+
 include(ExternalProject)
 
 if(WIN32 OR NOT MINIMAL_BUILD)

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -21,6 +21,27 @@ include_directories(./include)
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
+if(NOT MSVC)
+	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+		add_definitions(-DHAS_CAPTURE)
+	endif()
+else() # MSVC
+	# todo(leogr): this should be removed - double check
+	add_definitions(-DHAS_CAPTURE)
+endif()
+
+include(CheckIncludeFile)
+
+check_include_file("pwd.h" HAVE_PWD_H)
+if (HAVE_PWD_H)
+	add_definitions(-DHAVE_PWD_H)
+endif()
+
+check_include_file("grp.h" HAVE_GRP_H)
+if (HAVE_GRP_H)
+	add_definitions(-DHAVE_GRP_H)
+endif()
+
 include(ExternalProject)
 
 if(NOT WIN32 AND NOT APPLE)

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1534,7 +1534,6 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 	}
 	ASSERT(parinfo->m_len == sizeof(int32_t));
 	tinfo->set_group(*(int32_t *)parinfo->m_val);
-	tinfo->m_user.gid = tinfo->m_group.gid;
 
 	//
 	// If we're in a container, vtid and vpid are

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -430,8 +430,8 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	ASSERT(m_inspector);
 	m_inspector->m_container_manager.resolve_container(this, !m_inspector->is_capture());
 
-	set_user(pi->uid);
 	set_group(pi->gid);
+	set_user(pi->uid);
 	set_loginuser((uint32_t)pi->loginuid);
 
 	//
@@ -537,6 +537,8 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 		m_group.gid = gid;
 		strcpy(m_group.name, "<NA>");
 	}
+	// Force-sync user.gid and group id
+	m_user.gid = m_group.gid;
 }
 
 void sinsp_threadinfo::set_loginuser(uint32_t loginuid)

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -149,10 +149,11 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 	if (!usr)
 	{
 #ifdef HAVE_PWD_H
+		struct passwd *p = nullptr;
 		if (container_id.empty() && !name)
 		{
 			// On Host, try to load info from db
-			auto *p = getpwuid(uid);
+			p = getpwuid(uid);
 			if (p)
 			{
 				name = p->pw_name;
@@ -217,10 +218,11 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 	if (!gr)
 	{
 #ifdef HAVE_GRP_H
+		struct group *p = nullptr;
 		if (container_id.empty() && !name)
 		{
 			// On Host, try to load info from db
-			auto *p = getgrgid(gid);
+			p = getgrgid(gid);
 			if (p)
 			{
 				name = p->gr_name;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -187,6 +187,8 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 		{
 			notify_user_changed(&userlist[uid], container_id);
 		}
+
+		usr = &userlist[uid];
 	}
 	return usr;
 }
@@ -243,6 +245,7 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 		{
 			notify_group_changed(&grplist[gid], container_id, true);
 		}
+		gr = &grplist[gid];
 	}
 	return gr;
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build
/area libsinsp


**What this PR does / why we need it**:

While testing the latest libs version on Falco, we noticed that user names were not correctly looked up. Digging into the problem, we discovered that a feature gate :point_down: was off when building Falco

https://github.com/falcosecurity/libs/blob/bd94f3189774e5298dd383bf913da7b3b620a94a/userspace/libsinsp/user.cpp#L151-L163

After a further investigation, we realized the root problem was that the `add_definition` was included in [CompilerFlags.cmake](https://github.com/falcosecurity/libs/blob/master/cmake/modules/CompilerFlags.cmake), which is not used by client projects (like Falco).

This PR moves relevant compiler definitions in cmake module files (intended to be used by client projects).

UPDATE:
We also found a bug in `add_user` and `add_group`. Fixed by https://github.com/falcosecurity/libs/pull/361/commits/7afbad4d4c720da210f044c7ee265437b71ac880

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

This hotfix is needed to release Falco 0.32

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
