### PR TITLE
fix(userspace/libsinsp/filter)!: use raw pointers in AST as_string signature

### DIFF
--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -171,11 +171,11 @@ const std::string& string_visitor::as_string()
 	return m_str;
 }
 
-std::string libsinsp::filter::ast::as_string(ast::expr &e)
+std::string libsinsp::filter::ast::as_string(ast::expr *e)
 {
 	string_visitor sv;
 
-	e.accept(&sv);
+	e->accept(&sv);
 
 	return sv.as_string();
 }

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -355,7 +355,7 @@ struct SINSP_PUBLIC binary_check_expr: expr
 	\brief Return a string representation of an AST.
 	\return A string representation of an AST.
 */
-std::string as_string(ast::expr &e);
+std::string as_string(ast::expr *e);
 
 /*!
 	\brief Creates a deep clone of a filter AST

--- a/userspace/libsinsp/test/string_visitor.ut.cpp
+++ b/userspace/libsinsp/test/string_visitor.ut.cpp
@@ -37,13 +37,13 @@ protected:
 
 		std::unique_ptr<ast::expr> e(parser.parse());
 
-		ASSERT_STREQ(as_string(*(e.get())).c_str(), out.c_str());
+		ASSERT_STREQ(as_string(e.get()).c_str(), out.c_str());
 	}
 
 	void bidirectional(const std::string &filter)
 	{
 		std::unique_ptr<ast::expr> e1(parser(filter).parse());
-		std::unique_ptr<ast::expr> e2(parser(as_string(*(e1.get()))).parse());
+		std::unique_ptr<ast::expr> e2(parser(as_string(e1.get())).parse());
 		ASSERT_TRUE(e1->is_equal(e2.get()));
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This makes the (yet unused) AST `as_string` signature use raw pointers instead of references in order to make it consistent with other AST related functions (e.g. `clone`, `is_equal`, etc.). Besides code consistency, ASTs factory constructors now always return unique_ptrs so it will be unlikely to have reference-compatible ASTs without additional and unneeded de-referencing.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp/filter)!: use raw pointers in AST as_string signature
```
