### PR TITLE
fix(userspace/libsinsp): reduce mem allocs for filter comparisons

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1455,16 +1455,15 @@ bool sinsp_filter_check::compare(gen_event *evt)
 
 bool sinsp_filter_check::compare(sinsp_evt *evt)
 {
-	bool sanitize_strings = false;
-	vector<extract_value_t> extracted_values;
-	if(!extract_cached(evt, extracted_values, sanitize_strings))
+	m_extracted_values.clear();
+	if(!extract_cached(evt, m_extracted_values, false))
 	{
 		return false;
 	}
 
 	return flt_compare(m_cmpop,
 		m_info.m_fields[m_field_id].m_type,
-		extracted_values,
+		m_extracted_values,
 		m_val_storage_len);
 }
 

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -200,6 +200,7 @@ protected:
 	uint32_t m_field_id;
 	uint32_t m_th_state_id;
 	uint32_t m_val_storage_len;
+	std::vector<extract_value_t> m_extracted_values;
 
 private:
 	void set_inspector(sinsp* inspector);


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This should reduce the memory allocations when comparing filter checks.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
