### PR TITLE
fix(gvisor): initialize missing variables

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -532,6 +532,11 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 		oargs.gvisor_socket = m_gvisor_socket.c_str();
 		oargs.gvisor_root_path = m_gvisor_root_path.c_str();
 		oargs.gvisor_trace_session_path = m_gvisor_trace_session_path.c_str();
+	} else {
+		oargs.gvisor = false;
+		oargs.gvisor_socket = NULL;
+		oargs.gvisor_root_path = NULL;
+		oargs.gvisor_trace_session_path = NULL;
 	}
 
 	fill_syscalls_of_interest(&oargs);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -526,14 +526,13 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 	oargs.proc_callback = NULL;
 	oargs.proc_callback_context = NULL;
 	oargs.udig = m_udig;
+	oargs.gvisor = m_gvisor;
 	if (m_gvisor)
 	{
-		oargs.gvisor = true;
 		oargs.gvisor_socket = m_gvisor_socket.c_str();
 		oargs.gvisor_root_path = m_gvisor_root_path.c_str();
 		oargs.gvisor_trace_session_path = m_gvisor_trace_session_path.c_str();
 	} else {
-		oargs.gvisor = false;
 		oargs.gvisor_socket = NULL;
 		oargs.gvisor_root_path = NULL;
 		oargs.gvisor_trace_session_path = NULL;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-gvisor

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Been playing around with [this repo](https://github.com/Molter73/falco-libs-qa) and was getting a segfault with the following backtrace:
```
#0  0x00007ffff6aa5bba in __strlen_sse2 () from /lib64/libc.so.6
#1  0x00000000007fae4f in std::char_traits<char>::length (__s=0x656d616e2e6466 <error: Cannot access memory at address 0x656d616e2e6466>)
    at /usr/include/c++/12/bits/char_traits.h:395
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string (__a=...,
    __s=0x656d616e2e6466 <error: Cannot access memory at address 0x656d616e2e6466>, this=0x7fffffffd500)
    at /usr/include/c++/12/bits/basic_string.h:641
#3  gvisor_init (main_handle=<optimized out>, open_args=0x7fffffffd5d0) at /libs/userspace/libscap/engine/gvisor/gvisor.cpp:51
#4  0x00000000007e6985 in scap_open_gvisor_int (error=error@entry=0x7fffffffd8a0 "\025", rc=rc@entry=0x7fffffffd89c, args=args@entry=0x7fffffffd5d0)
    at /libs/userspace/libscap/scap.c:471
#5  0x00000000007e6f46 in scap_open (args=..., error=0x7fffffffd8a0 "\025", rc=0x7fffffffd89c) at /libs/userspace/libscap/scap.c:906
#6  0x00000000005d6f95 in sinsp::open_live_common (this=0x7fffffffdd20, timeout_ms=<optimized out>, mode=<optimized out>)
    at /libs/userspace/libsinsp/sinsp.cpp:572
#7  0x0000000000575889 in main (argc=4, argv=0x7fffffffe698) at /libs/userspace/libsinsp/examples/test.cpp:109
```

After swimming upstream from the error, I found a few variables associated with gvisor are not actually being initialized, potentially leading to the crash above. Properly initializing the strings to `NULL` fixes the issue.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
