### PR TITLE
fix(userspace/libscap): propagate scap open errors

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -256,6 +256,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	*rc = check_api_compatibility(handle, handle->m_lasterr);
 	if(*rc != SCAP_SUCCESS)
 	{
+		snprintf(error, SCAP_LASTERR_SIZE, "%s", handle->m_lasterr);
 		scap_close(handle);
 		return NULL;
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -281,6 +281,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 	//
 	if((*rc = scap_start_capture(handle)) != SCAP_SUCCESS)
 	{
+		snprintf(error, SCAP_LASTERR_SIZE, "%s", handle->m_lasterr);
 		scap_close(handle);
 		return NULL;
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

Errors regarding driver API checks and capture starting were not properly propagated due to the recent vtable-related refactoring.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
