### PR TITLE
new(modern_bpf): add support for last `network` family syscalls

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -114,5 +114,6 @@
 #define SETRLIMIT_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + PARAM_LEN * 3
 #define PRLIMIT64_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
 #define PRLIMIT64_X_SIZE HEADER_LEN + sizeof(int64_t) * 5 + PARAM_LEN * 5
+#define SETSOCKOPT_E_SIZE HEADER_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -115,5 +115,6 @@
 #define PRLIMIT64_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
 #define PRLIMIT64_X_SIZE HEADER_LEN + sizeof(int64_t) * 5 + PARAM_LEN * 5
 #define SETSOCKOPT_E_SIZE HEADER_LEN
+#define RECVMSG_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -116,5 +116,6 @@
 #define PRLIMIT64_X_SIZE HEADER_LEN + sizeof(int64_t) * 5 + PARAM_LEN * 5
 #define SETSOCKOPT_E_SIZE HEADER_LEN
 #define RECVMSG_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define RECVFROM_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -1050,10 +1050,6 @@ static __always_inline void auxmap__store_iovec_data_param(struct auxiliary_map 
 			break;
 		}
 
-		/* Please note: in `recvmsg` syscalls, `iov_len` is equal to the size of
-		 * buffers passed to recvmsg, so in our tests `MAX_RECVMSG_BUF_SIZE`!
-		 */
-
 		u16 bytes_read = push__bytebuf(auxmap->data, &auxmap->payload_pos, (unsigned long)iovec[j].iov_base, iovec[j].iov_len, USER);
 		if(!bytes_read)
 		{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(recvfrom_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, RECVFROM_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVFROM_E, RECVFROM_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	u32 size = (u32)extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, size);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(recvfrom_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_RECVFROM_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Please note: when the peer has performed an orderly shutdown the return value is 0
+	 * and we cannot catch the right length of the data received from the return value.
+	 * Right now in this case we send an empty parameter to userspace.
+	 */
+	if(ret > 0)
+	{
+		/* We read the minimum between `snaplen` and what we really
+		 * have in the buffer.
+		 */
+		unsigned long bytes_to_read = maps__get_snaplen();
+
+		if(bytes_to_read > ret)
+		{
+			bytes_to_read = ret;
+		}
+
+		/* Parameter 2: data (type: PT_BYTEBUF) */
+		unsigned long received_data_pointer = extract__syscall_argument(regs, 1);
+		auxmap__store_bytebuf_param(auxmap, received_data_pointer, bytes_to_read, USER);
+
+		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+		u32 socket_fd = (u32)extract__syscall_argument(regs, 0);
+		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
+	}
+	else
+	{
+		/* Parameter 2: data (type: PT_BYTEBUF) */
+		auxmap__store_empty_param(auxmap);
+
+		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(recvmsg_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, RECVMSG_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVMSG_E, RECVMSG_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD)*/
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(recvmsg_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_RECVMSG_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Please note: when the peer has performed an orderly shutdown the return value is 0
+	 * and we cannot catch the right length of the data received from the return value.
+	 * Right now in this case we send an empty parameter to userspace.
+	 */
+	if(ret > 0)
+	{
+
+		/* Parameter 2: size (type: PT_UINT32) */
+		auxmap__store_u32_param(auxmap, (u32)ret);
+
+		/* We read the minimum between `snaplen` and what we really
+		 * have in the buffer.
+		 */
+		unsigned long bytes_to_read = maps__get_snaplen();
+
+		if(bytes_to_read > ret)
+		{
+			bytes_to_read = ret;
+		}
+
+		/* Parameter 3: data (type: PT_BYTEBUF) */
+		unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+		auxmap__store_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
+
+		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+		u32 socket_fd = (u32)extract__syscall_argument(regs, 0);
+		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
+	}
+	else
+	{
+		/* Parameter 2: size (type: PT_UINT32) */
+		auxmap__store_u32_param(auxmap, 0);
+
+		/* Parameter 3: data (type: PT_BYTEBUF) */
+		auxmap__store_empty_param(auxmap);
+
+		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(sendmsg_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_SENDMSG_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_iovec_size_param(auxmap, msghdr_pointer);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE)*/
+	/* TODO: Here we don't know if this fd is a socket or not,
+	 * since we are in the enter event and the syscall could fail.
+	 * This shouldn't be a problem since if it is not a socket fd
+	 * the `bpf_probe_read()` call we fail. Probably we have to move it
+	 * in the exit event.
+	 */
+	if(socket_fd >= 0)
+	{
+		auxmap__store_socktuple_param(auxmap, socket_fd, OUTBOUND);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(sendmsg_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_SENDMSG_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	/* Here we want to read some data sent by the `sendmsg()` syscall.
+	 * If the syscall fails we send an empty parameter.
+	 */
+	if(ret >= 0)
+	{
+		/* We read the minimum between `snaplen` and what we really
+		 * have in the buffer.
+		 */
+		unsigned long bytes_to_read = maps__get_snaplen();
+
+		if(bytes_to_read > ret)
+		{
+			bytes_to_read = ret;
+		}
+
+		unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+		auxmap__store_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(sendto_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_SENDTO_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	u32 size = (u32)extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, size);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE)*/
+	/* TODO: Here we don't know if this fd is a socket or not,
+	 * since we are in the enter event and the syscall could fail.
+	 * This shouldn't be a problem since if it is not a socket fd
+	 * the `bpf_probe_read()` call we fail. Probably we have to move it
+	 * in the exit event.
+	 */
+	if(socket_fd >= 0)
+	{
+		auxmap__store_socktuple_param(auxmap, socket_fd, OUTBOUND);
+	}
+	else
+	{
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(sendto_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_SENDTO_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Here we want to read some data sent by the `sendto()` syscall.
+	 * If the syscall fails we send an empty parameter.
+	 */
+	if(ret >= 0)
+	{
+		/* We read the minimum between `snaplen` and what we really
+		 * have in the buffer.
+		 */
+		unsigned long bytes_to_read = maps__get_snaplen();
+
+		if(bytes_to_read > ret)
+		{
+			bytes_to_read = ret;
+		}
+
+		/* Parameter 2: data (type: PT_BYTEBUF) */
+		unsigned long sent_data_pointer = extract__syscall_argument(regs, 1);
+		auxmap__store_bytebuf_param(auxmap, sent_data_pointer, bytes_to_read, USER);
+	}
+	else
+	{
+		/* Parameter 2: data (type: PT_BYTEBUF) */
+		auxmap__store_empty_param(auxmap);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(setsockopt_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SETSOCKOPT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SETSOCKOPT_E, SETSOCKOPT_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(setsockopt_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SOCKET_SETSOCKOPT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	auxmap__store_s64_param(auxmap, (s64)fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	u8 level = (u8)extract__syscall_argument(regs, 1);
+	auxmap__store_u8_param(auxmap, sockopt_level_to_scap(level));
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	u8 optname = (u8)extract__syscall_argument(regs, 2);
+	auxmap__store_u8_param(auxmap, sockopt_optname_to_scap(level, optname));
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	unsigned long optval = extract__syscall_argument(regs, 3);
+	u16 optlen = (u16)extract__syscall_argument(regs, 4);
+	auxmap__store_sockopt_param(auxmap, level, optname, optlen, optval);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	auxmap__store_u32_param(auxmap, (u32)optlen);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -154,6 +154,80 @@ void event_test::parse_event()
 }
 
 /////////////////////////////////
+// NETWORK SCAFFOLDING
+/////////////////////////////////
+
+void event_test::client_reuse_address_port(int32_t socketfd)
+{
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client address)", syscall(__NR_setsockopt, socketfd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (client port)", syscall(__NR_setsockopt, socketfd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+}
+
+void event_test::server_reuse_address_port(int32_t socketfd)
+{
+	/* Allow the socket to reuse the port and address. */
+	int option_value = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server address)", syscall(__NR_setsockopt, socketfd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server port)", syscall(__NR_setsockopt, socketfd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+}
+
+void event_test::client_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sin_family = AF_INET;
+	sockaddr->sin_port = htons(ipv4_port);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, ipv4_string, &(sockaddr->sin_addr)), NOT_EQUAL, -1);
+}
+
+void event_test::server_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sin_family = AF_INET;
+	sockaddr->sin_port = htons(ipv4_port);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, ipv4_string, &(sockaddr->sin_addr)), NOT_EQUAL, -1);
+}
+
+void event_test::client_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sin6_family = AF_INET6;
+	sockaddr->sin6_port = htons(ipv6_port);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, ipv6_string, &(sockaddr->sin6_addr)), NOT_EQUAL, -1);
+}
+
+void event_test::server_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sin6_family = AF_INET6;
+	sockaddr->sin6_port = htons(ipv6_port);
+	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, ipv6_string, &(sockaddr->sin6_addr)), NOT_EQUAL, -1);
+}
+
+void event_test::client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sun_family = AF_UNIX;
+
+	if(strncpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (client)' must not fail." << std::endl;
+	}
+}
+
+void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path)
+{
+	memset(sockaddr, 0, sizeof(*sockaddr));
+	sockaddr->sun_family = AF_UNIX;
+
+	if(strncpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH) == NULL)
+	{
+		FAIL() << "'strncpy (server)' must not fail." << std::endl;
+	}
+}
+
+/////////////////////////////////
 // GENERIC EVENT ASSERTIONS
 /////////////////////////////////
 

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -227,6 +227,88 @@ void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	}
 }
 
+void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr)
+{
+	/* Create the server socket. */
+	*server_socket = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", *server_socket, NOT_EQUAL, -1);
+	server_reuse_address_port(*server_socket);
+
+	memset(server_sockaddr, 0, sizeof(*server_sockaddr));
+	server_fill_sockaddr_in(server_sockaddr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	*client_socket = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", *client_socket, NOT_EQUAL, -1);
+	client_reuse_address_port(*client_socket);
+
+	memset(client_sockaddr, 0, sizeof(*client_sockaddr));
+	client_fill_sockaddr_in(client_sockaddr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+}
+
+void event_test::connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr)
+{
+	/* Create the server socket. */
+	*server_socket = syscall(__NR_socket, AF_INET6, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", *server_socket, NOT_EQUAL, -1);
+	server_reuse_address_port(*server_socket);
+
+	memset(server_sockaddr, 0, sizeof(*server_sockaddr));
+	server_fill_sockaddr_in6(server_sockaddr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	*client_socket = syscall(__NR_socket, AF_INET6, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", *client_socket, NOT_EQUAL, -1);
+	client_reuse_address_port(*client_socket);
+
+	memset(client_sockaddr, 0, sizeof(*client_sockaddr));
+	client_fill_sockaddr_in6(client_sockaddr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+}
+
+void event_test::connect_unix_client_to_server(int32_t* client_socket, struct sockaddr_un* client_sockaddr, int32_t* server_socket, struct sockaddr_un* server_sockaddr)
+{
+	/* Create the server socket. */
+	*server_socket = syscall(__NR_socket, AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", *server_socket, NOT_EQUAL, -1);
+
+	memset(server_sockaddr, 0, sizeof(*server_sockaddr));
+	server_fill_sockaddr_un(server_sockaddr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	*client_socket = syscall(__NR_socket, AF_UNIX, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", *client_socket, NOT_EQUAL, -1);
+
+	memset(client_sockaddr, 0, sizeof(*client_sockaddr));
+	client_fill_sockaddr_un(client_sockaddr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+}
+
 /////////////////////////////////
 // GENERIC EVENT ASSERTIONS
 /////////////////////////////////

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -511,6 +511,53 @@ void event_test::assert_tuple_unix_param(int param_num, uint8_t desired_family, 
 	assert_param_len(FAMILY_SIZE + 8 + 8 + strlen(desired_path) + 1);
 }
 
+void event_test::assert_setsockopt_val(int param_num, int sockopt, void* option_value, int option_len)
+{
+	/* 1 byte for the PPM type. */
+	assert_param_boundaries(param_num);
+	uint16_t expected_size = 1;
+	ASSERT_EQ(*(uint8_t*)(m_event_params[m_current_param].valptr), sockopt) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+
+	switch(sockopt)
+	{
+	case PPM_SOCKOPT_IDX_ERRNO:
+		ASSERT_EQ(*(int64_t*)(m_event_params[m_current_param].valptr + 1), *(int64_t*)option_value)
+			<< VALUE_NOT_CORRECT << m_current_param << std::endl;
+		expected_size += 8;
+		break;
+
+	case PPM_SOCKOPT_IDX_TIMEVAL:
+		ASSERT_EQ(*(uint64_t*)(m_event_params[m_current_param].valptr + 1), *(uint64_t*)option_value) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+		expected_size += 8;
+		break;
+
+	case PPM_SOCKOPT_IDX_UINT64:
+		ASSERT_EQ(*(uint64_t*)(m_event_params[m_current_param].valptr + 1), *(uint64_t*)option_value) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+		expected_size += 8;
+		break;
+
+	case PPM_SOCKOPT_IDX_UINT32:
+		ASSERT_EQ(*(uint32_t*)(m_event_params[m_current_param].valptr + 1), *(uint32_t*)option_value) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+		expected_size += 4;
+		break;
+
+	case PPM_SOCKOPT_IDX_UNKNOWN:
+		/* if option_len is zero we should have just the `scap` code.*/
+		if(option_len == 0)
+		{
+			assert_param_len(expected_size);
+			break;
+		}
+		ASSERT_EQ(*(uint32_t*)(m_event_params[m_current_param].valptr + 1), *(uint32_t*)option_value) << VALUE_NOT_CORRECT << m_current_param << std::endl;
+		expected_size += 4;
+		break;
+	default:
+		FAIL();
+		break;
+	}
+	assert_param_len(expected_size);
+}
+
 void event_test::assert_ptrace_addr(int param_num)
 {
 	assert_param_boundaries(param_num);

--- a/test/modern_bpf/event_class/event_class.h
+++ b/test/modern_bpf/event_class/event_class.h
@@ -45,6 +45,9 @@ enum direction
 	DEST = 1,
 };
 
+/* Default snaplen that we use in the modern probe */
+#define DEFAULT_SNAPLEN 80
+
 /* Syscall return code assertions. */
 #define SYSCALL_FAILURE 0
 #define SYSCALL_SUCCESS 1

--- a/test/modern_bpf/event_class/event_class.h
+++ b/test/modern_bpf/event_class/event_class.h
@@ -190,6 +190,18 @@ public:
 	void client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path = UNIX_CLIENT);
 	void server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path = UNIX_SERVER);
 
+	/**
+	 * @brief Connect a client to a server that is now ready to receive messages
+	 * and accept new connections.
+	 *
+	 * @param client_socket client socket file descriptor.
+	 * @param client_sockaddr client `sockaddr` struct to fill.
+	 * @param server_socket server socket file descriptor.
+	 * @param server_sockaddr server `sockaddr` struct to fill.
+	 */
+	void connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr);
+	void connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr);
+	void connect_unix_client_to_server(int32_t* client_socket, struct sockaddr_un* client_sockaddr, int32_t* server_socket, struct sockaddr_un* server_sockaddr);
 	/////////////////////////////////
 	// GENERIC EVENT ASSERTIONS
 	/////////////////////////////////

--- a/test/modern_bpf/event_class/event_class.h
+++ b/test/modern_bpf/event_class/event_class.h
@@ -425,6 +425,17 @@ public:
 	void assert_tuple_unix_param(int param_num, uint8_t desired_family, const char* desired_path);
 
 	/**
+	 * @brief The setsockopt `optval` is a `PT_DYN`, so we need
+	 * a dedicated helper to assert it.
+	 *
+	 * @param param_num number of the parameter to assert into the event.
+	 * @param sockopt scap code that indicates the type of option.
+	 * @param option_value value that changes according to the option involved.
+	 * @param option_len length of the value.
+	 */
+	void assert_setsockopt_val(int param_num, int sockopt, void* option_value, int option_len);
+
+	/**
 	 * @brief The ptrace `addr` param is a `PT_DYN`, so we need
 	 * a dedicated helper to assert it.
 	 *

--- a/test/modern_bpf/event_class/event_class.h
+++ b/test/modern_bpf/event_class/event_class.h
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include "network_utils.h"
 #include <arpa/inet.h>
+#include <sys/un.h>
 
 #define CURRENT_PID 0
 
@@ -141,6 +142,50 @@ public:
 	 *
 	 */
 	void parse_event();
+
+	/////////////////////////////////
+	// NETWORK SCAFFOLDING
+	/////////////////////////////////
+
+	/**
+	 * @brief Allow sockets to reuse the same port and address.
+	 *
+	 * @param socketfd socket file descriptor.
+	 */
+	void client_reuse_address_port(int32_t socketfd);
+	void server_reuse_address_port(int32_t socketfd);
+
+	/**
+	 * @brief Fill a `sockaddr_in` struct. It uses default values defined
+	 * in `network_utils.h`, if the user doesn't provide them.
+	 *
+	 * @param sockaddr `sockaddr_in` struct to fill.
+	 * @param ipv4_port port as an integer value.
+	 * @param ipv4_string ipv4 as a string.
+	 */
+	void client_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port = IPV4_PORT_CLIENT, const char* ipv4_string = IPV4_CLIENT);
+	void server_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port = IPV4_PORT_SERVER, const char* ipv4_string = IPV4_SERVER);
+
+	/**
+	 * @brief Fill a `sockaddr_in6` struct. It uses default values defined
+	 * in `network_utils.h`, if the user doesn't provide them.
+	 *
+	 * @param sockaddr `sockaddr_in6` struct to fill.
+	 * @param ipv6_port port as an integer value.
+	 * @param ipv6_string ipv6 as a string.
+	 */
+	void client_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port = IPV6_PORT_CLIENT, const char* ipv6_string = IPV6_CLIENT);
+	void server_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port = IPV6_PORT_SERVER, const char* ipv6_string = IPV6_SERVER);
+
+	/**
+	 * @brief Fill a `sockaddr_un` struct. It uses default values defined
+	 * in `network_utils.h`, if the user doesn't provide them.
+	 *
+	 * @param sockaddr `sockaddr_un` struct to fill.
+	 * @param unix_path unix socket path.
+	 */
+	void client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path = UNIX_CLIENT);
+	void server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path = UNIX_SERVER);
 
 	/////////////////////////////////
 	// GENERIC EVENT ASSERTIONS

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -55,7 +55,7 @@
 
 /*=============================== SEND/RECEIVE ===========================*/
 
-/* Sendmsg */
+/* sendmsg/sendto */
 /* we have also the null terminator because in all our messages
  * (first, second, third) we have left the last byte for the
  * null terminator.
@@ -72,5 +72,8 @@
 #define SENDMSG_FULL_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0hey! there is a third message here."
 #define SENDMSG_NO_SNAPLEN_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN
 #define SENDMSG_NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0"
+
+/* recvmsg/recvfrom */
+#define MAX_RECV_BUF_SIZE 100
 
 /*=============================== SEND/RECEIVE ===========================*/

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -52,3 +52,25 @@
 #define UNIX_SERVER "/tmp/xyzxe-server"
 
 /*=============================== UNIX ===========================*/
+
+/*=============================== SEND/RECEIVE ===========================*/
+
+/* Sendmsg */
+/* we have also the null terminator because in all our messages
+ * (first, second, third) we have left the last byte for the
+ * null terminator.
+ *
+ * Please note: if we left further space in our message the bpf
+ * side will catch the entire length of the message, so will catch
+ * all these extra bytes as `\0` bytes. Look at example here: the
+ * second message has 38 bytes so the last 2 are `\0`.
+ */
+#define SENDMSG_FIRST_LEN 36
+#define SENDMSG_SECOND_LEN 38
+#define SENDMSG_THIRD_LEN 55
+#define SENDMSG_FULL_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN + SENDMSG_THIRD_LEN
+#define SENDMSG_FULL_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0hey! there is a third message here."
+#define SENDMSG_NO_SNAPLEN_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN
+#define SENDMSG_NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0"
+
+/*=============================== SEND/RECEIVE ===========================*/

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -55,7 +55,6 @@
 
 /*=============================== SEND/RECEIVE ===========================*/
 
-/* sendmsg/sendto */
 /* we have also the null terminator because in all our messages
  * (first, second, third) we have left the last byte for the
  * null terminator.
@@ -65,15 +64,13 @@
  * all these extra bytes as `\0` bytes. Look at example here: the
  * second message has 38 bytes so the last 2 are `\0`.
  */
-#define SENDMSG_FIRST_LEN 36
-#define SENDMSG_SECOND_LEN 38
-#define SENDMSG_THIRD_LEN 55
-#define SENDMSG_FULL_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN + SENDMSG_THIRD_LEN
-#define SENDMSG_FULL_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0hey! there is a third message here."
-#define SENDMSG_NO_SNAPLEN_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN
-#define SENDMSG_NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0"
-
-/* recvmsg/recvfrom */
+#define FIRST_MESSAGE_LEN 36
+#define SECOND_MESSAGE_LEN 38
+#define THIRD_MESSAGE_LEN 55
+#define FULL_MESSAGE_LEN FIRST_MESSAGE_LEN + SECOND_MESSAGE_LEN + THIRD_MESSAGE_LEN
+#define FULL_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0hey! there is a third message here."
+#define NO_SNAPLEN_MESSAGE_LEN FIRST_MESSAGE_LEN + SECOND_MESSAGE_LEN
+#define NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0"
 #define MAX_RECV_BUF_SIZE 100
 
 /*=============================== SEND/RECEIVE ===========================*/

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -71,6 +71,6 @@
 #define SENDMSG_FULL_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN + SENDMSG_THIRD_LEN
 #define SENDMSG_FULL_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0hey! there is a third message here."
 #define SENDMSG_NO_SNAPLEN_LEN SENDMSG_FIRST_LEN + SENDMSG_SECOND_LEN
-#define SENDMSG_NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0\0"
+#define SENDMSG_NO_SNAPLEN_MESSAGE "hey! there is a first message here.\0hey! there is a second message here.\0"
 
 /*=============================== SEND/RECEIVE ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/accept_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/accept_e.cpp
@@ -11,7 +11,9 @@ TEST(SyscallEnter, acceptE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, NULL, NULL));
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, addr, addrlen));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -13,17 +13,9 @@ TEST(SyscallEnter, connectE_INET)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	struct sockaddr_in server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-
-	server_addr.sin_family = AF_INET;
-	server_addr.sin_port = htons(IPV4_PORT_SERVER);
-
-	/// TODO: this is not a syscall probably we need to change the name of the helper
-	/// in something more generic...
-	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
-	/*  We pass an invalid socket fd so the `connect` must fail. */
 	int32_t mock_fd = -1;
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
@@ -62,15 +54,9 @@ TEST(SyscallEnter, connectE_INET6)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	struct sockaddr_in6 server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-
-	server_addr.sin6_family = AF_INET6;
-	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
-
-	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
-	/*  We pass an invalid socket fd so the `connect` must fail. */
 	int32_t mock_fd = -1;
+	struct sockaddr_in6 server_addr;
+	evt_test->server_fill_sockaddr_in6(&server_addr);
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
@@ -109,18 +95,12 @@ TEST(SyscallEnter, connectE_UNIX)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	struct sockaddr_un server_addr;
 	/* BPF-side, we read the path until we face a `\0` or until we reach
 	 * the maximum length (`MAX_SUN_PATH`).
 	 */
-	memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sun_family = AF_UNIX;
-	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
-	{
-		FAIL() << "'strncpy' must not fail." << std::endl;
-	}
-	/*  We pass an invalid socket fd so the `connect` must fail. */
 	int32_t mock_fd = -1;
+	struct sockaddr_un server_addr;
+	evt_test->server_fill_sockaddr_un(&server_addr);
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
@@ -170,16 +150,9 @@ TEST(SyscallEnter, connectE_UNIX_max_path)
 	 * also the terminator `\0` at the end.
 	 */
 
-	struct sockaddr_un server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sun_family = AF_UNIX;
-	/* we use `memcpy` to avoid the warning message from `strncpy` */
-	if(memcpy(server_addr.sun_path, UNIX_LONG_PATH, MAX_SUN_PATH) == NULL)
-	{
-		FAIL() << "'strncpy' must not fail." << std::endl;
-	}
-	/*  We pass an invalid socket fd so the `connect` must fail. */
 	int32_t mock_fd = -1;
+	struct sockaddr_un server_addr;
+	evt_test->server_fill_sockaddr_un(&server_addr, UNIX_LONG_PATH);
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -2,9 +2,6 @@
 
 #if defined(__NR_connect)
 
-#include <netdb.h>
-#include <sys/un.h>
-
 TEST(SyscallEnter, connectE_INET)
 {
 	auto evt_test = new event_test(__NR_connect, ENTER_EVENT);

--- a/test/modern_bpf/test_suites/syscall_enter_suite/recvfrom_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/recvfrom_e.cpp
@@ -1,0 +1,48 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvfrom
+
+TEST(SyscallEnter, recvfromE)
+{
+	auto evt_test = new event_test(__NR_recvfrom, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_recvfrom, mock_fd, received_data, received_data_len, flags, src_addr, addrlen));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)received_data_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/recvmsg_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/recvmsg_e.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvmsg
+TEST(SyscallEnter, recvmsgE)
+{
+	auto evt_test = new event_test(__NR_recvmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmsg", syscall(__NR_recvmsg, mock_fd, msg, flags));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -42,9 +42,9 @@ TEST(SyscallEnter, sendmsgE)
 	memset(iov, 0, sizeof(iov));
 	send_msg.msg_name = (struct sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
-	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
-	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
-	char sent_data_3[SENDMSG_THIRD_LEN] = "hey! there is a third message here.";
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
+	char sent_data_3[THIRD_MESSAGE_LEN] = "hey! there is a third message here.";
 	iov[0].iov_base = sent_data_1;
 	iov[0].iov_len = sizeof(sent_data_1);
 	iov[1].iov_base = sent_data_2;
@@ -84,7 +84,7 @@ TEST(SyscallEnter, sendmsgE)
 	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32)*/
-	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
 
 	/* Parameter 3: addr (type: PT_SOCKADDR)*/
 	/* The client performs a `sendmsg` to the server so the src_ipv4 is the client one. */

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -1,0 +1,97 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendmsg)
+
+TEST(SyscallEnter, sendmsgE)
+{
+	auto evt_test = new event_test(__NR_sendmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[3];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
+	char sent_data_3[SENDMSG_THIRD_LEN] = "hey! there is a third message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	iov[2].iov_base = sent_data_3;
+	iov[2].iov_len = sizeof(sent_data_3);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", syscall(__NR_sendmsg, client_socket_fd, &send_msg, sendmsg_flags), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+
+	/* Parameter 3: addr (type: PT_SOCKADDR)*/
+	/* The client performs a `sendmsg` to the server so the src_ipv4 is the client one. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -10,30 +10,11 @@ TEST(SyscallEnter, sendmsgE)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	struct msghdr send_msg;

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -37,7 +37,7 @@ TEST(SyscallEnter, sendtoE)
 	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Send a message to the server */
-	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
@@ -68,7 +68,7 @@ TEST(SyscallEnter, sendtoE)
 	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32)*/
-	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
 
 	/* Parameter 3: addr (type: PT_SOCKADDR)*/
 	/* The client performs a `sendto` to the server so the src_ipv4 is the client one. */

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -10,31 +10,11 @@ TEST(SyscallEnter, sendtoE)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	memset(&client_addr, 0, sizeof(client_addr));
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;

--- a/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -1,0 +1,81 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallEnter, sendtoE)
+{
+	auto evt_test = new event_test(__NR_sendto, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	memset(&client_addr, 0, sizeof(client_addr));
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+
+	/* Parameter 3: addr (type: PT_SOCKADDR)*/
+	/* The client performs a `sendto` to the server so the src_ipv4 is the client one. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/setsockopt_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/setsockopt_e.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_setsockopt
+
+#include <netdb.h>
+
+TEST(SyscallEnter, setsockoptE)
+{
+	auto evt_test = new event_test(__NR_setsockopt, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int socket_fd = 0;
+	int level = 0;
+	int option_name = 0;
+	const void* option_value = NULL;
+	socklen_t option_len = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, socket_fd, level, option_name, option_value, option_len));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/socketpair_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/socketpair_e.cpp
@@ -15,7 +15,8 @@ TEST(SyscallEnter, socketpairE)
 	int domain = PF_LOCAL;
 	int type = SOCK_STREAM;
 	int protocol = 0;
-	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, NULL));
+	int32_t* fds = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, fds));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept4_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept4_x.cpp
@@ -1,11 +1,233 @@
 #include "../../event_class/event_class.h"
 
-#ifdef __NR_accept4
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
 
-/* We follow the same BPF logic of the `accept` so right now there is no need to test all
- * cases like in the `accept` syscall, here we only want to test that the correct BPF program
- * is called.
- */
+/* On `s390x` architectures only `accept4` (`accept` is not defined) is used so we need to test all the cases also here. */
+
+TEST(SyscallExit, accept4X_INET)
+{
+	auto evt_test = new event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, accept4X_INET6)
+{
+	auto evt_test = new event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in6 client_addr = {0};
+	struct sockaddr_in6 server_addr = {0};
+	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet6_param(2, PPM_AF_INET6, IPV6_CLIENT, IPV6_SERVER, IPV6_PORT_CLIENT_STRING, IPV6_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, accept4X_UNIX)
+{
+	auto evt_test = new event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_un client_addr = {0};
+	struct sockaddr_un server_addr = {0};
+	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* In unix sockets the maximum queue length seems to be 512. */
+	FILE *f = fopen("/proc/sys/net/unix/max_dgram_qlen", "r");
+	if(f == NULL)
+	{
+		FAIL() << "'fopen' must not fail." << std::endl;
+	}
+	int unix_max_queue_len = 0;
+	if(fscanf(f, "%d", &unix_max_queue_len) != 1)
+	{
+		fclose(f);
+		FAIL() << "'fscanf' must not fail." << std::endl;
+	}
+	fclose(f);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_CLIENT, 0);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)unix_max_queue_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif /* __NR_unlinkat */
 
 TEST(SyscallExit, accept4X_failure)
 {

--- a/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/accept_x.cpp
@@ -10,30 +10,11 @@ TEST(SyscallExit, acceptX_INET)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
 	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
@@ -95,30 +76,11 @@ TEST(SyscallExit, acceptX_INET6)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in6 server_addr;
-	evt_test->server_fill_sockaddr_in6(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in6 client_addr;
-	evt_test->client_fill_sockaddr_in6(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in6 client_addr = {0};
+	struct sockaddr_in6 server_addr = {0};
+	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
 	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
@@ -181,28 +143,11 @@ TEST(SyscallExit, acceptX_UNIX)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-
-	struct sockaddr_un server_addr;
-	evt_test->server_fill_sockaddr_un(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-
-	struct sockaddr_un client_addr;
-	evt_test->client_fill_sockaddr_un(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_un client_addr = {0};
+	struct sockaddr_un server_addr = {0};
+	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
 	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);

--- a/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/bind_x.cpp
@@ -14,17 +14,10 @@ TEST(SyscallExit, bindX_INET)
 
 	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
-
-	/* Allow the socket to reuse the port and address. */
-	int option_value = 1;
-	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
 
 	struct sockaddr_in server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sin_family = AF_INET;
-	server_addr.sin_port = htons(IPV4_PORT_SERVER);
-	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET, IPV4_SERVER, &server_addr.sin_addr), NOT_EQUAL, -1);
+	evt_test->server_fill_sockaddr_in(&server_addr);
 
 	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
@@ -69,17 +62,10 @@ TEST(SyscallExit, bindX_INET6)
 
 	int32_t server_socket_fd = syscall(__NR_socket, AF_INET6, SOCK_DGRAM, 0);
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
-
-	/* Allow the socket to reuse the port and address. */
-	int option_value = 1;
-	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (address)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEADDR, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (port)", syscall(__NR_setsockopt, server_socket_fd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
 
 	struct sockaddr_in6 server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sin6_family = AF_INET6;
-	server_addr.sin6_port = htons(IPV6_PORT_SERVER);
-	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton", inet_pton(AF_INET6, IPV6_SERVER, &server_addr.sin6_addr), NOT_EQUAL, -1);
+	evt_test->server_fill_sockaddr_in6(&server_addr);
 
 	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
@@ -127,12 +113,7 @@ TEST(SyscallExit, bindX_UNIX)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
 
 	struct sockaddr_un server_addr;
-	memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sun_family = AF_UNIX;
-	if(strncpy(server_addr.sun_path, UNIX_SERVER, MAX_SUN_PATH) == NULL)
-	{
-		FAIL() << "'strncpy' must not fail." << std::endl;
-	}
+	evt_test->server_fill_sockaddr_un(&server_addr);
 
 	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -1,0 +1,202 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvfrom
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallExit, recvfromX_no_snaplen)
+{
+	auto evt_test = new event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t recvfrom_flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+
+	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, src_addr, addrlen);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)received_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, received_bytes);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvfrom` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+TEST(SyscallExit, recvfromX_snaplen)
+{
+	auto evt_test = new event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t recvfrom_flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+
+	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, src_addr, addrlen);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)MAX_RECV_BUF_SIZE);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvfrom` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif
+
+TEST(SyscallExit, recvfromX_fail)
+{
+	auto evt_test = new event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_recvfrom, mock_fd, received_data, received_data_len, flags, src_addr, addrlen));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(3);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -2,7 +2,7 @@
 
 #ifdef __NR_recvfrom
 
-#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
 
 TEST(SyscallExit, recvfromX_no_snaplen)
 {
@@ -25,8 +25,8 @@ TEST(SyscallExit, recvfromX_no_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
-	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
-	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
 
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
@@ -98,8 +98,8 @@ TEST(SyscallExit, recvfromX_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
-	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
-	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
 
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -12,30 +12,11 @@ TEST(SyscallExit, recvmsgX_no_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
@@ -117,30 +98,11 @@ TEST(SyscallExit, recvmsgX_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -2,7 +2,7 @@
 
 #ifdef __NR_recvmsg
 
-#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
 
 TEST(SyscallExit, recvmsgX_no_snaplen)
 {
@@ -25,8 +25,8 @@ TEST(SyscallExit, recvmsgX_no_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
-	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
-	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
 
 	struct msghdr recv_msg;
 	struct iovec iov[2];
@@ -111,8 +111,8 @@ TEST(SyscallExit, recvmsgX_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
-	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
-	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
 
 	struct msghdr recv_msg;
 	struct iovec iov[2];

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -38,7 +38,7 @@ TEST(SyscallExit, recvmsgX_no_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Send a message to the server */
-	char sent_data[SENDMSG_NO_SNAPLEN_LEN] = SENDMSG_NO_SNAPLEN_MESSAGE;
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
@@ -98,7 +98,7 @@ TEST(SyscallExit, recvmsgX_no_snaplen)
 	evt_test->assert_numeric_param(2, (uint32_t)received_bytes);
 
 	/* Parameter 3: data (type: PT_BYTEBUF) */
-	evt_test->assert_bytebuf_param(3, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+	evt_test->assert_bytebuf_param(3, NO_SNAPLEN_MESSAGE, sent_bytes);
 
 	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
 	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
@@ -143,7 +143,7 @@ TEST(SyscallExit, recvmsgX_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Send a message to the server */
-	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
@@ -197,13 +197,13 @@ TEST(SyscallExit, recvmsgX_snaplen)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	evt_test->assert_numeric_param(1, (int64_t)SENDMSG_FULL_LEN);
+	evt_test->assert_numeric_param(1, (int64_t)FULL_MESSAGE_LEN);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
 
 	/* Parameter 3: data (type: PT_BYTEBUF) */
-	evt_test->assert_bytebuf_param(3, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+	evt_test->assert_bytebuf_param(3, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
 	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */

--- a/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -1,0 +1,264 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvmsg
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallExit, recvmsgX_no_snaplen)
+{
+	auto evt_test = new event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	char sent_data[SENDMSG_NO_SNAPLEN_LEN] = SENDMSG_NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	struct msghdr recv_msg;
+	struct iovec iov[2];
+	memset(&recv_msg, 0, sizeof(recv_msg));
+	memset(iov, 0, sizeof(iov));
+	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_namelen = sizeof(client_addr);
+	char data_1[MAX_RECV_BUF_SIZE];
+	char data_2[MAX_RECV_BUF_SIZE];
+	iov[0].iov_base = data_1;
+	iov[0].iov_len = MAX_RECV_BUF_SIZE;
+	iov[1].iov_base = data_2;
+	iov[1].iov_len = MAX_RECV_BUF_SIZE;
+	recv_msg.msg_iov = iov;
+	recv_msg.msg_iovlen = 2;
+	uint32_t recvmsg_flags = 0;
+
+	int64_t received_bytes = syscall(__NR_recvmsg, connected_socket_fd, &recv_msg, recvmsg_flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvmsg (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)received_bytes);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)received_bytes);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(3, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(4, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+
+TEST(SyscallExit, recvmsgX_snaplen)
+{
+	auto evt_test = new event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept, server_socket_fd, NULL, NULL);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	struct msghdr recv_msg;
+	struct iovec iov[2];
+	memset(&recv_msg, 0, sizeof(recv_msg));
+	memset(iov, 0, sizeof(iov));
+	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_namelen = sizeof(client_addr);
+	char data_1[MAX_RECV_BUF_SIZE];
+	char data_2[MAX_RECV_BUF_SIZE];
+	iov[0].iov_base = data_1;
+	iov[0].iov_len = MAX_RECV_BUF_SIZE;
+	iov[1].iov_base = data_2;
+	iov[1].iov_len = MAX_RECV_BUF_SIZE;
+	recv_msg.msg_iov = iov;
+	recv_msg.msg_iovlen = 2;
+	uint32_t recvmsg_flags = 0;
+
+	int64_t received_bytes = syscall(__NR_recvmsg, connected_socket_fd, &recv_msg, recvmsg_flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvmsg (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)SENDMSG_FULL_LEN);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)SENDMSG_FULL_LEN);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(3, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(4, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif
+
+TEST(SyscallExit, recvmsgX_fail)
+{
+	auto evt_test = new event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmsg", syscall(__NR_recvmsg, mock_fd, msg, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)0);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(3);
+
+	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(4);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -1,0 +1,230 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendmsg
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+/* By default `snaplen` is 80 bytes.
+ * No `snaplen` because here we don't hit the 80 bytes so we don't have to truncate the message.
+ */
+TEST(SyscallExit, sendmsgX_no_snaplen)
+{
+	auto evt_test = new event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[2];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 2;
+	uint32_t sendmsg_flags = 0;
+
+	int64_t sent_bytes = syscall(__NR_sendmsg, client_socket_fd, &send_msg, sendmsg_flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+/* Here we need to truncate our message since it is greater than `snaplen` */
+TEST(SyscallExit, sendmsgX_snaplen)
+{
+	auto evt_test = new event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[3];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
+	char sent_data_3[SENDMSG_THIRD_LEN] = "hey! there is a third message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	iov[2].iov_base = sent_data_3;
+	iov[2].iov_len = sizeof(sent_data_3);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	int64_t sent_bytes = syscall(__NR_sendmsg, client_socket_fd, &send_msg, sendmsg_flags);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+TEST(SyscallExit, sendmsgX_fail)
+{
+	auto evt_test = new event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr* send_msg = NULL;
+	uint32_t sendmsg_flags = 0;
+
+	assert_syscall_state(SYSCALL_FAILURE, "sendmsg", syscall(__NR_sendmsg, mock_fd, send_msg, sendmsg_flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+#endif /* __NR_sendmsg */

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -47,8 +47,8 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 	memset(iov, 0, sizeof(iov));
 	send_msg.msg_name = (struct sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
-	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
-	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
 	iov[0].iov_base = sent_data_1;
 	iov[0].iov_len = sizeof(sent_data_1);
 	iov[1].iov_base = sent_data_2;
@@ -87,7 +87,7 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
 
 	/* Parameter 2: data (type: PT_BYTEBUF)*/
-	evt_test->assert_bytebuf_param(2, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, sent_bytes);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
@@ -135,9 +135,9 @@ TEST(SyscallExit, sendmsgX_snaplen)
 	memset(iov, 0, sizeof(iov));
 	send_msg.msg_name = (struct sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
-	char sent_data_1[SENDMSG_FIRST_LEN] = "hey! there is a first message here.";
-	char sent_data_2[SENDMSG_SECOND_LEN] = "hey! there is a second message here.";
-	char sent_data_3[SENDMSG_THIRD_LEN] = "hey! there is a third message here.";
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
+	char sent_data_3[THIRD_MESSAGE_LEN] = "hey! there is a third message here.";
 	iov[0].iov_base = sent_data_1;
 	iov[0].iov_len = sizeof(sent_data_1);
 	iov[1].iov_base = sent_data_2;
@@ -178,7 +178,7 @@ TEST(SyscallExit, sendmsgX_snaplen)
 	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
 
 	/* Parameter 2: data (type: PT_BYTEBUF)*/
-	evt_test->assert_bytebuf_param(2, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -15,30 +15,11 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	struct msghdr send_msg;
@@ -103,30 +84,11 @@ TEST(SyscallExit, sendmsgX_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	struct msghdr send_msg;

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -1,0 +1,201 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendto
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+/* By default `snaplen` is 80 bytes.
+ * No `snaplen` because here we don't hit the 80 bytes so we don't have to truncate the message.
+ */
+TEST(SyscallExit, sendtoX_no_snaplen)
+{
+	auto evt_test = new event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	char sent_data[SENDMSG_NO_SNAPLEN_LEN] = SENDMSG_NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+/* Here we need to truncate our message since it is greater than `snaplen` */
+TEST(SyscallExit, sendtoX_snaplen)
+{
+	auto evt_test = new event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create the server socket. */
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* Now we bind the server socket with the server address. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
+
+	/* The server now is ready, we need to create at least one connection from the client. */
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+
+	/* Send a message to the server */
+	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+TEST(SyscallExit, sendtoX_fail)
+{
+	auto evt_test = new event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char* sent_data = NULL;
+	size_t len = 0;
+	uint32_t sendto_flags = 0;
+	struct sockaddr* dest_addr = NULL;
+	socklen_t addrlen = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "sendto", syscall(__NR_sendto, mock_fd, sent_data, len, sendto_flags, dest_addr, addrlen));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+#endif /* __NR_sendmsg */

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -41,7 +41,7 @@ TEST(SyscallExit, sendtoX_no_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Send a message to the server */
-	char sent_data[SENDMSG_NO_SNAPLEN_LEN] = SENDMSG_NO_SNAPLEN_MESSAGE;
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
@@ -73,7 +73,7 @@ TEST(SyscallExit, sendtoX_no_snaplen)
 	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
 
 	/* Parameter 2: data (type: PT_BYTEBUF)*/
-	evt_test->assert_bytebuf_param(2, SENDMSG_NO_SNAPLEN_MESSAGE, sent_bytes);
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, sent_bytes);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
@@ -115,7 +115,7 @@ TEST(SyscallExit, sendtoX_snaplen)
 	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Send a message to the server */
-	char sent_data[SENDMSG_FULL_LEN] = SENDMSG_FULL_MESSAGE;
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
@@ -147,7 +147,7 @@ TEST(SyscallExit, sendtoX_snaplen)
 	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
 
 	/* Parameter 2: data (type: PT_BYTEBUF)*/
-	evt_test->assert_bytebuf_param(2, SENDMSG_FULL_MESSAGE, DEFAULT_SNAPLEN);
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -15,30 +15,11 @@ TEST(SyscallExit, sendtoX_no_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
@@ -89,30 +70,11 @@ TEST(SyscallExit, sendtoX_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* Create the server socket. */
-	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
-	evt_test->server_reuse_address_port(server_socket_fd);
-
-	struct sockaddr_in server_addr;
-	evt_test->server_fill_sockaddr_in(&server_addr);
-
-	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, server_socket_fd, QUEUE_LENGTH), NOT_EQUAL, -1);
-
-	/* The server now is ready, we need to create at least one connection from the client. */
-
-	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
-	evt_test->client_reuse_address_port(client_socket_fd);
-
-	struct sockaddr_in client_addr;
-	evt_test->client_fill_sockaddr_in(&client_addr);
-
-	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;

--- a/test/modern_bpf/test_suites/syscall_exit_suite/setsockopt_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/setsockopt_x.cpp
@@ -1,0 +1,397 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_setsockopt
+
+#include <netdb.h>
+#include <time.h>
+
+/* Used in `SO_RCVTIMEO` test. */
+#define SEC_FACTOR 1000000000
+#define USEC_FACTOR 1000
+
+TEST(SyscallExit, setsockoptX_SO_ERROR)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_ERROR;
+	int32_t option_value = 14;
+	socklen_t option_len = sizeof(int32_t);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_ERROR);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	/* In case of `PPM_SOCKOPT_IDX_ERRNO` we receive the negative `option_value`*/
+	int64_t negative_option_value = -option_value;
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_ERRNO, &negative_option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, setsockoptX_SO_RCVTIMEO)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_RCVTIMEO;
+	struct timeval option_value = {0};
+	option_value.tv_sec = 5;
+	option_value.tv_usec = 10;
+	socklen_t option_len = sizeof(struct timeval);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_RCVTIMEO);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	uint64_t total_timeval = option_value.tv_sec * SEC_FACTOR + option_value.tv_usec * USEC_FACTOR;
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_TIMEVAL, &total_timeval, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+TEST(SyscallExit, setsockoptX_SO_COOKIE)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_COOKIE;
+	uint64_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_COOKIE);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT64, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+TEST(SyscallExit, setsockoptX_SO_PASSCRED)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_PASSCRED);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT32, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+TEST(SyscallExit, setsockoptX_UNKNOWN_OPTION)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = -1; /* this is an unknown option. */
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+TEST(SyscallExit, setsockoptX_SOL_UNKNOWN)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+TEST(SyscallExit, setsockoptX_ZERO_OPTLEN)
+{
+	auto evt_test = new event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 0;
+	socklen_t option_len = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_setsockopt, mock_fd, level, option_name, &option_value, option_len));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/socketpair_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/socketpair_x.cpp
@@ -70,7 +70,8 @@ TEST(SyscallExit, socketpairX_failure)
 	int domain = PF_LOCAL;
 	int type = SOCK_STREAM;
 	int protocol = 0;
-	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, NULL));
+	int32_t* fd = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketpair, domain, type, protocol, fd));
 	int64_t errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -166,6 +166,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SENDMSG_X] = "sendmsg_x",
 	[PPME_SOCKET_SENDTO_E] = "sendto_e",
 	[PPME_SOCKET_SENDTO_X] = "sendto_x",
+	[PPME_SOCKET_RECVMSG_E] = "recvmsg_e",
+	[PPME_SOCKET_RECVMSG_X] = "recvmsg_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -160,6 +160,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_SETRLIMIT_X] = "setrlimit_x",
 	[PPME_SYSCALL_PRLIMIT_E] = "prlimit64_e",
 	[PPME_SYSCALL_PRLIMIT_X] = "prlimit64_x",
+	[PPME_SOCKET_SETSOCKOPT_E] = "setsockopt_e",
+	[PPME_SOCKET_SETSOCKOPT_X] = "setsockopt_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -162,6 +162,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_PRLIMIT_X] = "prlimit64_x",
 	[PPME_SOCKET_SETSOCKOPT_E] = "setsockopt_e",
 	[PPME_SOCKET_SETSOCKOPT_X] = "setsockopt_x",
+	[PPME_SOCKET_SENDMSG_E] = "sendmsg_e",
+	[PPME_SOCKET_SENDMSG_X] = "sendmsg_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -164,6 +164,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SETSOCKOPT_X] = "setsockopt_x",
 	[PPME_SOCKET_SENDMSG_E] = "sendmsg_e",
 	[PPME_SOCKET_SENDMSG_X] = "sendmsg_x",
+	[PPME_SOCKET_SENDTO_E] = "sendto_e",
+	[PPME_SOCKET_SENDTO_X] = "sendto_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -168,6 +168,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SENDTO_X] = "sendto_x",
 	[PPME_SOCKET_RECVMSG_E] = "recvmsg_e",
 	[PPME_SOCKET_RECVMSG_X] = "recvmsg_x",
+	[PPME_SOCKET_RECVFROM_E] = "recvfrom_e",
+	[PPME_SOCKET_RECVFROM_X] = "recvfrom_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This is the last PR of the https://github.com/falcosecurity/libs/issues/513, we have done it :tada: :tada: 
This PR introduces:

* `setsockopt`
* `sendmsg`
* `sendto`
* `recvmsg`
* `recvfrom`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(modern_bpf): add support for last `network` family syscalls
```
