### PR TITLE
fix(kmod): support `clone child` exit events on `s390x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,13 @@ If you build this project from a git working directory, the main [CMakeLists.txt
 
 Right now our drivers officially support the following architectures:
 
-### x86_64
-- **Kernel module** requires kernel versions greater or equal than `2.6`
-- **eBPF probe** requires kernel versions greater or equal than `4.14`
-- **Modern eBPF probe** work in progress...
+|             | Kernel module | eBPF probe | Modern eBPF probe |
+| ----------- | ------------- | ---------- | ----------------- |
+| **x86_64**  | >= 2.6        | >= 4.14    | WIP 👷            |
+| **aarch64** | >= 3.4        | >= 4.17    | WIP 👷            |
+| **s390x**   | >= 2.6        | ❌         | ❌                |
 
-### ARM64
-- **Kernel module** requires kernel versions greater or equal than `3.4`
-- **eBPF probe** requires kernel versions greater or equal than `4.17`
-- **Modern eBPF probe** work in progress...
-
-### s390x
-- **Kernel module** requires kernel versions greater or equal than `2.6`
-- **eBPF probe** not supported right now.
-- **Modern eBPF probe** not supported right now.
+>**Please note**: BPF has some issues with architectures like `s390x`! Some helpers like `bpf_probe_read()` and `bpf_probe_read_str()` are broken on archs with overlapping address ranges.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,22 @@ If you build this project from a git working directory, the main [CMakeLists.txt
 
 ## Drivers officially supported architectures
 
-Right now our drivers (kernel module, eBPF probe) officially support two main architectues: `ARM64` and `x86_64`.
+Right now our drivers officially support the following architectures:
 
 ### x86_64
-- **eBPF probe** requires kernel versions greater or equal than `4.14`
 - **Kernel module** requires kernel versions greater or equal than `2.6`
+- **eBPF probe** requires kernel versions greater or equal than `4.14`
+- **Modern eBPF probe** work in progress...
 
 ### ARM64
-- **eBPF probe** requires kernel versions greater or equal than `4.17`
 - **Kernel module** requires kernel versions greater or equal than `3.4`
+- **eBPF probe** requires kernel versions greater or equal than `4.17`
+- **Modern eBPF probe** work in progress...
+
+### s390x
+- **Kernel module** requires kernel versions greater or equal than `2.6`
+- **eBPF probe** not supported right now.
+- **Modern eBPF probe** not supported right now.
 
 ## Build
 

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -9,7 +9,9 @@ cmake_minimum_required(VERSION 2.8.5)
 project(driver)
 
 set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
-if((NOT TARGET_ARCH STREQUAL "x86_64") AND (NOT TARGET_ARCH STREQUAL "aarch64"))
+if((NOT TARGET_ARCH STREQUAL "x86_64") AND
+   (NOT TARGET_ARCH STREQUAL "aarch64") AND
+   (NOT TARGET_ARCH STREQUAL "s390x"))
 	message(WARNING "Target architecture not officially supported by our drivers!")
 endif()
 

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -225,7 +225,7 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	case 3:
 	case 4:
 	case 5:
-		arg = _READ(user_regs->gprs[idx]);
+		arg = _READ(user_regs->gprs[idx+2]);
 		break;
 	default:
 		arg = 0;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -120,11 +120,6 @@ static __always_inline long bpf_syscall_get_nr(void *ctx)
 	id = _READ(regs->int_code);
 	id = id & 0xffff;
 
-#else 
-	
-	/* Unknown architecture. */
-	id = 0;
-
 #endif /* CONFIG_X86_64 */
 
 #else
@@ -142,10 +137,10 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_args(unsigned
 {
 	unsigned long arg = 0;
 
-	if (idx <= 5)
+	if(idx <= 5)
+	{
 		arg = args[idx];
-	else
-		arg = 0;
+	}
 
 	return arg;
 }
@@ -230,11 +225,6 @@ static __always_inline unsigned long bpf_syscall_get_argument_from_ctx(void *ctx
 	default:
 		arg = 0;
 	}
-
-#else
-
-	/* Unknown architecture. */
-	arg = 0;
 
 #endif /* CONFIG_X86_64 */
 

--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -59,7 +59,7 @@ or GPL2.txt for full copies of the license.
  * been introduced in the following kernel release:
  * https://github.com/torvalds/linux/commit/0a16b6075843325dc402edf80c1662838b929aff
  */
-#if defined(CONFIG_ARM64)
+#if defined(CONFIG_ARM64) || defined(CONFIG_S390)
 	#define CAPTURE_SCHED_PROC_FORK 
 #endif
 


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR introduces 2 main changes:
* enable support for BPF `raw_tracepoint` on `s390x` architectures. BPF has some problems with architectures like `s390x` as also described in this issue https://github.com/falcosecurity/libs/issues/497.  With this fix the BPF probe can works also on kernel versions >= `4.17`, but the problem is that there are many instrumentation drops due to the use of `bpf_probe_read()` and `bpf_probe_read_str()` that don't work at all on architectures like `s390x` as you can read [here](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=0ebeea8ca8a4d1d453ad299aef0507dab04f6e8d). In the end I would say that we cannot use bpf on these architectures, at least for the moment
* enable the `CAPTURE_SCHED_PROC_FORK` logic in order to catch the `clone_child` exit events on `s390x` architectures. Like in `ARM64`, the clone child exit event is not traced by the `syscalls:sys_exit` tracepoint, while the `excve` exit event, in this case, is traced! So to reuse the same logic introduced in `ARM64` we have just to enable it in this way:

  ```c
  #if defined(CONFIG_ARM64) || defined(CONFIG_S390)
	  #define CAPTURE_SCHED_PROC_FORK 
  #endif
  ```

   For more info about this problem of the `clone_child` exit event take a look at the [ARM64 fix](https://github.com/falcosecurity/libs/pull/416).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(kmod): support `clone child` exit events on `s390x`
```
