### PR TITLE
fix(userspace/libsinsp): solve filter parser 'not' and position ambiguities

### DIFF
--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -31,7 +31,7 @@ limitations under the License.
 //     AndExprTail         ::= ' ' NotExpr
 //                             | '(' Expr ')'
 //     NotExpr             ::= ('not ')* NotExprTail
-//     NotExprTail         ::= 'not' '(' Expr ')'
+//     NotExprTail         ::= 'not(' Expr ')'
 //                             | Check
 //     Check               ::= CheckField CheckCondition
 //                             | Identifier

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -376,6 +376,10 @@ TEST(parser, parse_position_info)
 	EXPECT_EQ(pos.idx, 12);
 	EXPECT_EQ(pos.line, 3);
 	EXPECT_EQ(pos.col, 4);
+	test_accept("a \n and \n not \n b", &pos);
+	EXPECT_EQ(pos.idx, 17);
+	EXPECT_EQ(pos.line, 4);
+	EXPECT_EQ(pos.col, 3);
 }
 
 // complex test case with all supported node types

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -131,6 +131,17 @@ TEST(parser, parse_smoke_test)
 	test_accept("evt.dir=> and fd.name=*.log");
 	test_accept("a.g in (1, 'a', b.c)");
 	test_accept("a.b = a.a");
+	test_accept("a and notb");
+	test_accept("a or notb");
+	test_accept("notz and a and b");
+	test_accept("macro and not_macro");
+	test_accept("macro and not not_macro");
+	test_accept("macro and not(not_macro)");
+	test_accept("((macro) and (not_macro))");
+	test_accept("macro and and_macro");
+	test_accept("((macro) and (and_macro))");
+	test_accept("macro and or_macro");
+	test_accept("((macro) and (or_macro))");
 
 	// marked as bad in Falco smoke checks, but they should be good instead
 	test_accept("evt.arg[0] contains /bin");
@@ -159,11 +170,9 @@ TEST(parser, parse_smoke_test)
 	test_reject("anot b");
 	test_reject("a andnot b");
 	test_reject("a andnotb");
-	test_reject("a and notb");
 	test_reject("(a)andnot(b)");
 	test_reject("a ornot b");
 	test_reject("a ornotb");
-	test_reject("a or notb");
 	test_reject("(a)ornot(b)");
 	test_reject("evt.arg[] contains /bin");
 	test_reject("a.b = b = 1");
@@ -176,7 +185,6 @@ TEST(parser, parse_smoke_test)
 	test_reject("#a and b; a and b");
 	test_reject("#a and b; # ; ; a and b");
 	test_reject("evt.dir=> and fd.name=/var/lo);g/httpd.log");
-	test_reject("notz and a and b");
 }
 
 TEST(parser, parse_str)
@@ -421,5 +429,9 @@ TEST(parser, expr_multi_negation)
 			}),
 			new binary_check_expr("proc.name", "", "=", new value_expr("cat")),
 		})
+	);
+	test_equal_ast(
+		"not not not not not(not not(not not_macro))",
+		new not_expr(new not_expr(new value_expr("not_macro")))
 	);
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**What this PR does / why we need it**:

This PR fixes the bug firstly reported by @dnwe in https://github.com/falcosecurity/falco/issues/2028 (thank you so much for spotting this! 🙏🏼 ). The parser incorrectly processed the `not` operator token, preventing macros/identifiers starting with `not` from being properly parsed. On top of that, this PR also fixes and unifies the parser position info updating logic, which now is more consistent and works across multiple line breaks. Unit tests have been updated accordingly.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/2028

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
