### PR TITLE
new(modern_bpf): add support for some `network` family syscalls

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -65,5 +65,6 @@
 #define SOCKET_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define SOCKETPAIR_E_SIZE HEADER_LEN + sizeof(uint32_t) * 3 + PARAM_LEN * 3
 #define SOCKETPAIR_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) * 2 + PARAM_LEN * 5
+#define ACCEPT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -68,5 +68,7 @@
 #define ACCEPT_E_SIZE HEADER_LEN
 #define ACCEPT4_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define BIND_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define LISTEN_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
+#define LISTEN_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -66,5 +66,6 @@
 #define SOCKETPAIR_E_SIZE HEADER_LEN + sizeof(uint32_t) * 3 + PARAM_LEN * 3
 #define SOCKETPAIR_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) * 2 + PARAM_LEN * 5
 #define ACCEPT_E_SIZE HEADER_LEN
+#define ACCEPT4_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -61,5 +61,7 @@
 #define PTRACE_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint16_t) + PARAM_LEN * 2
 #define CAPSET_E_SIZE HEADER_LEN
 #define CAPSET_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 3 + PARAM_LEN * 4
+#define SOCKET_E_SIZE HEADER_LEN + sizeof(uint32_t) * 3 + PARAM_LEN * 3
+#define SOCKET_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -63,5 +63,7 @@
 #define CAPSET_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 3 + PARAM_LEN * 4
 #define SOCKET_E_SIZE HEADER_LEN + sizeof(uint32_t) * 3 + PARAM_LEN * 3
 #define SOCKET_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define SOCKETPAIR_E_SIZE HEADER_LEN + sizeof(uint32_t) * 3 + PARAM_LEN * 3
+#define SOCKETPAIR_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) * 2 + PARAM_LEN * 5
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -67,5 +67,6 @@
 #define SOCKETPAIR_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) * 2 + PARAM_LEN * 5
 #define ACCEPT_E_SIZE HEADER_LEN
 #define ACCEPT4_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define BIND_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -606,8 +606,7 @@ static __always_inline void auxmap__store_socktuple_param(struct auxiliary_map *
 
 	/* Get the socket family directly from the socket */
 	u16 socket_family = 0;
-	struct file *file = NULL;
-	file = extract__file_struct_from_fd(socket_fd);
+	struct file *file = extract__file_struct_from_fd(socket_fd);
 	struct socket *socket = BPF_CORE_READ(file, private_data);
 	struct sock *sk = BPF_CORE_READ(socket, sk);
 	BPF_CORE_READ_INTO(&socket_family, socket, ops, family);

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -607,7 +607,7 @@ static __always_inline void auxmap__store_socktuple_param(struct auxiliary_map *
 	struct file *file = extract__file_struct_from_fd(socket_fd);
 	struct socket *socket = BPF_CORE_READ(file, private_data);
 	struct sock *sk = BPF_CORE_READ(socket, sk);
-	BPF_CORE_READ_INTO(&socket_family, socket, ops, family);
+	BPF_CORE_READ_INTO(&socket_family, sk, __sk_common.skc_family);
 
 	switch(socket_family)
 	{

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -483,9 +483,7 @@ static __always_inline void auxmap__store_sockaddr_param(struct auxiliary_map *a
 	 */
 
 	/* If we are not able to save the sockaddr return an empty parameter. */
-	if(bpf_probe_read_user((void *)&auxmap->data[MAX_PARAM_SIZE],
-			       addrlen,
-			       (void *)sockaddr_pointer))
+	if(bpf_probe_read_user((void *)&auxmap->data[MAX_PARAM_SIZE], addrlen, (void *)sockaddr_pointer) || addrlen == 0)
 	{
 		push__param_len(auxmap->data, &auxmap->lengths_pos, 0);
 		return;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(accept_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, ACCEPT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT_5_E, ACCEPT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(accept_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_ACCEPT_5_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* If the syscall `connect` succeeds, it creates a new connected socket
+	 * with file descriptor `ret` and we can get some parameters, otherwise we return
+	 * default values.
+	 */
+
+	/* actual dimension of the server queue. */
+	u32 queuelen = 0;
+
+	/* max dimension of the server queue. */
+	u32 queuemax = 0;
+
+	/* occupancy percentage of the server queue. */
+	u8 queuepct = 0;
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	if(ret >= 0)
+	{
+		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
+
+		/* Perform some computations to get queue information. */
+		struct file *file = NULL;
+		file = extract__file_struct_from_fd(ret);
+		struct socket *socket = BPF_CORE_READ(file, private_data);
+		struct sock *sk = BPF_CORE_READ(socket, sk);
+		BPF_CORE_READ_INTO(&queuelen, sk, sk_ack_backlog);
+		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
+		if(queuelen && queuemax)
+		{
+			queuepct = (u8)((u64)queuelen * 100 / queuemax);
+		}
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	auxmap__store_u8_param(auxmap, queuepct);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, queuelen);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, queuemax);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(accept4_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, ACCEPT4_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT4_5_E, ACCEPT4_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	/// TODO: we don't support flags yet and so we just return zero.
+	u32 flags = 0;
+	ringbuf__store_u32(&ringbuf, flags);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(accept4_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_ACCEPT4_5_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* If the syscall `connect` succeeds, it creates a new connected socket
+	 * with file descriptor `ret` and we can get some parameters, otherwise we return
+	 * default values.
+	 */
+
+	/* actual dimension of the server queue. */
+	u32 queuelen = 0;
+
+	/* max dimension of the server queue. */
+	u32 queuemax = 0;
+
+	/* occupancy percentage of the server queue. */
+	u8 queuepct = 0;
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	if(ret >= 0)
+	{
+		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
+
+		/* Perform some computations to get queue information. */
+		struct file *file = NULL;
+		file = extract__file_struct_from_fd(ret);
+		struct socket *socket = BPF_CORE_READ(file, private_data);
+		struct sock *sk = BPF_CORE_READ(socket, sk);
+		BPF_CORE_READ_INTO(&queuelen, sk, sk_ack_backlog);
+		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
+		if(queuelen && queuemax)
+		{
+			queuepct = (u8)((u64)queuelen * 100 / queuemax);
+		}
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	auxmap__store_u8_param(auxmap, queuepct);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, queuelen);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, queuemax);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(bind_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, BIND_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_BIND_E, BIND_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(bind_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_BIND_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* We return the sockaddr only in case of success. */
+	if(ret == 0)
+	{
+		/* Parameter 2: addr (type: PT_SOCKADDR) */
+		unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
+		u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+		auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
+	}
+	else
+	{
+		/* Parameter 2: addr (type: PT_SOCKADDR) */
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -58,19 +58,10 @@ int BPF_PROG(bind_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	/* We return the sockaddr only in case of success. */
-	if(ret == 0)
-	{
-		/* Parameter 2: addr (type: PT_SOCKADDR) */
-		unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
-		u16 addrlen = (u16)extract__syscall_argument(regs, 2);
-		auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
-	}
-	else
-	{
-		/* Parameter 2: addr (type: PT_SOCKADDR) */
-		auxmap__store_empty_param(auxmap);
-	}
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
+	u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+	auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -28,20 +28,9 @@ int BPF_PROG(connect_e,
 	auxmap__store_s64_param(auxmap, (s64)socket_fd);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR)*/
-	/* We catch information about the destination ip and port or if
-	 * unix socket about the socket pathname. If socket_fd is `<0`, the call
-	 * will surely fail so we are not interested in catching parameters.
-	 */
-	if(socket_fd > 0)
-	{
-		unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
-		u16 addrlen = (u16)extract__syscall_argument(regs, 2);
-		auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
-	}
-	else
-	{
-		auxmap__store_empty_param(auxmap);
-	}
+	unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
+	u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+	auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(connect_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_CONNECT_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD)*/
+	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	/* We catch information about the destination ip and port or if
+	 * unix socket about the socket pathname. If socket_fd is `<0`, the call
+	 * will surely fail so we are not interested in catching parameters.
+	 */
+	if(socket_fd > 0)
+	{
+		unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
+		u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+		auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(connect_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_CONNECT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* We need a valid sockfd to extract source data.*/
+	if(ret == 0)
+	{
+		auxmap__store_socktuple_param(auxmap, socket_fd, OUTBOUND);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(listen_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, LISTEN_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_E, LISTEN_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 2: backlog (type: PT_UINT32) */
+	/// TODO: This should be an `int` not a `uint32_t`
+	u32 backlog = (u32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, backlog);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(listen_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, LISTEN_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_X, LISTEN_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(socket_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SOCKET_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_E, SOCKET_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	/* why to send 32 bits if we need only 8 bits? */
+	u8 domain = (u8)extract__syscall_argument(regs, 0);
+	ringbuf__store_u32(&ringbuf, (u32)socket_family_to_scap(domain));
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	/* this should be an int, not a uint32 */
+	u32 type = (u32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, type);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	/* this should be an int, not a uint32 */
+	u32 proto = (u32)extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, proto);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(socket_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SOCKET_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_X, SOCKET_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(socketpair_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SOCKETPAIR_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_E, SOCKETPAIR_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	/* why to send 32 bits if we need only 8 bits? */
+	u8 domain = (u8)extract__syscall_argument(regs, 0);
+	ringbuf__store_u32(&ringbuf, (u32)socket_family_to_scap(domain));
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	/* this should be an int, not a uint32 */
+	u32 type = (u32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, type);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	/* this should be an int, not a uint32 */
+	u32 proto = (u32)extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, proto);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(socketpair_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SOCKETPAIR_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_X, SOCKETPAIR_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	s32 fds[2] = {-1, -1};
+	unsigned long source = 0;
+	unsigned long peer = 0;
+	unsigned long fds_pointer = 0;
+
+	/* In case of success we have 0. */
+	if(ret == 0)
+	{
+		/* Get new sockets. */
+		fds_pointer = extract__syscall_argument(regs, 3);
+		bpf_probe_read_user((void *)fds, 2 * sizeof(s32), (void *)fds_pointer);
+
+		/* Get source and peer. */
+		struct file *file = extract__file_struct_from_fd((s32)fds[0]);
+		struct socket *socket = BPF_CORE_READ(file, private_data);
+		BPF_CORE_READ_INTO(&source, socket, sk);
+		struct unix_sock *us = (struct unix_sock *)source;
+		BPF_CORE_READ_INTO(&peer, us, peer);
+	}
+
+	/* Parameter 2: fd1 (type: PT_FD) */
+	ringbuf__store_s64(&ringbuf, (s64)fds[0]);
+
+	/* Parameter 3: fd2 (type: PT_FD) */
+	ringbuf__store_s64(&ringbuf, (s64)fds[1]);
+
+	/* Parameter 4: source (type: PT_UINT64) */
+	ringbuf__store_u64(&ringbuf, source);
+
+	/* Parameter 5: peer (type: PT_UINT64) */
+	ringbuf__store_u64(&ringbuf, peer);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -45,10 +45,10 @@
 /* Max length socket unix path. */
 #define MAX_SUN_PATH 108
 
-/* Unix Client */
-#define UNIX_CLIENT "/tmp/client"
+/* Unix Client: the `xyzxe-` prefix is used to avoid name collisions */
+#define UNIX_CLIENT "/tmp/xyzxe-client"
 
-/* Unix Server */
-#define UNIX_SERVER "/tmp/server"
+/* Unix Server: the `xyzxe-` prefix is used to avoid name collisions */
+#define UNIX_SERVER "/tmp/xyzxe-server"
 
 /*=============================== UNIX ===========================*/

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -1,0 +1,54 @@
+#pragma once
+
+/* Network components size. */
+#define FAMILY_SIZE sizeof(uint8_t)
+#define IPV4_SIZE sizeof(uint32_t)
+#define IPV6_SIZE 16
+#define PORT_SIZE sizeof(uint16_t)
+
+/* This is used when we convert IPV4 or IPV6 addresses to a string. */
+#define ADDRESS_LENGTH 100
+
+/* Server queue length. */
+#define QUEUE_LENGTH 2
+
+/*=============================== IPV4 ===========================*/
+
+/* IPv4 Client */
+#define IPV4_CLIENT "127.0.21.34"
+#define IPV4_PORT_CLIENT 51789
+#define IPV4_PORT_CLIENT_STRING "51789"
+
+/* IPv4 Server */
+#define IPV4_SERVER "127.0.21.35"
+#define IPV4_PORT_SERVER 52889
+#define IPV4_PORT_SERVER_STRING "52889"
+
+/*=============================== IPV4 ===========================*/
+
+/*=============================== IPV6 ===========================*/
+
+/* IPv6 Client */
+#define IPV6_CLIENT "::ffff:127.0.0.4"
+#define IPV6_PORT_CLIENT 51790
+#define IPV6_PORT_CLIENT_STRING "51790"
+
+/* IPv6 Server */
+#define IPV6_SERVER "::ffff:127.0.0.5"
+#define IPV6_PORT_SERVER 52890
+#define IPV6_PORT_SERVER_STRING "52890"
+
+/*=============================== IPV6 ===========================*/
+
+/*=============================== UNIX ===========================*/
+
+/* Max length socket unix path. */
+#define MAX_SUN_PATH 108
+
+/* Unix Client */
+#define UNIX_CLIENT "/tmp/client"
+
+/* Unix Server */
+#define UNIX_SERVER "/tmp/server"
+
+/*=============================== UNIX ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/accept4_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/accept4_e.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_accept4
+
+TEST(SyscallEnter, accept4E)
+{
+	auto evt_test = new event_test(__NR_accept4, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "accept4", syscall(__NR_accept4, mock_fd, addr, addrlen, flags));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	/* Right now `flags` are not supported so we will catch always `0` */
+	evt_test->assert_numeric_param(1, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/accept_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/accept_e.cpp
@@ -1,0 +1,39 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_accept
+
+TEST(SyscallEnter, acceptE)
+{
+	auto evt_test = new event_test(__NR_accept, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, NULL, NULL));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/bind_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/bind_e.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_bind
+TEST(SyscallEnter, bindE)
+{
+	auto evt_test = new event_test(__NR_bind, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t addrlen = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, mock_fd, addr, addrlen));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -23,8 +23,8 @@ TEST(SyscallEnter, connectE_INET)
 	/// in something more generic...
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
 	/*  We pass an invalid socket fd so the `connect` must fail. */
-	int32_t mock_fd = 5;
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -70,8 +70,8 @@ TEST(SyscallEnter, connectE_INET6)
 
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
 	/*  We pass an invalid socket fd so the `connect` must fail. */
-	int32_t mock_fd = 5;
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -120,8 +120,8 @@ TEST(SyscallEnter, connectE_UNIX)
 		FAIL() << "'strncpy' must not fail." << std::endl;
 	}
 	/*  We pass an invalid socket fd so the `connect` must fail. */
-	int32_t mock_fd = 5;
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -179,8 +179,8 @@ TEST(SyscallEnter, connectE_UNIX_max_path)
 		FAIL() << "'strncpy' must not fail." << std::endl;
 	}
 	/*  We pass an invalid socket fd so the `connect` must fail. */
-	int32_t mock_fd = 5;
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -222,7 +222,9 @@ TEST(SyscallEnter, connectE_negative_socket)
 	 * The invalid socket fd, in this case, is negative so the `sockaddr` param will be empty.
 	 */
 	int32_t mock_fd = -1;
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, NULL, 0));
+	struct sockaddr *addr = NULL;
+	socklen_t addrlen = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, addr, addrlen));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -245,7 +247,7 @@ TEST(SyscallEnter, connectE_negative_socket)
 	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR)*/
-	/* The param must be empty since we pass an invalid socket_id. */
+	/* Since the pointer to the `sockaddr` is `NULL` we expect an empty param here. */
 	evt_test->assert_empty_param(2);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -14,7 +14,7 @@ TEST(SyscallEnter, connectE_INET)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	struct sockaddr_in server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_port = htons(IPV4_PORT_SERVER);
@@ -63,7 +63,7 @@ TEST(SyscallEnter, connectE_INET6)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	struct sockaddr_in6 server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 
 	server_addr.sin6_family = AF_INET6;
 	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
@@ -113,7 +113,7 @@ TEST(SyscallEnter, connectE_UNIX)
 	/* BPF-side, we read the path until we face a `\0` or until we reach
 	 * the maximum length (`MAX_SUN_PATH`).
 	 */
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sun_family = AF_UNIX;
 	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
 	{
@@ -171,7 +171,7 @@ TEST(SyscallEnter, connectE_UNIX_max_path)
 	 */
 
 	struct sockaddr_un server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sun_family = AF_UNIX;
 	/* we use `memcpy` to avoid the warning message from `strncpy` */
 	if(memcpy(server_addr.sun_path, UNIX_LONG_PATH, MAX_SUN_PATH) == NULL)

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -1,0 +1,255 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_connect)
+
+#include <netdb.h>
+#include <sys/un.h>
+
+TEST(SyscallEnter, connectE_INET)
+{
+	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	struct sockaddr_in server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port = htons(IPV4_PORT_SERVER);
+
+	/// TODO: this is not a syscall probably we need to change the name of the helper
+	/// in something more generic...
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
+	/*  We pass an invalid socket fd so the `connect` must fail. */
+	int32_t mock_fd = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	evt_test->assert_addr_info_inet_param(2, PPM_AF_INET, IPV4_SERVER, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, connectE_INET6)
+{
+	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	struct sockaddr_in6 server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+
+	server_addr.sin6_family = AF_INET6;
+	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
+
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
+	/*  We pass an invalid socket fd so the `connect` must fail. */
+	int32_t mock_fd = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	evt_test->assert_addr_info_inet6_param(2, PPM_AF_INET6, IPV6_SERVER, IPV6_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, connectE_UNIX)
+{
+	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	struct sockaddr_un server_addr;
+	/* BPF-side, we read the path until we face a `\0` or until we reach
+	 * the maximum length (`MAX_SUN_PATH`).
+	 */
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy' must not fail." << std::endl;
+	}
+	/*  We pass an invalid socket fd so the `connect` must fail. */
+	int32_t mock_fd = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	evt_test->assert_addr_info_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+/* This is long 109 chars, so no null terminator will be put inside the `sun_path` during the socket call.
+ * The BPF prog can read at least `108` chars so instead of the `*`, it will put the `\0`.
+ */
+#define UNIX_LONG_PATH "/unix_socket/test/too_long/too_long/too_long/too_long/unix_socket/test/too_long/too_long/too_long/too_longgg*"
+#define EXPECTED_UNIX_LONG_PATH "/unix_socket/test/too_long/too_long/too_long/too_long/unix_socket/test/too_long/too_long/too_long/too_longgg"
+
+TEST(SyscallEnter, connectE_UNIX_max_path)
+{
+	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* The unix socket pathname has the maximum length so there is
+	 * no null terminator `\0`. We want to see if BPF can manage this case by putting
+	 * also the terminator `\0` at the end.
+	 */
+
+	struct sockaddr_un server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	/* we use `memcpy` to avoid the warning message from `strncpy` */
+	if(memcpy(server_addr.sun_path, UNIX_LONG_PATH, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy' must not fail." << std::endl;
+	}
+	/*  We pass an invalid socket fd so the `connect` must fail. */
+	int32_t mock_fd = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	evt_test->assert_addr_info_unix_param(2, PPM_AF_UNIX, EXPECTED_UNIX_LONG_PATH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, connectE_negative_socket)
+{
+	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* We pass an invalid socket `fd` so the `connect` must fail.
+	 * The invalid socket fd, in this case, is negative so the `sockaddr` param will be empty.
+	 */
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, NULL, 0));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	/* The param must be empty since we pass an invalid socket_id. */
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/listen_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/listen_e.cpp
@@ -1,0 +1,43 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_listen
+TEST(SyscallEnter, listenE)
+{
+	auto evt_test = new event_test(__NR_listen, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t socket_fd = 2;
+	int backlog = 3;
+	assert_syscall_state(SYSCALL_FAILURE, "listen", syscall(__NR_listen, socket_fd, backlog));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)socket_fd);
+
+	/* Parameter 2: backlog (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)backlog);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/socket_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/socket_e.cpp
@@ -1,0 +1,52 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_socket) && defined(__NR_close)
+
+#include <sys/socket.h>
+
+TEST(SyscallEnter, socketE)
+{
+	auto evt_test = new event_test(__NR_socket, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = AF_INET;
+	int type = SOCK_RAW;
+	int protocol = PF_INET;
+	int32_t socket_fd = syscall(__NR_socket, domain, type, protocol);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket_fd", socket_fd, NOT_EQUAL, -1);
+	syscall(__NR_close, socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_INET);
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)type);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)protocol);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/socketpair_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/socketpair_e.cpp
@@ -1,0 +1,50 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_socketpair
+
+#include <sys/socket.h>
+
+TEST(SyscallEnter, socketpairE)
+{
+	auto evt_test = new event_test(__NR_socketpair, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, NULL));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_LOCAL);
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)type);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)protocol);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept4_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept4_x.cpp
@@ -1,0 +1,61 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_accept4
+
+/* We follow the same BPF logic of the `accept` so right now there is no need to test all
+ * cases like in the `accept` syscall, here we only want to test that the correct BPF program
+ * is called.
+ */
+
+TEST(SyscallExit, accept4X_failure)
+{
+	auto evt_test = new event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "accept4", syscall(__NR_accept4, mock_fd, addr, addrlen, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
@@ -283,7 +283,16 @@ TEST(SyscallExit, acceptX_UNIX)
 
 	/* Parameter 5: queuemax (type: PT_UINT32) */
 	/* In unix sockets the maximum queue length seems to be 512. */
-	uint32_t unix_max_queue_len = 512;
+	FILE *f = fopen("/proc/sys/net/unix/max_dgram_qlen", "r");
+	if(f == NULL)
+	{
+		FAIL() << "'fopen' must not fail." << std::endl;
+	}
+	int unix_max_queue_len = 0;
+	if(fscanf(f, "%d", &unix_max_queue_len) != 1)
+	{
+		FAIL() << "'fscanf' must not fail." << std::endl;
+	}
 	evt_test->assert_numeric_param(5, (uint32_t)unix_max_queue_len);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
@@ -23,7 +23,7 @@ TEST(SyscallExit, acceptX_INET)
 
 	/* Now we bind the server socket with the server address. */
 	struct sockaddr_in server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_port = htons(IPV4_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
@@ -41,7 +41,7 @@ TEST(SyscallExit, acceptX_INET)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_in client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sin_family = AF_INET;
 	client_addr.sin_port = htons(IPV4_PORT_CLIENT);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, IPV4_CLIENT, &client_addr.sin_addr), NOT_EQUAL, -1);
@@ -119,7 +119,7 @@ TEST(SyscallExit, acceptX_INET6)
 
 	/* Now we bind the server socket with the server address. */
 	struct sockaddr_in6 server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin6_family = AF_INET6;
 	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
@@ -137,7 +137,7 @@ TEST(SyscallExit, acceptX_INET6)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_in6 client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sin6_family = AF_INET6;
 	client_addr.sin6_port = htons(IPV6_PORT_CLIENT);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, IPV6_CLIENT, &client_addr.sin6_addr), NOT_EQUAL, -1);
@@ -211,7 +211,7 @@ TEST(SyscallExit, acceptX_UNIX)
 
 	/* Now we bind the server socket with the server address. */
 	struct sockaddr_un server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sun_family = AF_UNIX;
 	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
 	{
@@ -226,7 +226,7 @@ TEST(SyscallExit, acceptX_UNIX)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_un client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sun_family = AF_UNIX;
 	if(strncpy(client_addr.sun_path, UNIX_CLIENT, MAX_SUN_PATH) == NULL)
 	{

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
@@ -1,0 +1,343 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_accept) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+#include <sys/un.h>
+
+TEST(SyscallExit, acceptX_INET)
+{
+	auto evt_test = new event_test(__NR_accept, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	/* Now we bind the server socket with the server address. */
+	struct sockaddr_in server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port = htons(IPV4_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client address)", syscall(__NR_setsockopt, client_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client port)", syscall(__NR_setsockopt, client_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_in client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sin_family = AF_INET;
+	client_addr.sin_port = htons(IPV4_PORT_CLIENT);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, IPV4_CLIENT, &client_addr.sin_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, acceptX_INET6)
+{
+	auto evt_test = new event_test(__NR_accept, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	/* Now we bind the server socket with the server address. */
+	struct sockaddr_in6 server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin6_family = AF_INET6;
+	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client address)", syscall(__NR_setsockopt, client_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client port)", syscall(__NR_setsockopt, client_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_in6 client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sin6_family = AF_INET6;
+	client_addr.sin6_port = htons(IPV6_PORT_CLIENT);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, IPV6_CLIENT, &client_addr.sin6_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet6_param(2, PPM_AF_INET6, IPV6_CLIENT, IPV6_SERVER, IPV6_PORT_CLIENT_STRING, IPV6_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, acceptX_UNIX)
+{
+	auto evt_test = new event_test(__NR_accept, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+
+	/* Now we bind the server socket with the server address. */
+	struct sockaddr_un server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (server)' must not fail." << std::endl;
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+	int32_t client_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_un client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sun_family = AF_UNIX;
+	if(strncpy(client_addr.sun_path, UNIX_CLIENT, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (client)' must not fail." << std::endl;
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_CLIENT, 0);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	/* In unix sockets the maximum queue length seems to be 512. */
+	uint32_t unix_max_queue_len = 512;
+	evt_test->assert_numeric_param(5, (uint32_t)unix_max_queue_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif /* __NR_unlinkat */
+
+TEST(SyscallExit, acceptX_failure)
+{
+	auto evt_test = new event_test(__NR_accept, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, NULL, NULL));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
@@ -239,6 +239,20 @@ TEST(SyscallExit, acceptX_UNIX)
 	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
 	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
 
+	/* In unix sockets the maximum queue length seems to be 512. */
+	FILE *f = fopen("/proc/sys/net/unix/max_dgram_qlen", "r");
+	if(f == NULL)
+	{
+		FAIL() << "'fopen' must not fail." << std::endl;
+	}
+	int unix_max_queue_len = 0;
+	if(fscanf(f, "%d", &unix_max_queue_len) != 1)
+	{
+		fclose(f);
+		FAIL() << "'fscanf' must not fail." << std::endl;
+	}
+	fclose(f);
+
 	/* Cleaning phase */
 	syscall(__NR_shutdown, connected_socket_fd, 2);
 	syscall(__NR_shutdown, server_socket_fd, 2);
@@ -282,17 +296,6 @@ TEST(SyscallExit, acceptX_UNIX)
 	evt_test->assert_numeric_param(4, (uint32_t)0);
 
 	/* Parameter 5: queuemax (type: PT_UINT32) */
-	/* In unix sockets the maximum queue length seems to be 512. */
-	FILE *f = fopen("/proc/sys/net/unix/max_dgram_qlen", "r");
-	if(f == NULL)
-	{
-		FAIL() << "'fopen' must not fail." << std::endl;
-	}
-	int unix_max_queue_len = 0;
-	if(fscanf(f, "%d", &unix_max_queue_len) != 1)
-	{
-		FAIL() << "'fscanf' must not fail." << std::endl;
-	}
 	evt_test->assert_numeric_param(5, (uint32_t)unix_max_queue_len);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
@@ -204,6 +204,7 @@ TEST(SyscallExit, bindX_failure)
 	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	/* Since the pointer to the `sockaddr` is `NULL` we expect an empty param here. */
 	evt_test->assert_empty_param(2);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/

--- a/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
@@ -21,7 +21,7 @@ TEST(SyscallExit, bindX_INET)
 	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
 
 	struct sockaddr_in server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_port = htons(IPV4_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
@@ -76,7 +76,7 @@ TEST(SyscallExit, bindX_INET6)
 	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
 
 	struct sockaddr_in6 server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin6_family = AF_INET6;
 	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
@@ -127,7 +127,7 @@ TEST(SyscallExit, bindX_UNIX)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
 
 	struct sockaddr_un server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sun_family = AF_UNIX;
 	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
 	{

--- a/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
@@ -1,0 +1,214 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_bind) && defined(__NR_setsockopt) && defined(__NR_socket) && defined(__NR_close)
+
+#include <sys/un.h>
+
+TEST(SyscallExit, bindX_INET)
+{
+	auto evt_test = new event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	struct sockaddr_in server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port = htons(IPV4_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
+
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, server_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	evt_test->assert_addr_info_inet_param(2, PPM_AF_INET, IPV4_SERVER, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, bindX_INET6)
+{
+	auto evt_test = new event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
+
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+
+	struct sockaddr_in6 server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin6_family = AF_INET6;
+	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
+
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, server_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	evt_test->assert_addr_info_inet6_param(2, PPM_AF_INET6, IPV6_SERVER, IPV6_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, bindX_UNIX)
+{
+	auto evt_test = new event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t server_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
+
+	struct sockaddr_un server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy' must not fail." << std::endl;
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	evt_test->assert_addr_info_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif /* __NR_unlinkat */
+
+TEST(SyscallExit, bindX_failure)
+{
+	auto evt_test = new event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t addrlen = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, mock_fd, addr, addrlen));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/connect_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/connect_x.cpp
@@ -18,7 +18,7 @@ TEST(SyscallExit, connectX_INET)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_in client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sin_family = AF_INET;
 	client_addr.sin_port = htons(IPV4_PORT_CLIENT);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, IPV4_CLIENT, &client_addr.sin_addr), NOT_EQUAL, -1);
@@ -26,7 +26,7 @@ TEST(SyscallExit, connectX_INET)
 
 	/* Now we associate the client socket with the server address. */
 	struct sockaddr_in server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_port = htons(IPV4_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
@@ -79,7 +79,7 @@ TEST(SyscallExit, connectX_INET6)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_in6 client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sin6_family = AF_INET6;
 	client_addr.sin6_port = htons(IPV6_PORT_CLIENT);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, IPV6_CLIENT, &client_addr.sin6_addr), NOT_EQUAL, -1);
@@ -87,7 +87,7 @@ TEST(SyscallExit, connectX_INET6)
 
 	/* Now we associate the client socket with the server address. */
 	struct sockaddr_in6 server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sin6_family = AF_INET6;
 	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
@@ -139,7 +139,7 @@ TEST(SyscallExit, connectX_UNIX)
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	struct sockaddr_un client_addr;
-	bzero(&client_addr, sizeof(client_addr));
+	memset(&client_addr, 0, sizeof(client_addr));
 	client_addr.sun_family = AF_UNIX;
 	if(strncpy(client_addr.sun_path, UNIX_CLIENT, MAX_SUN_PATH) == NULL)
 	{
@@ -152,7 +152,7 @@ TEST(SyscallExit, connectX_UNIX)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
 
 	struct sockaddr_un server_addr;
-	bzero(&server_addr, sizeof(server_addr));
+	memset(&server_addr, 0, sizeof(server_addr));
 	server_addr.sun_family = AF_UNIX;
 	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
 	{

--- a/test/modern_bpf/test_suites/syscall_exit_suite/connect_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/connect_x.cpp
@@ -1,0 +1,241 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_close)
+
+#include <netdb.h>
+#include <sys/un.h>
+
+TEST(SyscallExit, connectX_INET)
+{
+	auto evt_test = new event_test(__NR_connect, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_in client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sin_family = AF_INET;
+	client_addr.sin_port = htons(IPV4_PORT_CLIENT);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, IPV4_CLIENT, &client_addr.sin_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+
+	/* Now we associate the client socket with the server address. */
+	struct sockaddr_in server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port = htons(IPV4_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
+
+	/* With `SOCK_DGRAM` the `connect` will not perform a connection this is why the syscall doesn't fail. */
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The client performs a `connect` so the client is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, connectX_INET6)
+{
+	auto evt_test = new event_test(__NR_connect, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_in6 client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sin6_family = AF_INET6;
+	client_addr.sin6_port = htons(IPV6_PORT_CLIENT);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, IPV6_CLIENT, &client_addr.sin6_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+
+	/* Now we associate the client socket with the server address. */
+	struct sockaddr_in6 server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sin6_family = AF_INET6;
+	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The client performs a `connect` so the client is the src. */
+	evt_test->assert_tuple_inet6_param(2, PPM_AF_INET6, IPV6_CLIENT, IPV6_SERVER, IPV6_PORT_CLIENT_STRING, IPV6_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, connectX_UNIX)
+{
+	auto evt_test = new event_test(__NR_connect, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	struct sockaddr_un client_addr;
+	bzero(&client_addr, sizeof(client_addr));
+	client_addr.sun_family = AF_UNIX;
+	if(strncpy(client_addr.sun_path, UNIX_CLIENT, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (client)' must not fail." << std::endl;
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+
+	/* We need to create a server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+
+	struct sockaddr_un server_addr;
+	bzero(&server_addr, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
+	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (server)' must not fail." << std::endl;
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, client_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_CLIENT, 0);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The client performs a `connect` so the client is the src. */
+	evt_test->assert_tuple_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif /* __NR_unlinkat */
+
+TEST(SyscallExit, connectX_failure)
+{
+	auto evt_test = new event_test(__NR_connect, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, NULL, 0));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/listen_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/listen_x.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_listen
+TEST(SyscallExit, listenX)
+{
+	auto evt_test = new event_test(__NR_listen, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t socket_fd = 2;
+	int backlog = 3;
+	assert_syscall_state(SYSCALL_FAILURE, "listen", syscall(__NR_listen, socket_fd, backlog));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/socket_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/socket_x.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_socket) && defined(__NR_close)
+
+#include <sys/socket.h>
+
+TEST(SyscallExit, socketX)
+{
+	auto evt_test = new event_test(__NR_socket, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = AF_INET;
+	int type = SOCK_RAW;
+	int protocol = PF_INET;
+	int32_t socket_fd = syscall(__NR_socket, domain, type, protocol);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket_fd", socket_fd, NOT_EQUAL, -1);
+	syscall(__NR_close, socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)socket_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/socketpair_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/socketpair_x.cpp
@@ -1,0 +1,113 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_socketpair) && defined(__NR_close)
+
+#include <sys/socket.h>
+
+TEST(SyscallExit, socketpairX_success)
+{
+	auto evt_test = new event_test(__NR_socketpair, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	int32_t fd[2];
+	assert_syscall_state(SYSCALL_SUCCESS, "socketpair", syscall(__NR_socketpair, domain, type, protocol, fd), NOT_EQUAL, -1);
+	syscall(__NR_close, fd[0]);
+	syscall(__NR_close, fd[1]);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: fd1 (type: PT_FD)*/
+	evt_test->assert_numeric_param(2, (int64_t)fd[0]);
+
+	/* Parameter 3: fd2 (type: PT_FD)*/
+	evt_test->assert_numeric_param(3, (int64_t)fd[1]);
+
+	/* Parameter 4: source (type: PT_UINT64)*/
+	/* Here we have a kernel pointer, we don't know the exact value. */
+	evt_test->assert_numeric_param(4, (uint64_t)0, NOT_EQUAL);
+
+	/* Parameter 5: peer (type: PT_UINT64)*/
+	/* Here we have a kernel pointer, we don't know the exact value. */
+	evt_test->assert_numeric_param(5, (uint64_t)0, NOT_EQUAL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, socketpairX_failure)
+{
+	auto evt_test = new event_test(__NR_socketpair, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, NULL));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd1 (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)-1);
+
+	/* Parameter 3: fd2 (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)-1);
+
+	/* Parameter 4: source (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)0);
+
+	/* Parameter 5: peer (type: PT_UINT64) */
+	evt_test->assert_numeric_param(5, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -81,6 +81,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_PTRACE_X] = "ptrace_x",
 	[PPME_SYSCALL_CAPSET_E] = "capset_e",
 	[PPME_SYSCALL_CAPSET_X] = "capset_x",
+	[PPME_SOCKET_SOCKET_E] = "socket_e",
+	[PPME_SOCKET_SOCKET_X] = "socket_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -91,6 +91,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_ACCEPT_5_X] = "accept_x",
 	[PPME_SOCKET_ACCEPT4_5_E] = "accept4_e",
 	[PPME_SOCKET_ACCEPT4_5_X] = "accept4_x",
+	[PPME_SOCKET_BIND_E] = "bind_e",
+	[PPME_SOCKET_BIND_X] = "bind_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -85,6 +85,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SOCKET_X] = "socket_x",
 	[PPME_SOCKET_CONNECT_E] = "connect_e",
 	[PPME_SOCKET_CONNECT_X] = "connect_x",
+	[PPME_SOCKET_SOCKETPAIR_E] = "socketpair_e",
+	[PPME_SOCKET_SOCKETPAIR_X] = "socketpair_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -87,6 +87,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_CONNECT_X] = "connect_x",
 	[PPME_SOCKET_SOCKETPAIR_E] = "socketpair_e",
 	[PPME_SOCKET_SOCKETPAIR_X] = "socketpair_x",
+	[PPME_SOCKET_ACCEPT_5_E] = "accept_e",
+	[PPME_SOCKET_ACCEPT_5_X] = "accept_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -93,6 +93,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_ACCEPT4_5_X] = "accept4_x",
 	[PPME_SOCKET_BIND_E] = "bind_e",
 	[PPME_SOCKET_BIND_X] = "bind_x",
+	[PPME_SOCKET_LISTEN_E] = "listen_e",
+	[PPME_SOCKET_LISTEN_X] = "listen_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -83,6 +83,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_CAPSET_X] = "capset_x",
 	[PPME_SOCKET_SOCKET_E] = "socket_e",
 	[PPME_SOCKET_SOCKET_X] = "socket_x",
+	[PPME_SOCKET_CONNECT_E] = "connect_e",
+	[PPME_SOCKET_CONNECT_X] = "connect_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -89,6 +89,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SOCKETPAIR_X] = "socketpair_x",
 	[PPME_SOCKET_ACCEPT_5_E] = "accept_e",
 	[PPME_SOCKET_ACCEPT_5_X] = "accept_x",
+	[PPME_SOCKET_ACCEPT4_5_E] = "accept4_e",
+	[PPME_SOCKET_ACCEPT4_5_X] = "accept4_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `socket`
* `connect`
* `socketpair`
* `accept`
* `accept4`
* `bind`
* `listen`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new(modern_bpf): add support for some network family syscalls
```
