### PR TITLE
fix(libsinsp): keep the copy of cgroups alive across the write

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1200,11 +1200,10 @@ void sinsp_threadinfo::add_to_iovec(const string &str,
 // iov will be allocated and must be freed. rem is used to hold a
 // possibly truncated final argument.
 void sinsp_threadinfo::cgroups_to_iovec(struct iovec **iov, int *iovcnt,
-				       std::string &rem) const
+				       std::string &rem, const cgroups_t& cgroups) const
 {
 	uint32_t alen = SCAP_MAX_ARGS_SIZE;
 	static const string eq = "=";
-	auto cgroups = this->cgroups();
 
 	// We allocate an iovec big enough to hold all the cgroups and
 	// intermediate '=' signs. Based on alen, we might not use all
@@ -1641,6 +1640,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 		int argscnt, envscnt, cgroupscnt;
 		string argsrem, envsrem, cgroupsrem;
 		uint32_t entrylen = 0;
+		auto cg = tinfo.cgroups();
 
 		if((sctinfo = scap_proc_alloc(m_inspector->m_h)) == NULL)
 		{
@@ -1651,7 +1651,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 		thread_to_scap(tinfo, sctinfo);
 		tinfo.args_to_iovec(&args_iov, &argscnt, argsrem);
 		tinfo.env_to_iovec(&envs_iov, &envscnt, envsrem);
-		tinfo.cgroups_to_iovec(&cgroups_iov, &cgroupscnt, cgroupsrem);
+		tinfo.cgroups_to_iovec(&cgroups_iov, &cgroupscnt, cgroupsrem, cg);
 
 		if(scap_write_proclist_entry_bufs(m_inspector->m_h, proclist_dumper, sctinfo, &entrylen,
 						  tinfo.m_comm.c_str(),

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -354,7 +354,7 @@ public:
 			  std::string &rem) const;
 
 	void cgroups_to_iovec(struct iovec **iov, int *iovcnt,
-			      std::string &rem) const;
+			      std::string &rem, const cgroups_t& cgroups) const;
 
 	//
 	// State for filtering


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
In https://github.com/falcosecurity/libs/pull/473 it was introduced a `cgroups` local variable in `sinsp_threadinfo::cgroups_to_iovec`, to have it work with a copy and avoid `sinsp_threadinfo::m_cgroups` being invalidated meanwhile.
Unfortunately, it slipped that `iovec` pointers reference the data owned by that local variable, thus becoming dangling at scope exit.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
