### PR TITLE
update(gvisor): implement get_stats for gVisor

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -88,7 +88,7 @@ static int32_t gvisor_configure(struct scap_engine_handle engine, enum scap_sett
 
 static int32_t gvisor_get_stats(struct scap_engine_handle engine, scap_stats* stats)
 {
-	return SCAP_SUCCESS;
+	return engine.m_handle->get_stats(stats);
 }
 
 static int32_t gvisor_get_n_tracepoint_hit(struct scap_engine_handle engine, long* ret)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -49,6 +49,8 @@ struct parse_result {
 	size_t size;
     // pointers to each encoded event within the supplied output buffer
 	std::vector<scap_evt*> scap_events;
+    // number of events dropped by gVisor
+    uint32_t dropped_count;
 };
 
 struct procfs_result {
@@ -140,6 +142,7 @@ public:
     uint32_t get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos);
     uint32_t get_fdinfos(const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos);
     uint32_t get_vxid(uint64_t pid);
+    int32_t get_stats(scap_stats  *stats);
 private:
     int32_t process_message_from_fd(int fd);
     void free_sandbox_buffers();
@@ -167,6 +170,16 @@ private:
     // and the path the trace session configuration file used to set up traces, respectively
     std::string m_root_path;
     std::string m_trace_session_path;
+
+    struct gvisor_stats
+    {
+        // total number of events received from gVisor
+        uint64_t n_evts;
+        // total number of drops due to parsig errors
+        uint64_t n_drops_parsing;
+        // total number of drops on gVisor side
+        uint64_t n_drops_gvisor;
+    } m_gvisor_stats;
 
 };
 

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -124,6 +124,7 @@ public:
     int32_t expand_buffer(size_t size);
 
     scap_sized_buffer m_buf;
+    uint64_t m_last_dropped_count;
 	bool m_closing;
 };
 

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -1331,6 +1331,8 @@ parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_b
 		return ret;
 	}
 
+	// dropped count is the absolute number of events dropped from gVisor side
+	ret.dropped_count = hdr->dropped_count;
 	const char *proto = &buf[hdr->header_size];
 	ssize_t proto_size = gvisor_buf.size - hdr->header_size;
 

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -47,6 +47,7 @@ sandbox_entry::sandbox_entry()
 {
 	m_buf.buf = nullptr;
 	m_buf.size = 0;
+	m_last_dropped_count = 0;
 	m_closing = false;
 }
 
@@ -473,7 +474,9 @@ int32_t engine::process_message_from_fd(int fd)
 		return SCAP_ILLEGAL_INPUT;
 	}
 
-	m_gvisor_stats.n_drops_gvisor = parse_result.dropped_count;
+	uint64_t delta = parse_result.dropped_count - m_sandbox_data[fd].m_last_dropped_count;
+	m_sandbox_data[fd].m_last_dropped_count = parse_result.dropped_count;
+	m_gvisor_stats.n_drops_gvisor += delta;
 
 	for(scap_evt *evt : parse_result.scap_events)
 	{


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

/area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR implements the `get_stats` vtable function for gVisor, letting Falco be able to retrieve statistics like the number of drops or events. 
Statistics are collected in a `scap_stats` structure like usual. To be precise: 

- `n_drops_bug` is used to count the number of dropped events due to parsing errors
- `n_drops_buffers` is used to count the number of dropped events from gVisor side. This number can be retrieved from the header of each message. 
- `n_drops` is the total number of dropped events, so it is computed as the sum of the previous two.
- `n_evts` counts the number of events that were successfully returned by `next` 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
