### PR TITLE
fix(userspace/libsinsp): immediately add synchronously spotted containers to list of containers

### DIFF
--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -60,6 +60,7 @@ bool bpm::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if(container_cache().should_lookup(container_info.m_id, CT_BPM))
 	{
 		container_info.m_name = container_info.m_id;
+		container_cache().add_container(std::make_shared<sinsp_container_info>(container_info), tinfo);
 		container_cache().notify_new_container(container_info, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -84,6 +84,7 @@ bool libvirt_lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_inf
 	if(container_cache().should_lookup(container.m_id, CT_LIBVIRT_LXC))
 	{
 		container.m_name = container.m_id;
+		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -63,6 +63,7 @@ bool lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if (container_cache().should_lookup(container.m_id, CT_LXC))
 	{
 		container.m_name = container.m_id;
+		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -61,6 +61,7 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_threadinfo* tinfo, bool qu
 	if(container_cache().should_lookup(container.m_id, CT_MESOS))
 	{
 		container.m_name = container.m_id;
+		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}
 	return true;

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -189,6 +189,7 @@ bool rkt::rkt::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 
 	if (have_rkt)
 	{
+		cache->add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		cache->notify_new_container(container, tinfo);
 		return true;
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR addresses a behavioral change that happened in https://github.com/falcosecurity/libs/pull/231 : before, synchronous container engines were seeing their containers immediately stored in the list, therefore their info was suddenly available.
After, everything was async, pushing a container event and awaiting for the parser logic to add the new container.

This PR reverts to old behavior.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

NOTE: this is a second shoot for #363; it is simpler and relies on existing code before #231.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
