### PR TITLE
new(modern_bpf): add support for `kill` family, `seccomp`, `ptrace`, `capset` syscalls 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install deps ⛓️
         run: |
           sudo apt update 
-          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev
+          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libtool libelf-dev libcap-dev
 
       - name: Build scap-open 🏗️
         run: |
@@ -144,7 +144,7 @@ jobs:
           githubToken: ${{ github.token }}
 
           install: |
-            pacman -Syu --noconfirm git cmake make llvm clang pkgconf libelf zlib libffi libbpf linux-tools glibc gcc gtest protobuf openssl tbb libb64 wget jq yaml-cpp curl c-ares grpc libyaml
+            pacman -Syu --noconfirm git cmake make llvm clang pkgconf libelf zlib libffi libbpf linux-tools glibc gcc gtest protobuf openssl tbb libb64 wget jq yaml-cpp curl c-ares grpc libyaml libpcap
             
           # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -59,5 +59,7 @@
 #define SECCOMP_E_SIZE HEADER_LEN + sizeof(uint64_t) + PARAM_LEN
 #define SECCOMP_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define PTRACE_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint16_t) + PARAM_LEN * 2
+#define CAPSET_E_SIZE HEADER_LEN
+#define CAPSET_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 3 + PARAM_LEN * 4
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -50,5 +50,7 @@
 #define USERFAULTFD_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 #define SIGNALFD_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + sizeof(uint8_t) + PARAM_LEN * 3
 #define SIGNALFD_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define KILL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
+#define KILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -52,5 +52,7 @@
 #define SIGNALFD_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define KILL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
 #define KILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define TGKILL_E_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) + PARAM_LEN * 3
+#define TGKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -54,5 +54,7 @@
 #define KILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define TGKILL_E_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) + PARAM_LEN * 3
 #define TGKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define TKILL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
+#define TKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -58,5 +58,6 @@
 #define TKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define SECCOMP_E_SIZE HEADER_LEN + sizeof(uint64_t) + PARAM_LEN
 #define SECCOMP_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define PTRACE_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint16_t) + PARAM_LEN * 2
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -56,5 +56,7 @@
 #define TGKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define TKILL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
 #define TKILL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define SECCOMP_E_SIZE HEADER_LEN + sizeof(uint64_t) + PARAM_LEN
+#define SECCOMP_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -807,8 +807,10 @@
 #define PTRACE_SEIZE 0x4206
 #define PTRACE_INTERRUPT 0x4207
 #define PTRACE_LISTEN 0x4208
+#define PTRACE_PEEKSIGINFO 0x4209
 #define PTRACE_GETSIGMASK 0x420a
 #define PTRACE_SETSIGMASK 0x420b
+#define PTRACE_SECCOMP_GET_FILTER 0x420c
 
 /* `/arch/x86/include/uapi/asm/ptrace-abi.h` from kernel source tree.  */
 
@@ -817,6 +819,7 @@
 #define PTRACE_SETREGS 13
 #define PTRACE_GETFPREGS 14
 #define PTRACE_SETFPREGS 15
+
 #define PTRACE_GETFPXREGS 18
 #define PTRACE_SETFPXREGS 19
 
@@ -827,10 +830,8 @@
 #define PTRACE_SET_THREAD_AREA 26
 
 #define PTRACE_ARCH_PRCTL 30
-
 #define PTRACE_SYSEMU 31
 #define PTRACE_SYSEMU_SINGLESTEP 32
-
 #define PTRACE_SINGLEBLOCK 33 /* resume execution until next branch */
 #endif
 

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -206,6 +206,22 @@ static __always_inline void ringbuf__store_u8(struct ringbuf_struct *ringbuf, u8
 }
 
 /**
+ * @brief This helper should be used to store unsigned 16 bit params.
+ * The following types are compatible with this helper:
+ * - PT_UINT16
+ * - PT_FLAGS16
+ * - PT_ENUMFLAGS16
+ *
+ * @param ringbuf pointer to the `ringbuf_struct`.
+ * @param param param to store
+ */
+static __always_inline void ringbuf__store_u16(struct ringbuf_struct *ringbuf, u16 param)
+{
+	push__u16(ringbuf->data, &ringbuf->payload_pos, param);
+	push__param_len(ringbuf->data, &ringbuf->lengths_pos, sizeof(u16));
+}
+
+/**
  * @brief This helper should be used to store unsigned 32 bit params.
  * The following types are compatible with this helper:
  * - PT_UINT32

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(capset_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CAPSET_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_E, CAPSET_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(capset_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CAPSET_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_X, CAPSET_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	struct task_struct *task = get_current_task();
+
+	/* Parameter 2: cap_inheritable (type: PT_UINT64) */
+	u64 cap_inheritable = extract__capability(task, CAP_INHERITABLE);
+	ringbuf__store_u64(&ringbuf, cap_inheritable);
+
+	/* Parameter 3: cap_permitted (type: PT_UINT64) */
+	u64 cap_permitted = extract__capability(task, CAP_PERMITTED);
+	ringbuf__store_u64(&ringbuf, cap_permitted);
+
+	/* Parameter 4: cap_effective (type: PT_UINT64) */
+	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
+	ringbuf__store_u64(&ringbuf, cap_effective);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(kill_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, KILL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_E, KILL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: pid (type: PT_PID) */
+	pid_t pid = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)pid);
+
+	/* Parameter 2: sig (type: PT_SIGTYPE) */
+	u8 sig = (u8)extract__syscall_argument(regs, 1);
+	ringbuf__store_u8(&ringbuf, sig);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(kill_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, KILL_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_X, KILL_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ptrace_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, PTRACE_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PTRACE_E, PTRACE_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: request (type: PT_FLAGS16) */
+	unsigned long request = extract__syscall_argument(regs, 0);
+	ringbuf__store_u16(&ringbuf, ptrace_requests_to_scap(request));
+
+	/* Parameter 2: pid (type: PT_PID) */
+	pid_t pid = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, (s64)pid);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(ptrace_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_PTRACE_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* We need the ptrace request type to understand how to parse `addr` and `data` */
+	unsigned long request = extract__syscall_argument(regs, 0);
+	u16 scap_ptrace_request = ptrace_requests_to_scap(request);
+
+	/* Parameter 2: addr (type: PT_DYN) */
+	u64 addr_pointer = (u64)extract__syscall_argument(regs, 2);
+	auxmap__store_ptrace_addr_param(auxmap, ret, addr_pointer);
+
+	/* Parameter 3: data (type: PT_DYN) */
+	u64 data_pointer = (u64)extract__syscall_argument(regs, 3);
+	auxmap__store_ptrace_data_param(auxmap, ret, scap_ptrace_request, data_pointer);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(seccomp_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SECCOMP_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_E, SECCOMP_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: operation (type: PT_UINT64)*/
+	u64 operation = (u64)extract__syscall_argument(regs, 0);
+	ringbuf__store_u64(&ringbuf, operation);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(seccomp_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SECCOMP_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_X, SECCOMP_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -24,9 +24,9 @@ int BPF_PROG(tgkill_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: pid (type: PT_PID) */
-	pid_t pid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	/* Parameter 1: tgid (type: PT_PID) */
+	pid_t tgid = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)tgid);
 
 	/* Parameter 2: tid (type: PT_PID) */
 	pid_t tid = (s32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(tgkill_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, TGKILL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_E, TGKILL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: pid (type: PT_PID) */
+	pid_t pid = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)pid);
+
+	/* Parameter 2: tid (type: PT_PID) */
+	pid_t tid = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, (s64)tid);
+
+	/* Parameter 3: sig (type: PT_SIGTYPE) */
+	u8 sig = (u8)extract__syscall_argument(regs, 2);
+	ringbuf__store_u8(&ringbuf, sig);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(tgkill_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, TGKILL_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_X, TGKILL_X_SIZE);
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(tkill_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, TKILL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_E, TKILL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: tid (type: PT_PID) */
+	pid_t tid = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)tid);
+
+	/* Parameter 2: sig (type: PT_SIGTYPE) */
+	u8 sig = (u8)extract__syscall_argument(regs, 1);
+	ringbuf__store_u8(&ringbuf, sig);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(tkill_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, TKILL_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_X, TKILL_X_SIZE);
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -248,6 +248,32 @@ void event_test::assert_bytebuf_param(int param_num, const char* param, int buf_
 	ASSERT_EQ(memcmp(m_event_params[m_current_param].valptr, param, buf_dimension), 0) << VALUE_NOT_CORRECT << m_current_param << std::endl;
 }
 
+void event_test::assert_ptrace_addr(int param_num)
+{
+	assert_param_boundaries(param_num);
+
+	/* Right now we test only the failure case.
+	 * - type: `PPM_PTRACE_IDX_UINT64`
+	 * - val: `0`
+	 */
+	assert_param_len(sizeof(uint8_t) + sizeof(uint64_t));
+	ASSERT_EQ(*(uint8_t*)(m_event_params[m_current_param].valptr), PPM_PTRACE_IDX_UINT64) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+	ASSERT_EQ(*(uint64_t*)(m_event_params[m_current_param].valptr + 1), 0) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+}
+
+void event_test::assert_ptrace_data(int param_num)
+{
+	assert_param_boundaries(param_num);
+
+	/* Right now we test only the failure case.
+	 * - type: `PPM_PTRACE_IDX_UINT64`
+	 * - val: `0`
+	 */
+	assert_param_len(sizeof(uint8_t) + sizeof(uint64_t));
+	ASSERT_EQ(*(uint8_t*)(m_event_params[m_current_param].valptr), PPM_PTRACE_IDX_UINT64) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+	ASSERT_EQ(*(uint64_t*)(m_event_params[m_current_param].valptr + 1), 0) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+}
+
 /////////////////////////////////
 // INTERNAL ASSERTIONS
 /////////////////////////////////

--- a/test/modern_bpf/event_class/event_class.h
+++ b/test/modern_bpf/event_class/event_class.h
@@ -216,9 +216,8 @@ public:
 	 * @param param expected value.
 	 * @param op the operation we want to perform in the assertion.
 	 */
-	template <class T>
+	template<class T>
 	void assert_numeric_param(int param_num, T param, enum assertion_operators op = EQUAL);
-
 
 	/**
 	 * @brief Assert that the parameter is a `charbuf` and
@@ -248,6 +247,28 @@ public:
 	 * @param param expected value.
 	 */
 	void assert_bytebuf_param(int param_num, const char* param, int buf_dimension);
+
+	/**
+	 * @brief The ptrace `addr` param is a `PT_DYN`, so we need
+	 * a dedicated helper to assert it.
+	 *
+	 * TODO: This is still a partial implementation, we assert
+	 * only the case in which the param is empty.
+	 *
+	 * @param param_num number of the parameter to assert into the event.
+	 */
+	void assert_ptrace_addr(int param_num);
+
+	/**
+	 * @brief The ptrace `data` param is a `PT_DYN`, so we need
+	 * a dedicated helper to assert it.
+	 *
+	 * TODO: This is still a partial implementation, we assert
+	 * only the case in which the param is empty.
+	 *
+	 * @param param_num number of the parameter to assert into the event.
+	 */
+	void assert_ptrace_data(int param_num);
 
 private:
 	enum ppm_event_type m_event_type;	  /* type of the event we want to assert in this test. */

--- a/test/modern_bpf/test_suites/syscall_enter_suite/capset_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/capset_e.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_capset
+
+#include <sys/capability.h>
+
+TEST(SyscallEnter, capsetE)
+{
+	auto evt_test = new event_test(__NR_capset, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* - `cap_user_header_t` is a pointer to `__user_cap_header_struct`
+	 * - `cap_user_data_t` is a pointer to `__user_cap_data_struct`
+	 */
+	cap_user_header_t hdrp = NULL;
+	cap_user_data_t datap = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "capset", syscall(__NR_capset, hdrp, datap));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/kill_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/kill_e.cpp
@@ -1,0 +1,49 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_kill
+
+TEST(SyscallEnter, killE)
+{
+	auto evt_test = new event_test(__NR_kill, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* If `pid` is `0`, then `signal` is sent to every process in the process
+	 * group of the calling process. If we use also `signal==0`, no signal is sent but
+	 * we only check for the existence of a process ID or process group ID that the caller is
+	 * permitted to signal. The process is always alive so the call should always succeed.
+	 */
+	int32_t mock_pid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "kill", syscall(__NR_kill, mock_pid, signal), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_pid);
+
+	/* Parameter 2: sig (type: PT_SIGTYPE) */
+	evt_test->assert_numeric_param(2, (uint8_t)signal);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/ptrace_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/ptrace_e.cpp
@@ -1,0 +1,48 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ptrace
+
+#include <sys/ptrace.h>
+
+TEST(SyscallEnter, ptraceE)
+{
+	auto evt_test = new event_test(__NR_ptrace, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	enum __ptrace_request request = PTRACE_PEEKSIGINFO;
+	pid_t pid = -1;
+	void* addr = NULL;
+	void* data = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "ptrace", syscall(__NR_ptrace, request, pid, addr, data));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: request (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_PTRACE_PEEKSIGINFO);
+
+	/* Parameter 2: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(2, (int64_t)pid);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/seccomp_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/seccomp_e.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_seccomp
+
+#include <linux/seccomp.h>
+
+TEST(SyscallEnter, seccompE)
+{
+	auto evt_test = new event_test(__NR_seccomp, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	uint32_t operation = SECCOMP_SET_MODE_FILTER;
+	uint32_t flags = 0;
+	void* args = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "seccomp", syscall(__NR_seccomp, operation, flags, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: operation (type: PT_UINT64) */
+	evt_test->assert_numeric_param(1, (uint64_t)operation);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/tgkill_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/tgkill_e.cpp
@@ -1,0 +1,50 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_tgkill
+TEST(SyscallEnter, tgkillE)
+{
+	auto evt_test = new event_test(__NR_tgkill, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* `mock_tgid==0` and `mock_tid==0` are invalid values so the syscall will
+	 * fail with `EINVAL`.
+	 */
+	int32_t mock_tgid = 0;
+	int32_t mock_tid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "tgkill", syscall(__NR_tgkill, mock_tgid, mock_tid, signal));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_tgid);
+
+	/* Parameter 2: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_tid);
+
+	/* Parameter 3: sig (type: PT_SIGTYPE) */
+	evt_test->assert_numeric_param(3, (uint8_t)signal);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/tgkill_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/tgkill_e.cpp
@@ -34,7 +34,7 @@ TEST(SyscallEnter, tgkillE)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	/* Parameter 1: pid (type: PT_PID) */
+	/* Parameter 1: tgid (type: PT_PID) */
 	evt_test->assert_numeric_param(1, (int64_t)mock_tgid);
 
 	/* Parameter 2: tid (type: PT_PID) */

--- a/test/modern_bpf/test_suites/syscall_enter_suite/tkill_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/tkill_e.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_tkill
+TEST(SyscallEnter, tkillE)
+{
+	auto evt_test = new event_test(__NR_tkill, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* `mock_tgid==0` and `mock_tid==0` are invalid values so the syscall will
+	 * fail with `EINVAL`.
+	 */
+	int32_t mock_tid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "tkill", syscall(__NR_tkill, mock_tid, signal));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_tid);
+
+	/* Parameter 2: sig (type: PT_SIGTYPE) */
+	evt_test->assert_numeric_param(2, (uint8_t)signal);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/capset_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/capset_x.cpp
@@ -6,20 +6,24 @@
 
 #ifndef CAP_PERFMON
 	#define CAP_PERFMON 38
-#endif	
+#endif
 
 #ifndef CAP_BPF
 	#define CAP_BPF 39
-#endif	
+#endif
 
 #ifndef CAP_CHECKPOINT_RESTORE
 	#define CAP_CHECKPOINT_RESTORE 40
-#endif 
+#endif
 
+/* This helper is a copy of the one you can find in `driver/ppm_flag_helpers.h`.
+ * Right now we cannot directly include it, let's see if we need other helpers
+ * from this file, in that case, we can think of splitting it.
+ */
 uint64_t capabilities_to_scap(unsigned long caps)
 {
 	uint64_t res = 0;
-	
+
 #ifdef CAP_CHOWN
 	if(caps & (1UL << CAP_CHOWN))
 		res |= PPM_CAP_CHOWN;

--- a/test/modern_bpf/test_suites/syscall_exit_suite/capset_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/capset_x.cpp
@@ -1,0 +1,255 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_capset
+
+#include <sys/capability.h>
+
+#ifndef CAP_PERFMON
+	#define CAP_PERFMON 38
+#endif	
+
+#ifndef CAP_BPF
+	#define CAP_BPF 39
+#endif	
+
+#ifndef CAP_CHECKPOINT_RESTORE
+	#define CAP_CHECKPOINT_RESTORE 40
+#endif 
+
+uint64_t capabilities_to_scap(unsigned long caps)
+{
+	uint64_t res = 0;
+	
+#ifdef CAP_CHOWN
+	if(caps & (1UL << CAP_CHOWN))
+		res |= PPM_CAP_CHOWN;
+#endif
+#ifdef CAP_DAC_OVERRIDE
+	if(caps & (1UL << CAP_DAC_OVERRIDE))
+		res |= PPM_CAP_DAC_OVERRIDE;
+#endif
+#ifdef CAP_DAC_READ_SEARCH
+	if(caps & (1UL << CAP_DAC_READ_SEARCH))
+		res |= PPM_CAP_DAC_READ_SEARCH;
+#endif
+#ifdef CAP_FOWNER
+	if(caps & (1UL << CAP_FOWNER))
+		res |= PPM_CAP_FOWNER;
+#endif
+#ifdef CAP_FSETID
+	if(caps & (1UL << CAP_FSETID))
+		res |= PPM_CAP_FSETID;
+#endif
+#ifdef CAP_KILL
+	if(caps & (1UL << CAP_KILL))
+		res |= PPM_CAP_KILL;
+#endif
+#ifdef CAP_SETGID
+	if(caps & (1UL << CAP_SETGID))
+		res |= PPM_CAP_SETGID;
+#endif
+#ifdef CAP_SETUID
+	if(caps & (1UL << CAP_SETUID))
+		res |= PPM_CAP_SETUID;
+#endif
+#ifdef CAP_SETPCAP
+	if(caps & (1UL << CAP_SETPCAP))
+		res |= PPM_CAP_SETPCAP;
+#endif
+#ifdef CAP_LINUX_IMMUTABLE
+	if(caps & (1UL << CAP_LINUX_IMMUTABLE))
+		res |= PPM_CAP_LINUX_IMMUTABLE;
+#endif
+#ifdef CAP_NET_BIND_SERVICE
+	if(caps & (1UL << CAP_NET_BIND_SERVICE))
+		res |= PPM_CAP_NET_BIND_SERVICE;
+#endif
+#ifdef CAP_NET_BROADCAST
+	if(caps & (1UL << CAP_NET_BROADCAST))
+		res |= PPM_CAP_NET_BROADCAST;
+#endif
+#ifdef CAP_NET_ADMIN
+	if(caps & (1UL << CAP_NET_ADMIN))
+		res |= PPM_CAP_NET_ADMIN;
+#endif
+#ifdef CAP_NET_RAW
+	if(caps & (1UL << CAP_NET_RAW))
+		res |= PPM_CAP_NET_RAW;
+#endif
+#ifdef CAP_IPC_LOCK
+	if(caps & (1UL << CAP_IPC_LOCK))
+		res |= PPM_CAP_IPC_LOCK;
+#endif
+#ifdef CAP_IPC_OWNER
+	if(caps & (1UL << CAP_IPC_OWNER))
+		res |= PPM_CAP_IPC_OWNER;
+#endif
+#ifdef CAP_SYS_MODULE
+	if(caps & (1UL << CAP_SYS_MODULE))
+		res |= PPM_CAP_SYS_MODULE;
+#endif
+#ifdef CAP_SYS_RAWIO
+	if(caps & (1UL << CAP_SYS_RAWIO))
+		res |= PPM_CAP_SYS_RAWIO;
+#endif
+#ifdef CAP_SYS_CHROOT
+	if(caps & (1UL << CAP_SYS_CHROOT))
+		res |= PPM_CAP_SYS_CHROOT;
+#endif
+#ifdef CAP_SYS_PTRACE
+	if(caps & (1UL << CAP_SYS_PTRACE))
+		res |= PPM_CAP_SYS_PTRACE;
+#endif
+#ifdef CAP_SYS_PACCT
+	if(caps & (1UL << CAP_SYS_PACCT))
+		res |= PPM_CAP_SYS_PACCT;
+#endif
+#ifdef CAP_SYS_ADMIN
+	if(caps & (1UL << CAP_SYS_ADMIN))
+		res |= PPM_CAP_SYS_ADMIN;
+#endif
+#ifdef CAP_SYS_BOOT
+	if(caps & (1UL << CAP_SYS_BOOT))
+		res |= PPM_CAP_SYS_BOOT;
+#endif
+#ifdef CAP_SYS_NICE
+	if(caps & (1UL << CAP_SYS_NICE))
+		res |= PPM_CAP_SYS_NICE;
+#endif
+#ifdef CAP_SYS_RESOURCE
+	if(caps & (1UL << CAP_SYS_RESOURCE))
+		res |= PPM_CAP_SYS_RESOURCE;
+#endif
+#ifdef CAP_SYS_TIME
+	if(caps & (1UL << CAP_SYS_TIME))
+		res |= PPM_CAP_SYS_TIME;
+#endif
+#ifdef CAP_SYS_TTY_CONFIG
+	if(caps & (1UL << CAP_SYS_TTY_CONFIG))
+		res |= PPM_CAP_SYS_TTY_CONFIG;
+#endif
+#ifdef CAP_MKNOD
+	if(caps & (1UL << CAP_MKNOD))
+		res |= PPM_CAP_MKNOD;
+#endif
+#ifdef CAP_LEASE
+	if(caps & (1UL << CAP_LEASE))
+		res |= PPM_CAP_LEASE;
+#endif
+#ifdef CAP_AUDIT_WRITE
+	if(caps & (1UL << CAP_AUDIT_WRITE))
+		res |= PPM_CAP_AUDIT_WRITE;
+#endif
+#ifdef CAP_AUDIT_CONTROL
+	if(caps & (1UL << CAP_AUDIT_CONTROL))
+		res |= PPM_CAP_AUDIT_CONTROL;
+#endif
+#ifdef CAP_SETFCAP
+	if(caps & (1UL << CAP_SETFCAP))
+		res |= PPM_CAP_SETFCAP;
+#endif
+#ifdef CAP_MAC_OVERRIDE
+	if(caps & (1UL << CAP_MAC_OVERRIDE))
+		res |= PPM_CAP_MAC_OVERRIDE;
+#endif
+#ifdef CAP_MAC_ADMIN
+	if(caps & (1UL << CAP_MAC_ADMIN))
+		res |= PPM_CAP_MAC_ADMIN;
+#endif
+#ifdef CAP_SYSLOG
+	if(caps & (1UL << CAP_SYSLOG))
+		res |= PPM_CAP_SYSLOG;
+#endif
+#ifdef CAP_WAKE_ALARM
+	if(caps & (1UL << CAP_WAKE_ALARM))
+		res |= PPM_CAP_WAKE_ALARM;
+#endif
+#ifdef CAP_BLOCK_SUSPEND
+	if(caps & (1UL << CAP_BLOCK_SUSPEND))
+		res |= PPM_CAP_BLOCK_SUSPEND;
+#endif
+#ifdef CAP_AUDIT_READ
+	if(caps & (1UL << CAP_AUDIT_READ))
+		res |= PPM_CAP_AUDIT_READ;
+#endif
+#ifdef CAP_PERFMON
+	if(caps & (1UL << CAP_PERFMON))
+		res |= PPM_CAP_PERFMON;
+#endif
+#ifdef CAP_BPF
+	if(caps & (1UL << CAP_BPF))
+		res |= PPM_CAP_BPF;
+#endif
+#ifdef CAP_CHECKPOINT_RESTORE
+	if(caps & (1UL << CAP_CHECKPOINT_RESTORE))
+		res |= PPM_CAP_CHECKPOINT_RESTORE;
+#endif
+
+	return res;
+}
+
+TEST(SyscallExit, capsetX)
+{
+	auto evt_test = new event_test(__NR_capset, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* In this test we don't want to modify the capabilities of the actual process
+	 * so as a first step we will get the actual capabilities of the process and
+	 * after it we will call `capset` with empty params just to trigger the BPF
+	 * program. In case of failure, the capset exit event returns the actual
+	 * capabilities of the process, in this way we can assert them against the ones
+	 * we have retrieved from the previous `capget` call.
+	 */
+
+	/* On kernels >= 5.8 the suggested version should be `_LINUX_CAPABILITY_VERSION_3` */
+	struct __user_cap_header_struct header = {0};
+	struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
+	cap_user_header_t hdrp = &header;
+	cap_user_data_t datap = data;
+
+	/* Prepare the header. */
+	header.pid = 0; /* `0` means the pid of the actual process. */
+	header.version = _LINUX_CAPABILITY_VERSION_3;
+
+	assert_syscall_state(SYSCALL_SUCCESS, "capget", syscall(__NR_capget, hdrp, datap), EQUAL, 0);
+
+	assert_syscall_state(SYSCALL_FAILURE, "capset", syscall(__NR_capset, NULL, NULL));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: cap_inheritable (type: PT_UINT64) */
+	evt_test->assert_numeric_param(2, (uint64_t)capabilities_to_scap(((unsigned long)data[1].inheritable << 32) | data[0].inheritable));
+
+	/* Parameter 3: cap_permitted (type: PT_UINT64) */
+	evt_test->assert_numeric_param(3, (uint64_t)capabilities_to_scap(((unsigned long)data[1].permitted << 32) | data[0].permitted));
+
+	/* Parameter 4: cap_effective (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)capabilities_to_scap(((unsigned long)data[1].effective << 32) | data[0].effective));
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/kill_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/kill_x.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_kill
+
+TEST(SyscallExit, killX)
+{
+	auto evt_test = new event_test(__NR_kill, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* If `pid` is `0`, then `signal` is sent to every process in the process
+	 * group of the calling process. If we use also `signal==0`, no signal is sent but
+	 * we only check for the existence of a process ID or process group ID that the caller is
+	 * permitted to signal. The process is always alive so the call should always succeed.
+	 */
+	int32_t mock_pid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "kill", syscall(__NR_kill, mock_pid, signal), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/ptrace_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/ptrace_x.cpp
@@ -1,0 +1,54 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ptrace
+
+#include <sys/ptrace.h>
+
+/// TODO: we need a test to assert the behavior in case of success.
+
+TEST(SyscallExit, ptraceX_failure)
+{
+	auto evt_test = new event_test(__NR_ptrace, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	enum __ptrace_request request = PTRACE_PEEKSIGINFO;
+	pid_t pid = -1;
+	void* addr = NULL;
+	void* data = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "ptrace", syscall(__NR_ptrace, request, pid, addr, data));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: addr (type: PT_DYN) */
+	evt_test->assert_ptrace_addr(2);
+
+	/* Parameter 3: data (type: PT_DYN) */
+	evt_test->assert_ptrace_addr(3);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/seccomp_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/seccomp_x.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_seccomp
+
+#include <linux/seccomp.h>
+
+TEST(SyscallExit, seccompX)
+{
+	auto evt_test = new event_test(__NR_seccomp, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	uint32_t operation = SECCOMP_SET_MODE_FILTER;
+	uint32_t flags = 0;
+	void* args = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "seccomp", syscall(__NR_seccomp, operation, flags, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/tgkill_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/tgkill_x.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_tgkill
+TEST(SyscallExit, tgkillX)
+{
+	auto evt_test = new event_test(__NR_tgkill, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* `mock_tgid==0` and `mock_tid==0` are invalid values so the syscall will
+	 * fail with `EINVAL`.
+	 */
+	int32_t mock_tgid = 0;
+	int32_t mock_tid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "tgkill", syscall(__NR_tgkill, mock_tgid, mock_tid, signal));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/tkill_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/tkill_x.cpp
@@ -1,0 +1,42 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_tkill
+TEST(SyscallExit, tkillX)
+{
+	auto evt_test = new event_test(__NR_tkill, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* `mock_tid==0` is an invalid value so the syscall will fail with `EINVAL`. */
+	int32_t mock_tid = 0;
+	int32_t signal = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "tkill", syscall(__NR_tkill, mock_tid, signal));
+    int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -69,6 +69,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_USERFAULTFD_X] = "userfaultfd_x",
 	[PPME_SYSCALL_SIGNALFD_E] = "signalfd_e",
 	[PPME_SYSCALL_SIGNALFD_X] = "signalfd_x",
+	[PPME_SYSCALL_KILL_E] = "kill_e",
+	[PPME_SYSCALL_KILL_X] = "kill_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -71,6 +71,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_SIGNALFD_X] = "signalfd_x",
 	[PPME_SYSCALL_KILL_E] = "kill_e",
 	[PPME_SYSCALL_KILL_X] = "kill_x",
+	[PPME_SYSCALL_TGKILL_E] = "tgkill_e",
+	[PPME_SYSCALL_TGKILL_X] = "tgkill_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -73,6 +73,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_KILL_X] = "kill_x",
 	[PPME_SYSCALL_TGKILL_E] = "tgkill_e",
 	[PPME_SYSCALL_TGKILL_X] = "tgkill_x",
+	[PPME_SYSCALL_TKILL_E] = "tkill_e",
+	[PPME_SYSCALL_TKILL_X] = "tkill_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -77,6 +77,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_TKILL_X] = "tkill_x",
 	[PPME_SYSCALL_SECCOMP_E] = "seccomp_e",
 	[PPME_SYSCALL_SECCOMP_X] = "seccomp_x",
+	[PPME_SYSCALL_PTRACE_E] = "ptrace_e",
+	[PPME_SYSCALL_PTRACE_X] = "ptrace_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -75,6 +75,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_TGKILL_X] = "tgkill_x",
 	[PPME_SYSCALL_TKILL_E] = "tkill_e",
 	[PPME_SYSCALL_TKILL_X] = "tkill_x",
+	[PPME_SYSCALL_SECCOMP_E] = "seccomp_e",
+	[PPME_SYSCALL_SECCOMP_X] = "seccomp_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -79,6 +79,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_SECCOMP_X] = "seccomp_x",
 	[PPME_SYSCALL_PTRACE_E] = "ptrace_e",
 	[PPME_SYSCALL_PTRACE_X] = "ptrace_x",
+	[PPME_SYSCALL_CAPSET_E] = "capset_e",
+	[PPME_SYSCALL_CAPSET_X] = "capset_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `kill`
* `tgkill`
* `tkill`
* `seccomp`
* `ptrace`
* `capset`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new(modern_bpf): add support for `kill` family, `seccomp`, `ptrace`, `capset` syscalls 
```
