### PR TITLE
fix: get_param_as_str for PT_ENUMFLAGS* fields

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2059,8 +2059,24 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	case PT_ENUMFLAGS16:
 	case PT_ENUMFLAGS32:
 		{
-			uint32_t val = (param_info->type == PT_FLAGS8) ? *(uint8_t *)payload :
-				(param_info->type == PT_FLAGS16) ? *(uint16_t *)payload : *(uint32_t *)payload;
+			uint32_t val = 0;
+			switch(param_info->type)
+			{
+			case PT_FLAGS8:
+			case PT_ENUMFLAGS8:
+				val = *(uint8_t *)payload;
+				break;
+			case PT_FLAGS16:
+			case PT_ENUMFLAGS16:
+				val = *(uint16_t *)payload;
+				break;
+			case PT_FLAGS32:
+			case PT_ENUMFLAGS32:
+				val = *(uint32_t *)payload;
+				break;
+			default:
+				ASSERT(false);
+			}
 			snprintf(&m_paramstr_storage[0],
 				     m_paramstr_storage.size(),
 				     "%" PRIu32, val);


### PR DESCRIPTION
Enum flags need to follow the same logic as bit flags,
i.e. cast the field value to the correct pointer type
before dereferencing.

Signed-off-by: Grzegorz Nosek <grzegorz.nosek@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Converting PT_ENUMFLAGS*  fields to strings treats all the fields as PT_ENUMFLAGS32 (i.e. takes 32 bits of the value). This breaks for fields smaller than 32 bits, since the high bits are undefined (and if we're unlucky enough, might point to unmapped memory).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
