### PR TITLE
build: versioning system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,32 +38,26 @@ option(MINIMAL_BUILD "Produce a minimal build with only the essential features (
 option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
 
 include(GNUInstallDirs)
+
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-include(GetGitRevisionDescription)
+include(versions)
 
+# Libs version
 if(NOT DEFINED FALCOSECURITY_LIBS_VERSION)
-	# Try to obtain the exact git tag
-	git_get_exact_tag(LIBS_TAG)
-	if(NOT LIBS_TAG)
-		# Obtain the closest tag
-		git_describe(FALCOSECURITY_LIBS_VERSION "--always" "--tags" "--abbrev=7")
-		# Fallback version
-		if(FALCOSECURITY_LIBS_VERSION MATCHES "NOTFOUND$")
-			set(FALCOSECURITY_LIBS_VERSION "0.1.1dev")
-		endif()
-		# Format FALCOSECURITY_LIBS_VERSION to be semver with prerelease and build part
-		string(REPLACE "-g" "+" FALCOSECURITY_LIBS_VERSION "${FALCOSECURITY_LIBS_VERSION}")
-	else()
-		# A tag has been found: use it as the Falco version
-		set(FALCOSECURITY_LIBS_VERSION "${LIBS_TAG}")
-	endif()
+	get_libs_version(FALCOSECURITY_LIBS_VERSION)
 endif()
 
-# Remove the starting "v" in case there is one
-string(REGEX REPLACE "^v(.*)" "\\1" FALCOSECURITY_LIBS_VERSION "${FALCOSECURITY_LIBS_VERSION}")
+message(STATUS "Libs version: ${FALCOSECURITY_LIBS_VERSION}")
+
+# Driver version
+if(NOT DEFINED DRIVER_VERSION)
+	get_drivers_version(DRIVER_VERSION)
+endif()
+
+message(STATUS "Driver version: ${DRIVER_VERSION}")
 
 if(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE Release)
@@ -73,6 +67,7 @@ set(LIBS_PACKAGE_NAME "falcosecurity")
 
 include(CheckSymbolExists)
 check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
+
 if(HAVE_STRLCPY)
 	message(STATUS "Existing strlcpy found, will *not* use local definition by setting -DHAVE_STRLCPY.")
 	add_definitions(-DHAVE_STRLCPY)
@@ -94,11 +89,10 @@ include(libscap)
 include(libsinsp)
 
 if(CREATE_TEST_TARGETS AND NOT WIN32)
-		# Add command to run all unit tests at once via the make system.
-		# This is preferred vs using ctest's add_test because it will build
-		# the code and output to stdout.
-		add_custom_target(run-unit-tests
-			COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
-		)
+	# Add command to run all unit tests at once via the make system.
+	# This is preferred vs using ctest's add_test because it will build
+	# the code and output to stdout.
+	add_custom_target(run-unit-tests
+		COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
+	)
 endif()
-

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ plus chisels related code and common utilities.
 external dependencies, plus the libscap and libsinsp ones; consumers
 (like Falco) use those modules to build the libs in their projects.
 
+## Versioning
+
+This project uses two different versioning schemes for the _libs_ and _driver_ components. In particular, the _driver_ versions are suffixed with `+driver` to distinguish them from the _libs_ ones. Both adhere to the [Semantic Versioning 2.0.0](https://semver.org/). You can find more detail about how we version those components in our [release process documentation](./release.md).
+
+If you build this project from a git working directory, the main [CMakeLists.txt](./CMakeLists.txt) will automatically compute the appropriate version for all components. Otherwise, if you use a source code copy with no the git information or pull the sources of the libs or the drivers directly in your project, it's up to you to correctly set the appropriate cmake variables (for example,  `-DFALCOSECURITY_LIBS_VERSION=x.y.z -DDRIVER_VERSION=a.b.c+driver`).
+
 ## Build
 
 Libs relies upon `cmake` build system.  

--- a/cmake/modules/versions.cmake
+++ b/cmake/modules/versions.cmake
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include(GetGitRevisionDescription)
+
+function(_get_git_version _var)
+    git_describe(tag "--tags" "--exact-match" ${ARGN})
+
+    if(tag)
+        # A tag has been found: use it as the libs version
+        set(${_var}
+            "${tag}"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    # Obtain the closest tag
+    git_describe(dev_version "--always" "--tags" "--abbrev=7" ${ARGN})
+
+    if(dev_version MATCHES "NOTFOUND$")
+        # Fallback version
+        set(dev_version "0.0.0")
+    else()
+        # Extract the git version part and make it SemVer friendly (ie. "-1-g02682d7" to "-1+02682d7" )
+        string(REGEX MATCH "(-[1-9][0-9]*-g[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])$"
+            git_ver_part "${dev_version}")
+        string(REPLACE "${git_ver_part}" "" dev_version "${dev_version}")
+        string(REPLACE "-g" "+" git_ver_part "${git_ver_part}")
+
+        if(dev_version MATCHES "\\+")
+            string(REPLACE "+" "${git_ver_part}-" dev_version "${dev_version}")
+        else()
+            string(CONCAT dev_version "${dev_version}" "${git_ver_part}")
+        endif()
+    endif()
+
+    set(${_var}
+        "${dev_version}"
+        PARENT_SCOPE)
+    return()
+endfunction()
+
+function(get_libs_version _var)
+    _get_git_version(ver "--exclude=+driver")
+
+    set(${_var}
+        "${ver}"
+        PARENT_SCOPE)
+    return()
+endfunction()
+
+function(get_drivers_version _var)
+    _get_git_version(ver "--match=*+driver")
+
+    set(${_var}
+        "${ver}"
+        PARENT_SCOPE)
+    return()
+endfunction()

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -40,7 +40,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	endif()
 
     if(NOT DEFINED DRIVER_VERSION)
-        set(DRIVER_VERSION "${FALCOSECURITY_LIBS_VERSION}")
+        message(ERROR 
+			"No driver version set. Please either build the project from a git working directory or explicitly set the DRIVER_VERSION cmake cache entry."
+		)
     endif()
 
     if(NOT DEFINED DRIVER_NAME)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:


/kind documentation

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR follows up #405 and #196 to implement the new versioning schemes as per [this proposal](https://github.com/falcosecurity/libs/blob/master/proposals/20220203-versioning-schema-amendment.md).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
build: libs and driver now use two different numbering scheme
build: `FALCOSECURITY_LIBS_VERSION` and `DRIVER_VERSION` are now automatically computed using git information
```
