### PR TITLE
chore: fix gtest fatal error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ cmake_minimum_required(VERSION 2.8.5)
 
 project(falcosecurity-libs)
 
+option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 option(MINIMAL_BUILD "Produce a minimal build with only the essential features (no eBPF probe driver, no kubernetes, no mesos, no marathon and no container metadata)" OFF)
 option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
 option(USE_BUNDLED_DRIVER "Use the driver/ subdirectory in the build process (only available in Linux)" ON)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

When we compile with `cmake -DCREATE_TEST_TARGETS=ON` the `gtest.cmake` search for local gtest lib if we use not bundled deps, the problem is that the bundled dep option is not defined in the root `CMakeLists.txt` causing:

```
CMake Error at cmake/modules/gtest.cmake:12 (message):
  Couldn't find system gtest
Call Stack (most recent call first):
  CMakeLists.txt:91 (include)
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
