### PR TITLE
new(modern_bpf): add support for `bpf`, `flock`, `ioctl`, `quotactl`, `unshare`, `mount`, `umount2`

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -86,5 +86,7 @@
 #define IOCTL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + PARAM_LEN * 3
 #define IOCTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define QUOTACTL_E_SIZE HEADER_LEN + sizeof(uint16_t) + sizeof(uint8_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 4
+#define UNSHARE_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define UNSHARE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -85,5 +85,6 @@
 #define FLOCK_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define IOCTL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + PARAM_LEN * 3
 #define IOCTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define QUOTACTL_E_SIZE HEADER_LEN + sizeof(uint16_t) + sizeof(uint8_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 4
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -88,5 +88,6 @@
 #define QUOTACTL_E_SIZE HEADER_LEN + sizeof(uint16_t) + sizeof(uint8_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 4
 #define UNSHARE_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define UNSHARE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define MOUNT_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -79,5 +79,7 @@
 #define RENAMEAT2_E_SIZE HEADER_LEN
 #define PIPE_E_SIZE HEADER_LEN
 #define PIPE_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) + PARAM_LEN * 4
+#define BPF_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define BPF_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -83,5 +83,7 @@
 #define BPF_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define FLOCK_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 #define FLOCK_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define IOCTL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + PARAM_LEN * 3
+#define IOCTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -89,5 +89,6 @@
 #define UNSHARE_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define UNSHARE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define MOUNT_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define UMOUNT2_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -81,5 +81,7 @@
 #define PIPE_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint64_t) + PARAM_LEN * 4
 #define BPF_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define BPF_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define FLOCK_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
+#define FLOCK_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -1258,4 +1258,32 @@
 
 /*=============================== UNIX SOCKET PATH ===========================*/
 
+/*=============================== QUOTACTL SYSCALL ===========================*/
+
+/* `/include/linux/quota.h` from kernel source tree. */
+
+/* QIF_BLIMITS_B are defined in the vmlinux.h */
+
+#define QIF_BLIMITS (1 << QIF_BLIMITS_B)
+#define QIF_SPACE (1 << QIF_SPACE_B)
+#define QIF_ILIMITS (1 << QIF_ILIMITS_B)
+#define QIF_INODES (1 << QIF_INODES_B)
+#define QIF_BTIME (1 << QIF_BTIME_B)
+#define QIF_ITIME (1 << QIF_ITIME_B)
+#define QIF_LIMITS (QIF_BLIMITS | QIF_ILIMITS)
+#define QIF_USAGE (QIF_SPACE | QIF_INODES)
+#define QIF_TIMES (QIF_BTIME | QIF_ITIME)
+#define QIF_ALL (QIF_LIMITS | QIF_USAGE | QIF_TIMES)
+
+/*
+ * Structure used for setting quota information about file via quotactl
+ * Following flags are used to specify which fields are valid
+ */
+#define IIF_BGRACE 1
+#define IIF_IGRACE 2
+#define IIF_FLAGS 4
+#define IIF_ALL (IIF_BGRACE | IIF_IGRACE | IIF_FLAGS)
+
+/*=============================== QUOTACTL SYSCALL ===========================*/
+
 #endif /* __MISSING_DEFINITIONS_H__ */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(bpf_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, BPF_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_E, BPF_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: cmd (type: PT_INT64) */
+	s32 cmd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)cmd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(bpf_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, BPF_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_X, BPF_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(flock_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FLOCK_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_E, FLOCK_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 2: operation (type: PT_FLAGS32) */
+	unsigned long operation = extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, flock_flags_to_scap(operation));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(flock_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FLOCK_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_X, FLOCK_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ioctl_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, IOCTL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_E, IOCTL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 2: request (type: PT_UINT64) */
+	u64 request = extract__syscall_argument(regs, 1);
+	ringbuf__store_u64(&ringbuf, request);
+
+	/* Parameter 3: argument (type: PT_UINT64) */
+	u64 argument = extract__syscall_argument(regs, 2);
+	ringbuf__store_u64(&ringbuf, argument);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(ioctl_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, IOCTL_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_X, IOCTL_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(mount_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, MOUNT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MOUNT_E, MOUNT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 3);
+
+	/* The `mountflags` argument may have the magic number 0xC0ED
+	 * (MS_MGC_VAL) in the top 16 bits. (All of the other flags
+	 * occupy the low order 16 bits of `mountflags`.)
+	 * Specifying MS_MGC_VAL was required in kernel
+	 * versions prior to 2.4, but since Linux 2.4 is no longer required
+	 * and is ignored if specified.
+	 */
+	/* Check the magic number 0xC0ED in the top 16 bits and ignore it if specified. */
+	if((flags & PPM_MS_MGC_MSK) == PPM_MS_MGC_VAL)
+	{
+		flags &= ~PPM_MS_MGC_MSK;
+	}
+	ringbuf__store_u32(&ringbuf, flags);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(mount_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_MOUNT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dev (type: PT_CHARBUF) */
+	unsigned long source_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, source_pointer, USER);
+
+	/* Parameter 3: dir (type: PT_FSPATH) */
+	unsigned long target_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, target_pointer, USER);
+
+	/* Parameter 4: type (type: PT_CHARBUF) */
+	unsigned long fstype_pointer = extract__syscall_argument(regs, 2);
+	auxmap__store_charbuf_param(auxmap, fstype_pointer, USER);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(quotactl_e,
+	     struct pt_regs *regs,
+	     long syscall_id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, QUOTACTL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_QUOTACTL_E, QUOTACTL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: cmd (type: PT_FLAGS16) */
+	unsigned long cmd = extract__syscall_argument(regs, 0);
+	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
+	ringbuf__store_u16(&ringbuf, scap_cmd);
+
+	/* Parameter 2: type (type: PT_FLAGS8) */
+	ringbuf__store_u8(&ringbuf, quotactl_type_to_scap(cmd));
+
+	/* Parameter 3: id (type: PT_UINT32) */
+	u32 id = (u32)extract__syscall_argument(regs, 2);
+	if(scap_cmd != PPM_Q_GETQUOTA &&
+	   scap_cmd != PPM_Q_SETQUOTA &&
+	   scap_cmd != PPM_Q_XGETQUOTA &&
+	   scap_cmd != PPM_Q_XSETQLIM)
+	{
+		/* In this case `id` don't represent a `userid` or a `groupid` */
+		ringbuf__store_u32(&ringbuf, 0);
+	}
+	else
+	{
+		ringbuf__store_u32(&ringbuf, id);
+	}
+
+	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
+	u8 quota_fmt = PPM_QFMT_NOT_USED;
+	if(scap_cmd == PPM_Q_QUOTAON)
+	{
+		quota_fmt = quotactl_fmt_to_scap(id);
+	}
+	ringbuf__store_u8(&ringbuf, quota_fmt);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(quotactl_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_QUOTACTL_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: special (type: PT_CHARBUF) */
+	/* The special argument is a pointer to a null-terminated string
+	 * containing the pathname of the (mounted) block special device for
+	 * the filesystem being manipulated.
+	 */
+	unsigned long special_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, special_pointer, USER);
+
+	unsigned long cmd = extract__syscall_argument(regs, 0);
+	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
+
+	/* The `addr` argument is the address of an optional, command-
+	 * specific data structure that is copied in or out of the system.
+	 * The interpretation of `addr` is given with each cmd.
+	 */
+	unsigned long addr_pointer = extract__syscall_argument(regs, 3);
+
+	/* We get `quotafilepath` only for `QUOTAON` command. */
+	if(scap_cmd == PPM_Q_QUOTAON)
+	{
+		/* Parameter 3: quotafilepath (type: PT_CHARBUF) */
+		auxmap__store_charbuf_param(auxmap, addr_pointer, USER);
+	}
+	else
+	{
+		/* Parameter 3: quotafilepath (type: PT_CHARBUF) */
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/* We extract the `struct if_dqblk` if possible. */
+	struct if_dqblk dqblk = {0};
+	if(scap_cmd == PPM_Q_GETQUOTA || scap_cmd == PPM_Q_SETQUOTA)
+	{
+		bpf_probe_read_user((void *)&dqblk, sizeof(dqblk), (void *)addr_pointer);
+	}
+
+	/* Please note that `dqblk` struct could be filled with values different from `0`,
+	 * even if these values are not valid, so we need to explicitly send `0`.
+	 */
+	if(dqblk.dqb_valid & QIF_BLIMITS)
+	{
+		/* Parameter 4: dqb_bhardlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_bhardlimit);
+
+		/* Parameter 5: dqb_bsoftlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_bsoftlimit);
+	}
+	else
+	{
+		/* Parameter 4: dqb_bhardlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, 0);
+
+		/* Parameter 5: dqb_bsoftlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqblk.dqb_valid & QIF_SPACE)
+	{
+		/* Parameter 6: dqb_curspace (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_curspace);
+	}
+	else
+	{
+		/* Parameter 6: dqb_curspace (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqblk.dqb_valid & QIF_ILIMITS)
+	{
+		/* Parameter 7: dqb_ihardlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_ihardlimit);
+
+		/* Parameter 8: dqb_isoftlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_isoftlimit);
+	}
+	else
+	{
+		/* Parameter 7: dqb_ihardlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, 0);
+
+		/* Parameter 8: dqb_isoftlimit (type: PT_UINT64) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqblk.dqb_valid & QIF_BTIME)
+	{
+		/* Parameter 9: dqb_btime (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_btime);
+	}
+	else
+	{
+		/* Parameter 9: dqb_btime (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqblk.dqb_valid & QIF_ITIME)
+	{
+		/* Parameter 10: dqb_itime (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, dqblk.dqb_itime);
+	}
+	else
+	{
+		/* Parameter 10: dqb_itime (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	/* We extract the `struct if_dqinfo` if possible. */
+	struct if_dqinfo dqinfo = {0};
+	if(scap_cmd == PPM_Q_GETINFO || scap_cmd == PPM_Q_SETINFO)
+	{
+		bpf_probe_read_user((void *)&dqinfo, sizeof(dqinfo), (void *)addr_pointer);
+	}
+
+	if(dqinfo.dqi_valid & IIF_BGRACE)
+	{
+		/* Parameter 11: dqi_bgrace (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, dqinfo.dqi_bgrace);
+	}
+	else
+	{
+		/* Parameter 11: dqi_bgrace (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqinfo.dqi_valid & IIF_IGRACE)
+	{
+		/* Parameter 12: dqi_igrace (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, dqinfo.dqi_igrace);
+	}
+	else
+	{
+		/* Parameter 12: dqi_igrace (type: PT_RELTIME) */
+		auxmap__store_u64_param(auxmap, 0);
+	}
+
+	if(dqinfo.dqi_valid & IIF_FLAGS)
+	{
+		/* Parameter 13: dqi_flags (type: PT_FLAGS8) */
+		auxmap__store_u8_param(auxmap, dqinfo.dqi_flags);
+	}
+	else
+	{
+		/* Parameter 13: dqi_flags (type: PT_FLAGS8) */
+		auxmap__store_u8_param(auxmap, 0);
+	}
+
+	/* Parameter 14: quota_fmt_out (type: PT_FLAGS8) */
+	u32 quota_fmt_out = PPM_QFMT_NOT_USED;
+	if(scap_cmd == PPM_Q_GETFMT)
+	{
+		u32 quota_fmt_out_tmp = 0;
+		bpf_probe_read_user(&quota_fmt_out_tmp, sizeof(quota_fmt_out_tmp), (void *)addr_pointer);
+		quota_fmt_out = quotactl_fmt_to_scap(quota_fmt_out_tmp);
+	}
+	auxmap__store_u8_param(auxmap, quota_fmt_out);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(quotactl_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: cmd (type: PT_FLAGS16) */
-	unsigned long cmd = extract__syscall_argument(regs, 0);
+	uint32_t cmd = (uint32_t)extract__syscall_argument(regs, 0);
 	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
 	ringbuf__store_u16(&ringbuf, scap_cmd);
 
@@ -93,7 +93,7 @@ int BPF_PROG(quotactl_x,
 	unsigned long special_pointer = extract__syscall_argument(regs, 1);
 	auxmap__store_charbuf_param(auxmap, special_pointer, USER);
 
-	unsigned long cmd = extract__syscall_argument(regs, 0);
+	uint32_t cmd = (uint32_t)extract__syscall_argument(regs, 0);
 	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
 
 	/* The `addr` argument is the address of an optional, command-

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(umount2_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, UMOUNT2_E_SIZE))
+	{
+		return 0;
+	}
+
+	/// TODO: This event should be called `PPME_SYSCALL_UMOUNT2_E`.
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UMOUNT_E, UMOUNT2_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	u32 flags = (u32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, flags);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(umount2_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	/// TODO: This event should be called `PPME_SYSCALL_UMOUNT2_X`.
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_UMOUNT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	unsigned long target_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, target_pointer, USER);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(unshare_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, UNSHARE_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_E, UNSHARE_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	unsigned long flags = extract__syscall_argument(regs, 0);
+	ringbuf__store_u32(&ringbuf, clone_flags_to_scap(flags));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(unshare_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, UNSHARE_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_X, UNSHARE_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/bpf_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/bpf_e.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_bpf
+
+#include <linux/bpf.h>
+
+TEST(SyscallEnter, bpfE)
+{
+	auto evt_test = new event_test(__NR_bpf, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t cmd = -1;
+	union bpf_attr *attr = NULL;
+	uint32_t size = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "bpf", syscall(__NR_bpf, cmd, attr, size));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: cmd (type: PT_INT64) */
+	evt_test->assert_numeric_param(1, (int64_t)cmd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/flock_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/flock_e.cpp
@@ -1,0 +1,43 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_flock
+TEST(SyscallEnter, flockE)
+{
+	auto evt_test = new event_test(__NR_flock, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t operation = LOCK_EX;
+	assert_syscall_state(SYSCALL_FAILURE, "flock", syscall(__NR_flock, mock_fd, operation));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: operation (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(2, (uint32_t)PPM_LOCK_EX);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/ioctl_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/ioctl_e.cpp
@@ -1,0 +1,53 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ioctl
+
+#include <sys/ioctl.h>
+
+TEST(SyscallEnter, ioctlE)
+{
+	auto evt_test = new event_test(__NR_ioctl, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* The `fd` must be an open file descriptor. In this case, we pass an invalid
+	 * file descriptor so the call will fail.
+	 */
+	int32_t mock_fd = -1;
+	uint64_t request = SIOCGIFCOUNT;
+	char* argp = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "ioctl", syscall(__NR_ioctl, mock_fd, request, argp));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: request (type: PT_UINT64) */
+	evt_test->assert_numeric_param(2, (uint64_t)request);
+
+	/* Parameter 3: argument (type: PT_UINT64) */
+	evt_test->assert_numeric_param(3, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/mount_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/mount_e.cpp
@@ -1,0 +1,49 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mount
+
+#include <sys/mount.h>
+
+TEST(SyscallEnter, mountE)
+{
+	auto evt_test = new event_test(__NR_mount, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	const char* source = "/no_mount_point/xyzk-source";
+	const char* target = "/no_mount_point/xyzk-target";
+	const char* filesystemtype = "not_supported";
+	unsigned long flags = MS_MGC_VAL | MS_RDONLY;
+	const void* data = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "mount", syscall(__NR_mount, source, target, filesystemtype, flags, data));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	/* According to the driver logic `MS_MGC_VAL` should be removed so here
+	 * we will obtain only `MS_RDONLY`
+	 */
+	evt_test->assert_numeric_param(1, (uint32_t)MS_RDONLY);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/quotactl_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/quotactl_e.cpp
@@ -1,0 +1,56 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_quotactl
+
+#include <sys/quota.h>
+
+TEST(SyscallEnter, quotactlE)
+{
+	auto evt_test = new event_test(__NR_quotactl, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int cmd = QCMD(Q_SYNC, USRQUOTA);
+	const char* special = "/dev//*null";
+	int id = 1;
+	struct if_dqblk addr = {0};
+	assert_syscall_state(SYSCALL_FAILURE, "quotactl", syscall(__NR_quotactl, cmd, special, id, &addr));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: cmd (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_Q_SYNC);
+
+	/* Parameter 2: type (type: PT_FLAGS8) */
+	evt_test->assert_numeric_param(2, (uint8_t)PPM_USRQUOTA);
+
+	/* Parameter 3: id (type: PT_UINT32) */
+	/* With `PPM_Q_SYNC` we expect `0` */
+	evt_test->assert_numeric_param(3, (uint32_t)0);
+
+	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
+	/* With `PPM_Q_SYNC` we expect `PPM_QFMT_NOT_USED` */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_QFMT_NOT_USED);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/umount2_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/umount2_e.cpp
@@ -1,0 +1,43 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_umount2
+
+#include <sys/mount.h>
+
+TEST(SyscallEnter, umount2E)
+{
+	auto evt_test = new event_test(__NR_umount2, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	const char* target = "/no_mount_point/xyzk-target";
+	unsigned long flags = MNT_FORCE;
+	assert_syscall_state(SYSCALL_FAILURE, "umount2", syscall(__NR_umount2, target, flags));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)MNT_FORCE);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/unshare_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/unshare_e.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_unshare
+
+#include <sched.h>
+
+TEST(SyscallEnter, unshareE)
+{
+	auto evt_test = new event_test(__NR_unshare, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* If `flags` is specified as zero, then unshare() is a no-op.
+	 * Here we want only the test that the correct event is sent not the value of the flags,
+	 * call unshare with some flags can alter the state of the actual process and here
+	 * we want to be as clear as possible, without changing namespace or something else.
+	 */
+	int flags = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "unshare", syscall(__NR_unshare, flags), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/bpf_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/bpf_x.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_bpf
+
+#include <linux/bpf.h>
+
+TEST(SyscallExit, bpfX)
+{
+	auto evt_test = new event_test(__NR_bpf, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t cmd = -1;
+	union bpf_attr *attr = NULL;
+	uint32_t size = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "bpf", syscall(__NR_bpf, cmd, attr, size));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/flock_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/flock_x.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_flock
+TEST(SyscallExit, flockX)
+{
+	auto evt_test = new event_test(__NR_flock, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t operation = LOCK_EX;
+	assert_syscall_state(SYSCALL_FAILURE, "flock", syscall(__NR_flock, mock_fd, operation));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/ioctl_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/ioctl_x.cpp
@@ -1,0 +1,48 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ioctl
+
+#include <sys/ioctl.h>
+
+TEST(SyscallExit, ioctlX)
+{
+	auto evt_test = new event_test(__NR_ioctl, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	/* The `fd` must be an open file descriptor. In this case, we pass an invalid
+	 * file descriptor so the call will fail.
+	 */
+	int32_t mock_fd = -1;
+	uint64_t request = SIOCGIFCOUNT;
+	char* argp = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "ioctl", syscall(__NR_ioctl, mock_fd, request, argp));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/mount_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/mount_x.cpp
@@ -1,0 +1,56 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mount
+
+#include <sys/mount.h>
+
+TEST(SyscallExit, mountX)
+{
+	auto evt_test = new event_test(__NR_mount, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	const char* source = "/no_mount_point/xyzk-source";
+	const char* target = "/no_mount_point/xyzk-target";
+	const char* filesystemtype = "not_supported";
+	unsigned long flags = MS_MGC_VAL | MS_RDONLY;
+	const void* data = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "mount", syscall(__NR_mount, source, target, filesystemtype, flags, data));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: dev (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, source);
+
+	/* Parameter 3: dir (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, target);
+
+	/* Parameter 4: type (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(4, filesystemtype);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/quotactl_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/quotactl_x.cpp
@@ -1,0 +1,91 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_quotactl
+
+#include <sys/quota.h>
+
+TEST(SyscallExit, quotactlX)
+{
+	auto evt_test = new event_test(__NR_quotactl, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int cmd = QCMD(Q_SYNC, USRQUOTA);
+	const char* special = "/dev//*null";
+	int id = 1;
+	struct if_dqblk addr = {0};
+	assert_syscall_state(SYSCALL_FAILURE, "quotactl", syscall(__NR_quotactl, cmd, special, id, &addr));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: special (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, special);
+
+	/* Parameter 3: quotafilepath (type: PT_CHARBUF) */
+	/* We get `quotafilepath` only for `QUOTAON` cmd. */
+	evt_test->assert_empty_param(3);
+
+	/* Since we use `PPM_Q_SYNC` we expect `0` for all params from 4 to 13 */
+
+	/* Parameter 4: dqb_bhardlimit (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)0);
+
+	/* Parameter 5: dqb_bsoftlimit (type: PT_UINT64) */
+	evt_test->assert_numeric_param(5, (uint64_t)0);
+
+	/* Parameter 6: dqb_curspace (type: PT_UINT64) */
+	evt_test->assert_numeric_param(6, (uint64_t)0);
+
+	/* Parameter 7: dqb_ihardlimit (type: PT_UINT64) */
+	evt_test->assert_numeric_param(7, (uint64_t)0);
+
+	/* Parameter 8: dqb_isoftlimit (type: PT_UINT64) */
+	evt_test->assert_numeric_param(8, (uint64_t)0);
+
+	/* Parameter 9: dqb_btime (type: PT_RELTIME) */
+	evt_test->assert_numeric_param(9, (uint64_t)0);
+
+	/* Parameter 10: dqb_itime (type: PT_RELTIME) */
+	evt_test->assert_numeric_param(10, (uint64_t)0);
+
+	/* Parameter 11: dqi_bgrace (type: PT_RELTIME) */
+	evt_test->assert_numeric_param(11, (uint64_t)0);
+
+	/* Parameter 12: dqi_igrace (type: PT_RELTIME) */
+	evt_test->assert_numeric_param(12, (uint64_t)0);
+
+	/* Parameter 13: dqi_flags (type: PT_FLAGS8) */
+	evt_test->assert_numeric_param(13, (uint8_t)0);
+
+	/* Parameter 14: quota_fmt_out (type: PT_FLAGS8) */
+	evt_test->assert_numeric_param(14, (uint8_t)PPM_QFMT_NOT_USED);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(14);
+}
+
+/// TODO: Probably we can add further tests on this exit event
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/umount2_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/umount2_x.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_umount2
+
+#include <sys/mount.h>
+
+TEST(SyscallExit, umount2X)
+{
+	auto evt_test = new event_test(__NR_umount2, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	const char* target = "/no_mount_point/xyzk-target";
+	unsigned long flags = MNT_FORCE;
+	assert_syscall_state(SYSCALL_FAILURE, "umount2", syscall(__NR_umount2, target, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, target);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/unshare_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/unshare_x.cpp
@@ -1,0 +1,47 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_unshare
+
+#include <sched.h>
+
+TEST(SyscallExit, unshareX)
+{
+	auto evt_test = new event_test(__NR_unshare, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* If `flags` is specified as zero, then unshare() is a no-op.
+	 * Here we want only the test that the correct event is sent not the value of the flags,
+	 * call unshare with some flags can alter the state of the actual process and here
+	 * we want to be as clear as possible, without changing namespace or something else.
+	 */
+	int flags = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "unshare", syscall(__NR_unshare, flags), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -127,6 +127,9 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_UNSHARE_X] = "unshare_x",
 	[PPME_SYSCALL_MOUNT_E] = "mount_e",
 	[PPME_SYSCALL_MOUNT_X] = "mount_x",
+	/* These events should be called `PPME_SYSCALL_UMOUNT2_...` */
+	[PPME_SYSCALL_UMOUNT_E] = "umount2_e",
+	[PPME_SYSCALL_UMOUNT_X] = "umount2_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -119,6 +119,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_BPF_2_X] = "bpf_x",
 	[PPME_SYSCALL_FLOCK_E] = "flock_e",
 	[PPME_SYSCALL_FLOCK_X] = "flock_x",
+	[PPME_SYSCALL_IOCTL_3_E] = "ioctl_e",
+	[PPME_SYSCALL_IOCTL_3_X] = "ioctl_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -117,6 +117,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_PIPE_X] = "pipe_x",
 	[PPME_SYSCALL_BPF_2_E] = "bpf_e",
 	[PPME_SYSCALL_BPF_2_X] = "bpf_x",
+	[PPME_SYSCALL_FLOCK_E] = "flock_e",
+	[PPME_SYSCALL_FLOCK_X] = "flock_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -121,6 +121,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_FLOCK_X] = "flock_x",
 	[PPME_SYSCALL_IOCTL_3_E] = "ioctl_e",
 	[PPME_SYSCALL_IOCTL_3_X] = "ioctl_x",
+	[PPME_SYSCALL_QUOTACTL_E] = "quotactl_e",
+	[PPME_SYSCALL_QUOTACTL_X] = "quotactl_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -115,6 +115,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_RENAMEAT2_X] = "renameat2_x",
 	[PPME_SYSCALL_PIPE_E] = "pipe_e",
 	[PPME_SYSCALL_PIPE_X] = "pipe_x",
+	[PPME_SYSCALL_BPF_2_E] = "bpf_e",
+	[PPME_SYSCALL_BPF_2_X] = "bpf_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -123,6 +123,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_IOCTL_3_X] = "ioctl_x",
 	[PPME_SYSCALL_QUOTACTL_E] = "quotactl_e",
 	[PPME_SYSCALL_QUOTACTL_X] = "quotactl_x",
+	[PPME_SYSCALL_UNSHARE_E] = "unshare_e",
+	[PPME_SYSCALL_UNSHARE_X] = "unshare_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -125,6 +125,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_QUOTACTL_X] = "quotactl_x",
 	[PPME_SYSCALL_UNSHARE_E] = "unshare_e",
 	[PPME_SYSCALL_UNSHARE_X] = "unshare_x",
+	[PPME_SYSCALL_MOUNT_E] = "mount_e",
+	[PPME_SYSCALL_MOUNT_X] = "mount_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `bpf`
* `flock`
* `ioctl`
* `quotactl`
* `unshare`
* `mount`
* `umount2`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Today we define the events `PPME_SYSCALL_UMOUNT_E` and `PPME_SYSCALL_UMOUNT_X`, but we use them for the `umount2` syscall, we don't instrument the `umount`. This is probably due to the fact that in many x64 architectures `__NR_umount` is not defined

**Does this PR introduce a user-facing change?**:

```release-note
new(modern_bpf): add support for `bpf`, `flock`, `ioctl`, `quotactl`, `unshare`, `mount`, `umount2`
```
