### PR TITLE
Move CMAKE_THREAD_LIBS_INIT to after gtest when linking

### DIFF
--- a/userspace/libscap/test/CMakeLists.txt
+++ b/userspace/libscap/test/CMakeLists.txt
@@ -33,9 +33,9 @@ add_executable(unit-test-libscap ${LIBSCAP_UNIT_TESTS_SOURCES})
 find_package(Threads)
 
 target_link_libraries(unit-test-libscap
-	"${CMAKE_THREAD_LIBS_INIT}"
 	"${GTEST_LIB}"
 	"${GTEST_MAIN_LIB}"
+	"${CMAKE_THREAD_LIBS_INIT}"
 	scap
 )
 


### PR DESCRIPTION
Move CMAKE_THREAD_LIBS_INIT (e.g. the library found by the
find_package(Threads)) to after gtest so the unresolved pthread
symbols in gtest will be picked up.

The current version builds with the toolchain used by CI, but for
other toolchains, the difference matters.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

/area libscap

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
