### PR TITLE
fix(driver): fixed kmod build on linux kernels >= 5.18.

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -70,8 +70,9 @@ MODULE_AUTHOR("the Falco authors");
     #define TRACEPOINT_PROBE(probe, args...) static void probe(void *__data, args)
 #endif
 
-#ifndef pgprot_encrypted
-#define pgprot_encrypted(x) (x)
+// Allow build even on arch where PAGE_ENC is not implemented
+#ifndef _PAGE_ENC
+#define _PAGE_ENC 0
 #endif
 
 struct ppm_device {
@@ -1217,8 +1218,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 
 			pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
+			pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
 			ret = remap_pfn_range(vma, useraddr, pfn,
-					      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
+					      PAGE_SIZE, vma->vm_page_prot);
 			if (ret < 0) {
 				pr_err("remap_pfn_range failed (1)\n");
 				goto cleanup_mmap;
@@ -1255,8 +1257,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 			while (mlength > 0) {
 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
+				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
 				ret = remap_pfn_range(vma, useraddr, pfn,
-						      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
+						      PAGE_SIZE, vma->vm_page_prot);
 				if (ret < 0) {
 					pr_err("remap_pfn_range failed (1)\n");
 					goto cleanup_mmap;
@@ -1277,8 +1280,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 			while (mlength > 0) {
 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
+				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
 				ret = remap_pfn_range(vma, useraddr, pfn,
-						      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
+						      PAGE_SIZE, vma->vm_page_prot);
 				if (ret < 0) {
 					pr_err("remap_pfn_range failed (1)\n");
 					goto cleanup_mmap;


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Linux 5.18 in [this](https://github.com/torvalds/linux/commit/b577f542f93cbba57f8d6185ef1fb13a41ddf162) commit , changed the macro `pgprot_encrypted`:
from
`__pgprot(__sme_set(pgprot_val(prot)))`

to:
`__pgprot(cc_mkenc(pgprot_val(prot)))`.

Unfortunately, `cc_mkenc` is not an exported symbol.
This patch aims to fix the build by properly directly setting the `_PAGE_ENC` prot value on the new page.

See https://lore.kernel.org/linux-api/CAMZm_C=o-rc4a+u_8-pFJtmL_2drwczASMRTqszamrks5Zm_OA@mail.gmail.com/T/#u for a kernel ML discussion.

I tested this on my pc and it now builds and works fine. I am not able to test on an AMD SME enabled pc (https://github.com/falcosecurity/libs/commit/0333501cf429c045c61aaf5909812156f090786e)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
