### PR TITLE
new(libscap): gVisor sandboxes trace session set up with runsc 

### DIFF
--- a/userspace/libscap/engine/gvisor/CMakeLists.txt
+++ b/userspace/libscap/engine/gvisor/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(Threads)
 target_link_libraries(scap_engine_gvisor 
     ${CMAKE_THREAD_LIBS_INIT}
     ${PROTOBUF_LIB}
+    ${JSONCPP_LIB}
     scap
 )
 

--- a/userspace/libscap/engine/gvisor/CMakeLists.txt
+++ b/userspace/libscap/engine/gvisor/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(protobuf)
+include(jsoncpp)
 
-include_directories(${LIBSCAP_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${JSONCPP_INCLUDE})
 
 add_library(scap_engine_gvisor STATIC
     pkg/sentry/seccheck/points/syscall.pb.cc
@@ -10,6 +11,7 @@ add_library(scap_engine_gvisor STATIC
     parsers.cpp
     gvisor.cpp
     scap_gvisor.cpp
+    ${JSONCPP_LIB_SRC}
 )
 
 if(USE_BUNDLED_PROTOBUF)

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -48,7 +48,7 @@ static SCAP_HANDLE_T *gvisor_alloc_handle(scap_t* main_handle, char *lasterr_ptr
 static int32_t gvisor_init(scap_t* main_handle, scap_open_args* open_args)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
-	return gv->init(open_args->gvisor_socket);
+	return gv->init(open_args->gvisor_socket, open_args->gvisor_root_path, open_args->gvisor_trace_session_path);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -29,10 +29,6 @@ limitations under the License.
 
 namespace scap_gvisor {
 
-constexpr uint32_t min_supported_version = 1;
-constexpr uint32_t current_version = 1;
-constexpr size_t max_line_size = 2048;
-
 #pragma pack(push, 1)
 struct header
 {

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -50,7 +50,6 @@ struct parse_result {
     // pointers to each encoded event within the supplied output buffer
 	std::vector<scap_evt*> scap_events;
 };
-typedef struct parse_result parse_result;
 
 /*!
     \brief Translate a gVisor seccheck protobuf into one, or more, scap events

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -93,7 +93,7 @@ class engine {
 public:
     engine(char *lasterr);
     ~engine();
-    int32_t init(std::string socket_path);
+    int32_t init(std::string socket_path, std::string root_path, std::string trace_session_path);
     int32_t close();
 
     int32_t start_capture();
@@ -110,7 +110,7 @@ private:
 
     std::vector<std::string> runsc(char *argv[]);
     std::vector<std::string> runsc_list();
-    void runsc_trace_create(std::string &sandbox_id);
+    void runsc_trace_create(const std::string &sandbox_id, bool force);
 
     char *m_lasterr;
     int m_listenfd = 0;
@@ -131,7 +131,7 @@ private:
     std::vector<scap_threadinfo> m_threadinfos_threads;
     std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
     std::string m_root_path;
-	std::string m_podinit_path;
+    std::string m_trace_session_path;
 };
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -110,6 +110,7 @@ private:
 
     std::vector<std::string> runsc(char *argv[]);
     std::vector<std::string> runsc_list();
+    void runsc_trace_create(std::string &sandbox_id);
 
     char *m_lasterr;
     int m_listenfd = 0;

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -106,6 +106,7 @@ private:
     std::vector<std::string> runsc(char *argv[]);
     std::vector<std::string> runsc_list();
     void runsc_trace_create(const std::string &sandbox_id, bool force);
+    void runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id);
 
     char *m_lasterr;
     int m_listenfd = 0;

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -109,6 +109,7 @@ private:
     void free_sandbox_buffers();
 
     std::vector<std::string> runsc(char *argv[]);
+    std::vector<std::string> runsc_list();
 
     char *m_lasterr;
     int m_listenfd = 0;

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -29,6 +29,10 @@ limitations under the License.
 
 namespace scap_gvisor {
 
+constexpr uint32_t min_supported_version = 1;
+constexpr uint32_t current_version = 1;
+constexpr size_t max_line_size = 2048;
+
 #pragma pack(push, 1)
 struct header
 {
@@ -104,6 +108,8 @@ private:
     int32_t process_message_from_fd(int fd);
     void free_sandbox_buffers();
 
+    std::vector<std::string> runsc(char *argv[]);
+
     char *m_lasterr;
     int m_listenfd = 0;
     int m_epollfd = 0;
@@ -122,6 +128,8 @@ private:
     // when get_threadinfos() is called. They are only updated upon get_threadinfos()
     std::vector<scap_threadinfo> m_threadinfos_threads;
     std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
+    std::string m_root_path;
+	std::string m_podinit_path;
 };
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -103,10 +103,16 @@ private:
     int32_t process_message_from_fd(int fd);
     void free_sandbox_buffers();
 
-    std::vector<std::string> runsc(char *argv[]);
-    std::vector<std::string> runsc_list();
-    void runsc_trace_create(const std::string &sandbox_id, bool force);
-    void runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id);
+    struct runsc_result {
+        int error;
+        std::vector<std::string> output;
+    };
+
+    runsc_result runsc(char *argv[]);
+    runsc_result runsc_version();
+    runsc_result runsc_list();
+    runsc_result runsc_trace_create(const std::string &sandbox_id, bool force);
+    runsc_result runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id);
 
     char *m_lasterr;
     int m_listenfd = 0;

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -70,7 +70,7 @@ static void fill_context_data(scap_evt *evt, T& gvisor_evt)
 
 static parse_result parse_container_start(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret;
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -246,9 +246,9 @@ static parse_result parse_container_start(const char *proto, size_t proto_size, 
 	return ret;
 }
 
-static struct parse_result parse_execve(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_execve(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret;
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -326,9 +326,9 @@ static struct parse_result parse_execve(const char *proto, size_t proto_size, sc
 	return ret;
 }
 
-static struct parse_result parse_clone(const gvisor::syscall::Syscall &gvisor_evt, scap_sized_buffer scap_buf, bool is_fork)
+static parse_result parse_clone(const gvisor::syscall::Syscall &gvisor_evt, scap_sized_buffer scap_buf, bool is_fork)
 {
-	struct parse_result ret;
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -376,9 +376,9 @@ static struct parse_result parse_clone(const gvisor::syscall::Syscall &gvisor_ev
 	return ret;
 }
 
-static struct parse_result parse_sentry_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_sentry_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret;
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -430,9 +430,9 @@ static struct parse_result parse_sentry_clone(const char *proto, size_t proto_si
 	return ret;
 }
 
-static struct parse_result parse_read(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_read(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret = {0};
+	parse_result ret = {0};
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Read gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -469,9 +469,9 @@ static struct parse_result parse_read(const char *proto, size_t proto_size, scap
 	return ret;
 }
 
-static struct parse_result parse_connect(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_connect(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret = {0};
+	parse_result ret = {0};
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Connect gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -560,9 +560,9 @@ static struct parse_result parse_connect(const char *proto, size_t proto_size, s
 	return ret;
 }
 
-static struct parse_result parse_socket(const char *proto, size_t proto_size, scap_sized_buffer event_buf)
+static parse_result parse_socket(const char *proto, size_t proto_size, scap_sized_buffer event_buf)
 {
-	struct parse_result ret = {0};
+	parse_result ret = {0};
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Socket gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -594,7 +594,7 @@ static struct parse_result parse_socket(const char *proto, size_t proto_size, sc
 	return ret;
 }
 
-static struct parse_result parse_generic_syscall(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_generic_syscall(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
 	parse_result ret = {0};
 	gvisor::syscall::Syscall gvisor_evt;
@@ -622,7 +622,7 @@ static struct parse_result parse_generic_syscall(const char *proto, size_t proto
 }
 
 
-static struct parse_result parse_open(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
+static parse_result parse_open(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
 	parse_result ret = {0};
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -679,9 +679,9 @@ std::vector<Callback> dispatchers = {
 	parse_socket,
 };
 
-struct parse_result parse_gvisor_proto(struct scap_const_sized_buffer gvisor_buf, struct scap_sized_buffer scap_buf)
+parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_buffer scap_buf)
 {
-	struct parse_result ret = {0};
+	parse_result ret = {0};
 	const char *buf = static_cast<const char*>(gvisor_buf.buf);
 
 	const header *hdr = reinterpret_cast<const header *>(buf);

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -70,7 +70,7 @@ static void fill_context_data(scap_evt *evt, T& gvisor_evt)
 
 static parse_result parse_container_start(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret;
+	parse_result ret = {0};
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -248,7 +248,7 @@ static parse_result parse_container_start(const char *proto, size_t proto_size, 
 
 static parse_result parse_execve(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret;
+	parse_result ret = {0};
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -328,7 +328,7 @@ static parse_result parse_execve(const char *proto, size_t proto_size, scap_size
 
 static parse_result parse_clone(const gvisor::syscall::Syscall &gvisor_evt, scap_sized_buffer scap_buf, bool is_fork)
 {
-	parse_result ret;
+	parse_result ret = {0};
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -378,7 +378,7 @@ static parse_result parse_clone(const gvisor::syscall::Syscall &gvisor_evt, scap
 
 static parse_result parse_sentry_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret;
+	parse_result ret = {0};
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <sys/un.h>
 #include <sys/epoll.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 #include <vector>
 
@@ -395,6 +396,54 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 
 	// nothing to do
     return SCAP_TIMEOUT;
+}
+
+std::vector<std::string> runsc(char *argv[])
+{
+	std::vector<std::string> res;
+	int pipefds[2];
+
+	int ret = pipe(pipefds);
+	if(ret)
+	{
+		return res;
+	}
+
+	int pid = fork();
+	if(pid > 0)
+	{
+		char line[max_line_size];
+		int status;
+		
+		::close(pipefds[1]);
+		wait(&status);
+		if(status)
+		{
+			return res;
+		}
+
+		FILE *f = fdopen(pipefds[0], "r");
+		if(!f)
+		{
+			return res;
+		}
+
+		while(fgets(line, max_line_size, f))
+		{
+			res.emplace_back(std::string(line));
+		}
+
+		fclose(f);
+	}
+	else
+	{
+		::close(pipefds[0]);
+		dup2(pipefds[1], STDOUT_FILENO);
+		execvp("runsc", argv);
+		exit(1);
+	}
+
+	return res;
 }
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -279,6 +279,14 @@ int32_t engine::stop_capture()
 	shutdown(m_listenfd, 2);
 	::close(m_epollfd);
 	free_sandbox_buffers();
+
+	// todo(loresuso): change session name when gVisor will support it
+	std::vector<std::string> sandboxes = runsc_list();
+	for(const auto &sandbox : sandboxes)
+	{
+		runsc_trace_delete("Default", sandbox);
+	}	
+
 	m_capture_started = false;
     return SCAP_SUCCESS;
 }

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -42,6 +42,9 @@ constexpr uint32_t max_ready_sandboxes = 32;
 constexpr size_t max_message_size = 300 * 1024;
 constexpr size_t initial_event_buffer_size = 32;
 constexpr int listen_backlog_size = 128;
+constexpr size_t max_line_size = 2048;
+// todo(loresuso): change default to k8s path
+const std::string default_runsc_root_path = "/var/run/docker/runtime-runc/moby";
 
 sandbox_entry::sandbox_entry()
 {

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -43,8 +43,6 @@ constexpr size_t max_message_size = 300 * 1024;
 constexpr size_t initial_event_buffer_size = 32;
 constexpr int listen_backlog_size = 128;
 constexpr size_t max_line_size = 2048;
-// todo(loresuso): change default to k8s path
-const std::string default_runsc_root_path = "/var/run/docker/runtime-runc/moby";
 
 sandbox_entry::sandbox_entry()
 {
@@ -524,6 +522,23 @@ void engine::runsc_trace_create(const std::string &sandbox_id, bool force)
 		force ? "--force" : "",
 		"--config", 
 		m_trace_session_path.c_str(),
+		sandbox_id.c_str(),
+		NULL
+	};
+
+	runsc((char **)argv);
+}
+
+void engine::runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		m_root_path.c_str(),
+		"trace",
+		"delete",
+		"--name",
+		session_name.c_str(),
 		sandbox_id.c_str(),
 		NULL
 	};

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -456,7 +456,7 @@ std::vector<std::string> engine::runsc(char *argv[])
 		return res;
 	}
 
-	int pid = fork();
+	pid_t pid = vfork();
 	if(pid > 0)
 	{
 		char line[max_line_size];

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -472,4 +472,22 @@ std::vector<std::string> engine::runsc_list()
 	return sandboxes;
 }
 
+void engine::runsc_trace_create(std::string &sandbox_id)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		m_root_path.c_str(),
+		"trace",
+		"create",
+		"--force",
+		"--config", 
+		m_trace_session_path.c_str(),
+		sandbox_id.c_str(),
+		NULL
+	};
+
+	std::vector<std::string> output = runsc((char **)argv);
+}
+
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -505,7 +505,7 @@ engine::runsc_result engine::runsc(char *argv[])
 		
 		::close(pipefds[1]);
 		wait(&status);
-		if(status)
+		if(!WIFEXITED(status) || WEXITSTATUS(status) != 0)
 		{
 			res.error = status;
 			return res;

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -398,7 +398,7 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
     return SCAP_TIMEOUT;
 }
 
-std::vector<std::string> runsc(char *argv[])
+std::vector<std::string> engine::runsc(char *argv[])
 {
 	std::vector<std::string> res;
 	int pipefds[2];
@@ -444,6 +444,32 @@ std::vector<std::string> runsc(char *argv[])
 	}
 
 	return res;
+}
+
+std::vector<std::string> engine::runsc_list()
+{
+	std::vector<std::string> sandboxes;
+
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		m_root_path.c_str(),
+		"list",
+		NULL
+	};
+
+	std::vector<std::string> output = runsc((char **)argv);
+
+	for(auto &line : output)
+	{
+		if(line.find("running") != std::string::npos)
+		{
+			std::string sandbox = line.substr(0, line.find_first_of(" ", 0));
+			sandboxes.emplace_back(sandbox);
+		}
+	}
+
+	return sandboxes;
 }
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -27,6 +27,8 @@ limitations under the License.
 
 #include <vector>
 
+#include <json/json.h>
+
 #include "gvisor.h"
 #include "pkg/sentry/seccheck/points/common.pb.h"
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -471,6 +471,7 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *args)
 	*rc = handle->m_vtable->init(handle, args);
 	if(*rc != SCAP_SUCCESS)
 	{
+		snprintf(error, SCAP_LASTERR_SIZE, "%s", handle->m_lasterr);
 		scap_close(handle);
 		return NULL;
 	}

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -86,6 +86,8 @@ typedef struct scap_open_args
 	// values via scap_suppress_events_comm().
 	bool udig; ///< If true, UDIG will be used for event capture.
 	const char *gvisor_socket; ///< If not null, gvisor will be used for event capture.
+	const char *gvisor_root_path; ///< When using gvisor, the root path used by runsc commands
+	const char *gvisor_trace_session_path; ///< When using gvisor, the trace session config file
 
 	interesting_ppm_sc_set ppm_sc_of_interest;
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -530,6 +530,16 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 	{
 		oargs.gvisor_socket = m_gvisor_socket.c_str();
 	}
+	oargs.gvisor_root_path = NULL;
+	if(m_gvisor_root_path != "")
+	{
+		oargs.gvisor_root_path = m_gvisor_root_path.c_str();
+	}
+	oargs.gvisor_trace_session_path = NULL;
+	if(m_gvisor_trace_session_path != "")
+	{
+		oargs.gvisor_trace_session_path = m_gvisor_trace_session_path.c_str();
+	}
 
 	fill_syscalls_of_interest(&oargs);
 
@@ -589,9 +599,11 @@ void sinsp::open_udig(uint32_t timeout_ms)
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
 }
 
-void sinsp::open_gvisor(std::string socket_path, uint32_t timeout_ms)
+void sinsp::open_gvisor(std::string socket_path, std::string root_path, std::string trace_session_path, uint32_t timeout_ms)
 {
 	m_gvisor_socket = socket_path;
+	m_gvisor_root_path = root_path, 
+	m_gvisor_trace_session_path = trace_session_path;
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
 	set_get_procs_cpu_from_driver(false);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -249,7 +249,7 @@ public:
 	void fdopen(int fd);
 
 	void open_udig(uint32_t timeout_ms = SCAP_TIMEOUT_MS);
-	void open_gvisor(std::string socket_path, uint32_t timeout_ms = SCAP_TIMEOUT_MS);
+	void open_gvisor(std::string socket_path, std::string root_path, std::string trace_session_path, uint32_t timeout_ms = SCAP_TIMEOUT_MS);
 
 	void open_nodriver();
 
@@ -1058,6 +1058,8 @@ private:
 	bool m_bpf;
 	bool m_udig;
 	std::string m_gvisor_socket = "";
+	std::string m_gvisor_root_path = "";
+	std::string m_gvisor_trace_session_path = "";
 	bool m_is_windows;
 	std::string m_bpf_probe;
 	bool m_isdebug_enabled;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR introduces the code used to set up new trace sessions for gVisor sandboxes. It does so by leveraging the `runsc` command line tool, which is the standard way to interact with the gVisor runtime. It uses the newly introduced commands for listing sandboxes, and creating and deleting trace sessions. Libs consumers and Falco in particular will have an option to specify the configuration of a trace session. If no file will be specified, we are able to autogenerate it on the fly and unlink it from the filesystem when it will be no more needed. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
