### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,6 @@
 approvers:
-  - fntlnz
-  - leodido
   - leogr
   - gnosek
-  - ldegio
   - mstemm
   - fededp
   - andreagit97
@@ -16,3 +13,8 @@ reviewers:
   - mstemm
   - fededp
   - andreagit97
+emeritus_approvers:
+  - fntlnz
+  - leodido
+  - ldegio
+  

--- a/OWNERS
+++ b/OWNERS
@@ -4,17 +4,7 @@ approvers:
   - mstemm
   - fededp
   - andreagit97
-reviewers:
-  - fntlnz
-  - leodido
-  - leogr
-  - gnosek
-  - ldegio
-  - mstemm
-  - fededp
-  - andreagit97
 emeritus_approvers:
   - fntlnz
   - leodido
   - ldegio
-  


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
