### PR TITLE
fix(ci): fixed checkout action fetch depth.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,17 @@ jobs:
     container:
       image: debian:buster
     steps:
+      - name: Install deps ⛓️
+        run: |
+          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
+    
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-            
-      - name: Install deps ⛓️
+
+      - name: Install valijson dep ⛓️
         run: |
-          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
           .github/install-valijson.sh
   
       - name: Build and test 🏗️🧪
@@ -80,6 +83,7 @@ jobs:
             apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev linux-headers-arm64
             
           run: |
+            git config --global --add safe.directory ${{ github.workspace }}
             .github/install-valijson.sh
             mkdir -p build
             cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False ../
@@ -144,6 +148,7 @@ jobs:
             
           # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |
+            git config --global --add safe.directory ${{ github.workspace }}
             .github/install-valijson.sh
             mkdir -p build
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
             
       - name: Install deps ⛓️
         run: |
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
   
       - name: Build and test 🏗️🧪
         run: |
@@ -62,6 +66,8 @@ jobs:
     steps:
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run aarch64 build 🏎️
@@ -87,6 +93,8 @@ jobs:
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install deps ⛓️
         run: |
@@ -121,6 +129,8 @@ jobs:
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run aarch64 build 🏎️


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

This PR address the issue that CI jobs are not able to compute libs version during cmake configure step; see here for example (https://github.com/falcosecurity/libs/runs/7652420577?check_suite_focus=true)

>-- Libs version: **0.0.0**
> -- Driver version: **0.0.0**
> -- Driver API version 2.0.0
> -- Driver schema version 2.0.0

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
