### PR TITLE
new(modern_bpf): add support for some `file` related syscalls 

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -20,5 +20,7 @@
 /// want to touch scap tables.
 #define MKDIR_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define OPEN_BY_HANDLE_AT_E_SIZE HEADER_LEN
+#define CLOSE_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define CLOSE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -28,5 +28,7 @@
 #define DUP_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + PARAM_LEN * 2
 #define DUP2_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define DUP2_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + PARAM_LEN * 3
+#define DUP3_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define DUP3_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint32_t) + PARAM_LEN * 4
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -22,5 +22,7 @@
 #define OPEN_BY_HANDLE_AT_E_SIZE HEADER_LEN
 #define CLOSE_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define CLOSE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define COPY_FILE_RANGE_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + PARAM_LEN * 3
+#define COPY_FILE_RANGE_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint64_t) + PARAM_LEN * 3
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -24,5 +24,7 @@
 #define CLOSE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define COPY_FILE_RANGE_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + PARAM_LEN * 3
 #define COPY_FILE_RANGE_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint64_t) + PARAM_LEN * 3
+#define DUP_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define DUP_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + PARAM_LEN * 2
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -26,5 +26,7 @@
 #define COPY_FILE_RANGE_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint64_t) + PARAM_LEN * 3
 #define DUP_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define DUP_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + PARAM_LEN * 2
+#define DUP2_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define DUP2_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + PARAM_LEN * 3
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(close_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CLOSE_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_E, CLOSE_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD)*/
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(close_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CLOSE_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_X, CLOSE_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(copy_file_range_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, COPY_FILE_RANGE_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_E, COPY_FILE_RANGE_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fdin (type: PT_FD) */
+	s32 fdin = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fdin);
+
+	/* Parameter 2: offin (type: PT_UINT64) */
+	u64 offin = extract__syscall_argument(regs, 1);
+	ringbuf__store_u64(&ringbuf, offin);
+
+	/* Parameter 3: len (type: PT_UINT64) */
+	u64 len = extract__syscall_argument(regs, 4);
+	ringbuf__store_u64(&ringbuf, len);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(copy_file_range_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, COPY_FILE_RANGE_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_X, COPY_FILE_RANGE_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: fdout (type: PT_FD) */
+	s32 fdout = (s32)extract__syscall_argument(regs, 2);
+	ringbuf__store_s64(&ringbuf, (s64)fdout);
+
+	/* Parameter 3: offout (type: PT_UINT64) */
+	u64 offout = extract__syscall_argument(regs, 3);
+	ringbuf__store_u64(&ringbuf, offout);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(creat_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CREAT_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: name (type: PT_FSPATH) */
+	unsigned long name_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, name_pointer, USER);
+
+	/* Parameter 2: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(O_CREAT, mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(creat_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CREAT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	unsigned long name_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, name_pointer, USER);
+
+	/* Parameter 3: mode (type: PT_UINT32) */
+	unsigned long mode = extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, open_modes_to_scap(O_CREAT, mode));
+
+	dev_t dev = 0;
+	u64 ino = 0;
+
+	if(ret > 0)
+	{
+		extract__dev_and_ino_from_fd(ret, &dev, &ino);
+	}
+
+	/* Parameter 4: dev (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, dev);
+
+	/* Parameter 5: ino (type: PT_UINT64) */
+	auxmap__store_u64_param(auxmap, ino);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -24,9 +24,9 @@ int BPF_PROG(dup_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	/* Parameter 1: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(dup_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_E, DUP_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(dup_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_X, DUP_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(dup2_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP2_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_E, DUP2_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(dup2_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP2_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_X, DUP2_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+
+	/* Parameter 3: newfd (type: PT_FD) */
+	s32 newfd = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, (s64)newfd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -24,9 +24,9 @@ int BPF_PROG(dup2_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	/* Parameter 1: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(dup3_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP3_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_E, DUP3_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(dup3_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DUP3_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_X, DUP3_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+
+	/* Parameter 3: newfd (type: PT_FD) */
+	s32 newfd = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, (s64)newfd);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	unsigned long flags = extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, dup3_flags_to_scap(flags));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -24,9 +24,9 @@ int BPF_PROG(dup3_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	/* Parameter 1: oldfd (type: PT_FD) */
+	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/close_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/close_e.cpp
@@ -1,0 +1,39 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_close
+TEST(SyscallEnter, closeE)
+{
+	auto evt_test = new event_test(__NR_close, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/copy_file_range_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/copy_file_range_e.cpp
@@ -1,0 +1,50 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_copy_file_range
+TEST(SyscallEnter, copy_file_rangeE)
+{
+	auto evt_test = new event_test(__NR_copy_file_range, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t fd_in = -3;
+	int32_t fd_out = -4;
+	off64_t off_in = 140;
+	off64_t off_out = 300;
+	size_t len = 20;
+	uint32_t flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "copy_file_range", syscall(__NR_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fdin (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)fd_in);
+
+	/* Parameter 2: offin (type: PT_UINT64) */
+	evt_test->assert_numeric_param(2, (uint64_t)off_in);
+
+	/* Parameter 3: len (type: PT_UINT64) */
+	evt_test->assert_numeric_param(3, (uint64_t)len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/creat_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/creat_e.cpp
@@ -1,0 +1,43 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_creat
+TEST(SyscallEnter, creatE)
+{
+	auto evt_test = new event_test(__NR_creat, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "*//null";
+	mode_t mode = S_IRGRP;
+	assert_syscall_state(SYSCALL_FAILURE, "creat", syscall(__NR_creat, path, mode));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(1, path);
+
+	/* Parameter 2: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)PPM_S_IRGRP);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup2_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup2_e.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup2) && defined(__NR_openat)
+TEST(SyscallEnter, dup2E)
+{
+	auto evt_test = new event_test(__NR_dup2, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	int32_t new_fd = old_fd;
+	int32_t res = syscall(__NR_dup2, old_fd, new_fd);
+	assert_syscall_state(SYSCALL_SUCCESS, "dup2", res, NOT_EQUAL, -1);
+
+	close(old_fd);
+	close(new_fd);
+	close(res);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)old_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup2_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup2_e.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup2) && defined(__NR_openat)
+#if defined(__NR_dup2) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallEnter, dup2E)
 {
 	auto evt_test = new event_test(__NR_dup2, ENTER_EVENT);
@@ -16,9 +16,9 @@ TEST(SyscallEnter, dup2E)
 	int32_t res = syscall(__NR_dup2, old_fd, new_fd);
 	assert_syscall_state(SYSCALL_SUCCESS, "dup2", res, NOT_EQUAL, -1);
 
-	close(old_fd);
-	close(new_fd);
-	close(res);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
+	syscall(__NR_close, res);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup3_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup3_e.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup3) && defined(__NR_openat)
+#if defined(__NR_dup3) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallEnter, dup3E)
 {
 	auto evt_test = new event_test(__NR_dup3, ENTER_EVENT);
@@ -18,9 +18,9 @@ TEST(SyscallEnter, dup3E)
 	int32_t res = syscall(__NR_dup3, old_fd, new_fd, flags);
 	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
 
-	close(old_fd);
-	close(new_fd);
-	close(res);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
+	syscall(__NR_close, res);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup3_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup3_e.cpp
@@ -1,0 +1,49 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup3) && defined(__NR_openat)
+TEST(SyscallEnter, dup3E)
+{
+	auto evt_test = new event_test(__NR_dup3, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	/* If `oldfd` equals `newfd`, then dup3() fails with the error `EINVAL`. */
+	int32_t new_fd = old_fd;
+	uint32_t flags = O_CLOEXEC;
+	int32_t res = syscall(__NR_dup3, old_fd, new_fd, flags);
+	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
+
+	close(old_fd);
+	close(new_fd);
+	close(res);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)old_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup_e.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup) && defined(__NR_openat)
+#if defined(__NR_dup) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallEnter, dupE)
 {
 	auto evt_test = new event_test(__NR_dup, ENTER_EVENT);
@@ -15,8 +15,8 @@ TEST(SyscallEnter, dupE)
 	int32_t new_fd = syscall(__NR_dup, old_fd);
 	assert_syscall_state(SYSCALL_SUCCESS, "dup", new_fd, NOT_EQUAL, -1);
 
-	close(old_fd);
-	close(new_fd);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/dup_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/dup_e.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup) && defined(__NR_openat)
+TEST(SyscallEnter, dupE)
+{
+	auto evt_test = new event_test(__NR_dup, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	int32_t new_fd = syscall(__NR_dup, old_fd);
+	assert_syscall_state(SYSCALL_SUCCESS, "dup", new_fd, NOT_EQUAL, -1);
+
+	close(old_fd);
+	close(new_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)old_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/close_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/close_x.cpp
@@ -1,0 +1,40 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_close
+TEST(SyscallExit, closeX)
+{
+	auto evt_test = new event_test(__NR_close, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/copy_file_range_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/copy_file_range_x.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_copy_file_range
+TEST(SyscallEnter, copy_file_rangeX)
+{
+	auto evt_test = new event_test(__NR_copy_file_range, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t fd_in = -3;
+	int32_t fd_out = -4;
+	off64_t off_in = 140;
+	off64_t off_out = 300;
+	size_t len = 20;
+	uint32_t flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "copy_file_range", syscall(__NR_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fdout (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)fd_out);
+
+	/* Parameter 3: offout (type: PT_UINT64) */
+	evt_test->assert_numeric_param(3, (uint64_t)off_out);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/copy_file_range_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/copy_file_range_x.cpp
@@ -1,7 +1,7 @@
 #include "../../event_class/event_class.h"
 
 #ifdef __NR_copy_file_range
-TEST(SyscallEnter, copy_file_rangeX)
+TEST(SyscallExit, copy_file_rangeX)
 {
 	auto evt_test = new event_test(__NR_copy_file_range, EXIT_EVENT);
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/creat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/creat_x.cpp
@@ -1,0 +1,116 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_creat
+
+#if defined(__NR_fstat) && defined(__NR_unlinkat)
+TEST(SyscallExit, creatX_success)
+{
+	auto evt_test = new event_test(__NR_creat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "tmp_file";
+	mode_t mode = S_IRWXU;
+	int fd = syscall(__NR_creat, path, mode);
+	assert_syscall_state(SYSCALL_SUCCESS, "creat", fd, NOT_EQUAL, -1);
+
+	/* Call `fstat` to retrieve the `dev` and `ino`. */
+	struct stat file_stat;
+	assert_syscall_state(SYSCALL_SUCCESS, "fstat", syscall(__NR_fstat, fd, &file_stat), NOT_EQUAL, -1);
+	uint32_t dev = (uint32_t)file_stat.st_dev;
+	uint64_t inode = file_stat.st_ino;
+
+	/* Remove the file. */
+	close(fd);
+	assert_syscall_state(SYSCALL_SUCCESS, "unlinkat", syscall(__NR_unlinkat, AT_FDCWD, path, 0), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)fd);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, path);
+
+	/* Parameter 3: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)(PPM_S_IRUSR | PPM_S_IWUSR | PPM_S_IXUSR));
+
+	/* Parameter 4: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)dev);
+
+	/* Parameter 5: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(5, (uint64_t)inode);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif /* defined(__NR_fstat) && defined(__NR_unlinkat) */
+
+TEST(SyscallExit, creatX_failure)
+{
+	auto evt_test = new event_test(__NR_creat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* path = "*//null";
+	mode_t mode = S_IRGRP;
+	assert_syscall_state(SYSCALL_FAILURE, "creat", syscall(__NR_creat, path, mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, path);
+
+	/* Parameter 3: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_S_IRGRP);
+
+	/* Parameter 4: dev (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(5, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/creat_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/creat_x.cpp
@@ -2,7 +2,7 @@
 
 #ifdef __NR_creat
 
-#if defined(__NR_fstat) && defined(__NR_unlinkat)
+#if defined(__NR_fstat) && defined(__NR_unlinkat) && defined(__NR_close)
 TEST(SyscallExit, creatX_success)
 {
 	auto evt_test = new event_test(__NR_creat, EXIT_EVENT);
@@ -23,8 +23,8 @@ TEST(SyscallExit, creatX_success)
 	uint64_t inode = file_stat.st_ino;
 
 	/* Remove the file. */
-	close(fd);
-	assert_syscall_state(SYSCALL_SUCCESS, "unlinkat", syscall(__NR_unlinkat, AT_FDCWD, path, 0), NOT_EQUAL, -1);
+	syscall(__NR_close, fd);
+	syscall(__NR_unlinkat, AT_FDCWD, path, 0);
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
@@ -62,7 +62,7 @@ TEST(SyscallExit, creatX_success)
 
 	evt_test->assert_num_params_pushed(5);
 }
-#endif /* defined(__NR_fstat) && defined(__NR_unlinkat) */
+#endif /* defined(__NR_fstat) && defined(__NR_unlinkat) && defined(__NR_close) */
 
 TEST(SyscallExit, creatX_failure)
 {

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup2_x.cpp
@@ -1,0 +1,53 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup2) && defined(__NR_openat)
+TEST(SyscallExit, dup2X)
+{
+	auto evt_test = new event_test(__NR_dup2, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	int32_t new_fd = old_fd;
+	int32_t res = syscall(__NR_dup2, old_fd, new_fd);
+	assert_syscall_state(SYSCALL_SUCCESS, "dup2", res, NOT_EQUAL, -1);
+
+	close(old_fd);
+	close(new_fd);
+	close(res);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)res);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)old_fd);
+
+	/* Parameter 3: newfd (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)new_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup2_x.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup2) && defined(__NR_openat)
+#if defined(__NR_dup2) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallExit, dup2X)
 {
 	auto evt_test = new event_test(__NR_dup2, EXIT_EVENT);
@@ -16,9 +16,9 @@ TEST(SyscallExit, dup2X)
 	int32_t res = syscall(__NR_dup2, old_fd, new_fd);
 	assert_syscall_state(SYSCALL_SUCCESS, "dup2", res, NOT_EQUAL, -1);
 
-	close(old_fd);
-	close(new_fd);
-	close(res);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
+	syscall(__NR_close, res);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup3_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup3_x.cpp
@@ -1,0 +1,59 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup3) && defined(__NR_openat)
+TEST(SyscallExit, dup3X)
+{
+	auto evt_test = new event_test(__NR_dup3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	/* If `oldfd` equals `newfd`, then dup3() fails with the error `EINVAL`. */
+	int32_t new_fd = old_fd;
+	uint32_t flags = O_CLOEXEC;
+	int32_t res = syscall(__NR_dup3, old_fd, new_fd, flags);
+	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
+	int64_t errno_value = -errno;
+
+	close(old_fd);
+	close(new_fd);
+	close(res);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)old_fd);
+
+	/* Parameter 3: newfd (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)new_fd);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_CLOEXEC);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup3_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup3_x.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup3) && defined(__NR_openat)
+#if defined(__NR_dup3) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallExit, dup3X)
 {
 	auto evt_test = new event_test(__NR_dup3, EXIT_EVENT);
@@ -19,9 +19,9 @@ TEST(SyscallExit, dup3X)
 	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
 	int64_t errno_value = -errno;
 
-	close(old_fd);
-	close(new_fd);
-	close(res);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
+	syscall(__NR_close, res);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup_x.cpp
@@ -1,0 +1,48 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_dup) && defined(__NR_openat)
+TEST(SyscallExit, dupX)
+{
+	auto evt_test = new event_test(__NR_dup, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t old_fd = syscall(__NR_openat, AT_FDCWD, ".", O_RDWR | O_TMPFILE);
+	assert_syscall_state(SYSCALL_SUCCESS, "openat", old_fd, NOT_EQUAL, -1);
+
+	int32_t new_fd = syscall(__NR_dup, old_fd);
+	assert_syscall_state(SYSCALL_SUCCESS, "dup", new_fd, NOT_EQUAL, -1);
+
+	close(old_fd);
+	close(new_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)new_fd);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)old_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/dup_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/dup_x.cpp
@@ -1,6 +1,6 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_dup) && defined(__NR_openat)
+#if defined(__NR_dup) && defined(__NR_openat) && defined(__NR_close)
 TEST(SyscallExit, dupX)
 {
 	auto evt_test = new event_test(__NR_dup, EXIT_EVENT);
@@ -15,8 +15,8 @@ TEST(SyscallExit, dupX)
 	int32_t new_fd = syscall(__NR_dup, old_fd);
 	assert_syscall_state(SYSCALL_SUCCESS, "dup", new_fd, NOT_EQUAL, -1);
 
-	close(old_fd);
-	close(new_fd);
+	syscall(__NR_close, old_fd);
+	syscall(__NR_close, new_fd);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -39,6 +39,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CREAT_X] = "creat_x",
 	[PPME_SYSCALL_DUP_1_E] = "dup_e",
 	[PPME_SYSCALL_DUP_1_X] = "dup_x",
+	[PPME_SYSCALL_DUP2_E] = "dup2_e",
+	[PPME_SYSCALL_DUP2_X] = "dup2_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -37,6 +37,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_COPY_FILE_RANGE_X] = "copy_file_range_x",
 	[PPME_SYSCALL_CREAT_E] = "creat_e",
 	[PPME_SYSCALL_CREAT_X] = "creat_x",
+	[PPME_SYSCALL_DUP_1_E] = "dup_e",
+	[PPME_SYSCALL_DUP_1_X] = "dup_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -33,6 +33,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_OPEN_BY_HANDLE_AT_X] = "open_by_handle_at_x",
 	[PPME_SYSCALL_CLOSE_E] = "close_e",
 	[PPME_SYSCALL_CLOSE_X] = "close_x",
+	[PPME_SYSCALL_COPY_FILE_RANGE_E] = "copy_file_range_e",
+	[PPME_SYSCALL_COPY_FILE_RANGE_X] = "copy_file_range_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -35,6 +35,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CLOSE_X] = "close_x",
 	[PPME_SYSCALL_COPY_FILE_RANGE_E] = "copy_file_range_e",
 	[PPME_SYSCALL_COPY_FILE_RANGE_X] = "copy_file_range_x",
+	[PPME_SYSCALL_CREAT_E] = "creat_e",
+	[PPME_SYSCALL_CREAT_X] = "creat_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -31,6 +31,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_OPENAT2_X] = "openat2_x",
 	[PPME_SYSCALL_OPEN_BY_HANDLE_AT_E] = "open_by_handle_at_e",
 	[PPME_SYSCALL_OPEN_BY_HANDLE_AT_X] = "open_by_handle_at_x",
+	[PPME_SYSCALL_CLOSE_E] = "close_e",
+	[PPME_SYSCALL_CLOSE_X] = "close_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -41,6 +41,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_DUP_1_X] = "dup_x",
 	[PPME_SYSCALL_DUP2_E] = "dup2_e",
 	[PPME_SYSCALL_DUP2_X] = "dup2_x",
+	[PPME_SYSCALL_DUP3_E] = "dup3_e",
+	[PPME_SYSCALL_DUP3_X] = "dup3_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `close`
* `copy_file_range`
* `creat`
* `dup`
* `dup2`
* `dup3`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This PR is based on https://github.com/falcosecurity/libs/pull/503 I will rebase it against master and remove the `[WIP]` when the previous one will be merged

**Does this PR introduce a user-facing change?**:


```release-note
new(modern_bpf): add support for some `file` related syscalls 
```
