### PR TITLE
fix(userspace/libsinsp): support bpf special case `res_or_fd` param naming in TYPE_RESSTR filtercheck

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3556,7 +3556,15 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint3
 
 	if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 	{
-		pi = evt->get_param_value_raw("fd");
+		const char *raw_param_name = "fd";
+		pi = evt->get_param_value_raw(raw_param_name);
+		if (pi == NULL)
+		{
+			// bpf exit uses this (instead of 2 params, just one with multiple meanings)
+			// fallback at trying to read the fd from here
+			raw_param_name = "res_or_fd";
+			pi = evt->get_param_value_raw(raw_param_name);
+		}
 
 		if(pi != NULL)
 		{
@@ -4054,8 +4062,15 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 			{
-				pi = evt->get_param_value_raw("fd");
-
+				const char *raw_param_name = "fd";
+				pi = evt->get_param_value_raw(raw_param_name);
+				if (pi == NULL)
+				{
+					// bpf exit uses this (instead of 2 params, just one with multiple meanings)
+					// fallback at trying to read the fd from here
+					raw_param_name = "res_or_fd";
+					pi = evt->get_param_value_raw(raw_param_name);
+				}
 				if(pi != NULL)
 				{
 					*len = pi->m_len;
@@ -4158,7 +4173,15 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			}
 			else if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 			{
-				pi = evt->get_param_value_raw("fd");
+				const char *raw_param_name = "fd";
+				pi = evt->get_param_value_raw(raw_param_name);
+				if (pi == NULL)
+				{
+					// bpf exit uses this (instead of 2 params, just one with multiple meanings)
+					// fallback at trying to read the fd from here
+					raw_param_name = "res_or_fd";
+					pi = evt->get_param_value_raw(raw_param_name);
+				}
 
 				if(pi != NULL)
 				{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Moreover, made it more resilient to crashes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): properly support various evt related filterchecks for bpf syscall
```
