### PR TITLE
build: reorganize driver cmake vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(falcosecurity-libs)
 
 option(MINIMAL_BUILD "Produce a minimal build with only the essential features (no eBPF probe driver, no kubernetes, no mesos, no marathon and no container metadata)" OFF)
 option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
+option(USE_BUNDLED_DRIVER "Use the driver/ subdirectory in the build process (only available in Linux)" ON)
 
 include(GNUInstallDirs)
 
@@ -52,12 +53,16 @@ endif()
 
 message(STATUS "Libs version: ${FALCOSECURITY_LIBS_VERSION}")
 
-# Driver version
-if(NOT DEFINED DRIVER_VERSION)
-	get_drivers_version(DRIVER_VERSION)
-endif()
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND USE_BUNDLED_DRIVER)
+	# Driver version
+	if(NOT DEFINED DRIVER_VERSION)
+		get_drivers_version(DRIVER_VERSION)
+	endif()
 
-message(STATUS "Driver version: ${DRIVER_VERSION}")
+	message(STATUS "Driver version: ${DRIVER_VERSION}")
+
+	add_subdirectory(driver ${PROJECT_BINARY_DIR}/driver)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE Release)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -5,12 +5,15 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
+cmake_minimum_required(VERSION 2.8.5)
+project(driver)
+
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 
 if(NOT DEFINED DRIVER_VERSION)
-	message(ERROR
-		"No driver version set. Please either build the project from a git working directory or explicitly set the DRIVER_VERSION cmake cache entry."
+	message(FATAL_ERROR
+		"No DRIVER_VERSION set.\nPlease either explicitly set it or build the root project 'falcosecurity/libs' from a git working directory."
 	)
 endif()
 

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -8,14 +8,26 @@
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 
+if(NOT DEFINED DRIVER_VERSION)
+	message(ERROR
+		"No driver version set. Please either build the project from a git working directory or explicitly set the DRIVER_VERSION cmake cache entry."
+	)
+endif()
+
 if(NOT DEFINED DRIVER_COMPONENT_NAME)
-    set(DRIVER_COMPONENT_NAME "scap-driver")
+	set(DRIVER_COMPONENT_NAME "scap-driver")
 endif()
+
 if(NOT DEFINED DRIVER_PACKAGE_NAME)
-        set(DRIVER_PACKAGE_NAME "scap")
+	set(DRIVER_PACKAGE_NAME "scap")
 endif()
+
 if(NOT DEFINED DRIVER_NAME)
-        set(DRIVER_NAME "scap")
+	set(DRIVER_NAME "scap")
+endif()
+
+if(NOT DEFINED DRIVER_DEVICE_NAME)
+	set(DRIVER_DEVICE_NAME "${DRIVER_NAME}")
 endif()
 
 # The driver build process is somewhat involved because we use the same
@@ -31,8 +43,8 @@ endif()
 # 1. The user (or some script) runs make in our driver directory
 # 2. Our Makefile runs the Makefile from kernel sources/headers
 # 3. The kernel Makefile calls our original Makefile again, with options that
-#    trigger the actual build. This step cannot know that our Makefile has
-#    a different name.
+# trigger the actual build. This step cannot know that our Makefile has
+# a different name.
 #
 # (DKMS needs a Makefile called Makefile as well).
 #
@@ -45,7 +57,6 @@ endif()
 # ${CMAKE_CURRENT_BINARY_DIR}/src. To maintain compatibility with older versions,
 # after the build we copy the compiled module one directory up,
 # to ${CMAKE_CURRENT_BINARY_DIR}.
-
 file(STRINGS API_VERSION DRIVER_API_VERSION LIMIT_COUNT 1)
 string(REGEX MATCHALL "[0-9]+" DRIVER_API_COMPONENTS "${DRIVER_API_VERSION}")
 list(GET DRIVER_API_COMPONENTS 0 PPM_API_CURRENT_VERSION_MAJOR)
@@ -133,7 +144,6 @@ if(ENABLE_DKMS)
 		${DRIVER_SOURCES}
 		DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}"
 		COMPONENT ${DRIVER_COMPONENT_NAME})
-
 endif()
 
 add_subdirectory(bpf)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -35,23 +35,11 @@ endif()
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
+
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		set(KBUILD_FLAGS "${FALCOSECURITY_LIBS_DEBUG_FLAGS}")
 	endif()
-
-    if(NOT DEFINED DRIVER_VERSION)
-        message(ERROR 
-			"No driver version set. Please either build the project from a git working directory or explicitly set the DRIVER_VERSION cmake cache entry."
-		)
-    endif()
-
-    if(NOT DEFINED DRIVER_NAME)
-        set(DRIVER_NAME "scap")
-    endif()
-
-    if(NOT DEFINED DRIVER_DEVICE_NAME)
-        set(DRIVER_DEVICE_NAME "${DRIVER_NAME}")
-    endif()
 
 	string(REPLACE "-" "_" SCAP_KERNEL_MODULE_NAME "${DRIVER_NAME}")
 	add_definitions(-DSCAP_KERNEL_MODULE_NAME="${SCAP_KERNEL_MODULE_NAME}")
@@ -126,8 +114,6 @@ target_link_libraries(scap
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
-
     option(BUILD_LIBSCAP_EXAMPLES "Build libscap examples" ON)
 
     if (BUILD_LIBSCAP_EXAMPLES)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -16,6 +16,7 @@
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../common")
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
+option(WITH_DRIVER "Include the driver sub-project in the current build (only available in Linux)" ON)
 
 if(NOT MSVC)
 	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -34,7 +35,7 @@ endif()
 
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+if(WITH_DRIVER AND CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
 
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -16,7 +16,6 @@
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../common")
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
-option(WITH_DRIVER "Add the driver subdirectory in scap (only available in Linux)" ON)
 
 if(NOT MSVC)
 	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -40,12 +39,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 		set(KBUILD_FLAGS "${FALCOSECURITY_LIBS_DEBUG_FLAGS}")
 	endif()
 
-	if(WITH_DRIVER)
-		add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
-	endif()
-
 	# do not remove this since when WITH_DRIVER is off
-	if (NOT DEFINED DRIVER_NAME)
+	if(NOT DEFINED DRIVER_NAME)
 		set(DRIVER_NAME "scap")
 	endif()
 

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -16,7 +16,7 @@
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../common")
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
-option(WITH_DRIVER "Include the driver sub-project in the current build (only available in Linux)" ON)
+option(WITH_DRIVER "Add the driver subdirectory in scap (only available in Linux)" ON)
 
 if(NOT MSVC)
 	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -35,11 +35,18 @@ endif()
 
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
 
-if(WITH_DRIVER AND CMAKE_SYSTEM_NAME MATCHES "Linux")
-    add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
-
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 		set(KBUILD_FLAGS "${FALCOSECURITY_LIBS_DEBUG_FLAGS}")
+	endif()
+
+	if(WITH_DRIVER)
+		add_subdirectory(../../driver ${PROJECT_BINARY_DIR}/driver)
+	endif()
+
+	# do not remove this since when WITH_DRIVER is off
+	if (NOT DEFINED DRIVER_NAME)
+		set(DRIVER_NAME "scap")
 	endif()
 
 	string(REPLACE "-" "_" SCAP_KERNEL_MODULE_NAME "${DRIVER_NAME}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is mainly required to allow Falco to include different versions of libs and drivers. Falco can now pull libs `WITH_DRIVER=Off` and separately pull the driver. Without this patch, the driver target was always added.
Some other minor improvements are included.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
