### PR TITLE
docs: update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,11 +30,25 @@
 
 > /area driver-kmod
 
-> /area driver-ebpf
+> /area driver-bpf
 
-> /area driver-modern_ebpf
+> /area driver-modern-bpf
 
-> /area driver-gvisor
+> /area libscap-engine-bpf
+
+> /area libscap-engine-gvisor
+
+> /area libscap-engine-kmod
+
+> /area libscap-engine-modern-bpf
+
+> /area libscap-engine-nodriver
+
+> /area libscap-engine-noop
+
+> /area libscap-engine-source-plugin
+
+> /area libscap-engine-udig
 
 > /area libscap
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,10 @@
 
 > /area driver-ebpf
 
+> /area driver-modern_ebpf
+
+> /area driver-gvisor
+
 > /area libscap
 
 > /area libsinsp
@@ -61,13 +65,15 @@ Fixes #
 **Does this PR introduce a user-facing change?**:
 
 <!--
-If no, just write "NONE" in the release-note block below.
+If no, you have to do nothing.
 If yes, a release note is required:
-Enter your extended release note in the block below.
+Delete `NONE` and enter your extended release note in the block below.
+Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
+For example: `fix: broken link`.
 If the PR requires additional action from users switching to the new release, prepend the string "action required:".
 For example, `action required: change the API interface of libscap`.
 -->
 
 ```release-note
-
+NONE
 ```


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

This PR updates the `PULL_REQUEST_TEMPLATE.md` with 2 new drivers: `gVisor` and `modern BPF probe`. Moreover, since many times the change proposed do not introduce a user-facing change, we can put `NONE` by default and change it only when it is necessary. Let me know what do you think about that :)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
