### PR TITLE
Add async key value unit tests

### DIFF
--- a/userspace/libsinsp/async/async_key_value_source.h
+++ b/userspace/libsinsp/async/async_key_value_source.h
@@ -180,6 +180,14 @@ public:
 	void set_running(bool running);
 
 	/**
+	 * Stops the thread associated with this async_key_value_source, if
+	 * it is running; otherwise, does nothing.  The only use for this is
+	 * in a destructor to ensure that the async thread stops when the
+	 * object is destroyed.
+	 */
+	void stop();
+
+	/**
 	 * Return all results available so far
 	 *
 	 * All available results are moved from the internal map to the returned map
@@ -204,13 +212,6 @@ public:
 	std::unordered_map<key_type, value_type> get_complete_results();
 
 protected:
-	/**
-	 * Stops the thread associated with this async_key_value_source, if
-	 * it is running; otherwise, does nothing.  The only use for this is
-	 * in a destructor to ensure that the async thread stops when the
-	 * object is destroyed.
-	 */
-	void stop();
 
 	/**
 	 * Dequeues an entry from the request queue and returns it in the given

--- a/userspace/libsinsp/async/async_key_value_source.tpp
+++ b/userspace/libsinsp/async/async_key_value_source.tpp
@@ -95,6 +95,8 @@ void async_key_value_source<key_type, value_type>::stop()
 		// Remove any pointers from the thread to this object
 		// (just to be safe)
 		m_thread = std::thread();
+
+		m_running = false;
 	}
 }
 
@@ -108,18 +110,8 @@ bool async_key_value_source<key_type, value_type>::is_running() const
 }
 
 template<typename key_type, typename value_type>
-void async_key_value_source<key_type, value_type>::set_running(bool running)
-{
-	std::unique_lock<std::mutex> guard(m_mutex);
-
-	m_running = running;
-}
-
-template<typename key_type, typename value_type>
 void async_key_value_source<key_type, value_type>::run()
 {
-	set_running(true);
-
 	bool terminate = false;
 
 	while(!terminate)
@@ -158,7 +150,6 @@ void async_key_value_source<key_type, value_type>::run()
 		}
 	}
 
-	set_running(false);
 }
 
 template<typename key_type, typename value_type>
@@ -172,6 +163,7 @@ bool async_key_value_source<key_type, value_type>::lookup_delayed(
 
 	if(!m_running && !m_thread.joinable())
 	{
+		m_running = true;
 		m_thread = std::thread(&async_key_value_source::run, this);
 	}
 

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories("..")
 include_directories(${LIBSCAP_INCLUDE_DIR} ${LIBSCAP_DIR}/driver)
 
 set(LIBSINSP_UNIT_TESTS_SOURCES
+	async_key_value_source.ut.cpp
 	cgroup_list_counter.ut.cpp
 	sinsp.ut.cpp
 	token_bucket.ut.cpp

--- a/userspace/libsinsp/test/async_key_value_source.ut.cpp
+++ b/userspace/libsinsp/test/async_key_value_source.ut.cpp
@@ -1,0 +1,104 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <async/async_key_value_source.h>
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <memory>
+
+class test_key_value_source : public libsinsp::async_key_value_source<std::string, uint64_t> {
+public:
+	test_key_value_source(uint64_t delay_sec, uint64_t wait_response_ms) :
+		async_key_value_source<std::string, uint64_t>(wait_response_ms, UINT64_MAX),
+		m_delay_sec(delay_sec)
+	{}
+
+	virtual ~test_key_value_source()
+	{
+		stop();
+	}
+
+	void run_impl()
+	{
+		std::string key;
+
+		while(dequeue_next_key(key))
+		{
+			if(m_delay_sec > 0)
+			{
+				sleep(m_delay_sec);
+			}
+			store_value(key, (uint64_t) atoi(key.c_str()));
+		}
+	}
+
+protected:
+	uint64_t m_delay_sec;
+};
+
+TEST(async_key_value_source_test, no_lookup)
+{
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(0, UINT64_MAX));
+}
+
+TEST(async_key_value_source_test, basic)
+{
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(0, UINT64_MAX));
+	uint64_t value;
+
+	while(!t->lookup("1", value))
+	{
+		sleep(1);
+	}
+	ASSERT_EQ(1, value);
+}
+
+TEST(async_key_value_source_test, long_delay_lookups)
+{
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(5, UINT64_MAX));
+	uint64_t value;
+
+	while(!t->lookup("1", value))
+	{
+		sleep(1);
+	}
+	ASSERT_EQ(1, value);
+}
+
+TEST(async_key_value_source_test, basic_nowait)
+{
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(0, 0));
+	uint64_t value;
+
+	while(!t->lookup("1", value))
+	{
+		sleep(1);
+	}
+	ASSERT_EQ(1, value);
+}
+
+TEST(async_key_value_source_test, long_delay_lookups_nowait)
+{
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(5, 0));
+	uint64_t value;
+
+	while(!t->lookup("1", value))
+	{
+		sleep(1);
+	}
+	ASSERT_EQ(1, value);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Add unit tests for async_key_value_source, along with some potential race conditions on startup found by helgrind.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
