### PR TITLE
fix(libscap): bpf probe was not correctly loaded

### DIFF
--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -167,7 +167,9 @@ int main()
 			&new_mask);
 	*/
 
-	scap_t* h = scap_open_live(error, &ret);
+	scap_open_args args = {.mode = SCAP_MODE_LIVE};
+
+	scap_t* h = scap_open(args, error, &ret);
 	if(h == NULL)
 	{
 		fprintf(stderr, "%s (%d)\n", error, ret);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -661,11 +661,6 @@ scap_t* scap_open_offline_fd(int fd, char *error, int32_t *rc)
 	return scap_open_offline_int(reader, error, rc, NULL, NULL, true, 0, NULL);
 }
 
-scap_t* scap_open_live(char *error, int32_t *rc)
-{
-	return scap_open_live_int(error, rc, NULL, NULL, true, NULL, NULL, NULL);
-}
-
 scap_t* scap_open_nodriver_int(char *error, int32_t *rc,
 			       proc_entry_callback proc_callback,
 			       void* proc_callback_context,
@@ -784,7 +779,7 @@ scap_t* scap_open_nodriver_int(char *error, int32_t *rc,
 	if((*rc = scap_proc_scan_proc_dir(handle, filename, proc_scan_err)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
-		snprintf(error, SCAP_LASTERR_SIZE, "scap_open_live() error creating the process list: %s. Make sure you have root credentials.", proc_scan_err);
+		snprintf(error, SCAP_LASTERR_SIZE, "error creating the process list: %s. Make sure you have root credentials.", proc_scan_err);
 		return NULL;
 	}
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -122,7 +122,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	char filename[SCAP_MAX_PATH_SIZE];
 	scap_t* handle = NULL;
 
-	scap_open_args oargs;
+	scap_open_args oargs = {0};
 	oargs.proc_callback = proc_callback;
 	oargs.proc_callback_context = proc_callback_context;
 	oargs.import_users = import_users;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -128,7 +128,19 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	oargs.import_users = import_users;
 	oargs.bpf_probe = bpf_probe;
 	memcpy(&oargs.suppressed_comms, suppressed_comms, sizeof(*suppressed_comms));
-	memcpy(&oargs.ppm_sc_of_interest, ppm_sc_of_interest, sizeof(*ppm_sc_of_interest));
+
+	if(!ppm_sc_of_interest)
+	{
+		/* Fallback: set all syscalls as interesting. */
+		for(int j = 0; j < PPM_SC_MAX; j++)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[j] = 1;
+		}
+	} 
+	else 
+	{
+		memcpy(&oargs.ppm_sc_of_interest, ppm_sc_of_interest, sizeof(*ppm_sc_of_interest));
+	}
 
 	//
 	// Allocate the handle

--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -1,7 +1,6 @@
 LIBRARY scap
 
 EXPORTS
-		scap_open_live
 		scap_open_offline
 		scap_open_offline_fd
 		scap_open

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -105,7 +105,7 @@ struct iovec;
 #define SCAP_NOT_SUPPORTED 9
 
 //
-// Last error string size for scap_open_live()
+// Last error string size for `scap_open...` methods.
 //
 #define SCAP_LASTERR_SIZE 256
 
@@ -552,22 +552,6 @@ void udig_free_ring_descriptors(uint8_t* addr);
 ///////////////////////////////////////////////////////////////////////////////
 // API functions
 ///////////////////////////////////////////////////////////////////////////////
-
-/** @defgroup scap_functs API Functions
- *  @{
- */
-
-/*!
-  \brief Start a live event capture.
-
-  \param error Pointer to a buffer that will contain the error string in case the
-    function fails. The buffer must have size SCAP_LASTERR_SIZE.
-  \param rc Integer pointer that will contain the scap return code in case the
-    function fails.
-
-  \return The capture instance handle in case of success. NULL in case of failure.
-*/
-scap_t* scap_open_live(char *error, int32_t *rc);
 
 /*!
   \brief Start an event capture from file.

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -553,6 +553,10 @@ void udig_free_ring_descriptors(uint8_t* addr);
 // API functions
 ///////////////////////////////////////////////////////////////////////////////
 
+/** @defgroup scap_functs API Functions
+ *  @{
+ */
+
 /*!
   \brief Start an event capture from file.
 

--- a/userspace/libscap/scap_engine_util.c
+++ b/userspace/libscap/scap_engine_util.c
@@ -25,34 +25,24 @@ limitations under the License.
 #include "driver_config.h"
 #endif
 
+/* `ppm_sc_of_interest` is never `NULL`, we check it before calling this method. */
 void fill_syscalls_of_interest(interesting_ppm_sc_set *ppm_sc_of_interest, bool (*syscalls_of_interest)[SYSCALL_TABLE_SIZE])
 {
-	if (ppm_sc_of_interest)
+	for (int i = 0; i < PPM_SC_MAX; i++)
 	{
-		for (int i = 0; i < PPM_SC_MAX; i++)
+		// We need to convert from PPM_SC to SYSCALL_NR, using the routing table
+		for(int syscall_nr = 0; syscall_nr < SYSCALL_TABLE_SIZE; syscall_nr++)
 		{
-			// We need to convert from PPM_SC to SYSCALL_NR, using the routing table
-			for(int syscall_nr = 0; syscall_nr < SYSCALL_TABLE_SIZE; syscall_nr++)
+			// Find the match between the ppm_sc and the syscall_nr
+			if(g_syscall_code_routing_table[syscall_nr] == i)
 			{
-				// Find the match between the ppm_sc and the syscall_nr
-				if(g_syscall_code_routing_table[syscall_nr] == i)
+				// UF_NEVER_DROP syscalls must be always traced
+				if (ppm_sc_of_interest->ppm_sc[i] || g_syscall_table[syscall_nr].flags & UF_NEVER_DROP)
 				{
-					// UF_NEVER_DROP syscalls must be always traced
-					if (ppm_sc_of_interest->ppm_sc[i] || g_syscall_table[syscall_nr].flags & UF_NEVER_DROP)
-					{
-						(*syscalls_of_interest)[syscall_nr] = true;
-					}
-					// DO NOT break as some PPM_SC are used multiple times for different syscalls! (eg: PPM_SC_SETRESUID...)
+					(*syscalls_of_interest)[syscall_nr] = true;
 				}
+				// DO NOT break as some PPM_SC are used multiple times for different syscalls! (eg: PPM_SC_SETRESUID...)
 			}
-		}
-	}
-	else
-	{
-		// fallback to trace all syscalls
-		for (int i = 0; i < SYSCALL_TABLE_SIZE; i++)
-		{
-			(*syscalls_of_interest[i]) = true;
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

This solves 3 important issues:

* fix: if we don't initialize the `scap_open_args` at the beginning of  `scap_open_live_int()` we risk to use junk data. For example, I've spotted a bug due to the `udig` bool inside `scap_open_args`. If we don't set it to `false` at the beginning it could cause issues [here](https://github.com/falcosecurity/libs/blob/b3588963c3ed1a412028e69354ab1e322ab6cf16/userspace/libscap/engine/bpf/scap_bpf.c#L127) so the probe won't be correctly loaded.
* fix: check that `ppm_sc_of_interest` is not a NULL pointer when passed to `scap_open_live_int`. This causes problem when we use the `scap_open_live` function, see the next point.
* cleanup: remove unused and dangerous function `scap_open_live` from the codebase

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: correctly load the bpf probe when required
```
