### PR TITLE
Add ast as string

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 set(SINSP_SOURCES
 	filter/ast.cpp
+	filter/escaping.cpp
 	filter/parser.cpp
 	container.cpp
 	container_engine/container_engine_base.cpp

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -83,6 +83,35 @@ private:
 };
 
 /*!
+    \brief A visitor that builds a string as it traverses the
+    ast. Used to convert to strings.
+*/
+struct SINSP_PUBLIC string_visitor: public expr_visitor
+{
+public:
+	virtual ~string_visitor() = default;
+	virtual void visit(and_expr*) override;
+	virtual void visit(or_expr*) override;
+	virtual void visit(not_expr*) override;
+	virtual void visit(value_expr*) override;
+	virtual void visit(list_expr*) override;
+	virtual void visit(unary_check_expr*) override;
+	virtual void visit(binary_check_expr*) override;
+
+	const std::string& as_string();
+
+protected:
+
+	void visit_logical_op(const char *op, std::vector<expr*> &children);
+
+	// If true, the next call to vist(value_expr*) will escape the
+	// value. This occurs for any right hand side of a binary check.
+	bool escape_next_value = false;
+
+	std::string m_str;
+};
+
+/*!
     \brief Base interface of AST hierarchy
 */
 struct SINSP_PUBLIC expr
@@ -283,6 +312,12 @@ struct SINSP_PUBLIC binary_check_expr: expr
     std::string op;
     expr* value;
 };
+
+/*!
+	\brief Return a string representation of an AST.
+	\return A string representation of an AST.
+*/
+std::string as_string(ast::expr &e);
 
 /*!
 	\brief Creates a deep clone of a filter AST

--- a/userspace/libsinsp/filter/escaping.cpp
+++ b/userspace/libsinsp/filter/escaping.cpp
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "escaping.h"
+#include "sinsp_exception.h"
+
+namespace libsinsp {
+namespace filter {
+
+std::string escape_str(const std::string& str)
+{
+	std::string res = "";
+	size_t len = str.size();
+	bool should_escape = false;
+	for (size_t i = 0; i < len; i++)
+	{
+		switch(str[i])
+		{
+		case '\b':
+			should_escape = true;
+			res += "\\b";
+			break;
+		case '\f':
+			should_escape = true;
+			res += "\\f";
+			break;
+		case '\n':
+			should_escape = true;
+			res += "\\n";
+			break;
+		case '\r':
+			should_escape = true;
+			res += "\\r";
+			break;
+		case '\t':
+			should_escape = true;
+			res += "\\t";
+			break;
+		case ' ':
+			should_escape = true;
+			res += ' ';
+			break;
+		case '\\':
+			should_escape = true;
+			res += "\\\\";
+			break;
+		case '"':
+			should_escape = true;
+			res += "\\\"";
+			break;
+		case '\'':
+			should_escape = true;
+			res += "'";
+			break;
+		default:
+			res += str[i];
+		}
+	}
+
+	if(should_escape)
+	{
+		res = "\"" + res + "\"";
+	}
+
+	return res;
+}
+
+std::string unescape_str(const std::string& str)
+{
+	std::string res = "";
+	size_t len = str.size() - 1;
+	bool escaped = false;
+	for (size_t i = 1; i < len; i++)
+	{
+		if (!escaped)
+		{
+			if (str[i] == '\\')
+			{
+				escaped = true;
+			}
+			else
+			{
+				res += str[i];
+			}
+		}
+		else
+		{
+			switch(str[i])
+			{
+				case 'b':
+					res += '\b';
+					break;
+				case 'f':
+					res += '\f';
+					break;
+				case 'n':
+					res += '\n';
+					break;
+				case 'r':
+					res += '\r';
+					break;
+				case 't':
+					res += '\t';
+					break;
+				case ' ':
+					// NOTE: we may need to initially support this to not create breaking changes with
+					// some existing wrongly-escaped rules. So far, I only found one, in Falco:
+					// https://github.com/falcosecurity/falco/blob/204f9ff875be035e620ca1affdf374dd1c610a98/rules/falco_rules.yaml#L3046
+					// todo(jasondellaluce): remove this once rules are rewritten with correct escaping
+				case '\\':
+					res += '\\';
+					break;
+				case '/':
+					res += '/';
+					break;
+				case '"':
+					if (str[0] != str[i])
+					{
+						throw sinsp_exception("invalid \\\" escape in '-quoted string");
+					}
+					res += '\"';
+					break;
+				case '\'':
+					if (str[0] != str[i])
+					{
+						throw sinsp_exception("invalid \\' escape in \"-quoted string");
+					}
+					res += '\'';
+					break;
+				case 'x':
+					// todo(jasondellaluce): support hex num escaping (not needed for now)
+				default:
+					throw sinsp_exception("unsupported string escape sequence: \\" + std::string(1, str[i]));
+			}
+			escaped = false;
+		}
+	}
+	return res;
+}
+
+}
+}

--- a/userspace/libsinsp/filter/escaping.h
+++ b/userspace/libsinsp/filter/escaping.h
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <string>
+
+namespace libsinsp {
+namespace filter {
+
+/*!
+	\brief Methods to escape/unescape strings
+	\note Throws a sinsp_exception in case of parsing errors.
+	\return an escaped/unescaped verison of the string
+*/
+std::string escape_str(const std::string& str);
+std::string unescape_str(const std::string& str);
+
+
+}
+}

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -175,7 +175,6 @@ private:
 	void depth_push();
 	void depth_pop();
 	const char* cursor();
-	std::string escape_str(const std::string& str);
 	std::string trim_str(std::string str);
 
 	bool m_parse_partial;

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	token_bucket.ut.cpp
 	ppm_api_version.ut.cpp
 	plugin_manager.ut.cpp
+	string_visitor.ut.cpp
 	filter_parser.ut.cpp
 	filter_op_bcontains.ut.cpp
 	filter_compiler.ut.cpp

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	ppm_api_version.ut.cpp
 	plugin_manager.ut.cpp
 	string_visitor.ut.cpp
+	filter_escaping.ut.cpp
 	filter_parser.ut.cpp
 	filter_op_bcontains.ut.cpp
 	filter_compiler.ut.cpp

--- a/userspace/libsinsp/test/filter_escaping.ut.cpp
+++ b/userspace/libsinsp/test/filter_escaping.ut.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <filter/escaping.h>
+#include <gtest/gtest.h>
+
+using namespace libsinsp::filter;
+
+class filter_escaping_test : public testing::Test
+{
+protected:
+	void unidirectional(const std::string& in, const std::string& out)
+	{
+		ASSERT_STREQ(libsinsp::filter::escape_str(in).c_str(), out.c_str());
+	}
+
+	void bidirectional(const std::string& in)
+	{
+		ASSERT_STREQ(in.c_str(),
+			     libsinsp::filter::unescape_str(libsinsp::filter::escape_str(in)).c_str());
+	}
+};
+
+TEST_F(filter_escaping_test, spaces)
+{
+	std::string in = "some string";
+	std::string out = "\"some string\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(filter_escaping_test, spaces_bidirectional)
+{
+	std::string in = "some string";
+
+	bidirectional(in);
+}
+
+TEST_F(filter_escaping_test, ws_chars)
+{
+	std::string in = "some\\b\\f\\n\\r\\tstring";
+	std::string out = "\"some\\\\b\\\\f\\\\n\\\\r\\\\tstring\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(filter_escaping_test, ws_chars_bidirectional)
+{
+	std::string in = "some\\b\\f\\n\\r\\tstring";
+
+	bidirectional(in);
+}
+
+TEST_F(filter_escaping_test, double_quotes)
+{
+	std::string in = "some \"quoted string\"";
+	std::string out = "\"some \\\"quoted string\\\"\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(filter_escaping_test, double_quotes_bidirectional)
+{
+	std::string in = "some \"quoted string\"";
+
+	bidirectional(in);
+}
+
+TEST_F(filter_escaping_test, single_quotes)
+{
+	std::string in = "some 'quoted string'";
+	std::string out = "\"some 'quoted string'\"";
+
+	unidirectional(in, out);
+}
+
+// Since this quoting is not truly reversible, this test simply
+// ensures that the unescaping can be done, although it results in a
+// different string than the original.
+
+TEST_F(filter_escaping_test, single_quotes_bidirectional)
+{
+	std::string in = "some 'quoted string'";
+	std::string out = "some 'quoted string'";
+
+	ASSERT_STREQ(out.c_str(),
+		     libsinsp::filter::unescape_str(libsinsp::filter::escape_str(in)).c_str());
+}

--- a/userspace/libsinsp/test/string_visitor.ut.cpp
+++ b/userspace/libsinsp/test/string_visitor.ut.cpp
@@ -1,0 +1,298 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <filter/parser.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace std;
+using namespace libsinsp::filter;
+using namespace libsinsp::filter::ast;
+
+class string_visitor_test : public testing::Test
+{
+protected:
+
+	// In and out are different to test minor things like
+	// consistent spacing between fields and values, top-level
+	// parentheses, etc.
+	void unidirectional(const std::string& in, const std::string& out)
+	{
+		parser parser(in);
+
+		std::unique_ptr<ast::expr> e(parser.parse());
+
+		ASSERT_STREQ(as_string(*(e.get())).c_str(), out.c_str());
+	}
+
+	void bidirectional(const std::string &filter)
+	{
+		std::unique_ptr<ast::expr> e1(parser(filter).parse());
+		std::unique_ptr<ast::expr> e2(parser(as_string(*(e1.get()))).parse());
+		ASSERT_TRUE(e1->is_equal(e2.get()));
+	}
+
+	std::string complex_filter =
+		"("
+		"	(evt.type = open or evt.type = openat)"
+		"	and evt.is_open_write = true"
+		"	and fd.typechar = f"
+		"	and fd.num >= 0"
+		")"
+		"and ("
+		"	fd.filename in ("
+		"		.bashrc, .bash_profile, .bash_history, .bash_login,"
+		"		.bash_logout, .inputrc, .profile, .cshrc, .login, .logout,"
+		"		.history, .tcshrc, .cshdirs, .zshenv, .zprofile, .zshrc,"
+		"		.zlogin, .zlogout"
+		"	)"
+		"	or fd.name in (/etc/profile, /etc/bashrc, /etc/csh.cshrc, /etc/csh.login)"
+		"	or fd.directory in (/etc/zsh)"
+		")"
+		"and not proc.name in (ash, bash, csh, ksh, sh, tcsh, zsh, dash)"
+		"and not ("
+		"	proc.name = exe"
+		"	and (proc.cmdline contains \"/var/lib/docker\" or proc.cmdline contains '/var/run/docker')"
+		"	and proc.pname in (dockerd, docker, dockerd-current, docker-current)"
+		")";
+
+};
+
+TEST_F(string_visitor_test, and_expr)
+{
+	std::string in = "proc.name=nginx and fd.name=/etc/passwd";
+	std::string out = "(proc.name = nginx and fd.name = /etc/passwd)";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, and_expr_bidirectional)
+{
+	std::string in = "proc.name=nginx and fd.name=/etc/passwd";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, or_expr)
+{
+	std::string in = "proc.name=nginx or fd.name=/etc/passwd";
+	std::string out = "(proc.name = nginx or fd.name = /etc/passwd)";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, or_expr_bidirectional)
+{
+	std::string in = "proc.name=nginx or fd.name=/etc/passwd";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, not_expr)
+{
+	std::string in = "not proc.name=nginx";
+	std::string out = "not proc.name = nginx";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, not_expr_bidirectional)
+{
+	std::string in = "not proc.name=nginx";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, list_expr)
+{
+	std::string in = "proc.name in (nginx, apache)";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, list_expr_bidirectional)
+{
+	std::string in = "proc.name in (nginx, apache)";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, list_expr_escaped)
+{
+	std::string in = "proc.name in (\"some proc\", apache)";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, list_expr_escaped_bidirectional)
+{
+	std::string in = "proc.name in (\"some proc\", apache)";
+
+	bidirectional(in);
+}
+
+// No unidirectional version of this test--the single quoted string
+// ends up being escaped with double quotes.
+TEST_F(string_visitor_test, list_expr_escaped_bidirectional_single_quote)
+{
+	std::string in = "proc.name in ('some proc', apache)";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, check_args)
+{
+	std::string in = "proc.aname[1] != nginx";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, check_args_bidirectional)
+{
+	std::string in = "proc.aname[1] != nginx";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, check_args_escaped)
+{
+	std::string in = "proc.aname[\"some proc\"] != nginx";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, check_args_escaped_bidirectional)
+{
+	std::string in = "proc.aname[\"some proc\"] != nginx";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, binary_check)
+{
+	std::string in = "proc.name=nginx";
+	std::string out = "proc.name = nginx";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, binary_check_bidirectional)
+{
+	std::string in = "proc.name=nginx";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, binary_check_escaped)
+{
+	std::string in = "proc.name=\"some proc\"";
+	std::string out = "proc.name = \"some proc\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, binary_check_escaped_bidirectional)
+{
+	std::string in = "proc.name=\"some proc\"";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, binary_check_escaped_single_quote)
+{
+	std::string in = "proc.name='some proc'";
+	std::string out = "proc.name = \"some proc\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, binary_check_escaped_nested_quotes)
+{
+	std::string in = "proc.name=\"some 'proc'\"";
+	std::string out = "proc.name = \"some 'proc'\"";
+
+	unidirectional(in, out);
+}
+
+TEST_F(string_visitor_test, unary_check)
+{
+	std::string in = "proc.name exists";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, unary_check_bidirectional)
+{
+	std::string in = "proc.name exists";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, unary_check_arg)
+{
+	std::string in = "proc.aname[1] exists";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, unary_check_arg_bidirectional)
+{
+	std::string in = "proc.aname[1] exists";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, unary_check_arg_escaped)
+{
+	std::string in = "proc.aname[\"some proc\"] exists";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, unary_check_arg_escaped_bidirectional)
+{
+	std::string in = "proc.aname[\"some proc\"] exists";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, macro_reference)
+{
+	std::string in = "(some_macro and proc.name = nginx)";
+
+	unidirectional(in, in);
+}
+
+TEST_F(string_visitor_test, macro_reference_bidirectional)
+{
+	std::string in = "some_macro and proc.name = nginx";
+
+	bidirectional(in);
+}
+
+TEST_F(string_visitor_test, complex)
+{
+	std::string out = "(((evt.type = open or evt.type = openat) and evt.is_open_write = true and fd.typechar = f and fd.num >= 0) and (fd.filename in (.bashrc, .bash_profile, .bash_history, .bash_login, .bash_logout, .inputrc, .profile, .cshrc, .login, .logout, .history, .tcshrc, .cshdirs, .zshenv, .zprofile, .zshrc, .zlogin, .zlogout) or fd.name in (/etc/profile, /etc/bashrc, /etc/csh.cshrc, /etc/csh.login) or fd.directory in (/etc/zsh)) and not proc.name in (ash, bash, csh, ksh, sh, tcsh, zsh, dash) and not (proc.name = exe and (proc.cmdline contains /var/lib/docker or proc.cmdline contains /var/run/docker) and proc.pname in (dockerd, docker, dockerd-current, docker-current)))";
+
+	unidirectional(complex_filter, out);
+}
+
+TEST_F(string_visitor_test, complex_bidirectional)
+{
+	bidirectional(complex_filter);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Add the ability to print an AST as a string. This is useful in code that works with ASTs that wants to include the string representation in log messages/return values.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
