### PR TITLE
feat: Add new return code for filtered events(1/3)

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -103,6 +103,7 @@ struct iovec;
 #define SCAP_UNEXPECTED_BLOCK 7
 #define SCAP_VERSION_MISMATCH 8
 #define SCAP_NOT_SUPPORTED 9
+#define SCAP_FILTERED_EVENT 10
 
 //
 // Last error string size for `scap_open...` methods.


### PR DESCRIPTION
/area libscap
/area libsinsp
/kind feature

This is change 1 of 3 (1 of 2 for this repository) for adding a new scap
return code for userspace filtering.

### Overview of the problem
Currently, when libscap (or libsinsp) chooses to filter an event in
userspace, the libraries return SCAP_TIMEOUT. The intent behind this
decision is to force the client to retry (which is the behavior for
SCAP_TIMEOUT). However, SCAP_TIMEOUT implies that there are no events in
the pipeline, which is not true for the filter case and may lead to
client behavior that is not ideal.

### The solution

Step 1: Add a new (unused) return code for filtered events (we are here)
Step 2: Handle the new return value in client code
Step 3: libsinsp / libscap begin returning the new code

Signed-off-by: Nathan Baker <nathanb@vt.edu>

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
