### PR TITLE
Support `execve` exit events and `clone` child exit events on `ARM64`

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -16,6 +16,8 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 # DEBUG = -DBPF_DEBUG
 
+ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
+
 #
 # https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
 # This commit diverged the ChromiumOS kernel from stock in the area of audit information, which this probe accesses.
@@ -56,6 +58,7 @@ $(obj)/probe.o: $(src)/probe.c \
 		$(DEBUG) \
 		-D__KERNEL__ \
 		-D__BPF_TRACING__ \
+		-D__TARGET_ARCH_${ARCH} \
 		-Wno-gnu-variable-sized-type-not-at-end \
 		-Wno-address-of-packed-member \
 		-fno-jump-tables \

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -16,8 +16,6 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 # DEBUG = -DBPF_DEBUG
 
-ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
-
 #
 # https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
 # This commit diverged the ChromiumOS kernel from stock in the area of audit information, which this probe accesses.
@@ -58,7 +56,6 @@ $(obj)/probe.o: $(src)/probe.c \
 		$(DEBUG) \
 		-D__KERNEL__ \
 		-D__BPF_TRACING__ \
-		-D__TARGET_ARCH_${ARCH} \
 		-Wno-gnu-variable-sized-type-not-at-end \
 		-Wno-address-of-packed-member \
 		-fno-jump-tables \

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1046,7 +1046,7 @@ static __always_inline bool bpf_in_ia32_syscall()
 	u32 status = 0;
 
 	task = (struct task_struct *)bpf_get_current_task();
-#if (defined(__i386__) || defined(__TARGET_ARCH_x86)  || defined(_M_IX86))
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86))
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 18)
 	status = _READ(task->thread.status);
@@ -1059,7 +1059,7 @@ static __always_inline bool bpf_in_ia32_syscall()
 #endif
 
 	return status & TS_COMPAT;
-#elif defined(__TARGET_ARCH_arm64)
+#elif defined(__aarch64__)
 	status = _READ(task->thread_info.flags);
 	return status & _TIF_32BIT;
 #else

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1042,10 +1042,9 @@ static __always_inline int bpf_val_to_ring_type(struct filler_data *data,
 
 static __always_inline bool bpf_in_ia32_syscall()
 {
-	struct task_struct *task;
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	u32 status = 0;
 
-	task = (struct task_struct *)bpf_get_current_task();
 #if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86))
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 18)
@@ -1057,14 +1056,18 @@ static __always_inline bool bpf_in_ia32_syscall()
 #else
 	status = _READ(task->thread_info.status);
 #endif
-
 	return status & TS_COMPAT;
+
 #elif defined(__aarch64__)
+
 	status = _READ(task->thread_info.flags);
 	return status & _TIF_32BIT;
+
 #else
+
 	/* Unknown architecture. */
 	return status;
+
 #endif 
 }
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4714,7 +4714,7 @@ FILLER(sched_switch_e, false)
 	return res;
 }
 
-#ifndef __TARGET_ARCH_arm64
+#ifndef __aarch64__
 FILLER(sys_pagefault_e, false)
 {
 	struct page_fault_args *ctx;
@@ -5753,7 +5753,7 @@ FILLER(sys_dup3_x, true)
 	return res;
 }
 
-#ifdef __TARGET_ARCH_arm64
+#ifdef __aarch64__
 /* We set `is_syscall` flag to `false` since this is not
  * a real syscall, we only send the same event from another
  * tracepoint.

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4716,12 +4716,17 @@ FILLER(sched_switch_e, false)
 
 FILLER(sys_pagefault_e, false)
 {
+	int res = 0;
+/* We cannot compile the whole filler out since in userspace we
+ * check that every filler-id (`PPM_FILLER_...`) has a corresponding BPF
+ * implementation.
+ */
+#ifndef __TARGET_ARCH_arm64
 	struct page_fault_args *ctx;
 	unsigned long error_code;
 	unsigned long address;
 	unsigned long ip;
 	u32 flags;
-	int res;
 
 	ctx = (struct page_fault_args *)data->ctx;
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
@@ -4746,7 +4751,7 @@ FILLER(sys_pagefault_e, false)
 
 	flags = pf_flags_to_scap(error_code);
 	res = bpf_val_to_ring(data, flags);
-
+#endif
 	return res;
 }
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6406,21 +6406,9 @@ FILLER(sched_prog_fork_3, false)
 	 */
 	struct pid_namespace *pidns = bpf_task_active_pid_ns(child);
 	int pidns_level = _READ(pidns->level);
-	if(pidns_level != 0) 
+	if(pidns_level != 0)
 	{
 		flags |= PPM_CL_CHILD_IN_PIDNS;
-	} 
-	else 
-	{
-		struct nsproxy *nsproxy = _READ(child->nsproxy);
-		if(nsproxy)
-		{
-			struct pid_namespace *pid_ns_for_children = _READ(nsproxy->pid_ns_for_children);
-			if(pid_ns_for_children != pidns)
-			{
-				flags |= PPM_CL_CHILD_IN_PIDNS;
-			}
-		}
 	}
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -5758,15 +5758,18 @@ FILLER(sys_dup3_x, true)
  * a real syscall, we only send the same event from another
  * tracepoint.
  * 
+ * These `sched_proc_exec` fillers will generate a 
+ * `PPME_SYSCALL_EXECVE_19_X` event.
+ * 
  * Please note: `is_syscall` is used only if `BPF_RAW_TRACEPOINT`
- * are not defined but in our ARM implementation they are akways defined,
- * so value of this flag is not relevant at all. 
+ * are not defined but in our ARM implementation they are always defined,
+ * so the value of this flag is not relevant at all.
  */
 FILLER(sched_prog_exec, false)
 {
 	int res = 0;
 
-	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Parameter 1: res (type: PT_ERRNO) */
 	/* Please note: if this filler is called the execve is correctly
 	 * performed, so the return value will be always 0.
 	 */
@@ -5784,10 +5787,8 @@ FILLER(sched_prog_exec, false)
 	}
 
 	/*
-	* The call always succeed so get `exe`, `args` from the current
-	* process; put one \0-separated exe-args string into
-	* str_storage
-	*/
+	 * The call always succeed so get `exe`, `args` from the current process.
+	 */
 	unsigned long arg_start = 0;
 	unsigned long arg_end = 0;
 
@@ -5811,7 +5812,6 @@ FILLER(sched_prog_exec, false)
 	 */
 	if(args_len && correctly_read == 0)
 	{
-
 		data->buf[(data->state->tail_ctx.curoff + args_len - 1) & SCRATCH_SIZE_MAX] = 0;
 
 		/* We need the len of the second param `exe`. */
@@ -5824,7 +5824,7 @@ FILLER(sched_prog_exec, false)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 		}
 
-		/* 2° Parameter: exe (type: PT_CHARBUF) */
+		/* Parameter 2: exe (type: PT_CHARBUF) */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, exe_len, PT_CHARBUF, -1, false);
 		if(res != PPM_SUCCESS)
@@ -5832,7 +5832,7 @@ FILLER(sched_prog_exec, false)
 			return res;
 		}
 
-		/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, args_len - exe_len, PT_BYTEBUF, -1, false);
 		if(res != PPM_SUCCESS)
@@ -5842,14 +5842,14 @@ FILLER(sched_prog_exec, false)
 	}
 	else
 	{
-		/* 2° Parameter: exe (type: PT_CHARBUF) */
+		/* Parameter 2: exe (type: PT_CHARBUF) */
 		res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
 		}
 
-		/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		res = bpf_val_to_ring_type(data, 0, PT_BYTEBUF);
 		if(res != PPM_SUCCESS)
 		{
@@ -5857,7 +5857,7 @@ FILLER(sched_prog_exec, false)
 		}
 	}
 
-	/* 4° Parameter: tid (type: PT_PID) */
+	/* Parameter 4: tid (type: PT_PID) */
 	pid_t pid = _READ(task->pid);
 	res = bpf_val_to_ring_type(data, pid, PT_PID);
 	if(res != PPM_SUCCESS)
@@ -5865,7 +5865,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 5° Parameter: pid (type: PT_PID) */
+	/* Parameter 5: pid (type: PT_PID) */
 	pid_t tgid = _READ(task->tgid);
 	res = bpf_val_to_ring_type(data, tgid, PT_PID);
 	if(res != PPM_SUCCESS)
@@ -5873,7 +5873,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 6° Parameter: ptid (type: PT_PID) */
+	/* Parameter 6: ptid (type: PT_PID) */
 	struct task_struct *real_parent = _READ(task->real_parent);
 	pid_t ptid = _READ(real_parent->pid);
 	res = bpf_val_to_ring_type(data, ptid, PT_PID);
@@ -5882,7 +5882,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
@@ -5892,7 +5892,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	struct signal_struct *signal = _READ(task->signal);
 	unsigned long fdlimit = _READ(signal->rlim[RLIMIT_NOFILE].rlim_cur);
 	res = bpf_val_to_ring_type(data, fdlimit, PT_UINT64);
@@ -5901,7 +5901,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	unsigned long maj_flt = _READ(task->maj_flt);
 	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
 	if(res != PPM_SUCCESS)
@@ -5909,7 +5909,7 @@ FILLER(sched_prog_exec, false)
 		return res;
 	}
 
-	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	unsigned long min_flt = _READ(task->min_flt);
 	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
 	if(res != PPM_SUCCESS)
@@ -5929,28 +5929,28 @@ FILLER(sched_prog_exec, false)
 		swap = bpf_get_mm_swap(mm) << (PAGE_SHIFT - 10);
 	}
 
-	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	/* Parameter 11: vm_size (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	/* Parameter 12: vm_rss (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	/* Parameter 13: vm_swap (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, swap, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = bpf_val_to_ring_type(data, (unsigned long)task->comm, PT_CHARBUF);
 	if(res != PPM_SUCCESS)
 	{
@@ -5966,7 +5966,6 @@ FILLER(sched_prog_exec_2, false)
 {
 	int cgroups_len = 0;
 	int res = 0;
-
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 
 	res = bpf_append_cgroup(task, data->tmp_scratch, &cgroups_len);
@@ -5975,7 +5974,7 @@ FILLER(sched_prog_exec_2, false)
 		return res;
 	}
 
-	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = __bpf_val_to_ring(data, (unsigned long)data->tmp_scratch, cgroups_len, PT_BYTEBUF, -1, false);
 	if(res != PPM_SUCCESS)
 	{
@@ -6021,7 +6020,7 @@ FILLER(sched_prog_exec_3, false)
 		}
 	}
 
-	/* 16° Parameter: env (type: PT_CHARBUFARRAY) */
+	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
 	data->curarg_already_on_frame = true;
 	res = __bpf_val_to_ring(data, 0, env_len, PT_BYTEBUF, -1, false);
 	if(res != PPM_SUCCESS)
@@ -6029,7 +6028,7 @@ FILLER(sched_prog_exec_3, false)
 		return res;
 	}
 
-	/* 17° Parameter: tty (type: PT_INT32) */
+	/* Parameter 17: tty (type: PT_INT32) */
 	int tty = bpf_ppm_get_tty(task);
 	res = bpf_val_to_ring_type(data, tty, PT_INT32);
 	if(res != PPM_SUCCESS)
@@ -6037,7 +6036,7 @@ FILLER(sched_prog_exec_3, false)
 		return res;
 	}
 
-	/* 18° Parameter: pgid (type: PT_PID) */
+	/* Parameter 18: pgid (type: PT_PID) */
 	res = bpf_val_to_ring_type(data, bpf_task_pgrp_vnr(task), PT_PID);
 	if(res != PPM_SUCCESS)
 	{
@@ -6062,7 +6061,7 @@ FILLER(sched_prog_exec_3, false)
 	loginuid = _READ(task->loginuid);
 #endif
 
-	/* 19° Parameter: loginuid (type: PT_INT32) */
+	/* Parameter 19: loginuid (type: PT_INT32) */
 	res = bpf_val_to_ring_type(data, loginuid.val, PT_INT32);
 	if(res != PPM_SUCCESS)
 	{
@@ -6078,11 +6077,10 @@ FILLER(sched_prog_exec_4, false)
 {
 
 	int res = 0;
-
+	uint32_t flags = 0;
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	struct cred *cred = (struct cred *)_READ(task->cred);
 
-	uint32_t flags = 0;
 
 	/* `exe_writable` flag logic */
 	bool exe_writable = false;
@@ -6094,7 +6092,7 @@ FILLER(sched_prog_exec_4, false)
 
 	// write all additional flags for execve family here...
 
-	/* 20° Parameter: flags (type: PT_FLAGS32) */
+	/* Parameter 20: flags (type: PT_FLAGS32) */
 	res = bpf_val_to_ring_type(data, flags, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
@@ -6104,7 +6102,7 @@ FILLER(sched_prog_exec_4, false)
 	kernel_cap_t cap;
 	unsigned long val;
 
-	/* 21° Parameter: cap_inheritable (type: PT_UINT64) */
+	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
 	cap = _READ(cred->cap_inheritable);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
 	res = bpf_val_to_ring(data, capabilities_to_scap(val));
@@ -6113,7 +6111,7 @@ FILLER(sched_prog_exec_4, false)
 		return res;
 	}
 
-	/* 22° Parameter: cap_permitted (type: PT_UINT64) */
+	/* Parameter 22: cap_permitted (type: PT_UINT64) */
 	cap = _READ(cred->cap_permitted);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
 	res = bpf_val_to_ring(data, capabilities_to_scap(val));
@@ -6122,7 +6120,7 @@ FILLER(sched_prog_exec_4, false)
 		return res;
 	}
 
-	/* 23° Parameter: cap_effective (type: PT_UINT64) */
+	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	cap = _READ(cred->cap_effective);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
 	res = bpf_val_to_ring(data, capabilities_to_scap(val));
@@ -6130,11 +6128,18 @@ FILLER(sched_prog_exec_4, false)
 	return res;
 }
 
+/* These `sched_proc_fork` fillers will generate a 
+ * `PPME_SYSCALL_CLONE_20_X` event.
+ */
 FILLER(sched_prog_fork, false)
 {
 	int res = 0;
 
-	/* First of all we need to update the event header with the child pid. */
+	/* First of all we need to update the event header with the child tid.
+	 * The clone child exit event must be generated by the child but while
+	 * we are sending this event, we are still the parent so we have to
+	 * modify the event header to simulate it.
+	 */
 	struct sched_process_fork_raw_args* original_ctx = (struct sched_process_fork_raw_args*)data->ctx;
 	struct task_struct *task = (struct task_struct *)original_ctx->child;
 	pid_t child_pid = _READ(task->pid);
@@ -6142,7 +6147,7 @@ FILLER(sched_prog_fork, false)
 	struct ppm_evt_hdr *evt_hdr = (struct ppm_evt_hdr *)data->buf;
 	evt_hdr->tid = (uint64_t)child_pid;
 
-	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Parameter 1: res (type: PT_ERRNO) */
 	/* Please note: here we are in the clone child exit
 	 * event, so the return value will be always 0.
 	 */
@@ -6186,7 +6191,6 @@ FILLER(sched_prog_fork, false)
 	 */
 	if(args_len && correctly_read == 0)
 	{
-
 		data->buf[(data->state->tail_ctx.curoff + args_len - 1) & SCRATCH_SIZE_MAX] = 0;
 
 		/* We need the len of the second param `exe`. */
@@ -6199,7 +6203,7 @@ FILLER(sched_prog_fork, false)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 		}
 
-		/* 2° Parameter: exe (type: PT_CHARBUF) */
+		/* Parameter 2: exe (type: PT_CHARBUF) */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, exe_len, PT_CHARBUF, -1, false);
 		if(res != PPM_SUCCESS)
@@ -6207,7 +6211,7 @@ FILLER(sched_prog_fork, false)
 			return res;
 		}
 
-		/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, args_len - exe_len, PT_BYTEBUF, -1, false);
 		if(res != PPM_SUCCESS)
@@ -6217,14 +6221,14 @@ FILLER(sched_prog_fork, false)
 	}
 	else
 	{
-		/* 2° Parameter: exe (type: PT_CHARBUF) */
+		/* Parameter 2: exe (type: PT_CHARBUF) */
 		res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
 		}
 
-		/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		res = bpf_val_to_ring_type(data, 0, PT_BYTEBUF);
 		if(res != PPM_SUCCESS)
 		{
@@ -6232,7 +6236,7 @@ FILLER(sched_prog_fork, false)
 		}
 	}
 
-	/* 4° Parameter: tid (type: PT_PID) */
+	/* Parameter 4: tid (type: PT_PID) */
 	pid_t pid = _READ(task->pid);
 	res = bpf_val_to_ring_type(data, pid, PT_PID);
 	if(res != PPM_SUCCESS)
@@ -6240,7 +6244,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 5° Parameter: pid (type: PT_PID) */
+	/* Parameter 5: pid (type: PT_PID) */
 	pid_t tgid = _READ(task->tgid);
 	res = bpf_val_to_ring_type(data, tgid, PT_PID);
 	if(res != PPM_SUCCESS)
@@ -6248,7 +6252,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 6° Parameter: ptid (type: PT_PID) */
+	/* Parameter 6: ptid (type: PT_PID) */
 	struct task_struct *real_parent = _READ(task->real_parent);
 	pid_t ptid = _READ(real_parent->pid);
 	res = bpf_val_to_ring_type(data, ptid, PT_PID);
@@ -6257,7 +6261,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
@@ -6267,7 +6271,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	struct signal_struct *signal = _READ(task->signal);
 	unsigned long fdlimit = _READ(signal->rlim[RLIMIT_NOFILE].rlim_cur);
 	res = bpf_val_to_ring_type(data, fdlimit, PT_UINT64);
@@ -6276,7 +6280,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	unsigned long maj_flt = _READ(task->maj_flt);
 	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
 	if(res != PPM_SUCCESS)
@@ -6284,7 +6288,7 @@ FILLER(sched_prog_fork, false)
 		return res;
 	}
 
-	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	unsigned long min_flt = _READ(task->min_flt);
 	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
 	if(res != PPM_SUCCESS)
@@ -6304,28 +6308,28 @@ FILLER(sched_prog_fork, false)
 		swap = bpf_get_mm_swap(mm) << (PAGE_SHIFT - 10);
 	}
 
-	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	/* Parameter 11: vm_size (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	/* Parameter 12: vm_rss (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	/* Parameter 13: vm_swap (type: PT_UINT32) */
 	res = bpf_val_to_ring_type(data, swap, PT_UINT32);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
 	}
 
-	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = bpf_val_to_ring_type(data, (unsigned long)task->comm, PT_CHARBUF);
 	if(res != PPM_SUCCESS)
 	{
@@ -6341,7 +6345,6 @@ FILLER(sched_prog_fork_2, false)
 {
 	int res = 0;
 	int cgroups_len = 0;
-
 	struct sched_process_fork_raw_args* original_ctx = (struct sched_process_fork_raw_args*)data->ctx;
 	struct task_struct *task = (struct task_struct *)original_ctx->child;
 
@@ -6351,7 +6354,7 @@ FILLER(sched_prog_fork_2, false)
 		return res;
 	}
 
-	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = __bpf_val_to_ring(data, (unsigned long)data->tmp_scratch, cgroups_len, PT_BYTEBUF, -1, false);
 	if(res != PPM_SUCCESS)
 	{
@@ -6369,7 +6372,7 @@ FILLER(sched_prog_fork_3, false)
 	struct sched_process_fork_raw_args* original_ctx = (struct sched_process_fork_raw_args*)data->ctx;
 	struct task_struct *task = (struct task_struct *)original_ctx->child;
 
-	/* 16° Parameter: flags (type: PT_FLAGS32) */
+	/* Parameter 16: flags (type: PT_FLAGS32) */
 	/// TODO: we have to recover them from the kernel in some way.
 	uint32_t flags = 0;
 	res = bpf_val_to_ring_type(data, flags, PT_FLAGS32);
@@ -6380,7 +6383,7 @@ FILLER(sched_prog_fork_3, false)
 
 	struct cred *cred = (struct cred *)_READ(task->cred);
 
-	/* 17° Parameter: uid (type: PT_UINT32) */
+	/* Parameter 17: uid (type: PT_UINT32) */
 	kuid_t euid = _READ(cred->euid);
 	res = bpf_val_to_ring_type(data, euid.val, PT_UINT32);
 	if(res != PPM_SUCCESS)
@@ -6388,7 +6391,7 @@ FILLER(sched_prog_fork_3, false)
 		return res;
 	}
 
-	/* 18° Parameter: gid (type: PT_UINT32) */
+	/* Parameter 18: gid (type: PT_UINT32) */
 	kgid_t egid = _READ(cred->egid);
 	res = bpf_val_to_ring_type(data, egid.val, PT_UINT32);
 	if(res != PPM_SUCCESS)
@@ -6396,13 +6399,13 @@ FILLER(sched_prog_fork_3, false)
 		return res;
 	}
 
-	/* 19° Parameter: vtid (type: PT_PID) */
+	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = bpf_task_pid_vnr(task);
 	res = bpf_val_to_ring_type(data, vtid, PT_PID);
 	if(res != PPM_SUCCESS)
 		return res;
 
-	/* 20° Parameter: vpid (type: PT_PID) */
+	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = bpf_task_tgid_vnr(task);
 	res = bpf_val_to_ring_type(data, vpid, PT_PID);
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4714,19 +4714,15 @@ FILLER(sched_switch_e, false)
 	return res;
 }
 
+#ifndef __TARGET_ARCH_arm64
 FILLER(sys_pagefault_e, false)
 {
-	int res = 0;
-/* We cannot compile the whole filler out since in userspace we
- * check that every filler-id (`PPM_FILLER_...`) has a corresponding BPF
- * implementation.
- */
-#ifndef __TARGET_ARCH_arm64
 	struct page_fault_args *ctx;
 	unsigned long error_code;
 	unsigned long address;
 	unsigned long ip;
 	u32 flags;
+	int res;
 
 	ctx = (struct page_fault_args *)data->ctx;
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
@@ -4751,9 +4747,9 @@ FILLER(sys_pagefault_e, false)
 
 	flags = pf_flags_to_scap(error_code);
 	res = bpf_val_to_ring(data, flags);
-#endif
 	return res;
 }
+#endif
 
 static __always_inline int siginfo_not_a_pointer(struct siginfo* info)
 {
@@ -5757,9 +5753,7 @@ FILLER(sys_dup3_x, true)
 	return res;
 }
 
-/// TODO: we need to compile it out in `x86`, look at the next commits,
-/// we want to change a little bit the logic in scap filler loading.
-
+#ifdef __TARGET_ARCH_arm64
 /* Please note: here we cannot use the FILLER macro since, this is
  * the unique case in which we need to set the `tid` in the header
  * different from the current thread id.
@@ -6141,5 +6135,6 @@ FILLER(sched_prog_exec_4, false)
 
 	return res;
 }
+#endif
 
 #endif

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6400,6 +6400,29 @@ FILLER(sched_prog_fork_3, false)
 		flags |= PPM_CL_CLONE_FILES;
 	}
 
+	/* It's possible to have a process in a PID namespace that 
+	 * nevertheless has tid == vtid,  so we need to generate this
+	 * custom flag `PPM_CL_CHILD_IN_PIDNS`.
+	 */
+	struct pid_namespace *pidns = bpf_task_active_pid_ns(task);
+	int pidns_level = _READ(pidns->level);
+	if(pidns_level != 0) 
+	{
+		flags |= PPM_CL_CHILD_IN_PIDNS;
+	} 
+	else 
+	{
+		struct nsproxy *nsproxy = _READ(task->nsproxy);
+		if(nsproxy)
+		{
+			struct pid_namespace *pid_ns_for_children = _READ(nsproxy->pid_ns_for_children);
+			if(pid_ns_for_children != pidns)
+			{
+				flags |= PPM_CL_CHILD_IN_PIDNS;
+			}
+		}
+	}
+
 	/* Parameter 16: flags (type: PT_FLAGS32) */
 	res = bpf_val_to_ring_type(data, flags, PT_FLAGS32);
 	if(res != PPM_SUCCESS)

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -97,7 +97,7 @@ static __always_inline long bpf_syscall_get_nr(void *ctx)
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
 	struct pt_regs *regs = (struct pt_regs *)args->regs;
 
-#if defined(__TARGET_ARCH_arm64)
+#ifdef __aarch64__
 	id = _READ(regs->syscallno);
 #else 
 	/* Right now we used this for all other architectures that are not ARM
@@ -139,7 +139,7 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	/* This is used both by ARM64 and x86. */
 	struct pt_regs *regs = (struct pt_regs *)args->regs;
 
-#if defined(__TARGET_ARCH_arm64)
+#ifdef __aarch64__
 	struct user_pt_regs *user_regs = (struct user_pt_regs *)args->regs;
 	switch (idx) {
 	case 0:

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -95,20 +95,27 @@ static __always_inline long bpf_syscall_get_nr(void *ctx)
 	long id;
 
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
+
 	struct pt_regs *regs = (struct pt_regs *)args->regs;
 
 #ifdef __aarch64__
+	
 	id = _READ(regs->syscallno);
+
 #else 
+	
 	/* Right now we used this for all other architectures that are not ARM
 	 * becuase we support only `x86`, but we have to check if it is correct
 	 * in case of other architectures.
 	 */
 	id = _READ(regs->orig_ax);
+
 #endif
 
 #else
+
 	id = args->id;
+
 #endif
 
 	return id;
@@ -135,11 +142,12 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	unsigned long arg;
 
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
+
 	struct sys_enter_args *args = (struct sys_enter_args *)ctx;
-	/* This is used both by ARM64 and x86. */
 	struct pt_regs *regs = (struct pt_regs *)args->regs;
 
 #ifdef __aarch64__
+	
 	struct user_pt_regs *user_regs = (struct user_pt_regs *)args->regs;
 	switch (idx) {
 	case 0:
@@ -155,7 +163,9 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	default:
 		arg = 0;
 	}
+
 #else
+	
 	switch (idx) {
 	case 0:
 		arg = _READ(regs->di);
@@ -178,15 +188,17 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	default:
 		arg = 0;
 	}
+
 #endif
 
 #else
-	unsigned long *args = unstash_args();
 
+	unsigned long *args = unstash_args();
 	if (args)
 		arg = bpf_syscall_get_argument_from_args(args, idx);
 	else
 		arg = 0;
+		
 #endif
 
 	return arg;

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -170,7 +170,7 @@ BPF_PROBE("sched/", sched_switch, sched_switch_args)
 	return 0;
 }
 
-#ifndef __TARGET_ARCH_arm64
+#ifndef __aarch64__
 /* Page fault tracepoints are not defined in ARM64, so
  * we don't inject anything into the kernel.
  */
@@ -252,7 +252,7 @@ int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
 }
 #endif
 
-#if defined(BPF_SUPPORTS_RAW_TRACEPOINTS) && defined(__TARGET_ARCH_arm64)
+#ifdef __aarch64__
 /* This section explains why we need two additional `raw_tracepoint`
  * in ARM64 architectures. Right now, we catch information from all
  * syscalls with `sys_enter` and `sys_exit` tracepoint. In x86 we are

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -170,6 +170,10 @@ BPF_PROBE("sched/", sched_switch, sched_switch_args)
 	return 0;
 }
 
+#ifndef __TARGET_ARCH_arm64
+/* Page fault tracepoints are not defined in ARM64, so
+ * we don't inject anything into the kernel.
+ */
 static __always_inline int bpf_page_fault(struct page_fault_args *ctx)
 {
 	struct scap_bpf_settings *settings;
@@ -200,6 +204,7 @@ BPF_PROBE("exceptions/", page_fault_kernel, page_fault_args)
 {
 	return bpf_page_fault(ctx);
 }
+#endif
 
 BPF_PROBE("signal/", signal_deliver, signal_deliver_args)
 {

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -263,6 +263,9 @@ int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
  * - `execve` exit event.
  * - `clone` child exit event.
  * 
+ * Here https://www.spinics.net/lists/linux-trace/msg01001.html
+ * you can find a brief description of the problem.
+ * 
  * This exit events don't call the `sys_exit` tracepoint and so our
  * bpf programs are not called. These events are really important so
  * in order to not lose them, we use 2 new tracepoints: 
@@ -277,9 +280,9 @@ int bpf_sched_process_fork(struct sched_process_fork_args *ctx)
  * essential for `sched_process_fork` since the only way we have to access the
  * child task struct is through the raw tracepoint arguments.
  * 
- * Since we need to use `BPF_PROG_TYPE_RAW_TRACEPOINT`, the ARM64 support for our 
- * BPF probe requires kernel greater or equal than `4.17`. If your run old kernel
- * version, you can use the kernel module which requires a kernel greater than `3.4`.
+ * Since we need to use `BPF_PROG_TYPE_RAW_TRACEPOINT`, the ARM64 support for our
+ * BPF probe requires kernel versions greater or equal than `4.17`. If you run old kernels, 
+ * you can use the kernel module which requires kernel versions greater or equal than `3.4`.
  */
 
 /* This macro `BPF_PROBE()` is equivalent to:
@@ -308,7 +311,7 @@ BPF_PROBE("sched_process_exec", sched_process_exec, sched_process_exec_raw_args)
 		return 0;
 	}
 
-	/* Reset the tail context in cpu state map. */
+	/* Reset the tail context in the CPU state map. */
 	uint32_t cpu = bpf_get_smp_processor_id();
 	struct scap_bpf_per_cpu_state * state = get_local_state(cpu);
 	if(!state)
@@ -349,7 +352,7 @@ BPF_PROBE("sched_process_fork", sched_process_fork, sched_process_fork_raw_args)
 		return 0;
 	}
 
-	/* Reset the tail context in cpu state map. */
+	/* Reset the tail context in the CPU state map. */
 	uint32_t cpu = bpf_get_smp_processor_id();
 	struct scap_bpf_per_cpu_state * state = get_local_state(cpu);
 	if(!state)

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -24,11 +24,14 @@ or GPL2.txt for full copies of the license.
 #define BPF_FORBIDS_ZERO_ACCESS
 #endif
 
-/* RAW_TRACEPOINTS logic is x86-specific */
-#if (defined(__i386__) || defined(__TARGET_ARCH_x86)  || defined(_M_IX86) || defined(__TARGET_ARCH_arm64))
+#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(__aarch64__))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif
+#endif
+
+#if defined(__aarch64__) && !defined(BPF_SUPPORTS_RAW_TRACEPOINTS)
+    #error The BPF ARM64 support requires 'raw_tracepoints' so a kernel version greater or equal than '4.17'
 #endif
 
 /* Redefine asm_volatile_goto to work around clang not supporting it

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -25,7 +25,7 @@ or GPL2.txt for full copies of the license.
 #endif
 
 /* RAW_TRACEPOINTS logic is x86-specific */
-#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
+#if (defined(__i386__) || defined(__TARGET_ARCH_x86)  || defined(_M_IX86) || defined(__TARGET_ARCH_arm64))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -24,14 +24,12 @@ or GPL2.txt for full copies of the license.
 #define BPF_FORBIDS_ZERO_ACCESS
 #endif
 
-#if (defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(__aarch64__))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif
-#endif
 
 #if defined(__aarch64__) && !defined(BPF_SUPPORTS_RAW_TRACEPOINTS)
-    #error The BPF ARM64 support requires 'raw_tracepoints' so a kernel version greater or equal than '4.17'
+    #error The BPF ARM64 support requires 'raw_tracepoints' so kernel versions greater or equal than '4.17'.
 #endif
 
 /* Redefine asm_volatile_goto to work around clang not supporting it

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -129,6 +129,27 @@ struct sys_stash_args {
 };
 #endif
 
+#ifdef __TARGET_ARCH_arm64
+/* TP_PROTO(struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm)
+ * Taken from `/include/trace/events/sched.h`
+ */
+ struct sched_process_exec_raw_args
+ {
+ 	struct task_struct *p;
+ 	pid_t old_pid;
+ 	struct linux_binprm *bprm;
+ };
+
+/* TP_PROTO(struct task_struct *parent, struct task_struct *child)
+ * Taken from `/include/trace/events/sched.h`
+ */
+struct sched_process_fork_raw_args
+{
+	struct task_struct *parent;
+ 	struct task_struct *child;
+};
+#endif
+
 struct filler_data {
 	void *ctx;
 	struct scap_bpf_settings *settings;

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -129,7 +129,7 @@ struct sys_stash_args {
 };
 #endif
 
-#ifdef __TARGET_ARCH_arm64
+#ifdef __aarch64__
 /* TP_PROTO(struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm)
  * Taken from `/include/trace/events/sched.h`
  */

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -15,7 +15,9 @@ or GPL2.txt for full copies of the license.
 #ifndef UDIG
 #define CAPTURE_CONTEXT_SWITCHES
 #define CAPTURE_SIGNAL_DELIVERIES
-#define CAPTURE_PAGE_FAULTS
+#ifdef __x86_64__
+	#define CAPTURE_PAGE_FAULTS
+#endif
 #endif /* UDIG */
 #endif /* __KERNEL__ */
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -61,7 +61,7 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("the Falco authors");
 
 #if defined(CONFIG_ARM64) && (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))
-	#error The kernel module ARM64 support requires a kernel version greater or equal than '3.4'
+	#error The kernel module ARM64 support requires kernel versions greater or equal than '3.4'.
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 35))
@@ -2256,6 +2256,9 @@ TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, 
 #endif
 
 #ifdef CONFIG_ARM64
+/* We explained why we need these tracepoints for ARM64 in the BPF probe code.
+ * Please take a look at `/bpf/probe.c`.
+ */ 
 TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm)
 {
 	struct event_data_t event_data;

--- a/driver/main.c
+++ b/driver/main.c
@@ -108,6 +108,12 @@ struct event_data_t {
 		} signal_data;
 
 #ifdef CONFIG_ARM64
+		/* Here we save only the child task struct since it is the
+		 * unique parameter we will use in our `f_sched_prog_fork`
+		 * filler. On the other side the `f_sched_prog_exec` filler
+		 * won't need any tracepoint parameter so we don't need a 
+		 * internal struct here.
+		 */
 		struct {
 			struct task_struct *child;
 		} sched_proc_fork_data;

--- a/driver/main.c
+++ b/driver/main.c
@@ -110,6 +110,13 @@ struct event_data_t {
 			struct linux_binprm *bprm;
 		} sched_proc_exec_data;
 
+#ifdef __aarch64__
+		struct {
+			struct task_struct *parent;
+			struct task_struct *child;
+		} sched_proc_fork_data;
+#endif
+
 		struct fault_data_t fault_data;
 	} event_info;
 };
@@ -163,6 +170,7 @@ TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
 TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm);
+TRACEPOINT_PROBE(sched_proc_fork_probe, struct task_struct *parent, struct task_struct *child);
 #endif
 
 static struct ppm_device *g_ppm_devs;
@@ -210,6 +218,7 @@ static bool g_fault_tracepoint_disabled;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
 static struct tracepoint *tp_sched_proc_exec;
+static struct tracepoint *tp_sched_proc_fork;
 #endif
 
 #ifdef _DEBUG
@@ -524,6 +533,11 @@ static int ppm_open(struct inode *inode, struct file *filp)
 			pr_err("can't create the 'sched_proc_exec' tracepoint\n");
 			goto err_sched_proc_exec;
 		}
+		ret = compat_register_trace(sched_proc_fork_probe, "sched_process_fork", tp_sched_proc_fork);
+		if (ret) {
+			pr_err("can't create the 'sched_proc_fork' tracepoint\n");
+			goto err_sched_proc_fork;
+		}
 #endif
 		g_tracepoint_registered = true;
 	}
@@ -533,6 +547,8 @@ static int ppm_open(struct inode *inode, struct file *filp)
 	goto cleanup_open;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+err_sched_proc_fork:
+	compat_unregister_trace(sched_proc_exec_probe, "sched_process_exec", tp_sched_proc_exec);
 err_sched_proc_exec:
 	compat_unregister_trace(signal_deliver_probe, "signal_deliver", tp_signal_deliver);
 #endif
@@ -646,6 +662,7 @@ static int ppm_release(struct inode *inode, struct file *filp)
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
 			compat_unregister_trace(sched_proc_exec_probe, "sched_process_exec", tp_sched_proc_exec);
+			compat_unregister_trace(sched_proc_fork_probe, "sched_process_fork", tp_sched_proc_fork);
 #endif
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
 			tracepoint_synchronize_unregister();
@@ -1839,19 +1856,24 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 		 * Fire the filler callback
 		 */
 		
-		/* For events of type `PPMC_SCHED_PROC_EXEC` or `PPMC_SCHED_PROC_FORK` we 
-		 * don't have a filler in the table or better we need to call another filler
-		 * for that event that is not in the table.
+		/* For events with category `PPMC_SCHED_PROC_EXEC` or `PPMC_SCHED_PROC_FORK`
+		 * we need to call dedicated fillers that are not in our `g_ppm_events` table.
 		 */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
-		if(event_datap->category == PPMC_SCHED_PROC_EXEC)
+		switch (event_datap->category)
 		{
+#ifdef __aarch64__
+		case PPMC_SCHED_PROC_EXEC:
 			cbres = f_sched_prog_exec(&args);
-		}
-#endif
+			break;
 
-		if(event_datap->category != PPMC_SCHED_PROC_EXEC) 
-		{
+		case PPMC_SCHED_PROC_FORK:
+			/* First of all we need to update the event header with the child pid. */
+			args.child = event_datap->event_info.sched_proc_fork_data.child;
+			hdr->tid = args.child->pid;
+			cbres = f_sched_prog_fork(&args);
+			break;
+#endif
+		default:
 			if (likely(g_ppm_events[event_type].filler_callback)) 
 			{
 				cbres = g_ppm_events[event_type].filler_callback(&args);
@@ -1861,6 +1883,7 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 				pr_err("corrupted filler for event type %d: NULL callback\n", event_type);
 				ASSERT(0);
 			}
+			break;
 		}
 
 		if (likely(cbres == PPM_SUCCESS)) {
@@ -2243,6 +2266,17 @@ TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, st
 
 	record_event_all_consumers(PPME_SYSCALL_EXECVE_19_X, UF_NEVER_DROP, &event_data);
 }
+
+TRACEPOINT_PROBE(sched_proc_fork_probe, struct task_struct *parent, struct task_struct *child)
+{
+	struct event_data_t event_data;
+
+	g_n_tracepoint_hit_inc();
+
+	event_data.category = PPMC_SCHED_PROC_FORK;
+	event_data.event_info.sched_proc_fork_data.child = child;
+	record_event_all_consumers(PPME_SYSCALL_CLONE_20_X, UF_NEVER_DROP, &event_data);
+}
 #endif
 
 static int init_ring_buffer(struct ppm_ring_buffer_context *ring)
@@ -2359,6 +2393,8 @@ static void visit_tracepoint(struct tracepoint *tp, void *priv)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
 	else if (!strcmp(tp->name, "sched_process_exec"))
 		tp_sched_proc_exec = tp;
+	else if (!strcmp(tp->name, "sched_process_fork"))
+		tp_sched_proc_fork = tp;	
 #endif
 }
 
@@ -2404,6 +2440,11 @@ static int get_tracepoint_handles(void)
 	if (!tp_sched_proc_exec)
 	{
 		pr_err("failed to find 'sched_process_exec' tracepoint\n");
+		return -ENOENT;
+	}
+	if (!tp_sched_proc_fork)
+	{
+		pr_err("failed to find 'sched_process_fork' tracepoint\n");
 		return -ENOENT;
 	}
 #endif

--- a/driver/main.c
+++ b/driver/main.c
@@ -103,16 +103,8 @@ struct event_data_t {
 			struct k_sigaction *ka;
 		} signal_data;
 
-		/* Not sure we have to add here since we don't need them... */
-		struct {
-			struct task_struct *p;
-			pid_t old_pid;
-			struct linux_binprm *bprm;
-		} sched_proc_exec_data;
-
 #ifdef __aarch64__
 		struct {
-			struct task_struct *parent;
 			struct task_struct *child;
 		} sched_proc_fork_data;
 #endif
@@ -2259,11 +2251,13 @@ TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, st
 
 	g_n_tracepoint_hit_inc();
 
-	event_data.category = PPMC_SCHED_PROC_EXEC;
-	// event_data.event_info.context_data.sched_proc_exec_data.p = p;
-	// event_data.event_info.context_data.sched_proc_exec_data.old_pid = old_pid;
-	// event_data.event_info.context_data.sched_proc_exec_data.bprm = bprm;
+	/* We are not interested in kernel threads. */
+	if(unlikely(current->flags & PF_KTHREAD))
+	{
+    	return;
+	}
 
+	event_data.category = PPMC_SCHED_PROC_EXEC;
 	record_event_all_consumers(PPME_SYSCALL_EXECVE_19_X, UF_NEVER_DROP, &event_data);
 }
 
@@ -2272,6 +2266,14 @@ TRACEPOINT_PROBE(sched_proc_fork_probe, struct task_struct *parent, struct task_
 	struct event_data_t event_data;
 
 	g_n_tracepoint_hit_inc();
+
+	/* We are not interested in kernel threads. 
+	 * The current thread here is the `parent`.
+	 */
+	if(unlikely(current->flags & PF_KTHREAD))
+	{
+    	return;
+	}
 
 	event_data.category = PPMC_SCHED_PROC_FORK;
 	event_data.event_info.sched_proc_fork_data.child = child;

--- a/driver/main.c
+++ b/driver/main.c
@@ -161,7 +161,7 @@ TRACEPOINT_PROBE(signal_deliver_probe, int sig, struct siginfo *info, struct k_s
 #endif
 
 /* tracepoints `page_fault_user/kernel` don't exist on ARM64 architecture .*/
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, unsigned long error_code);
 #endif
 
@@ -204,7 +204,7 @@ static struct tracepoint *tp_sched_switch;
 #ifdef CAPTURE_SIGNAL_DELIVERIES
 static struct tracepoint *tp_signal_deliver;
 #endif
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 // Even in kernels that can support page fault tracepoints, tracepoints may be
 // disabled so check if g_fault_tracepoint_disabled is set.
 static struct tracepoint *tp_page_fault_user;
@@ -649,7 +649,7 @@ static int ppm_release(struct inode *inode, struct file *filp)
 #ifdef CAPTURE_SIGNAL_DELIVERIES
 			compat_unregister_trace(signal_deliver_probe, "signal_deliver", tp_signal_deliver);
 #endif
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 			if (g_fault_tracepoint_registered) {
 				compat_unregister_trace(page_fault_probe, "page_fault_user", tp_page_fault_user);
 				compat_unregister_trace(page_fault_probe, "page_fault_kernel", tp_page_fault_kernel);
@@ -1137,7 +1137,7 @@ cleanup_ioctl_procinfo:
 	case PPM_IOCTL_ENABLE_PAGE_FAULTS:
 	{
 		vpr_info("PPM_IOCTL_ENABLE_PAGE_FAULTS\n");
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 		ASSERT(g_tracepoint_registered);
 
 		if (g_fault_tracepoint_disabled) {
@@ -1177,7 +1177,7 @@ cleanup_ioctl_procinfo:
 		goto cleanup_ioctl;
 	}
 
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 err_page_fault_kernel:
 	compat_unregister_trace(page_fault_probe, "page_fault_user", tp_page_fault_user);
 #endif
@@ -2223,7 +2223,7 @@ TRACEPOINT_PROBE(signal_deliver_probe, int sig, struct siginfo *info, struct k_s
 }
 #endif
 
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, unsigned long error_code)
 {
 	struct event_data_t event_data;
@@ -2391,7 +2391,7 @@ static void visit_tracepoint(struct tracepoint *tp, void *priv)
 	else if (!strcmp(tp->name, "signal_deliver"))
 		tp_signal_deliver = tp;
 #endif
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 	else if (!strcmp(tp->name, "page_fault_user"))
 		tp_page_fault_user = tp;
 	else if (!strcmp(tp->name, "page_fault_kernel"))
@@ -2433,7 +2433,7 @@ static int get_tracepoint_handles(void)
 		return -ENOENT;
 	}
 #endif
-#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
+#ifdef CAPTURE_PAGE_FAULTS
 	if (!tp_page_fault_user) {
 		pr_notice("failed to find page_fault_user tracepoint, disabling page-faults\n");
 		g_fault_tracepoint_disabled = true;

--- a/driver/main.c
+++ b/driver/main.c
@@ -103,6 +103,13 @@ struct event_data_t {
 			struct k_sigaction *ka;
 		} signal_data;
 
+		/* Not sure we have to add here since we don't need them... */
+		struct {
+			struct task_struct *p;
+			pid_t old_pid;
+			struct linux_binprm *bprm;
+		} sched_proc_exec_data;
+
 		struct fault_data_t fault_data;
 	} event_info;
 };
@@ -154,6 +161,10 @@ TRACEPOINT_PROBE(signal_deliver_probe, int sig, struct siginfo *info, struct k_s
 TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, unsigned long error_code);
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm);
+#endif
+
 static struct ppm_device *g_ppm_devs;
 static struct class *g_ppm_class;
 static unsigned int g_ppm_numdevs;
@@ -195,6 +206,10 @@ static struct tracepoint *tp_page_fault_user;
 static struct tracepoint *tp_page_fault_kernel;
 static bool g_fault_tracepoint_registered;
 static bool g_fault_tracepoint_disabled;
+#endif
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+static struct tracepoint *tp_sched_proc_exec;
 #endif
 
 #ifdef _DEBUG
@@ -502,6 +517,14 @@ static int ppm_open(struct inode *inode, struct file *filp)
 			goto err_signal_deliver;
 		}
 #endif
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+		ret = compat_register_trace(sched_proc_exec_probe, "sched_process_exec", tp_sched_proc_exec);
+		if (ret) {
+			pr_err("can't create the 'sched_proc_exec' tracepoint\n");
+			goto err_sched_proc_exec;
+		}
+#endif
 		g_tracepoint_registered = true;
 	}
 
@@ -509,6 +532,10 @@ static int ppm_open(struct inode *inode, struct file *filp)
 
 	goto cleanup_open;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+err_sched_proc_exec:
+	compat_unregister_trace(signal_deliver_probe, "signal_deliver", tp_signal_deliver);
+#endif
 #ifdef CAPTURE_SIGNAL_DELIVERIES
 err_signal_deliver:
 	compat_unregister_trace(sched_switch_probe, "sched_switch", tp_sched_switch);
@@ -616,6 +643,9 @@ static int ppm_release(struct inode *inode, struct file *filp)
 
 				g_fault_tracepoint_registered = false;
 			}
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+			compat_unregister_trace(sched_proc_exec_probe, "sched_process_exec", tp_sched_proc_exec);
 #endif
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
 			tracepoint_synchronize_unregister();
@@ -1808,11 +1838,29 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 		/*
 		 * Fire the filler callback
 		 */
-		if (likely(g_ppm_events[event_type].filler_callback)) {
-			cbres = g_ppm_events[event_type].filler_callback(&args);
-		} else {
-			pr_err("corrupted filler for event type %d: NULL callback\n", event_type);
-			ASSERT(0);
+		
+		/* For events of type `PPMC_SCHED_PROC_EXEC` or `PPMC_SCHED_PROC_FORK` we 
+		 * don't have a filler in the table or better we need to call another filler
+		 * for that event that is not in the table.
+		 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+		if(event_datap->category == PPMC_SCHED_PROC_EXEC)
+		{
+			cbres = f_sched_prog_exec(&args);
+		}
+#endif
+
+		if(event_datap->category != PPMC_SCHED_PROC_EXEC) 
+		{
+			if (likely(g_ppm_events[event_type].filler_callback)) 
+			{
+				cbres = g_ppm_events[event_type].filler_callback(&args);
+			} 
+			else 
+			{
+				pr_err("corrupted filler for event type %d: NULL callback\n", event_type);
+				ASSERT(0);
+			}
 		}
 
 		if (likely(cbres == PPM_SUCCESS)) {
@@ -2181,6 +2229,22 @@ TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, 
 }
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+TRACEPOINT_PROBE(sched_proc_exec_probe, struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm)
+{
+	struct event_data_t event_data;
+
+	g_n_tracepoint_hit_inc();
+
+	event_data.category = PPMC_SCHED_PROC_EXEC;
+	// event_data.event_info.context_data.sched_proc_exec_data.p = p;
+	// event_data.event_info.context_data.sched_proc_exec_data.old_pid = old_pid;
+	// event_data.event_info.context_data.sched_proc_exec_data.bprm = bprm;
+
+	record_event_all_consumers(PPME_SYSCALL_EXECVE_19_X, UF_NEVER_DROP, &event_data);
+}
+#endif
+
 static int init_ring_buffer(struct ppm_ring_buffer_context *ring)
 {
 	unsigned int j;
@@ -2292,6 +2356,10 @@ static void visit_tracepoint(struct tracepoint *tp, void *priv)
 	else if (!strcmp(tp->name, "page_fault_kernel"))
 		tp_page_fault_kernel = tp;
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+	else if (!strcmp(tp->name, "sched_process_exec"))
+		tp_sched_proc_exec = tp;
+#endif
 }
 
 static int get_tracepoint_handles(void)
@@ -2332,7 +2400,13 @@ static int get_tracepoint_handles(void)
 		g_fault_tracepoint_disabled = true;
 	}
 #endif
-
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+	if (!tp_sched_proc_exec)
+	{
+		pr_err("failed to find 'sched_process_exec' tracepoint\n");
+		return -ENOENT;
+	}
+#endif
 	return 0;
 }
 #else

--- a/driver/main.c
+++ b/driver/main.c
@@ -160,7 +160,8 @@ TRACEPOINT_PROBE(sched_switch_probe, bool preempt, struct task_struct *prev, str
 TRACEPOINT_PROBE(signal_deliver_probe, int sig, struct siginfo *info, struct k_sigaction *ka);
 #endif
 
-#ifdef CAPTURE_PAGE_FAULTS
+/* tracepoints `page_fault_user/kernel` don't exist on ARM64 architecture .*/
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, unsigned long error_code);
 #endif
 
@@ -203,7 +204,7 @@ static struct tracepoint *tp_sched_switch;
 #ifdef CAPTURE_SIGNAL_DELIVERIES
 static struct tracepoint *tp_signal_deliver;
 #endif
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 // Even in kernels that can support page fault tracepoints, tracepoints may be
 // disabled so check if g_fault_tracepoint_disabled is set.
 static struct tracepoint *tp_page_fault_user;
@@ -648,7 +649,7 @@ static int ppm_release(struct inode *inode, struct file *filp)
 #ifdef CAPTURE_SIGNAL_DELIVERIES
 			compat_unregister_trace(signal_deliver_probe, "signal_deliver", tp_signal_deliver);
 #endif
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 			if (g_fault_tracepoint_registered) {
 				compat_unregister_trace(page_fault_probe, "page_fault_user", tp_page_fault_user);
 				compat_unregister_trace(page_fault_probe, "page_fault_kernel", tp_page_fault_kernel);
@@ -1136,7 +1137,7 @@ cleanup_ioctl_procinfo:
 	case PPM_IOCTL_ENABLE_PAGE_FAULTS:
 	{
 		vpr_info("PPM_IOCTL_ENABLE_PAGE_FAULTS\n");
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 		ASSERT(g_tracepoint_registered);
 
 		if (g_fault_tracepoint_disabled) {
@@ -1176,7 +1177,7 @@ cleanup_ioctl_procinfo:
 		goto cleanup_ioctl;
 	}
 
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 err_page_fault_kernel:
 	compat_unregister_trace(page_fault_probe, "page_fault_user", tp_page_fault_user);
 #endif
@@ -2222,7 +2223,7 @@ TRACEPOINT_PROBE(signal_deliver_probe, int sig, struct siginfo *info, struct k_s
 }
 #endif
 
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 TRACEPOINT_PROBE(page_fault_probe, unsigned long address, struct pt_regs *regs, unsigned long error_code)
 {
 	struct event_data_t event_data;
@@ -2390,7 +2391,7 @@ static void visit_tracepoint(struct tracepoint *tp, void *priv)
 	else if (!strcmp(tp->name, "signal_deliver"))
 		tp_signal_deliver = tp;
 #endif
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 	else if (!strcmp(tp->name, "page_fault_user"))
 		tp_page_fault_user = tp;
 	else if (!strcmp(tp->name, "page_fault_kernel"))
@@ -2432,7 +2433,7 @@ static int get_tracepoint_handles(void)
 		return -ENOENT;
 	}
 #endif
-#ifdef CAPTURE_PAGE_FAULTS
+#if defined(CAPTURE_PAGE_FAULTS) && !defined(CONFIG_ARM64)
 	if (!tp_page_fault_user) {
 		pr_notice("failed to find page_fault_user tracepoint, disabling page-faults\n");
 		g_fault_tracepoint_disabled = true;

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -63,7 +63,7 @@ struct event_filler_arguments {
 	struct task_struct *sched_prev; /* for context switch events, the task that is being scheduled out */
 	struct task_struct *sched_next; /* for context switch events, the task that is being scheduled in */
 
-#ifdef __aarch64__
+#ifdef CONFIG_ARM64
 	struct task_struct *child; /* for sched_process_fork events, this is the child task */
 #endif
 

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -62,6 +62,11 @@ struct event_filler_arguments {
 #endif
 	struct task_struct *sched_prev; /* for context switch events, the task that is being scheduled out */
 	struct task_struct *sched_next; /* for context switch events, the task that is being scheduled in */
+
+#ifdef __aarch64__
+	struct task_struct *child; /* for sched_process_fork events, this is the child task */
+#endif
+
 	char *str_storage; /* String storage. Size is one page. */
 #ifndef UDIG
 	unsigned long socketcall_args[6];

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -767,6 +767,7 @@ enum ppm_capture_category {
 	PPMC_SIGNAL = 3,
 	PPMC_PAGE_FAULT = 4,
 	PPMC_SCHED_PROC_EXEC = 5,
+	PPMC_SCHED_PROC_FORK = 6,
 };
 
 /** @defgroup etypes Event Types

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -766,6 +766,7 @@ enum ppm_capture_category {
 	PPMC_CONTEXT_SWITCH = 2,
 	PPMC_SIGNAL = 3,
 	PPMC_PAGE_FAULT = 4,
+	PPMC_SCHED_PROC_EXEC = 5,
 };
 
 /** @defgroup etypes Event Types

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6883,7 +6883,7 @@ cgroups_error:
 	 * nevertheless has tid == vtid,  so we need to generate this
 	 * custom flag `PPM_CL_CHILD_IN_PIDNS`.
 	 */
-	if(pidns != &init_pid_ns || pid_ns_for_children(child) != pidns)
+	if(pidns != &init_pid_ns)
 	{
 		flags |= PPM_CL_CHILD_IN_PIDNS;
 	}

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6693,7 +6693,7 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 	}
 
 	/*
-	* The call always succeed so get `exe`, `args` from the current
+	* The call always succeed so get `exe`, `args` from the child
 	* process; put one \0-separated exe-args string into
 	* str_storage
 	*/
@@ -6859,6 +6859,16 @@ cgroups_error:
 	}
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
+	if(child->pid != child->tgid)
+	{
+		flags |= PPM_CL_CLONE_THREAD | PPM_CL_CLONE_SIGHAND | PPM_CL_CLONE_VM;
+	}
+
+	if(child->files == current->files)
+	{
+		flags |= PPM_CL_CLONE_FILES;
+	}
+
 	res = val_to_ring(args, flags, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6371,7 +6371,7 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 	const struct cred *cred = NULL;
 
 
-	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Parameter 1: res (type: PT_ERRNO) */
 	/* Please note: if this filler is called the execve is correctly
 	 * performed, so the return value will be always 0.
 	 */
@@ -6426,35 +6426,35 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 		++exe_len;
 	}
 
-	/* 2° Parameter: exe (type: PT_CHARBUF) */
+	/* Parameter 2: exe (type: PT_CHARBUF) */
 	res = val_to_ring(args, (uint64_t)(long)args->str_storage, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	res = val_to_ring(args, (int64_t)(long)args->str_storage + exe_len, args_len - exe_len, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 4° Parameter: tid (type: PT_PID) */
+	/* Parameter 4: tid (type: PT_PID) */
 	res = val_to_ring(args, (int64_t)current->pid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 5° Parameter: pid (type: PT_PID) */
+	/* Parameter 5: pid (type: PT_PID) */
 	res = val_to_ring(args, (int64_t)current->tgid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 6° Parameter: ptid (type: PT_PID) */
+	/* Parameter 6: ptid (type: PT_PID) */
 	if(current->real_parent)
 	{
 		ptid = current->real_parent->pid;
@@ -6466,7 +6466,7 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 		return res;
 	}
 
-	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
@@ -6476,21 +6476,21 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 		return res;
 	}
 
-	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	res = val_to_ring(args, (int64_t)rlimit(RLIMIT_NOFILE), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	res = val_to_ring(args, current->maj_flt, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	res = val_to_ring(args, current->min_flt, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6504,28 +6504,28 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 		swap = ppm_get_mm_swap(mm) << (PAGE_SHIFT - 10);
 	}
 
-	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	/* Parameter 11: vm_size (type: PT_UINT32) */
 	res = val_to_ring(args, total_vm, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	/* Parameter 12: vm_rss (type: PT_UINT32) */
 	res = val_to_ring(args, total_rss, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	/* Parameter 13: vm_swap (type: PT_UINT32) */
 	res = val_to_ring(args, swap, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = val_to_ring(args, (uint64_t)current->comm, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6540,7 +6540,7 @@ cgroups_error:
 	rcu_read_unlock();
 #endif
 
-	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = val_to_ring(args, (int64_t)(long)args->str_storage, STR_STORAGE_SIZE - available, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6561,18 +6561,18 @@ cgroups_error:
 	}
 	else
 	{
-		args_len = 0;
+		env_len = 0;
 		*args->str_storage = 0;
 	}
 
-	/* 16° Parameter: env (type: PT_CHARBUFARRAY) */
+	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
 	res = val_to_ring(args, (int64_t)(long)args->str_storage, env_len, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 17° Parameter: tty (type: PT_INT32) */
+	/* Parameter 17: tty (type: PT_INT32) */
 	tty_nr = ppm_get_tty();
 	res = val_to_ring(args, tty_nr, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
@@ -6580,14 +6580,14 @@ cgroups_error:
 		return res;
 	}
 
-	/* 18° Parameter: pgid (type: PT_PID) */
+	/* Parameter 18: pgid (type: PT_PID) */
 	res = val_to_ring(args, (int64_t)task_pgrp_nr_ns(current, task_active_pid_ns(current)), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 19° Parameter: loginuid (type: PT_INT32) */
+	/* Parameter 19: loginuid (type: PT_INT32) */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
 	val = from_kuid(current_user_ns(), audit_get_loginuid(current));
 #else
@@ -6623,7 +6623,7 @@ cgroups_error:
 
 	// write all the additional flags for execve family here...
 
-	/* 20° Parameter: flags (type: PT_FLAGS32) */
+	/* Parameter 20: flags (type: PT_FLAGS32) */
 	res = val_to_ring(args, flags, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6632,7 +6632,7 @@ cgroups_error:
 
 	cred = get_current_cred();
 
-	/* 21° Parameter: cap_inheritable (type: PT_UINT64) */
+	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
 	val = ((uint64_t)cred->cap_inheritable.cap[1] << 32) | cred->cap_inheritable.cap[0];
 	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
@@ -6640,7 +6640,7 @@ cgroups_error:
 		goto out;
 	}
 
-	/* 22° Parameter: cap_permitted (type: PT_UINT64) */
+	/* Parameter 22: cap_permitted (type: PT_UINT64) */
 	val = ((uint64_t)cred->cap_permitted.cap[1] << 32) | cred->cap_permitted.cap[0];
 	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
@@ -6648,7 +6648,7 @@ cgroups_error:
 		goto out;
 	}
 
-	/* 23° Parameter: cap_effective (type: PT_UINT64) */
+	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	val = ((uint64_t)cred->cap_effective.cap[1] << 32) | cred->cap_effective.cap[0];
 	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
@@ -6682,7 +6682,7 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 	uint64_t euid = task_euid(child).val;
 	uint64_t egid = child->cred->egid.val;
 
-	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Parameter 1: res (type: PT_ERRNO) */
 	/* Please note: here we are in the clone child exit
 	 * event, so the return value will be always 0.
 	 */
@@ -6737,35 +6737,35 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 		++exe_len;
 	}
 
-	/* 2° Parameter: exe (type: PT_CHARBUF) */
+	/* Parameter 2: exe (type: PT_CHARBUF) */
 	res = val_to_ring(args, (uint64_t)(long)args->str_storage, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	res = val_to_ring(args, (int64_t)(long)args->str_storage + exe_len, args_len - exe_len, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 4° Parameter: tid (type: PT_PID) */
+	/* Parameter 4: tid (type: PT_PID) */
 	res = val_to_ring(args, (int64_t)child->pid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 5° Parameter: pid (type: PT_PID) */
+	/* Parameter 5: pid (type: PT_PID) */
 	res = val_to_ring(args, (int64_t)child->tgid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 6° Parameter: ptid (type: PT_PID) */
+	/* Parameter 6: ptid (type: PT_PID) */
 	if(child->real_parent)
 	{
 		ptid = child->real_parent->pid;
@@ -6777,7 +6777,7 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 		return res;
 	}
 
-	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
@@ -6787,21 +6787,21 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 		return res;
 	}
 
-	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	res = val_to_ring(args, (int64_t)rlimit(RLIMIT_NOFILE), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	res = val_to_ring(args, child->maj_flt, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	res = val_to_ring(args, child->min_flt, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6815,28 +6815,28 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 		swap = ppm_get_mm_swap(mm) << (PAGE_SHIFT - 10);
 	}
 
-	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	/* Parameter 11: vm_size (type: PT_UINT32) */
 	res = val_to_ring(args, total_vm, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	/* Parameter 12: vm_rss (type: PT_UINT32) */
 	res = val_to_ring(args, total_rss, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	/* Parameter 13: vm_swap (type: PT_UINT32) */
 	res = val_to_ring(args, swap, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = val_to_ring(args, (uint64_t)child->comm, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -6851,42 +6851,42 @@ cgroups_error:
 	rcu_read_unlock();
 #endif
 
-	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = val_to_ring(args, (int64_t)(long)args->str_storage, STR_STORAGE_SIZE - available, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 16° Parameter: flags (type: PT_FLAGS32) */
+	/* Parameter 16: flags (type: PT_FLAGS32) */
 	res = val_to_ring(args, flags, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 17° Parameter: uid (type: PT_UINT32) */
+	/* Parameter 17: uid (type: PT_UINT32) */
 	res = val_to_ring(args, euid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 18° Parameter: gid (type: PT_UINT32) */
+	/* Parameter 18: gid (type: PT_UINT32) */
 	res = val_to_ring(args, egid, 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 19° Parameter: vtid (type: PT_PID) */
+	/* Parameter 19: vtid (type: PT_PID) */
 	res = val_to_ring(args, task_pid_vnr(child), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
-	/* 20° Parameter: vpid (type: PT_PID) */
+	/* Parameter 20: vpid (type: PT_PID) */
 	res = val_to_ring(args, task_tgid_vnr(child), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6663,6 +6663,238 @@ out:
 	put_cred(cred);
 	return res;
 }
+
+int f_sched_prog_fork(struct event_filler_arguments *args)
+{
+	int res = 0;
+	struct task_struct *child = args->child;
+	struct mm_struct *mm = child->mm;
+	int args_len = 0;
+	int correctly_read = 0;
+	unsigned int exe_len = 0; /* the length of the executable string. */
+	int ptid = 0;
+	char *spwd = "";
+	long total_vm = 0;
+	long total_rss = 0;
+	long swap = 0;
+	int available = STR_STORAGE_SIZE;
+	uint32_t flags = 0;
+	uint64_t euid = task_euid(child).val;
+	uint64_t egid = child->cred->egid.val;
+
+	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Please note: here we are in the clone child exit
+	 * event, so the return value will be always 0.
+	 */
+	res = val_to_ring(args, 0, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/*
+	* The call always succeed so get `exe`, `args` from the current
+	* process; put one \0-separated exe-args string into
+	* str_storage
+	*/
+	if(unlikely(!mm))
+	{
+		args->str_storage[0] = 0;
+		pr_info("'f_sched_prog_fork' drop, mm=NULL\n");
+		return PPM_FAILURE_BUG;
+	}
+
+	if(unlikely(!mm->arg_end))
+	{
+		args->str_storage[0] = 0;
+		pr_info("'f_sched_prog_fork' drop, mm->arg_end=NULL\n");
+		return PPM_FAILURE_BUG;
+	}
+
+	/* the combined length of the arguments string + executable string. */
+	args_len = mm->arg_end - mm->arg_start;
+
+	if(args_len > PAGE_SIZE)
+	{
+		args_len = PAGE_SIZE;
+	}
+
+	correctly_read = ppm_copy_from_user(args->str_storage, (const void __user *)mm->arg_start, args_len);
+
+	if(args_len && correctly_read == 0)
+	{
+		args->str_storage[args_len - 1] = 0;
+	}
+	else
+	{
+		args_len = 0;
+		*args->str_storage = 0;
+	}
+
+	exe_len = strnlen(args->str_storage, args_len);
+	if(exe_len < args_len)
+	{
+		++exe_len;
+	}
+
+	/* 2° Parameter: exe (type: PT_CHARBUF) */
+	res = val_to_ring(args, (uint64_t)(long)args->str_storage, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+	res = val_to_ring(args, (int64_t)(long)args->str_storage + exe_len, args_len - exe_len, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 4° Parameter: tid (type: PT_PID) */
+	res = val_to_ring(args, (int64_t)child->pid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 5° Parameter: pid (type: PT_PID) */
+	res = val_to_ring(args, (int64_t)child->tgid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 6° Parameter: ptid (type: PT_PID) */
+	if(child->real_parent)
+	{
+		ptid = child->real_parent->pid;
+	}
+
+	res = val_to_ring(args, (int64_t)ptid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	 * cwd, pushed empty to avoid breaking compatibility
+	 * with the older event format
+	 */
+	res = val_to_ring(args, (uint64_t)(long)spwd, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	res = val_to_ring(args, (int64_t)rlimit(RLIMIT_NOFILE), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	res = val_to_ring(args, child->maj_flt, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	res = val_to_ring(args, child->min_flt, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	if(mm)
+	{
+		total_vm = mm->total_vm << (PAGE_SHIFT - 10);
+		total_rss = ppm_get_mm_rss(mm) << (PAGE_SHIFT - 10);
+		swap = ppm_get_mm_swap(mm) << (PAGE_SHIFT - 10);
+	}
+
+	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	res = val_to_ring(args, total_vm, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	res = val_to_ring(args, total_rss, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	res = val_to_ring(args, swap, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	res = val_to_ring(args, (uint64_t)child->comm, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	args->str_storage[0] = 0;
+#ifdef CONFIG_CGROUPS
+	rcu_read_lock();
+#include <linux/cgroup_subsys.h>
+cgroups_error:
+	rcu_read_unlock();
+#endif
+
+	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	res = val_to_ring(args, (int64_t)(long)args->str_storage, STR_STORAGE_SIZE - available, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 16° Parameter: flags (type: PT_FLAGS32) */
+	res = val_to_ring(args, flags, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 17° Parameter: uid (type: PT_UINT32) */
+	res = val_to_ring(args, euid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 18° Parameter: gid (type: PT_UINT32) */
+	res = val_to_ring(args, egid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 19° Parameter: vtid (type: PT_PID) */
+	res = val_to_ring(args, task_pid_vnr(child), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 20° Parameter: vpid (type: PT_PID) */
+	res = val_to_ring(args, task_tgid_vnr(child), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	return add_sentinel(args);
+}
 #endif
 
 #endif /* WDIG */

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6348,4 +6348,321 @@ out:
 	return res;
 }
 
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+int f_sched_prog_exec(struct event_filler_arguments *args)
+{
+	int res = 0;
+	unsigned long val = 0;
+	struct mm_struct *mm = current->mm;
+	int args_len = 0;
+	int correctly_read = 0;
+	unsigned int exe_len = 0; /* the length of the executable string. */
+	int ptid = 0;
+	char *spwd = "";
+	long total_vm = 0;
+	long total_rss = 0;
+	long swap = 0;
+	int available = STR_STORAGE_SIZE;
+	long env_len = 0;
+	int tty_nr = 0;
+	uint32_t flags = 0;
+	bool exe_writable = false;
+	struct file *exe_file = NULL;
+	const struct cred *cred = NULL;
+
+
+	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Please note: if this filler is called the execve is correctly
+	 * performed, so the return value will be always 0.
+	 */
+	res = val_to_ring(args, 0, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/*
+	* The call always succeed so get `exe`, `args` from the current
+	* process; put one \0-separated exe-args string into
+	* str_storage
+	*/
+	if(unlikely(!mm))
+	{
+		args->str_storage[0] = 0;
+		pr_info("'f_sched_prog_exec' drop, mm=NULL\n");
+		return PPM_FAILURE_BUG;
+	}
+
+	if(unlikely(!mm->arg_end))
+	{
+		args->str_storage[0] = 0;
+		pr_info("'f_sched_prog_exec' drop, mm->arg_end=NULL\n");
+		return PPM_FAILURE_BUG;
+	}
+
+	/* the combined length of the arguments string + executable string. */
+	args_len = mm->arg_end - mm->arg_start;
+
+	if(args_len > PAGE_SIZE)
+	{
+		args_len = PAGE_SIZE;
+	}
+
+	correctly_read = ppm_copy_from_user(args->str_storage, (const void __user *)mm->arg_start, args_len);
+
+	if(args_len && correctly_read == 0)
+	{
+		args->str_storage[args_len - 1] = 0;
+	}
+	else
+	{
+		args_len = 0;
+		*args->str_storage = 0;
+	}
+
+	exe_len = strnlen(args->str_storage, args_len);
+	if(exe_len < args_len)
+	{
+		++exe_len;
+	}
+
+	/* 2° Parameter: exe (type: PT_CHARBUF) */
+	res = val_to_ring(args, (uint64_t)(long)args->str_storage, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 3° Parameter: args (type: PT_CHARBUFARRAY) */
+	res = val_to_ring(args, (int64_t)(long)args->str_storage + exe_len, args_len - exe_len, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 4° Parameter: tid (type: PT_PID) */
+	res = val_to_ring(args, (int64_t)current->pid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 5° Parameter: pid (type: PT_PID) */
+	res = val_to_ring(args, (int64_t)current->tgid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 6° Parameter: ptid (type: PT_PID) */
+	if(current->real_parent)
+	{
+		ptid = current->real_parent->pid;
+	}
+
+	res = val_to_ring(args, (int64_t)ptid, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 7° Parameter: cwd (type: PT_CHARBUF)
+	 * cwd, pushed empty to avoid breaking compatibility
+	 * with the older event format
+	 */
+	res = val_to_ring(args, (uint64_t)(long)spwd, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 8° Parameter: fdlimit (type: PT_UINT64) */
+	res = val_to_ring(args, (int64_t)rlimit(RLIMIT_NOFILE), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 9° Parameter: pgft_maj (type: PT_UINT64) */
+	res = val_to_ring(args, current->maj_flt, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 10° Parameter: pgft_min (type: PT_UINT64) */
+	res = val_to_ring(args, current->min_flt, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	if(mm)
+	{
+		total_vm = mm->total_vm << (PAGE_SHIFT - 10);
+		total_rss = ppm_get_mm_rss(mm) << (PAGE_SHIFT - 10);
+		swap = ppm_get_mm_swap(mm) << (PAGE_SHIFT - 10);
+	}
+
+	/* 11° Parameter: vm_size (type: PT_UINT32) */
+	res = val_to_ring(args, total_vm, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 12° Parameter: vm_rss (type: PT_UINT32) */
+	res = val_to_ring(args, total_rss, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 13° Parameter: vm_swap (type: PT_UINT32) */
+	res = val_to_ring(args, swap, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 14° Parameter: comm (type: PT_CHARBUF) */
+	res = val_to_ring(args, (uint64_t)current->comm, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	args->str_storage[0] = 0;
+#ifdef CONFIG_CGROUPS
+	rcu_read_lock();
+#include <linux/cgroup_subsys.h>
+cgroups_error:
+	rcu_read_unlock();
+#endif
+
+	/* 15° Parameter: cgroups (type: PT_CHARBUFARRAY) */
+	res = val_to_ring(args, (int64_t)(long)args->str_storage, STR_STORAGE_SIZE - available, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	env_len = mm->env_end - mm->env_start;
+	if(env_len > PAGE_SIZE)
+	{
+		env_len = PAGE_SIZE;
+	}
+
+	correctly_read = ppm_copy_from_user(args->str_storage, (const void __user *)mm->env_start, env_len);
+
+	if(env_len && correctly_read == 0)
+	{
+		args->str_storage[env_len - 1] = 0;
+	}
+	else
+	{
+		args_len = 0;
+		*args->str_storage = 0;
+	}
+
+	/* 16° Parameter: env (type: PT_CHARBUFARRAY) */
+	res = val_to_ring(args, (int64_t)(long)args->str_storage, env_len, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 17° Parameter: tty (type: PT_INT32) */
+	tty_nr = ppm_get_tty();
+	res = val_to_ring(args, tty_nr, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 18° Parameter: pgid (type: PT_PID) */
+	res = val_to_ring(args, (int64_t)task_pgrp_nr_ns(current, task_active_pid_ns(current)), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* 19° Parameter: loginuid (type: PT_INT32) */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
+	val = from_kuid(current_user_ns(), audit_get_loginuid(current));
+#else
+	val = audit_get_loginuid(current);
+#endif
+	res = val_to_ring(args, val, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	/* `exe_writable` flag logic */
+	exe_file = ppm_get_mm_exe_file(mm);
+	if(exe_file != NULL)
+	{
+		if(file_inode(exe_file) != NULL)
+		{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+			exe_writable |= (inode_permission(current_user_ns(), file_inode(exe_file), MAY_WRITE) == 0);
+			exe_writable |= inode_owner_or_capable(current_user_ns(), file_inode(exe_file));
+#else
+			exe_writable |= (inode_permission(file_inode(exe_file), MAY_WRITE) == 0);
+			exe_writable |= inode_owner_or_capable(file_inode(exe_file));
+#endif
+		}
+		fput(exe_file);
+	}
+
+	if(exe_writable)
+	{
+		flags |= PPM_EXE_WRITABLE;
+	}
+
+	// write all the additional flags for execve family here...
+
+	/* 20° Parameter: flags (type: PT_FLAGS32) */
+	res = val_to_ring(args, flags, 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		return res;
+	}
+
+	cred = get_current_cred();
+
+	/* 21° Parameter: cap_inheritable (type: PT_UINT64) */
+	val = ((uint64_t)cred->cap_inheritable.cap[1] << 32) | cred->cap_inheritable.cap[0];
+	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		goto out;
+	}
+
+	/* 22° Parameter: cap_permitted (type: PT_UINT64) */
+	val = ((uint64_t)cred->cap_permitted.cap[1] << 32) | cred->cap_permitted.cap[0];
+	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		goto out;
+	}
+
+	/* 23° Parameter: cap_effective (type: PT_UINT64) */
+	val = ((uint64_t)cred->cap_effective.cap[1] << 32) | cred->cap_effective.cap[0];
+	res = val_to_ring(args, capabilities_to_scap(val), 0, false, 0);
+	if(unlikely(res != PPM_SUCCESS))
+	{
+		goto out;
+	}
+
+	put_cred(cred);
+	return add_sentinel(args);
+
+out:
+	put_cred(cred);
+	return res;
+}
+#endif
+
 #endif /* WDIG */

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6348,7 +6348,7 @@ out:
 	return res;
 }
 
-#if(LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)) && defined(__aarch64__)
+#ifdef CONFIG_ARM64
 int f_sched_prog_exec(struct event_filler_arguments *args)
 {
 	int res = 0;

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -146,6 +146,9 @@ or GPL2.txt for full copies of the license.
 	FN(sched_prog_exec_2)		\
 	FN(sched_prog_exec_3)		\
 	FN(sched_prog_exec_4)		\
+	FN(sched_prog_fork)			\
+	FN(sched_prog_fork_2)		\
+	FN(sched_prog_fork_3)		\
 	FN(terminate_filler)
 
 #define FILLER_ENUM_FN(x) PPM_FILLER_##x,

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -142,6 +142,10 @@ or GPL2.txt for full copies of the license.
 	FN(sys_dup3_x)				\
 	FN(sys_dup_e)				\
 	FN(sys_dup_x)				\
+	FN(sched_prog_exec)			\
+	FN(sched_prog_exec_2)		\
+	FN(sched_prog_exec_3)		\
+	FN(sched_prog_exec_4)		\
 	FN(terminate_filler)
 
 #define FILLER_ENUM_FN(x) PPM_FILLER_##x,

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -35,7 +35,6 @@ struct bpf_engine
 	char* m_lasterr;
 	int m_bpf_prog_fds[BPF_PROGS_MAX];
 	int m_bpf_prog_cnt;
-	bool m_bpf_fillers[BPF_PROGS_MAX];
 	int m_bpf_event_fd[BPF_PROGS_MAX];
 	int m_bpf_map_fds[BPF_MAPS_MAX];
 	int m_bpf_prog_array_map_idx;

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -24,8 +24,11 @@ limitations under the License.
 //
 // ebpf defs
 //
-/// TODO: why we have 2 definitions ?
+
+#ifndef BPF_PROGS_MAX
 #define BPF_PROGS_MAX 156
+#endif
+
 #define BPF_MAPS_MAX 32
 
 struct bpf_engine

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -24,7 +24,8 @@ limitations under the License.
 //
 // ebpf defs
 //
-#define BPF_PROGS_MAX 128
+/// TODO: why we have 2 definitions ?
+#define BPF_PROGS_MAX 156
 #define BPF_MAPS_MAX 32
 
 struct bpf_engine

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -599,13 +599,6 @@ static int32_t load_tracepoint(struct bpf_engine* handle, const char *event, str
 			return SCAP_FAILURE;
 		}
 
-		/* If there is an elf section with the bpf implmentation of the filler with id `prog_id` 
-		 * set the entry in this table to `true`. When we will populate the filler map in 
-		 * `populate_fillers_table_map` function, we will check that every filler defined by us with
-		 * an enum code has its corresponding bpf implementation through this boolean table.
-		 */
-		handle->m_bpf_fillers[prog_id] = true;
-
 		return SCAP_SUCCESS;
 	}
 
@@ -963,14 +956,11 @@ static int32_t populate_fillers_table_map(struct bpf_engine *handle)
 		}
 	}
 
-	for(j = 0; j < PPM_FILLER_MAX; ++j)
-	{
-		if(!handle->m_bpf_fillers[j])
-		{
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Missing filler %d (%s)\n", j, g_filler_names[j]);
-			return SCAP_FAILURE;
-		}
-	}
+	/* Even if the filler ppm code is defined it could happen that there 
+	 * is no filler implementation, some fillers are architecture-specifc.
+	 * For example `sched_prog_exec` filler exists only on `ARM64` while
+	 * `sys_pagefault_e` exists only on `x86`.
+	 */
 
 	return bpf_map_freeze(handle->m_bpf_map_fds[SCAP_FILLERS_TABLE]);
 }

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -559,7 +559,7 @@ static int32_t load_tracepoint(struct bpf_engine* handle, const char *event, str
 	free(error);
 
 	if (handle->m_bpf_prog_cnt + 1 >= BPF_PROGS_MAX) {
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "libscap: too many programs recorded (limit is %d)", BPF_PROGS_MAX);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "libscap: too many programs recorded: %d (limit is %d)", handle->m_bpf_prog_cnt + 1 ,BPF_PROGS_MAX);
 		return SCAP_FAILURE;
 	}
 

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -77,15 +77,6 @@ inline const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error readi
 //
 #define PF_CLONING 1
 
-//
-// ebpf defs
-//
-#ifndef BPF_PROGS_MAX
-#define BPF_PROGS_MAX 156
-#endif
-
-#define BPF_MAPS_MAX 32
-
 typedef struct scap_tid
 {
 	uint64_t tid;

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -81,7 +81,7 @@ inline const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error readi
 // ebpf defs
 //
 #ifndef BPF_PROGS_MAX
-#define BPF_PROGS_MAX 128
+#define BPF_PROGS_MAX 156
 #endif
 
 #define BPF_MAPS_MAX 32


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area libscap-engine-bpf

**What this PR does / why we need it**:

This PR wants to fix a known problem regarding `ARM64` architecture, described here in this [thread](https://www.spinics.net/lists/linux-trace/msg01001.html) of the kernel mailing list. In a nutshell the `exeve` exit event is not traced by the `syscalls:sys_exit` tracepoint and same thing for the `clone` child exit event. These 2 events are really important for the state of the so we implemented this workaround to catch this 2 missing events.  We have instrumented 2 new tracepoints:

*  [`sched_proc_exec`](https://github.com/torvalds/linux/commit/4ff16c25e2cc48cbe6956e356c38a25ac063a64d) to catch the `execve` exit events. This tracepoint sends the same event `PPME_SYSCALL_EXECVE_19_X` to userspace, so the consumer won't notice any difference. This new tracepoint calls a new filler that is really similar to our actual `proc_startupdate` filler. 
* [`sched_proc_fork`](https://github.com/torvalds/linux/commit/0a16b6075843325dc402edf80c1662838b929aff) to catch the `clone` child exit events.  Again we send the same event `PPME_SYSCALL_CLONE_20_X` and we have a new filler. The only change seen by userspace is that the clone child exit event will be received before the clone parent exit event, but this shouldn't be a problem since `libsinsp` already has the code to manage this situation.

Some important notes:

* This solution is only for ARM64 and it is completely compiled out on other supported architectures (`x86`)
*  The only pieces of information we lose are the followings:
   - the clone child exit event has no `flags` information so param number `16` is always `0`.
   - the clone child exit event gets `euid` and `guid` directly from the task struct without relating them to the user namespace (param numbers `17` and `18`)
   - even if the system throws a `clone3` the child exit event will be of type `clone` and not `clone3` because we are not able to distinguish kernel side which syscall has been called. In the end, this doesn't change so much since the 2 events follow the same path both kernel side and userspace side.
* `fork` and `vfork`  are not defined in `ARM64` so we don't lose information.
*  In case the `execve` or `clone` syscalls fail, we catch the exit events with our `sys_exit` tracepoint as usual, so we don't lose information at all in this case.

Compatibility:

* BPF: we need kernel version `>=4.17` since we need bpf `raw_tracepoints` programs to catch this new information. We lose 3 supported versions (`x86` support BPF starting from `4.14`) but we have no alternatives with this approach. If we want to support them we have to use `kprobes`.
* KERNEL MODULE: we need kernel versions `>=3.4` since `sched/sched_process_exec` is available only kernels >= `3.4`

Kernel engineers are working to find solution as you can see [here](https://marc.info/?l=linux-arm-kernel&m=165218044913020&w=1) , in the meanwhile this could be a possible solution, let me know what to you think about that.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Next steps:
- [x] add further comments
- [x] test it on more machines (any help is well accepted).
- [x] remove the `test` commits since they are only useful to test the new patch (I removed the DCO from them, so we cannot merge the PR)
- [x] add logic to catch clone child flags.
- [x] remove the [WIP] tag.

--> **One last note**
We compiled out also the `page_fault` tracepoints both from BPF and kernel module since they are not supported on `ARM64`

**Does this PR introduce a user-facing change?**:

```release-note
fix: enable `execve` exit events and `clone` child exit events on `ARM64` architecture
```



