### PR TITLE
update(libsinsp/drivers): send empty params from drivers and manage them in userspace

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1669,12 +1669,6 @@ FILLER(sys_execve_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res == PPM_FAILURE_INVALID_USER_MEMORY) {
-		char na[] = "<NA>";
-
-		res = bpf_val_to_ring(data, (unsigned long)na);
-	}
-
 	return res;
 }
 
@@ -1706,11 +1700,6 @@ FILLER(sys_execveat_e, true)
 	val = bpf_syscall_get_argument(data, 1);
 
 	res = bpf_val_to_ring(data, val);
-	if (res == PPM_FAILURE_INVALID_USER_MEMORY)
-	{
-		char na[] = "<NA>";
-		res = bpf_val_to_ring(data, (unsigned long)na);
-	}
 	if (res != PPM_SUCCESS)
 	{
 		return res;
@@ -3263,20 +3252,14 @@ FILLER(sys_open_by_handle_at_x, true)
 	}
 	
 	/*
-	 * filepath
+	 * path
 	 */
-	if (retval > 0)
+	char* filepath = NULL;
+	if(retval > 0)
 	{
 		char* filepath = bpf_get_path(data, retval);
-		if (filepath != NULL)
-		{
-			res = bpf_val_to_ring(data,(unsigned long)filepath);
-			return res;	
-		}
 	} 
-
-	char na[] = "<NA>";
-	res = bpf_val_to_ring(data, (unsigned long)na);
+	res = bpf_val_to_ring(data,(unsigned long)filepath);
 	return res;
 }
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3257,7 +3257,7 @@ FILLER(sys_open_by_handle_at_x, true)
 	char* filepath = NULL;
 	if(retval > 0)
 	{
-		char* filepath = bpf_get_path(data, retval);
+		filepath = bpf_get_path(data, retval);
 	} 
 	res = bpf_val_to_ring(data,(unsigned long)filepath);
 	return res;

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -748,33 +748,39 @@ send_empty_bytebuf_param:
 	case PT_SOCKADDR:
 	case PT_SOCKTUPLE:
 	case PT_FDLIST:
-		if (likely(val != 0)) {
+		if(likely(val != 0))
+		{
 			if (unlikely(val_len >= max_arg_size))
 				return PPM_FAILURE_BUFFER_FULL;
 
-			if (fromuser) {
+			if(fromuser)
+			{
 				len = (int)ppm_copy_from_user(args->buffer + args->arg_data_offset,
 						(const void __user *)(syscall_arg_t)val,
 						val_len);
 
-				if (unlikely(len != 0))
-					return PPM_FAILURE_INVALID_USER_MEMORY;
+				if(unlikely(len != 0))
+				{
+					goto send_empty_sock_param;
+				}
 
 				len = val_len;
-			} else {
+			}
+			else
+			{
 				memcpy(args->buffer + args->arg_data_offset,
 					(void *)(syscall_arg_t)val, val_len);
 
 				len = val_len;
 			}
-		} else {
-			/*
-			 * Handle NULL pointers
-			 */
-			len = 0;
+			/* If we arrive here we have something to send. */
+			break;
 		}
 
+send_empty_sock_param:
+		len = 0;
 		break;
+
 	case PT_FLAGS8:
 	case PT_ENUMFLAGS8:
 	case PT_UINT8:

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4877,6 +4877,7 @@ int f_sys_open_by_handle_at_x(struct event_filler_arguments *args)
 	unsigned long val;
 	int res;
 	int64_t retval;
+	char *pathname = NULL;
 
 	/*
 	 * fd
@@ -4918,7 +4919,6 @@ int f_sys_open_by_handle_at_x(struct event_filler_arguments *args)
 	/*
 	 * path
 	 */
-	char *pathname = NULL;
 	if (retval > 0)
 	{
 		/* String storage size is exactly one page. 

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -123,6 +123,65 @@ uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *p
 
 		params[i].buf = param_buf;
 		param_buf += params[i].size;
+
+		/* Here we need to manage a particular case:
+		 * 
+		 *    - PT_CHARBUF
+		 *    - PT_FSRELPATH
+		 *    - PT_BYTEBUF
+		 *    - PT_BYTEBUF
+		 * 
+		 * In the past these params could be `<NA>` or `(NULL)` or empty.
+		 * Now they can be only empty! The ideal solution would be:
+		 * 	params[i].buf = NULL;
+		 *	params[i].size = 0;
+		 * 
+		 * The problem is that userspace is not
+		 * able to manage `NULL` pointers... but it manages `<NA>` so we
+		 * convert all these cases to `<NA>` when they are empty!
+		 * 
+		 * If we read scap-files we could face `(NULL)` params, so also in
+		 * this case we convert them to `<NA>`.
+		 * 
+		 * To be honest there could be another corner case, but right now
+		 * we don't have to manage it:
+		 *    
+		 *    - PT_SOCKADDR
+		 *    - PT_SOCKTUPLE
+		 *    - PT_FDLIST
+		 * 
+		 * Could be empty, so we will have:
+		 * 	params[i].buf = "pointer to the next param";
+		 *	params[i].size = 0;
+		 * 
+		 * However, as we said in the previous case, the ideal outcome would be:
+		 * 	params[i].buf = NULL;
+		 *	params[i].size = 0;
+		 * 
+		 * The difference with the previous case is that the userspace can manage
+		 * these params when they have `params[i].size == 0`, so we don't have
+		 * to use the `<NA>` workaround! We could also introduce the `NULL` and so
+		 * put in place the ideal solution for this parameter, but before doing this
+		 * we need to be sure that the userspace never tries to deference the pointer
+		 * otherwise it will trigger a segmentation fault at run-time. So as a first
+		 * step we would keep them as they are.
+		 */
+		int param_type = event_info->params[i].type;
+		
+		if((param_type == PT_CHARBUF ||
+			param_type == PT_FSRELPATH ||
+			param_type == PT_BYTEBUF ||
+			param_type == PT_FSPATH)
+			&&
+			(params[i].size == 0 ||
+			(params[i].size == 7 && strncmp(params[i].buf, "(NULL)", 7) == 0)))
+		{
+			/* Overwrite the value and the size of the param. 
+			 * 5 = strlen("<NA>") + `\0`.
+			 */
+			params[i].buf = "<NA>";
+			params[i].size = 5;
+		}
 	}
 
 	return n;

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -176,7 +176,7 @@ uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *p
 			(params[i].size == 0 ||
 			(params[i].size == 7 && strncmp(params[i].buf, "(NULL)", 7) == 0)))
 		{
-			/* Overwrite the value and the size of the param. 
+			/* Overwrite the value and the size of the param.
 			 * 5 = strlen("<NA>") + `\0`.
 			 */
 			params[i].buf = "<NA>";

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -305,7 +305,14 @@ int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf, siz
 		case PT_FSPATH:
 		case PT_FSRELPATH:
             param.buf = va_arg(args, char*);
-            param.size = strlen(param.buf) + 1;
+			if(param.buf == NULL)
+			{
+				param.size = 0;
+			}
+			else
+			{
+				param.size = strlen(param.buf) + 1;
+			}
 			break;
 
 		case PT_BYTEBUF: /* A raw buffer of bytes not suitable for printing */

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -503,8 +503,7 @@ private:
 			
 			if((param_type == PT_CHARBUF ||
 				param_type == PT_FSRELPATH ||
-				param_type == PT_FSPATH ||
-				param_type == PT_BYTEBUF)
+				param_type == PT_FSPATH)
 				&&
 				(params[j].size == 0 ||
 				(params[j].size == 7 && strncmp((char*)params[j].buf, "(NULL)", 7) == 0)))

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1856,7 +1856,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 		{
 			char fullpath[SCAP_MAX_PATH_SIZE];
 			parinfo = enter_evt->get_param(0);
-			if (strncmp(parinfo->m_val, "<NA>", 4) == 0)
+			if (strncmp(parinfo->m_val, "<NA>", 5) == 0)
 			{
 				evt->m_tinfo->m_exepath = "<NA>";
 			}
@@ -1884,7 +1884,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 			 * Get pathname
 			 */
 			parinfo = enter_evt->get_param(1);
-			if (strncmp(parinfo->m_val, "<NA>", 4) == 0)
+			if (strncmp(parinfo->m_val, "<NA>", 5) == 0)
 			{
 				evt->m_tinfo->m_exepath = "<NA>";
 				break;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2289,9 +2289,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			ASSERT(parinfo->m_len == sizeof(uint32_t));
 			enter_evt_flags = *(uint32_t *)parinfo->m_val;
 
-			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
-			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_namelen != 0 && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2330,9 +2328,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 
 			enter_evt_flags = 0;
 
-			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
-			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_namelen != 0 && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;
@@ -2402,9 +2398,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			ASSERT(parinfo->m_len == sizeof(int64_t));
 			int64_t enter_evt_dirfd = *(int64_t *)parinfo->m_val;
 
-			if(enter_evt_namelen != 0
-			   && strncmp(enter_evt_name, "(NULL)", 7) != 0
-			   && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_namelen != 0 && strncmp(enter_evt_name, "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 				namelen = enter_evt_namelen;

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -159,7 +159,7 @@ TEST_F(sinsp_with_test_input, check_charbuf_NULL_param)
 	ASSERT_STREQ(param->m_val, "<NA>");
 }
 
-/* Assert that an empty `PT_BYTEBUF` param is converted to `<NA>` */
+/* Assert that an empty `PT_BYTEBUF` param is NOT converted to `<NA>` */
 TEST_F(sinsp_with_test_input, check_bytebuf_empty_param)
 {
 	add_default_init_thread();
@@ -174,8 +174,7 @@ TEST_F(sinsp_with_test_input, check_bytebuf_empty_param)
 	bytebuf_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PWRITE_X, 2, 0, bytebuf_param);
 	param = evt->get_param(1);
-	ASSERT_EQ(param->m_len, 5);
-	ASSERT_STREQ(param->m_val, "<NA>");
+	ASSERT_EQ(param->m_len, 0);
 }
 
 /* Assert that empty (`PT_SOCKADDR`, `PT_SOCKTUPLE`, `PT_FDLIST`) params are NOT converted to `<NA>` */

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -211,3 +211,104 @@ TEST_F(sinsp_with_test_input, check_sockaddr_empty_param)
 	param = evt->get_param(1);
 	ASSERT_EQ(param->m_len, 0);
 }
+
+TEST_F(sinsp_with_test_input, enter_event_retrieval)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	const char* expected_string = "/tmp/the_file";
+	int dirfd = 0;
+	int new_fd = 0;
+
+	/* Check `openat` syscall.
+	 * `(NULL)` should be converted to `<NA>` and recognized as an invalid param.
+	 */
+	dirfd = 3;
+	new_fd = 10;
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, dirfd, "(NULL)", 0, 0);
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, new_fd, dirfd, expected_string, 0, 0, 0, 0);
+
+	evt = next_event();
+	if(evt->get_type() != PPME_SYSCALL_OPENAT_2_X)
+	{
+		evt = next_event();
+	}
+
+	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
+	{
+		ASSERT_EQ(evt->get_thread_info()->get_fd(new_fd)->m_name, expected_string);
+	}
+	else
+	{
+		FAIL();
+	}
+
+	/* Check `openat2` syscall.
+	 * `<NA>` should be recognized as an invalid param.
+	 */
+	dirfd = 5;
+	new_fd = 11;
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 5, dirfd, "<NA>", 0, 0, 0);
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 6, new_fd, dirfd, expected_string, 0, 0, 0);
+
+	evt = next_event();
+	if(evt->get_type() != PPME_SYSCALL_OPENAT2_X)
+	{
+		evt = next_event();
+	}
+
+	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
+	{
+		ASSERT_EQ(evt->get_thread_info()->get_fd(new_fd)->m_name, expected_string);
+	}
+	else
+	{
+		FAIL();
+	}
+
+	/* Check `open` syscall.
+	 * The empty param should be converted to `<NA>` and recognized as an invalid param.
+	 */
+	new_fd = 12;
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, NULL, 0, 0);
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, new_fd, expected_string, 0, 0, 0, 0);
+
+	evt = next_event();
+	if(evt->get_type() != PPME_SYSCALL_OPEN_X)
+	{
+		evt = next_event();
+	}
+
+	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
+	{
+		ASSERT_EQ(evt->get_thread_info()->get_fd(new_fd)->m_name, expected_string);
+	}
+	else
+	{
+		FAIL();
+	}
+
+	/* Check `creat` syscall.
+	 * The empty param should be converted to `<NA>` and recognized as an invalid param.
+	 */
+	new_fd = 13;
+	add_event(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 3, NULL, 0);
+	add_event(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, 0);
+
+	evt = next_event();
+	if(evt->get_type() != PPME_SYSCALL_CREAT_X)
+	{
+		evt = next_event();
+	}
+
+	if(evt->get_thread_info() != NULL)
+	{
+		ASSERT_EQ(evt->get_thread_info()->get_fd(new_fd)->m_name, expected_string);
+	}
+	else
+	{
+		FAIL();
+	}
+}

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -211,6 +211,7 @@ TEST_F(sinsp_with_test_input, check_sockaddr_empty_param)
 	ASSERT_EQ(param->m_len, 0);
 }
 
+/* Assert that invalid params in enter events are not considered in the TOCTOU prevention logic. */
 TEST_F(sinsp_with_test_input, enter_event_retrieval)
 {
 	add_default_init_thread();
@@ -226,14 +227,8 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 	 */
 	dirfd = 3;
 	new_fd = 10;
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, dirfd, "(NULL)", 0, 0);
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, new_fd, dirfd, expected_string, 0, 0, 0, 0);
-
-	evt = next_event();
-	if(evt->get_type() != PPME_SYSCALL_OPENAT_2_X)
-	{
-		evt = next_event();
-	}
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, dirfd, "(NULL)", 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, new_fd, dirfd, expected_string, 0, 0, 0, 0);
 
 	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
 	{
@@ -249,14 +244,8 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 	 */
 	dirfd = 5;
 	new_fd = 11;
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 5, dirfd, "<NA>", 0, 0, 0);
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 6, new_fd, dirfd, expected_string, 0, 0, 0);
-
-	evt = next_event();
-	if(evt->get_type() != PPME_SYSCALL_OPENAT2_X)
-	{
-		evt = next_event();
-	}
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 5, dirfd, "<NA>", 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 6, new_fd, dirfd, expected_string, 0, 0, 0);
 
 	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
 	{
@@ -271,14 +260,8 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 	 * The empty param should be converted to `<NA>` and recognized as an invalid param.
 	 */
 	new_fd = 12;
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, NULL, 0, 0);
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, new_fd, expected_string, 0, 0, 0, 0);
-
-	evt = next_event();
-	if(evt->get_type() != PPME_SYSCALL_OPEN_X)
-	{
-		evt = next_event();
-	}
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, NULL, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, new_fd, expected_string, 0, 0, 0, 0);
 
 	if(evt->get_thread_info() && evt->get_thread_info()->get_fd(new_fd))
 	{
@@ -293,14 +276,8 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 	 * The empty param should be converted to `<NA>` and recognized as an invalid param.
 	 */
 	new_fd = 13;
-	add_event(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 3, NULL, 0);
-	add_event(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, 0);
-
-	evt = next_event();
-	if(evt->get_type() != PPME_SYSCALL_CREAT_X)
-	{
-		evt = next_event();
-	}
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 3, NULL, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, 0);
 
 	if(evt->get_thread_info() != NULL)
 	{

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -42,7 +42,7 @@ TEST_F(sinsp_with_test_input, file_open)
 	add_default_init_thread();
 
 	open_inspector();
-	sinsp_evt *evt;
+	sinsp_evt* evt = NULL;
 
 	// since adding and reading events happens on a single thread they can be interleaved.
 	// tests may need to change if that will not be the case anymore
@@ -62,10 +62,10 @@ TEST_F(sinsp_with_test_input, dup_dup2_dup3)
 	add_default_init_thread();
 
 	open_inspector();
-	sinsp_evt *evt;
+	sinsp_evt* evt = NULL;
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/test", PPM_O_TRUNC|PPM_O_CREAT|PPM_O_WRONLY, 0666);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/test", PPM_O_TRUNC|PPM_O_CREAT|PPM_O_WRONLY, 0666, 0xCA02, 123);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/test", PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY, 0666);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/test", PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY, 0666, 0xCA02, 123);
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_E, 1, 3);
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_X, 1, 1);
@@ -86,4 +86,128 @@ TEST_F(sinsp_with_test_input, dup_dup2_dup3)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_1_X, 2, 1, 3);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "1");
+}
+
+/* Assert that empty (`PT_CHARBUF`, `PT_FSPATH`, `PT_FSRELPATH`) params are converted to `<NA>` */
+TEST_F(sinsp_with_test_input, check_charbuf_empty_param)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF`.
+	 * A `NULL` `PT_CHARBUF` param is always converted to `<NA>`.
+	 */
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, NULL);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 5);
+	ASSERT_STREQ(param->m_val, "<NA>");
+
+	/* `PPME_SYSCALL_CREAT_E` is a simple event that uses a `PT_FSPATH`
+	 * A `NULL` `PT_FSPATH` param is always converted to `<NA>`.
+	 */
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 2, NULL, 0);
+	param = evt->get_param(0);
+	ASSERT_EQ(param->m_len, 5);
+	ASSERT_STREQ(param->m_val, "<NA>");
+
+	/* `PPME_SYSCALL_EXECVEAT_E` is a simple event that uses a `PT_FSRELPATH`
+	 * A `NULL` `PT_FSRELPATH` param is always converted to `<NA>`.
+	 */
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, 0, NULL, 0);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 5);
+	ASSERT_STREQ(param->m_val, "<NA>");
+}
+
+/* Assert that a `PT_CHARBUF` with `len==1` (just the `\0`) is not changed. */
+TEST_F(sinsp_with_test_input, check_charbuf_len_1)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF`.
+	 * An empty `PT_CHARBUF` param ("") is not converted to `<NA>` since the length is 1.
+	 */
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, "");
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 1);
+	ASSERT_STREQ(param->m_val, "");
+}
+
+/* Assert that a "(NULL)" `PT_CHARBUF` param is converted to `<NA>`
+ * Only scap-file could send a `PT_CHARBUF` with "(NULL)", in our
+ * actual drivers this value is no more supported.
+ */
+TEST_F(sinsp_with_test_input, check_charbuf_NULL_param)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF` */
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, "(NULL)");
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 5);
+	ASSERT_STREQ(param->m_val, "<NA>");
+}
+
+/* Assert that an empty `PT_BYTEBUF` param is converted to `<NA>` */
+TEST_F(sinsp_with_test_input, check_bytebuf_empty_param)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SYSCALL_PWRITE_X` is a simple event that uses a `PT_BYTEBUF` */
+	struct scap_const_sized_buffer bytebuf_param;
+	bytebuf_param.buf = NULL;
+	bytebuf_param.size = 0;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PWRITE_X, 2, 0, bytebuf_param);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 5);
+	ASSERT_STREQ(param->m_val, "<NA>");
+}
+
+/* Assert that empty (`PT_SOCKADDR`, `PT_SOCKTUPLE`, `PT_FDLIST`) params are NOT converted to `<NA>` */
+TEST_F(sinsp_with_test_input, check_sockaddr_empty_param)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SOCKET_CONNECT_E` is a simple event that uses a `PT_SOCKADDR` */
+	struct scap_const_sized_buffer sockaddr_param;
+	sockaddr_param.buf = NULL;
+	sockaddr_param.size = 0;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, 0, sockaddr_param);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 0);
+
+	/* `PPME_SOCKET_CONNECT_X` is a simple event that uses a `PT_SOCKTUPLE` */
+	struct scap_const_sized_buffer socktuple_param;
+	socktuple_param.buf = NULL;
+	socktuple_param.size = 0;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 2, 0, socktuple_param);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 0);
+
+	/* `PPME_SYSCALL_POLL_X` is a simple event that uses a `PT_FDLIST` */
+	struct scap_const_sized_buffer fdlist_param;
+	fdlist_param.buf = NULL;
+	fdlist_param.size = 0;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_POLL_X, 2, 0, fdlist_param);
+	param = evt->get_param(1);
+	ASSERT_EQ(param->m_len, 0);
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area libscap

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

This shouldn't require an API VERSION change since we have already bumped the major version [here](https://github.com/falcosecurity/libs/pull/492) 

**What this PR does / why we need it**:

To understand why we need this PR I need to provide you with a bit of context.
Some of our params send different values in case of failure:

**First group**

- `PT_CHARBUF`
- `PT_FSPATH`
- `PT_FSRELPATH`

could be:  `<NA>`, `(NULL)` or an empty param (`len=0`)

**Second group**

- `PT_BYTEBUF` 

could be: empty param (`len=0`) or **NOTHING**. What I mean with "nothing" is that if we are not able to correctly collect the param in the kernel the entire EVENT will be dropped and not sent to userspace, we call it "drop with invalid user memory instrumentation"

**Third group**

- `PT_SOCKADDR`
- `PT_SOCKTUPLE`
- `PT_FDLIST`

could be: empty param (`len=0`) or **NOTHING**. What I mean with "nothing" is that if we are not able to correctly collect the param in the kernel the entire EVENT will be dropped and not sent to userspace, we call it "drop with invalid user memory instrumentation"

**Issues related to this behavior**

* There is a lot of ambiguity, we don't know what to expect in userspace when we manage them, (see the issue [here](https://github.com/falcosecurity/libs/issues/477))
* When we send a param with `len==0 ` the userspace fills the struct of this param in the following way
```c
/// this is pseudo-code
struct param
{
      uint32_t  param_size = 0; // this is correct
      char*  val_of_the_param = "pointer to the next param"; // this could cause problem if we try to read this pointer
}
```
* if we hit invalid instrumentation with params of type PT_BYTEBUF (for example) there is the risk that the entire event is lost.

**How to solve it**

Our drivers always send empty parameters and the userspace is able to handle them through null pointers. The param struct should be something like this

```c
/// this is pseudo-code
struct param
{
      uint32_t  param_size = 0; // this is correct
      char*  val_of_the_param = NULL; // this is correct
}
```

The problem is that our userspace is not able to manage `NULL` pointers, and introducing the support for this would be huge work and very risky since if we forget to manage a single case we would cause a segmentation fault at **run-time**!! So my proposal here is to follow 3 steps:

1. This PR corrects the drivers' behavior, now they send only empty params in all the cases! ( I will come back later on this).
2. Introduce a solid test framework for `libsinsp`  that could help us in struggling against these kinds of widespread issues without excessive pain. https://github.com/falcosecurity/libs/pull/485
3. Solve the issue allowing the userspace to manage NULL pointers, this step is really risky for this reason we need a solid test framework for the most critical paths.

**This pull request**

As we said before, this PR corrects the drivers' behavior, now they send only empty params in all the cases!

For the **Second group** and **Third group** there is no problem since the userspace is already able to manage empty params, with this fix we only avoid losing the entire event if the instrumentation fails! Please note the userspace should be able to manage empty params checking the `param.len==0`, but just to be safe we don't set the pointer to `NULL` to not trigger unexpected segmentation faults :/ . So we would leave these params as they are in userspace, so:
```c
/// this is pseudo-code
struct param
{
      uint32_t  param_size = 0; // this is correct
      char*  val_of_the_param = NULL; // this is correct
}
```
For the **first group**, the issue is more complex, since the userspace doesn't check for empty params with `param.len==0` it tries to access them directly with the pointers, for this reason, we cannot receive real empty params in userspace and we need to find a workaround :( Since the userspace is already able to manage `<NA>` params, when sinsp loads an empty param of type `PT_CHARBUF`, `PT_FSPATH`, `PT_FSRELPATH` it could default it to `<NA>` in this way:

```c
if((param_type == PT_CHARBUF ||
    param_type == PT_FSRELPATH ||
    param_type == PT_FSPATH)
    &&
    (params[j].size == 0 ||
    (params[j].size == 7 && strncmp((char*)params[j].buf, "(NULL)", 7) == 0)))
   {
		/* Overwrite the value and the size of the param.
		* 5 = strlen("<NA>") + `\0`.
		*/
		params[j].buf = (void*)"<NA>";
		params[j].size = 5;
    }
```

This is not probably the best solution but it seems a reasonable workaround to address this first step without causing unexpected segmentation faults (hopefully:crossed_fingers:).

Please note, just to simplify the number of cases I've decided to convert also `(NULL)` to `<NA>`, in this way the userspace has to manage only 1 case, avoiding problems like this https://github.com/falcosecurity/libs/issues/477. With this fix our drivers won't send anymore `(NULL)` but in the scap files this value is still possible, so this conversion should address also this problem.

Just to conclude I've added some test cases to stress this new logic :) 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This shouldn't require an API VERSION change since we have already bumped the major version [here](https://github.com/falcosecurity/libs/pull/492) 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```