### PR TITLE
wip: fix(userspace/libsinsp): actually immediately add synchronously spotted containers to list of containers

### DIFF
--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -60,7 +60,6 @@ bool bpm::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if(container_cache().should_lookup(container_info.m_id, CT_BPM))
 	{
 		container_info.m_name = container_info.m_id;
-		container_cache().add_container(std::make_shared<sinsp_container_info>(container_info), tinfo);
 		container_cache().notify_new_container(container_info, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/docker/base.h
+++ b/userspace/libsinsp/container_engine/docker/base.h
@@ -19,7 +19,7 @@ public:
 	void cleanup() override;
 
 protected:
-	void parse_docker(const docker_lookup_request& request, container_cache_interface *cache);
+	void parse_docker(sinsp_threadinfo *tinfo, const docker_lookup_request& request, container_cache_interface *cache);
 
 	bool resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& request,
 			  bool query_os_for_missing_info);

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -84,7 +84,6 @@ bool libvirt_lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_inf
 	if(container_cache().should_lookup(container.m_id, CT_LIBVIRT_LXC))
 	{
 		container.m_name = container.m_id;
-		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -63,7 +63,6 @@ bool lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if (container_cache().should_lookup(container.m_id, CT_LXC))
 	{
 		container.m_name = container.m_id;
-		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -61,7 +61,6 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_threadinfo* tinfo, bool qu
 	if(container_cache().should_lookup(container.m_id, CT_MESOS))
 	{
 		container.m_name = container.m_id;
-		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -189,7 +189,6 @@ bool rkt::rkt::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 
 	if (have_rkt)
 	{
-		cache->add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		cache->notify_new_container(container, tinfo);
 		return true;
 	}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -134,6 +134,11 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 	m_self_pid = getpid();
 #endif
 
+#ifdef _WIN32
+	m_self_pthread = GetCurrentThreadId();
+#else
+	m_self_pthread = pthread_self();
+#endif
 	uint32_t evlen = sizeof(scap_evt) + 2 * sizeof(uint16_t) + 2 * sizeof(uint64_t);
 	m_meinfo.m_piscapevt = (scap_evt*)new char[evlen];
 	m_meinfo.m_piscapevt->type = PPME_PROCINFO_E;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1265,6 +1265,12 @@ public:
 	int64_t m_self_pid;
 #endif
 
+#ifdef _WIN32
+	DWORD m_self_pthread;
+#else
+	pthread_t m_self_pthread;
+#endif
+
 	// Any thread with a comm in this set will not have its events
 	// returned in sinsp::next()
 	std::set<std::string> m_suppressed_comms;


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR addresses a behavioral change that happened in #231 : before, synchronous container engines were seeing their containers immediately stored in the list, therefore their info was suddenly available.
After, everything was async, pushing a container event and awaiting for the parser logic to add the new container.

This PR reverts to old behavior with a small plus: it adds immediately containers from async container engines (cri/docker/podman) when the informations are actually synchronously retrieved.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
