### PR TITLE
new(ci): build libs and modern-bpf for s390x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,31 @@ jobs:
             KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
             make run-unit-tests
 
+  build-libs-s390x:
+    name: build-libs-s390x 😁 (system_deps)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+
+      - uses: uraimo/run-on-arch-action@v2.2.0
+        name: Run s390x build 🏗️
+        with:
+          arch: s390x
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+
+          install: |
+            apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev linux-headers-generic
+
+          run: |
+            git config --global --add safe.directory ${{ github.workspace }}
+            .github/install-valijson.sh
+            mkdir -p build
+            cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False ../
+            KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
+            make run-unit-tests
+
   build-and-test-modern-bpf-x86:
     name: build-and-test-modern-bpf-x86 😇 (bundled_deps)
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           githubToken: ${{ github.token }}
 
           install: |
-            dnf install -y bpftool c-ares-devel clang cmake curl-devel git grpc-devel grpc-plugins gtest-devel jq-devel jsoncpp-devel libb64-devel libbpf-devel openssl-devel protobuf-devel tbb-devel wget
+            dnf install -y bpftool c-ares-devel clang cmake curl-devel git grpc-devel grpc-plugins gtest-devel jq-devel jsoncpp-devel libb64-devel libbpf-devel libcap-devel openssl-devel protobuf-devel tbb-devel wget
 
           # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,32 @@ jobs:
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
             make scap-open
             make bpf_test
+
+  build-modern-bpf-s390x:
+    name: build-modern-bpf-s390x 😁 (system_deps)
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: uraimo/run-on-arch-action@v2.2.0
+        name: Run s390x build 🏗️
+        with:
+          arch: s390x
+          distro: fedora_latest
+          githubToken: ${{ github.token }}
+
+          install: |
+            dnf install -y bpftool c-ares-devel clang cmake curl-devel git grpc-devel grpc-plugins gtest-devel jq-devel jsoncpp-devel libb64-devel libbpf-devel openssl-devel protobuf-devel tbb-devel wget
+
+          # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
+          run: |
+            git config --global --add safe.directory ${{ github.workspace }}
+            .github/install-valijson.sh
+            mkdir -p build
+            cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DUSE_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
+            make scap-open
+            make bpf_test


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**Any specific area of the project related to this PR?**

/area build
/area CI
/area tests

**Does this PR require a change in the driver versions?**

None.

**What this PR does / why we need it**:

Include s390x to the CI workflow  to build and run unit tests and build modern-bpf using the `run-on-arch` similar to aarch64. This PR is based on the discussion [here](https://github.com/falcosecurity/libs/pull/533#issuecomment-1205197373) in #533.

The `build-libs-s390x` uses ubuntu as host and build image. For `build-modern-bpf-s390x`, ubuntu is used for host but I had to use fedora for building the modern-bpf parts. There was an issue regarding bpf header definitions that might be sorted out separately. Details can be found [here](https://github.com/hbrueckner/falcosecurity-libs/pull/1#issuecomment-1205520249). At least, there are now two distributions for building it.
Some preliminary test results can be found (here)[https://github.com/hbrueckner/falcosecurity-libs/pull/1#issuecomment-1205570268].

@Andreagit97 Regarding the [libcap dependency](https://github.com/falcosecurity/libs/pull/517/commits/8b4bb192c50faa700b7911fe6edad8d4a83e1439) in #517, I have added [update(ci): add libcap dependency for capset syscalls for s390x](https://github.com/hbrueckner/falcosecurity-libs/commit/b94df5921bf35f73e4af46d0074b90c6c9e20351) respectively to this PR. Let me know if you like to handle it differently.

cc: @Andreagit97 @FedeDP 

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(ci): build libs and modern-bpf for s390x
```
