### PR TITLE
fix(build): make codebase more robust to __STDC_FORMAT_MACROS definitions

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -45,6 +45,8 @@ if(NOT MSVC)
 		add_definitions(-DHAS_CAPTURE)
 	endif()
 
+	add_definitions(-D__STDC_FORMAT_MACROS)
+
 else() # MSVC
 	set(MINIMAL_BUILD ON)
 

--- a/userspace/chisel/chisel_fields_info.cpp
+++ b/userspace/chisel/chisel_fields_info.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 //
 // Various helper functions to render stuff on the screen
 //
-#define __STDC_FORMAT_MACROS
 #include <stdio.h>
 #include <iostream>
 #include <assert.h>

--- a/userspace/common/types.h
+++ b/userspace/common/types.h
@@ -20,7 +20,6 @@ limitations under the License.
 #define strcasecmp _stricmp
 #endif
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdbool.h>
 

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -35,7 +35,6 @@ limitations under the License.
 #include <arpa/inet.h>
 #include <errno.h>
 #else
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <unistd.h>
 #include <sys/param.h>

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include "sinsp_errno.h"
 
 #ifndef _WIN32
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <sys/socket.h>
 #include <algorithm>

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 #ifndef _WIN32
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <algorithm>
 #endif

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -18,8 +18,6 @@ limitations under the License.
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
-// This makes inttypes.h define PRIu32 (ISO C99 plus older g++ versions)
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <string.h>
 #include <vector>

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -54,8 +54,6 @@ limitations under the License.
 #include "sinsp_public.h"
 #include "sinsp_exception.h"
 
-#define __STDC_FORMAT_MACROS
-
 #include <string>
 #include <map>
 #include <queue>

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 #ifndef _WIN32
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <unistd.h>
 #endif

--- a/userspace/libsinsp/version.h
+++ b/userspace/libsinsp/version.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 #include <cstdio>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /*!


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area libscap

/area libsinsp

**What this PR does / why we need it**:

This PR fixes the compilation issues reported in #346 by implementing the approach suggested by @FedeDP. Instead of defining `__STDC_FORMAT_MACROS` in many parts of the codebase, it is now defined as a compiler flag within CMake for non-windows builds.

**Which issue(s) this PR fixes**:

Fixes #346

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
