### PR TITLE
wip: new: runtime tracepoints management

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -744,7 +744,18 @@ static int force_tp_set(u32 new_tp_set, u32 max_val)
 			}
 			else
 			{
-				pr_err("can't create the %s tracepoint\n", tp_names[idx]);
+				pr_err("can't attach the %s tracepoint\n", tp_names[idx]);
+			}
+		}
+		else
+		{
+			if (ret == 0)
+			{
+				g_tracepoints_attached &= ~(1 << idx);
+			}
+			else
+			{
+				pr_err("can't detach the %s tracepoint\n", tp_names[idx]);
 			}
 		}
 	}
@@ -905,6 +916,12 @@ cleanup_ioctl_procinfo:
 		unsigned long long __user *out = (unsigned long long __user *) arg;
 		ret = 0;
 		if(put_user(PPM_SCHEMA_CURRENT_VERSION, out))
+			ret = -EINVAL;
+		goto cleanup_ioctl_nolock;
+	} else if (cmd == PPM_IOCTL_GET_TPMASK) {
+		u32 __user *out = (u32 __user *) arg;
+		ret = 0;
+		if(put_user(g_tracepoints_attached, out))
 			ret = -EINVAL;
 		goto cleanup_ioctl_nolock;
 	}

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1719,6 +1719,7 @@ struct ppm_evt_hdr {
 #define PPM_IOCTL_GET_API_VERSION _IO(PPM_IOCTL_MAGIC, 24)
 #define PPM_IOCTL_GET_SCHEMA_VERSION _IO(PPM_IOCTL_MAGIC, 25)
 #define PPM_IOCTL_MANAGE_TP _IO(PPM_IOCTL_MAGIC, 26)
+#define PPM_IOCTL_GET_TPMASK _IO(PPM_IOCTL_MAGIC, 27)
 #endif // CYGWING_AGENT
 
 extern const struct ppm_name_value socket_families[];

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -31,16 +31,22 @@ limitations under the License.
 
 #define BPF_MAPS_MAX 32
 
+struct bpf_prog {
+	int fd;
+	int efd;
+	char name[NAME_MAX];
+};
+
 struct bpf_engine
 {
 	struct scap_device_set m_dev_set;
 	size_t m_ncpus;
 	char* m_lasterr;
-	int m_bpf_prog_fds[BPF_PROGS_MAX];
+	struct bpf_prog m_bpf_progs[BPF_PROGS_MAX];
 	int m_bpf_prog_cnt;
-	int m_bpf_event_fd[BPF_PROGS_MAX];
 	int m_bpf_map_fds[BPF_MAPS_MAX];
 	int m_bpf_prog_array_map_idx;
+	char m_filepath[PATH_MAX];
 };
 
 #define SCAP_HANDLE_T struct bpf_engine

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -74,7 +74,46 @@ static uint32_t get_max_consumers()
 	return 0;
 }
 
-/// TODO: we need to pass directly the system syscall number not the `ppm_sc` here.
+int32_t scap_kmod_handle_tp_mask(struct scap_engine_handle engine, uint32_t op, uint32_t tp)
+{
+	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
+
+	uint32_t curr_set;
+	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_GET_TPMASK, &curr_set))
+	{
+		snprintf(engine.m_handle->m_lasterr, SCAP_LASTERR_SIZE,
+			 "%s(%d) failed",
+			 __FUNCTION__, op);
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+
+	uint32_t new_set;
+	if (op == SCAP_TPMASK_SET)
+	{
+		new_set = curr_set | (1 << tp);
+	}
+	else
+	{
+		new_set = curr_set & ~(1 << tp);
+	}
+	if(new_set == curr_set)
+	{
+		return SCAP_SUCCESS;
+	}
+
+	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_MANAGE_TP, new_set))
+	{
+		snprintf(engine.m_handle->m_lasterr, SCAP_LASTERR_SIZE,
+			 "%s(%d) failed for tpmask %d",
+			 __FUNCTION__, op, new_set);
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+	return SCAP_SUCCESS;
+}
+
+/// TODO: it would be better to pass directly the system syscall number not the `ppm_sc` here.
 int32_t scap_kmod_handle_event_mask(struct scap_engine_handle engine, uint32_t op, uint32_t ppm_sc)
 {
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
@@ -305,19 +344,10 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	}
 
 	/* Set interesting Tracepoints */
-	uint32_t tp_of_interest = 0;
 	for (int i = 0; i < TP_VAL_MAX; i++)
 	{
-		if (oargs->tp_of_interest.tp[i])
-		{
-			tp_of_interest |= (1 << i);
-		}
-	}
-	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_MANAGE_TP, tp_of_interest))
-	{
-		strncpy(handle->m_lasterr, "PPM_IOCTL_MANAGE_TP failed", SCAP_LASTERR_SIZE);
-		ASSERT(false);
-		return SCAP_FAILURE;
+		uint32_t op = oargs->tp_of_interest.tp[i] ? SCAP_TPMASK_SET : SCAP_TPMASK_UNSET;
+		scap_kmod_handle_tp_mask(engine, op, i);
 	}
 
 	return SCAP_SUCCESS;
@@ -663,6 +693,8 @@ static int32_t configure(struct scap_engine_handle engine, enum scap_setting set
 		return scap_kmod_set_snaplen(engine, arg1);
 	case SCAP_EVENTMASK:
 		return scap_kmod_handle_event_mask(engine, arg1, arg2);
+	case SCAP_TPMASK:
+		return scap_kmod_handle_tp_mask(engine, arg1, arg2);
 	case SCAP_DYNAMIC_SNAPLEN:
 		if(arg1 == 0)
 		{

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -28,6 +28,40 @@ limitations under the License.
 
 /*=============================== UTILS ===============================*/
 
+static int32_t update_single_tp_of_interest(int tp, bool interesting)
+{
+	int ret = SCAP_SUCCESS;
+	switch(tp)
+	{
+	case SYS_ENTER:
+		if (interesting)
+		{
+			ret = pman_attach_syscall_enter_dispatcher();
+		}
+		else
+		{
+			ret = pman_detach_syscall_enter_dispatcher();
+		}
+		break;
+
+	case SYS_EXIT:
+		if (interesting)
+		{
+			ret = pman_attach_syscall_exit_dispatcher();
+		}
+		else
+		{
+			ret = pman_detach_syscall_exit_dispatcher();
+		}
+		break;
+
+	default:
+		/* Do nothing right now. */
+		break;
+	}
+	return ret;
+}
+
 static int32_t attach_interesting_tracepoints(bool* tp_array)
 {
 	int ret = SCAP_SUCCESS;
@@ -43,21 +77,7 @@ static int32_t attach_interesting_tracepoints(bool* tp_array)
 		{
 			continue;
 		}
-
-		switch(tp)
-		{
-		case SYS_ENTER:
-			ret = pman_attach_syscall_enter_dispatcher();
-			break;
-
-		case SYS_EXIT:
-			ret = pman_attach_syscall_exit_dispatcher();
-			break;
-
-		default:
-			/* Do nothing right now. */
-			break;
-		}
+		ret = update_single_tp_of_interest(tp, true);
 	}
 	return ret;
 }
@@ -145,6 +165,8 @@ static int32_t scap_modern_bpf__configure(struct scap_engine_handle engine, enum
 			pman_clean_all_64bit_interesting_syscalls();
 		}
 		return SCAP_SUCCESS;
+	case SCAP_TPMASK:
+		return update_single_tp_of_interest(arg2, arg1 == SCAP_TPMASK_SET);
 	case SCAP_DYNAMIC_SNAPLEN:
 		/* Not supported */
 		return SCAP_SUCCESS;

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -825,6 +825,7 @@ static int32_t configure(struct scap_engine_handle engine, enum scap_setting set
 	case SCAP_SNAPLEN:
 		return udig_set_snaplen(engine, arg1);
 	case SCAP_EVENTMASK:
+	case SCAP_TPMASK:
 	case SCAP_DYNAMIC_SNAPLEN:
 	case SCAP_STATSD_PORT:
 	case SCAP_FULLCAPTURE_PORT_RANGE:

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1392,6 +1392,13 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t ppm_s
 		break;
 	}
 
+	if (ppm_sc >= PPM_SC_MAX)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "%s(%d) wrong param", __FUNCTION__, ppm_sc);
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_EVENTMASK, op, ppm_sc);
@@ -1416,6 +1423,50 @@ int32_t scap_clear_eventmask(scap_t* handle) {
 
 int32_t scap_set_eventmask(scap_t* handle, uint32_t ppm_sc, bool enabled) {
 	return(scap_handle_eventmask(handle, enabled ? SCAP_EVENTMASK_SET : SCAP_EVENTMASK_UNSET, ppm_sc));
+}
+
+static int32_t scap_handle_tpmask(scap_t* handle, uint32_t op, uint32_t tp)
+{
+	switch(op)
+	{
+	case SCAP_TPMASK_SET:
+	case SCAP_TPMASK_UNSET:
+		break;
+
+	default:
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "%s(%d) internal error", __FUNCTION__, op);
+		ASSERT(false);
+		return SCAP_FAILURE;
+		break;
+	}
+
+	if (tp >= TP_VAL_MAX)
+	{
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "%s(%d) wrong param", __FUNCTION__, tp);
+		ASSERT(false);
+		return SCAP_FAILURE;
+	}
+
+	if(handle->m_vtable)
+	{
+		return handle->m_vtable->configure(handle->m_engine, SCAP_TPMASK, op, tp);
+	}
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "tpmask not supported on %s", PLATFORM_NAME);
+	return SCAP_FAILURE;
+#else
+	if (handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
+	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "manipulating tpmask not supported on this scap mode");
+	return SCAP_FAILURE;
+#endif // HAS_CAPTURE
+}
+
+int32_t scap_set_tpmask(scap_t* handle, uint32_t tp, bool enabled) {
+	return(scap_handle_tpmask(handle, enabled ? SCAP_TPMASK_SET : SCAP_TPMASK_UNSET, tp));
 }
 
 uint32_t scap_event_get_dump_flags(scap_t* handle)

--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -39,6 +39,7 @@ EXPORTS
 		scap_clear_eventmask
 		scap_set_eventmask
 		scap_unset_eventmask
+		scap_set_tpmask
 		scap_number_of_bytes_to_write
 		scap_event_get_dump_flags
 		scap_enable_dynamic_snaplen

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -954,6 +954,16 @@ int32_t scap_clear_eventmask(scap_t* handle);
 */
 int32_t scap_set_eventmask(scap_t* handle, uint32_t ppm_sc, bool enabled);
 
+/*!
+  \brief Set the tp into the tpmask so that
+  users can attach the related tracepoint.
+
+  \param handle Handle to the capture instance.
+  \param tp id (example SYS_ENTER)
+  \note This function can only be called for live captures.
+*/
+int32_t scap_set_tpmask(scap_t* handle, uint32_t tp, bool enabled);
+
 
 /*!
   \brief Get the root directory of the system. This usually changes

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -43,6 +43,11 @@ enum scap_eventmask_op {
 	SCAP_EVENTMASK_UNSET = 0x7307, //< disable an event
 };
 
+enum scap_tpmask_op {
+	SCAP_TPMASK_SET = 0x8306, //< enable a to
+	SCAP_TPMASK_UNSET = 0x8307, //< disable a tp
+};
+
 /**
  * @brief settings configurable for scap engines
  */
@@ -64,7 +69,7 @@ enum scap_setting {
 	 */
 	SCAP_SNAPLEN,
 	/**
-	 * @brief enable/disable individual events
+	 * @brief enable/disable individual syscalls
 	 * arg1: scap_eventmask_op
 	 * arg2: event id (ignored for SCAP_EVENTMASK_ZERO)
 	 */
@@ -85,6 +90,12 @@ enum scap_setting {
 	 * arg1: statsd port
 	 */
 	SCAP_STATSD_PORT,
+	/**
+	 * @brief enable/disable individual tracepoints
+	 * arg1: scap_tpmask_op
+	 * arg2: tp id
+	 */
+	SCAP_TPMASK,
 };
 
 struct scap_savefile_vtable {

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -459,11 +459,21 @@ void sinsp::mark_ppm_sc_of_interest(uint32_t ppm_sc, bool enable)
 	{
 		throw sinsp_exception("you cannot use this method before opening the inspector!");
 	}
-	if (ppm_sc >= PPM_SC_MAX || ppm_sc < 0)
-	{
-		throw sinsp_exception("inexistent ppm_sc code: " + std::to_string(ppm_sc));
-	}
 	int ret = scap_set_eventmask(m_h, ppm_sc, enable);
+	if (ret != SCAP_SUCCESS)
+	{
+		throw sinsp_exception(scap_getlasterr(m_h));
+	}
+}
+
+void sinsp::mark_tp_of_interest(uint32_t tp, bool enable)
+{
+	/* This API must be used only after the initialization phase. */
+	if (!m_inited)
+	{
+		throw sinsp_exception("you cannot use this method before opening the inspector!");
+	}
+	int ret = scap_set_tpmask(m_h, tp, enable);
 	if (ret != SCAP_SUCCESS)
 	{
 		throw sinsp_exception(scap_getlasterr(m_h));

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -845,6 +845,8 @@ public:
 	*/
 	void mark_ppm_sc_of_interest(uint32_t ppm_sc, bool enabled = true);
 
+	void mark_tp_of_interest(uint32_t tp, bool enabled = true);
+
 	/*!
 		\brief Provide the minimum set of syscalls required by `libsinsp` state collection.
 		If you call it without arguments it returns a new set with just these syscalls


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

/area libscap

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

/version driver-API-version-major

new ioctl introduced in kmod.

**What this PR does / why we need it**:

This PR completes part of #521  allowing even tracepoints to be runtime modified, just like we allow it for ppm_sc.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
