### PR TITLE
new(gvisor): retrieve procfs state from gvisor

### DIFF
--- a/userspace/libscap/engine/gvisor/CMakeLists.txt
+++ b/userspace/libscap/engine/gvisor/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(scap_engine_gvisor STATIC
     parsers.cpp
     gvisor.cpp
     scap_gvisor.cpp
+    runsc.cpp
     ${JSONCPP_LIB_SRC}
 )
 

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -75,6 +75,22 @@ uint64_t get_vxid(uint64_t vxid);
 
 } // namespace parsers
 
+namespace runsc
+{
+
+    struct result {
+        int error;
+        std::vector<std::string> output;
+    };
+
+    result version();
+    result list(const std::string &root_path);
+    result trace_create(const std::string &root_path, const std::string &trace_session_path, const std::string &sandbox_id, bool force);
+    result trace_delete(const std::string &root_path, const std::string &session_name, const std::string &sandbox_id);
+    result trace_procfs(const std::string &root_path, const std::string &sandbox_id);
+
+} // namespace runsc
+
 // contains entries to store per-sandbox data and buffers to use to write events in
 class sandbox_entry {
 public:
@@ -105,18 +121,6 @@ private:
     int32_t process_message_from_fd(int fd);
     void free_sandbox_buffers();
 
-    struct runsc_result {
-        int error;
-        std::vector<std::string> output;
-    };
-
-    runsc_result runsc(char *argv[]);
-    runsc_result runsc_version();
-    runsc_result runsc_list();
-    runsc_result runsc_trace_create(const std::string &sandbox_id, bool force);
-    runsc_result runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id);
-    runsc_result runsc_trace_procfs(const std::string &sandbox_id);
-
     char *m_lasterr;
     int m_listenfd = 0;
     int m_epollfd = 0;
@@ -136,8 +140,11 @@ private:
     std::vector<scap_threadinfo> m_threadinfos_threads;
     std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
 
+    // the following two strings contains the path of the root dir used by the runsc command
+    // and the path the trace session configuration file used to set up traces, respectively
     std::string m_root_path;
     std::string m_trace_session_path;
+
 };
 
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -51,6 +51,15 @@ struct parse_result {
 	std::vector<scap_evt*> scap_events;
 };
 
+struct procfs_result {
+    // the scap status of the operation
+    uint32_t status;
+    // description of the error in case of failure
+    std::string error;
+    // the resulting thread information
+    scap_threadinfo tinfo;
+};
+
 /*!
     \brief Translate a gVisor seccheck protobuf into one, or more, scap events
     \param gvisor_buf the source buffer that contains the raw event coming from gVisor
@@ -69,7 +78,7 @@ struct parse_result {
 */
 parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_buffer scap_buf);
 
-bool parse_procfs_json(const std::string &input, const std::string &sandbox, scap_threadinfo &tinfo);
+procfs_result parse_procfs_json(const std::string &input, const std::string &sandbox);
 
 uint64_t get_vxid(uint64_t vxid);
 

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -69,6 +69,8 @@ struct parse_result {
 */
 parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_buffer scap_buf);
 
+bool parse_procfs_json(const std::string &input, const std::string &sandbox, scap_threadinfo &tinfo);
+
 uint64_t get_vxid(uint64_t vxid);
 
 } // namespace parsers

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -113,6 +113,7 @@ private:
     runsc_result runsc_list();
     runsc_result runsc_trace_create(const std::string &sandbox_id, bool force);
     runsc_result runsc_trace_delete(const std::string &session_name, const std::string &sandbox_id);
+    runsc_result runsc_trace_procfs(const std::string &sandbox_id);
 
     char *m_lasterr;
     int m_listenfd = 0;
@@ -132,6 +133,7 @@ private:
     // when get_threadinfos() is called. They are only updated upon get_threadinfos()
     std::vector<scap_threadinfo> m_threadinfos_threads;
     std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
+
     std::string m_root_path;
     std::string m_trace_session_path;
 };

--- a/userspace/libscap/engine/gvisor/runsc.cpp
+++ b/userspace/libscap/engine/gvisor/runsc.cpp
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "gvisor.h"
+
+namespace scap_gvisor {
+
+namespace runsc {
+
+constexpr size_t max_line_size = 8192;
+
+result runsc(char *argv[])
+{
+	result res = {0};
+	int pipefds[2];
+
+	int ret = pipe(pipefds);
+	if(ret)
+	{
+		return res;
+	}
+
+	pid_t pid = vfork();
+	if(pid > 0)
+	{
+		char line[max_line_size];
+		int status;
+		
+		close(pipefds[1]);
+		wait(&status);
+		if(!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		{
+			res.error = status;
+			return res;
+		}
+
+		FILE *f = fdopen(pipefds[0], "r");
+		if(!f)
+		{
+			return res;
+		}
+
+		while(fgets(line, max_line_size, f))
+		{
+			res.output.emplace_back(std::string(line));
+		}
+
+		fclose(f);
+	}
+	else
+	{
+		close(pipefds[0]);
+		dup2(pipefds[1], STDOUT_FILENO);
+		execvp("runsc", argv);
+		exit(1);
+	}
+
+	return res;
+}
+
+result version()
+{
+	const char *argv[] = {
+		"runsc",
+		"--version",
+		NULL
+	};
+
+	return runsc((char **)argv);
+}
+
+result list(const std::string &root_path)
+{
+	result res = {0};
+	std::vector<std::string> running_sandboxes;
+
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		root_path.c_str(),
+		"list",
+		NULL
+	};
+
+	res = runsc((char **)argv);
+	if(res.error)
+	{
+		return res;
+	}
+
+	for(const auto &line : res.output)
+	{
+		if(line.find("running") != std::string::npos)
+		{
+			std::string sandbox = line.substr(0, line.find_first_of(" ", 0));
+			running_sandboxes.emplace_back(sandbox);
+		}
+	}
+
+	res.output = running_sandboxes;
+	return res;
+}
+
+result trace_create(const std::string &root_path, const std::string &trace_session_path, const std::string &sandbox_id, bool force)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		root_path.c_str(),
+		"trace",
+		"create",
+		force ? "--force" : "",
+		"--config", 
+		trace_session_path.c_str(),
+		sandbox_id.c_str(),
+		NULL
+	};
+
+	return runsc((char **)argv);
+}
+
+result trace_delete(const std::string &root_path, const std::string &session_name, const std::string &sandbox_id)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		root_path.c_str(),
+		"trace",
+		"delete",
+		"--name",
+		session_name.c_str(),
+		sandbox_id.c_str(),
+		NULL
+	};
+
+	return runsc((char **)argv);
+}
+
+result trace_procfs(const std::string &root_path, const std::string &sandbox_id)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		root_path.c_str(),
+		"trace",
+		"procfs",
+		sandbox_id.c_str(),
+		NULL, 
+	};
+
+	return runsc((char **)argv);
+}
+
+} // namespace runsc
+
+} // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -27,8 +27,6 @@ limitations under the License.
 
 #include <vector>
 
-#include <json/json.h>
-
 #include "gvisor.h"
 #include "pkg/sentry/seccheck/points/common.pb.h"
 
@@ -42,7 +40,7 @@ constexpr uint32_t max_ready_sandboxes = 32;
 constexpr size_t max_message_size = 300 * 1024;
 constexpr size_t initial_event_buffer_size = 32;
 constexpr int listen_backlog_size = 128;
-constexpr size_t max_line_size = 2048;
+constexpr size_t max_line_size = 8192;
 
 sandbox_entry::sandbox_entry()
 {
@@ -608,6 +606,21 @@ engine::runsc_result engine::runsc_trace_delete(const std::string &session_name,
 		session_name.c_str(),
 		sandbox_id.c_str(),
 		NULL
+	};
+
+	return runsc((char **)argv);
+}
+
+engine::runsc_result engine::runsc_trace_procfs(const std::string &sandbox_id)
+{
+	const char *argv[] = {
+		"runsc", 
+		"--root",
+		m_root_path.c_str(),
+		"trace",
+		"procfs",
+		sandbox_id.c_str(),
+		NULL, 
 	};
 
 	return runsc((char **)argv);

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -346,17 +346,16 @@ uint32_t engine::get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos)
 				continue;
 			}
 
-			scap_threadinfo tinfo;
-			bool res = parsers::parse_procfs_json(line, sandbox, tinfo);
-			if(!res)
+			parsers::procfs_result res = parsers::parse_procfs_json(line, sandbox);
+			if(res.status != SCAP_SUCCESS)
 			{
 				*tinfos = NULL;
 				*n = 0;
-				snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot retrieve procfs state information");
-				return SCAP_FAILURE;
+				snprintf(m_lasterr, SCAP_LASTERR_SIZE, "%s", res.error.c_str());
+				return res.status;
 			}
-
-			m_threadinfos_threads.emplace_back(tinfo);
+			
+			m_threadinfos_threads.emplace_back(res.tinfo);
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces support for retrieving and parsing procfs state information from gVisor. 
It does so by:
- adding a new function to interact with the `procfs` subcommand of `runsc trace`
- adding a new parser that specifically handles the json strings returned by the above command
- managing the internal state of the engine so that `m_threadinfos_threads` member gets filled with proper information

Subsequent PRs will also handle file descriptors, for now we decided to only take care of process information.
In the future we may want to introduce json validation of each json string received by the runsc command. We could use `valijson` for that, but we have encountered a problem with cmake.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
