### PR TITLE
fix(driver/bpf): accessing loginuid depends upon a config flag in the kernel

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2566,6 +2566,7 @@ FILLER(proc_startupdate_3, true)
 		 * loginuid
 		 */
 		/* TODO: implement user namespace support */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0) && CONFIG_AUDIT) || (LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0) && CONFIG_AUDITSYSCALL)
 #ifdef COS_73_WORKAROUND
 		{
 			struct audit_task_info* audit = _READ(task->audit);
@@ -2577,7 +2578,10 @@ FILLER(proc_startupdate_3, true)
 		}
 #else
 		loginuid = _READ(task->loginuid);
-#endif
+#endif /* COS_73_WORKAROUND */
+#else
+		loginuid.val = -1;
+#endif /* CONFIG_AUDIT... */
 
 		res = bpf_val_to_ring_type(data, loginuid.val, PT_INT32);
 		if (res != PPM_SUCCESS)
@@ -6047,6 +6051,7 @@ FILLER(sched_prog_exec_3, false)
 
 	/* TODO: implement user namespace support */
 	kuid_t loginuid;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0) && CONFIG_AUDIT) || (LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0) && CONFIG_AUDITSYSCALL)
 #ifdef COS_73_WORKAROUND
 	{
 		struct audit_task_info *audit = _READ(task->audit);
@@ -6061,7 +6066,10 @@ FILLER(sched_prog_exec_3, false)
 	}
 #else
 	loginuid = _READ(task->loginuid);
-#endif
+#endif /* COS_73_WORKAROUND */
+#else
+	loginuid.val = -1;
+#endif /* CONFIG_AUDIT... */
 
 	/* Parameter 19: loginuid (type: PT_INT32) */
 	res = bpf_val_to_ring_type(data, loginuid.val, PT_INT32);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area driver-bpf

**What this PR does / why we need it**:

The config flag is either CONFIG_AUDITSYSCALL for kernels < 5.1.0, or CONFIG_AUDIT for newer ones.
See https://github.com/torvalds/linux/blob/master/include/linux/sched.h#L1104.

I caught this build issue while testing an archlinux builder for driverkit using a cross-build to arm through qemu, building kernel 4.17.0.
Possibly, the archlinux arm folks did not enable those flags in their kernel configs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
