### PR TITLE
fix(driver): Remove __NR_socketcall check

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -194,21 +194,49 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_pause - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_GENERIC_E, PPME_GENERIC_X},
 #endif
 
-#ifndef __NR_socketcall
+#ifdef __NR_socket
 	[__NR_socket - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_NEVER_DROP | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X},
+#endif
+#ifdef __NR_bind
 	[__NR_bind - SYSCALL_TABLE_ID0] =                       {UF_USED | UF_NEVER_DROP, PPME_SOCKET_BIND_E,  PPME_SOCKET_BIND_X},
+#endif
+#ifdef __NR_connect
 	[__NR_connect - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X},
+#endif
+#ifdef __NR_listen
 	[__NR_listen - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X},
+#endif
+#ifdef __NR_accept
 	[__NR_accept - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_ACCEPT_5_E, PPME_SOCKET_ACCEPT_5_X},
+#endif
+#ifdef __NR_getsockname
 	[__NR_getsockname - SYSCALL_TABLE_ID0] =                {UF_USED | UF_ALWAYS_DROP, PPME_SOCKET_GETSOCKNAME_E, PPME_SOCKET_GETSOCKNAME_X},
+#endif
+#ifdef __NR_getpeername
 	[__NR_getpeername - SYSCALL_TABLE_ID0] =                {UF_USED | UF_ALWAYS_DROP, PPME_SOCKET_GETPEERNAME_E, PPME_SOCKET_GETPEERNAME_X},
+#endif
+#ifdef __NR_socketpair
 	[__NR_socketpair - SYSCALL_TABLE_ID0] =                 {UF_USED | UF_NEVER_DROP, PPME_SOCKET_SOCKETPAIR_E, PPME_SOCKET_SOCKETPAIR_X},
+#endif
+#ifdef __NR_sendto
 	[__NR_sendto - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SOCKET_SENDTO_E, PPME_SOCKET_SENDTO_X},
+#endif
+#ifdef __NR_recvfrom
 	[__NR_recvfrom - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SOCKET_RECVFROM_E, PPME_SOCKET_RECVFROM_X},
+#endif
+#ifdef __NR_shutdown
 	[__NR_shutdown - SYSCALL_TABLE_ID0] =                   {UF_USED, PPME_SOCKET_SHUTDOWN_E, PPME_SOCKET_SHUTDOWN_X},
+#endif
+#ifdef __NR_setsockopt
 	[__NR_setsockopt - SYSCALL_TABLE_ID0] =                 {UF_USED | UF_ALWAYS_DROP, PPME_SOCKET_SETSOCKOPT_E, PPME_SOCKET_SETSOCKOPT_X},
+#endif
+#ifdef __NR_getsockopt
 	[__NR_getsockopt - SYSCALL_TABLE_ID0] =                 {UF_USED, PPME_SOCKET_GETSOCKOPT_E, PPME_SOCKET_GETSOCKOPT_X},
+#endif
+#ifdef __NR_sendmsg
 	[__NR_sendmsg - SYSCALL_TABLE_ID0] =                    {UF_USED, PPME_SOCKET_SENDMSG_E, PPME_SOCKET_SENDMSG_X},
+#endif
+#ifdef __NR_accept4
 	[__NR_accept4 - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_SIMPLEDRIVER_KEEP, PPME_SOCKET_ACCEPT4_5_E, PPME_SOCKET_ACCEPT4_5_X},
 #endif
 
@@ -755,32 +783,62 @@ const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_syncfs - SYSCALL_TABLE_ID0] = PPM_SC_SYNCFS,
 #endif
 	[__NR_getdents64 - SYSCALL_TABLE_ID0] =  PPM_SC_GETDENTS64,
-#ifndef __NR_socketcall
 	/*
 	 * Non-multiplexed socket family
 	 */
+#ifdef __NR_socket
 	[__NR_socket - SYSCALL_TABLE_ID0] =  PPM_SC_SOCKET,
+#endif
+#ifdef __NR_bind
 	[__NR_bind - SYSCALL_TABLE_ID0] =	PPM_SC_BIND,
+#endif
+#ifdef __NR_connect
 	[__NR_connect - SYSCALL_TABLE_ID0] =  PPM_SC_CONNECT,
+#endif
+#ifdef __NR_listen
 	[__NR_listen - SYSCALL_TABLE_ID0] =  PPM_SC_LISTEN,
+#endif
+#ifdef __NR_accept
 	[__NR_accept - SYSCALL_TABLE_ID0] =  PPM_SC_ACCEPT,
+#endif
+#ifdef __NR_getsockname
 	[__NR_getsockname - SYSCALL_TABLE_ID0] = PPM_SC_GETSOCKNAME,
+#endif
+#ifdef __NR_getpeername
 	[__NR_getpeername - SYSCALL_TABLE_ID0] = PPM_SC_GETPEERNAME,
+#endif
+#ifdef __NR_socketpair
 	[__NR_socketpair - SYSCALL_TABLE_ID0] = PPM_SC_SOCKETPAIR,
-/* [__NR_send - SYSCALL_TABLE_ID0] =	PPM_SC_NR_SEND, */
+#endif
+#ifdef __NR_sendto
 	[__NR_sendto - SYSCALL_TABLE_ID0] =  PPM_SC_SENDTO,
+#endif
+/* [__NR_send - SYSCALL_TABLE_ID0] =	PPM_SC_NR_SEND, */
 /* [__NR_recv - SYSCALL_TABLE_ID0] =	PPM_SC_NR_RECV, */
+#ifdef __NR_recvfrom
 	[__NR_recvfrom - SYSCALL_TABLE_ID0] =  PPM_SC_RECVFROM,
+#endif
+#ifdef __NR_shutdown
 	[__NR_shutdown - SYSCALL_TABLE_ID0] =  PPM_SC_SHUTDOWN,
+#endif
+#ifdef __NR_setsockopt
 	[__NR_setsockopt - SYSCALL_TABLE_ID0] = PPM_SC_SETSOCKOPT,
+#endif
+#ifdef __NR_getsockopt
 	[__NR_getsockopt - SYSCALL_TABLE_ID0] = PPM_SC_GETSOCKOPT,
+#endif
+#ifdef __NR_sendmsg
 	[__NR_sendmsg - SYSCALL_TABLE_ID0] =  PPM_SC_SENDMSG,
+#endif
+#ifdef __NR_recvmsg
 	[__NR_recvmsg - SYSCALL_TABLE_ID0] =  PPM_SC_RECVMSG,
+#endif
+#ifdef __NR_accept4
 	[__NR_accept4 - SYSCALL_TABLE_ID0] =  PPM_SC_ACCEPT4,
-#else
+#endif
+#ifdef __NR_socketcall
 	[__NR_socketcall - SYSCALL_TABLE_ID0] = PPM_SC_SOCKETCALL,
 #endif
-
 
 #ifdef __NR_sendmmsg
 	[__NR_sendmmsg - SYSCALL_TABLE_ID0] =  PPM_SC_SENDMMSG,


### PR DESCRIPTION
Signed-off-by: Sumit Dubey <sumit.dubey2@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

/area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Both the socket family system calls, and __NR_socketcall are defined on ppc64le. So removed the __NR_socketcall check in syscall_table.c.

**Which issue(s) this PR fixes**:

Socket events not being reported by sinsp-example. https://github.com/falcosecurity/libs/issues/360 (Second comment from author).

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
No
<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
