### PR TITLE
update(gvisor): add retries and ignore_setup_error to gvisor config g…

### DIFF
--- a/userspace/libscap/engine/gvisor/config.json
+++ b/userspace/libscap/engine/gvisor/config.json
@@ -545,8 +545,10 @@
       "sinks": [
         {
           "name": "remote",
+          "ignore_setup_error" : true,
           "config": {
-            "endpoint": "/tmp/gvisor.sock"
+            "endpoint": "/tmp/gvisor.sock",
+            "retries" : 3
           }
         }
       ]

--- a/userspace/libsinsp/gvisor_config.cpp
+++ b/userspace/libsinsp/gvisor_config.cpp
@@ -82,6 +82,8 @@ static const std::vector<std::string> s_context_fields = {
 	"time",
 };
 
+constexpr unsigned int max_retries = 3;
+
 std::string generate(std::string socket_path)
 {
 	Json::Value context_fields;
@@ -102,6 +104,8 @@ std::string generate(std::string socket_path)
 	Json::Value sinks, sink;
 	sink["name"] = "remote";
 	sink["config"]["endpoint"] = socket_path.empty() ? s_default_socket_path : socket_path;
+	sink["config"]["retries"] = max_retries;
+	sink["ignore_setup_error"] = true;
 	sinks.append(sink);
 
 	Json::Value trace_session;


### PR DESCRIPTION
…eneration

Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Add `ignore_setup_error` and `retries` to gVisor configuration.
`ignore_setup_error` is useful to let pods start even if Falco is not running. This is perfectly ok since Falco has the logic to connect to running sandboxes.
On the other hand, `retries` is the number of times gVisor will try to send again the message in case the buffer is full and Falco can't keep up with it. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
