### PR TITLE
fix(userspace/libsinsp): avoid string copy in plugin extraction

### DIFF
--- a/userspace/libsinsp/plugin_filtercheck.cpp
+++ b/userspace/libsinsp/plugin_filtercheck.cpp
@@ -205,27 +205,6 @@ bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, OUT vector<extract_value
 	}
 
 	values.clear();
-	switch(type)
-	{
-		case PT_CHARBUF:
-		{
-			if (m_res_str_storage.size() < efield.res_len)
-			{
-				m_res_str_storage.resize(efield.res_len);
-			}
-			break;
-		}
-		case PT_UINT64:
-		{
-			if (m_res_u64_storage.size() < efield.res_len)
-			{
-				m_res_u64_storage.resize(efield.res_len);
-			}
-			break;
-		}
-		default:
-			break;
-	}
 	for (uint32_t i = 0; i < efield.res_len; ++i)
 	{
 		extract_value_t res;
@@ -233,16 +212,14 @@ bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, OUT vector<extract_value
 		{
 			case PT_CHARBUF:
 			{
-				m_res_str_storage[i] = efield.res.str[i];
-				res.len = m_res_str_storage[i].size();
-				res.ptr = (uint8_t*) m_res_str_storage[i].c_str();
+				res.len = strlen(efield.res.str[i]);
+				res.ptr = (uint8_t*) efield.res.str[i];
 				break;
 			}
 			case PT_UINT64:
 			{
-				m_res_u64_storage[i] = efield.res.u64[i];
 				res.len = sizeof(uint64_t);
-				res.ptr = (uint8_t*) &m_res_u64_storage[i];
+				res.ptr = (uint8_t*) &efield.res.u64[i];
 				break;
 			}
 			default:

--- a/userspace/libsinsp/plugin_filtercheck.h
+++ b/userspace/libsinsp/plugin_filtercheck.h
@@ -58,8 +58,6 @@ private:
 	char* m_arg_key;
 	uint64_t m_arg_index;
 	bool m_arg_present;
-	std::vector<std::string> m_res_str_storage;
-	std::vector<uint64_t> m_res_u64_storage;
 	std::set<size_t>* m_compatible_sources = NULL;
 	std::shared_ptr<sinsp_plugin_cap_extraction> m_eplugin;
 


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR avoids an unnecessary string copy when performing field extraction in plugins. As per documentation, plugins are responsible of owning the memory returned during extraction, so it is unnecessary to store it internally in the filtercheck.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
