### PR TITLE
Add e2e tests based on sinsp-example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,4 +102,6 @@ if(CREATE_TEST_TARGETS AND NOT WIN32)
 		COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libsinsp
 		COMMAND ${CMAKE_MAKE_PROGRAM} run-unit-test-libscap
 	)
+
+	add_subdirectory(test/e2e)
 endif()

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -1,0 +1,48 @@
+# TODO: find a better way to determine if we run ebpf tests or not
+if(NOT BUILD_BPF)
+	message(WARNING e2e tests can only be run with the eBPF probe)
+	return()
+endif()
+
+add_custom_target(e2e-containers
+	COMMAND docker build
+		--tag sinsp-example:latest
+		-f ${CMAKE_CURRENT_SOURCE_DIR}/containers/sinsp.Dockerfile
+		${CMAKE_BINARY_DIR}
+	COMMAND docker build
+		--tag falco-e2e-tester:latest
+		-f ${CMAKE_CURRENT_SOURCE_DIR}/containers/tests.Dockerfile
+		${CMAKE_CURRENT_SOURCE_DIR}
+	DEPENDS sinsp-example driver bpf
+)
+
+add_custom_target(kmod-tests
+	COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/report/kmod
+	# Run e2e tests with the kernel module
+	COMMAND docker run --rm
+		--privileged
+		--name falco-e2e-tester
+		-e KERNEL_MODULE=/driver/scap.ko
+		-v /var/run/docker.sock:/var/run/docker.sock
+		-v ${CMAKE_CURRENT_BINARY_DIR}/report/kmod:/report
+		falco-e2e-tester:latest
+	DEPENDS e2e-containers
+)
+
+add_custom_target(ebpf-tests
+	COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/report/ebpf
+	# Run e2e tests with the eBPF probe
+	COMMAND docker run --rm
+		--privileged
+		--name falco-e2e-tester
+		-e BPF_PROBE=/driver/probe.o
+		-v /var/run/docker.sock:/var/run/docker.sock
+		-v ${CMAKE_CURRENT_BINARY_DIR}/report/ebpf:/report
+		falco-e2e-tester:latest
+	# Run eBPF tests after kmod
+	DEPENDS e2e-containers kmod-tests
+)
+
+add_custom_target(e2e-tests
+	DEPENDS ebpf-tests
+)

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -1,4 +1,8 @@
 # TODO: find a better way to determine if we run ebpf tests or not
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
+	return()
+endif()
+
 if(NOT BUILD_BPF)
 	message(WARNING e2e tests can only be run with the eBPF probe)
 	return()

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -4,45 +4,51 @@ if(NOT BUILD_BPF)
 	return()
 endif()
 
+set(E2E_CONTEXT ${CMAKE_CURRENT_BINARY_DIR}/ctx)
+
+add_custom_target(e2e-context
+	COMMAND mkdir -p ${E2E_CONTEXT}
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/libsinsp/examples/sinsp-example ${E2E_CONTEXT}
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/driver/scap.ko ${E2E_CONTEXT}
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/driver/bpf/probe.o ${E2E_CONTEXT}
+	DEPENDS sinsp-example driver bpf
+)
+
 add_custom_target(e2e-containers
 	COMMAND docker build
 		--tag sinsp-example:latest
 		-f ${CMAKE_CURRENT_SOURCE_DIR}/containers/sinsp.Dockerfile
-		${CMAKE_BINARY_DIR}
+		${E2E_CONTEXT}
 	COMMAND docker build
-		--tag falco-e2e-tester:latest
+		--tag sinsp-e2e-tester:latest
 		-f ${CMAKE_CURRENT_SOURCE_DIR}/containers/tests.Dockerfile
 		${CMAKE_CURRENT_SOURCE_DIR}
-	DEPENDS sinsp-example driver bpf
-)
-
-add_custom_target(kmod-tests
-	COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/report/kmod
-	# Run e2e tests with the kernel module
-	COMMAND docker run --rm
-		--privileged
-		--name falco-e2e-tester
-		-e KERNEL_MODULE=/driver/scap.ko
-		-v /var/run/docker.sock:/var/run/docker.sock
-		-v ${CMAKE_CURRENT_BINARY_DIR}/report/kmod:/report
-		falco-e2e-tester:latest
-	DEPENDS e2e-containers
-)
-
-add_custom_target(ebpf-tests
-	COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/report/ebpf
-	# Run e2e tests with the eBPF probe
-	COMMAND docker run --rm
-		--privileged
-		--name falco-e2e-tester
-		-e BPF_PROBE=/driver/probe.o
-		-v /var/run/docker.sock:/var/run/docker.sock
-		-v ${CMAKE_CURRENT_BINARY_DIR}/report/ebpf:/report
-		falco-e2e-tester:latest
-	# Run eBPF tests after kmod
-	DEPENDS e2e-containers kmod-tests
+	DEPENDS e2e-context
 )
 
 add_custom_target(e2e-tests
-	DEPENDS ebpf-tests
+	COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/report
+	# Run e2e tests with the kernel module
+	COMMAND docker run --rm
+		--name sinsp-e2e-tester
+		-e KERNEL_MODULE=/driver/scap.ko
+		-e BPF_PROBE=/driver/probe.o
+		-v /var/run/docker.sock:/var/run/docker.sock
+		-v ${CMAKE_CURRENT_BINARY_DIR}/report:/report
+		sinsp-e2e-tester:latest
+	DEPENDS e2e-containers
+)
+
+# This is a list of containers run by the e2e tests, if you add a different one
+# please add it to the list
+set(E2E_CONTAINERS
+	sinsp
+	nginx
+	sinsp-e2e-tester
+	curl
+	generator
+)
+
+ add_custom_target(e2e-cleanup
+	 COMMAND docker rm -f ${E2E_CONTAINERS}
 )

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,7 +6,7 @@ libsinsp. Said tests are based around 2 containers:
 - Another one running the actual tests and verifying their outcome.
 
 ## sinsp container
-A container holding the `sinsp-example` binary. Its entrpoint is set to the
+A container holding the `sinsp-example` binary. Its entrypoint is set to the
 binary, so it can be run in the same way as explained in [this README file](https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/examples/README.md).
 The build for this container is based off of `containers/sinsp.Dockerfile`
 
@@ -22,7 +22,7 @@ This container is in charge of running any tests that are created under the
 written need to follow the pattern `test_*/test_*.py` in order for them to be
 properly picked up. Additionally, a module called `sinspqa` lives in
 `tests/commons/`, it is installed directly to the tester container and is meant
-to house any functions/classes that might be useful accross multiple tests. The
+to house any functions/classes that might be useful across multiple tests. The
 dockerfile for this image can be found under `containers/tests.Dockerfile`.
 
 ## Running the tests

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,36 @@
+# e2e tests
+The sources found in this folder are aimed at building containers for running
+e2e tests on the libs. That is, tests that make use of the drivers, libscap and
+libsinsp. Said tests are based around 2 containers:
+- One running the `sinsp-example` binary
+- Another one running the actual tests and verifying their outcome.
+
+## sinsp container
+A container holding the `sinsp-example` binary. Its entrpoint is set to the
+binary, so it can be run in the same way as explained in [this README file](https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/examples/README.md).
+The build for this container is based off of `containers/sinsp.Dockerfile`
+
+## Drivers
+The drivers used by `sinsp-example` to capture events on the system need to be
+built as part of the tests. The drivers are embedded in the `sinsp-example`
+container. The same container can be used with other drivers by mounting them
+in and setting either the `KERNEL_MODULE` or `BPF_PROBE` environment variables.
+
+## Tester container
+This container is in charge of running any tests that are created under the
+`tests/` subdirectory. The engine behind it is pytest and, as such, the tests
+written need to follow the pattern `test_*/test_*.py` in order for them to be
+properly picked up. Additionally, a module called `sinspqa` lives in
+`tests/commons/`, it is installed directly to the tester container and is meant
+to house any functions/classes that might be useful accross multiple tests. The
+dockerfile for this image can be found under `containers/tests.Dockerfile`.
+
+## Running the tests
+An `e2e-tests` target has been added. It requires the `BUILD_BPF` option to be
+set.
+
+## Potential future improvements
+Aside from the obvious improvement of adding additional tests, here are some
+ideas of things that could be changed to improve the quality of the tests:
+- Implement a way to check non-deterministic values such as `pids` are found in
+  subsequent events.

--- a/test/e2e/containers/sinsp.Dockerfile
+++ b/test/e2e/containers/sinsp.Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:buster
+
+RUN apt-get update && \
+    apt-get install -y \
+    libcurl4 \
+    libgrpc++1 \
+    jq \
+    libjsoncpp1 \
+    openssl \
+    libb64-0d \
+    libtbb2
+
+COPY /libsinsp/examples/sinsp-example /usr/local/bin/sinsp-example
+COPY /driver/bpf/probe.o /driver/probe.o
+COPY /driver/scap.ko /driver/scap.ko
+
+ENTRYPOINT [ "sinsp-example", "-j", "-a" ]

--- a/test/e2e/containers/sinsp.Dockerfile
+++ b/test/e2e/containers/sinsp.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     libjsoncpp1 \
     openssl \
     libb64-0d \
+    libre2-5 \
     libtbb2
 
 COPY /sinsp-example /usr/local/bin/sinsp-example

--- a/test/e2e/containers/sinsp.Dockerfile
+++ b/test/e2e/containers/sinsp.Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && \
     libb64-0d \
     libtbb2
 
-COPY /libsinsp/examples/sinsp-example /usr/local/bin/sinsp-example
-COPY /driver/bpf/probe.o /driver/probe.o
-COPY /driver/scap.ko /driver/scap.ko
+COPY /sinsp-example /usr/local/bin/sinsp-example
+COPY /probe.o /driver/probe.o
+COPY /scap.ko /driver/scap.ko
 
 ENTRYPOINT [ "sinsp-example", "-j", "-a" ]

--- a/test/e2e/containers/tests.Dockerfile
+++ b/test/e2e/containers/tests.Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:buster
+
+WORKDIR /tests
+
+RUN mkdir -p /logs && \
+    apt-get update && \
+    apt-get install -y python3 \
+    python3-pip \
+    curl \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+# Install docker CLI
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli
+
+COPY /tests/requirements.txt /tests/
+RUN pip3 install -r /tests/requirements.txt
+
+COPY /tests/commons/ /tests/commons/
+RUN pip3 install /tests/commons/
+
+COPY /tests/test_* /tests/
+COPY /tests/conftest.py /tests/conftest.py
+
+# TODO: tagging for containers built on PRs
+ARG SINSP_TAG=latest
+ENV SINSP_TAG=${SINSP_TAG}
+
+ENTRYPOINT [ "pytest", "--html=/report/report.html" ]

--- a/test/e2e/tests/commons/setup.py
+++ b/test/e2e/tests/commons/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup, find_packages
+
+print(find_packages())
+
+setup(name="sinspqa", packages=find_packages())

--- a/test/e2e/tests/commons/sinspqa/__init__.py
+++ b/test/e2e/tests/commons/sinspqa/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+LOGS_PATH = '/logs'
+SINSP_LOG_PATH = os.path.join(LOGS_PATH, 'sinsp.log')

--- a/test/e2e/tests/commons/sinspqa/docker.py
+++ b/test/e2e/tests/commons/sinspqa/docker.py
@@ -1,0 +1,24 @@
+from docker.models.containers import Container
+
+
+def get_container_id(container: Container) -> str:
+    """
+    Get the ID of the given container, truncated to 12 characters
+    """
+    return container.id[:12]
+
+
+def get_network_data(container: Container) -> str:
+    """
+    Returns the first exposed port of the given container
+    """
+    container.reload()
+
+    ip = container.attrs['NetworkSettings']['IPAddress']
+    # Try and get a single port number
+    ports = container.attrs['NetworkSettings']['Ports']
+    ports = list(ports.keys())
+
+    port = ports[0].split('/')[0] if len(ports) else None
+
+    return f'{ip}:{port}' if port else ip

--- a/test/e2e/tests/commons/sinspqa/event_generator.py
+++ b/test/e2e/tests/commons/sinspqa/event_generator.py
@@ -1,0 +1,6 @@
+def container_spec(syscall):
+    return {
+        'image': 'falcosecurity/event-generator',
+        'args': ['run', syscall],
+        'privileged': True,
+    }

--- a/test/e2e/tests/commons/sinspqa/event_generator.py
+++ b/test/e2e/tests/commons/sinspqa/event_generator.py
@@ -4,3 +4,7 @@ def container_spec(syscall):
         'args': ['run', syscall],
         'privileged': True,
     }
+
+
+def generate_id(spec: dict) -> str:
+    return spec['args'][1]

--- a/test/e2e/tests/commons/sinspqa/event_generator.py
+++ b/test/e2e/tests/commons/sinspqa/event_generator.py
@@ -1,4 +1,4 @@
-def container_spec(syscall):
+def container_spec(syscall: str) -> dict:
     return {
         'image': 'falcosecurity/event-generator',
         'args': ['run', syscall],

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -152,18 +152,21 @@ def validate_event(expected_fields: dict, event: dict) -> bool:
     return True
 
 
-def assert_events(expected_events: dict, container: docker.models.containers.Container):
+def assert_events(expected_events: dict,
+                  container: docker.models.containers.Container,
+                  timeout: int = 10):
     """
-    Takes a list of dictionionaries describing the events we want to receive
+    Takes a list of dictionaries describing the events we want to receive
     from a sinsp-example container and the reads events from the provided
     container handle until either all events are found or a timeout occurs.
 
     Parameters:
         expected_fields (dict): A dictionary holding the values expected in the event.
         container (docker.Container): A container object to stream logs from.
+        timeout (int): The seconds to wait for the events to be asserted
     """
 
-    reader = SinspStreamer(container)
+    reader = SinspStreamer(container, timeout=timeout)
 
     for event in expected_events:
         success = False

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -1,0 +1,218 @@
+from datetime import datetime
+from time import sleep
+import os
+import json
+import docker
+import re
+from enum import Enum
+
+SINSP_TAG = os.environ.get('SINSP_TAG', 'latest')
+
+
+class SinspStreamer:
+    """
+    Allows streaming of `sinsp-example` logs for analysis.
+    """
+
+    def __init__(self, container, timeout=10):
+        """
+        Parameters:
+            container (docker.Container): A container object to stream logs from.
+            timeout (int): The maximum amount of time the streamer will read logs from the container.
+        """
+        self.container = container
+        self.timeout = timeout
+        self.last_timestamp = None
+
+    def read(self):
+        """
+        Reads logs from a container and returns them as a generator.
+
+        Returns:
+            A string holding a single log line from the container.
+        """
+        start = datetime.now()
+
+        while True:
+            sleep(0.2)
+
+            for raw_log in self.container.logs(stream=True,
+                                               follow=False,
+                                               timestamps=True,
+                                               since=self.last_timestamp):
+                self.last_timestamp, log = self.extract_log(raw_log)
+                yield log
+
+            if (datetime.now() - start).total_seconds() > self.timeout:
+                break
+
+    def extract_log(self, raw_log):
+        """
+        Split the docker log timestamp from the log line and return them
+
+        Parameters:
+            raw_log (binary): The log line as extracted from the logs call.
+
+        Returns:
+            A tuple holding a datetime object with the timestamp and a string with the log line.
+        """
+        decoded_log = raw_log.decode("ascii").strip()
+        split_log = decoded_log.split(" ")
+        return datetime.strptime(split_log[0][:-4], "%Y-%m-%dT%H:%M:%S.%f"), " ".join(split_log[1:])
+
+
+class SinspFieldTypes(Enum):
+    STRING = 0
+    REGEX = 1
+
+
+class SinspField:
+    """
+    Stores the value expected in a field output by sinsp-example.
+    """
+    def __init__(self, value, value_type=SinspFieldTypes.STRING):
+        self.value_type = value_type
+
+        if self.value_type == SinspFieldTypes.REGEX:
+            self.value = re.compile(value)
+        else:
+            self.value = value
+
+    def compare(self, other: str) -> bool:
+        if self.value_type == SinspFieldTypes.REGEX:
+            return self.value.match(other)
+
+        return self.value == other
+
+    def __repr__(self):
+        if self.value_type == SinspFieldTypes.REGEX:
+            return f"r'{self.value.pattern}'"
+        else:
+            return self.value
+
+    def numeric_field():
+        return SinspField(r'^\d+$', SinspFieldTypes.REGEX)
+
+    def regex_field(regex: str):
+        return SinspField(regex, SinspFieldTypes.REGEX)
+
+
+def parse_log(log):
+    """
+    Parses a log line from the `sinsp-example` binary.
+
+    Parameters:
+        log (str): A string holding a single log line from `sinsp-example``
+
+    Returns:
+        A dictionary holding all the captured values for the event.
+    """
+    return json.loads(log)
+
+
+def validate_event(expected_fields, event):
+    """
+    Checks all `expected_fields` are in the `event`
+
+    Parameters:
+        expected_fields (dict): A dictionary holding the values expected in the event.
+        event (dict): A sinsp event parsed by calling `parse_log`
+
+    Returns:
+        True if all `expected_fields` are in the event and have matching values, False otherwise.
+    """
+    for k in expected_fields:
+        if k not in event:
+            return False
+
+        expected = expected_fields[k]
+
+        if isinstance(expected, str) or expected is None:
+            if expected == event[k]:
+                continue
+            return False
+
+        if not expected.compare(str(event[k])):
+            return False
+
+    return True
+
+
+def assert_events(expected_events, container):
+    """
+    Takes a list of dictionionaries describing the events we want to receive
+    from a sinsp-example container and the reads events from the provided
+    container handle until either all events are found or a timeout occurs.
+
+    Parameters:
+        expected_fields (dict): A dictionary holding the values expected in the event.
+        container (docker.Container): A container object to stream logs from.
+    """
+
+    reader = SinspStreamer(container)
+
+    for event in expected_events:
+        success = False
+
+        for log in reader.read():
+            if not log:
+                continue
+
+            if validate_event(event, parse_log(log)):
+                success = True
+                break
+        assert success, f"Did not receive expected event: {event}"
+
+
+def is_ebpf():
+    """
+    Checks if the tests are being run with eBPF.
+
+    Returns:
+        True if the test is running with the eBPF driver, False otherwise.
+    """
+    return "BPF_PROBE" in os.environ
+
+
+def sinsp_validation(container: docker.models.containers.Container) -> (bool, str):
+    """
+    Checks a container exited correctly
+    """
+    container.reload()
+    exit_code = container.attrs['State']['ExitCode']
+    if exit_code != 0:
+        return False, f'container exited with code {exit_code}'
+
+    return True, None
+
+
+def container_spec(image=f'sinsp-example:latest', args=[]):
+    """
+    Generates a dictionary describing how to run the sinsp-example container
+
+    Parameters:
+        image (str): The name of the image used for running
+        args (list): A list of arguments to supply into the container
+    Returns:
+        A dictionary describing how to run the sinsp-example container
+    """
+    mounts = [
+        docker.types.Mount("/dev", "/dev", type="bind",
+                           consistency="delegated", read_only=True)
+    ]
+    environment = {}
+
+    if is_ebpf():
+        environment["BPF_PROBE"] = os.environ.get("BPF_PROBE")
+    else:
+        environment["KERNEL_MODULE"] = os.environ.get("KERNEL_MODULE")
+
+    return {
+        'image': image,
+        'args': args,
+        'mounts': mounts,
+        'env': environment,
+        'privileged': True,
+        'init_wait': 2,
+        'post_validation': sinsp_validation,
+    }

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -225,11 +225,16 @@ def generate_specs(image: str = 'sinsp-example:latest', args: list = []) -> list
         A dictionary describing how to run the sinsp-example container
     """
     specs = []
+    bpf_args = args.copy()
+    bpf_args.extend([
+        '-e', 'bpf',
+        '-b', os.environ.get('BPF_PROBE'),
+    ])
 
     specs.append(container_spec(
         image, args, {'KERNEL_MODULE': os.environ.get('KERNEL_MODULE')}))
     specs.append(container_spec(
-        image, args, {'BPF_PROBE': os.environ.get('BPF_PROBE')}))
+        image, bpf_args, {'BPF_PROBE': os.environ.get('BPF_PROBE')}))
 
     return specs
 

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -14,7 +14,7 @@ class SinspStreamer:
     Allows streaming of `sinsp-example` logs for analysis.
     """
 
-    def __init__(self, container, timeout=10):
+    def __init__(self, container: docker.models.containers.Container, timeout: int = 10):
         """
         Parameters:
             container (docker.Container): A container object to stream logs from.
@@ -46,7 +46,7 @@ class SinspStreamer:
             if (datetime.now() - start).total_seconds() > self.timeout:
                 break
 
-    def extract_log(self, raw_log):
+    def extract_log(self, raw_log: str):
         """
         Split the docker log timestamp from the log line and return them
 
@@ -103,7 +103,7 @@ class SinspField:
         return SinspField(regex, SinspFieldTypes.REGEX)
 
 
-def parse_log(log):
+def parse_log(log: str) -> dict:
     """
     Parses a log line from the `sinsp-example` binary.
 
@@ -121,7 +121,7 @@ def parse_log(log):
         return None
 
 
-def validate_event(expected_fields, event):
+def validate_event(expected_fields: dict, event: dict) -> bool:
     """
     Checks all `expected_fields` are in the `event`
 
@@ -152,7 +152,7 @@ def validate_event(expected_fields, event):
     return True
 
 
-def assert_events(expected_events, container):
+def assert_events(expected_events: dict, container: docker.models.containers.Container):
     """
     Takes a list of dictionionaries describing the events we want to receive
     from a sinsp-example container and the reads events from the provided
@@ -188,7 +188,7 @@ def sinsp_validation(container: docker.models.containers.Container) -> (bool, st
     assert exit_code == 0, f'container exited with code {exit_code}'
 
 
-def container_spec(image='sinsp-example:latest', args=[], env={}):
+def container_spec(image: str = 'sinsp-example:latest', args: list = [], env: dict = {}) -> dict:
     """
     Generates a dictionary describing how to run the sinsp-example container
 

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -83,7 +83,10 @@ def run_containers(request, docker_client: docker.client.DockerClient):
             'signal': stop_signal
         }
 
-        wait_container_running(handle, additional_wait)
+        try:
+            wait_container_running(handle, additional_wait)
+        except TimeoutError as e:
+            print(f'{name} failed to start, the test will fail')
 
     yield containers
 

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -1,0 +1,148 @@
+import pytest
+import subprocess
+import docker
+import os
+from time import sleep
+from sinspqa import SINSP_LOG_PATH, LOGS_PATH
+from sinspqa.sinsp import is_ebpf
+
+
+@pytest.fixture(scope="session", autouse=True)
+def docker_client():
+    """
+    Create a docker client to be used by the tests.
+
+    Returns:
+        A docker.DockerClient object created from the environment the tests run on.
+    """
+    return docker.from_env()
+
+
+@pytest.fixture(scope="module")
+def tester_id(docker_client):
+    """
+    Get the truncated ID of the test runner.
+
+    Returns:
+        A 12 character string with the ID.
+    """
+    return docker_client.containers.get("falco-e2e-tester").id[:12]
+
+
+def wait_container_running(container: docker.models.containers.Container, additional_wait):
+    retries = 6
+    container.reload()
+
+    while container.status != 'running':
+        retries -= 1
+        if retries == 0:
+            raise TimeoutError
+
+        sleep(0.5)
+        container.reload()
+
+    if additional_wait:
+        sleep(additional_wait)
+
+
+@pytest.fixture(scope="function")
+def run_containers(request, docker_client):
+    """
+    Runs containers, dumps their logs and cleans'em up
+    """
+    containers = {}
+    post = {}
+
+    for name, container in request.param.items():
+        image = container['image']
+        args = container.get('args', '')
+        privileged = container.get('privileged', False)
+        mounts = container.get('mounts', [])
+        environment = container.get('env', {})
+        additional_wait = container.get('init_wait', 0)
+        post_validation = container.get('post_validation', None)
+        stop_signal = container.get('signal', None)
+
+        handle = docker_client.containers.run(
+            image,
+            args,
+            name=name,
+            detach=True,
+            privileged=privileged,
+            mounts=mounts,
+            environment=environment
+        )
+
+        containers[name] = handle
+        post[name] = {
+            'validation': post_validation,
+            'signal': stop_signal
+        }
+
+        wait_container_running(handle, additional_wait)
+
+    yield containers
+
+    success = True
+    errors = []
+
+    for name, container in containers.items():
+        validation = post[name]['validation']
+        stop_signal = post[name]['signal']
+
+        if stop_signal:
+            container.kill(stop_signal)
+
+        # The stop command is issued regardless of the kill command to ensure
+        # the container stops
+        container.stop()
+
+        logs = container.logs().decode('ascii')
+        if logs:
+            with open(os.path.join(LOGS_PATH, f'{name}.log'), 'w') as f:
+                f.write(logs)
+
+        if validation:
+            res, msg = validation(container)
+            if not res:
+                errors.append(f'{name}: {msg}')
+                success = False
+
+        container.remove()
+
+    assert success, '\n'.join(errors)
+
+
+def pytest_html_report_title(report):
+    report.title = "sinsp e2e tests"
+
+
+def dump_logs(pytest_html, extra):
+    """
+    Finds all logs dumped to LOGS_PATH and makes them available through the
+    auto-generated report
+    """
+    for file in os.listdir(LOGS_PATH):
+        full_path = os.path.join(LOGS_PATH, file)
+        if not os.path.isfile(full_path):
+            continue
+
+        with open(full_path, 'r', errors='replace') as f:
+            logs = f.read()
+            extra.append(pytest_html.extras.text(logs, name=file))
+
+        # Remove file so it doesn't bleed to following tests
+        os.remove(full_path)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    pytest_html = item.config.pluginmanager.getplugin("html")
+    outcome = yield
+    report = outcome.get_result()
+    extra = getattr(report, "extra", [])
+
+    if report.when == "teardown":
+        dump_logs(pytest_html, extra)
+
+    report.extra = extra

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -18,7 +18,7 @@ def docker_client():
 
 
 @pytest.fixture(scope="module")
-def tester_id(docker_client):
+def tester_id(docker_client: docker.client.DockerClient):
     """
     Get the truncated ID of the test runner.
 
@@ -30,7 +30,7 @@ def tester_id(docker_client):
     return get_container_id(tester_container)
 
 
-def wait_container_running(container: docker.models.containers.Container, additional_wait=0, retries=5):
+def wait_container_running(container: docker.models.containers.Container, additional_wait: int = 0, retries: int = 5):
     success = False
 
     for _ in range(retries):
@@ -50,7 +50,7 @@ def wait_container_running(container: docker.models.containers.Container, additi
 
 
 @pytest.fixture(scope="function")
-def run_containers(request, docker_client):
+def run_containers(request, docker_client: docker.client.DockerClient):
     """
     Runs containers, dumps their logs and cleans'em up
     """

--- a/test/e2e/tests/requirements.txt
+++ b/test/e2e/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==7.1.1
+pytest-html==3.1.1
+docker==5.0.3

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -1,0 +1,61 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+from sinspqa.docker import get_container_id
+
+sinsp_filters = ["-f", "evt.category=process and not container.id=host"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.DbProgramSpawnedProcess')
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_db_program_spawned_process(run_containers):
+    sinsp_container = run_containers['sinsp']
+    generator_container = run_containers['generator']
+
+    generator_id = get_container_id(generator_container)
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "container.id": generator_id,
+            "evt.args": "filename=/bin/ls ",
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "execve",
+            "proc.cmdline": "mysqld --loglevel info run ^helper.ExecLs$",
+            "proc.exe": SinspField.regex_field(r"/tmp/falco-event-generator\d+/mysqld"),
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(r'^res=\d+ exe=/tmp/falco-event-generator\d+/mysqld args=--loglevel\.info\.run\.\^helper.ExecLs\$\. tid=\d+\(mysqld\) pid=\d+\(mysqld\) ptid=\d+\(event-generator\) .* flags=\d+\([|A-Z_]+\) uid=0 gid=0 vtid=\d+ vpid=\d+ $'),
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "clone",
+            "proc.cmdline": "mysqld --loglevel info run ^helper.ExecLs$",
+            "proc.exe": SinspField.regex_field(r'/tmp/falco-event-generator\d+/mysqld'),
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(r'^res=0 exe=/bin/ls args= tid=\d+\(ls\) pid=\d+\(ls\) ptid=\d+\(mysqld\) .* tty=0 pgid=1\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "execve",
+            "proc.cmdline": "ls",
+            "proc.exe": "/bin/ls",
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        }
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -5,13 +5,20 @@ from sinspqa.docker import get_container_id
 
 sinsp_filters = ["-f", "evt.category=process and not container.id=host"]
 
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
-    'generator': event_generator.container_spec('syscall.DbProgramSpawnedProcess')
-}]
+containers = [
+    {
+        'sinsp': sinsp_container,
+        'generator': event_generator.container_spec('syscall.DbProgramSpawnedProcess')
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_db_program_spawned_process(run_containers):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -53,7 +53,7 @@ def test_db_program_spawned_process(run_containers: dict):
         },
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=/bin/ls args= tid=\d+\(ls\) pid=\d+\(ls\) ptid=\d+\(mysqld\) .* tty=0 pgid=1\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=/bin/ls args=NULL tid=\d+\(ls\) pid=\d+\(ls\) ptid=\d+\(mysqld\) .* tty=0 pgid=1\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -19,7 +19,7 @@ ids = [
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_db_program_spawned_process(run_containers):
+def test_db_program_spawned_process(run_containers: dict):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']
 

--- a/test/e2e/tests/test_event_generator/test_file_writes.py
+++ b/test/e2e/tests/test_event_generator/test_file_writes.py
@@ -1,0 +1,46 @@
+import pytest
+import re
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+
+
+def create_containers(sinsp_filter, syscall):
+    return {
+        'sinsp': sinsp.container_spec(args=sinsp_filter),
+        'generator': event_generator.container_spec(syscall),
+    }
+
+
+def create_expected_arg(directory):
+    return fr'^fd=3\(<f>{re.escape(directory)}\/created-by-event-generator\) dirfd=-100\(AT_FDCWD\) name={re.escape(directory)}\/created-by-event-generator flags=4358\(O_TRUNC\|O_CREAT\|O_WRONLY\|O_CLOEXEC\) mode=0755 dev=.* ino=\d+ $'
+
+
+sinsp_filters = ["-f", "evt.is_open_write=true and fd.typechar='f' and fd.num>=0"]
+parameters = [
+    (create_containers(sinsp_filters, 'syscall.WriteBelowEtc'), create_expected_arg('/etc')),
+    (create_containers(sinsp_filters, 'syscall.WriteBelowBinaryDir'), create_expected_arg('/bin')),
+    (create_containers(sinsp_filters, 'syscall.CreateFilesBelowDev'), create_expected_arg('/dev')),
+    (create_containers(sinsp_filters, 'syscall.WriteBelowRpmDatabase'), create_expected_arg('/var/lib/rpm')),
+]
+
+
+@pytest.mark.parametrize('run_containers,expected_arg', parameters, indirect=['run_containers'])
+def test_file_writes(run_containers, expected_arg):
+    sinsp_container = run_containers['sinsp']
+    generator_container = run_containers['generator']
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "evt.args": SinspField.regex_field(expected_arg),
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": SinspField.regex_field(r'^(?:open|openat|openat2)$'),
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        }
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_file_writes.py
+++ b/test/e2e/tests/test_event_generator/test_file_writes.py
@@ -4,7 +4,7 @@ from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events, SinspField
 
 
-def create_expected_arg(directory):
+def create_expected_arg(directory: str) -> str:
     return fr'^fd=3\(<f>{re.escape(directory)}\/created-by-event-generator\) dirfd=-100\(AT_FDCWD\) name={re.escape(directory)}\/created-by-event-generator flags=4358\(O_TRUNC\|O_CREAT\|O_WRONLY\|O_CLOEXEC\) mode=0755 dev=.* ino=\d+ $'
 
 
@@ -52,7 +52,7 @@ parameters = [
 
 
 @pytest.mark.parametrize('run_containers,expected_arg', parameters, indirect=['run_containers'], ids=generate_ids(parameters))
-def test_file_writes(run_containers, expected_arg):
+def test_file_writes(run_containers: dict, expected_arg: str):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']
     generator_container.wait()

--- a/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
@@ -1,0 +1,81 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+
+sinsp_filters = ["-f", "proc.name = event-generator"]
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.MkdirBinaryDirs'),
+}]
+
+
+@pytest.mark.parametrize('run_containers', containers, indirect=True)
+def test_make_binary_dirs(run_containers):
+    sinsp_container = run_containers['sinsp']
+    generator_container = run_containers['generator']
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "evt.args": "",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": ">",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "mkdirat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "res=0 dirfd=-100(AT_FDCWD) path=/bin/directory-created-by-event-generator mode=1ED ",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "mkdirat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": ">",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "unlinkat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "res=-21(EISDIR) dirfd=-100(AT_FDCWD) name=/bin/directory-created-by-event-generator flags=0 ",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "unlinkat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": ">",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "unlinkat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "res=0 dirfd=-100(AT_FDCWD) name=/bin/directory-created-by-event-generator flags=512(AT_REMOVEDIR) ",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "unlinkat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
@@ -3,13 +3,20 @@ from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events, SinspField
 
 sinsp_filters = ["-f", "proc.name = event-generator"]
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
-    'generator': event_generator.container_spec('syscall.MkdirBinaryDirs'),
-}]
+containers = [
+    {
+        'sinsp': sinsp_container,
+        'generator': event_generator.container_spec('syscall.MkdirBinaryDirs'),
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize('run_containers', containers, indirect=True)
+@pytest.mark.parametrize('run_containers', containers, indirect=True, ids=ids)
 def test_make_binary_dirs(run_containers):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
@@ -17,7 +17,7 @@ ids = [
 
 
 @pytest.mark.parametrize('run_containers', containers, indirect=True, ids=ids)
-def test_make_binary_dirs(run_containers):
+def test_make_binary_dirs(run_containers: dict):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']
     generator_container.wait()

--- a/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
@@ -1,0 +1,61 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+
+sinsp_filters = ["-f", "proc.name = event-generator"]
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.ModifyBinaryDirs'),
+}]
+
+
+@pytest.mark.parametrize('run_containers', containers, indirect=True)
+def test_modify_binary_dirs(run_containers):
+    sinsp_container = run_containers['sinsp']
+    generator_container = run_containers['generator']
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "evt.args": "",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": ">",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "renameat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "res=0 olddirfd=-100(AT_FDCWD) oldpath=/bin/true newdirfd=-100(AT_FDCWD) newpath=/bin/true.event-generator ",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "renameat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": ">",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "renameat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+        {
+            "evt.args": "res=0 olddirfd=-100(AT_FDCWD) oldpath=/bin/true.event-generator newdirfd=-100(AT_FDCWD) newpath=/bin/true ",
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "renameat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        },
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
@@ -3,13 +3,20 @@ from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events, SinspField
 
 sinsp_filters = ["-f", "proc.name = event-generator"]
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
-    'generator': event_generator.container_spec('syscall.ModifyBinaryDirs'),
-}]
+containers = [
+    {
+        'sinsp': sinsp_container,
+        'generator': event_generator.container_spec('syscall.ModifyBinaryDirs'),
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize('run_containers', containers, indirect=True)
+@pytest.mark.parametrize('run_containers', containers, indirect=True, ids=ids)
 def test_modify_binary_dirs(run_containers):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
@@ -17,7 +17,7 @@ ids = [
 
 
 @pytest.mark.parametrize('run_containers', containers, indirect=True, ids=ids)
-def test_modify_binary_dirs(run_containers):
+def test_modify_binary_dirs(run_containers: dict):
     sinsp_container = run_containers['sinsp']
     generator_container = run_containers['generator']
     generator_container.wait()

--- a/test/e2e/tests/test_event_generator/test_network_activity.py
+++ b/test/e2e/tests/test_event_generator/test_network_activity.py
@@ -1,0 +1,52 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+from sinspqa.docker import get_container_id
+
+sinsp_filters = ["-f", "evt.category=net and not container.id=host"]
+ipv4_regex = r'\d+\.\d+\.\d+\.\d+:\d+'
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.SystemProcsNetworkActivity')
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_network_activity(run_containers):
+    sinsp_container = run_containers['sinsp']
+
+    generator_container = run_containers['generator']
+    generator_id = get_container_id(generator_container)
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "container.id": generator_id,
+            "evt.args": "fd=3(<4>) addr=10.2.3.4:8192 ",
+            "evt.category": "net",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "connect",
+            "fd.name": "",
+            "proc.cmdline": "sha1sum --loglevel info run ^helper.NetworkActivity$",
+            "proc.exe": SinspField.regex_field(r'^/tmp/falco-event-generator\d+/sha1sum$'),
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(fr'^res=0 tuple={ipv4_regex}->10\.2\.3\.4:8192 $'),
+            "evt.category": "net",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "connect",
+            "fd.name": SinspField.regex_field(fr'^{ipv4_regex}->10\.2\.3\.4:8192$'),
+            "proc.cmdline": "sha1sum --loglevel info run ^helper.NetworkActivity$",
+            "proc.exe": SinspField.regex_field(r'^/tmp/falco-event-generator\d+/sha1sum$'),
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_network_activity.py
+++ b/test/e2e/tests/test_event_generator/test_network_activity.py
@@ -20,7 +20,7 @@ ids = [
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_network_activity(run_containers):
+def test_network_activity(run_containers: dict):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
+++ b/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
@@ -1,0 +1,47 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events
+
+sinsp_filters = ["-f", "evt.type=setuid"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.NonSudoSetuid'),
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_non_sudo_setuid(run_containers):
+    sinsp_container = run_containers['sinsp']
+
+    generator_container = run_containers['generator']
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "evt.args": "uid=2(<NA>) ",
+            "evt.dir": ">",
+            "evt.type": "setuid",
+            "proc.name": "child",
+        },
+        {
+            "evt.args": "res=0 ",
+            "evt.dir": "<",
+            "evt.type": "setuid",
+            "proc.name": "child",
+        },
+        {
+            "evt.args": "uid=0(<NA>) ",
+            "evt.dir": ">",
+            "evt.type": "setuid",
+            "proc.name": "child",
+        },
+        {
+            "evt.args": "res=-1(EPERM) ",
+            "evt.dir": "<",
+            "evt.type": "setuid",
+            "proc.name": "child",
+        },
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
+++ b/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
@@ -4,13 +4,20 @@ from sinspqa.sinsp import assert_events
 
 sinsp_filters = ["-f", "evt.type=setuid"]
 
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
-    'generator': event_generator.container_spec('syscall.NonSudoSetuid'),
-}]
+containers = [
+    {
+        'sinsp': sinsp_container,
+        'generator': event_generator.container_spec('syscall.NonSudoSetuid'),
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_non_sudo_setuid(run_containers):
     sinsp_container = run_containers['sinsp']
 

--- a/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
+++ b/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
@@ -1,0 +1,40 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+
+
+def create_containers(sinsp_filter, syscall):
+    return {
+        'sinsp': sinsp.container_spec(args=sinsp_filter),
+        'generator': event_generator.container_spec('syscall.ReadSensitiveFileUntrusted')
+    }
+
+
+sinsp_filters = ["-f", "evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0"]
+containers = [
+    create_containers(sinsp_filters, 'syscall.ReadSensitiveFileUntrusted'),
+    create_containers(sinsp_filters, 'syscall.ReadSensitiveFileTrustedAfterStartup'),
+]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_read_sensitive_file(run_containers):
+    sinsp_container = run_containers['sinsp']
+
+    generator_container = run_containers['generator']
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "evt.args": SinspField.regex_field(r'fd=3\(<f>/etc/shadow\) dirfd=-100\(AT_FDCWD\) name=/etc/shadow flags=4097\(O_RDONLY|O_CLOEXEC\) mode=0 dev=\W+ ino=\d+ '),
+            "evt.cpu": SinspField.numeric_field(),
+            "evt.dir": "<",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "openat",
+            "proc.name": "event-generator",
+            "thread.tid": SinspField.numeric_field()
+        }
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
+++ b/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
@@ -2,23 +2,49 @@ import pytest
 from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events, SinspField
 
+generator_containers = [
+    event_generator.container_spec(syscall)
+    for syscall in [
+            'syscall.ReadSensitiveFileUntrusted',
+            'syscall.ReadSensitiveFileTrustedAfterStartup'
+        ]
+]
+expected_processes = [
+    'event-generator',
+    'httpd'
+]
+generator_tuples = zip(generator_containers, expected_processes)
 
-def create_containers(sinsp_filter, syscall):
-    return {
-        'sinsp': sinsp.container_spec(args=sinsp_filter),
-        'generator': event_generator.container_spec('syscall.ReadSensitiveFileUntrusted')
-    }
-
-
-sinsp_filters = ["-f", "evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0"]
-containers = [
-    create_containers(sinsp_filters, 'syscall.ReadSensitiveFileUntrusted'),
-    create_containers(sinsp_filters, 'syscall.ReadSensitiveFileTrustedAfterStartup'),
+sinsp_filters = [
+    "-f", "evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0"]
+parameters = [
+    (
+        {
+            'sinsp': sinsp_container,
+            'generator': generator_container,
+        },
+        expected_process
+    )
+    for (generator_container, expected_process) in generator_tuples
+    for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
 ]
 
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
-def test_read_sensitive_file(run_containers):
+def generate_ids(parameters: list) -> list:
+    ret = []
+
+    for parameter in parameters:
+        containers = parameter[0]
+        sinsp_id = sinsp.generate_id(containers['sinsp'])
+        generator_id = event_generator.generate_id(containers['generator'])
+
+        ret.append(f'{sinsp_id}-{generator_id}')
+
+    return ret
+
+
+@pytest.mark.parametrize("run_containers,expected_process", parameters, indirect=['run_containers'], ids=generate_ids(parameters))
+def test_read_sensitive_file(run_containers, expected_process):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']
@@ -32,7 +58,7 @@ def test_read_sensitive_file(run_containers):
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "openat",
-            "proc.name": "event-generator",
+            "proc.name": expected_process,
             "thread.tid": SinspField.numeric_field()
         }
     ]

--- a/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
+++ b/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
@@ -44,7 +44,7 @@ def generate_ids(parameters: list) -> list:
 
 
 @pytest.mark.parametrize("run_containers,expected_process", parameters, indirect=['run_containers'], ids=generate_ids(parameters))
-def test_read_sensitive_file(run_containers, expected_process):
+def test_read_sensitive_file(run_containers: dict, expected_process: str):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -1,0 +1,49 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+from sinspqa.docker import get_container_id
+
+sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.RunShellUntrusted')
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_run_shell_untrusted(run_containers):
+    sinsp_container = run_containers['sinsp']
+
+    generator_container = run_containers['generator']
+    generator_id = get_container_id(generator_container)
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(r'^res=0 exe=\/tmp\/falco-event-generator\d+\/httpd args=--loglevel.info.run.\^helper.RunShell\$. tid=\d+\(httpd\) pid=\d+\(httpd\) ptid=\d+\(event-generator\) .* tty=0 pgid=\d+\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "execve",
+            "proc.cmdline": "httpd --loglevel info run ^helper.RunShell$",
+            "proc.exe": SinspField.regex_field(r'^\/tmp\/falco-event-generator\d+\/httpd$'),
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(r'^res=0 exe=bash args=-c.ls > \/dev\/null. tid=\d+\(bash\) pid=\d+\(bash\) ptid=\d+\(httpd\) .* tty=0 pgid=\d+\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "execve",
+            "proc.cmdline": "bash -c ls > /dev/null",
+            "proc.exe": "bash",
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        },
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -17,7 +17,7 @@ ids = [
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_run_shell_untrusted(run_containers):
+def test_run_shell_untrusted(run_containers: dict):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -6,12 +6,17 @@ from sinspqa.docker import get_container_id
 sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
 
 containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'sinsp': sinsp_container,
     'generator': event_generator.container_spec('syscall.RunShellUntrusted')
-}]
+} for sinsp_container in sinsp.generate_specs(args=sinsp_filters)]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_run_shell_untrusted(run_containers):
     sinsp_container = run_containers['sinsp']
 

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -1,0 +1,37 @@
+import pytest
+from sinspqa import sinsp, event_generator
+from sinspqa.sinsp import assert_events, SinspField
+from sinspqa.docker import get_container_id
+
+sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'generator': event_generator.container_spec('syscall.SystemUserInteractive')
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_run_shell_untrusted(run_containers):
+    sinsp_container = run_containers['sinsp']
+
+    generator_container = run_containers['generator']
+    generator_id = get_container_id(generator_container)
+    generator_container.wait()
+
+    expected_events = [
+        {
+            "container.id": generator_id,
+            "evt.args": SinspField.regex_field(r'^res=0 exe=\/bin\/login args= tid=\d+\(login\) pid=\d+\(login\) ptid=\d+\(event-generator\) .* pgid=\d+\(sinsp-example\) loginuid=-1 flags=0 cap_inheritable=0 cap_permitted=0 cap_effective=0 $'),
+            "evt.category": "process",
+            "evt.num": SinspField.numeric_field(),
+            "evt.time": SinspField.numeric_field(),
+            "evt.type": "execve",
+            "proc.cmdline": "login",
+            "proc.exe": "/bin/login",
+            "proc.pid": SinspField.numeric_field(),
+            "proc.ppid": SinspField.numeric_field()
+        }
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -6,13 +6,18 @@ from sinspqa.docker import get_container_id
 sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
 
 containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'sinsp': sinsp_container,
     'generator': event_generator.container_spec('syscall.SystemUserInteractive')
-}]
+} for sinsp_container in sinsp.generate_specs(args=sinsp_filters)]
+
+ids = [
+    f'{sinsp.generate_id(c["sinsp"])}-{event_generator.generate_id(c["generator"])}'
+    for c in containers
+]
 
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
-def test_run_shell_untrusted(run_containers):
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
+def test_system_user_interactive(run_containers):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -27,7 +27,7 @@ def test_system_user_interactive(run_containers: dict):
     expected_events = [
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=\/bin\/login args= tid=\d+\(login\) pid=\d+\(login\) ptid=\d+\(event-generator\) .* pgid=\d+\(sinsp-example\) loginuid=-1 flags=0 cap_inheritable=0 cap_permitted=0 cap_effective=0 $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=\/bin\/login args=NULL tid=\d+\(login\) pid=\d+\(login\) ptid=\d+\(event-generator\) .* pgid=\d+\(sinsp-example\) loginuid=-1 flags=0 cap_inheritable=0 cap_permitted=0 cap_effective=0 $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -17,7 +17,7 @@ ids = [
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_system_user_interactive(run_containers):
+def test_system_user_interactive(run_containers: dict):
     sinsp_container = run_containers['sinsp']
 
     generator_container = run_containers['generator']

--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -1,0 +1,107 @@
+import pytest
+from sinspqa import sinsp
+from sinspqa.sinsp import assert_events
+from sinspqa.docker import get_container_id, get_network_data
+
+sinsp_filters = ["-f", "evt.category=net and not container.id=host"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'nginx': {
+        'image': 'nginx:1.14-alpine',
+    },
+    'curl': {
+        'image': 'pstauffer/curl:latest',
+        'args': ["sleep", "300"]
+    }
+}]
+
+
+def expected_events(origin: dict, destination: dict) -> list:
+    return [
+        {
+            "container.id": origin['id'],
+            "evt.args": "domain=2 type=1 proto=0 ",
+            "evt.category": "net",
+            "evt.type": "socket",
+            "fd.name": None,
+            "proc.cmdline": f"curl --local-port {origin['local_port']} {destination['ip']}",
+            "proc.exe": "curl",
+        }, {
+            "container.id": origin['id'],
+            "evt.args": "fd=3(<4>) ",
+            "evt.category": "net",
+            "evt.type": "socket",
+            "fd.name": "",
+            "proc.cmdline": f"curl --local-port {origin['local_port']} {destination['ip']}",
+            "proc.exe": "curl",
+        }, {
+            "container.id": origin['id'],
+            "evt.args": f"fd=3(<4t>0.0.0.0:{origin['local_port']}) addr={destination['ip']} ",
+            "evt.category": "net",
+            "evt.type": "connect",
+            "fd.name": f"0.0.0.0:{origin['local_port']}",
+            "proc.cmdline": f"curl --local-port {origin['local_port']} {destination['ip']}",
+            "proc.exe": "curl",
+        }, {
+            "container.id": destination['id'],
+            "evt.args": "flags=0 ",
+            "evt.category": "net",
+            "evt.type": "accept",
+            "fd.name": None,
+            "proc.cmdline": "nginx",
+            "proc.exe": "nginx: master proces",
+        }, {
+            "container.id": destination['id'],
+            "evt.args": f"fd=3(<4t>{origin['ip']}->{destination['ip']}) tuple={origin['ip']}->{destination['ip']} queuepct=0 queuelen=0 queuemax=511 ",
+            "evt.category": "net",
+            "evt.type": "accept",
+            "fd.name": f"{origin['ip']}->{destination['ip']}",
+            "proc.cmdline": "nginx",
+            "proc.exe": "nginx: master proces",
+        }, {
+            "evt.args": f"fd=3(<4t>{origin['ip']}->{destination['ip']}) ",
+            "evt.dir": ">",
+            "evt.type": "close",
+            "proc.name": "curl",
+        }, {
+            "evt.args": "res=0 ",
+            "evt.dir": "<",
+            "evt.type": "close",
+            "proc.name": "curl",
+        }, {
+            "evt.args": f"fd=3(<4t>{origin['ip']}->{destination['ip']}) ",
+            "evt.dir": ">",
+            "evt.type": "close",
+            "proc.name": "nginx",
+        }, {
+            "evt.args": "res=0 ",
+            "evt.dir": "<",
+            "evt.type": "close",
+            "proc.name": "nginx",
+        }
+    ]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_curl_nginx(run_containers):
+    # Use a specific local port so validation of events is easier
+    local_port = 40000
+
+    sinsp_container = run_containers['sinsp']
+    nginx_container = run_containers['nginx']
+    curl_container = run_containers['curl']
+
+    destination = {
+        'id': get_container_id(nginx_container),
+        'ip': get_network_data(nginx_container)
+    }
+    origin = {
+        'id': get_container_id(curl_container),
+        'ip': f'{get_network_data(curl_container)}:{local_port}',
+        'local_port': local_port
+    }
+
+    curl_container.exec_run(f'curl --local-port {local_port} {destination["ip"]}')
+
+    assert_events(expected_events(origin, destination), sinsp_container)

--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -88,7 +88,7 @@ def expected_events(origin: dict, destination: dict) -> list:
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_curl_nginx(run_containers):
+def test_curl_nginx(run_containers: dict):
     # Use a specific local port so validation of events is easier
     local_port = 40000
 

--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -5,15 +5,18 @@ from sinspqa.docker import get_container_id
 
 sinsp_filters = ["-f", "evt.category=process and not container.id=host"]
 
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters),
-    'nginx': {
-        'image': 'nginx:1.14-alpine',
-    }
-}]
+containers = [
+    {
+        'sinsp': sinsp_container,
+        'nginx': {
+            'image': 'nginx:1.14-alpine',
+        }
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
 
+ids = [ sinsp.generate_id(c['sinsp']) for c in containers ]
 
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_exec_in_container(run_containers):
     nginx_container = run_containers['nginx']
     sinsp_container = run_containers['sinsp']

--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -1,0 +1,55 @@
+import pytest
+from sinspqa import sinsp
+from sinspqa.sinsp import assert_events
+from sinspqa.docker import get_container_id
+
+sinsp_filters = ["-f", "evt.category=process and not container.id=host"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters),
+    'nginx': {
+        'image': 'nginx:1.14-alpine',
+    }
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_exec_in_container(run_containers):
+    nginx_container = run_containers['nginx']
+    sinsp_container = run_containers['sinsp']
+
+    container_id = get_container_id(nginx_container)
+
+    nginx_container.exec_run("sleep 5")
+    nginx_container.exec_run("sh -c ls")
+
+    expected_events = [
+        {
+            'container.id': container_id,
+            'evt.args': 'filename=/usr/sbin/nginx ',
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'runc',
+            'proc.cmdline': 'runc:[1:CHILD] init',
+        }, {
+            'container.id': container_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'nginx',
+            'proc.cmdline': 'nginx -g daemon off;'
+        }, {
+            'container.id': container_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'sleep',
+            'proc.cmdline': 'sleep 5'
+        }, {
+            'container.id': container_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'sh',
+            'proc.cmdline': 'sh -c ls'
+        }
+    ]
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -17,7 +17,7 @@ containers = [
 ids = [ sinsp.generate_id(c['sinsp']) for c in containers ]
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_exec_in_container(run_containers):
+def test_exec_in_container(run_containers: dict):
     nginx_container = run_containers['nginx']
     sinsp_container = run_containers['sinsp']
 

--- a/test/e2e/tests/test_process/test_process.py
+++ b/test/e2e/tests/test_process/test_process.py
@@ -1,0 +1,43 @@
+import pytest
+import subprocess
+from sinspqa import sinsp
+from sinspqa.sinsp import assert_events
+
+
+sinsp_filters = ["-f", "evt.category=process and evt.type=execve"]
+
+containers = [{
+    'sinsp': sinsp.container_spec(args=sinsp_filters)
+}]
+
+
+@pytest.mark.parametrize("run_containers", containers, indirect=True)
+def test_process(run_containers, tester_id):
+    """
+    Runs a simple test where a bash script is executed and a corresponding sinsp event is found in the provided
+    container's logs
+
+    Parameters:
+        sinsp (docker.Container): A detached container running the `sinsp-example` binary
+    """
+    sinsp_container = run_containers['sinsp']
+
+    expected_events = [
+        {
+            'container.id': tester_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'cat',
+            'proc.cmdline': 'cat /tmp/test.txt'
+        }, {
+            'container.id': tester_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'rm',
+            'proc.cmdline': 'rm -f /tmp/test.txt'
+        }
+    ]
+
+    subprocess.run("./test_sample.sh")
+
+    assert_events(expected_events, sinsp_container)

--- a/test/e2e/tests/test_process/test_process.py
+++ b/test/e2e/tests/test_process/test_process.py
@@ -14,7 +14,7 @@ ids = [ sinsp.generate_id(c['sinsp']) for c in containers ]
 
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
-def test_process(run_containers, tester_id):
+def test_process(run_containers: dict, tester_id: str):
     """
     Runs a simple test where a bash script is executed and a corresponding sinsp event is found in the provided
     container's logs

--- a/test/e2e/tests/test_process/test_process.py
+++ b/test/e2e/tests/test_process/test_process.py
@@ -5,13 +5,15 @@ from sinspqa.sinsp import assert_events
 
 
 sinsp_filters = ["-f", "evt.category=process and evt.type=execve"]
+containers = [
+    {
+        'sinsp': sinsp_container
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+]
+ids = [ sinsp.generate_id(c['sinsp']) for c in containers ]
 
-containers = [{
-    'sinsp': sinsp.container_spec(args=sinsp_filters)
-}]
 
-
-@pytest.mark.parametrize("run_containers", containers, indirect=True)
+@pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_process(run_containers, tester_id):
     """
     Runs a simple test where a bash script is executed and a corresponding sinsp event is found in the provided

--- a/test/e2e/tests/test_process/test_sample.sh
+++ b/test/e2e/tests/test_process/test_sample.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+echo "Some random string" > /tmp/test.txt
+cat /tmp/test.txt
+rm -f /tmp/test.txt

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -24,11 +24,13 @@ limitations under the License.
 #include <functional>
 #include "util.h"
 
+#ifndef WIN32
 extern "C" {
 #include <sys/syscall.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 }
+#endif
 
 using namespace std;
 

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -200,7 +200,7 @@ void open_engine(sinsp& inspector)
 	std::cout << "-- Engine '" + engine_string + "' correctly opened." << std::endl;
 }
 
-#ifndef WIN32
+#ifdef __linux__
 #define insmod(fd, opts, flags) syscall(__NR_finit_module, fd, opts, flags)
 #define rmmod(name, flags) syscall(__NR_delete_module, name, flags)
 
@@ -265,12 +265,14 @@ int main(int argc, char** argv)
 #ifndef WIN32
 	parse_CLI_options(inspector, argc, argv);
 
+#ifdef __linux__
     // Try inserting the kernel module
     bool res = insert_module();
     if (!res)
     {
         return -1;
     }
+#endif
 
     signal(SIGPIPE, sigint_handler);
 #endif

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -214,7 +214,7 @@ static void remove_module()
 
 static bool insert_module()
 {
-	// Check if we are configured to run with the eBPF probe
+	// Check if we are configured to run with the kernel module
 	if(engine_string.compare(KMOD_ENGINE))
 		return true;
 
@@ -241,7 +241,10 @@ static bool insert_module()
 error:
 	cerr << "[ERROR] Failed to insert kernel module: " << strerror(errno) << endl;
 
-	close(fd);
+	if (fd > 0)
+	{
+		close(fd);
+	}
 
 	return false;
 }

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -228,17 +228,25 @@ static bool insert_module()
         return true;
     }
 
+    int res;
     int fd = open(driver_path, O_RDONLY);
     if (fd < 0)
-        return false;
+        goto error;
 
-    int res = insmod(fd, "", 0);
+    res = insmod(fd, "", 0);
     if (res != 0)
-        return false;
+        goto error;
 
     atexit(remove_module);
 
     return true;
+
+error:
+    cerr << "[ERROR] Failed to insert kernel module: " << strerror(errno) << endl;
+
+    close(fd);
+
+    return false;
 }
 #endif
 
@@ -259,7 +267,6 @@ int main(int argc, char** argv)
     bool res = insert_module();
     if (!res)
     {
-        cerr << "[ERROR] Failed to insert kernel module: " << strerror(errno) << endl;
         return -1;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds the e2e tests previously held under [Molter73/falco-libs-qa](https://github.com/Molter73/falco-libs-qa) into the repository.

The way the tests work is by building the `sinsp-example` binary and embedding it into a container. Said container expects the binary to be built in an environment similar to the one used by the CI (so a `debian:buster` image). Then a separate container is built to run the actual tests using pytest and spawning containers using Docker-in-Docker, this approach was chosen as an OK way to limit events to the ones coming from a specific container, which should help diminish failures because of interference of other syscalls from processes running in the system. Everything is built and run from cmake, these are the commands I've been using to compile and run the tests:
```sh
mkdir build && cd build
cmake -DUSE_BUNDLED_DEPS=OFF -DBUILD_BPF=ON ..
make e2e-tests
```

Pytest was chosen because of my familiarity with it, but also due to the great range of flexibility it provides with its `fixtures` and the fact that Python makes it very easy and quick to draft and implement changes, this also includes the ease of working with containers through the Docker SDK for Python. Pytest also has the added bonus it generates a nice HTML user-friendly report in the build directory, after running the test you should find them under `build/test/e2e/report` and they look a little something like this:
![image](https://user-images.githubusercontent.com/20206636/181275488-9b067452-fbb8-4861-8f01-20d716d10472.png)
The logs for all the containers used on each test can be accessed from the report, which should come in handy when debugging.

From the previously mentioned PoC repository, these tests have successfully been run on GHA, so if this PR is accepted it should be possible to integrate it with the existing CI in a follow up.

Finally, `sinsp-example` has been modified so it can load and remove the kernel module driver, this is mostly done to make the behavior of the container closer to what it is when running with eBPF, but can easily be rolled back in favor of loading and removing the kernel module from the tests container.

**Important!!**
This PR is a WIP and open to anyone that may want to comment on it. Any and all thoughts are welcomed.

It would also be great to have input on how easy or hard people find it to build and run the tests. IMO, they should be aimed to not only run on CI, but also locally on any developer's machine for debugging any potential issues.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #271

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
