### PR TITLE
update(scap-open): handle all scap return codes

### DIFF
--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -761,7 +761,7 @@ int main(int argc, char** argv)
 	print_configurations();
 
 	g_h = scap_open(args, error, &res);
-	if(g_h == NULL)
+	if(g_h == NULL || res != SCAP_SUCCESS)
 	{
 		fprintf(stderr, "%s (%d)\n", error, res);
 		return EXIT_FAILURE;
@@ -778,7 +778,7 @@ int main(int argc, char** argv)
 			if(res != SCAP_EOF)
 			{
 				scap_close(g_h);
-				fprintf(stderr, "%s\n", scap_getlasterr(g_h));
+				fprintf(stderr, "%s (%d)\n", scap_getlasterr(g_h), res);
 				return -1;
 			}
 			break;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The scap-open example, which we now use extensively for testing, did not properly handle the `SCAP_UNEXPECTED_BLOCK` and `SCAP_FILTERED_EVENT` scap return codes. The first is specifically useful when reading from trace files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
