### PR TITLE
fix(libsinsp): have the schema and api version bump automatically

### DIFF
--- a/driver/ppm_api_version.h
+++ b/driver/ppm_api_version.h
@@ -1,6 +1,8 @@
 #ifndef PPM_API_VERSION_H
 #define PPM_API_VERSION_H
 
+#include "driver_config.h"
+
 /*
  * API version component macros
  *

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -87,8 +87,8 @@ struct iovec;
 // call `scap_get_driver_api_version()` and/or `scap_get_driver_schema_version()`
 // and handle the result
 //
-#define SCAP_MINIMUM_DRIVER_API_VERSION PPM_API_VERSION(1, 0, 0)
-#define SCAP_MINIMUM_DRIVER_SCHEMA_VERSION PPM_API_VERSION(1, 0, 0)
+#define SCAP_MINIMUM_DRIVER_API_VERSION PPM_API_CURRENT_VERSION
+#define SCAP_MINIMUM_DRIVER_SCHEMA_VERSION PPM_SCHEMA_CURRENT_VERSION
 
 //
 // Return types
@@ -995,7 +995,7 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid);
 
 /*!
   \brief Get (at most) n parameters for this event.
- 
+
   \param e The scap event.
   \param params An array large enough to contain at least one entry per event parameter (which is at most PPM_MAX_EVENT_PARAMS).
  */
@@ -1009,7 +1009,7 @@ uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *p
    - String types (including PT_FSPATH, PT_FSRELPATH) are passed via a null-terminated char*
    - Buffer types, variable size types and similar, including PT_BYTEBUF, PT_SOCKTUPLE are passed with
      a struct scap_const_sized_buffer
-  
+
   If the event was written successfully, SCAP_SUCCESS is returned. If the supplied buffer is not large enough to contain
   the event, SCAP_INPUT_TOO_SMALL is returned and event_size is set with the required size to contain the entire event.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

After #436 updated the schema version in the driver, `sinsp-example` started failing to start for me saying that the schema version was not being satisfied.

Since the driver version needs to be equal to or greater than the version stored in the userspace component, it needs to be set at compile time. This change makes it so the latest driver version is always included in userspace.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
