### PR TITLE
fix(kmod): add the string terminator if not present

### DIFF
--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -212,7 +212,7 @@ long ppm_strncpy_from_user(char *to, const char __user *from, unsigned long n)
 		}
 	}
 	/* We read all the `n` bytes. */
-	res = n;
+	res = string_length;
 
 strncpy_end:
 	pagefault_enable();


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

The previous way to add the string terminator `\0` was broken since even if the terminator was already present we pushed a further character, causing issues like the following

```
------------------ EVENT: 330 TID:128998
------ HEADER
timestamp: 1661879160280229084
tid: 128998
len: 50
type: 330
num params: 3
------
------ PARAMS
PARAM 0: -100
PARAM 1: testU  <---- This is a junk char
PARAM 2: 2
------
------------------
```

Instead of

```
------------------ EVENT: 330 TID:27963
------ HEADER
timestamp: 1661879495207653622
tid: 27963
len: 49
type: 330
num params: 3
------
------ PARAMS
PARAM 0: -100
PARAM 1: test <----
PARAM 2: 2
------
------------------
```

This was the wrong line, we incremented the `len++` instead of doing `len+1`

```
if (++len > (int)max_arg_size)
```

BTW, we have replaced the old logic with a more robust one

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(kmod): add the string terminator if not present
```
