### PR TITLE
Lookup retry on asynchronous container engines

### DIFF
--- a/userspace/libsinsp/async/async_key_value_source.h
+++ b/userspace/libsinsp/async/async_key_value_source.h
@@ -217,10 +217,11 @@ protected:
 	 * Dequeues an entry from the request queue and returns it in the given
 	 * key.  Concrete subclasses will call this method to get the next key
 	 * for which to collect values.
+	 * Get also the associated value by providing @p value_ptr
 	 *
 	 * @returns true if there was a key to dequeue, false otherwise.
 	 */
-	bool dequeue_next_key(key_type& key);
+	bool dequeue_next_key(key_type& key, value_type* value_ptr = nullptr);
 
 	/**
 	 * Get the (potentially partial) value for the given key.

--- a/userspace/libsinsp/async/async_key_value_source.tpp
+++ b/userspace/libsinsp/async/async_key_value_source.tpp
@@ -251,7 +251,7 @@ bool async_key_value_source<key_type, value_type>::lookup(
 }
 
 template<typename key_type, typename value_type>
-bool async_key_value_source<key_type, value_type>::dequeue_next_key(key_type& key)
+bool async_key_value_source<key_type, value_type>::dequeue_next_key(key_type& key, value_type* value_ptr)
 {
 	std::lock_guard<std::mutex> guard(m_mutex);
 	bool key_found = false;
@@ -265,6 +265,11 @@ bool async_key_value_source<key_type, value_type>::dequeue_next_key(key_type& ke
 			key = std::move(top_element.second);
 			m_request_queue.pop();
 			m_request_set.erase(key);
+
+			if(value_ptr)
+			{
+				*value_ptr = m_value_map[key].m_value;
+			}
 		}
 	}
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -169,7 +169,7 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["imagedigest"] = container_info.m_imagedigest;
 	container["privileged"] = container_info.m_privileged;
 	container["is_pod_sandbox"] = container_info.m_is_pod_sandbox;
-	container["lookup_state"] = static_cast<int>(container_info.m_lookup_state);
+	container["lookup_state"] = static_cast<int>(container_info.get_lookup_status());
 	container["created_time"] = static_cast<Json::Value::Int64>(container_info.m_created_time);
 
 	Json::Value mounts = Json::arrayValue;
@@ -298,7 +298,8 @@ sinsp_container_manager::map_ptr_t sinsp_container_manager::get_containers() con
 
 void sinsp_container_manager::add_container(const sinsp_container_info::ptr_t& container_info, sinsp_threadinfo *thread)
 {
-	set_lookup_status(container_info->m_id, container_info->m_type, container_info->m_lookup_state);
+	set_lookup_status(container_info->m_id, container_info->m_type, container_info->get_lookup_status());
+
 	{
 		auto containers = m_containers.lock();
 		(*containers)[container_info->m_id] = container_info;

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -694,13 +694,6 @@ void sinsp_container_manager::set_cri_async(bool async)
 #endif
 }
 
-void sinsp_container_manager::set_cri_delay(uint64_t delay_ms)
-{
-#if !defined(MINIMAL_BUILD) && defined(HAS_CAPTURE)
-	libsinsp::container_engine::cri::set_cri_delay(delay_ms);
-#endif
-}
-
 void sinsp_container_manager::set_container_labels_max_len(uint32_t max_label_len)
 {
 	sinsp_container_info::m_container_label_max_length = max_label_len;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -156,7 +156,6 @@ public:
 	void add_cri_socket_path(const std::string &path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
-	void set_cri_delay(uint64_t delay_ms);
 	void set_container_labels_max_len(uint32_t max_label_len);
 	sinsp* get_inspector() { return m_inspector; }
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -171,7 +171,7 @@ public:
 	 * state of the lookup via this method and call should_lookup() before
 	 * starting a new lookup.
 	 */
-	void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup_state state) override
+	void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup::state state) override
 	{
 		m_lookups[container_id][ctype] = state;
 	}
@@ -206,7 +206,7 @@ private:
 
 	sinsp* m_inspector;
 	libsinsp::Mutex<std::unordered_map<std::string, std::shared_ptr<const sinsp_container_info>>> m_containers;
-	std::unordered_map<std::string, std::unordered_map<sinsp_container_type, sinsp_container_lookup_state>> m_lookups;
+	std::unordered_map<std::string, std::unordered_map<sinsp_container_type, sinsp_container_lookup::state>> m_lookups;
 	uint64_t m_last_flush_time_ns;
 	std::list<new_container_cb> m_new_callbacks;
 	std::list<remove_container_cb> m_remove_callbacks;

--- a/userspace/libsinsp/container_engine/container_async_source.h
+++ b/userspace/libsinsp/container_engine/container_async_source.h
@@ -1,0 +1,72 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "async/async_key_value_source.h"
+#include "container_info.h"
+#include <chrono>
+
+namespace libsinsp
+{
+namespace container_engine
+{
+
+class container_cache_interface;
+
+/**
+ * Asynchronous metadata lookup base class.
+ *
+ * @tparam key_type lookup key
+ */
+template<typename key_type>
+class container_async_source : public libsinsp::async_key_value_source<key_type, sinsp_container_info>
+{
+	using parent_type = libsinsp::async_key_value_source<key_type, sinsp_container_info>;
+	using callback_handler = typename parent_type::callback_handler;
+
+public:
+	container_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface* cache);
+	virtual ~container_async_source() {}
+
+	/// convenience method with default callback
+	bool lookup(const key_type& key,
+		    sinsp_container_info& value,
+		    const callback_handler& handler = callback_handler());
+
+	bool lookup_sync(const key_type& key, sinsp_container_info& value);
+
+	void source_callback(const key_type& key, const sinsp_container_info& res);
+
+protected:
+	virtual const char* name() const = 0;
+
+	virtual bool parse(const key_type& key, sinsp_container_info& value) = 0;
+
+	virtual sinsp_container_type container_type(const key_type& key) const = 0;
+	virtual std::string container_id(const key_type& key) const = 0;
+
+	container_cache_interface* m_cache;
+
+private:
+	void run_impl() override;
+};
+
+} // namespace container_engine
+} // namespace libsinsp
+
+#include "container_async_source.tpp"

--- a/userspace/libsinsp/container_engine/container_async_source.tpp
+++ b/userspace/libsinsp/container_engine/container_async_source.tpp
@@ -111,10 +111,14 @@ void container_async_source<key_type>::run_impl()
 
 		if(res.m_lookup.should_retry())
 		{
+			res.m_lookup.attempt_increment();
+
 			g_logger.format(sinsp_logger::SEV_DEBUG,
-					"%s_async (%s): lookup retry scheduled",
+					"%s_async (%s): lookup retry no. %d",
 					name(),
-					container_id(key).c_str());
+					container_id(key).c_str(),
+					res.m_lookup.retry_no());
+
 			this->lookup_delayed(
 				key,
 				res,

--- a/userspace/libsinsp/container_engine/container_async_source.tpp
+++ b/userspace/libsinsp/container_engine/container_async_source.tpp
@@ -1,0 +1,124 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "logger.h"
+
+#include "container_engine/container_cache_interface.h"
+
+namespace libsinsp
+{
+
+namespace container_engine
+{
+
+template<typename key_type>
+container_async_source<key_type>::container_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface* cache):
+	parent_type(max_wait_ms, ttl_ms),
+	m_cache(cache)
+{
+}
+
+template<typename key_type>
+bool container_async_source<key_type>::lookup(const key_type& key,
+					      sinsp_container_info& value,
+					      const callback_handler& handler)
+{
+	if(handler)
+	{
+		return parent_type::lookup(key, value, handler);
+	}
+	else
+	{
+		return parent_type::lookup(
+			key,
+			value,
+			std::bind(
+				&container_async_source::source_callback,
+				this,
+				std::placeholders::_1,
+				std::placeholders::_2));
+	}
+}
+
+template<typename key_type>
+bool container_async_source<key_type>::lookup_sync(const key_type& key, sinsp_container_info& value)
+{
+	value.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
+	value.m_type = container_type(key);
+	value.m_id = container_id(key);
+
+	if(!parse(key, value))
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"%s (%s): Failed to get metadata, returning successful=false",
+				name(),
+				value.m_id.c_str());
+
+		value.set_lookup_status(sinsp_container_lookup::state::FAILED);
+	}
+
+	return true;
+}
+
+template<typename key_type>
+void container_async_source<key_type>::source_callback(const key_type& key, const sinsp_container_info& res)
+{
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"%s_async (%s): Source callback result=%d",
+			name(),
+			container_id(key).c_str(),
+			res.get_lookup_status());
+
+	m_cache->notify_new_container(res);
+};
+
+template<typename key_type>
+void container_async_source<key_type>::run_impl()
+{
+	key_type key;
+
+	while(this->dequeue_next_key(key))
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"%s_async (%s): Source dequeued key",
+				name(),
+				container_id(key).c_str());
+
+		sinsp_container_info res;
+		lookup_sync(key, res);
+
+		// For security reasons we store the value regardless of the lookup status,
+		// so we can track the container activity even without its metadata.
+		this->store_value(key, res);
+
+		if(res.m_lookup.should_retry())
+		{
+			this->lookup_delayed(
+				key,
+				res,
+				std::chrono::milliseconds(res.m_lookup.delay()),
+				std::bind(
+					&container_async_source::source_callback,
+					this,
+					std::placeholders::_1,
+					std::placeholders::_2));
+		}
+	}
+}
+
+} // namespace container_engine
+} // namespace libsinsp

--- a/userspace/libsinsp/container_engine/container_async_source.tpp
+++ b/userspace/libsinsp/container_engine/container_async_source.tpp
@@ -90,15 +90,15 @@ template<typename key_type>
 void container_async_source<key_type>::run_impl()
 {
 	key_type key;
+	sinsp_container_info res;
 
-	while(this->dequeue_next_key(key))
+	while(this->dequeue_next_key(key, &res))
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"%s_async (%s): Source dequeued key",
 				name(),
 				container_id(key).c_str());
 
-		sinsp_container_info res;
 		lookup_sync(key, res);
 
 		// For security reasons we store the value regardless of the lookup status on the
@@ -111,6 +111,7 @@ void container_async_source<key_type>::run_impl()
 
 		if(res.m_lookup.should_retry())
 		{
+			// Make a new attempt
 			res.m_lookup.attempt_increment();
 
 			g_logger.format(sinsp_logger::SEV_DEBUG,
@@ -129,6 +130,9 @@ void container_async_source<key_type>::run_impl()
 					std::placeholders::_1,
 					std::placeholders::_2));
 		}
+
+		// Reset res
+		res.clear();
 	}
 }
 

--- a/userspace/libsinsp/container_engine/container_cache_interface.h
+++ b/userspace/libsinsp/container_engine/container_cache_interface.h
@@ -36,7 +36,7 @@ public:
 
 	virtual bool should_lookup(const std::string& container_id, sinsp_container_type ctype) = 0;
 
-	virtual void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup_state state) = 0;
+	virtual void set_lookup_status(const std::string& container_id, sinsp_container_type ctype, sinsp_container_lookup::state state) = 0;
 
 	/**
 	 * Get a container from the cache.

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -179,7 +179,7 @@ void cri_async_source::run_impl()
 bool cri_async_source::lookup_sync(const libsinsp::cgroup_limits::cgroup_limits_key& key,
 		 sinsp_container_info& value)
 {
-	value.m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
+	value.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	value.m_type = m_cri->get_cri_runtime_type();
 	value.m_id = key.m_container_id;
 
@@ -188,7 +188,7 @@ bool cri_async_source::lookup_sync(const libsinsp::cgroup_limits::cgroup_limits_
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"cri (%s): Failed to get CRI metadata, returning successful=false",
 				key.m_container_id.c_str());
-		value.m_lookup_state = sinsp_container_lookup_state::FAILED;
+		value.set_lookup_status(sinsp_container_lookup::state::FAILED);
 	}
 
 	return true;
@@ -318,7 +318,7 @@ bool cri::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 				"cri (%s): Performing lookup",
 				container_id.c_str());
 
-		container.m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
+		container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		libsinsp::cgroup_limits::cgroup_limits_key key(
 			container.m_id,
 			tinfo->get_cgroup("cpu"),
@@ -331,13 +331,13 @@ bool cri::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 			m_async_source = std::unique_ptr<cri_async_source>(async_source);
 		}
 
-		cache->set_lookup_status(container_id, m_cri->get_cri_runtime_type(), sinsp_container_lookup_state::STARTED);
+		cache->set_lookup_status(container_id, m_cri->get_cri_runtime_type(), sinsp_container_lookup::state::STARTED);
 		auto cb = [cache](const libsinsp::cgroup_limits::cgroup_limits_key& key, const sinsp_container_info& res)
 		{
 			g_logger.format(sinsp_logger::SEV_DEBUG,
 					"cri_async (%s): Source callback result=%d",
 					key.m_container_id.c_str(),
-					res.m_lookup_state);
+					res.get_lookup_status());
 
 			cache->notify_new_container(res);
 		};

--- a/userspace/libsinsp/container_engine/cri.h
+++ b/userspace/libsinsp/container_engine/cri.h
@@ -86,7 +86,6 @@ public:
 	static void set_cri_timeout(int64_t timeout_ms);
 	static void set_extra_queries(bool extra_queries);
 	static void set_async(bool async_limits);
-	static void set_cri_delay(uint64_t delay_ms);
 
 private:
 	std::unique_ptr<cri_async_source> m_async_source;

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -43,7 +43,7 @@ docker_async_source::~docker_async_source()
 
 bool docker_async_source::lookup_sync(const docker_lookup_request& request, sinsp_container_info& value)
 {
-	value.m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
+	value.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	value.m_type = request.container_type;
 	value.m_id = request.container_id;
 
@@ -57,7 +57,7 @@ bool docker_async_source::lookup_sync(const docker_lookup_request& request, sins
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Failed to get Docker metadata, returning successful=false",
 				request.container_id.c_str());
-		value.m_lookup_state = sinsp_container_lookup_state::FAILED;
+		value.set_lookup_status(sinsp_container_lookup::state::FAILED);
 	}
 
 	return true;

--- a/userspace/libsinsp/container_engine/docker/base.cpp
+++ b/userspace/libsinsp/container_engine/docker/base.cpp
@@ -60,22 +60,12 @@ docker_base::resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& 
 
 void docker_base::parse_docker(const docker_lookup_request& request, container_cache_interface *cache)
 {
-	auto cb = [cache](const docker_lookup_request& request, const sinsp_container_info& res)
-	{
-		g_logger.format(sinsp_logger::SEV_DEBUG,
-				"docker (%s): Source callback result=%d",
-				request.container_id.c_str(),
-				res.get_lookup_status());
-
-		cache->notify_new_container(res);
-	};
-
 	sinsp_container_info result;
 
 	bool done;
 	if (cache->async_allowed())
 	{
-		done = m_docker_info_source->lookup(request, result, cb);
+		done = m_docker_info_source->lookup(request, result);
 	}
 	else
 	{
@@ -84,7 +74,7 @@ void docker_base::parse_docker(const docker_lookup_request& request, container_c
 	if (done)
 	{
 		// if a previous lookup call already found the metadata, process it now
-		cb(request, result);
+		m_docker_info_source->source_callback(request, result);
 
 		if(cache->async_allowed())
 		{

--- a/userspace/libsinsp/container_engine/docker/base.cpp
+++ b/userspace/libsinsp/container_engine/docker/base.cpp
@@ -45,7 +45,7 @@ docker_base::resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& 
 					request.container_id.c_str());
 
 			// give docker a chance to return metadata for this container
-			cache->set_lookup_status(request.container_id, request.container_type, sinsp_container_lookup_state::STARTED);
+			cache->set_lookup_status(request.container_id, request.container_type, sinsp_container_lookup::state::STARTED);
 			parse_docker(request, cache);
 		}
 #endif
@@ -65,7 +65,7 @@ void docker_base::parse_docker(const docker_lookup_request& request, container_c
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker (%s): Source callback result=%d",
 				request.container_id.c_str(),
-				res.m_lookup_state);
+				res.get_lookup_status());
 
 		cache->notify_new_container(res);
 	};

--- a/userspace/libsinsp/container_engine/docker/docker_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker/docker_linux.cpp
@@ -56,7 +56,7 @@ void docker_linux::update_with_size(const std::string &container_id)
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): with size callback result=%d",
 				instruction.container_id.c_str(),
-				res.m_lookup_state);
+				res.get_lookup_status());
 
 		sinsp_container_info::ptr_t updated = make_shared<sinsp_container_info>(res);
 		container_cache().replace_container(updated);

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -93,6 +93,14 @@ public:
 	}
 
 	/**
+	 * i.e. whether we didn't do any retry yet
+	 */
+	bool first_attempt() const
+	{
+		return m_retry == 0;
+	}
+
+	/**
 	 * Compute the delay and increment retry count
 	 */
 	short delay()

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -79,8 +79,30 @@ public:
 		return m_state == state::SUCCESSFUL;
 	}
 
+	/**
+	 * True when not successful and we didn't do too many attempts
+	 */
+	bool should_retry() const
+	{
+		if(is_successful())
+		{
+			return false;
+		}
+
+		return m_retry < 3;
+	}
+
+	/**
+	 * Compute the delay and increment retry count
+	 */
+	short delay()
+	{
+		return 125 << m_retry++;
+	}
+
 private:
 	state m_state = state::SUCCESSFUL;
+	short m_retry = 0;
 };
 
 class sinsp_container_info

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -100,12 +100,22 @@ public:
 		return m_retry == 0;
 	}
 
+	short retry_no() const
+	{
+		return m_retry;
+	}
+
+	void attempt_increment()
+	{
+		++m_retry;
+	}
+
 	/**
 	 * Compute the delay and increment retry count
 	 */
 	short delay()
 	{
-		return 125 << m_retry++;
+		return 125 << (m_retry-1);
 	}
 
 private:

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -49,22 +49,38 @@ static inline bool is_docker_compatible(sinsp_container_type t)
 		t == CT_PODMAN;
 }
 
-/**
- * \brief the state of a container metadata lookup
- *
- * Some container engines (Docker, CRI) do external API calls to find container
- * metadata. This value stores the state of the lookup (a separate value is kept
- * for each container_id/engine pair). The purpose is to avoid repeated lookups
- * after failure, especially when multiple engines match against the same process
- * (e.g. Docker and containerd may use the same cgroup layout).
- *
- * If all engines fail to find metadata for a container, we need to remember that
- * for each engine individually and there's only one sinsp_container_info->m_type
- */
-enum class sinsp_container_lookup_state {
-	STARTED = 0,
-	SUCCESSFUL = 1,
-	FAILED = 2
+class sinsp_container_lookup
+{
+public:
+	/**
+	 * \brief the state of a container metadata lookup
+	 *
+	 * Some container engines (Docker, CRI) do external API calls to find container
+	 * metadata. This value stores the state of the lookup (a separate value is kept
+	 * for each container_id/engine pair). The purpose is to avoid repeated lookups
+	 * after failure, especially when multiple engines match against the same process
+	 * (e.g. Docker and containerd may use the same cgroup layout).
+	 *
+	 * If all engines fail to find metadata for a container, we need to remember that
+	 * for each engine individually and there's only one sinsp_container_info->m_type
+	 */
+	enum class state
+	{
+		STARTED = 0,
+		SUCCESSFUL = 1,
+		FAILED = 2
+	};
+
+	state get_status() const { return m_state; }
+	void set_status(state s) { m_state = s; }
+
+	bool is_successful() const
+	{
+		return m_state == state::SUCCESSFUL;
+	}
+
+private:
+	state m_state = state::SUCCESSFUL;
 };
 
 class sinsp_container_info
@@ -196,7 +212,6 @@ public:
 		m_cpu_period(100000),
 		m_cpuset_cpu_count(0),
 		m_is_pod_sandbox(false),
-		m_lookup_state(sinsp_container_lookup_state::SUCCESSFUL),
 		m_metadata_deadline(0),
 		m_size_rw_bytes(-1)
 	{
@@ -212,8 +227,15 @@ public:
 		return m_is_pod_sandbox;
 	}
 
-	bool is_successful() const {
-		return m_lookup_state == sinsp_container_lookup_state::SUCCESSFUL;
+	bool is_successful() const { return m_lookup.is_successful(); }
+
+	void set_lookup_status(sinsp_container_lookup::state s)
+	{
+		m_lookup.set_status(s);
+	}
+	sinsp_container_lookup::state get_lookup_status() const
+	{
+		return m_lookup.get_status();
 	}
 
 	std::shared_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
@@ -247,7 +269,7 @@ public:
 
 	bool m_is_pod_sandbox;
 
-	sinsp_container_lookup_state m_lookup_state;
+	sinsp_container_lookup m_lookup;
 #ifdef HAS_ANALYZER
 	std::string m_sysdig_agent_conf;
 #endif

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -257,6 +257,12 @@ public:
 	{
 	}
 
+	void clear()
+	{
+		this->~sinsp_container_info();
+		new(this) sinsp_container_info();
+	}
+
 	const std::vector<std::string>& get_env() const { return m_env; }
 
 	const container_mount_info *mount_by_idx(uint32_t idx) const;

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -255,7 +255,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 				{
 					g_logger.format(sinsp_logger::SEV_DEBUG,
 						"Checking IP address of container %s with incomplete metadata (state=%d)",
-						tinfo->m_container_id.c_str(), container_info->m_lookup_state);
+						tinfo->m_container_id.c_str(), container_info->get_lookup_status());
 				}
 
 				const sinsp_container_manager::map_ptr_t clist = m_inspector->m_container_manager.get_containers();
@@ -267,7 +267,7 @@ bool sinsp_network_interfaces::is_ipv4addr_in_local_machine(uint32_t addr, sinsp
 						g_logger.format(sinsp_logger::SEV_DEBUG,
 							"Checking IP address of container %s with incomplete metadata (in context of %s; state=%d)",
 							it.second->m_id.c_str(), tinfo->m_container_id.c_str(),
-							it.second->m_lookup_state);
+							it.second->get_lookup_status());
 					}
 
 					if(htonl(it.second->m_container_ip) == addr)

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5077,24 +5077,24 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		const Json::Value& lookup_state = container["lookup_state"];
 		if(check_json_val_is_convertible(lookup_state, Json::uintValue, "lookup_state"))
 		{
-			container_info->m_lookup_state = static_cast<sinsp_container_lookup_state>(lookup_state.asUInt());
-			switch(container_info->m_lookup_state)
+			container_info->set_lookup_status(static_cast<sinsp_container_lookup::state>(lookup_state.asUInt()));
+			switch(container_info->get_lookup_status())
 			{
-			case sinsp_container_lookup_state::STARTED:
-			case sinsp_container_lookup_state::SUCCESSFUL:
-			case sinsp_container_lookup_state::FAILED:
+			case sinsp_container_lookup::state::STARTED:
+			case sinsp_container_lookup::state::SUCCESSFUL:
+			case sinsp_container_lookup::state::FAILED:
 				break;
 			default:
-				container_info->m_lookup_state = sinsp_container_lookup_state::SUCCESSFUL;
+				container_info->set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 			}
 
 			// state == STARTED doesn't make sense in a scap file
 			// as there's no actual lookup that would ever finish
-			if(!evt->m_tinfo_ref && container_info->m_lookup_state == sinsp_container_lookup_state::STARTED)
+			if(!evt->m_tinfo_ref && container_info->get_lookup_status() == sinsp_container_lookup::state::STARTED)
 			{
 				SINSP_DEBUG("Rewriting lookup_state = STARTED from scap file to FAILED for container %s",
 					container_info->m_id.c_str());
-				container_info->m_lookup_state = sinsp_container_lookup_state::FAILED;
+				container_info->set_lookup_status(sinsp_container_lookup::state::FAILED);
 			}
 		}
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1646,9 +1646,10 @@ void sinsp::set_cri_async(bool async)
 	m_container_manager.set_cri_async(async);
 }
 
-void sinsp::set_cri_delay(uint64_t delay_ms)
+void sinsp::set_cri_delay(uint64_t)
 {
-	m_container_manager.set_cri_delay(delay_ms);
+	g_logger.format(sinsp_logger::SEV_WARNING, "%s is deprecated", __FUNCTION__);
+	ASSERT(false);
 }
 
 void sinsp::set_container_labels_max_len(uint32_t max_label_len)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -964,7 +964,10 @@ public:
 	void add_cri_socket_path(const std::string &path);
 	void set_cri_timeout(int64_t timeout_ms);
 	void set_cri_async(bool async);
+
+	// TODO DEPRECATED: drop this method after a release or two
 	void set_cri_delay(uint64_t delay_ms);
+
 	void set_container_labels_max_len(uint32_t max_label_len);
 
 	// Create and register a plugin from a shared library pointed


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:
In Docker and in CRI-O (when started with `cri_timeout` 0 or with `async` false) it happens to have the lookup without any metadata for some containers (e.g. OWASP Juice Shop):
```
Debug, cri (fa94c3cc2006): Performing lookup
Debug, cri (fa94c3cc2006): Status from ContainerStatus: (could not find container "fa94c3cc2006": specified container fa94c3cc20063363a52ece696999e974d7472d4c76395ca5f19f55c883c8080a is not yet created)
Debug, cri (fa94c3cc2006): id is neither a container nor a pod sandbox
Debug, cri_async (fa94c3cc2006): Failed to get CRI metadata, returning successful=false
Debug, cri_async (fa94c3cc2006): Source callback result=2
Debug, notify_new_container (fa94c3cc2006): created CONTAINER_JSON event, queuing to inspector
Debug, Parsing Container JSON={"container":{"Mounts":[],"User":"<NA>","cpu_period":100000,"cpu_quota":0,"cpu_shares":1024,"cpuset_cpu_count":0,"created_time":28467688,"env":[],"full_id":"","id":"fa94c3cc2006","image":"","imagedigest":"","imageid":"","imagerepo":"","imagetag":"","ip":"0.0.0.0","is_pod_sandbox":false,"labels":null,"lookup_state":2,"memory_limit":0,"metadata_deadline":0,"name":"","port_mappings":[],"privileged":false,"swap_limit":0,"type":8}}
```

While it is advantageous to have the container in the container manager as soon as possible to track its activity, we would eventually need its metadata.

Implement a lookup retry with delays of 125, 250, and 500 ms.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): improve situation with CRI containers being discovered late
update(userspace/libsinsp)!: deprecated sinsp::set_cri_delay
update(userspace/libsinsp): add retry to failed Docker containers lookups
```
