### PR TITLE
bpf: fix build on some kernels

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -56,6 +56,7 @@ $(obj)/probe.o: $(src)/probe.c \
 		$(DEBUG) \
 		-D__KERNEL__ \
 		-D__BPF_TRACING__ \
+		-DKBUILD_MODNAME='"falcobpf"' \
 		-Wno-gnu-variable-sized-type-not-at-end \
 		-Wno-address-of-packed-member \
 		-fno-jump-tables \


### PR DESCRIPTION
Signed-off-by: Alban Crequy <albancrequy@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

/area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR makes the bpf code compile on kernel 5.13.0-1023-azure (Ubuntu 20.04.4 LTS)

On some new kernels, the bpf code does not compile because some kernel headers expect KBUILD_MODNAME to be defined.

Tested on Ubuntu 20.04.4 LTS with Linux 5.13.0-1023-azure.

Symptoms:

```
In file included from /.../sysdig/bpf/probe.c:22:
In file included from /.../sysdig/bpf/filler_helpers.h:13:
In file included from ./include/net/sock.h:59:
In file included from ./include/linux/filter.h:27:
In file included from ./include/net/sch_generic.h:21:
./include/net/flow_offload.h:324:4: error: use of undeclared identifier 'KBUILD_MODNAME'
                        NL_SET_ERR_MSG_MOD(extack, "Mixing HW stats types for actions is not supported");
                        ^
./include/linux/netlink.h:102:27: note: expanded from macro 'NL_SET_ERR_MSG_MOD'
        NL_SET_ERR_MSG((extack), KBUILD_MODNAME ": " msg)
```

Our BPF code does not use the functions using KBUILD_MODNAME, so it is safe to set it to an arbitrary value to make it compile.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
