### PR TITLE
Don't use C99 initializers in C++

### DIFF
--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -121,32 +121,31 @@ protected:
 		uint32_t vmsize_kb=10000, uint32_t vmrss_kb=100, uint32_t vmswap_kb=0, uint64_t pfmajor=222, uint64_t pfminor=22,
 		std::vector<std::string> cgroups={}, std::string root="/", int filtered_out=0, int32_t tty=0, int32_t loginuid=-1)
 	{
-		scap_threadinfo tinfo = {
-			.tid = tid,
-			.pid = pid,
-			.ptid = ptid,
-			.sid = sid,
-			.vpgid = vpgid,
-			.exe_writable = exe_writable,
-			.fdlimit = fdlimit,
-			.flags = flags,
-			.uid = uid,
-			.gid = gid,
-			.cap_permitted = cap_permitted,
-			.cap_effective = cap_effective,
-			.cap_inheritable = cap_inheritable,
-			.vmsize_kb = vmsize_kb,
-			.vmrss_kb = vmrss_kb,
-			.pfmajor = pfmajor,
-			.pfminor = pfminor,
-			.vtid = vtid,
-			.vpid = vpid,
-			.filtered_out = filtered_out,
-			.fdlist = nullptr,
-			.clone_ts = clone_ts,
-			.tty = tty,
-			.loginuid = loginuid
-		};
+		scap_threadinfo tinfo = {};
+		tinfo.tid = tid;
+		tinfo.pid = pid;
+		tinfo.ptid = ptid;
+		tinfo.sid = sid;
+		tinfo.vpgid = vpgid;
+		tinfo.exe_writable = exe_writable;
+		tinfo.fdlimit = fdlimit;
+		tinfo.flags = flags;
+		tinfo.uid = uid;
+		tinfo.gid = gid;
+		tinfo.cap_permitted = cap_permitted;
+		tinfo.cap_effective = cap_effective;
+		tinfo.cap_inheritable = cap_inheritable;
+		tinfo.vmsize_kb = vmsize_kb;
+		tinfo.vmrss_kb = vmrss_kb;
+		tinfo.pfmajor = pfmajor;
+		tinfo.pfminor = pfminor;
+		tinfo.vtid = vtid;
+		tinfo.vpid = vpid;
+		tinfo.filtered_out = filtered_out;
+		tinfo.fdlist = nullptr;
+		tinfo.clone_ts = clone_ts;
+		tinfo.tty = tty;
+		tinfo.loginuid = loginuid;
 
 		std::string argsv = "";
 		for (std::string a : args) {


### PR DESCRIPTION
With an old enough compiler this causes the following error:

    sinsp_with_test_input.h:149:3: sorry, unimplemented: non-trivial designated initializers not supported

Signed-off-by: Grzegorz Nosek <grzegorz.nosek@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Make the libs build again, at least with my old gcc

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
