### PR TITLE
update(OWNERS): move inactive approvers to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,11 @@
 approvers:
-  - fntlnz
-  - leodido
   - leogr
   - gnosek
-  - ldegio
   - mstemm
   - fededp
   - andreagit97
   - molter73
-reviewers:
+emeritus_approvers:
   - fntlnz
   - leodido
-  - leogr
-  - gnosek
   - ldegio
-  - mstemm
-  - fededp
-  - andreagit97
-  - molter73


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it:**

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from approvers to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

Opened this in place of https://github.com/falcosecurity/libs/pull/460 and https://github.com/falcosecurity/libs/pull/471, following up the suggestion at https://github.com/falcosecurity/libs/pull/460#issuecomment-1190005584 and the comment at https://github.com/falcosecurity/libs/pull/471#issuecomment-1190030598.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```