### PR TITLE
update(bpf): disable BPF raw tracepoints for not supported architectures

### DIFF
--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -24,8 +24,8 @@ or GPL2.txt for full copies of the license.
 #define BPF_FORBIDS_ZERO_ACCESS
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
-#define BPF_SUPPORTS_RAW_TRACEPOINTS
+#if (defined(CONFIG_X86_64) || defined(CONFIG_ARM64) || defined(CONFIG_S390)) && LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+    #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif
 
 #if CAPTURE_SCHED_PROC_FORK && !defined(BPF_SUPPORTS_RAW_TRACEPOINTS)


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

On unsupported architectures, we don't perform argument retrieval in case of bpf raw tracepoint this will cause compilation problems as you can see [here](https://github.com/falcosecurity/libs/issues/360#issuecomment-1193846793). This PR should fix this kind of issue.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
