### PR TITLE
new(gvisor): add new syscalls (update to gvisor 45b06bbb)

### DIFF
--- a/userspace/libscap/engine/gvisor/config.json
+++ b/userspace/libscap/engine/gvisor/config.json
@@ -520,6 +520,26 @@
             "task_start_time",
             "time"
           ]
+        },
+        {
+          "name": "syscall/eventfd2/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/eventfd2/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
         }
       ],
       "sinks": [

--- a/userspace/libscap/engine/gvisor/config.json
+++ b/userspace/libscap/engine/gvisor/config.json
@@ -6,7 +6,7 @@
           "name": "container/start", 
           "context_fields": [
             "cwd",
-			"time"
+			      "time"
           ]
         },
         {
@@ -21,29 +21,6 @@
         },
         {
           "name": "syscall/openat/exit",
-          "context_fields": [
-            "credentials",
-            "container_id",
-            "thread_id",
-            "task_start_time",
-            "time"
-          ]
-        },
-        {
-          "name": "syscall/read/enter",
-          "optional_fields": [
-            "fd_path"
-          ],
-          "context_fields": [
-            "credentials",
-            "container_id",
-            "thread_id",
-            "task_start_time",
-            "time"
-          ]
-        },
-        {
-          "name": "syscall/read/exit",
           "context_fields": [
             "credentials",
             "container_id",
@@ -316,6 +293,106 @@
         },
         {
           "name": "syscall/chroot/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/pipe/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/pipe/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/fcntl/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/fcntl/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/bind/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/bind/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/accept/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/accept/exit",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/accept4/enter",
+          "context_fields": [
+            "credentials",
+            "container_id",
+            "thread_id",
+            "task_start_time",
+            "time"
+          ]
+        },
+        {
+          "name": "syscall/accept4/exit",
           "context_fields": [
             "credentials",
             "container_id",

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -829,24 +829,25 @@ static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_
 	}
 
 	char targetbuf[socktuple_buffer_size]; // XXX maybe a smaller version for addr
-	if(gvisor_evt.address().size() == 0)
-	{
-		ret.status = SCAP_FAILURE;
-		ret.error = "No address data received";
-		return ret;
-	}
-
-	sockaddr *addr = (sockaddr *)gvisor_evt.address().data();
-	size_t size = pack_sockaddr(addr, targetbuf);
-	if (size == 0)
-	{
-		ret.status = SCAP_FAILURE;
-		ret.error = "Could not parse received address";
-		return ret;
-	}
 
 	if(gvisor_evt.has_exit())
 	{
+		if(gvisor_evt.address().size() == 0)
+		{
+			ret.status = SCAP_FAILURE;
+			ret.error = "No address data received";
+			return ret;
+		}
+
+		sockaddr *addr = (sockaddr *)gvisor_evt.address().data();
+		size_t size = pack_sockaddr(addr, targetbuf);
+		if (size == 0)
+		{
+			ret.status = SCAP_FAILURE;
+			ret.error = "Could not parse received address";
+			return ret;
+		}
+
 		ret.status = scap_event_encode_params(scap_buf, &ret.size, scap_err, PPME_SOCKET_BIND_X, 2,
 			gvisor_evt.exit().result(),
 			scap_const_sized_buffer{targetbuf, size});

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -460,7 +460,7 @@ static parse_result parse_read(const char *proto, size_t proto_size, scap_sized_
 	{
 		ret.status = scap_event_encode_params(scap_buf, &ret.size, scap_err, PPME_SYSCALL_READ_X, 2,
 								gvisor_evt.exit().result(),
-								scap_const_sized_buffer{nullptr, 0});
+								scap_const_sized_buffer{NULL, 0});
 	}
 
 	if (ret.status != SCAP_SUCCESS) {

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -573,7 +573,7 @@ static size_t pack_sockaddr_to_remote_tuple(sockaddr *sa, char *targetbuf)
 			size += pack_sock_family(sa, buf);
 			memset(targetbuf + 1, 0, 2 * sizeof(uint64_t)); //saddr
 			memset(targetbuf + 17, 0, sizeof(uint16_t)); //sport
-			size += sizeof(uint64_t) + sizeof(uint16_t);
+			size += 2 * sizeof(uint64_t) + sizeof(uint16_t);
 			buf = targetbuf + size;
 			size += pack_addr_port(sa, buf);
 		}

--- a/userspace/libscap/engine/gvisor/parsers.h
+++ b/userspace/libscap/engine/gvisor/parsers.h
@@ -44,6 +44,10 @@ static parse_result parse_dup(const char *proto, size_t proto_size, scap_sized_b
 static parse_result parse_task_exit(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 static parse_result parse_prlimit64(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 static parse_result parse_signalfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+static parse_result parse_pipe(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+static parse_result parse_fcntl(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+static parse_result parse_accept(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 
 // List of parsers. Indexes are based on MessageType enum values
 std::vector<parser> dispatchers = {
@@ -62,17 +66,17 @@ std::vector<parser> dispatchers = {
 	parse_socket,
 	parse_chdir,
 	parse_setid,
-	parse_setresid, 
+	parse_setresid,
 	parse_prlimit64,
-  	nullptr, 				// MESSAGE_SYSCALL_PIPE
-  	nullptr, 				// MESSAGE_SYSCALL_FCNTL
+  	parse_pipe,
+  	parse_fcntl,
   	parse_dup,
    	parse_signalfd,
   	parse_chroot,
   	nullptr, 				// MESSAGE_SYSCALL_EVENTFD
   	nullptr, 				// MESSAGE_SYSCALL_CLONE
-  	nullptr, 				// MESSAGE_SYSCALL_BIND
-  	nullptr, 				// MESSAGE_SYSCALL_ACCEPT
+  	parse_bind,
+  	parse_accept,
 };
 
 } // namespace parsers

--- a/userspace/libscap/engine/gvisor/parsers.h
+++ b/userspace/libscap/engine/gvisor/parsers.h
@@ -48,6 +48,7 @@ static parse_result parse_pipe(const char *proto, size_t proto_size, scap_sized_
 static parse_result parse_fcntl(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 static parse_result parse_accept(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+static parse_result parse_eventfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
 
 // List of parsers. Indexes are based on MessageType enum values
 std::vector<parser> dispatchers = {
@@ -73,7 +74,7 @@ std::vector<parser> dispatchers = {
   	parse_dup,
    	parse_signalfd,
   	parse_chroot,
-  	nullptr, 				// MESSAGE_SYSCALL_EVENTFD
+  	parse_eventfd,
   	nullptr, 				// MESSAGE_SYSCALL_CLONE
   	parse_bind,
   	parse_accept,

--- a/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/common.proto
+++ b/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/common.proto
@@ -94,6 +94,8 @@ message ContextData {
   string process_name = 9;
 }
 
+// MessageType describes the payload of a message sent to the remote process.
+// LINT.IfChange
 enum MessageType {
   MESSAGE_UNKNOWN = 0;
   MESSAGE_CONTAINER_START = 1;
@@ -122,3 +124,4 @@ enum MessageType {
   MESSAGE_SYSCALL_BIND = 24;
   MESSAGE_SYSCALL_ACCEPT = 25;
 }
+// LINT.ThenChange(../../../../examples/seccheck/server.cc)

--- a/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/sentry.proto
+++ b/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/sentry.proto
@@ -22,13 +22,16 @@ import "pkg/sentry/seccheck/points/common.proto";
 message CloneInfo {
   gvisor.common.ContextData context_data = 1;
 
-  // CreatedThreadID is the thread's ID in the root PID namespace.
+  // created_thread_id is the thread's ID in the root PID namespace.
   int32 created_thread_id = 3;
 
   int32 created_thread_group_id = 4;
 
-  // CreatedThreadStartTime is the thread's CLOCK_REALTIME start time.
+  // created_thread_start_time_ns is the thread's CLOCK_REALTIME start time.
   int64 created_thread_start_time_ns = 5;
+
+  // flags are equivalent to the flags passed to clone(2).
+  uint64 flags = 6;
 }
 
 // ExecveInfo contains information used by the Execve checkpoint.

--- a/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/syscall.proto
+++ b/userspace/libscap/engine/gvisor/proto/pkg/sentry/seccheck/points/syscall.proto
@@ -61,7 +61,6 @@ message Read {
   int64 fd = 4;
   string fd_path = 5;
   uint64 count = 6;
-  bytes data = 7;
 }
 
 message Connect {

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -451,7 +451,7 @@ int32_t engine::process_message_from_fd(int fd)
 	if(parse_result.status != SCAP_SUCCESS)
 	{
 		strlcpy(m_lasterr, parse_result.error.c_str(), SCAP_LASTERR_SIZE);
-		return parse_result.status;
+		return SCAP_ILLEGAL_INPUT;
 	}
 
 	for(scap_evt *evt : parse_result.scap_events)
@@ -465,6 +465,7 @@ int32_t engine::process_message_from_fd(int fd)
 int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 {
 	epoll_event evts[max_ready_sandboxes];
+	*pcpuid = 0;
 
 	// if there are still events to process do it before getting more
 	if(!m_event_queue.empty())
@@ -494,9 +495,9 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 				return SCAP_FAILURE;
 			}
 
-			// useful for debugging but we might want to do better
+			// ignore parsing errors, we will simply discard the message
 			if (status == SCAP_ILLEGAL_INPUT) {
-				return SCAP_FAILURE;
+				continue;
 			}
 		}
 

--- a/userspace/libsinsp/gvisor_config.cpp
+++ b/userspace/libsinsp/gvisor_config.cpp
@@ -63,6 +63,14 @@ static const std::vector<std::string> s_gvisor_points = {
 	"sentry/clone",
 	"sentry/task_exit",
 	"sentry/execve",
+	"syscall/pipe/enter",
+	"syscall/pipe/exit",
+	"syscall/fcntl/enter",
+	"syscall/fcntl/exit",
+	"syscall/bind/enter",
+	"syscall/bind/exit",
+	"syscall/accept/enter",
+	"syscall/accept/exit"
 };
 
 static const std::vector<std::string> s_context_fields = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for the syscalls added in https://github.com/google/gvisor/commit/45b06bbb763662579dcc35b9d70f56ce85cf3370 .
Also present the following refactors:
* network "one sided tuple" factored out
* "read" syscall updated to reflect removal of the data field (which was already empty)
* refactor error codes to be consistent with function contracts in comments

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(gvisor): add support for setresid, pipe, fcntl, eventfd, bind and accept
```
