### PR TITLE
chore(userspace/libscap): fixed printf on error when check_api_compatibility() fails

### DIFF
--- a/userspace/libscap/scap_engine_util.c
+++ b/userspace/libscap/scap_engine_util.c
@@ -52,25 +52,25 @@ int32_t check_api_compatibility(scap_t *handle, char *error)
 #ifdef PPM_API_CURRENT_VERSION_MAJOR
 	if(!scap_is_api_compatible(handle->m_api_version, SCAP_MINIMUM_DRIVER_API_VERSION))
 	{
-		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports API version %llu.%llu.%llu, but running version needs %d.%d.%d",
+		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports API version %llu.%llu.%llu, but running version needs %llu.%llu.%llu",
 			 PPM_API_VERSION_MAJOR(handle->m_api_version),
 			 PPM_API_VERSION_MINOR(handle->m_api_version),
 			 PPM_API_VERSION_PATCH(handle->m_api_version),
-			 PPM_API_CURRENT_VERSION_MAJOR,
-			 PPM_API_CURRENT_VERSION_MINOR,
-			 PPM_API_CURRENT_VERSION_PATCH);
+			 PPM_API_VERSION_MAJOR(SCAP_MINIMUM_DRIVER_API_VERSION),
+			 PPM_API_VERSION_MINOR(SCAP_MINIMUM_DRIVER_API_VERSION),
+			 PPM_API_VERSION_PATCH(SCAP_MINIMUM_DRIVER_API_VERSION));
 		return SCAP_FAILURE;
 	}
 
 	if(!scap_is_api_compatible(handle->m_schema_version, SCAP_MINIMUM_DRIVER_SCHEMA_VERSION))
 	{
-		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports schema version %llu.%llu.%llu, but running version needs %d.%d.%d",
+		snprintf(error, SCAP_LASTERR_SIZE, "Driver supports schema version %llu.%llu.%llu, but running version needs %llu.%llu.%llu",
 			 PPM_API_VERSION_MAJOR(handle->m_schema_version),
 			 PPM_API_VERSION_MINOR(handle->m_schema_version),
 			 PPM_API_VERSION_PATCH(handle->m_schema_version),
-			 PPM_SCHEMA_CURRENT_VERSION_MAJOR,
-			 PPM_SCHEMA_CURRENT_VERSION_MINOR,
-			 PPM_SCHEMA_CURRENT_VERSION_PATCH);
+			 PPM_API_VERSION_MAJOR(SCAP_MINIMUM_DRIVER_SCHEMA_VERSION),
+			 PPM_API_VERSION_MINOR(SCAP_MINIMUM_DRIVER_SCHEMA_VERSION),
+			 PPM_API_VERSION_PATCH(SCAP_MINIMUM_DRIVER_SCHEMA_VERSION));
 		return SCAP_FAILURE;
 	}
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

Fixes error `snprintf` correctly using values used in the check.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
