### PR TITLE
fix(bpf): fix compilation issue on `4.18.0-193.75.1.el8_2.x86_64`

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3126,7 +3126,7 @@ FILLER(sys_io_uring_setup_x, true)
 	unsigned long flags;
 	unsigned long sq_thread_cpu;
 	unsigned long sq_thread_idle;
-	unsigned long features;
+	unsigned long features = 0;
 
 #ifdef __NR_io_uring_setup
 	struct io_uring_params params;
@@ -3157,7 +3157,9 @@ FILLER(sys_io_uring_setup_x, true)
 	flags = io_uring_setup_flags_to_scap(params.flags);
 	sq_thread_cpu = params.sq_thread_cpu;
 	sq_thread_idle = params.sq_thread_idle;
+#ifdef IORING_FEAT_SINGLE_MMAP	
 	features = io_uring_setup_feats_to_scap(params.features);
+#endif	
 #else
 	sq_entries = 0;
 	cq_entries = 0;


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf

**What this PR does / why we need it**:

This PR fixes a compilation issue on RHEL8 machine `4.18.0-193.75.1.el8_2.x86_64`. This `ifdef` is already used in the kernel module corresponding helper... we need to introduce it also here

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
