### PR TITLE
new(libscap): add /proc scan vtable functions, wire them to gvisor implementation

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -110,7 +110,18 @@ static int32_t gvisor_get_threadlist(struct scap_engine_handle engine, struct pp
 {
 	// placeholder
 	(*procinfo_p)->n_entries = 0;
+
 	return SCAP_SUCCESS;
+}
+
+static int32_t gvisor_get_threadinfos(struct scap_engine_handle engine, uint64_t *n, const scap_threadinfo **tinfos)
+{
+	return engine.m_handle->get_threadinfos(n, tinfos);
+}
+
+static int32_t gvisor_get_fdinfos(struct scap_engine_handle engine, const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos)
+{
+	return engine.m_handle->get_fdinfos(tinfo, n, fdinfos);
 }
 
 static int32_t gvisor_get_vxid(struct scap_engine_handle engine, uint64_t xid, int64_t *vxid)
@@ -148,6 +159,8 @@ extern const struct scap_vtable scap_gvisor_engine = {
 	.get_n_devs = gvisor_get_n_devs,
 	.get_max_buf_used = gvisor_get_max_buf_used,
 	.get_threadlist = gvisor_get_threadlist,
+	.get_threadinfos = gvisor_get_threadinfos,
+	.get_fdinfos = gvisor_get_fdinfos,
 	.get_vpid = gvisor_get_vxid,
 	.get_vtid = gvisor_get_vxid,
 	.getpid_global = gvisor_getpid_global

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -97,6 +97,8 @@ public:
 
     int32_t next(scap_evt **pevent, uint16_t *pcpuid);
 
+    uint32_t get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos);
+    uint32_t get_fdinfos(const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos);
     uint32_t get_vxid(uint64_t pid);
 private:
     int32_t process_message_from_fd(int fd);
@@ -115,6 +117,11 @@ private:
 
     // stores per-sandbox data. All buffers used to contain parsed event data are owned by this map
     std::unordered_map<int, sandbox_entry> m_sandbox_data;
+
+    // the following two maps store and manage memory for thread information requested
+    // when get_threadinfos() is called. They are only updated upon get_threadinfos()
+    std::vector<scap_threadinfo> m_threadinfos_threads;
+    std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
 };
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -243,6 +243,26 @@ int32_t engine::stop_capture()
     return SCAP_SUCCESS;
 }
 
+uint32_t engine::get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos)
+{
+	// Add logic to parse process and file list from runsc here
+
+	*tinfos = m_threadinfos_threads.data();
+	*n = m_threadinfos_threads.size();
+
+	return SCAP_SUCCESS;
+}
+
+uint32_t engine::get_fdinfos(const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos)
+{
+	*n = m_threadinfos_fds[tinfo->tid].size();
+	if (*n != 0) {
+		*fdinfos = m_threadinfos_fds[tinfo->tid].data();
+	}
+
+	return SCAP_SUCCESS;
+}
+
 uint32_t engine::get_vxid(uint64_t xid)
 {
 	return parsers::get_vxid(xid);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -208,6 +208,8 @@ int32_t scap_readbuf(scap_t* handle, uint32_t proc, OUT char** buf, OUT uint32_t
 int32_t scap_proc_read_thread(scap_t* handle, char* procdirname, uint64_t tid, struct scap_threadinfo** pi, char *error, bool scan_sockets);
 // Scan a directory containing process information
 int32_t scap_proc_scan_proc_dir(scap_t* handle, char* procdirname, char *error);
+// Scan process information from engine vtable
+int32_t scap_proc_scan_vtable(char *error, scap_t *handle);
 // Remove an entry from the process list by parsing a PPME_PROC_EXIT event
 // void scap_proc_schedule_removal(scap_t* handle, scap_evt* e);
 // Remove the process that was scheduled for deletion for this handle
@@ -253,6 +255,8 @@ void scap_fd_remove(scap_t* handle, scap_threadinfo* pi, int64_t fd);
 int32_t scap_next_offline(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid);
 // read the file descriptors for a given process directory
 int32_t scap_fd_scan_fd_dir(scap_t* handle, char * procdir, scap_threadinfo* pi, struct scap_ns_socket_list** sockets_by_ns, char *error);
+// scan fd information for a specific thread from engine vtable. src_tinfo is a pointer to a threadinfo returned by the engine
+int32_t scap_fd_scan_vtable(scap_t *handle, const scap_threadinfo *src_tinfo, scap_threadinfo *dst_tinfo, char *error);
 // read tcp or udp sockets from the proc filesystem
 int32_t scap_fd_read_ipv4_sockets_from_proc_fs(scap_t* handle, const char * dir, int l4proto, scap_fdinfo ** sockets);
 // read all sockets and add them to the socket table hashed by their ino

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -497,6 +497,9 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *args)
 	handle->m_suppressed_tids = NULL;
 	handle->m_num_suppressed_evts = 0;
 
+	handle->m_proc_callback = args->proc_callback;
+	handle->m_proc_callback_context = args->proc_callback_context;
+
 	if ((*rc = copy_comms(handle, args->suppressed_comms)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
@@ -504,7 +507,11 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *args)
 		return NULL;
 	}
 
-	// XXX - process / sandbox initialization goes here
+	if ((*rc = scap_proc_scan_vtable(error, handle)) != SCAP_SUCCESS)
+	{
+		scap_close(handle);
+		return NULL;
+	}
 
 	if(handle->m_vtable->start_capture(handle->m_engine) != SCAP_SUCCESS)
 	{

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -238,6 +238,28 @@ struct scap_vtable {
 	int32_t (*get_threadlist)(struct scap_engine_handle engine, struct ppm_proclist_info **procinfo_p, char *lasterr);
 
 	/**
+	 * @brief get information about all threads in the system
+	 * @param engine wraps the pointer to the engine-specific handle
+	 * @param n [out] the number of scap_threadinfo structures returned
+	 * @param tinfos [out] an array of scap_threadinfo structures
+	 * 				 that represent the state of the system, owned by the engine
+	 * @return SCAP_SUCCESS or a failure code
+	 *
+	 */
+	int32_t (*get_threadinfos)(struct scap_engine_handle engine, uint64_t *n, const scap_threadinfo **tinfos);
+
+	/**
+	 * @brief get information about file descriptors for a thread that was identified by get_threadinfos
+	 * @param engine wraps the pointer to the engine-specific handle
+	 * @param tinfo a thread pointer returned by get_threadinfos
+	 * @param n [out] the number of scap_fdinfo structures returned 
+	 * @param fdinfos [out] an array of scap_fdinfo structures
+	 * @return SCAP_SUCCESS or a failure code
+	 *
+	 */
+	int32_t (*get_fdinfos)(struct scap_engine_handle engine, const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos);
+
+	/**
 	 * @brief get the vpid of a process
 	 * @param engine wraps the pointer to the engine-specific handle
 	 * @param pid the pid of the process to check

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -593,6 +593,7 @@ void sinsp::open_gvisor(std::string socket_path, uint32_t timeout_ms)
 {
 	m_gvisor_socket = socket_path;
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
+	set_get_procs_cpu_from_driver(false);
 }
 
 void sinsp::open_nodriver()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-gvisor

/area libscap


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces the ability for a scap engine to provide functions to scan processes in the system. In addition, a placeholder implementation is added to gvisor to show how to use this API.

*Rationale for the API naming and functionality*

In general, we want to replicate the `/proc` scan functionality usually found in scap but in a generic way via vtables.

The API I implemented involves having two functions, `get_threadinfos()` and `get_fdinfos()` to retrieve thread information for all threads and fd information for a single one respectively. However, there are several possible alternative approaches. To answer some questions that reviewers might have, these were some other options I evaluated:
- Having libscap use `get_threadlist` to retrieve the list and then provide a `get_thread()` method for each of them
  - Such an API would be a bit dangerous in my opinion because it'd look like like scap could, at any time, ask for a single thread given the ID. Not all engines may expose this functionality, which could be a separate API if required.
  - I would like the threads API to be consistent, so it should try to get all information close together and possibly remove inconsistent data before it reaches scap. If we used an API like the one described above we would have a list of threads that may possibly exist and have to skip the ones that are already terminated in scap, in this way we get one consistent list
- Having one single `get_threadinfos()` call that gets both thread information and fd information
  - Returned structs would contain the fdinfo array owned by the engine, leading to confusion
  - Also, `scap_threadinfo` does not have information about the number of elements of the fdinfo array which should be passed in some other way
  - Scap sometimes only wants fd information about certain threads, this way it would retrieve them all

The proposed implementation specifies that all the data is retrieved at `get_threadinfos()` call, and `get_fdinfos()` can only retrieve file descriptor information pertaining to a previous call to `get_threadinfos()`. To remark this, the call to `get_fdinfos()` requires a previously identified `threadinfo` structure.

The reason why I propose to do it this way instead of having an API to retrieve fdinfo for a single process at any given time is that in this way fdinfo and procinfo is consistent and is always linked to the same moment in time, especially for engines that allow to retrieve a "state snapshot" like gVisor. The existing `scap_dir_scan_proc_dir` attempts to do all operations in the same call as well.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Currently this implementation is _only used for gVisor_. Could be refactored if we see that it doesn't work right.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
