### PR TITLE
new(modern_bpf): add support for `chdir` family syscalls

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -38,5 +38,6 @@
 #define FCHMOD_E_SIZE HEADER_LEN
 #define FCHMOD_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
 #define FCHMODAT_E_SIZE HEADER_LEN
+#define MKDIRAT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -31,5 +31,6 @@
 #define DUP3_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define DUP3_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint32_t) + PARAM_LEN * 4
 #define CHDIR_E_SIZE HEADER_LEN
+#define CHMOD_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -33,5 +33,7 @@
 #define CHDIR_E_SIZE HEADER_LEN
 #define CHMOD_E_SIZE HEADER_LEN
 #define CHROOT_E_SIZE HEADER_LEN
+#define FCHDIR_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define FCHDIR_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -39,5 +39,6 @@
 #define FCHMOD_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
 #define FCHMODAT_E_SIZE HEADER_LEN
 #define MKDIRAT_E_SIZE HEADER_LEN
+#define RMDIR_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -30,5 +30,6 @@
 #define DUP2_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + PARAM_LEN * 3
 #define DUP3_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define DUP3_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint32_t) + PARAM_LEN * 4
+#define CHDIR_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -37,5 +37,6 @@
 #define FCHDIR_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define FCHMOD_E_SIZE HEADER_LEN
 #define FCHMOD_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
+#define FCHMODAT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -35,5 +35,7 @@
 #define CHROOT_E_SIZE HEADER_LEN
 #define FCHDIR_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define FCHDIR_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define FCHMOD_E_SIZE HEADER_LEN
+#define FCHMOD_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -32,5 +32,6 @@
 #define DUP3_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint32_t) + PARAM_LEN * 4
 #define CHDIR_E_SIZE HEADER_LEN
 #define CHMOD_E_SIZE HEADER_LEN
+#define CHROOT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(chdir_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CHDIR_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHDIR_E, CHDIR_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(chdir_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CHDIR_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: path (type: PT_CHARBUF) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(chmod_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CHMOD_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHMOD_E, CHMOD_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(chmod_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CHMOD_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/* Parameter 3: mode (type: PT_MODE) */
+	unsigned long mode = extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, chmod_mode_to_scap(mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(chroot_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CHROOT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHROOT_E, CHROOT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(chroot_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CHROOT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fchdir_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHDIR_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_E, FCHDIR_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fchdir_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHDIR_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_X, FCHDIR_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fchmod_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHMOD_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_E, FCHMOD_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fchmod_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHMOD_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_X, FCHMOD_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 3: mode (type: PT_MODE) */
+	unsigned long mode = extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, chmod_mode_to_scap(mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fchmodat_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHMODAT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMODAT_E, FCHMODAT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fchmodat_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_FCHMODAT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 3: filename (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/* Parameter 4: mode (type: PT_MODE) */
+	unsigned long mode = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, chmod_mode_to_scap(mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(mkdirat_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, MKDIRAT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MKDIRAT_E, MKDIRAT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(mkdirat_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_MKDIRAT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 3: path (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	u32 mode = (u32)extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, mode);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(rmdir_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, RMDIR_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RMDIR_2_E, RMDIR_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(rmdir_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_RMDIR_2_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: path (type: PT_CHARBUF) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, USER);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/chdir_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/chdir_e.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chdir
+TEST(SyscallEnter, chdirE)
+{
+	auto evt_test = new event_test(__NR_chdir, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * `chdir()` changes the current working directory of the calling
+	 * process to the directory specified in path. Here we pass a mock dir
+	 * so the call must fail.
+	 */
+
+	const char* new_dir = "mock_dir";
+	assert_syscall_state(SYSCALL_FAILURE, "chdir", syscall(__NR_chdir, new_dir));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/chmod_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/chmod_e.cpp
@@ -1,0 +1,37 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chmod
+TEST(SyscallEnter, chmodE)
+{
+	auto evt_test = new event_test(__NR_chmod, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "chmod", syscall(__NR_chmod, NULL, 0));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/chroot_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/chroot_e.cpp
@@ -1,0 +1,38 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chroot
+TEST(SyscallEnter, chrootE)
+{
+
+	auto evt_test = new event_test(__NR_chroot, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "chroot", syscall(__NR_chroot, NULL));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/fchdir_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/fchdir_e.cpp
@@ -1,0 +1,39 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchdir
+TEST(SyscallEnter, fchdirE)
+{
+	auto evt_test = new event_test(__NR_fchdir, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "fchdir", syscall(__NR_fchdir, invalid_fd));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/fchmod_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/fchmod_e.cpp
@@ -1,0 +1,39 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchmod
+TEST(SyscallEnter, fchmodE)
+{
+	auto evt_test = new event_test(__NR_fchmod, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	uint32_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchmod", syscall(__NR_fchmod, mock_fd, mode));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/fchmodat_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/fchmodat_e.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchmodat
+TEST(SyscallEnter, fchmodatE)
+{
+	auto evt_test = new event_test(__NR_fchmodat, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = 0;
+	const char* pathname = NULL;
+	uint32_t mode = 0;
+	uint32_t flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchmodat", syscall(__NR_fchmodat, mock_dirfd, pathname, mode, flags));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/mkdirat_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/mkdirat_e.cpp
@@ -1,0 +1,40 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mkdirat
+TEST(SyscallEnter, mkdiratE)
+{
+	auto evt_test = new event_test(__NR_mkdirat, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = 0;
+	const char* path = NULL;
+	uint32_t mode = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "mkdirat", syscall(__NR_mkdirat, mock_dirfd, path, mode));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/rmdir_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/rmdir_e.cpp
@@ -1,0 +1,38 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_rmdir
+TEST(SyscallEnter, rmdirE)
+{
+	auto evt_test = new event_test(__NR_rmdir, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "*//null";
+	assert_syscall_state(SYSCALL_FAILURE, "rmdir", syscall(__NR_rmdir, path));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/chdir_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/chdir_x.cpp
@@ -1,0 +1,49 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chdir
+TEST(SyscallExit, chdirX)
+{
+	auto evt_test = new event_test(__NR_chdir, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Syscall special notes:
+	 * `chdir()` changes the current working directory of the calling
+	 * process to the directory specified in path. Here we pass a mock dir
+	 * so the call must fail.
+	 */
+
+	const char* new_dir = "mock_dir";
+	assert_syscall_state(SYSCALL_FAILURE, "chdir", syscall(__NR_chdir, new_dir));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: path (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, new_dir);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/chmod_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/chmod_x.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chmod
+TEST(SyscallExit, chmodX)
+{
+	auto evt_test = new event_test(__NR_chmod, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* filename = "*//null";
+	uint32_t mode = S_IXUSR;
+	assert_syscall_state(SYSCALL_FAILURE, "chmod", syscall(__NR_chmod, filename, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, filename);
+
+	/* Parameter 3: mode (type: PT_MODE) */
+	evt_test->assert_numeric_param(3, PPM_S_IXUSR);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/chroot_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/chroot_x.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chroot
+TEST(SyscallExit, chrootX)
+{
+
+	auto evt_test = new event_test(__NR_chroot, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "*//null";
+	assert_syscall_state(SYSCALL_FAILURE, "chroot", syscall(__NR_chroot, path));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, path);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/fchdir_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/fchdir_x.cpp
@@ -1,0 +1,40 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchdir
+TEST(SyscallExit, fchdirX)
+{
+	auto evt_test = new event_test(__NR_fchdir, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "fchdir", syscall(__NR_fchdir, invalid_fd));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/fchmod_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/fchmod_x.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchmod
+TEST(SyscallExit, fchmodX)
+{
+	auto evt_test = new event_test(__NR_fchmod, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	uint32_t mode = S_IXUSR;
+	assert_syscall_state(SYSCALL_FAILURE, "fchmod", syscall(__NR_fchmod, mock_fd, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: mode (type: PT_MODE) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_S_IXUSR);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/fchmodat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/fchmodat_x.cpp
@@ -1,0 +1,52 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchmodat
+TEST(SyscallExit, fchmodatX)
+{
+	auto evt_test = new event_test(__NR_fchmodat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = -1;
+	const char* pathname = "*//null";
+	uint32_t mode = S_IXUSR;
+	uint32_t flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchmodat", syscall(__NR_fchmodat, mock_dirfd, pathname, mode, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_dirfd);
+
+	/* Parameter 3: filename (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, pathname);
+
+	/* Parameter 4: mode (type: PT_MODE) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_S_IXUSR);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/mkdirat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/mkdirat_x.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mkdirat
+TEST(SyscallExit, mkdiratX)
+{
+	auto evt_test = new event_test(__NR_mkdirat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = -1;
+	const char* path = "/invalid/path";
+	uint32_t mode = 8;
+	assert_syscall_state(SYSCALL_FAILURE, "mkdirat", syscall(__NR_mkdirat, mock_dirfd, path, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_dirfd);
+
+	/* Parameter 3: path (type: PT_FSRELPATH) */
+	evt_test->assert_charbuf_param(3, path);
+
+	/* Parameter 4: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)mode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/rmdir_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/rmdir_x.cpp
@@ -1,0 +1,43 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_rmdir
+TEST(SyscallExit, rmdirX)
+{
+	auto evt_test = new event_test(__NR_rmdir, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "*//null";
+	assert_syscall_state(SYSCALL_FAILURE, "rmdir", syscall(__NR_rmdir, path));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, path);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -51,6 +51,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CHROOT_X] = "chroot_x",
 	[PPME_SYSCALL_FCHDIR_E] = "fchdir_e",
 	[PPME_SYSCALL_FCHDIR_X] = "fchdir_x",
+	[PPME_SYSCALL_FCHMOD_E] = "fchmod_e",
+	[PPME_SYSCALL_FCHMOD_X] = "fchmod_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -49,6 +49,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CHMOD_X] = "chmod_x",
 	[PPME_SYSCALL_CHROOT_E] = "chroot_e",
 	[PPME_SYSCALL_CHROOT_X] = "chroot_x",
+	[PPME_SYSCALL_FCHDIR_E] = "fchdir_e",
+	[PPME_SYSCALL_FCHDIR_X] = "fchdir_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -45,6 +45,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_DUP3_X] = "dup3_x",
 	[PPME_SYSCALL_CHDIR_E] = "chdir_e",
 	[PPME_SYSCALL_CHDIR_X] = "chdir_x",
+	[PPME_SYSCALL_CHMOD_E] = "chmod_e",
+	[PPME_SYSCALL_CHMOD_X] = "chmod_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -47,6 +47,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CHDIR_X] = "chdir_x",
 	[PPME_SYSCALL_CHMOD_E] = "chmod_e",
 	[PPME_SYSCALL_CHMOD_X] = "chmod_x",
+	[PPME_SYSCALL_CHROOT_E] = "chroot_e",
+	[PPME_SYSCALL_CHROOT_X] = "chroot_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -43,6 +43,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_DUP2_X] = "dup2_x",
 	[PPME_SYSCALL_DUP3_E] = "dup3_e",
 	[PPME_SYSCALL_DUP3_X] = "dup3_x",
+	[PPME_SYSCALL_CHDIR_E] = "chdir_e",
+	[PPME_SYSCALL_CHDIR_X] = "chdir_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -55,6 +55,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_FCHMOD_X] = "fchmod_x",
 	[PPME_SYSCALL_FCHMODAT_E] = "fchmodat_e",
 	[PPME_SYSCALL_FCHMODAT_X] = "fchmodat_x",
+	[PPME_SYSCALL_MKDIRAT_E] = "mkdirat_e",
+	[PPME_SYSCALL_MKDIRAT_X] = "mkdirat_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -57,6 +57,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_FCHMODAT_X] = "fchmodat_x",
 	[PPME_SYSCALL_MKDIRAT_E] = "mkdirat_e",
 	[PPME_SYSCALL_MKDIRAT_X] = "mkdirat_x",
+	[PPME_SYSCALL_RMDIR_2_E] = "rmdir_e",
+	[PPME_SYSCALL_RMDIR_2_X] = "rmdir_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -53,6 +53,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_FCHDIR_X] = "fchdir_x",
 	[PPME_SYSCALL_FCHMOD_E] = "fchmod_e",
 	[PPME_SYSCALL_FCHMOD_X] = "fchmod_x",
+	[PPME_SYSCALL_FCHMODAT_E] = "fchmodat_e",
+	[PPME_SYSCALL_FCHMODAT_X] = "fchmodat_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `chdir`
* `chmod`
* `chroot`
* `fchdir`
* `fchmod`
* `fchmodat`
* `mkdirat`
* `rmdir`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This PR is based on https://github.com/falcosecurity/libs/pull/503 I will rebase it against master and remove the `[WIP]` when the previous one will be merged

**Does this PR introduce a user-facing change?**:


```release-note
new(modern_bpf): add support for `chdir` family syscalls
```
