### PR TITLE
new(modern_bpf): add support for `open` family syscalls

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -19,5 +19,6 @@
 /// TODO: We have to move these in the event_table.c. Right now we don't
 /// want to touch scap tables.
 #define MKDIR_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define OPEN_BY_HANDLE_AT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -1170,13 +1170,16 @@
 /*=============================== DIRECTORY_NOTIFICATIONS ===========================*/
 
 /*=============================== DEVICE_VERSIONS ===========================*/
-/*
-Some programs want their definitions of MAJOR and MINOR and MKDEV
-from the kernel sources. These must be the externally visible ones.
-*/
-#define MAJOR(dev) ((dev) >> 8)
-#define MINOR(dev) ((dev)&0xff)
-#define MKDEV(ma, mi) ((ma) << 8 | (mi))
+
+/* `/include/linux/kdev_t.h` from kernel source tree. */
+
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
+#define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
+#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+
 /*=============================== DEVICE_VERSIONS ===========================*/
 
 /*=============================== RLIMIT_ID ===========================*/

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -96,12 +96,28 @@
 #define O_TRUNC 00001000  /* not fcntl */
 #define O_APPEND 00002000
 #define O_NONBLOCK 00004000
-#define O_DSYNC 00010000  /* used to be O_SYNC, see below */
-#define FASYNC 00020000	  /* fcntl, for BSD compatibility */
+#define O_NDELAY O_NONBLOCK
+#define O_DSYNC 00010000 /* used to be O_SYNC, see below */
+#define FASYNC 00020000	 /* fcntl, for BSD compatibility */
+
+#if defined(__TARGET_ARCH_x86)
+
 #define O_DIRECT 00040000 /* direct disk access hint */
 #define O_LARGEFILE 00100000
 #define O_DIRECTORY 00200000 /* must be a directory */
 #define O_NOFOLLOW 00400000  /* don't follow links */
+
+#elif defined(__TARGET_ARCH_arm64)
+
+/* `/arch/arm64/include/uapi/asm/fcntl.h` from kernel source tree. */
+
+#define O_DIRECTORY 040000 /* must be a directory */
+#define O_NOFOLLOW 0100000 /* don't follow links */
+#define O_DIRECT 0200000   /* direct disk access hint - currently ignored */
+#define O_LARGEFILE 0400000
+
+#endif
+
 #define O_NOATIME 01000000
 #define O_CLOEXEC 02000000 /* set close_on_exec */
 #define __O_SYNC 04000000
@@ -112,8 +128,6 @@
 /* a horrid kludge trying to make sure that this will fail on old kernels */
 #define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
 #define O_TMPFILE_MASK (__O_TMPFILE | O_DIRECTORY | O_CREAT)
-
-#define O_NDELAY O_NONBLOCK
 
 //////////////////////////
 // openat2 flags
@@ -1173,12 +1187,12 @@
 
 /* `/include/linux/kdev_t.h` from kernel source tree. */
 
-#define MINORBITS	20
-#define MINORMASK	((1U << MINORBITS) - 1)
+#define MINORBITS 20
+#define MINORMASK ((1U << MINORBITS) - 1)
 
-#define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
-#define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
-#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+#define MAJOR(dev) ((unsigned int)((dev) >> MINORBITS))
+#define MINOR(dev) ((unsigned int)((dev)&MINORMASK))
+#define MKDEV(ma, mi) (((ma) << MINORBITS) | (mi))
 
 /*=============================== DEVICE_VERSIONS ===========================*/
 

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -100,7 +100,7 @@
 #define O_DSYNC 00010000 /* used to be O_SYNC, see below */
 #define FASYNC 00020000	 /* fcntl, for BSD compatibility */
 
-#if defined(__TARGET_ARCH_x86)
+#if defined(__TARGET_ARCH_x86) || defined(__TARGET_ARCH_s390)
 
 #define O_DIRECT 00040000 /* direct disk access hint */
 #define O_LARGEFILE 00100000

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -204,7 +204,7 @@ static __always_inline u16 push__charbuf(u8* data, u64 *payload_pos, unsigned lo
 	int written_bytes = bpf_probe_read_str(&data[SAFE_ACCESS(*payload_pos)],
 					       limit,
 					       (char *)charbuf_pointer);
-	if(written_bytes < 0)
+	if(written_bytes <= 0)
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -58,31 +58,6 @@ static __always_inline unsigned long extract__syscall_argument(struct pt_regs *r
 	return arg;
 }
 
-/////////////////////////
-// GENERIC EXTRACTION
-////////////////////////
-
-/**
- * @brief Extract `len_to_read` bytes from the pointer.
- *
- * The `dest` pointer usually is the stack or the auxmap.
- * If it is the auxmap we don't have to increment the payload_pos
- * since we are using the map as a scratch space!
- *
- * Please note: in case of failure the content of `dest` is not
- * changed so we don't have to manage the return value, we have only
- * to pass an empty value by default
- *
- * @param dest pointer to the destination buffer.
- * @param len_to_read number of bytes to be read.
- * @param src pointer to the source buffer.
- * @return return code of `bpf_probe_read`
- */
-static __always_inline int extract__bytebuf_from_pointer(void *dest, unsigned long len_to_read, void *src)
-{
-	return bpf_probe_read(dest, SAFE_ACCESS(len_to_read), src);
-}
-
 ///////////////////////////
 // ENCODE DEVICE NUMBER
 ///////////////////////////

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -114,7 +114,7 @@ static __always_inline dev_t encode_dev(dev_t dev)
  * @return struct file* pointer to the `struct file` associated with the
  * file descriptor. Return a NULL pointer in case of failure.
  */
-static __always_inline struct file *extract__file_struct_from_fd(int file_descriptor)
+static __always_inline struct file *extract__file_struct_from_fd(s32 file_descriptor)
 {
 	struct file *f = NULL;
 	if(file_descriptor > 0)

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -79,7 +79,7 @@ static __always_inline dev_t encode_dev(dev_t dev)
 }
 
 ///////////////////////////
-// FILE EXTRACION
+// FILE EXTRACTION
 ///////////////////////////
 
 /**
@@ -92,7 +92,7 @@ static __always_inline dev_t encode_dev(dev_t dev)
 static __always_inline struct file *extract__file_struct_from_fd(s32 file_descriptor)
 {
 	struct file *f = NULL;
-	if(file_descriptor > 0)
+	if(file_descriptor >= 0)
 	{
 		struct file **fds;
 		struct task_struct *task = get_current_task();

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -58,6 +58,31 @@ static __always_inline unsigned long extract__syscall_argument(struct pt_regs *r
 	return arg;
 }
 
+/////////////////////////
+// GENERIC EXTRACTION
+////////////////////////
+
+/**
+ * @brief Extract `len_to_read` bytes from the pointer.
+ *
+ * The `dest` pointer usually is the stack or the auxmap.
+ * If it is the auxmap we don't have to increment the payload_pos
+ * since we are using the map as a scratch space!
+ *
+ * Please note: in case of failure the content of `dest` is not
+ * changed so we don't have to manage the return value, we have only
+ * to pass an empty value by default
+ *
+ * @param dest pointer to the destination buffer.
+ * @param len_to_read number of bytes to be read.
+ * @param src pointer to the source buffer.
+ * @return return code of `bpf_probe_read`
+ */
+static __always_inline int extract__bytebuf_from_pointer(void *dest, unsigned long len_to_read, void *src)
+{
+	return bpf_probe_read(dest, SAFE_ACCESS(len_to_read), src);
+}
+
 ///////////////////////////
 // ENCODE DEVICE NUMBER
 ///////////////////////////

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -272,11 +272,12 @@ static __always_inline void auxmap__store_u64_param(struct auxiliary_map *auxmap
  *
  * @param auxmap pointer to the auxmap in which we are storing the param.
  * @param charbuf_pointer pointer to the charbuf to store.
+ * @param mem from which memory we need to read: user-space or kernel-space.
  * @return number of bytes read.
  */
-static __always_inline u16 auxmap__store_charbuf_param(struct auxiliary_map *auxmap, unsigned long charbuf_pointer)
+static __always_inline u16 auxmap__store_charbuf_param(struct auxiliary_map *auxmap, unsigned long charbuf_pointer, enum read_memory mem)
 {
-	u16 charbuf_len = push__charbuf(auxmap->data, &auxmap->payload_pos, charbuf_pointer, MAX_PARAM_SIZE);
+	u16 charbuf_len = push__charbuf(auxmap->data, &auxmap->payload_pos, charbuf_pointer, MAX_PARAM_SIZE, mem);
 	/* If we are not able to push anything with `push__charbuf`
 	 * `charbuf_len` will be equal to `0` so we will send an
 	 * empty param to userspace.
@@ -367,7 +368,7 @@ static __always_inline void auxmap__store_path_from_fd(struct auxiliary_map *aux
 	{
 		if(path_pointers[k])
 		{
-			total_size += push__charbuf(auxmap->data, &auxmap->payload_pos, path_pointers[k], MAX_PARAM_SIZE);
+			total_size += push__charbuf(auxmap->data, &auxmap->payload_pos, path_pointers[k], MAX_PARAM_SIZE, KERNEL);
 			push__previous_character(auxmap->data, &auxmap->payload_pos, '/');
 		}
 	}

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -374,10 +374,10 @@ static __always_inline void auxmap__store_path_from_fd(struct auxiliary_map *aux
 
 	/* Different cases:
 	 * - `path_components==0` we have to do nothing we will push an empty param.
-	 * - `path_components==1` we have to do nothing the path is already `/\0`.
+	 * - `path_components==1` we need to replace the last `/` with a `\0`.
 	 * - `path_components>1` we need to replace the last `/` with a `\0`.
 	 */
-	if(path_components > 1)
+	if(path_components >= 1)
 	{
 		push__previous_character(auxmap->data, &auxmap->payload_pos, '\0');
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(mkdir_x,
 
 	/* Parameter 2: path (type: PT_FSPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 0);
-	auxmap__store_charbuf_param(auxmap, path_pointer);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -25,7 +25,7 @@ int BPF_PROG(mkdir_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* 1° Parameter: mode (type: PT_UINT32) */
+	/* Parameter 1: mode (type: PT_UINT32) */
 	u32 mode = (u32)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, mode);
 
@@ -55,10 +55,10 @@ int BPF_PROG(mkdir_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* 1° Parameter: res (type: PT_ERRNO) */
+	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	/* 2° Parameter: path (type: PT_FSPATH) */
+	/* Parameter 2: path (type: PT_FSPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 0);
 	auxmap__store_charbuf_param(auxmap, path_pointer);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(open_e,
 
 	/* Parameter 1: name (type: PT_FSPATH) */
 	unsigned long name_pointer = extract__syscall_argument(regs, 0);
-	auxmap__store_charbuf_param(auxmap, name_pointer);
+	auxmap__store_charbuf_param(auxmap, name_pointer, USER);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)extract__syscall_argument(regs, 1);
@@ -69,7 +69,7 @@ int BPF_PROG(open_x,
 
 	/* Parameter 2: name (type: PT_FSPATH) */
 	unsigned long name_pointer = extract__syscall_argument(regs, 0);
-	auxmap__store_charbuf_param(auxmap, name_pointer);
+	auxmap__store_charbuf_param(auxmap, name_pointer, USER);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(open_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPEN_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: name (type: PT_FSPATH) */
+	unsigned long name_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, name_pointer);
+
+	/* Parameter 2: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
+
+	/* Parameter 3: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(open_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPEN_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	unsigned long name_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, name_pointer);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
+
+	dev_t dev = 0;
+	u64 ino = 0;
+
+	if(ret > 0)
+	{
+		extract__dev_and_ino_from_fd(ret, &dev, &ino);
+	}
+
+	/* Parameter 5: dev (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, dev);
+
+	/* Parameter 6: ino (type: PT_UINT64) */
+	auxmap__store_u64_param(auxmap, ino);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(open_by_handle_at_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, OPEN_BY_HANDLE_AT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, OPEN_BY_HANDLE_AT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(open_by_handle_at_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: mountfd (type: PT_FD) */
+	s32 mountfd = (s32)extract__syscall_argument(regs, 0);
+	if(mountfd == AT_FDCWD)
+	{
+		mountfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)mountfd);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
+
+	/* Parameter 4: path (type: PT_FSPATH) */
+	/* We collect the file path from the file descriptor only if it is valid */
+	if(ret > 0)
+	{
+		auxmap__store_path_from_fd(auxmap, (s32)ret);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(openat_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPENAT_2_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 2: name (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 3);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(openat_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPENAT_2_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 3: name (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
+
+	/* Parameter 5: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 3);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
+
+	dev_t dev = 0;
+	u64 ino = 0;
+
+	if(ret > 0)
+	{
+		extract__dev_and_ino_from_fd(ret, &dev, &ino);
+	}
+
+	/* Parameter 6: dev (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, dev);
+
+	/* Parameter 7: ino (type: PT_UINT64) */
+	auxmap__store_u64_param(auxmap, ino);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
@@ -34,7 +34,7 @@ int BPF_PROG(openat_e,
 
 	/* Parameter 2: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_charbuf_param(auxmap, path_pointer);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)extract__syscall_argument(regs, 2);
@@ -85,7 +85,7 @@ int BPF_PROG(openat_x,
 
 	/* Parameter 3: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_charbuf_param(auxmap, path_pointer);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
@@ -34,12 +34,12 @@ int BPF_PROG(openat2_e,
 
 	/* Parameter 2: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_charbuf_param(auxmap, path_pointer);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
 
 	/* the `open_how` struct is defined since kernel version 5.6 */
 	unsigned long open_how_pointer = extract__syscall_argument(regs, 2);
 	struct open_how how = {0};
-	extract__bytebuf_from_pointer((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
+	bpf_probe_read_user((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	auxmap__store_u32_param(auxmap, open_flags_to_scap(how.flags));
@@ -91,12 +91,12 @@ int BPF_PROG(openat2_x,
 
 	/* Parameter 3: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_charbuf_param(auxmap, path_pointer);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
 
 	/* the `open_how` struct is defined since kernel version 5.6 */
 	unsigned long open_how_pointer = extract__syscall_argument(regs, 2);
 	struct open_how how = {0};
-	extract__bytebuf_from_pointer((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
+	bpf_probe_read_user((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	auxmap__store_u32_param(auxmap, open_flags_to_scap(how.flags));

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(openat2_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPENAT2_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 2: name (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer);
+
+	/* the `open_how` struct is defined since kernel version 5.6 */
+	unsigned long open_how_pointer = extract__syscall_argument(regs, 2);
+	struct open_how how = {0};
+	extract__bytebuf_from_pointer((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(how.flags));
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(how.flags, how.mode));
+
+	/* Parameter 5: resolve (type: PT_FLAGS32) */
+	auxmap__store_u32_param(auxmap, openat2_resolve_to_scap(how.resolve));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(openat2_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_OPENAT2_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 3: name (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer);
+
+	/* the `open_how` struct is defined since kernel version 5.6 */
+	unsigned long open_how_pointer = extract__syscall_argument(regs, 2);
+	struct open_how how = {0};
+	extract__bytebuf_from_pointer((void *)&how, sizeof(struct open_how), (void *)open_how_pointer);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	auxmap__store_u32_param(auxmap, open_flags_to_scap(how.flags));
+
+	/* Parameter 5: mode (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(how.flags, how.mode));
+
+	/* Parameter 6: resolve (type: PT_FLAGS32) */
+	auxmap__store_u32_param(auxmap, openat2_resolve_to_scap(how.resolve));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -15,7 +15,7 @@ void assert_syscall_state(int syscall_state, const char* syscall_name, long sysc
 {
 	bool match = false;
 
-	switch (op)
+	switch(op)
 	{
 	case EQUAL:
 		match = syscall_rc == expected_rc;
@@ -26,13 +26,13 @@ void assert_syscall_state(int syscall_state, const char* syscall_name, long sysc
 		break;
 
 	default:
-		FAIL() << "Operation currently not supported!";
+		FAIL() << "Operation currently not supported!" << std::endl;
 		return;
 	}
 
 	if(!match)
 	{
-		if(syscall_state==SYSCALL_SUCCESS)
+		if(syscall_state == SYSCALL_SUCCESS)
 		{
 			FAIL() << ">>>>> The syscall '" << syscall_name << "' must be successful. Errno: " << errno << " err_message: " << strerror(errno) << std::endl;
 		}
@@ -158,8 +158,7 @@ void event_test::assert_event_presence()
 		consume_ret = pman_consume_one_from_buffers((void**)&m_event_header, &cpu_id);
 		if(consume_ret == -1 || m_event_header == NULL)
 		{
-			FAIL() << "There is no event in the buffer.";
-			exit(EXIT_SUCCESS);
+			FAIL() << "There is no event in the buffer." << std::endl;
 		}
 		if(m_event_header->tid == pid && m_event_header->type == m_event_type)
 		{
@@ -201,27 +200,26 @@ void event_test::assert_only_param_len(int param_num, uint16_t expected_size)
 	assert_param_len(expected_size);
 }
 
-template <typename T>
+template<typename T>
 void event_test::assert_numeric_param(int param_num, T param, enum assertion_operators op)
 {
 	assert_param_boundaries(param_num);
 	assert_param_len(sizeof(T));
 
-	switch (op)
+	switch(op)
 	{
-		case EQUAL:
+	case EQUAL:
 		ASSERT_EQ(*(T*)(m_event_params[m_current_param].valptr), param) << VALUE_NOT_CORRECT << m_current_param << std::endl;
 		break;
 
-		case GREATER_EQUAL:
+	case GREATER_EQUAL:
 		ASSERT_GE(*(T*)(m_event_params[m_current_param].valptr), param) << VALUE_NOT_CORRECT << m_current_param << std::endl;
 		break;
 
-		default:
+	default:
 		FAIL() << "Operation currently not supported!";
 		return;
 	}
-
 }
 
 template void event_test::assert_numeric_param<uint8_t>(int, uint8_t, enum assertion_operators);

--- a/test/modern_bpf/test_suites/syscall_enter_suite/mkdir_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/mkdir_e.cpp
@@ -22,6 +22,11 @@ TEST(SyscallEnter, mkdirE)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/modern_bpf/test_suites/syscall_enter_suite/mkdir_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/mkdir_e.cpp
@@ -28,7 +28,7 @@ TEST(SyscallEnter, mkdirE)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	/* 1° Parameter: mode (type: PT_UINT32) */
+	/* Parameter 1: mode (type: PT_UINT32) */
 	evt_test->assert_numeric_param(1, mode);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/open_by_handle_at_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/open_by_handle_at_e.cpp
@@ -1,0 +1,48 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_open_by_handle_at
+TEST(SyscallEnter, open_by_handle_atE)
+{
+	auto evt_test = new event_test(__NR_open_by_handle_at, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * Here `mount_fd` is invalid so the call will fail.
+	 */
+
+	int mount_fd = -1;
+	struct file_handle *fhp = NULL;
+	int flags = O_RDWR;
+	assert_syscall_state(SYSCALL_FAILURE, "open_by_handle_at", syscall(__NR_open_by_handle_at, mount_fd, fhp, flags));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		/* This could happen if:
+		 * - the syscall result state is different from the expected one.
+		 * - we are not able to find the event in the ring buffers.
+		 */
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/open_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/open_e.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_open
+TEST(SyscallEnter, openE)
+{
+	auto evt_test = new event_test(__NR_open, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory
+	 * but here it is a filename so the call will fail!
+	 */
+	const char* pathname = "mock_path";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "open", syscall(__NR_open, pathname, flags, mode));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(1, pathname);
+
+	/* Parameter 2: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(2, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 3: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)mode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/open_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/open_e.cpp
@@ -24,6 +24,11 @@ TEST(SyscallEnter, openE)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/modern_bpf/test_suites/syscall_enter_suite/openat2_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/openat2_e.cpp
@@ -1,0 +1,59 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_openat2
+
+#include <linux/openat2.h> /* Definition of RESOLVE_* constants */
+
+TEST(SyscallEnter, openat2E)
+{
+	auto evt_test = new event_test(__NR_openat2, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory
+	 * but here it is a filename so the call will fail!
+	 */
+
+	int dirfd = AT_FDCWD;
+	const char* pathname = "mock_path";
+	struct open_how how;
+	how.flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	how.mode = 0;
+	how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
+	assert_syscall_state(SYSCALL_FAILURE, "openat2", syscall(__NR_openat2, dirfd, pathname, &how, sizeof(struct open_how)));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)PPM_AT_FDCWD);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)how.mode);
+
+	/* Parameter 5: resolve (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(5, (uint32_t)PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/openat2_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/openat2_e.cpp
@@ -31,6 +31,11 @@ TEST(SyscallEnter, openat2E)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/modern_bpf/test_suites/syscall_enter_suite/openat_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/openat_e.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_openat
+TEST(SyscallEnter, openatE)
+{
+	auto evt_test = new event_test(__NR_openat, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory
+	 * but here it is a filename so the call will fail!
+	 */
+
+	int dirfd = AT_FDCWD;
+	const char* pathname = "mock_path";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "openat", syscall(__NR_openat, dirfd, pathname, flags, mode));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)PPM_AT_FDCWD);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)mode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/openat_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/openat_e.cpp
@@ -26,6 +26,11 @@ TEST(SyscallEnter, openatE)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/modern_bpf/test_suites/syscall_exit_suite/mkdir_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/mkdir_x.cpp
@@ -26,10 +26,10 @@ TEST(SyscallExit, mkdirX)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	/* 1° Parameter: res (type: PT_ERRNO)*/
+	/* Parameter 1: res (type: PT_ERRNO)*/
 	evt_test->assert_numeric_param(1, errno_value);
 
-	/* 2° Parameter: path (type: PT_FSPATH) */
+	/* Parameter 2: path (type: PT_FSPATH) */
 	evt_test->assert_charbuf_param(2, path);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_exit_suite/mkdir_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/mkdir_x.cpp
@@ -20,6 +20,11 @@ TEST(SyscallExit, mkdirX)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
@@ -54,73 +54,27 @@ TEST(SyscallExit, open_by_handle_atX_success)
 	assert_syscall_state(SYSCALL_SUCCESS, "name_to_handle_at", syscall(__NR_name_to_handle_at, dirfd, pathname, fhp, &mount_id, flags), NOT_EQUAL, -1);
 
 	/*
-	 * 4. Retrieve the `mount_fd`.
+	 * 4. Call `open_by_handle_at`.
 	 */
-	char *linep = NULL;
-	size_t lsize = 0;
-	char mount_path[4096];
-	int mi_mount_id = 0;
-	int found = 0;
-	ssize_t nread = 0;
-	FILE *fp = NULL;
-
-	fp = fopen("/proc/self/mountinfo", "r");
-	if(fp == NULL)
-	{
-		FAIL() << "Error in opening /proc/self/mountinfo" << std::endl;
-	}
-
-	while(!found)
-	{
-		nread = getline(&linep, &lsize, fp);
-		if(nread == -1)
-		{
-			break;
-		}
-
-		nread = sscanf(linep, "%d %*d %*s %*s %s", &mi_mount_id, mount_path);
-		if(nread != 2)
-		{
-			FAIL() << "Bad sscanf()" << std::endl;
-		}
-
-		if(mi_mount_id == mount_id)
-		{
-			found = 1;
-		}
-	}
-
-	if(!found)
-	{
-		FAIL() << "Could not find mount point" << std::endl;
-	}
-
-	/*
-	 * 5. Call `open_by_handle_at`.
-	 */
-	int mount_fd = open(mount_path, O_RDONLY);
 	flags = O_RDONLY;
-	int open_by_handle_fd = syscall(__NR_open_by_handle_at, mount_fd, fhp, flags);
+	int open_by_handle_fd = syscall(__NR_open_by_handle_at, AT_FDCWD, fhp, flags);
 	assert_syscall_state(SYSCALL_SUCCESS, "open_by_handle_at", open_by_handle_fd, NOT_EQUAL, -1);
 
 	/*
-	 * 6. Get the current working directory.
+	 * 5. Get the current working directory.
 	 */
 	char tmp[4096];
-	char* err = getcwd(tmp, 4096);
+	char *err = getcwd(tmp, 4096);
 	if(!err)
 	{
 		FAIL() << "Could not get the current working directory" << std::endl;
 	}
 
 	/*
-	 * 7. Cleaning phase.
+	 * 6. Cleaning phase.
 	 */
 	close(open_by_handle_fd);
-	close(mount_fd);
-	fclose(fp);
 	close(fd);
-	free(linep);
 	free(fhp);
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
@@ -144,7 +98,7 @@ TEST(SyscallExit, open_by_handle_atX_success)
 	evt_test->assert_numeric_param(1, (int64_t)open_by_handle_fd);
 
 	/* Parameter 2: mountfd (type: PT_FD) */
-	evt_test->assert_numeric_param(2, (int64_t)mount_fd);
+	evt_test->assert_numeric_param(2, (int64_t)PPM_AT_FDCWD);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDONLY);

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
@@ -26,8 +26,9 @@ void do___open_by_handle_atX_success(int *open_by_handle_fd, int *dirfd, char *f
 		rc = syscall(__NR_mount, "none", dir_name, "tmpfs", 0, "size=1M,uid=0,gid=0,mode=700");
 		assert_syscall_state(SYSCALL_SUCCESS, "mount", rc, NOT_EQUAL, -1);
 
-		*dirfd = syscall(__NR_open, dir_name, O_DIRECTORY);
-		assert_syscall_state(SYSCALL_SUCCESS, "open", *dirfd, NOT_EQUAL, -1);
+		/* Since `dir_name` is always an absolute path `dirfd` can be `0` here. */
+		*dirfd = syscall(__NR_openat, 0, dir_name, O_DIRECTORY);
+		assert_syscall_state(SYSCALL_SUCCESS, "openat", *dirfd, NOT_EQUAL, -1);
 	}
 
 	/*

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
@@ -1,0 +1,215 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_open_by_handle_at) && defined(__NR_name_to_handle_at) && defined(__NR_openat)
+
+TEST(SyscallExit, open_by_handle_atX_success)
+{
+	auto evt_test = new event_test(__NR_open_by_handle_at, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/*
+	 * 1. Open a temp file.
+	 */
+	int dirfd = AT_FDCWD;
+	const char *pathname = ".";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	int fd = syscall(__NR_openat, dirfd, pathname, flags, mode);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", fd, NOT_EQUAL, -1);
+
+	/* Allocate file_handle structure. */
+	struct file_handle *fhp;
+	int fhsize = sizeof(*fhp);
+	fhp = (struct file_handle *)malloc(fhsize);
+	if(fhp == NULL)
+	{
+		FAIL() << "Error in allocating the `struct file_handle` with malloc" << std::endl;
+	}
+
+	/* Make an initial call to name_to_handle_at() to discover the size required for the file handle.
+	 * The caller can discover the required size for the file_handle structure by making a call in which handle->handle_bytes is zero;
+	 * in this case, the call fails with the error EOVERFLOW and handle->handle_bytes is set to indicate the required size;
+	 */
+	int mount_id;
+	flags = 0;
+	fhp->handle_bytes = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "name_to_handle_at", syscall(__NR_name_to_handle_at, dirfd, pathname, fhp, &mount_id, flags));
+
+	/*
+	 * 2. Reallocate file_handle structure with the correct size.
+	 */
+	fhsize = sizeof(*fhp) + fhp->handle_bytes;
+	fhp = (struct file_handle *)realloc(fhp, fhsize);
+	if(fhp == NULL)
+	{
+		FAIL() << "Error in allocating the `struct file_handle` with realloc" << std::endl;
+	}
+
+	/*
+	 * 3. Get file handle.
+	 */
+	assert_syscall_state(SYSCALL_SUCCESS, "name_to_handle_at", syscall(__NR_name_to_handle_at, dirfd, pathname, fhp, &mount_id, flags), NOT_EQUAL, -1);
+
+	/*
+	 * 4. Retrieve the `mount_fd`.
+	 */
+	char *linep = NULL;
+	size_t lsize = 0;
+	char mount_path[4096];
+	int mi_mount_id = 0;
+	int found = 0;
+	ssize_t nread = 0;
+	FILE *fp = NULL;
+
+	fp = fopen("/proc/self/mountinfo", "r");
+	if(fp == NULL)
+	{
+		FAIL() << "Error in opening /proc/self/mountinfo" << std::endl;
+	}
+
+	while(!found)
+	{
+		nread = getline(&linep, &lsize, fp);
+		if(nread == -1)
+		{
+			break;
+		}
+
+		nread = sscanf(linep, "%d %*d %*s %*s %s", &mi_mount_id, mount_path);
+		if(nread != 2)
+		{
+			FAIL() << "Bad sscanf()" << std::endl;
+		}
+
+		if(mi_mount_id == mount_id)
+		{
+			found = 1;
+		}
+	}
+
+	if(!found)
+	{
+		FAIL() << "Could not find mount point" << std::endl;
+	}
+
+	/*
+	 * 5. Call `open_by_handle_at`.
+	 */
+	int mount_fd = open(mount_path, O_RDONLY);
+	flags = O_RDONLY;
+	int open_by_handle_fd = syscall(__NR_open_by_handle_at, mount_fd, fhp, flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "open_by_handle_at", open_by_handle_fd, NOT_EQUAL, -1);
+
+	/*
+	 * 6. Get the current working directory.
+	 */
+	char tmp[4096];
+	char* err = getcwd(tmp, 4096);
+	if(!err)
+	{
+		FAIL() << "Could not get the current working directory" << std::endl;
+	}
+
+	/*
+	 * 7. Cleaning phase.
+	 */
+	close(open_by_handle_fd);
+	close(mount_fd);
+	fclose(fp);
+	close(fd);
+	free(linep);
+	free(fhp);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)open_by_handle_fd);
+
+	/* Parameter 2: mountfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mount_fd);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDONLY);
+
+	/* Parameter 4: path (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(4, tmp);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+
+TEST(SyscallExit, open_by_handle_atX_failure)
+{
+	auto evt_test = new event_test(__NR_open_by_handle_at, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * Here `mount_fd` is invalid so the call will fail.
+	 */
+
+	int mount_fd = -1;
+	struct file_handle *fhp = NULL;
+	int flags = O_RDWR;
+	assert_syscall_state(SYSCALL_FAILURE, "open_by_handle_at", syscall(__NR_open_by_handle_at, mount_fd, fhp, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		/* This could happen if:
+		 * - the syscall result state is different from the expected one.
+		 * - we are not able to find the event in the ring buffers.
+		 */
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: mountfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mount_fd);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDWR);
+
+	/* Parameter 4: path (type: PT_FSPATH) */
+	evt_test->assert_empty_param(4);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
@@ -1,7 +1,9 @@
 #include "../../event_class/event_class.h"
-#include <sys/stat.h>
 
 #if defined(__NR_open) && defined(__NR_fstat)
+
+#include <sys/stat.h> /* Definitions for `fstat` syscall. */
+
 TEST(SyscallExit, openX_success)
 {
 	auto evt_test = new event_test(__NR_open, EXIT_EVENT);

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
@@ -34,6 +34,11 @@ TEST(SyscallExit, openX_success)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();
@@ -87,6 +92,11 @@ TEST(SyscallExit, openX_failure)
 	evt_test->disable_capture();
 
 	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
 
 	evt_test->parse_event();
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_x.cpp
@@ -1,0 +1,120 @@
+#include "../../event_class/event_class.h"
+#include <sys/stat.h>
+
+#if defined(__NR_open) && defined(__NR_fstat)
+TEST(SyscallExit, openX_success)
+{
+	auto evt_test = new event_test(__NR_open, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory.
+	 */
+	const char* pathname = ".";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	int fd = syscall(__NR_open, pathname, flags, mode);
+	assert_syscall_state(SYSCALL_SUCCESS, "open", fd, NOT_EQUAL, -1);
+
+	/* Call `fstat` to retrieve the `dev` and `ino`. */
+	struct stat file_stat;
+	assert_syscall_state(SYSCALL_SUCCESS, "fstat", syscall(__NR_fstat, fd, &file_stat), NOT_EQUAL, -1);
+	uint32_t dev = (uint32_t)file_stat.st_dev;
+	uint64_t inode = file_stat.st_ino;
+	close(fd);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD)*/
+	evt_test->assert_numeric_param(1, (int64_t)fd);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	/* mode is 0 so it must remain 0. */
+	evt_test->assert_numeric_param(4, (uint32_t)mode);
+
+	/* Parameter 5: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)dev);
+
+	/* Parameter 6: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(6, inode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, openX_failure)
+{
+	auto evt_test = new event_test(__NR_open, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory
+	 * but here it is a filename so the call will fail!
+	 */
+	const char* pathname = "mock_path";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "open", syscall(__NR_open, pathname, flags, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	/* mode is 0 so it must remain 0. */
+	evt_test->assert_numeric_param(4, (uint32_t)mode);
+
+	/* Syscall fails so dev=0 && ino=0.*/
+
+	/* Parameter 5: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
+
+	/* Parameter 6: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(6, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
@@ -1,12 +1,12 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_openat) && defined(__NR_fstat)
+#ifdef __NR_openat2
 
-#include <sys/stat.h> /* Definitions for `fstat` syscall. */
+#include <linux/openat2.h> /* Definition of RESOLVE_* constants */
 
-TEST(SyscallExit, openatX_success)
+TEST(SyscallExit, openat2X_success)
 {
-	auto evt_test = new event_test(__NR_openat, EXIT_EVENT);
+	auto evt_test = new event_test(__NR_openat2, EXIT_EVENT);
 
 	evt_test->enable_capture();
 
@@ -17,16 +17,12 @@ TEST(SyscallExit, openatX_success)
 	 */
 	int dirfd = AT_FDCWD;
 	const char* pathname = ".";
-	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
-	mode_t mode = 0;
-	int fd = syscall(__NR_openat, dirfd, pathname, flags, mode);
-	assert_syscall_state(SYSCALL_SUCCESS, "openat", fd, NOT_EQUAL, -1);
-
-	/* Call `fstat` to retrieve the `dev` and `ino`. */
-	struct stat file_stat;
-	assert_syscall_state(SYSCALL_SUCCESS, "fstat", syscall(__NR_fstat, fd, &file_stat), NOT_EQUAL, -1);
-	uint32_t dev = (uint32_t)file_stat.st_dev;
-	uint64_t inode = file_stat.st_ino;
+    struct open_how how;
+	how.flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	how.mode = 0;
+	how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
+	int32_t fd = syscall(__NR_openat2, dirfd, pathname, &how, sizeof(struct open_how));
+	assert_syscall_state(SYSCALL_SUCCESS, "openat2", fd, NOT_EQUAL, -1);
 	close(fd);
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
@@ -54,22 +50,19 @@ TEST(SyscallExit, openatX_success)
 	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
 
 	/* Parameter 5: mode (type: PT_UINT32) */
-	evt_test->assert_numeric_param(5, (uint32_t)mode);
+	evt_test->assert_numeric_param(5, (uint32_t)how.mode);
 
-	/* Parameter 6: dev (type: PT_UINT32) */
-	evt_test->assert_numeric_param(6, (uint32_t)dev);
-
-	/* Parameter 7: ino (type: PT_UINT64) */
-	evt_test->assert_numeric_param(7, inode);
+	/* Parameter 6: resolve (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(6, (uint32_t)PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	evt_test->assert_num_params_pushed(7);
+	evt_test->assert_num_params_pushed(6);
 }
 
-TEST(SyscallExit, openatX_failure)
+TEST(SyscallExit, openat2X_failure)
 {
-	auto evt_test = new event_test(__NR_openat, EXIT_EVENT);
+	auto evt_test = new event_test(__NR_openat2, EXIT_EVENT);
 
 	evt_test->enable_capture();
 
@@ -82,9 +75,11 @@ TEST(SyscallExit, openatX_failure)
 
 	int dirfd = AT_FDCWD;
 	const char* pathname = "mock_path";
-	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
-	mode_t mode = 0;
-	assert_syscall_state(SYSCALL_FAILURE, "openat", syscall(__NR_openat, dirfd, pathname, flags, mode));
+	struct open_how how;
+	how.flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	how.mode = 0;
+	how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
+	assert_syscall_state(SYSCALL_FAILURE, "openat2", syscall(__NR_openat2, dirfd, pathname, &how, sizeof(struct open_how)));
 	int64_t errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
@@ -100,30 +95,25 @@ TEST(SyscallExit, openatX_failure)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+	evt_test->assert_s64_param(1, (int64_t)errno_value);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	evt_test->assert_numeric_param(2, (int64_t)PPM_AT_FDCWD);
+	evt_test->assert_s64_param(2, (int64_t)PPM_AT_FDCWD);
 
 	/* Parameter 3: name (type: PT_FSPATH) */
 	evt_test->assert_charbuf_param(3, pathname);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+	evt_test->assert_u32_param(4, PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
 
 	/* Parameter 5: mode (type: PT_UINT32) */
-	evt_test->assert_numeric_param(5, (uint32_t)mode);
+	evt_test->assert_u32_param(5, how.mode);
 
-	/* Syscall fails so dev=0 && ino=0. */
-
-	/* Parameter 6: dev (type: PT_UINT32) */
-	evt_test->assert_numeric_param(6, (uint32_t)0);
-
-	/* Parameter 7: ino (type: PT_UINT64) */
-	evt_test->assert_numeric_param(7, (uint64_t)0);
+	/* Parameter 6: resolve (type: PT_FLAGS32) */
+	evt_test->assert_u32_param(6, PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	evt_test->assert_num_params_pushed(7);
+	evt_test->assert_num_params_pushed(6);
 }
 #endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
@@ -17,7 +17,7 @@ TEST(SyscallExit, openat2X_success)
 	 */
 	int dirfd = AT_FDCWD;
 	const char* pathname = ".";
-    struct open_how how;
+	struct open_how how;
 	how.flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
 	how.mode = 0;
 	how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
@@ -95,22 +95,22 @@ TEST(SyscallExit, openat2X_failure)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	evt_test->assert_s64_param(1, (int64_t)errno_value);
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	evt_test->assert_s64_param(2, (int64_t)PPM_AT_FDCWD);
+	evt_test->assert_numeric_param(2, (int64_t)PPM_AT_FDCWD);
 
 	/* Parameter 3: name (type: PT_FSPATH) */
 	evt_test->assert_charbuf_param(3, pathname);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	evt_test->assert_u32_param(4, PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
 
 	/* Parameter 5: mode (type: PT_UINT32) */
-	evt_test->assert_u32_param(5, how.mode);
+	evt_test->assert_numeric_param(5, (uint32_t)how.mode);
 
 	/* Parameter 6: resolve (type: PT_FLAGS32) */
-	evt_test->assert_u32_param(6, PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
+	evt_test->assert_numeric_param(6, (uint32_t)PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/openat2_x.cpp
@@ -31,6 +31,11 @@ TEST(SyscallExit, openat2X_success)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();
@@ -87,6 +92,11 @@ TEST(SyscallExit, openat2X_failure)
 	evt_test->disable_capture();
 
 	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
 
 	evt_test->parse_event();
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/openat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/openat_x.cpp
@@ -35,6 +35,11 @@ TEST(SyscallExit, openatX_success)
 
 	evt_test->assert_event_presence();
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();
@@ -92,6 +97,11 @@ TEST(SyscallExit, openatX_failure)
 	evt_test->disable_capture();
 
 	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
 
 	evt_test->parse_event();
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/openat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/openat_x.cpp
@@ -1,0 +1,126 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_open) && defined(__NR_fstat)
+TEST(SyscallExit, openatX_success)
+{
+	auto evt_test = new event_test(__NR_openat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory.
+	 */
+	int dirfd = AT_FDCWD;
+	const char* pathname = ".";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	int fd = syscall(__NR_openat, dirfd, pathname, flags, mode);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", fd, NOT_EQUAL, -1);
+
+	/* Call `fstat` to retrieve the `dev` and `ino`. */
+	struct stat file_stat;
+	assert_syscall_state(SYSCALL_SUCCESS, "fstat", syscall(__NR_fstat, fd, &file_stat), NOT_EQUAL, -1);
+	uint32_t dev = (uint32_t)file_stat.st_dev;
+	uint64_t inode = file_stat.st_ino;
+	close(fd);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)fd);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)PPM_AT_FDCWD);
+
+	/* Parameter 3: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, pathname);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 5: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)mode);
+
+	/* Parameter 6: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)dev);
+
+	/* Parameter 7: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(7, inode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(7);
+}
+
+TEST(SyscallExit, openatX_failure)
+{
+	auto evt_test = new event_test(__NR_openat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * With `O_TMPFILE` flag the pathname must be a directory
+	 * but here it is a filename so the call will fail!
+	 */
+
+	int dirfd = AT_FDCWD;
+	const char* pathname = "mock_path";
+	int flags = O_RDWR | O_TMPFILE | O_DIRECTORY;
+	mode_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "openat", syscall(__NR_openat, dirfd, pathname, flags, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)PPM_AT_FDCWD);
+
+	/* Parameter 3: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, pathname);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR | PPM_O_TMPFILE | PPM_O_DIRECTORY);
+
+	/* Parameter 5: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)mode);
+
+	/* Syscall fails so dev=0 && ino=0. */
+
+	/* Parameter 6: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)0);
+
+	/* Parameter 7: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(7, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(7);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -27,6 +27,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_OPEN_X] = "open_x",
 	[PPME_SYSCALL_OPENAT_2_E] = "openat_e",
 	[PPME_SYSCALL_OPENAT_2_X] = "openat_x",
+	[PPME_SYSCALL_OPENAT2_E] = "openat2_e",
+	[PPME_SYSCALL_OPENAT2_X] = "openat2_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -29,6 +29,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_OPENAT_2_X] = "openat_x",
 	[PPME_SYSCALL_OPENAT2_E] = "openat2_e",
 	[PPME_SYSCALL_OPENAT2_X] = "openat2_x",
+	[PPME_SYSCALL_OPEN_BY_HANDLE_AT_E] = "open_by_handle_at_e",
+	[PPME_SYSCALL_OPEN_BY_HANDLE_AT_X] = "open_by_handle_at_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -25,6 +25,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_MKDIR_2_X] = "mkdir_x",
 	[PPME_SYSCALL_OPEN_E] = "open_e",
 	[PPME_SYSCALL_OPEN_X] = "open_x",
+	[PPME_SYSCALL_OPENAT_2_E] = "openat_e",
+	[PPME_SYSCALL_OPENAT_2_X] = "openat_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -23,6 +23,8 @@ limitations under the License.
 static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_MKDIR_2_E] = "mkdir_e",
 	[PPME_SYSCALL_MKDIR_2_X] = "mkdir_x",
+	[PPME_SYSCALL_OPEN_E] = "open_e",
+	[PPME_SYSCALL_OPEN_X] = "open_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `open`
* `openat`
* `openat2`
* `open_by_handle_at`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new(modern_bpf): add support for `open` family syscalls
```
