### PR TITLE
refactor(userspace/libsinsp): remove unused check_id from events

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1490,7 +1490,6 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = true;
-	m_check_id = 0;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1504,7 +1503,6 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = true;
-	m_check_id = 0;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1517,7 +1515,6 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_ast = fltast;
 	m_ttable_only = ttable_only;
 	m_internal_parsing = false;
-	m_check_id = 0;
 }
 
 sinsp_filter_compiler::~sinsp_filter_compiler()
@@ -1527,11 +1524,6 @@ sinsp_filter_compiler::~sinsp_filter_compiler()
 	{
 		delete m_flt_ast;
 	}
-}
-
-void sinsp_filter_compiler::set_check_id(int32_t id)
-{
-	m_check_id = id;
 }
 
 sinsp_filter* sinsp_filter_compiler::compile()
@@ -1637,7 +1629,6 @@ void sinsp_filter_compiler::visit(libsinsp::filter::ast::unary_check_expr* e)
 	check->m_cmpop = str_to_cmpop(e->op);
 	check->m_boolop = m_last_boolop;
 	check->parse_field_name(field.c_str(), true, true);
-	check->set_check_id(m_check_id);
 }
 
 static void add_filtercheck_value(gen_event_filter_check *chk, size_t idx, const std::string& value)
@@ -1668,7 +1659,6 @@ void sinsp_filter_compiler::visit(libsinsp::filter::ast::binary_check_expr* e)
 	check->m_cmpop = str_to_cmpop(e->op);
 	check->m_boolop = m_last_boolop;
 	check->parse_field_name(field.c_str(), true, true);
-	check->set_check_id(m_check_id);
 
 	// Read the the the right-hand values of the filtercheck. 
 	// For list-related operators ('in', 'intersects', 'pmatch'), the vector

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -107,8 +107,6 @@ public:
 	*/
 	sinsp_filter* compile();
 
-	void set_check_id(int32_t id);
-
 private:
 	void visit(libsinsp::filter::ast::and_expr*) override;
 	void visit(libsinsp::filter::ast::or_expr*) override;
@@ -122,7 +120,6 @@ private:
 	std::string create_filtercheck_name(std::string& name, std::string& arg);
 	gen_event_filter_check* create_filtercheck(std::string& field);
 
-	int32_t m_check_id;
 	bool m_ttable_only;
 	bool m_internal_parsing;
 	bool m_expect_values;

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -31,34 +31,12 @@ gen_event::~gen_event()
 {
 }
 
-void gen_event::set_check_id(int32_t id)
-{
-	if (id) {
-		m_check_id = id;
-	}
-}
-
-int32_t gen_event::get_check_id() const
-{
-	return m_check_id;
-}
-
 gen_event_filter_check::gen_event_filter_check()
 {
 }
 
 gen_event_filter_check::~gen_event_filter_check()
 {
-}
-
-void gen_event_filter_check::set_check_id(int32_t id)
-{
-	m_check_id = id;
-}
-
-int32_t gen_event_filter_check::get_check_id()
-{
-	return m_check_id;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -102,9 +80,6 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 			{
 			case BO_NONE:
 				res = chk->compare(evt);
-				if (res) {
-					evt->set_check_id(chk->get_check_id());
-				}
 				break;
 			case BO_NOT:
 				res = !chk->compare(evt);
@@ -124,9 +99,6 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 					goto done;
 				}
 				res = chk->compare(evt);
-				if (res) {
-					evt->set_check_id(chk->get_check_id());
-				}
 				break;
 			case BO_AND:
 				if(!res)
@@ -134,9 +106,6 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 					goto done;
 				}
 				res = chk->compare(evt);
-				if (res) {
-					evt->set_check_id(chk->get_check_id());
-				}
 				break;
 			case BO_ORNOT:
 				if(res)
@@ -144,9 +113,6 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 					goto done;
 				}
 				res = !chk->compare(evt);
-				if (res) {
-					evt->set_check_id(chk->get_check_id());
-				}
 				break;
 			case BO_ANDNOT:
 				if(!res)
@@ -154,9 +120,6 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 					goto done;
 				}
 				res = !chk->compare(evt);
-				if (res) {
-					evt->set_check_id(chk->get_check_id());
-				}
 				break;
 			default:
 				ASSERT(false);

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -73,16 +73,6 @@ public:
 	gen_event();
 	virtual ~gen_event();
 
-	/*!
-	  \brief Set an opaque "check id", corresponding to the id of the last filtercheck that matched this event.
-	*/
-	void set_check_id(int32_t id);
-
-	/*!
-	  \brief Get the opaque "check id" (-1 if not set).
-	*/
-	int32_t get_check_id() const;
-
 	// Every event must expose a timestamp
 	virtual uint64_t get_ts() const = 0;
 
@@ -95,9 +85,6 @@ public:
 	  \brief Get the type of the event.
 	*/
 	virtual uint16_t get_type() const = 0;
-
-private:
-	int32_t m_check_id = 0;
 
 };
 
@@ -119,16 +106,6 @@ public:
 	virtual void add_filter_value(const char* str, uint32_t len, uint32_t i = 0 ) = 0;
 	virtual bool compare(gen_event *evt) = 0;
 	virtual bool extract(gen_event *evt, std::vector<extract_value_t>& values, bool sanitize_strings = true) = 0;
-
-	//
-	// Configure numeric id to be set on events that match this filter
-	//
-	void set_check_id(int32_t id);
-	virtual int32_t get_check_id();
-
-private:
-	int32_t m_check_id = 0;
-
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Since merging https://github.com/falcosecurity/falco/pull/2017, the `set_check_id` and `get_check_id` methods are not required in events anymore. The check id was an historically instrumental for Falco to figure out _which_ rule and filtercheck matched a given event. This is now not used anymore because the rule-event matching is a responsiblity of the Falco Engine exclusively. Removing this also saves the cost of many memory writes at each filtercheck evaluation.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```