### PR TITLE
new(ci): port to github actions. Added a windows CI too.

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,0 +1,35 @@
+name: Builder update
+on:
+  push:
+    branches: [master]
+    paths: ['docker/**']
+
+jobs:
+  update-builder:
+    env:
+      REGISTRY: ghcr.io
+      BUILDER_IMAGE_BASE: ghcr.io/fededp/libs-builder
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build new builder
+        id: libs-builder
+        uses: docker/build-push-action@v3
+        with:
+          context: docker
+          file: docker/builder.Dockerfile
+          platforms: amd64,arm64
+          push: true
+          tags: ${{ format('{0}:dev,{0}:{1}', env.BUILDER_IMAGE_BASE, github.sha) }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - name: Checkout Libs
         uses: actions/checkout@v3
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ jobs:
   update-builder:
     env:
       REGISTRY: ghcr.io
-      BUILDER_IMAGE_BASE: ghcr.io/fededp/libs-builder
+      BUILDER_IMAGE_BASE: ghcr.io/falcosecurity/libs-builder
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,17 @@ jobs:
             
           run: |
             docker run -ti --rm -v $GITHUB_WORKSPACE:/workspace ${{ needs.builder.outputs.builder_image }} -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False
+            
+  build-libs-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          cd build && cmake ..
+  
+      - name: Build
+        run: cd build && cmake --build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,155 @@
+name: CI Build
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  builder:
+    env:
+      REGISTRY: ghcr.io
+      BUILDER_IMAGE_BASE: ghcr.io/fededp/libs-builder
+      BUILDER_DEV: ghcr.io/fededp/libs-builder:dev
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+        
+      - name: Check if docker builder is modified
+        id: builder-files
+        uses: tj-actions/changed-files@v10.1
+        with:
+          files: |
+            ^docker/  
+
+      - name: Set up QEMU
+        if: steps.builder-files.outputs.any_changed == 'true'
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        if: steps.builder-files.outputs.any_changed == 'true'
+        uses: docker/setup-buildx-action@v2
+        
+      - name: Login to GitHub Container Registry
+        if: steps.builder-files.outputs.any_changed == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  
+        
+      - name: Get new builder image tag
+        id: get-new-builder
+        if: steps.builder-files.outputs.any_changed == 'true'
+        run: |
+          echo "::set-output name=builder_image::${{ env.BUILDER_IMAGE_BASE }}:${{ github.event.pull_request.number }}"
+        
+      - name: Build libs-builder
+        id: libs-builder
+        if: steps.builder-files.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          context: docker
+          file: docker/builder.Dockerfile
+          platforms: amd64,arm64
+          push: true
+          tags: ${{ steps.get-new-builder.outputs.builder_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          
+    outputs:
+      builder_image: ${{ (steps.builder-files.outputs.any_changed == 'true') && steps.get-new-builder.outputs.builder_image || env.BUILDER_DEV }}      
+
+  build-libs:
+    needs: builder
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.builder.outputs.builder_image }}
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Link libs repo to /workspace
+        run: |
+          mkdir -p /workspace
+          ln -s "$GITHUB_WORKSPACE" /workspace
+  
+      - name: Build and test
+        run: /build.sh -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False
+        
+  build-libs-bundled-deps:
+    needs: builder
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.builder.outputs.builder_image }}
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Link libs repo to /workspace
+        run: |
+          mkdir -p /workspace
+          ln -s "$GITHUB_WORKSPACE" /workspace
+  
+      - name: Build and test
+        run: /build.sh -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=True
+        
+  build-libs-with-chisels:
+    needs: builder
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.builder.outputs.builder_image }}
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Link libs repo to /workspace
+        run: |
+          mkdir -p /workspace
+          ln -s "$GITHUB_WORKSPACE" /workspace
+  
+      - name: Build and test
+        run: /build.sh -DBUILD_BPF=On -DWITH_CHISEL=True
+        
+  build-libs-minimal:
+    needs: builder
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.builder.outputs.builder_image }}
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - name: Link libs repo to /workspace
+        run: |
+          mkdir -p /workspace
+          ln -s "$GITHUB_WORKSPACE" /workspace
+  
+      - name: Build and test
+        run: /build.sh -DMINIMAL_BUILD=True
+        
+  build-libs-arm64:
+    needs: builder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@v3
+
+      - uses: uraimo/run-on-arch-action@v2
+        name: Run aarch64 build
+        with:
+          arch: aarch64
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+
+          # Set an output parameter `uname` for use in subsequent steps
+          install: |
+            apk add docker
+            
+          run: |
+            docker run -ti --rm -v $GITHUB_WORKSPACE:/workspace ${{ needs.builder.outputs.builder_image }} -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   builder:
     env:
       REGISTRY: ghcr.io
-      BUILDER_IMAGE_BASE: ghcr.io/fededp/libs-builder
-      BUILDER_DEV: ghcr.io/fededp/libs-builder:dev
+      BUILDER_IMAGE_BASE: ghcr.io/falcosecurity/libs-builder
+      BUILDER_DEV: ghcr.io/falcosecurity/libs-builder:dev
 
     runs-on: ubuntu-latest
     steps:

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 The Falco Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+mkdir -p build
+pushd build
+
+cmake "$@" ..
+
+KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
+
+make run-unit-tests

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:buster
+
+LABEL usage="docker run -i -t -v /path/to/source:/workspace libs-builder [cmake options]"
+
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    build-essential \
+    clang \
+    llvm \
+    git \
+    libncurses-dev \
+    pkg-config \
+    autoconf \ 
+    automake \
+    libtool \
+    libelf-dev \
+    wget \
+    libb64-dev \
+    libc-ares-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libtbb-dev \
+    libjq-dev \
+    libjsoncpp-dev \
+    libgrpc++-dev \
+    protobuf-compiler-grpc \
+    libgtest-dev \
+    libprotobuf-dev \
+    linux-headers-${TARGETARCH} \
+    && apt-get clean
+
+COPY build.sh /
+RUN chmod +x /build.sh
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/build.sh"]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR ports the libs CI to github actions; it does so by using an internally stored (on GitHub Container Registry) and cached builder image (that strictly follows [test-infra build-libs image] (https://github.com/falcosecurity/test-infra/blob/master/images/build-libs/Dockerfile), that is itself private).  

The builder image is automatically refreshed upon any change to its files.

This allows us:
* free up prow 
* avoid ok-to-test for new PRs
* quicker CI
* Easily test windows build
* allow much easier changes to CI, for everyone

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(ci): ported ci from prow to gh actions
```
