### PR TITLE
update(CI): build also `bpf_test` in ARM64 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,5 +133,6 @@ jobs:
           # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |
             mkdir -p build
-            cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF -DCREATE_TEST_TARGETS=OFF ../
+            cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
             make scap-open
+            make bpf_test


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR allows us to build also the `bpf_test` executable in CI, this could help us in not introducing tests not compatible with some architectures, like in this case https://github.com/falcosecurity/libs/pull/503/commits/bee4e7bbe54e3ab573e9dfd3a2a4844d15b0579a

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
