### PR TITLE
fix(build): USE_BUNDLED_DRIVER=OFF allows userspace to be built correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 message(STATUS "Libs version: ${FALCOSECURITY_LIBS_VERSION}")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND USE_BUNDLED_DRIVER)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	# Driver version
 	if(NOT DEFINED DRIVER_VERSION)
 		get_drivers_version(DRIVER_VERSION)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -114,6 +114,10 @@ foreach(FILENAME IN LISTS DRIVER_SOURCES)
 	configure_file(${FILENAME} src/${FILENAME} COPYONLY)
 endforeach()
 
+if(NOT USE_BUNDLED_DRIVER)
+	return()
+endif()
+
 # make can be self-referenced as $(MAKE) only from Makefiles but this
 # triggers syntax errors with other generators such as Ninja
 if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Configuring the project with `-DUSE_BUNDLED_DRIVER=OFF` fails to compile with the following message:
```
/libs/userspace/libscap/scap_engine_util.c:25:10: fatal error: driver_config.h: No such file or directory
   25 | #include "driver_config.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [libscap/CMakeFiles/scap_engine_util.dir/build.make:76: libscap/CMakeFiles/scap_engine_util.dir/scap_engine_util.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

This PR moves the `USE_BUNDLED_DRIVER` into the `driver` configuration so that needed files can be configured and copied to the build directories, but stops before the driver targets are defined.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
