### PR TITLE
refactor(libsinsp): manage memory in ast/parser via unique_ptrs

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1512,7 +1512,6 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_str = fltstr;
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
-	m_internal_parsing = true;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1525,7 +1524,6 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_flt_str = fltstr;
 	m_flt_ast = NULL;
 	m_ttable_only = ttable_only;
-	m_internal_parsing = true;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
@@ -1537,27 +1535,18 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 	m_filter = NULL;
 	m_flt_ast = fltast;
 	m_ttable_only = ttable_only;
-	m_internal_parsing = false;
-}
-
-sinsp_filter_compiler::~sinsp_filter_compiler()
-{
-	// we delete the AST only if it was parsed internally
-	if (m_internal_parsing && m_flt_ast != NULL)
-	{
-		delete m_flt_ast;
-	}
 }
 
 sinsp_filter* sinsp_filter_compiler::compile()
 {
 	// parse filter string on-the-fly if not pre-parsed AST is provided
-	if (m_internal_parsing && m_flt_ast == NULL)
+	if (m_flt_ast == NULL)
 	{
 		libsinsp::filter::parser parser(m_flt_str);
 		try
 		{
-			m_flt_ast = parser.parse();
+			m_internal_flt_ast = parser.parse();
+			m_flt_ast = m_internal_flt_ast.get();
 		}
 		catch (const sinsp_exception& e)
 		{

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -97,8 +97,6 @@ public:
 		libsinsp::filter::ast::expr* fltast,
 		bool ttable_only=false);
 
-	~sinsp_filter_compiler();
-
 	/*!
 		\brief Builds a filtercheck tree and bundles it in sinsp_filter
 		\return The resulting pointer is owned by the caller and must be deleted

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -121,12 +121,12 @@ private:
 	gen_event_filter_check* create_filtercheck(std::string& field);
 
 	bool m_ttable_only;
-	bool m_internal_parsing;
 	bool m_expect_values;
 	boolop m_last_boolop;
 	std::string m_flt_str;
 	sinsp_filter* m_filter;
 	std::vector<std::string> m_field_values;
+	std::unique_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 	libsinsp::filter::ast::expr* m_flt_ast;
 	std::shared_ptr<gen_event_filter_factory> m_factory;
 

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -192,9 +192,9 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(expr* e)
             for (auto &c: e->children)
             {
                 c->accept(this);
-                children.push_back(std::move(m_last_node)); /// NOTE FOR THE REVIEWER: should work as long as m_last_node is not used more than once
+                children.push_back(std::move(m_last_node));
             }
-            m_last_node = std::unique_ptr<and_expr>(new and_expr(children));
+            m_last_node = and_expr::create(children);
         }
 
         void visit(or_expr* e) override
@@ -205,40 +205,37 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(expr* e)
                 c->accept(this);
                 children.push_back(std::move(m_last_node));
             }
-            m_last_node = std::unique_ptr<or_expr>(new or_expr(children));
+            m_last_node = or_expr::create(children);
         }
 
         void visit(not_expr* e) override
         {
             e->child->accept(this);
-            m_last_node = std::unique_ptr<not_expr>(new not_expr(m_last_node));
+            m_last_node = not_expr::create(std::move(m_last_node));
         }
 
         void visit(binary_check_expr* e) override
         {
             e->value->accept(this);
-            m_last_node = std::unique_ptr<binary_check_expr>(new binary_check_expr(
-                e->field, e->arg, e->op, m_last_node));
+            m_last_node = binary_check_expr::create(e->field, e->arg, e->op, std::move(m_last_node));
         }
 
         void visit(unary_check_expr* e) override
         {
-            m_last_node = std::unique_ptr<unary_check_expr>(new unary_check_expr(
-                e->field, e->arg, e->op));
+            m_last_node = unary_check_expr::create(e->field, e->arg, e->op);
         }
 
         void visit(value_expr* e) override
         {
-            m_last_node = std::unique_ptr<value_expr>(new value_expr(e->value));
+            m_last_node = value_expr::create(e->value);
         }
 
         void visit(list_expr* e) override
         {
-            m_last_node = std::unique_ptr<list_expr>(new list_expr(e->values));
+            m_last_node = list_expr::create(e->values);
         }
     } visitor;
 
-    visitor.m_last_node = NULL;
     e->accept(&visitor);
     return std::move(visitor.m_last_node);
 }

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -66,7 +66,7 @@ void base_expr_visitor::visit(list_expr* e) { }
 
 void base_expr_visitor::visit(unary_check_expr* e) { }
 
-void string_visitor::visit_logical_op(const char *op, std::vector<std::unique_ptr<expr>> &children)
+void string_visitor::visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children)
 {
 	bool first = true;
 

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -177,7 +177,7 @@ struct SINSP_PUBLIC or_expr: expr
 {
     or_expr() { }
 
-    explicit or_expr(std::vector<std::unique_ptr<expr>> c): children(std::move(c)) { }
+    explicit or_expr(std::vector<std::unique_ptr<expr>> &c): children(std::move(c)) { }
 
     void accept(expr_visitor* v) override
     {
@@ -212,7 +212,7 @@ struct SINSP_PUBLIC or_expr: expr
 
     static std::unique_ptr<or_expr> create(std::vector<std::unique_ptr<expr>> &c)
     {
-        return std::unique_ptr<or_expr>(new or_expr(std::move(c)));
+        return std::unique_ptr<or_expr>(new or_expr(c));
     }
 };
 

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -103,7 +103,7 @@ public:
 
 protected:
 
-	void visit_logical_op(const char *op, std::vector<std::unique_ptr<expr>> &children);
+	void visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children);
 
 	// If true, the next call to vist(value_expr*) will escape the
 	// value. This occurs for any right hand side of a binary check.

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -134,7 +134,7 @@ struct SINSP_PUBLIC and_expr: expr
 {
     and_expr() { }
 
-    explicit and_expr(std::vector<std::unique_ptr<expr>>& c): children(std::move(c)) { }
+    explicit and_expr(std::vector<std::unique_ptr<expr>> &c): children(std::move(c)) { }
 
     void accept(expr_visitor* v) override
     {
@@ -166,13 +166,18 @@ struct SINSP_PUBLIC and_expr: expr
     }
 
     std::vector<std::unique_ptr<expr>> children;
+
+    static std::unique_ptr<and_expr> create(std::vector<std::unique_ptr<expr>> &c)
+    {
+        return std::unique_ptr<and_expr>(new and_expr(c));
+    }
 };
 
 struct SINSP_PUBLIC or_expr: expr
 {
     or_expr() { }
 
-    explicit or_expr(std::vector<std::unique_ptr<expr>>& c): children(std::move(c)) { }
+    explicit or_expr(std::vector<std::unique_ptr<expr>> c): children(std::move(c)) { }
 
     void accept(expr_visitor* v) override
     {
@@ -204,13 +209,18 @@ struct SINSP_PUBLIC or_expr: expr
     }
 
     std::vector<std::unique_ptr<expr>> children;
+
+    static std::unique_ptr<or_expr> create(std::vector<std::unique_ptr<expr>> &c)
+    {
+        return std::unique_ptr<or_expr>(new or_expr(std::move(c)));
+    }
 };
 
 struct SINSP_PUBLIC not_expr: expr
 {
     not_expr() { }
 
-    explicit not_expr(std::unique_ptr<expr> &c): child(std::move(c)) { }
+    explicit not_expr(std::unique_ptr<expr> c): child(std::move(c)) { }
 
     void accept(expr_visitor* v) override
     {
@@ -224,6 +234,11 @@ struct SINSP_PUBLIC not_expr: expr
     }
 
     std::unique_ptr<expr> child;
+
+    static std::unique_ptr<not_expr> create(std::unique_ptr<expr> c)
+    {
+        return std::unique_ptr<not_expr>(new not_expr(std::move(c)));
+    }
 };
 
 struct SINSP_PUBLIC value_expr: expr
@@ -244,6 +259,11 @@ struct SINSP_PUBLIC value_expr: expr
     }
 
     std::string value;
+
+    static std::unique_ptr<value_expr> create(const std::string& v)
+    {
+        return std::unique_ptr<value_expr>(new value_expr(v));
+    }
 };
 
 struct SINSP_PUBLIC list_expr: expr
@@ -264,6 +284,11 @@ struct SINSP_PUBLIC list_expr: expr
     }
 
     std::vector<std::string> values;
+
+    static std::unique_ptr<list_expr> create(const std::vector<std::string>& v)
+    {
+        return std::unique_ptr<list_expr>(new list_expr(v));
+    }
 };
 
 struct SINSP_PUBLIC unary_check_expr: expr
@@ -290,6 +315,13 @@ struct SINSP_PUBLIC unary_check_expr: expr
     std::string field;
     std::string arg;
     std::string op;
+
+    static std::unique_ptr<unary_check_expr> create(const std::string& f,
+        const std::string& a,
+        const std::string& o)
+    {
+        return std::unique_ptr<unary_check_expr>(new unary_check_expr(f, a, o));
+    }
 };
 
 struct SINSP_PUBLIC binary_check_expr: expr
@@ -318,6 +350,15 @@ struct SINSP_PUBLIC binary_check_expr: expr
     std::string arg;
     std::string op;
     std::unique_ptr<expr> value;
+
+    static std::unique_ptr<binary_check_expr> create(
+        const std::string& f,
+        const std::string& a,
+        const std::string& o,
+        std::unique_ptr<expr> v)
+    {
+        return std::unique_ptr<binary_check_expr>(new binary_check_expr(f, a, o, v));
+    }
 };
 
 /*!

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -144,18 +144,13 @@ struct SINSP_PUBLIC and_expr: expr
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const and_expr*>(other);
-        if (o == nullptr)
+        if (o == nullptr || o->children.size() != children.size())
         {
             return false;
         }
 
         for (size_t i = 0; i < children.size(); i++)
         {
-            if (o->children.size() <= i)
-            {
-                return false;
-            }
-
             if (!compare(children[i].get(), o->children[i].get()))
             {
                 return false;
@@ -187,18 +182,13 @@ struct SINSP_PUBLIC or_expr: expr
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const or_expr*>(other);
-        if (o == nullptr)
+        if (o == nullptr || o->children.size() != children.size())
         {
             return false;
         }
 
         for (size_t i = 0; i < children.size(); i++)
         {
-            if (o->children.size() <= i)
-            {
-                return false;
-            }
-
             if (!compare(children[i].get(), o->children[i].get()))
             {
                 return false;

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -146,17 +146,17 @@ public:
 		by it. The pointer is automatically deleted in case of exception.
 		On delete, each node of the AST deletes all its subnodes.
 	*/
-	ast::expr* parse();
+	std::unique_ptr<ast::expr> parse();
 
 private:
-	ast::expr* parse_or();
-	ast::expr* parse_and();
-	ast::expr* parse_not();
-	ast::expr* parse_embedded_remainder();
-	ast::expr* parse_check();
-	ast::expr* parse_list_value();
-	ast::value_expr* parse_num_value();
-	ast::value_expr* parse_str_value();
+	std::unique_ptr<ast::expr> parse_or();
+	std::unique_ptr<ast::expr> parse_and();
+	std::unique_ptr<ast::expr> parse_not();
+	std::unique_ptr<ast::expr> parse_embedded_remainder();
+	std::unique_ptr<ast::expr> parse_check();
+	std::unique_ptr<ast::expr> parse_list_value();
+	std::unique_ptr<ast::value_expr> parse_num_value();
+	std::unique_ptr<ast::value_expr> parse_str_value();
 	bool lex_blank();
 	bool lex_identifier();
 	bool lex_field_name();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This refactor is also the larger part of the effort to make our tests pass under AddressSanitizer.

All the `ast::expr` classes were holding pointers or vectors of pointers allocated manually via `new` and removed via `delete`, sometimes through virtual destructors. This should be fine in the happy path where everything works as planned, but becomes an issue where any unexpected behavior happens, such as any `throw` in the parsers. In that case, any allocated memory would not be freed and thus leaked. The issue is apparent in tests that exercise parsing errors or other edge cases when using LeakSanitizer which will loudly complain about a lot of leaked memory. This PR aims to remove any manual memory management in those classes and replace it with `std::unique_ptr`s. 

I decided to solve the issue this way because any expression node owns the nodes below it, and the parser is recursive, normally operating by allocating the lower nodes and then assigning them to the nodes one level up. This also has the added benefit of removing virtual destructors since we don't need them anymore.

The contract with functions that return or get parameters as `std::unique_ptr` works as follows:
* If the function/constructor _requires_ a `std::unique_ptr` it means that it's going to acquire full ownership of that pointer, which of course needs to be `std::move`d there.
* If the function _returns_ a `std::unique_ptr` it means that it will give ownership of the object to the caller
* Same goes for `std::vector<std::unique_ptr<>>`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

See inline comments.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
