### PR TITLE
Refactor freeing of devices in scap

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -848,13 +848,15 @@ cleanup:
 	return res;
 }
 
-static void *perf_event_mmap(struct bpf_engine *handle, int fd)
+static void *perf_event_mmap(struct bpf_engine *handle, int fd, int *size)
 {
 	int page_size = getpagesize();
 	int ring_size = page_size * BUF_SIZE_PAGES;
 	int header_size = page_size;
 	int total_size = ring_size * 2 + header_size;
 	char buf[SCAP_LASTERR_SIZE];
+
+	*size = 0;
 
 	//
 	// All this playing with MAP_FIXED might be very very wrong, revisit
@@ -888,6 +890,8 @@ static void *perf_event_mmap(struct bpf_engine *handle, int fd)
 	}
 
 	ASSERT(p2 == tmp);
+
+	*size = total_size;
 
 	return tmp;
 }
@@ -1273,31 +1277,9 @@ int32_t scap_bpf_close(struct scap_engine_handle engine)
 	struct bpf_engine *handle = engine.m_handle;
 	int j;
 
-	int page_size = getpagesize();
-	int ring_size = page_size * BUF_SIZE_PAGES;
-	int header_size = page_size;
-	int total_size = ring_size * 2 + header_size;
 	struct scap_device_set *devset = &handle->m_dev_set;
 
-	for(j = 0; j < devset->m_ndevs; j++)
-	{
-		struct scap_device *dev = &devset->m_devs[j];
-		if(dev->m_buffer != MAP_FAILED)
-		{
-#ifdef _DEBUG
-			int ret;
-			ret = munmap(dev->m_buffer, total_size);
-#else
-			munmap(dev->m_buffer, total_size);
-#endif
-			ASSERT(ret == 0);
-		}
-
-		if(dev->m_fd > 0)
-		{
-			close(dev->m_fd);
-		}
-	}
+	devset_free(devset);
 
 	for(j = 0; j < sizeof(handle->m_bpf_event_fd) / sizeof(handle->m_bpf_event_fd[0]); ++j)
 	{
@@ -1588,7 +1570,7 @@ int32_t scap_bpf_load(
 		//
 		// Map the ring buffer
 		//
-		dev->m_buffer = perf_event_mmap(handle, pmu_fd);
+		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size);
 		if(dev->m_buffer == MAP_FAILED)
 		{
 			return SCAP_FAILURE;

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -223,6 +223,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer for device %s", filename);
 			return SCAP_FAILURE;
 		}
+		dev->m_buffer_size = len;
 
 		//
 		// Map the ppm_ring_buffer_info that contains the buffer pointers
@@ -243,6 +244,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer info for device %s", filename);
 			return SCAP_FAILURE;
 		}
+		dev->m_bufinfo_size = sizeof(struct ppm_ring_buffer_info);
 
 		++j;
 	}
@@ -270,29 +272,7 @@ int32_t scap_kmod_close(struct scap_engine_handle engine)
 {
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
 
-	if(devset->m_devs != NULL)
-	{
-		{
-			//
-			// Destroy all the device descriptors
-			//
-			uint32_t j;
-			for(j = 0; j < devset->m_ndevs; j++)
-			{
-				struct scap_device *dev = &devset->m_devs[j];
-				if(dev->m_buffer != MAP_FAILED)
-				{
-					munmap(dev->m_bufinfo, sizeof(struct ppm_ring_buffer_info));
-					munmap(dev->m_buffer, RING_BUF_SIZE * 2);
-					close(dev->m_fd);
-				}
-			}
-		}
-		//
-		// Free the memory
-		//
-		free(devset->m_devs);
-	}
+	devset_free(devset);
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/ringbuffer/devset.c
+++ b/userspace/libscap/ringbuffer/devset.c
@@ -38,3 +38,38 @@ int32_t devset_init(struct scap_device_set *devset, size_t num_devs, char *laste
 
 	return SCAP_SUCCESS;
 }
+
+void devset_free(struct scap_device_set *devset)
+{
+	if(devset == NULL || devset->m_devs == NULL)
+	{
+		return;
+	}
+
+	uint32_t j;
+	for(j = 0; j < devset->m_ndevs; j++)
+	{
+		struct scap_device *dev = &devset->m_devs[j];
+		if(dev->m_buffer != MAP_FAILED)
+		{
+#ifdef _DEBUG
+			int ret;
+			ret = munmap(dev->m_buffer, dev->m_buffer_size);
+#else
+			munmap(dev->m_buffer, dev->m_buffer_size);
+#endif
+			ASSERT(ret == 0);
+		}
+
+		if(dev->m_bufinfo != MAP_FAILED)
+		{
+			munmap(dev->m_bufinfo, dev->m_bufinfo_size);
+		}
+
+		if(dev->m_fd > 0)
+		{
+			close(dev->m_fd);
+		}
+	}
+	free(devset->m_devs);
+}

--- a/userspace/libscap/ringbuffer/devset.c
+++ b/userspace/libscap/ringbuffer/devset.c
@@ -55,10 +55,10 @@ void devset_free(struct scap_device_set *devset)
 #ifdef _DEBUG
 			int ret;
 			ret = munmap(dev->m_buffer, dev->m_buffer_size);
+			ASSERT(ret == 0);
 #else
 			munmap(dev->m_buffer, dev->m_buffer_size);
 #endif
-			ASSERT(ret == 0);
 		}
 
 		if(dev->m_bufinfo != MAP_FAILED)

--- a/userspace/libscap/ringbuffer/devset.h
+++ b/userspace/libscap/ringbuffer/devset.h
@@ -41,6 +41,7 @@ typedef struct scap_device
 		struct
 		{
 			struct ppm_ring_buffer_info* m_bufinfo;
+			int m_bufinfo_size;
 			struct udig_ring_buffer_status* m_bufstatus; // used by udig
 		};
 	};
@@ -55,3 +56,4 @@ struct scap_device_set
 };
 
 int32_t devset_init(struct scap_device_set *devset, size_t num_devs, char *lasterr);
+void devset_free(struct scap_device_set *devset);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR might be a little overkill, it started because of a very minor leak [here](https://github.com/falcosecurity/libs/blob/c2b89c1f715b660586a316e17d0f2dd9fc47ffea/userspace/libscap/engine/bpf/scap_bpf.c#L1282-L1300), `devset->m_devs` is not being free'd. I could've added the missing `free`, but instead chose to refactor `free`ing of `devsets` into its own function. This lead me to a few unhappy implementation choices, since we need the sizes of each `m_buffer` and `m_bufinfo`, I'm open to hearing alternatives for this.

If maintainers deem the PR as too much overkill, I'm happy to close it and open a new one adding the missing free 🤷🏻‍♂️ 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
