### PR TITLE
fix(gvisor): fix off-by-one in json parsing eating the last character

### DIFF
--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -727,11 +727,11 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	std::string err;
 	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 
-	bool json_parse = reader->parse(input.c_str(), input.c_str() + input.size() - 1, &root, &err);
+	bool json_parse = reader->parse(input.c_str(), input.c_str() + input.size(), &root, &err);
 	if(!json_parse)
 	{
 		res.status = SCAP_FAILURE;
-		res.error = "Malformed json string: cannot parse procfs entry";
+		res.error = "Malformed json string: cannot parse procfs entry: " + err;
 		return res;
 	}
 
@@ -943,10 +943,10 @@ config_result parse_config(std::string config)
 	Json::CharReaderBuilder builder;
 	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 	
-	bool json_parse = reader->parse(config.c_str(), config.c_str() + config.size() - 1, &root, &err);
+	bool json_parse = reader->parse(config.c_str(), config.c_str() + config.size(), &root, &err);
 	if(!json_parse)
 	{
-		res.error = "Could not parse configuration file contents.";
+		res.error = "Could not parse configuration file contents: " + err;
 		return res;
 	}
 


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It's ok to add a pointer to the end of the string when parsing json as that would point to the `\0` character since `.size()` works like `strlen()`. In addition, the error is added to the return status of the json parsing functions in gVisor.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
