### PR TITLE
fix(libsinsp): retrieve the correct `exepath` with `execveat` syscall

### DIFF
--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -387,7 +387,7 @@ protected:
 	{
 		if(!(m_flags & PPM_CL_CLONE_FILES))
 		{
-			return &m_fdtable;;
+			return &m_fdtable;
 		}
 		else
 		{
@@ -401,7 +401,7 @@ protected:
 	{
 		if(!(m_flags & PPM_CL_CLONE_FILES))
 		{
-			return &m_fdtable;;
+			return &m_fdtable;
 		}
 		else
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR fixes the retrieval of the `execveat` enter event when sinsp is parsing the `execve` exit event. Before this commit it was only possible to retrieve the enter event associated with the exit event we are parsing, so for example `PPME_SYSCALL_EXECVE_19_X` could only retrieve `PPME_SYSCALL_EXECVE_19_E` but not `PPME_SYSCALL_EXECVEAT_E` and this was a bug since in some cases the `PPME_SYSCALL_EXECVE_19_X` corresponds to a `PPME_SYSCALL_EXECVEAT_E` and not to a `PPME_SYSCALL_EXECVE_19_E`.


The `execveat` syscall is a wrapper of `execve`, when the call succeeds the event returned is simply an `execve` exit event. So if an `execveat` is correctly executed we will have, a  `PPME_SYSCALL_EXECVEAT_E` as enter event and a `PPME_SYSCALL_EXECVE_19_X` as exit one.

Moreover since we parse the exit event only if the syscall succeeds, i removed the support for `PPME_SYSCALL_EXECVEAT_X` in the `parse_execve_exit` method since we will never obtain a `PPME_SYSCALL_EXECVEAT_X` if the `execveat` call is successful.

I've added some tests to stress the new logic :) 

**Which issue(s) this PR fixes**:

Fixes #543 

**Special notes for your reviewer**:

This PR depends on https://github.com/falcosecurity/libs/pull/551, here we suppose that in userspace we receive only `<NA>` for empty `PT_CHARBUF` params.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): retrieve the correct `exepath` with `execveat` syscall
```
