### PR TITLE
fix(install): install the 10 libscap related libraries

### DIFF
--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -16,9 +16,22 @@ get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSO
 set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
 
 add_subdirectory(${LIBSCAP_DIR}/userspace/libscap ${PROJECT_BINARY_DIR}/libscap)
-set(LIBSCAP_LIB "${PROJECT_BINARY_DIR}/libscap/libscap.a")
-install(FILES "${LIBSCAP_LIB}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
-			COMPONENT "scap")
+
+set(LIBSCAP_LIBS "")
+list(APPEND LIBSCAP_LIBS
+	"${PROJECT_BINARY_DIR}/libscap/libscap.a"
+	"${PROJECT_BINARY_DIR}/libscap/libscap_engine_util.a"
+	"${PROJECT_BINARY_DIR}/libscap/libscap_event_schema.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/bpf/libscap_engine_bpf.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/gvisor/libscap_engine_gvisor.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/kmod/libscap_engine_kmod.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/nodriver/libscap_engine_nodriver.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/noop/libscap_engine_noop.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/source_plugin/libscap_engine_source_plugin.a"
+	"${PROJECT_BINARY_DIR}/libscap/engine/udig/libscap_engine_udig.a"
+)
+install(FILES ${LIBSCAP_LIBS} DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+			COMPONENT "scap" OPTIONAL)
 install(DIRECTORY "${LIBSCAP_INCLUDE_DIR}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/userspace"
 			COMPONENT "scap"
 			FILES_MATCHING PATTERN "*.h"


### PR DESCRIPTION
Signed-off-by: Teryl <terylt@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build
/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The scap library was recently broken out into 10 separate libs, but they were not added to the installation script in cmake.  All 10 libraries are needed to build consumer applications.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
It installs all 10 libraries.
<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
added scap engine related libs to install
```
