### PR TITLE
fix(gvisor): cleanup tests, consistent return values

### DIFF
--- a/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
+++ b/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
@@ -152,7 +152,7 @@ TEST(gvisor_parsers, unhandled_syscall)
 
     scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
     EXPECT_NE(res.error.find("Unhandled syscall"), std::string::npos);
-    EXPECT_EQ(res.status, SCAP_TIMEOUT);
+    EXPECT_EQ(res.status, SCAP_NOT_SUPPORTED);
 }
 
 TEST(gvisor_parsers, small_buffer)

--- a/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
+++ b/userspace/libscap/test/scap_gvisor_parsers.ut.cpp
@@ -190,7 +190,6 @@ TEST(gvisor_parsers, procfs_entry)
 
     res = scap_gvisor::parsers::parse_procfs_json(not_json, sandbox_id);
     EXPECT_EQ(res.status, SCAP_FAILURE);
-    EXPECT_STREQ(res.error.c_str(), "Malformed json string: cannot parse procfs entry");
 
     std::string json = R"(
 {
@@ -206,18 +205,23 @@ TEST(gvisor_parsers, procfs_entry)
   "exe": "/usr/bin/bash",
   "fdlist": [
     {
+      "number": 0,
+      "mode": 0,
       "path": "host:[1]"
     },
     {
       "number": 1,
+      "mode": 0,
       "path": "host:[1]"
     },
     {
       "number": 2,
+      "mode": 0,
       "path": "host:[1]"
     },
     {
       "number": 255,
+      "mode": 0,
       "path": "host:[1]"
     }
   ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently, gVisor tests are failing because they were not updated after the latest change. This PR fixes the tests and cleans up another return value, making it clear whether a parser encountered a fatal error or it simply doesn't know a syscall or an event yet.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
