### PR TITLE
[WIP] new(libsinsp,engines): add support for variable shared buffer dimension 

### DIFF
--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -17,11 +17,6 @@
  */
 #define AUXILIARY_MAP_SIZE 128 * 1024
 
-/* The actual dimension of every single ringbuf is 8 MB.
- * Right now, this macro is used only by the userspace.
- */
-#define SINGLE_RINGBUF_DIMENSION 8 * 1024 * 1024
-
 /**
  * @brief General settings shared among all the CPUs.
  *

--- a/driver/ppm_ringbuffer.h
+++ b/driver/ppm_ringbuffer.h
@@ -14,9 +14,6 @@ or GPL2.txt for full copies of the license.
 #include <linux/types.h>
 #endif
 
-static const __u32 RING_BUF_SIZE = 8 * 1024 * 1024;
-static const __u32 MIN_USERSPACE_READ_SIZE = 128 * 1024;
-
 /*
  * This gets mapped to user level, so we want to keep it as clean as possible
  */

--- a/test/modern_bpf/start_tests.cpp
+++ b/test/modern_bpf/start_tests.cpp
@@ -6,6 +6,9 @@
 #include <libpman.h>
 #include <gtest/gtest.h>
 
+/* Dimension of every single ring buffer in these tests is 8 MB. */
+#define SINGLE_RINGBUF_DIMENSION 8 * 1024 * 1024
+
 void print_setup_phase_message()
 {
 	std::cout << std::endl;
@@ -52,7 +55,7 @@ int main(int argc, char** argv)
 	::testing::InitGoogleTest(&argc, argv);
 
 	/* Configure and load BPF probe. */
-	ret = pman_set_libbpf_configuration(libbpf_verbosity);
+	ret = pman_init_state(libbpf_verbosity, SINGLE_RINGBUF_DIMENSION);
 	ret = ret ?: pman_open_probe();
 	ret = ret ?: pman_prepare_ringbuf_array_before_loading();
 	ret = ret ?: pman_prepare_maps_before_loading();

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -39,15 +39,16 @@ extern "C"
 	/////////////////////////////
 
 	/**
-	 * @brief Set libbpf inital configurations:
-	 * - libbpf strict mode.
-	 * - libbpf logging function according to the verbosity.
+	 * @brief Set `libpman` initial state:
+	 * - set `libbpf` strict mode.
+	 * - set `libbpf` logging function according to the verbosity.
 	 * - set available number of CPUs.
+	 * - set dimension of a single per-CPU ring buffer.
 	 *
 	 * @param verbosity use `true` if you want to activate libbpf verbosity.
 	 * @return `0` on success, `-1` in case of error.
 	 */
-	int pman_set_libbpf_configuration(bool verbosity);
+	int pman_init_state(bool verbosity, uint64_t single_buf_dim);
 
 	/**
 	 * @brief Return the number of available CPUs on the system, not the

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -44,7 +44,7 @@ static void setup_libbpf_logging(bool verbosity)
 	}
 }
 
-int pman_set_libbpf_configuration(bool verbosity)
+int pman_init_state(bool verbosity, uint64_t single_buf_dim)
 {
 
 	/* `LIBBPF_STRICT_ALL` turns on all supported strict features
@@ -56,13 +56,16 @@ int pman_set_libbpf_configuration(bool verbosity)
 	/* Set libbpf verbosity. */
 	setup_libbpf_logging(verbosity);
 
-	/* Set available number of CPUs inside the internal state. */
+	/* Set the available number of CPUs inside the internal state. */
 	g_state.n_cpus = libbpf_num_possible_cpus();
 	if(g_state.n_cpus <= 0)
 	{
 		pman_print_error("no available cpus");
 		return -1;
 	}
+
+	/* Set the dimension of a single per-CPU ring buffer. */
+	g_state.single_ringbuf_dimension = single_buf_dim;
 	return 0;
 }
 

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -31,7 +31,7 @@ limitations under the License.
 static int ringbuf_array_set_inner_map()
 {
 	int err = 0;
-	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 	if(inner_map_fd < 0)
 	{
 		pman_print_error("failed to create the dummy inner map");
@@ -103,7 +103,7 @@ static int create_first_ringbuffer_map()
 	}
 
 	/* create the first ringbuf map. */
-	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 	if(ringbuf_map_fd <= 0)
 	{
 		pman_print_error("failed to create the first ringbuf map");
@@ -157,7 +157,7 @@ static int create_remaining_ringbuffer_maps()
 	 */
 	for(index = 1; index < g_state.n_cpus; index++)
 	{
-		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 		if(ringbuf_map_fd <= 0)
 		{
 			sprintf(error_message, "failed to create the ringbuf map for CPU %d", index);

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -34,6 +34,7 @@ struct internal_state
 	unsigned long* cons_pos;	/* every ringbuf has a consumer position. */
 	unsigned long* prod_pos;	/* every ringbuf has a producer position. */
 	int32_t inner_ringbuf_map_fd;	/* inner map used to configure the ringbuf array before loading phase. */
+	uint64_t single_ringbuf_dimension; /* dimension of a single per-CPU ringbuffer. */
 };
 
 extern struct internal_state g_state;

--- a/userspace/libscap/engine/bpf/bpf_public.h
+++ b/userspace/libscap/engine/bpf/bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_bpf_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 		const char* bpf_probe;	    ///<  The path to the BPF probe object file.
 	};
 

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -109,8 +109,6 @@ static void free_handle(struct scap_engine_handle engine)
 
 # define UINT32_MAX (4294967295U)
 
-static const int BUF_SIZE_PAGES = 2048;
-
 /* Recommended log buffer size. 
  * Taken from libbpf source code: https://github.com/libbpf/libbpf/blob/67a4b1464349345e483df26ed93f8d388a60cee1/src/bpf.h#L201
  */
@@ -835,13 +833,13 @@ cleanup:
 	return res;
 }
 
-static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size)
+static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, uint64_t buf_num_pages)
 {
 	int page_size = getpagesize();
-	int ring_size = page_size * BUF_SIZE_PAGES;
+	int ring_size = page_size * buf_num_pages;
 	int header_size = page_size;
 	int total_size = ring_size * 2 + header_size;
-	char buf[SCAP_LASTERR_SIZE];
+	char buf[SCAP_LASTERR_SIZE] = {0};
 
 	*size = 0;
 
@@ -1450,6 +1448,7 @@ int32_t scap_bpf_load(
 	int online_cpu;
 	int j;
 	char buf[SCAP_LASTERR_SIZE];
+	struct scap_bpf_engine_params* bpf_args = oargs->engine_params;
 
 	if(set_runtime_params(handle) != SCAP_SUCCESS)
 	{
@@ -1571,7 +1570,7 @@ int32_t scap_bpf_load(
 		//
 		// Map the ring buffer
 		//
-		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size);
+		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size, bpf_args->buffer_num_pages);
 		if(dev->m_buffer == MAP_FAILED)
 		{
 			return SCAP_FAILURE;

--- a/userspace/libscap/engine/kmod/kmod_public.h
+++ b/userspace/libscap/engine/kmod/kmod_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_kmod_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_modern_bpf_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -183,12 +183,22 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 {
 	int ret = 0;
 	struct scap_engine_handle engine = handle->m_engine;
+	struct scap_modern_bpf_engine_params* params = oargs->engine_params;
 	bool libbpf_verbosity = false;
 
-	/* Configure libbpf library used under the hood. */
-	if(pman_set_libbpf_configuration(libbpf_verbosity))
+	/* Obtain the single buffer dimension */
+	long page_size = sysconf(_SC_PAGESIZE);
+	if(page_size <= 0)
 	{
-		snprintf(handle->m_engine.m_handle->m_lasterr, SCAP_LASTERR_SIZE, "Unable to get configure libbpf.");
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to get the system page size: %s", strerror(errno));
+		return SCAP_FAILURE;
+	}
+	unsigned long single_buffer_dim = page_size * params->buffer_num_pages;
+
+	/* Initialize the libpman internal state */
+	if(pman_init_state(libbpf_verbosity, single_buffer_dim))
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to configure libbpf.");
 		return SCAP_FAILURE;
 	}
 

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -97,6 +97,9 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
+	/* Set the dimension of the per-cpu buffer. */
+	set_per_cpu_buffer_dim((unsigned long)*ringsize);
+
 	//
 	// Map the ring. This is a multi-step process because we want to map two
 	// consecutive copies of the same memory to reuse the driver fillers, which

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -36,6 +36,7 @@ limitations under the License.
 #define PPM_SC_OPTION "--ppm_sc"
 #define NUM_EVENTS_OPTION "--num_events"
 #define EVENT_TYPE_OPTION "--evt_type"
+#define BUFFER_OPTION "--pages"
 
 /* PRINT */
 #define VALIDATION_OPTION "--validate_syscalls"
@@ -49,6 +50,8 @@ extern const enum ppm_syscall_code g_syscall_code_routing_table[SYSCALL_TABLE_SI
 
 /* Engine params */
 struct scap_bpf_engine_params bpf_params = {0};
+struct scap_kmod_engine_params kmod_params = {0};
+struct scap_modern_bpf_engine_params modern_bpf_params = {0};
 struct scap_savefile_engine_params savefile_params = {0};
 
 /* Configuration variables set through CLI. */
@@ -686,6 +689,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = KMOD_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			oargs.engine_params = &kmod_params;
 		}
 		if(!strcmp(argv[i], BPF_OPTION))
 		{
@@ -696,7 +700,6 @@ void parse_CLI_options(int argc, char** argv)
 			}
 			oargs.engine_name = BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
-
 			bpf_params.bpf_probe = argv[++i];
 			oargs.engine_params = &bpf_params;
 		}
@@ -704,6 +707,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = MODERN_BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			oargs.engine_params = &modern_bpf_params;
 		}
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
 		{
@@ -714,7 +718,6 @@ void parse_CLI_options(int argc, char** argv)
 			}
 			oargs.engine_name = SAVEFILE_ENGINE;
 			oargs.mode = SCAP_MODE_CAPTURE;
-
 			savefile_params.fname = argv[++i];
 			oargs.engine_params = &savefile_params;
 		}
@@ -723,6 +726,18 @@ void parse_CLI_options(int argc, char** argv)
 
 		/*=============================== CONFIGURATIONS ===========================*/
 
+		if(!strcmp(argv[i], BUFFER_OPTION))
+		{
+			if(!(i + 1 < argc))
+			{
+				printf("\nYou need to specify also the number of pages! Bye!\n");
+				exit(EXIT_FAILURE);
+			}
+			uint64_t buffer_num_pages = strtoul(argv[++i], NULL, 10);
+			kmod_params.buffer_num_pages = buffer_num_pages;
+			bpf_params.buffer_num_pages = buffer_num_pages;
+			modern_bpf_params.buffer_num_pages = buffer_num_pages;
+		}
 		if(!strcmp(argv[i], TP_OPTION))
 		{
 			if(!(i + 1 < argc))

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -23,6 +23,13 @@ limitations under the License.
 #include "barrier.h"
 #include "sleep.h"
 
+static unsigned long per_cpu_buffer_dim;
+
+static inline void set_per_cpu_buffer_dim(unsigned long buf_dim)
+{
+	per_cpu_buffer_dim = buf_dim;
+}
+
 #ifndef GET_BUF_POINTERS
 #define GET_BUF_POINTERS ringbuffer_get_buf_pointers
 static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead, uint64_t* ptail, uint64_t* pread_size)
@@ -33,7 +40,7 @@ static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead
 
 	if(*ptail > *phead)
 	{
-		*pread_size = RING_BUF_SIZE - *ptail + *phead;
+		*pread_size = per_cpu_buffer_dim - *ptail + *phead;
 	}
 	else
 	{
@@ -63,13 +70,13 @@ static inline void ringbuffer_advance_tail(struct scap_device* dev)
 	//
 	mem_barrier();
 
-	if(ttail < RING_BUF_SIZE)
+	if(ttail < per_cpu_buffer_dim)
 	{
 		dev->m_bufinfo->tail = ttail;
 	}
 	else
 	{
-		dev->m_bufinfo->tail = ttail - RING_BUF_SIZE;
+		dev->m_bufinfo->tail = ttail - per_cpu_buffer_dim;
 	}
 
 	dev->m_lastreadsize = 0;

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -41,7 +41,7 @@ string filter_string = "";
 string file_path = "";
 string bpf_path = "";
 string output_fields_json = "";
-uint64_t buffer_dim = 0;
+uint64_t num_pages = 0;
 
 sinsp_evt* get_event(sinsp& inspector);
 
@@ -72,7 +72,7 @@ Options:
   -m, --modern_bpf               			 modern BPF probe.
   -k, --kmod								 Kernel module
   -s <path>, --scap_file <path>   			 Scap file
-  -d <dim>, --buffer_dim <dim>               Buffer dimension.
+  -p <#pages>, --pages <#pages>              Number of pages that every per-CPU buffer will have.
   -o <fields>, --output-fields-json <fields>    [JSON support only, can also use without -j] Output fields string (see <filter> for supported display fields) that overwrites JSON default output fields for all events. * at the beginning prints JSON keys with null values, else no null fields are printed.
 )";
 	cout << usage << endl;
@@ -91,14 +91,14 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 		{"modern_bpf", no_argument, 0, 'm'},
 		{"kmod", no_argument, 0, 'k'},
 		{"scap_file", required_argument, 0, 's'},
-		{"buffer_dim", required_argument, 0, 'd'},
+		{"pages", required_argument, 0, 'p'},
 		{"output-fields-json", required_argument, 0, 'o'},
 		{0, 0, 0, 0}};
 
 	int op;
 	int long_index = 0;
 	while((op = getopt_long(argc, argv,
-				"hf:jae:b:d:s:o:",
+				"hf:jae:b:p:s:o:",
 				long_options, &long_index)) != -1)
 	{
 		switch(op)
@@ -129,8 +129,8 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 			engine_string = SAVEFILE_ENGINE;
 			file_path = optarg;
 			break;
-		case 'd':
-			buffer_dim = strtoul(optarg, NULL, 10);
+		case 'p':
+			num_pages = strtoul(optarg, NULL, 10);
 			break;
 		case 'o':
 			output_fields_json = optarg;
@@ -154,7 +154,7 @@ void open_engine(sinsp& inspector)
 
 	if(!engine_string.compare(KMOD_ENGINE))
 	{
-		inspector.open_kmod(buffer_dim, ppm_sc, tp_set);
+		inspector.open_kmod(num_pages, ppm_sc, tp_set);
 	}
 	else if(!engine_string.compare(BPF_ENGINE))
 	{
@@ -167,7 +167,7 @@ void open_engine(sinsp& inspector)
 		{
 			std::cerr << bpf_path << std::endl;
 		}
-		inspector.open_bpf(buffer_dim, bpf_path.c_str(), ppm_sc, tp_set);
+		inspector.open_bpf(num_pages, bpf_path.c_str(), ppm_sc, tp_set);
 	}
 	else if(!engine_string.compare(SAVEFILE_ENGINE))
 	{
@@ -180,7 +180,7 @@ void open_engine(sinsp& inspector)
 	}
 	else if(!engine_string.compare(MODERN_BPF_ENGINE))
 	{
-		inspector.open_modern_bpf(buffer_dim, ppm_sc, tp_set);
+		inspector.open_modern_bpf(num_pages, ppm_sc, tp_set);
 	}
 	else
 	{

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -219,14 +219,14 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	void open_kmod(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	void open_bpf(uint64_t buffer_dimension, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_udig();
 	void open_nodriver();
 	void open_savefile(const std::string &filename, int fd);
 	void open_plugin(std::string plugin_name, std::string plugin_open_params);
 	void open_gvisor(std::string config_path, std::string root_path);
-	void open_modern_bpf(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_test_input(scap_test_input_data *data);
 
 	scap_open_args factory_open_args(const char* engine, scap_mode_t scap_mode);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

/area libpman

/area libsinsp

**Does this PR require a change in the driver versions?**

/version driver-API-version-major

But we have already bumped it here https://github.com/falcosecurity/libs/pull/492

**What this PR does / why we need it**:

As previously discussed [here](https://github.com/falcosecurity/libs/pull/414#issue-1277253587 ) and in various other issues this PR introduces the possibility of choosing the dimension of the shared buffers (between userspace/kernel) at initialization time. The rationale here is:
* `libsinsp` receives the number of pages that every single per-CPU buffer must have through the specific engine `open_` method.
* `libsinsp` validates the number of pages that must be a power of 2, right now the allowed values are the following:
```c
{262144, 131072, 65536, 32768, 16384, 8192, 4096, 2048, 1024, 512, 256, 128}
```
* every engine receives this number of pages through the `scap_open_args`, it multiplies it by the effective size of the page and uses the obtained size (`number_of_pages` * `page_size`) to initialize the per-CPU buffers


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new(libsinsp,engines): add support for variable shared buffer dimension 
```
