### PR TITLE
new(CI): add GH actions for modern BPF probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           cmake --build .
 
   build-libs-arm64:
-    name: build-libs-arm64 🥶
+    name: build-libs-arm64 🥶 (system_deps)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Libs ⤵️
@@ -79,7 +79,7 @@ jobs:
             make run-unit-tests
 
   build-and-test-modern-bpf-x86:
-    name: build-and-test-modern-bpf-x86 😇
+    name: build-and-test-modern-bpf-x86 😇 (bundled_deps)
     runs-on: ubuntu-22.04
     steps:
 
@@ -113,7 +113,7 @@ jobs:
           sudo ./test/modern_bpf/bpf_test --verbose
 
   build-modern-bpf-arm64:
-    name: build-modern-bpf-arm64 🙃
+    name: build-modern-bpf-arm64 🙃 (system_deps)
     runs-on: ubuntu-22.04
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,74 @@ jobs:
             cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False ../
             KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
             make run-unit-tests
+
+  build-modern-bpf-x86:
+    name: build-modern-bpf-x86 🏗️
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+
+      - name: Install deps ⛓️
+        run: |
+          sudo apt update 
+          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
+
+      - name: Build scap-open using BUNDLED_DEPS 🏗️
+        run: |
+          mkdir -p build
+          cd build && cmake -DUSE_BUNDLED_DEPS=ON -DUSE_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
+          make scap-open
+
+      - name: Check no verifier issues 👀
+        run: |
+          cd build
+          sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
+
+  test-modern-bpf-x86:
+    name: test-modern-bpf-x86 🧪
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+
+      - name: Install deps ⛓️
+        run: |
+          sudo apt update 
+          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
+
+      - name: Build bpf_test using BUNDLED_DEPS 🏗️
+        run: |
+          mkdir -p build
+          cd build && cmake -DUSE_BUNDLED_DEPS=ON -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
+          make bpf_test
+
+      - name: Check all test are successful 👀
+        run: |
+          cd build
+          sudo ./test/modern_bpf/bpf_test
+
+  build-modern-bpf-arm64:
+    name: build-modern-bpf-arm64 🏗️ 
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+
+      - uses: uraimo/run-on-arch-action@v2.2.0
+        name: Run aarch64 build 🏎️
+        with:
+          arch: aarch64
+          distro: archarm_latest
+          githubToken: ${{ github.token }}
+
+          install: |
+            pacman -Sy --noconfirm git cmake make llvm clang pkgconf libelf zlib libffi libbpf linux-tools glibc gcc gtest protobuf openssl tbb libb64 wget jq yaml-cpp curl c-ares grpc libyaml
+
+          run: |
+            mkdir -p build
+            cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF -DCREATE_TEST_TARGETS=OFF ../
+            make scap-open

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,18 +86,26 @@ jobs:
           sudo apt update 
           sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
 
-      - name: Build scap-open and check no verifier issues 👀
+      - name: Build scap-open 🏗️
         run: |
           mkdir -p build
           cd build && cmake -DUSE_BUNDLED_DEPS=ON -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
           make scap-open
+
+      - name: Run scap-open 🏎️
+        run: |
+          cd build
           sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
 
-      - name: Build bpf_test and running tests 🧪
+      - name: Build bpf_test 🏗️
         run: |
           cd build 
           make bpf_test
-          sudo ./test/modern_bpf/bpf_test
+
+      - name: Running tests 🧪
+        run: |
+          cd build 
+          sudo ./test/modern_bpf/bpf_test --verbose
 
   build-modern-bpf-arm64:
     name: build-modern-bpf-arm64 🏗️ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-libs-linux-amd64:
+    name: build-libs-linux-amd64 😁
     strategy:
       matrix:
         name: [system_deps, bundled_deps, system_deps_w_chisels, system_deps_minimal]
@@ -24,13 +25,14 @@ jobs:
     container:
       image: debian:buster
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
             
-      - name: Install deps
+      - name: Install deps ⛓️
         run: |
           apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
   
-      - name: Build and test
+      - name: Build and test 🏗️🧪
         run: |
           mkdir -p build
           cd build && cmake ${{ matrix.cmake_opts }} ../
@@ -38,27 +40,30 @@ jobs:
           make run-unit-tests
           
   build-libs-others-amd64:
+    name: build-libs-others-amd64 😨
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
   
-      - name: Build and test
+      - name: Build and test 🏗️🧪
         run: |
           mkdir -p build
           cd build && cmake -DCREATE_TEST_TARGETS=OFF ..
           cmake --build .
 
   build-libs-arm64:
+    name: build-libs-arm64 🥶
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Libs
+      - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
 
       - uses: uraimo/run-on-arch-action@v2.2.0
-        name: Run aarch64 build
+        name: Run aarch64 build 🏎️
         with:
           arch: aarch64
           distro: buster
@@ -74,7 +79,7 @@ jobs:
             make run-unit-tests
 
   build-and-test-modern-bpf-x86:
-    name: build-and-test-modern-bpf-x86 🏗️🧪
+    name: build-and-test-modern-bpf-x86 😇
     runs-on: ubuntu-22.04
     steps:
 
@@ -108,7 +113,7 @@ jobs:
           sudo ./test/modern_bpf/bpf_test --verbose
 
   build-modern-bpf-arm64:
-    name: build-modern-bpf-arm64 🏗️ 
+    name: build-modern-bpf-arm64 🙃
     runs-on: ubuntu-22.04
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
             KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
             make run-unit-tests
 
-  build-modern-bpf-x86:
-    name: build-modern-bpf-x86 🏗️
+  build-and-test-modern-bpf-x86:
+    name: build-and-test-modern-bpf-x86 🏗️🧪
     runs-on: ubuntu-22.04
     steps:
 
@@ -86,39 +86,17 @@ jobs:
           sudo apt update 
           sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
 
-      - name: Build scap-open using BUNDLED_DEPS 🏗️
-        run: |
-          mkdir -p build
-          cd build && cmake -DUSE_BUNDLED_DEPS=ON -DUSE_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
-          make scap-open
-
-      - name: Check no verifier issues 👀
-        run: |
-          cd build
-          sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
-
-  test-modern-bpf-x86:
-    name: test-modern-bpf-x86 🧪
-    runs-on: ubuntu-22.04
-    steps:
-
-      - name: Checkout Libs ⤵️
-        uses: actions/checkout@v3
-
-      - name: Install deps ⛓️
-        run: |
-          sudo apt update 
-          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
-
-      - name: Build bpf_test using BUNDLED_DEPS 🏗️
+      - name: Build scap-open and check no verifier issues 👀
         run: |
           mkdir -p build
           cd build && cmake -DUSE_BUNDLED_DEPS=ON -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
-          make bpf_test
+          make scap-open
+          sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
 
-      - name: Check all test are successful 👀
+      - name: Build bpf_test and running tests 🧪
         run: |
-          cd build
+          cd build 
+          make bpf_test
           sudo ./test/modern_bpf/bpf_test
 
   build-modern-bpf-arm64:
@@ -139,6 +117,7 @@ jobs:
           install: |
             pacman -Sy --noconfirm git cmake make llvm clang pkgconf libelf zlib libffi libbpf linux-tools glibc gcc gtest protobuf openssl tbb libb64 wget jq yaml-cpp curl c-ares grpc libyaml
 
+          # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |
             mkdir -p build
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF -DCREATE_TEST_TARGETS=OFF ../


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR adds GitHub actions workflow to test the modern BPF probe. More precisely:

* `build-modern-bpf-x86`:  compile the `scap-open` example e tries to inject the modern probe looking for verifier issues
* `test-modern-bpf-x86`: run the `gtest` framework (introduced here https://github.com/falcosecurity/libs/pull/484) looking for failing tests.
* `build-modern-bpf-arm64`: compile the `scap-open` example on ARM64 looking for compilation issues. Unfortunately, we are not able to inject the probe using QEMU, and GH doesn't provide native ARM64 runners, so we cannot run our tests for ARM64 :(  Maybe we could introduce self-hosted runners on ARM64, but I don't know if the CNCF could provide us resources for this or not, so right now I don't see many solutions :/

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
