### PR TITLE
fix(userspace/libscap): solve compilation warnings and errors

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -841,7 +841,7 @@ cleanup:
 	return res;
 }
 
-static void *perf_event_mmap(struct bpf_engine *handle, int fd, int *size)
+static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size)
 {
 	int page_size = getpagesize();
 	int ring_size = page_size * BUF_SIZE_PAGES;

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -23,7 +23,9 @@ limitations under the License.
 
 #define KMOD_OPTION "--kmod"
 #define BPF_OPTION "--bpf"
-#define MODERN_BPF_OPTION "--modern_bpf"
+#ifdef HAS_ENGINE_MODERN_BPF
+	#define MODERN_BPF_OPTION "--modern_bpf"
+#endif
 #define SCAP_FILE_OPTION "--scap_file"
 #define SIMPLE_CONSUMER_OPTION "--simple_consumer"
 #define NUM_EVENTS_OPTION "--num_events"
@@ -503,7 +505,9 @@ void print_help()
 	printf("------> SCAP SOURCES\n");
 	printf("'%s': enable the kernel module.\n", KMOD_OPTION);
 	printf("'%s <probe_path>': enable the BPF probe.\n", BPF_OPTION);
+#ifdef HAS_ENGINE_MODERN_BPF
 	printf("'%s': enable modern BPF probe.\n", MODERN_BPF_OPTION);
+#endif
 	printf("'%s <file.scap>': read events from scap file.\n", SCAP_FILE_OPTION);
 	printf("\n------> CONFIGURATIONS OPTIONS\n");
 	printf("'%s': enable the simple consumer mode. (default: disabled)\n", SIMPLE_CONSUMER_OPTION);
@@ -604,11 +608,13 @@ void parse_CLI_options(int argc, char** argv)
 			args.bpf_probe = argv[++i];
 			source = BPF_PROBE;
 		}
+#ifdef HAS_ENGINE_MODERN_BPF
 		if(!strcmp(argv[i], MODERN_BPF_OPTION))
 		{
 			args.mode = SCAP_MODE_MODERN_BPF;
 			source = MODERN_BPF_PROBE;
 		}
+#endif
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
 		{
 			if(!(i + 1 < argc))

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -59,11 +59,13 @@ typedef enum {
 	 * Do not read system call data. Events come from the configured input plugin.
 	 */
 	SCAP_MODE_PLUGIN,
+#ifdef HAS_ENGINE_MODERN_BPF
 	/*!
 	 * Read system call data from the underlying operating system using a modern
 	 * bpf probe.
 	 */
 	SCAP_MODE_MODERN_BPF,
+#endif
 } scap_mode_t;
 
 /*!


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

This fixes two warnings that prevented libscap from compiling when warnings are considered as errors.
```
scap.c:926:2: error: enumeration value ‘SCAP_MODE_MODERN_BPF’ not handled in switch [-Werror=switch]
  926 |  switch(args.mode)
      |  ^~~~~~
```
```
scap_bpf.c:1563:51: error: pointer targets in passing argument 3 of ‘perf_event_mmap’ differ in signedness [-Werror=pointer-sign]
 1563 |   dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size);
      |                                                   ^~~~~~~~~~~~~~~~~~~
      |                                                   |
      |                                                   uint32_t * {aka unsigned int *}
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
