### PR TITLE
new(sinsp/test): add event based tests

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -148,8 +148,13 @@ endif()
 option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
 
 if(CREATE_TEST_TARGETS AND NOT WIN32)
-		# Add unit test directories
-		add_subdirectory(test)
+	# Add engine only used for testing
+	add_definitions(-DHAS_ENGINE_TEST_INPUT)
+	add_subdirectory(engine/test_input)
+	target_link_libraries(scap scap_engine_test_input)
+
+	# Add unit test directories
+	add_subdirectory(test)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -211,10 +216,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_definitions(-DHAS_ENGINE_KMOD)
 	add_subdirectory(engine/kmod)
 	target_link_libraries(scap scap_engine_kmod)
-
-	add_definitions(-DHAS_ENGINE_TEST_INPUT)
-	add_subdirectory(engine/test_input)
-	target_link_libraries(scap scap_engine_test_input)
 
 	if(USE_MODERN_BPF)
 		add_subdirectory(engine/modern_bpf)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -212,6 +212,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_subdirectory(engine/kmod)
 	target_link_libraries(scap scap_engine_kmod)
 
+	add_definitions(-DHAS_ENGINE_TEST_INPUT)
+	add_subdirectory(engine/test_input)
+	target_link_libraries(scap scap_engine_test_input)
+
 	if(USE_MODERN_BPF)
 		add_subdirectory(engine/modern_bpf)
 		target_link_libraries(scap scap_engine_modern_bpf)

--- a/userspace/libscap/engine/test_input/CMakeLists.txt
+++ b/userspace/libscap/engine/test_input/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+add_library(scap_engine_test_input test_input.c)
+target_link_libraries(scap_engine_test_input scap_engine_noop)

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+struct scap;
+struct scap_test_input_data;
+
+struct test_input_engine
+{
+	char* m_lasterr;
+	struct scap_test_input_data *m_data;
+	size_t m_event_index;
+};
+
+typedef struct test_input_engine test_input_engine;
+
+#define SCAP_HANDLE_T struct test_input_engine
+
+#include "noop.h"
+
+#include "scap.h"
+#include "scap-int.h"
+#include "../common/strlcpy.h"
+
+static struct test_input_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+{
+	struct test_input_engine *engine = calloc(1, sizeof(struct test_input_engine));
+	if(engine == NULL)
+	{
+		return NULL;
+	}
+
+	engine->m_lasterr = lasterr_ptr;
+
+	return engine;
+}
+
+static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid)
+{
+	test_input_engine *engine = handle.m_handle;
+	if (engine->m_data == NULL)
+	{
+		strlcpy(engine->m_lasterr, "No test input data provided", SCAP_LASTERR_SIZE);
+		return SCAP_FAILURE;
+	}
+
+	if (engine->m_event_index >= engine->m_data->event_count)
+	{
+		return SCAP_EOF;
+	}
+	
+	*pevent = engine->m_data->events[engine->m_event_index];
+	engine->m_event_index++;
+
+	return SCAP_SUCCESS;
+}
+
+static int32_t init(scap_t* main_handle, scap_open_args* open_args)
+{
+	test_input_engine *engine = main_handle->m_engine.m_handle;
+	engine->m_data = open_args->test_input_data;
+	return SCAP_SUCCESS;
+}
+
+const struct scap_vtable scap_test_input_engine = {
+	.name = "test_source",
+	.mode = SCAP_MODE_LIVE,
+
+	.alloc_handle = alloc_handle,
+	.init = init,
+	.free_handle = noop_free_handle,
+	.close = noop_close_engine,
+	.next = next,
+	.start_capture = noop_start_capture,
+	.stop_capture = noop_stop_capture,
+	.configure = noop_configure,
+	.get_stats = noop_get_stats,
+	.get_n_tracepoint_hit = noop_get_n_tracepoint_hit,
+	.get_n_devs = noop_get_n_devs,
+	.get_max_buf_used = noop_get_max_buf_used,
+	.get_threadlist = noop_get_threadlist,
+	.get_vpid = noop_get_vxid,
+	.get_vtid = noop_get_vxid,
+	.getpid_global = noop_getpid_global,
+};

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -514,6 +514,12 @@ scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *args)
 		return NULL;
 	}
 
+	if ((*rc = scap_proc_scan_vtable(error, handle)) != SCAP_SUCCESS)
+	{
+		scap_close(handle);
+		return NULL;
+	}
+
 	if(handle->m_vtable->start_capture(handle->m_engine) != SCAP_SUCCESS)
 	{
 		scap_close(handle);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -451,6 +451,7 @@ scap_t* scap_open_udig_int(char *error, int32_t *rc,
 }
 #endif // !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
 
+#ifdef HAS_ENGINE_TEST_INPUT
 scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *args)
 {
 	scap_t* handle = NULL;
@@ -520,6 +521,14 @@ scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *args)
 	}
 	return handle;
 }
+#else
+scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *args)
+{
+	snprintf(error, SCAP_LASTERR_SIZE, "the test_input engine is only available for testing");
+	*rc = SCAP_NOT_SUPPORTED;
+	return NULL;
+}
+#endif
 
 #ifdef HAS_ENGINE_GVISOR
 scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *args)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -504,8 +504,10 @@ scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *args)
 	handle->m_suppressed_tids = NULL;
 	handle->m_num_suppressed_evts = 0;
 
-	handle->m_proc_callback = args->proc_callback;
-	handle->m_proc_callback_context = args->proc_callback_context;
+	handle->m_proclist.m_main_handle = handle;
+	handle->m_proclist.m_proc_callback = args->proc_callback;
+	handle->m_proclist.m_proc_callback_context = args->proc_callback_context;
+	handle->m_proclist.m_proclist = NULL;
 
 	if ((*rc = copy_comms(handle, args->suppressed_comms)) != SCAP_SUCCESS)
 	{

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -72,6 +72,7 @@ struct iovec;
 #include "scap_open.h"
 #include "scap_procs.h"
 #include "engine/bpf/bpf_public.h"
+#include "scap_test.h"
 
 //
 // The minimum API and schema versions the driver has to support before we can use it

--- a/userspace/libscap/scap_engines.h
+++ b/userspace/libscap/scap_engines.h
@@ -50,3 +50,7 @@ extern const struct scap_vtable scap_gvisor_engine;
 #ifdef HAS_ENGINE_MODERN_BPF
 extern const struct scap_vtable scap_modern_bpf_vtable;
 #endif
+
+#ifdef HAS_ENGINE_TEST_INPUT
+extern const struct scap_vtable scap_test_input_engine;
+#endif

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "plugin_info.h"
 #include "scap_limits.h"
 #include "scap_procs.h"
+#include "scap_test.h"
 #include "../../driver/ppm_events_public.h"
 
 #ifdef __cplusplus
@@ -100,6 +101,8 @@ typedef struct scap_open_args
 
 	scap_source_plugin* input_plugin; ///< use this to configure a source plugin that will produce the events for this capture
 	char* input_plugin_params; ///< optional parameters string for the source plugin pointed by src_plugin
+
+	scap_test_input_data* test_input_data; ///< only used for testing scap consumers by supplying arbitrary test data
 }scap_open_args;
 
 #ifdef __cplusplus

--- a/userspace/libscap/scap_test.h
+++ b/userspace/libscap/scap_test.h
@@ -7,10 +7,24 @@
 //
 
 struct ppm_evt_hdr;
+struct scap_threadinfo;
+struct scap_fdinfo;
+
+struct scap_test_fdinfo_data {
+  const struct scap_fdinfo *fdinfos;
+  size_t fdinfo_count;
+};
+
+typedef struct scap_test_thread_data scap_test_thread_data;
 
 struct scap_test_input_data {
   struct ppm_evt_hdr** events;
   size_t event_count;
+
+  struct scap_threadinfo *threads;
+  size_t thread_count;
+
+  struct scap_test_fdinfo_data *fdinfo_data;
 };
 
 typedef struct scap_test_input_data scap_test_input_data;

--- a/userspace/libscap/scap_test.h
+++ b/userspace/libscap/scap_test.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdlib.h>
+
+//
+// Structs used for testing
+//
+
+struct ppm_evt_hdr;
+
+struct scap_test_input_data {
+  struct ppm_evt_hdr** events;
+  size_t event_count;
+};
+
+typedef struct scap_test_input_data scap_test_input_data;

--- a/userspace/libscap/scap_test.h
+++ b/userspace/libscap/scap_test.h
@@ -1,3 +1,20 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 #pragma once
 
 #include <stdlib.h>

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -536,6 +536,9 @@ void sinsp::open_live_common(uint32_t timeout_ms, scap_mode_t mode)
 		oargs.gvisor_config_path = NULL;
 	}
 
+	// only useful for testing
+	oargs.test_input_data = m_test_input_data;
+
 	fill_syscalls_of_interest(&oargs);
 
 	if(!m_filter_proc_table_when_saving)
@@ -600,6 +603,13 @@ void sinsp::open_gvisor(std::string config_path, std::string root_path, uint32_t
 	m_gvisor_root_path = root_path;
 	m_gvisor_config_path = config_path;
 	open_live_common(timeout_ms, SCAP_MODE_LIVE);
+	set_get_procs_cpu_from_driver(false);
+}
+
+void sinsp::open_test_input(scap_test_input_data *data)
+{
+	m_test_input_data = data;
+	open_live_common(SCAP_TIMEOUT_MS, SCAP_MODE_LIVE);
 	set_get_procs_cpu_from_driver(false);
 }
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -255,6 +255,8 @@ public:
 
 	void open_nodriver();
 
+	void open_test_input(scap_test_input_data *data);
+
 	/*!
 	  \brief Ends a capture and release all resources.
 	*/
@@ -1100,6 +1102,7 @@ private:
 	bool m_is_tracers_capture_enabled;
 	bool m_flush_memory_dump;
 	bool m_large_envs_enabled;
+	scap_test_input_data *m_test_input_data = nullptr;
 
 	sinsp_network_interfaces* m_network_interfaces;
 

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -95,6 +95,9 @@ protected:
 		}
 
 		scap_evt *event = static_cast<scap_evt*>(event_buf.buf);
+		event->ts = ts;
+		event->tid = tid;
+
 		m_events.push_back(event);
 		m_test_data->events = m_events.data();
 		m_test_data->event_count = m_events.size();

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -15,9 +15,10 @@ limitations under the License.
 
 */
 
-#include "sinsp.h"
-#include "filterchecks.h"
 #include <gtest/gtest.h>
+
+#include "sinsp_with_test_input.h"
+#include "sinsp.h"
 
 using namespace libsinsp;
 
@@ -37,93 +38,19 @@ TEST(sinsp, external_event_processor_initialization)
 	EXPECT_EQ(my_sinsp.get_external_event_processor(), &processor);
 }
 
-class sinsp_with_test_input : public ::testing::Test {
-protected:
-	void SetUp() override
-	{
-		m_test_data = std::unique_ptr<scap_test_input_data>(new scap_test_input_data);
-		m_test_data->event_count = 0;
-		m_test_data->events = nullptr;
-	}
-
-	void TearDown() override
-	{
-		for (size_t i = 0; i < m_events.size(); i++)
-		{
-			free(m_events[i]);
-		}
-	}
-
-	sinsp inspector;
-
-	void open_inspector()
-	{
-		inspector.open_test_input(m_test_data.get());
-	}
-
-	scap_evt* add_event(uint64_t ts, uint64_t tid, enum ppm_event_type event_type, uint32_t n, ...)
-	{
-		struct scap_sized_buffer event_buf = {NULL, 0};
-		size_t event_size;
-		char error[SCAP_LASTERR_SIZE] = {'\0'};
-
-		va_list args;
-		va_start(args, n);
-		int32_t ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
-		va_end(args);
-
-		if(ret != SCAP_INPUT_TOO_SMALL) {
-			return nullptr;
-		}
-
-		event_buf.buf = malloc(event_size);
-		event_buf.size = event_size;
-
-		if(event_buf.buf == NULL) {
-			return nullptr;
-		}
-
-		va_start(args, n);
-		ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
-		va_end(args);
-
-		if(ret != SCAP_SUCCESS) {
-			free(event_buf.buf);
-			event_buf.size = 0;
-			return nullptr;
-		}
-
-		scap_evt *event = static_cast<scap_evt*>(event_buf.buf);
-		event->ts = ts;
-		event->tid = tid;
-
-		m_events.push_back(event);
-		m_test_data->events = m_events.data();
-		m_test_data->event_count = m_events.size();
-
-		return event;
-	}
-
-	std::string get_field_as_string(sinsp_evt *evt, std::string field_name)
-	{
-		sinsp_filter_check *chk = g_filterlist.new_filter_check_from_fldname(field_name, &inspector, false);
-		chk->parse_field_name(field_name.c_str(), true, false);
-		std::string result = chk->tostring(evt);
-		return result;
-	}
-
-	unique_ptr<scap_test_input_data> m_test_data;
-	std::vector<scap_evt*> m_events;
-};
-
-TEST_F(sinsp_with_test_input, test_event)
+TEST_F(sinsp_with_test_input, file_open)
 {
-	add_event(1657881958, 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", 0, 0);
+	add_default_init_thread();
 
 	open_inspector();
-
 	sinsp_evt *evt;
-	inspector.next(&evt);
-	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_E);
-	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), "/tmp/the_file");
+
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", PPM_O_RDWR, 0);
+	evt = next_event();
+
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/the_file", PPM_O_RDWR, 0, 5, 123);
+	evt = next_event();
+
+	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
 }

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -45,10 +45,13 @@ TEST_F(sinsp_with_test_input, file_open)
 	open_inspector();
 	sinsp_evt *evt;
 
+	// since adding and reading events happens on a single thread they can be interleaved.
+	// tests may need to change if that will not be the case anymore
 	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", PPM_O_RDWR, 0);
 	evt = next_event();
 
 	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/the_file", PPM_O_RDWR, 0, 5, 123);
+	// every subsequent call to next_event() will invalidate any previous event
 	evt = next_event();
 
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 #include <gtest/gtest.h>
 
 #include "sinsp_with_test_input.h"
-#include "sinsp.h"
 
 using namespace libsinsp;
 

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 #include "sinsp.h"
+#include "filterchecks.h"
 #include <gtest/gtest.h>
 
 using namespace libsinsp;
@@ -36,3 +37,91 @@ TEST(sinsp, external_event_processor_initialization)
 	EXPECT_EQ(my_sinsp.get_external_event_processor(), &processor);
 }
 
+class sinsp_with_test_input : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		m_test_data = std::unique_ptr<scap_test_input_data>(new scap_test_input_data);
+		m_test_data->event_count = 0;
+		m_test_data->events = nullptr;
+	}
+
+	void TearDown() override
+	{
+		for (size_t i = 0; i < m_events.size(); i++)
+		{
+			free(m_events[i]);
+		}
+	}
+
+	sinsp inspector;
+
+	void open_inspector()
+	{
+		inspector.open_test_input(m_test_data.get());
+	}
+
+	scap_evt* add_event(uint64_t ts, uint64_t tid, enum ppm_event_type event_type, uint32_t n, ...)
+	{
+		struct scap_sized_buffer event_buf = {NULL, 0};
+		size_t event_size;
+		char error[SCAP_LASTERR_SIZE];
+		error[0] = '\0';
+
+		va_list args;
+		va_start(args, n);
+		int32_t ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+		va_end(args);
+
+		if(ret != SCAP_INPUT_TOO_SMALL) {
+			return nullptr;
+		}
+
+		event_buf.buf = malloc(event_size);
+		event_buf.size = event_size;
+
+		if(event_buf.buf == NULL) {
+			return nullptr;
+		}
+
+		va_start(args, n);
+		ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+		va_end(args);
+
+		if(ret != SCAP_SUCCESS) {
+			free(event_buf.buf);
+			event_buf.size = 0;
+			return nullptr;
+		}
+
+		scap_evt *event = static_cast<scap_evt*>(event_buf.buf);
+		m_events.push_back(event);
+		m_test_data->events = m_events.data();
+		m_test_data->event_count = m_events.size();
+
+		return event;
+	}
+
+	std::string get_field_as_string(sinsp_evt *evt, std::string field_name)
+	{
+		sinsp_filter_check *chk = g_filterlist.new_filter_check_from_fldname(field_name, &inspector, false);
+		chk->parse_field_name(field_name.c_str(), true, false);
+		std::string result = chk->tostring(evt);
+		return result;
+	}
+
+	unique_ptr<scap_test_input_data> m_test_data;
+	std::vector<scap_evt*> m_events;
+};
+
+TEST_F(sinsp_with_test_input, test_event)
+{
+	add_event(1657881958, 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", 0, 0);
+
+	open_inspector();
+
+	sinsp_evt *evt;
+	inspector.next(&evt);
+	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_E);
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), "/tmp/the_file");
+}

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -65,8 +65,7 @@ protected:
 	{
 		struct scap_sized_buffer event_buf = {NULL, 0};
 		size_t event_size;
-		char error[SCAP_LASTERR_SIZE];
-		error[0] = '\0';
+		char error[SCAP_LASTERR_SIZE] = {'\0'};
 
 		va_list args;
 		va_start(args, n);

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "scap.h"
+#include "filterchecks.h"
+#include "../../common/strlcpy.h"
+
+class sinsp_with_test_input : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		m_test_data = std::unique_ptr<scap_test_input_data>(new scap_test_input_data);
+		m_test_data->event_count = 0;
+		m_test_data->events = nullptr;
+		m_test_data->thread_count = 0;
+		m_test_data->threads = nullptr;
+
+		m_test_timestamp = 1566230400000000000;
+	}
+
+	void TearDown() override
+	{
+		for (size_t i = 0; i < m_events.size(); i++)
+		{
+			free(m_events[i]);
+		}
+	}
+
+	sinsp m_inspector;
+
+	void open_inspector()
+	{
+		m_inspector.open_test_input(m_test_data.get());
+	}
+
+	scap_evt* add_event(uint64_t ts, uint64_t tid, enum ppm_event_type event_type, uint32_t n, ...)
+	{
+		struct scap_sized_buffer event_buf = {NULL, 0};
+		size_t event_size;
+		char error[SCAP_LASTERR_SIZE] = {'\0'};
+
+		va_list args;
+		va_start(args, n);
+		int32_t ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+		va_end(args);
+
+		if(ret != SCAP_INPUT_TOO_SMALL) {
+			return nullptr;
+		}
+
+		event_buf.buf = malloc(event_size);
+		event_buf.size = event_size;
+
+		if(event_buf.buf == NULL) {
+			return nullptr;
+		}
+
+		va_start(args, n);
+		ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+		va_end(args);
+
+		if(ret != SCAP_SUCCESS) {
+			free(event_buf.buf);
+			event_buf.size = 0;
+			return nullptr;
+		}
+
+		scap_evt *event = static_cast<scap_evt*>(event_buf.buf);
+		event->ts = ts;
+		event->tid = tid;
+
+		m_events.push_back(event);
+		m_test_data->events = m_events.data();
+		m_test_data->event_count = m_events.size();
+
+		return event;
+	}
+
+	void add_thread(const scap_threadinfo &tinfo, const std::vector<scap_fdinfo> &fdinfos)
+	{
+		m_threads.push_back(tinfo);
+		m_test_data->threads = m_threads.data();
+		m_test_data->thread_count = m_threads.size();
+
+		m_fdinfos.push_back(fdinfos);
+		scap_test_fdinfo_data fdinfo_descriptor = {
+			.fdinfos = m_fdinfos.back().data(),
+			.fdinfo_count = m_fdinfos.back().size()
+		};
+		m_test_fdinfo_data.push_back(fdinfo_descriptor);
+
+		m_test_data->fdinfo_data = m_test_fdinfo_data.data();
+	}
+
+	static scap_threadinfo create_threadinfo(
+		uint64_t tid, uint64_t pid, uint64_t ptid, uint64_t vpgid, int64_t vtid, int64_t vpid,
+		std::string comm, std::string exe, std::string exepath, uint64_t clone_ts, uint32_t uid, uint32_t gid,
+
+		std::vector<std::string> args={}, uint64_t sid=0, std::vector<std::string> env={}, std::string cwd="",
+		int64_t fdlimit=0x100000, uint32_t flags=0, bool exe_writable=true, 
+		uint64_t cap_permitted=0x1ffffffffff, uint64_t cap_inheritable=0, uint64_t cap_effective=0x1ffffffffff,
+		uint32_t vmsize_kb=10000, uint32_t vmrss_kb=100, uint32_t vmswap_kb=0, uint64_t pfmajor=222, uint64_t pfminor=22,
+		std::vector<std::string> cgroups={}, std::string root="/", int filtered_out=0, int32_t tty=0, int32_t loginuid=-1)
+	{
+		scap_threadinfo tinfo = {
+			.tid = tid,
+			.pid = pid,
+			.ptid = ptid,
+			.sid = sid,
+			.vpgid = vpgid,
+			.exe_writable = exe_writable,
+			.fdlimit = fdlimit,
+			.flags = flags,
+			.uid = uid,
+			.gid = gid,
+			.cap_permitted = cap_permitted,
+			.cap_effective = cap_effective,
+			.cap_inheritable = cap_inheritable,
+			.vmsize_kb = vmsize_kb,
+			.vmrss_kb = vmrss_kb,
+			.pfmajor = pfmajor,
+			.pfminor = pfminor,
+			.vtid = vtid,
+			.vpid = vpid,
+			.filtered_out = filtered_out,
+			.fdlist = nullptr,
+			.clone_ts = clone_ts,
+			.tty = tty,
+			.loginuid = loginuid
+		};
+
+		std::string argsv = "";
+		for (std::string a : args) {
+			argsv += a;
+			argsv.push_back('\0');
+		}
+		argsv.push_back('\0');
+
+		std::string envv = "";
+		for (std::string a : env) {
+			envv += a;
+			envv.push_back('\0');
+		}
+		envv.push_back('\0');
+
+		std::string cgroupsv = "";
+		for (std::string a : cgroups) {
+			cgroupsv += a;
+			cgroupsv.push_back('\0');
+		}
+		cgroupsv.push_back('\0');
+
+		memcpy(tinfo.args, argsv.data(), argsv.size());
+		tinfo.args_len = argsv.size();
+		memcpy(tinfo.env, envv.data(), envv.size());
+		tinfo.env_len = envv.size();
+		memcpy(tinfo.cgroups, cgroupsv.data(), cgroupsv.size());
+		tinfo.cgroups_len = cgroupsv.size();
+
+		strlcpy(tinfo.cwd, cwd.c_str(), sizeof(tinfo.cwd));
+		strlcpy(tinfo.comm, comm.c_str(), sizeof(tinfo.comm));
+		strlcpy(tinfo.exe, exe.c_str(), sizeof(tinfo.exe));
+		strlcpy(tinfo.exepath, exepath.c_str(), sizeof(tinfo.exepath));
+		strlcpy(tinfo.root, root.c_str(), sizeof(tinfo.root));
+
+		return tinfo;
+	}
+
+	void add_default_init_thread()
+	{
+		scap_threadinfo tinfo = create_threadinfo(1, 1, 0, 1, 1, 1, "init", "/sbin/init", "/sbin/init", increasing_ts(), 0, 0);
+
+		std::vector<scap_fdinfo> fdinfos;
+		scap_fdinfo fdinfo = {
+			.fd = 0,
+			.ino = 5,
+			.type = SCAP_FD_FILE_V2
+		};
+
+		fdinfo.info.regularinfo.open_flags = PPM_O_RDONLY;
+		fdinfo.info.regularinfo.mount_id = 25;
+		fdinfo.info.regularinfo.dev = 0;
+		strlcpy(fdinfo.info.regularinfo.fname, "/dev/null", sizeof(fdinfo.info.regularinfo.fname));
+
+		fdinfos.push_back(fdinfo);
+
+		add_thread(tinfo, fdinfos);
+	}
+
+	uint64_t increasing_ts()
+	{
+		uint64_t ret = m_test_timestamp;
+		m_test_timestamp += 10000000; // 10 msec increment
+		return ret;
+	}
+
+	std::string get_field_as_string(sinsp_evt *evt, std::string field_name)
+	{
+		std::unique_ptr<sinsp_filter_check> chk(g_filterlist.new_filter_check_from_fldname(field_name, &m_inspector, false));
+		chk->parse_field_name(field_name.c_str(), true, false);
+		std::string result = chk->tostring(evt);
+		return result;
+	}
+
+	sinsp_evt *next_event()
+	{
+		sinsp_evt *evt;
+		m_inspector.next(&evt);
+		return evt;
+	}
+
+	std::unique_ptr<scap_test_input_data> m_test_data;
+	std::vector<scap_evt*> m_events;
+
+	std::vector<scap_threadinfo> m_threads;
+	std::vector<std::vector<scap_fdinfo>> m_fdinfos;
+	std::vector<scap_test_fdinfo_data> m_test_fdinfo_data;
+
+	uint64_t m_test_timestamp;
+};

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -1,3 +1,20 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 #pragma once
 
 #include <gtest/gtest.h>

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 
 #include "scap.h"
+#include "sinsp.h"
 #include "filterchecks.h"
 #include "../../common/strlcpy.h"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**Any specific area of the project related to this PR?**

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I would like to propose to add the necessary plumbing to have event-based testing for libsinsp, based on scap events. This PR's goal is to give the reader an idea of what I'd like to do and how this could be accomplished with code in our libs and start a discussion on whether this is useful, how to do this properly, or maybe we want to approach the problem in a different way.

_Update_: people liked the idea and so the PR is now more than a WIP :)

*Goal:*
I propose to have tests to verify the following: given a specific machine initial state and a certain series of events, will the sinsp state be updated correctly? Will Falco or any other client see the expected field for any of the [supported fields for conditions and output](https://falco.org/docs/rules/supported-fields/)? When I patch something inside the parsers, threadinfo and (especially) networking code, can I check if I broke something that was expected (speaking from experience, this happened many times :roll_eyes: ) 

*How:*
Since the latest refactor, libscap gained the feature of having multiple possible syscall sources, neatly divided into engines that can be optionally compiled in the code. I propose to use this feature to:
* Introduce a new module (called `test_input` in the code you see) that will "echo" any event are passed to it and send them straight to sinsp without modification, also optionally able to set a fixed initial state (threads/fds)
* Add a test fixture in libsinsp that will load this engine and can then be used to tell which events to create
* Add tests that will check field values (such as `fd.name`, `proc.name`, ...) potentially after every event to verify that the state has been properly tracked (one example is currently added)

*Why don't you do this with scap files?*

The intelligent reader will have noticed that what I propose is essentially a way to "replay" a bunch of events and an initial state and check a bunch of fields, like Falco rules do. This is done in the official Falco test suite with scap files, so why can't we just do the same? In my opinion:

* Scap files are hard to read for a human and cannot be commented, it's not easy to understand at first glance what they contain and what is the interesting part that should trigger a test
* Scap files are binary, which means they are hard to add / cannot be added to git repos
* Scap files are meant to be read entirely from beginning to end, so it's hard to test the state after a specific event
* Scap files are hard to edit by hand in case we need to test specific corner cases that may be hard to reproduce and record on a live system

**Special notes for your reviewer**:

Do you like the approach? Can you think of a better way? I will add inline comments on some critical parts that we can think about together.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
