### PR TITLE
fix(userspace/libsinsp): define HAVE_PWD_H and HAVE_GRP_H on every non-windows system

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -25,21 +25,11 @@ if(NOT MSVC)
 	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 		add_definitions(-DHAS_CAPTURE)
 	endif()
+	add_definitions(-DHAVE_PWD_H)
+	add_definitions(-DHAVE_GRP_H)
 else() # MSVC
 	# todo(leogr): this should be removed - double check
 	add_definitions(-DHAS_CAPTURE)
-endif()
-
-include(CheckIncludeFile)
-
-check_include_file("pwd.h" HAVE_PWD_H)
-if (HAVE_PWD_H)
-	add_definitions(-DHAVE_PWD_H)
-endif()
-
-check_include_file("grp.h" HAVE_GRP_H)
-if (HAVE_GRP_H)
-	add_definitions(-DHAVE_GRP_H)
 endif()
 
 include(ExternalProject)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

`HAVE_PWD_H` and `HAVE_GRP_H` represent feature gates in libsinsp, which are expected to be compiled in any non-windows system. However, those definitions are added depending on the presence of an include file using CMake, which seems to be non-totally predictable in all systems. In case this section is now compiled, libsinsp fails to consistently fetch user data and extract fields such as `user.name`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
