### PR TITLE
fix(userspace/libsinsp): revert container.mount source and dest extraction

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -6582,11 +6582,11 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 			{
 				if (m_field_id == TYPE_CONTAINER_MOUNT_SOURCE)
 				{
-					mntinfo = container_info->mount_by_source(m_argstr);
+					mntinfo = container_info->mount_by_dest(m_argstr);
 				}
 				else
 				{
-					mntinfo = container_info->mount_by_dest(m_argstr);
+					mntinfo = container_info->mount_by_source(m_argstr);
 				}
 			}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This reverts a change of #493 that inverts the extracted values of `container.mount.source` and `container.mount.dest`, which caused an unwanted breaking change on libs consumers. Reminding the field documentation:
```
container.mount.source        (ARG_REQUIRED) the mount source, specified by number (e.g. container.mount.source[0]) or 
                              mount destination (container.mount.source[/host/lib/modules]). The pathname can be a 
                              glob. 
container.mount.dest          (ARG_REQUIRED) the mount destination, specified by number (e.g. container.mount.dest[0]) 
                              or mount source (container.mount.dest[/lib/modules]). The pathname can be a glob. 
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): revert container.mount source and dest extraction
```
