### PR TITLE
create static method to clone existing sinsp_evt

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2816,6 +2816,13 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 
 	// fd info
 	dest.m_fdinfo = nullptr;
+	if (src.m_fdinfo != nullptr)
+	{
+		//m_fdinfo_ref is only used to keep a handle to this
+		// copy of the fdinfo which was copied from the global fdinfo table
+		dest.m_fdinfo_ref.reset(new sinsp_fdinfo_t(*src.m_fdinfo));
+		dest.m_fdinfo = dest.m_fdinfo_ref.get();
+	}
 	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;
 
 	return true;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2788,9 +2788,11 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 		}
 		dest.m_tinfo = dest.m_tinfo_ref.get();
 	}
-
-	dest.m_tinfo_ref = src.m_tinfo_ref;
-	dest.m_tinfo = src.m_tinfo;
+	else
+	{
+		dest.m_tinfo_ref = nullptr;
+		dest.m_tinfo = nullptr;
+	}
 
 	// scalars
 	dest.m_cpuid = src.m_cpuid;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2751,19 +2751,6 @@ uint64_t sinsp_evt::get_lastevent_ts() const
 bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 {
 	dest.m_inspector = src.m_inspector;
-
-	if (src.m_pevt != nullptr)
-	{
-		dest.m_pevt_storage = new char[src.m_pevt->len];
-		memcpy(dest.m_pevt_storage, src.m_pevt, src.m_pevt->len);
-		dest.m_pevt = (scap_evt *) dest.m_pevt_storage;
-	}
-	else
-	{
-		dest.m_pevt_storage = nullptr;
-		dest.m_pevt = nullptr;
-	}
-
 	dest.m_poriginal_evt = nullptr;
 
 	// tinfo
@@ -2792,6 +2779,18 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 	{
 		dest.m_tinfo_ref = nullptr;
 		dest.m_tinfo = nullptr;
+	}
+
+	if (src.m_pevt != nullptr)
+	{
+		dest.m_pevt_storage = new char[src.m_pevt->len];
+		memcpy(dest.m_pevt_storage, src.m_pevt, src.m_pevt->len);
+		dest.m_pevt = (scap_evt *) dest.m_pevt_storage;
+	}
+	else
+	{
+		dest.m_pevt_storage = nullptr;
+		dest.m_pevt = nullptr;
 	}
 
 	// scalars

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2773,8 +2773,6 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 		return false;
 	}
 
-	dest.m_tinfo_ref = src.m_tinfo_ref;
-	dest.m_tinfo = src.m_tinfo;
 	if (src.m_tinfo_ref)
 	{
 		dest.m_tinfo_ref = src.m_tinfo_ref;
@@ -2816,11 +2814,6 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 
 	// fd info
 	dest.m_fdinfo = nullptr;
-	if (src.m_fdinfo != nullptr)
-	{
-		// dest.m_fdinfo_ref.reset(new sinsp_fdinfo_t(*src.m_fdinfo));
-		// dest.m_fdinfo = dest.m_fdinfo_ref.get();
-	}
 	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;
 
 	return true;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2747,3 +2747,81 @@ uint64_t sinsp_evt::get_lastevent_ts() const
 {
 	return m_tinfo->m_lastevent_ts;
 }
+
+bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
+{
+	dest.m_inspector = src.m_inspector;
+
+	if (src.m_pevt != nullptr)
+	{
+		dest.m_pevt_storage = new char[src.m_pevt->len];
+		memcpy(dest.m_pevt_storage, src.m_pevt, src.m_pevt->len);
+		dest.m_pevt = (scap_evt *) dest.m_pevt_storage;
+	}
+	else
+	{
+		dest.m_pevt_storage = nullptr;
+		dest.m_pevt = nullptr;
+	}
+
+	dest.m_poriginal_evt = nullptr;
+
+	// tinfo
+	if (src.m_tinfo_ref && src.m_tinfo && src.m_tinfo_ref.get() != src.m_tinfo)
+	{
+		// bad data
+		return false;
+	}
+
+	dest.m_tinfo_ref = src.m_tinfo_ref;
+	dest.m_tinfo = src.m_tinfo;
+	if (src.m_tinfo_ref)
+	{
+		dest.m_tinfo_ref = src.m_tinfo_ref;
+		dest.m_tinfo = dest.m_tinfo_ref.get();
+	}
+	else if (src.m_tinfo)
+	{
+		dest.m_tinfo_ref = dest.m_inspector->get_thread_ref(src.m_tinfo->m_tid, false, false);
+		if (dest.m_tinfo_ref == nullptr)
+		{
+			// no tinfo
+			return false;
+		}
+		dest.m_tinfo = dest.m_tinfo_ref.get();
+	}
+
+	dest.m_tinfo_ref = src.m_tinfo_ref;
+	dest.m_tinfo = src.m_tinfo;
+
+	// scalars
+	dest.m_cpuid = src.m_cpuid;
+	dest.m_evtnum = src.m_evtnum;
+	dest.m_flags = src.m_flags;
+	dest.m_params_loaded = src.m_params_loaded;
+
+	dest.m_iosize = src.m_iosize;
+	dest.m_errorcode = src.m_errorcode;
+	dest.m_rawbuf_str_len = src.m_rawbuf_str_len;
+	dest.m_filtered_out = src.m_filtered_out;
+
+	// vectors
+	dest.m_params = src.m_params;
+	dest.m_paramstr_storage = src.m_paramstr_storage;
+	dest.m_resolved_paramstr_storage = src.m_resolved_paramstr_storage;
+
+	// global table
+	dest.m_event_info_table = src.m_event_info_table;
+	dest.m_info = src.m_info;
+
+	// fd info
+	dest.m_fdinfo = nullptr;
+	if (src.m_fdinfo != nullptr)
+	{
+		// dest.m_fdinfo_ref.reset(new sinsp_fdinfo_t(*src.m_fdinfo));
+		// dest.m_fdinfo = dest.m_fdinfo_ref.get();
+	}
+	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;
+
+	return true;
+}

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -462,6 +462,7 @@ private:
 	char* render_fd(int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
 	int render_fd_json(Json::Value *ret, int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
 	uint32_t get_dump_flags();
+	static bool clone_event(sinsp_evt& dest, const sinsp_evt& src);
 
 VISIBILITY_PRIVATE
 	enum flags

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -502,6 +502,8 @@ VISIBILITY_PRIVATE
 	bool m_filtered_out;
 	const struct ppm_event_info* m_event_info_table;
 
+	std::shared_ptr<sinsp_fdinfo_t> m_fdinfo_ref;
+
 	friend class sinsp;
 	friend class sinsp_parser;
 	friend class sinsp_threadinfo;


### PR DESCRIPTION
Signed-off-by: vadim.zyarko <vadim.zyarko@sysdig.com>

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR creates a facility for cloning sinsp_evts, thus detaching it from the sinsp::next loop.  

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
