### PR TITLE
cleanup(gvisor): use SYS_ macros instead of syscall numbers

### DIFF
--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -15,12 +15,13 @@ or GPL2.txt for full copies of the license.
 #include <linux/ptrace.h>
 #include <linux/capability.h>
 #include "ppm.h"
-#endif
-#ifdef WDIG
-#include <fcntl.h>
-#endif
 #ifdef __NR_io_uring_register
 #include <uapi/linux/io_uring.h>
+#endif
+#endif // ifndef UDIG
+
+#ifdef WDIG
+#include <fcntl.h>
 #endif
 #define PPM_MS_MGC_MSK 0xffff0000
 #define PPM_MS_MGC_VAL 0xC0ED0000

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -24,6 +24,8 @@ limitations under the License.
 #include <linux/un.h>
 #include <arpa/inet.h>
 #include <stdint.h>
+#include <unistd.h>
+#include <sys/syscall.h> // SYS_* constants
 
 #include <functional>
 #include <unordered_map>
@@ -611,9 +613,9 @@ static parse_result parse_generic_syscall(const char *proto, size_t proto_size, 
 
 	switch(gvisor_evt.sysno())
 	{
-		case 56:
+		case SYS_clone:
 			return parse_clone(gvisor_evt, scap_buf, true);
-		case 57:
+		case SYS_fork:
 			return parse_clone(gvisor_evt, scap_buf, false);
 		default:
 			ret.error = std::string("Unhandled syscall: ") + std::to_string(gvisor_evt.sysno());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

/area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We'll need to add a few more syscalls in gvisor. Using numbers when necessary can lead to unnecessary confusion so we're going to use SYS_ macros instead.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
