### PR TITLE
fix(gvisor): use strlcpy to copy unix path strings

### DIFF
--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "../../driver/ppm_events_public.h"
 
 #include "userspace_flag_helpers.h"
+#include "../common/strlcpy.h"
 
 #include "pkg/sentry/seccheck/points/syscall.pb.h"
 #include "pkg/sentry/seccheck/points/sentry.pb.h"
@@ -526,8 +527,7 @@ static parse_result parse_connect(const char *proto, size_t proto_size, scap_siz
 				memcpy(targetbuf, &sock_family, sizeof(uint8_t));
 				memset(targetbuf + 1, 0, sizeof(uint64_t)); // TODO: understand how to fill this 
 				memset(targetbuf + 1 + 8, 0, sizeof(uint64_t));
-				memcpy(targetbuf + 1 + 8 + 8, &unix_addr->sun_path, 108);
-				memset(targetbuf + 1 + 8 + 8 + UNIX_PATH_MAX - 1, 0, sizeof(uint8_t));
+				strlcpy(targetbuf + 1 + 8 + 8, unix_addr->sun_path, UNIX_PATH_MAX);
 				size = sizeof(uint8_t) + sizeof(uint64_t) + sizeof(uint64_t) + UNIX_PATH_MAX;
 				break;
 			}


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Change UNIX socket path copying in the gvisor parsers. The previous implementation had two issues:
* It was copying 108 bytes into the destination buffer even if the source string was smaller. As long as the string was null-terminated it wouldn't result in a crash but it's technically not correct to copy data that isn't part of the right buffer.
* It was not checking that the source string was actually within the right size. This should never happen unless the sentry is compromised but it's still right to check.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
