### PR TITLE
fix(libsinsp): consider <NA> as an empty param

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2238,8 +2238,8 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			enter_evt_flags = *(uint32_t *)parinfo->m_val;
 
 			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
-			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
+			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
+			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2279,8 +2279,8 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			enter_evt_flags = 0;
 
 			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
-			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
+			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
+			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2351,8 +2351,8 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			int64_t enter_evt_dirfd = *(int64_t *)parinfo->m_val;
 
 			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
-			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
+			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
+			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2237,7 +2237,9 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			ASSERT(parinfo->m_len == sizeof(uint32_t));
 			enter_evt_flags = *(uint32_t *)parinfo->m_val;
 
-			if(enter_evt_namelen != 0 && strcmp(enter_evt_name, "(NULL)") != 0)
+			if(enter_evt_namelen != 0
+			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
+			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2276,7 +2278,9 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 
 			enter_evt_flags = 0;
 
-			if(enter_evt_namelen != 0 && strcmp(enter_evt_name, "(NULL)") != 0)
+			if(enter_evt_namelen != 0
+			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
+			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2346,7 +2350,9 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			ASSERT(parinfo->m_len == sizeof(int64_t));
 			int64_t enter_evt_dirfd = *(int64_t *)parinfo->m_val;
 
-			if(enter_evt_namelen != 0 && strcmp(enter_evt_name, "(NULL)") != 0)
+			if(enter_evt_namelen != 0
+			   && strncmp(enter_evt_name, "(NULL)", 6) != 0
+			   && strncmp(enter_evt_name, "<NA>", 4) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

With some syscalls like `open`, `creat`, `openat`, we check if the enter event has correctly collected the parameters and when the exit event arrives we replace the exit params with the enter ones, this is done to prevent some possible TOCTOU attacks as described more in detail [here](https://github.com/falcosecurity/libs/pull/235). Look at the issue to obtain more information https://github.com/falcosecurity/libs/issues/477. Right now only `(NULL)` is considered as an empty param by userspace, but our drivers also send `<NA>` to represent a not available param, for this reason, we need also to check this string in our parsers.

**Which issue(s) this PR fixes**:

Fixes #477

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): consider <NA> as an empty param
```
