### PR TITLE
fix(libscap): fix call to ioctl when getting proclist

### DIFF
--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -729,7 +729,7 @@ static int32_t configure(struct scap_engine_handle engine, enum scap_setting set
 static int32_t scap_kmod_get_threadlist(struct scap_engine_handle engine, struct ppm_proclist_info **procinfo_p, char *lasterr)
 {
 	struct kmod_engine* kmod_engine = engine.m_handle;
-	int ioctlres = ioctl(kmod_engine->m_dev_set.m_devs[0].m_fd, PPM_IOCTL_GET_PROCLIST, procinfo_p);
+	int ioctlres = ioctl(kmod_engine->m_dev_set.m_devs[0].m_fd, PPM_IOCTL_GET_PROCLIST, *procinfo_p);
 	if(ioctlres)
 	{
 		if(errno == ENOSPC)


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

/area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I was experiencing a segfault when using OSS Sysdig, the same described in this issue: https://github.com/falcosecurity/libs/issues/465.
I also noticed that the crash was occurring in Sysdig but not in Falco and I wanted to understand this better. By taking a look at the branch that helped closing that issue, I noticed that the function `sinsp::get_procs_cpu_from_driver` was commented out. This function only gets called in Sysdig `dev` and not in Falco and Sysdig `gvisor-with-libs-drivers` and would eventually call the `scap_kmod_get_threadlist`, where the segfault occur. 

After taking a close look at the issue, I compared the current implementation with the one we had before the introduction of the vtable and noticed that we forgot to dereference the `procinfo_p` double pointer when calling the `PPM_IOCTL_GET_PROCLIST` ioctl. The kernel module would then write the `ppm_proclist_info` in `procinfo_p` that is pointing to `handle->m_driver_procinfo`, causing the segfault when calling `scap_alloc_proclist_info` right after.

**Which issue(s) this PR fixes**:



<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/libs/issues/465.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
