### PR TITLE
fix(userspace/libsinsp): fix parse_field_name() wrong check (size_t, aka uint32_t, cast of max_fldlen)

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1143,7 +1143,7 @@ int32_t sinsp_filter_check::parse_field_name(const char* str, bool alloc_state, 
 
 	for(j = 0; j < m_info.m_nfields; j++)
 	{
-		auto fldlen = strlen(m_info.m_fields[j].m_name);
+		int32_t fldlen = (int32_t)strlen(m_info.m_fields[j].m_name);
 		if(fldlen <= max_fldlen)
 		{
 			continue;
@@ -1153,7 +1153,7 @@ int32_t sinsp_filter_check::parse_field_name(const char* str, bool alloc_state, 
 		{
 			m_field_id = j;
 			m_field = &m_info.m_fields[j];
-			max_fldlen = (int32_t) fldlen;
+			max_fldlen = fldlen;
 			max_flags = (m_info.m_fields[j]).m_flags;
 		}
 	}

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -244,7 +244,7 @@ protected:
 		return ret;
 	}
 
-	std::string get_field_as_string(sinsp_evt *evt, std::string field_name)
+	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name)
 	{
 		std::unique_ptr<sinsp_filter_check> chk(g_filterlist.new_filter_check_from_fldname(field_name, &m_inspector, false));
 		chk->parse_field_name(field_name.c_str(), true, false);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

A recent PR #530, introduced a bug in `parse_field_name` where the 
```
if(fldlen <= max_fldlen)
```
check was made with `fdlen -> size_t` -> therefore the second argument `max_fldlen` was casted to size_t too.
But initial value of `max_fldlen` was `-1` -> aka UINT32_T MAX when casted to uint32_t, skipping all fields.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
