### PR TITLE
new(gvisor): get socket from configuration file, fix tests

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -48,7 +48,7 @@ static SCAP_HANDLE_T *gvisor_alloc_handle(scap_t* main_handle, char *lasterr_ptr
 static int32_t gvisor_init(scap_t* main_handle, scap_open_args* open_args)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
-	return gv->init(open_args->gvisor_socket, open_args->gvisor_root_path, open_args->gvisor_trace_session_path);
+	return gv->init(open_args->gvisor_config_path, open_args->gvisor_root_path);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)
@@ -78,7 +78,7 @@ static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt **pevent, 
 
 static bool gvisor_match(scap_open_args* open_args)
 {
-	return open_args->gvisor_socket != NULL;
+	return open_args->gvisor_config_path != NULL;
 }
 
 static int32_t gvisor_configure(struct scap_engine_handle engine, enum scap_setting setting, unsigned long arg1, unsigned long arg2)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -60,6 +60,15 @@ struct procfs_result {
     scap_threadinfo tinfo;
 };
 
+struct config_result {
+    // the scap status of the operation
+    uint32_t status;
+    // description of the error in case of failure
+    std::string error;
+    // the socket path
+    std::string socket_path;
+};
+
 /*!
     \brief Translate a gVisor seccheck protobuf into one, or more, scap events
     \param gvisor_buf the source buffer that contains the raw event coming from gVisor
@@ -81,6 +90,8 @@ parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_b
 procfs_result parse_procfs_json(const std::string &input, const std::string &sandbox);
 
 uint64_t get_vxid(uint64_t vxid);
+
+config_result parse_config(std::string config);
 
 } // namespace parsers
 
@@ -115,7 +126,7 @@ class engine {
 public:
     engine(char *lasterr);
     ~engine();
-    int32_t init(std::string socket_path, std::string root_path, std::string trace_session_path);
+    int32_t init(std::string config_path, std::string root_path);
     int32_t close();
 
     int32_t start_capture();

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -882,5 +882,65 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	return res;
 }
 
+config_result parse_config(std::string config)
+{
+	config_result res;
+	res.socket_path = "";
+	res.error = "";
+	res.status = SCAP_FAILURE;	
+
+	std::string err;
+	Json::Value root;
+	Json::CharReaderBuilder builder;
+	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+	
+	bool json_parse = reader->parse(config.c_str(), config.c_str() + config.size() - 1, &root, &err);
+	if(!json_parse)
+	{
+		res.error = "Could not parse configuration file contents.";
+		return res;
+	}
+
+	if(!root.isMember("trace_session"))
+	{
+		res.error = "Could not find trace_session entry in configuration";
+		return res;
+	}
+	Json::Value &trace_session = root["trace_session"];
+
+	if(!trace_session.isMember("sinks") || !trace_session["sinks"].isArray())
+	{
+		res.error = "Could not find trace_session -> sinks array in configuration";
+		return res;
+	}
+
+	if(trace_session["sinks"].size() == 0)
+	{
+		res.error = "trace_session -> sinks array is empty";
+		return res;
+	}
+
+	// We don't know how to distinguish between sinks in case there is more than one
+	// we're taking the first for now but this can be tweaked if necessary.
+	Json::Value &sink = trace_session["sinks"][0];
+
+	if(!sink.isMember("config"))
+	{
+		res.error = "Could not find config in sink item";
+		return res;
+	}
+	Json::Value &sink_config = sink["config"];
+
+	if(!sink_config.isMember("endpoint") || !sink_config["endpoint"].isString())
+	{
+		res.error = "Could not find endpoint in sink configuration";
+		return res;
+	}
+	
+	res.socket_path = sink_config["endpoint"].asString();
+	res.status = SCAP_SUCCESS;
+	return res;
+}
+
 } // namespace parsers
 } // namespace scap_gvisor

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -808,7 +808,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 		return res;
 	}
 	std::string args;
-	for(Json::Value::ArrayIndex i = 0; i != root.size(); i++)
+	for(Json::Value::ArrayIndex i = 0; i < root["args"].size(); i++)
 	{
 		args += root["args"][i].asString();
 		args.push_back('\0');
@@ -824,7 +824,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 		return res;
 	}
 	std::string env;
-	for(Json::Value::ArrayIndex i = 0; i != root.size(); i++)
+	for(Json::Value::ArrayIndex i = 0; i < root["env"].size(); i++)
 	{
 		env += root["env"][i].asString();
 		env.push_back('\0');

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -901,7 +901,7 @@ scap_t* scap_open(scap_open_args args, char *error, int32_t *rc)
 						args.import_users,
 						args.suppressed_comms);
 		}
-		else if (args.gvisor_socket != NULL)
+		else if (args.gvisor)
 		{
 			return scap_open_gvisor_int(error, rc, &args);
 		}

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -86,9 +86,8 @@ typedef struct scap_open_args
 	// values via scap_suppress_events_comm().
 	bool udig; ///< If true, UDIG will be used for event capture.
 	bool gvisor; //< If true, gVisor will be used for event capture
-	const char *gvisor_socket; ///< When using gVisor, this contains the gvisor socket
 	const char *gvisor_root_path; ///< When using gvisor, the root path used by runsc commands
-	const char *gvisor_trace_session_path; ///< When using gvisor, the trace session config file
+	const char *gvisor_config_path; ///< When using gvisor, the path to the configuration file
 
 	interesting_ppm_sc_set ppm_sc_of_interest;
 

--- a/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
+++ b/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
@@ -270,3 +270,67 @@ TEST(gvisor_parsers, procfs_entry)
     EXPECT_STREQ(res.error.c_str(), "Missing json field or wrong type: cannot parse procfs entry");
 
 }
+
+TEST(gvisor_parsers, config_socket)
+{
+    std::string config = R"(
+{
+    "trace_session": {
+        "name": "Default",
+        "points": [
+        {
+            "name": "container/start", 
+            "context_fields": [
+                "cwd",
+                "time"
+            ]
+        },
+        {
+            "name": "syscall/openat/enter",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        },
+        {
+            "name": "syscall/openat/exit",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        },
+        {
+            "name": "sentry/task_exit",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        }
+        ],
+        "sinks": [
+        {
+            "name": "remote",
+            "config": {
+                "endpoint": "/tmp/gvisor.sock"
+            }
+        }
+        ]
+    }
+}
+    )";
+
+    scap_gvisor::parsers::config_result res;
+
+    res = scap_gvisor::parsers::parse_config(config);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+    EXPECT_STREQ(res.socket_path.c_str(), "/tmp/gvisor.sock");
+}

--- a/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
+++ b/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
@@ -192,55 +192,57 @@ TEST(gvisor_parsers, procfs_entry)
     EXPECT_EQ(res.status, SCAP_FAILURE);
     EXPECT_STREQ(res.error.c_str(), "Malformed json string: cannot parse procfs entry");
 
-    std::string json = 
-        "{"
-        "   \"args\" : [ \"bash\" ],"
-        "   \"clone_ts\" : 1655473752715788585,"
-        "   \"cwd\" : \"/\","
-        "   \"env\" : ["
-        "      \"HOSTNAME=91e91fdd849d\","
-        "      \"TERM=xterm\","
-        "      \"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\","
-        "      \"HOME=/root\""
-        "   ],"
-        "   \"exe\" : \"/usr/bin/bash\","
-        "   \"fdlist\" : ["
-        "      {"
-        "         \"path\" : \"host:[1]\""
-        "      },"
-        "      {"
-        "         \"number\" : 1,"
-        "         \"path\" : \"host:[1]\""
-        "      },"
-        "      {"
-        "         \"number\" : 2,"
-        "         \"path\" : \"host:[1]\""
-        "      },"
-        "      {"
-        "         \"number\" : 255,"
-        "         \"path\" : \"host:[1]\""
-        "      }"
-        "   ],"
-        "   \"limits\" : {"
-        "      \"RLIMIT_NOFILE\" : {"
-        "         \"cur\" : 1048576,"
-        "         \"max\" : 1048576"
-        "      }"
-        "   },"
-        "   \"root\" : \"/\","
-        "   \"stat\" : {"
-        "      \"pgid\" : 1,"
-        "      \"sid\" : 1"
-        "   },"
-        "   \"status\" : {"
-        "      \"comm\" : \"bash\","
-        "      \"gid\" : {},"
-        "      \"pid\" : 1,"
-        "      \"uid\" : {},"
-        "      \"vm_rss\" : 4664,"
-        "      \"vm_size\" : 12164"
-        "   }"
-        "}\n";
+    std::string json = R"(
+{
+  "args": [ "bash" ],
+  "clone_ts": 1655473752715788585,
+  "cwd": "/",
+  "env": [
+    "HOSTNAME=91e91fdd849d",
+    "TERM=xterm",
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "HOME=/root"
+  ],
+  "exe": "/usr/bin/bash",
+  "fdlist": [
+    {
+      "path": "host:[1]"
+    },
+    {
+      "number": 1,
+      "path": "host:[1]"
+    },
+    {
+      "number": 2,
+      "path": "host:[1]"
+    },
+    {
+      "number": 255,
+      "path": "host:[1]"
+    }
+  ],
+  "limits": {
+    "RLIMIT_NOFILE": {
+      "cur": 1048576,
+      "max": 1048576
+    }
+  },
+  "root": "/",
+  "stat": {
+    "pgid": 1,
+    "sid": 1
+  },
+  "status": {
+    "comm": "bash",
+    "gid": {"effective": 0, "real": 0, "saved": 0},
+    "pid": 1,
+    "uid": {"effective": 0, "real": 0, "saved": 0},
+    "vm_rss": 4664,
+    "vm_size": 12164
+  }
+}
+    )";
+
     res = scap_gvisor::parsers::parse_procfs_json(json, sandbox_id);
     EXPECT_EQ(res.status, SCAP_SUCCESS);
     EXPECT_EQ(res.tinfo.vtid, 1);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -529,13 +529,11 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 	oargs.gvisor = m_gvisor;
 	if (m_gvisor)
 	{
-		oargs.gvisor_socket = m_gvisor_socket.c_str();
 		oargs.gvisor_root_path = m_gvisor_root_path.c_str();
-		oargs.gvisor_trace_session_path = m_gvisor_trace_session_path.c_str();
+		oargs.gvisor_config_path = m_gvisor_config_path.c_str();
 	} else {
-		oargs.gvisor_socket = NULL;
 		oargs.gvisor_root_path = NULL;
-		oargs.gvisor_trace_session_path = NULL;
+		oargs.gvisor_config_path = NULL;
 	}
 
 	fill_syscalls_of_interest(&oargs);
@@ -596,12 +594,11 @@ void sinsp::open_udig(uint32_t timeout_ms)
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
 }
 
-void sinsp::open_gvisor(std::string socket_path, std::string root_path, std::string trace_session_path, uint32_t timeout_ms)
+void sinsp::open_gvisor(std::string config_path, std::string root_path, uint32_t timeout_ms)
 {
 	m_gvisor = true;
-	m_gvisor_socket = socket_path;
-	m_gvisor_root_path = root_path, 
-	m_gvisor_trace_session_path = trace_session_path;
+	m_gvisor_root_path = root_path;
+	m_gvisor_config_path = config_path;
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
 	set_get_procs_cpu_from_driver(false);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -250,7 +250,7 @@ public:
 	void fdopen(int fd);
 
 	void open_udig(uint32_t timeout_ms = SCAP_TIMEOUT_MS);
-	void open_gvisor(std::string socket_path, std::string root_path, std::string trace_session_path, uint32_t timeout_ms = SCAP_TIMEOUT_MS);
+	void open_gvisor(std::string config_path, std::string root_path, uint32_t timeout_ms = SCAP_TIMEOUT_MS);
 
 	std::string generate_gvisor_config(std::string socket_path);
 
@@ -1069,9 +1069,8 @@ private:
 	bool m_bpf;
 	bool m_udig;
 	bool m_gvisor;
-	std::string m_gvisor_socket = "";
 	std::string m_gvisor_root_path = "";
-	std::string m_gvisor_trace_session_path = "";
+	std::string m_gvisor_config_path = "";
 	bool m_is_windows;
 	std::string m_bpf_probe;
 	bool m_isdebug_enabled;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds some enhancements to gVisor support:
1. small change to the interface to be able to read the socket directly from the configuration file
2. fixes to the procfs unit test and parsing

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(gvisor): enable reading the socket path from configuration file
```
