### PR TITLE
fix(userspace/libscap): set gzerror fallback to static

### DIFF
--- a/userspace/libscap/scap_zlib.h
+++ b/userspace/libscap/scap_zlib.h
@@ -32,6 +32,6 @@ limitations under the License.
 #define gzwrite(F, B, S) fwrite(B, 1, S, F)
 #define gzread(F, B, S) fread(B, 1, S, F)
 #define gztell(F) ftell(F)
-inline const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error reading file descriptor";}
+inline static const char *gzerror(FILE *F, int *E) {*E = ferror(F); return "error reading file descriptor";}
 #define gzseek fseek
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

I had trouble compiling with the MINIMAL_BUILD option due to the gzerror fallback not being declared static.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
