### PR TITLE
update(userspace/libscap): improve scap reader

### DIFF
--- a/userspace/libscap/engine/savefile/savefile.h
+++ b/userspace/libscap/engine/savefile/savefile.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <stdint.h>
 #include <stddef.h>
 #include "scap_reader.h"
+#include "scap_savefile.h"
 
 #define SCAP_HANDLE_T struct savefile_engine
 
@@ -31,7 +32,8 @@ struct savefile_engine
 {
 	char* m_lasterr;
 	scap_reader_t* m_reader;
-	uint64_t m_unexpected_block_readsize;
+	block_header m_last_block_header;
+	bool m_use_last_block_header;
 	char* m_reader_evt_buf;
 	size_t m_reader_evt_buf_size;
 	uint32_t m_last_evt_dump_flags;

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2068,11 +2068,22 @@ static int32_t init(struct scap* main_handle, struct scap_open_args* args)
 		return SCAP_FAILURE;
 	}
 
-	scap_reader_t* reader = scap_reader_open_buffered(scap_reader_open_gzfile(gzfile), READER_BUF_SIZE, true);
+	scap_reader_t* reader = scap_reader_open_gzfile(gzfile);
 	if(!reader)
 	{
 		gzclose(gzfile);
 		return SCAP_FAILURE;
+	}
+
+	if (args->fbuffer_size > 0)
+	{
+		scap_reader_t* buffered_reader = scap_reader_open_buffered(reader, args->fbuffer_size, true);
+		if(!buffered_reader)
+		{
+			reader->close(reader);
+			return SCAP_FAILURE;
+		}
+		reader = buffered_reader;
 	}
 
 	//

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -83,6 +83,7 @@ typedef struct scap_open_args
 	scap_mode_t mode;
 	int fd; // If non-zero, will be used instead of fname.
 	const char* fname; ///< The name of the file to open. NULL for live captures.
+	uint32_t fbuffer_size; ///< If non-zero, offline captures will read from file using a buffer of this size.
 	proc_entry_callback proc_callback; ///< Callback to be invoked for each thread/fd that is extracted from /proc, or NULL if no callback is needed.
 	void* proc_callback_context; ///< Opaque pointer that will be included in the calls to proc_callback. Ignored if proc_callback is NULL.
 	bool import_users; ///< true if the user list should be created when opening the capture.

--- a/userspace/libscap/scap_savefile.h
+++ b/userspace/libscap/scap_savefile.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+
+#pragma once
 
 // Force struct alignment
 #if defined _MSC_VER

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -771,6 +771,7 @@ void sinsp::open_int()
 	m_mode = SCAP_MODE_CAPTURE;
 	scap_open_args oargs;
 	oargs.mode = SCAP_MODE_CAPTURE;
+	oargs.fbuffer_size = 0;
 	if(m_input_fd != 0)
 	{
 		oargs.fd = m_input_fd;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-savefile

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This follows-up the changes of https://github.com/falcosecurity/libs/pull/525 by:
- Making the buffered `scap_reader` implementation optional and configurable through `scap_open_args`
- Avoiding all corner cases in which the scap reader needs to seek backwards

Again, the end goal is to allow stream scap data from sockets or pipe, which can be useful for automated tools and testing.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
