### PR TITLE
fix(scap_engine_bpf): enable `_64BIT_ARGS_SINGLE_REGISTER` on ARM64

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -3559,19 +3559,15 @@ int f_sys_pread64_e(struct event_filler_arguments *args)
 
 	return add_sentinel(args);
 }
-#endif /* _64BIT_ARGS_SINGLE_REGISTER */
 
-#ifndef _64BIT_ARGS_SINGLE_REGISTER
 int f_sys_pwrite64_e(struct event_filler_arguments *args)
 {
 	unsigned long val;
 	unsigned long size;
 	int res;
-#ifndef _64BIT_ARGS_SINGLE_REGISTER
 	unsigned long pos0;
 	unsigned long pos1;
 	uint64_t pos64;
-#endif
 
 	/*
 	 * fd
@@ -3594,32 +3590,63 @@ int f_sys_pwrite64_e(struct event_filler_arguments *args)
 	 * NOTE: this is a 64bit value, which means that on 32bit systems it uses two
 	 * separate registers that we need to merge.
 	 */
-#ifdef _64BIT_ARGS_SINGLE_REGISTER
-	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
-	res = val_to_ring(args, val, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
-#else
- #if defined CONFIG_X86
+#if defined CONFIG_X86
 	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &pos0);
 	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &pos1);
- #elif defined CONFIG_ARM && CONFIG_AEABI
+#elif defined CONFIG_ARM && CONFIG_AEABI
 	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &pos0);
 	syscall_get_arguments_deprecated(current, args->regs, 5, 1, &pos1);
- #else
+#else
   #error This architecture/abi not yet supported
- #endif
+#endif
 
 	pos64 = merge_64(pos1, pos0);
 
 	res = val_to_ring(args, pos64, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
-#endif
 
 	return add_sentinel(args);
 }
-#endif
+
+int f_sys_preadv64_e(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	unsigned long pos0;
+	unsigned long pos1;
+	uint64_t pos64;
+
+	/*
+	 * fd
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	res = val_to_ring(args, val, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	/*
+	 * pos
+	 */
+
+	/*
+	 * Note that in preadv and pwritev have NO 64-bit arguments in the
+	 * syscall (despite having one in the userspace API), so no alignment
+	 * requirements apply here. For an overly-detailed discussion about
+	 * this, see https://lwn.net/Articles/311630/
+	 */
+	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &pos0);
+	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &pos1);
+
+	pos64 = merge_64(pos1, pos0);
+
+	res = val_to_ring(args, pos64, 0, false, 0);
+	if (unlikely(res != PPM_SUCCESS))
+		return res;
+
+	return add_sentinel(args);
+}
+#endif /* _64BIT_ARGS_SINGLE_REGISTER */
 
 int f_sys_readv_preadv_x(struct event_filler_arguments *args)
 {
@@ -3754,46 +3781,6 @@ int f_sys_writev_pwritev_x(struct event_filler_arguments *args)
 	return add_sentinel(args);
 }
 
-#ifndef _64BIT_ARGS_SINGLE_REGISTER
-int f_sys_preadv64_e(struct event_filler_arguments *args)
-{
-	unsigned long val;
-	int res;
-	unsigned long pos0;
-	unsigned long pos1;
-	uint64_t pos64;
-
-	/*
-	 * fd
-	 */
-	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
-	res = val_to_ring(args, val, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
-
-	/*
-	 * pos
-	 */
-
-	/*
-	 * Note that in preadv and pwritev have NO 64-bit arguments in the
-	 * syscall (despite having one in the userspace API), so no alignment
-	 * requirements apply here. For an overly-detailed discussion about
-	 * this, see https://lwn.net/Articles/311630/
-	 */
-	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &pos0);
-	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &pos1);
-
-	pos64 = merge_64(pos1, pos0);
-
-	res = val_to_ring(args, pos64, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
-
-	return add_sentinel(args);
-}
-#endif /* _64BIT_ARGS_SINGLE_REGISTER */
-
 int f_sys_pwritev_e(struct event_filler_arguments *args)
 {
 	unsigned long val;
@@ -3867,7 +3854,7 @@ int f_sys_pwritev_e(struct event_filler_arguments *args)
 	res = val_to_ring(args, pos64, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
-#endif
+#endif /* _64BIT_ARGS_SINGLE_REGISTER */
 
 	return add_sentinel(args);
 }

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -19,11 +19,11 @@ or GPL2.txt for full copies of the license.
  */
 #ifdef __KERNEL__
 #ifdef CONFIG_64BIT
-#define _64BIT_ARGS_SINGLE_REGISTER
+	#define _64BIT_ARGS_SINGLE_REGISTER
 #endif /* CONFIG_64BIT */
 #else
-#ifdef __x86_64__
-#define _64BIT_ARGS_SINGLE_REGISTER
+#if defined(__x86_64__) || defined(__aarch64__)
+	#define _64BIT_ARGS_SINGLE_REGISTER
 #endif /* __x86_64__ */
 #endif /* __KERNEL__ */
 


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf

/area libscap-engine-bpf

**What this PR does / why we need it**:

If we are on a `64-bit` architecture we need to enable the `_64BIT_ARGS_SINGLE_REGISTER` macro and this is done correctly in our drivers. The problem is that when we compile `scap` we enable this define only in `x86`

```c
#ifdef __x86_64__
      #define _64BIT_ARGS_SINGLE_REGISTER
#endif /* __x86_64__ */
```

So on ARM64, when we fill the filler table in the libscap bpf engine we use the wrong fillers for some syscalls:

```c
#ifdef _64BIT_ARGS_SINGLE_REGISTER
	[PPME_SYSCALL_PREAD_E] = {FILLER_REF(sys_autofill), 3, APT_REG, {{0}, {2}, {3} } },
#else
	[PPME_SYSCALL_PREAD_E] = {FILLER_REF(sys_pread64_e)},
#endif
#ifdef _64BIT_ARGS_SINGLE_REGISTER
	[PPME_SYSCALL_PWRITE_E] = {FILLER_REF(sys_autofill), 3, APT_REG, {{0}, {2}, {3} } },
#else
	[PPME_SYSCALL_PWRITE_E] = {FILLER_REF(sys_pwrite64_e)},
 #endif
```
For  `PPME_SYSCALL_PREAD_E`  event we use the `sys_pread64_e` filler instead of `sys_autofill` and this cause an event drop since we define the `sys_pread64_e` in this way:

```c
FILLER(sys_pread64_e, true)
{
#ifndef _64BIT_ARGS_SINGLE_REGISTER
    #error Implement this
#endif
	return PPM_FAILURE_BUG;
}
```

Causing a `scap-open` output similar to this:

```
---------------------- STATS -----------------------
events captured: 28545
seen by driver: 28741
Number of dropped events: 42
Number of dropped events caused by full buffer: 0
Number of dropped events caused by full scratch map: 0
Number of dropped events caused by invalid memory access: 0
Number of dropped events caused by an invalid condition in the kernel instrumentation: 42
Number of preemptions: 0
Number of events skipped due to the tid being in a set of suppressed tids: 0
Number of threads currently being suppressed: 0
-----------------------------------------------------
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
