### PR TITLE
refactor(userspace/libsinsp)!: split plugin creation and initialization phases

### DIFF
--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -56,7 +56,7 @@ public:
 
 	virtual ss_plugin_caps caps() const = 0;
 
-	virtual bool init(const char* config) = 0;
+	virtual bool init(const std::string &config, std::string &errstr) = 0;
 
 	virtual void destroy() = 0;
 
@@ -121,11 +121,10 @@ class sinsp_plugin: public sinsp_plugin_cap_sourcing, public sinsp_plugin_cap_ex
 {
 public:
 	// Create a plugin from the dynamic library at the provided
-	// path. On error, the shared_ptr will == NULL and errstr is
+	// path. On error, the shared_ptr will == nullptr and errstr is
 	// set with an error.
 	static std::shared_ptr<sinsp_plugin> create(
 		const std::string &filepath,
-		const std::string &config,
 		std::string &errstr);
 
 	// Return whether a filesystem object is loaded
@@ -139,7 +138,7 @@ public:
 	virtual ~sinsp_plugin();
 
 	/** Common API **/
-	virtual bool init(const char* config) override;
+	virtual bool init(const std::string &config, std::string &errstr) override;
 	virtual void destroy() override;
 	virtual std::string get_last_error() const override;
 	virtual const std::string &name() const override;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1697,10 +1697,10 @@ void sinsp::set_statsd_port(const uint16_t port)
 }
 
 
-std::shared_ptr<sinsp_plugin> sinsp::register_plugin(const std::string& filepath, const std::string& config)
+std::shared_ptr<sinsp_plugin> sinsp::register_plugin(const std::string& filepath)
 {
 	string errstr;
-	std::shared_ptr<sinsp_plugin> plugin = sinsp_plugin::create(filepath, config, errstr);
+	std::shared_ptr<sinsp_plugin> plugin = sinsp_plugin::create(filepath, errstr);
 	if (!plugin)
 	{
 		throw sinsp_exception("cannot load plugin " + filepath + ": " + errstr.c_str());

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -960,7 +960,7 @@ public:
 	// Create and register a plugin from a shared library pointed
 	// to by filepath, and add it to the inspector.
 	// The created sinsp_plugin is returned.
-	std::shared_ptr<sinsp_plugin> register_plugin(const std::string& filepath, const std::string& config);
+	std::shared_ptr<sinsp_plugin> register_plugin(const std::string& filepath);
 	const sinsp_plugin_manager* get_plugin_manager();
 	void set_input_plugin(const string& name, const string& params);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

So far, we initialized plugins right in the moment we create and register them through the inspector. The creation and initialization phases should not be tied together, otherwise we force consumers to initialize the plugin even if they are just interested in accessing the plugin static info (e.g. plugin name, init config schema, supported fields, etc). In the specific case of the init config schema, it should be possible to print it _before_ initializing the plugin in order to let it describe its initialization requirements (if present).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
