### PR TITLE
update(libsinsp): add a way to generate gVisor trace session config file

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -111,7 +111,8 @@ set(SINSP_SOURCES
 	user_event.cpp
 	value_parser.cpp
 	viewinfo.cpp
-	user.cpp)
+	user.cpp
+	gvisor_config.cpp)
 
 if(WITH_CHISEL)
 	list(APPEND SINSP_SOURCES

--- a/userspace/libsinsp/gvisor_config.cpp
+++ b/userspace/libsinsp/gvisor_config.cpp
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <iostream>
+#include <vector>
+#include <json/json.h>
+
+#include "gvisor_config.h"
+
+namespace gvisor_config
+{
+
+static const std::string s_default_socket_path = "/tmp/gvisor.sock";
+
+static const std::vector<std::string> s_gvisor_points = {
+	"container/start",
+	"syscall/openat/enter",
+	"syscall/openat/exit",
+	"syscall/execve/enter",
+	"syscall/execve/exit",
+	"syscall/socket/enter",
+	"syscall/socket/exit",
+	"syscall/connect/enter",
+	"syscall/connect/enter",
+	"sentry/clone",
+	"sentry/task_exit",
+	"sentry/execve",
+};
+
+static const std::vector<std::string> s_context_fields = {
+	"cwd",
+	"credentials",
+	"container_id",
+	"thread_id",
+	"task_start_time",
+	"time",
+};
+
+std::string generate(std::string socket_path)
+{
+	Json::Value context_fields;
+	for(const auto &field : s_context_fields)
+	{
+		context_fields.append(field);
+	}
+
+	Json::Value points;
+	for(const auto &point_name : s_gvisor_points)
+	{
+		Json::Value point;
+		point["name"] = point_name;
+		point["context_fields"] = context_fields;
+		points.append(point);
+	}
+
+	Json::Value sinks, sink;
+	sink["name"] = "remote";
+	sink["config"]["endpoint"] = socket_path.empty() ? s_default_socket_path : socket_path;
+	sinks.append(sink);
+
+	Json::Value trace_session;
+	trace_session["name"] = "Default";
+	trace_session["points"] = points;
+	trace_session["sinks"] = sinks;
+
+	Json::Value root;
+	root["trace_session"] = trace_session;
+
+	return root.toStyledString();
+}
+
+} // namespace gvisor_config

--- a/userspace/libsinsp/gvisor_config.h
+++ b/userspace/libsinsp/gvisor_config.h
@@ -1,0 +1,23 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <string>
+
+namespace gvisor_config 
+{
+	std::string generate(std::string socket_path);
+}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -602,6 +602,11 @@ void sinsp::open_gvisor(std::string socket_path, std::string root_path, std::str
 	set_get_procs_cpu_from_driver(false);
 }
 
+std::string sinsp::generate_gvisor_config(std::string socket_path)
+{
+	return gvisor_config::generate(socket_path);
+}
+
 void sinsp::open_nodriver()
 {
 	char error[SCAP_LASTERR_SIZE];

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -100,6 +100,7 @@ using namespace std;
 
 #include "include/sinsp_external_processor.h"
 #include "plugin.h"
+#include "gvisor_config.h"
 class sinsp_partial_transaction;
 class sinsp_parser;
 class sinsp_analyzer;
@@ -250,6 +251,8 @@ public:
 
 	void open_udig(uint32_t timeout_ms = SCAP_TIMEOUT_MS);
 	void open_gvisor(std::string socket_path, std::string root_path, std::string trace_session_path, uint32_t timeout_ms = SCAP_TIMEOUT_MS);
+
+	std::string generate_gvisor_config(std::string socket_path);
 
 	void open_nodriver();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

For the gVisor support, we need to be able to generate a configuration file on the fly, containing all the syscalls we are interested in and tell gVisor where to connect. To do this, we considered a few alternatives. First of all, we need to take in mind that the generation of the configuration file is so peculiar to gVisor and it is not part of the interface implemented via vtables, of course. For this reason, we could:

- add an extra function to `scap.c` and define it pretty much like `scap_open_gvisor_int`, using the `HAS_ENGINE_GVISOR` ifdef. This function could be called from sinsp, and it will internally call another one defined in the gvisor engine, that actually generates the configuration. To make it work, we would also need to add something into sinsp, so that libs consumers can call it. The advantage of this approach would be that the code used to generate the config would be close to the engine. The drawback is that we would need to have a huge tour in libs code, just to print out a configuration string. Does this bring any value? I think it brings only useless complexity. 
- the second approach is the one we implemented. Since `sinsp` already contains functions and variables for gVisor, we thought that we could directly generate the config file from there. Libs consumers will be able to call the gvisor config generation function, get the config string as a result, print it and just exit

In any case, I am open to any discussion: if some of the maintainers have better ideas on how to implement this, I am happy to modify this PR 🙂 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
