### PR TITLE
new(modern_bpf): add `fcntl` and `shutdown` syscalls

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -119,5 +119,7 @@
 #define RECVFROM_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 #define FCNTL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
 #define FCNTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define SHUTDOWN_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
+#define SHUTDOWN_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -117,5 +117,7 @@
 #define SETSOCKOPT_E_SIZE HEADER_LEN
 #define RECVMSG_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define RECVFROM_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
+#define FCNTL_E_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint8_t) + PARAM_LEN * 2
+#define FCNTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fcntl_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCNTL_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_E, FCNTL_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
+	int cmd = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u8(&ringbuf, fcntl_cmd_to_scap(cmd));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fcntl_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCNTL_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_X, FCNTL_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_FD)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(shutdown_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SHUTDOWN_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_E, SHUTDOWN_E_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
+	int how = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_u8(&ringbuf, (u8)shutdown_how_to_scap(how));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(shutdown_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SHUTDOWN_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_X, SHUTDOWN_X_SIZE);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/modern_bpf/test_suites/syscall_enter_suite/fcntl_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/fcntl_e.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fcntl
+
+#include <fcntl.h>
+
+TEST(SyscallEnter, fcntlE)
+{
+	auto evt_test = new event_test(__NR_fcntl, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	int cmd = F_DUPFD_CLOEXEC;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
+
+	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(2, (uint8_t)PPM_FCNTL_F_DUPFD_CLOEXEC);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/shutdown_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/shutdown_e.cpp
@@ -1,0 +1,46 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_shutdown
+
+#include <sys/socket.h>
+
+TEST(SyscallEnter, shutdownE)
+{
+	auto evt_test = new event_test(__NR_shutdown, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	int how = SHUT_RD;
+	assert_syscall_state(SYSCALL_FAILURE, "shutdown", syscall(__NR_shutdown, invalid_fd, how));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
+
+	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(2, (uint8_t)PPM_SHUT_RD);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/fcntl_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/fcntl_x.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fcntl
+
+#include <fcntl.h>
+
+TEST(SyscallExit, fcntlX)
+{
+	auto evt_test = new event_test(__NR_fcntl, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	int cmd = F_DUPFD_CLOEXEC;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/shutdown_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/shutdown_x.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_shutdown
+
+#include <sys/socket.h>
+
+TEST(SyscallExit, shutdownX)
+{
+	auto evt_test = new event_test(__NR_shutdown, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	int how = SHUT_RD;
+	assert_syscall_state(SYSCALL_FAILURE, "shutdown", syscall(__NR_shutdown, invalid_fd, how));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -172,6 +172,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_RECVFROM_X] = "recvfrom_x",
 	[PPME_SYSCALL_FCNTL_E] = "fcntl_e",
 	[PPME_SYSCALL_FCNTL_X] = "fcntl_x",
+	[PPME_SOCKET_SHUTDOWN_E] = "shutdown_e",
+	[PPME_SOCKET_SHUTDOWN_X] = "shutdown_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -170,6 +170,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_RECVMSG_X] = "recvmsg_x",
 	[PPME_SOCKET_RECVFROM_E] = "recvfrom_e",
 	[PPME_SOCKET_RECVFROM_X] = "recvfrom_x",
+	[PPME_SYSCALL_FCNTL_E] = "fcntl_e",
+	[PPME_SYSCALL_FCNTL_X] = "fcntl_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/513, the final aim is to support the most important syscalls also in the new probe. This PR introduces:

* `fcntl`
* `shutdown`

This syscall wasn't in the original set but probably it will be needed by the new `interesting` syscall approach

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(modern_bpf): add `fcntl` and `shutdown` syscall
```
