### PR TITLE
fix(libsinsp): Don't overwrite good container metadata with bad

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -330,7 +330,15 @@ void sinsp_container_manager::notify_new_container(const sinsp_container_info& c
 		//
 		// Fallback at just storing the new container.
 		// NOTE: this must be kept in sync with what happens on container event parsing, in parsers.cpp.
-		add_container(std::make_shared<sinsp_container_info>(container_info), tinfo);
+		const auto container = m_inspector->m_container_manager.get_container(container_info.m_id);
+		if(container != nullptr && container->is_successful())
+		{
+			SINSP_DEBUG("Ignoring new container notification for already successful lookup of %s", container_info.m_id.c_str());
+		}
+		else
+		{
+			add_container(std::make_shared<sinsp_container_info>(container_info), tinfo);
+		}
 		return;
 	}
 


### PR DESCRIPTION
PR#231 caused a regression with container metadata:

When a container engine reported a failure *after* we have already
received the full metadata from a different engine, the call
to add_container for the failed lookup overwrote the metadata
coming from the good lookup.

Note: this brings the code into agreement with the comment
that says we should follow the same logic as parsing container
JSON events.

Note: based on code inspection, the issue was supposed to happen
only while the inspector isn't fully initialized, but we've observed
it also while the event loop was up and running.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

/area libsinsp

> /area tests

> /area proposals

```release-note
NONE
```
