### PR TITLE
fix(userspace/libsinsp): avoid crashing in TYPE_RESSTR when an EF_CREATES_FD event has no "fd" param

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4103,25 +4103,27 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 				{
 					pi = evt->get_param_value_raw("fd");
-
-					int64_t res = *(int64_t*)pi->m_val;
-
-					if(res >= 0)
+					if (pi)
 					{
-						RETURN_EXTRACT_CSTR("SUCCESS");
-					}
-					else
-					{
-						argstr = evt->get_param_value_str("fd", &resolved_argstr);
-						ASSERT(resolved_argstr != NULL && resolved_argstr[0] != 0);
+						int64_t res = *(int64_t*)pi->m_val;
 
-						if(resolved_argstr != NULL && resolved_argstr[0] != 0)
+						if(res >= 0)
 						{
-							RETURN_EXTRACT_CSTR(resolved_argstr);
+							RETURN_EXTRACT_CSTR("SUCCESS");
 						}
-						else if(argstr != NULL)
+						else
 						{
-							RETURN_EXTRACT_CSTR(argstr);
+							argstr = evt->get_param_value_str("fd", &resolved_argstr);
+							ASSERT(resolved_argstr != NULL && resolved_argstr[0] != 0);
+
+							if(resolved_argstr != NULL && resolved_argstr[0] != 0)
+							{
+								RETURN_EXTRACT_CSTR(resolved_argstr);
+							}
+							else if(argstr != NULL)
+							{
+								RETURN_EXTRACT_CSTR(argstr);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): do not crash in TYPE_RESSTR filtercheck when EF_CREATES_FD event has no fd param
```
