### PR TITLE
fix(userspace/libscap,userspace/libsinsp): properly add parsers for multiple EF_CREATES_FD events.

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1549,8 +1549,8 @@ enum ppm_event_category {
 
 enum ppm_event_flags {
 	EF_NONE = 0,
-	EF_CREATES_FD = (1 << 0), /* This event creates an FD (e.g. open) */
-	EF_DESTROYS_FD = (1 << 1), /* This event destroys an FD (e.g. close) */
+	EF_CREATES_FD = (1 << 0), /* This event creates an FD (e.g. open). NOTE: a parser MUST always be created when this flag is set, to parse fd and add it to threadinfo list of fds */
+	EF_DESTROYS_FD = (1 << 1), /* This event destroys an FD (e.g. close). NOTE: a parser MUST always be created when this flag is set, to parse fd and erasing it from threadinfo list (using sinsp_parser::erase_fd) */
 	EF_USES_FD = (1 << 2), /* This event operates on an FD. */
 	EF_READS_FROM_FD = (1 << 3), /* This event reads data from an FD. */
 	EF_WRITES_TO_FD = (1 << 4), /* This event writes data to an FD. */

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -1467,6 +1467,9 @@ static uint32_t scap_fd_read_from_disk(scap_fdinfo *fdi, size_t *nbytes, uint32_
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
+	case SCAP_FD_BPF:
+	case SCAP_FD_USERFAULTFD:
+	case SCAP_FD_IOURING:
 		res = scap_fd_read_fname_from_disk(fdi->info.fname, nbytes, r, error);
 		break;
 	case SCAP_FD_UNKNOWN:

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -182,7 +182,10 @@ typedef enum scap_fd_type
 	SCAP_FD_INOTIFY = 13,
 	SCAP_FD_TIMERFD = 14,
 	SCAP_FD_NETLINK = 15,
-	SCAP_FD_FILE_V2 = 16
+	SCAP_FD_FILE_V2 = 16,
+	SCAP_FD_BPF = 17,
+	SCAP_FD_USERFAULTFD = 18,
+	SCAP_FD_IOURING = 19,
 }scap_fd_type;
 
 /*!

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -120,6 +120,9 @@ uint32_t scap_fd_info_len(scap_fdinfo *fdi)
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
+	case SCAP_FD_BPF:
+	case SCAP_FD_USERFAULTFD:
+	case SCAP_FD_IOURING:
 		res += (uint32_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE) + 2;    // 2 is the length field before the string
 		break;
 	default:
@@ -233,6 +236,9 @@ int32_t scap_fd_write_to_disk(scap_t *handle, scap_fdinfo *fdi, scap_dumper_t *d
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
+	case SCAP_FD_BPF:
+	case SCAP_FD_USERFAULTFD:
+	case SCAP_FD_IOURING:
 		stlen = (uint16_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE);
 		if(scap_dump_write(d, &stlen,  sizeof(uint16_t)) != sizeof(uint16_t) ||
 		        (stlen > 0 && scap_dump_write(d, fdi->info.fname, stlen) != stlen))
@@ -641,7 +647,22 @@ int32_t scap_fd_handle_regular_file(scap_t *handle, char *fname, scap_threadinfo
 		{
 			fdi->type = SCAP_FD_TIMERFD;
 		}
-
+		else if (0 == strcmp(link_name, "anon_inode:[io_uring]"))
+		{
+			fdi->type = SCAP_FD_IOURING;
+		}
+		else if (0 == strcmp(link_name, "anon_inode:[userfaultfd]"))
+		{
+			fdi->type = SCAP_FD_USERFAULTFD;
+		}
+		// anon_inode:bpf-map
+		// anon_inode:bpf_link
+		// anon_inode:bpf-prog
+		// anon_inode:bpf_iter
+		else if (0 == strncmp(link_name, "anon_inode:[bpf", strlen("anon_inode:[bpf")))
+		{
+			fdi->type = SCAP_FD_BPF;
+		}
 
 		if(SCAP_FD_UNSUPPORTED == fdi->type)
 		{

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2590,11 +2590,14 @@ void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 					case SCAP_FD_EVENT:
 					case SCAP_FD_SIGNALFD:
 					case SCAP_FD_INOTIFY:
+					case SCAP_FD_USERFAULTFD:
 						cat->m_subcategory = SC_IPC;
 						break;
 					case SCAP_FD_UNSUPPORTED:
 					case SCAP_FD_EVENTPOLL:
 					case SCAP_FD_TIMERFD:
+					case SCAP_FD_BPF:
+					case SCAP_FD_IOURING:
 					case SCAP_FD_NETLINK:
 						cat->m_subcategory = SC_OTHER;
 						break;

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -85,6 +85,12 @@ template<> char sinsp_fdinfo_t::get_typechar()
 		return CHAR_FD_TIMERFD;
 	case SCAP_FD_NETLINK:
 		return CHAR_FD_NETLINK;
+	case SCAP_FD_BPF:
+		return CHAR_FD_BPF;
+	case SCAP_FD_USERFAULTFD:
+		return CHAR_FD_USERFAULTFD;
+	case SCAP_FD_IOURING:
+		return CHAR_FD_IO_URING;
 	default:
 //		ASSERT(false);
 		return '?';
@@ -122,6 +128,12 @@ template<> char* sinsp_fdinfo_t::get_typestring()
 		return (char*)"timerfd";
 	case SCAP_FD_NETLINK:
 		return (char*)"netlink";
+	case SCAP_FD_BPF:
+		return (char*)"bpf";
+	case SCAP_FD_USERFAULTFD:
+		return (char*)"userfaultfd";
+	case SCAP_FD_IOURING:
+		return (char*)"io_uring";
 	default:
 		return (char*)"<NA>";
 	}

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -45,6 +45,9 @@ class sinsp_protodecoder;
 #define CHAR_FD_INOTIFY			'i'
 #define CHAR_FD_TIMERFD			't'
 #define CHAR_FD_NETLINK			'n'
+#define CHAR_FD_BPF     		'b'
+#define CHAR_FD_USERFAULTFD		'u'
+#define CHAR_FD_IO_URING		'r'
 
 /** @defgroup state State management 
  * A collection of classes to query process and FD state.

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -104,7 +104,7 @@ const filtercheck_field_info sinsp_filter_check_fd_fields[] =
 {
 	{PT_INT64, EPF_NONE, PF_ID, "fd.num", "FD Number", "the unique number identifying the file descriptor."},
 	{PT_CHARBUF, EPF_NONE, PF_DEC, "fd.type", "FD Type", "type of FD. Can be 'file', 'directory', 'ipv4', 'ipv6', 'unix', 'pipe', 'event', 'signalfd', 'eventpoll', 'inotify' or 'signalfd'."},
-	{PT_CHARBUF, EPF_NONE, PF_DEC, "fd.typechar", "FD Type Char", "type of FD as a single character. Can be 'f' for file, 4 for IPv4 socket, 6 for IPv6 socket, 'u' for unix socket, p for pipe, 'e' for eventfd, 's' for signalfd, 'l' for eventpoll, 'i' for inotify, 'o' for unknown."},
+	{PT_CHARBUF, EPF_NONE, PF_DEC, "fd.typechar", "FD Type Char", "type of FD as a single character. Can be 'f' for file, 4 for IPv4 socket, 6 for IPv6 socket, 'u' for unix socket, p for pipe, 'e' for eventfd, 's' for signalfd, 'l' for eventpoll, 'i' for inotify, 'b' for bpf, 'u' for userfaultd, 'r' for io_uring, 'o' for unknown."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "fd.name", "FD Name", "FD full name. If the fd is a file, this field contains the full path. If the FD is a socket, this field contain the connection tuple."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "fd.directory", "FD Directory", "If the fd is a file, the directory that contains it."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "fd.filename", "FD Filename", "If the fd is a file, the filename without the path."},

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -501,6 +501,15 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	case PPME_GROUP_DELETED_E:
 		parse_group_evt(evt);
 		break;
+	case PPME_SYSCALL_BPF_2_X:
+		parse_bpf_exit(evt);
+		break;
+	case PPME_SYSCALL_USERFAULTFD_X:
+		parse_userfaultfd_exit(evt);
+		break;
+	case PPME_SYSCALL_IO_URING_SETUP_X:
+		parse_io_uring_setup_exit(evt);
+		break;
 	default:
 		break;
 	}
@@ -4665,6 +4674,117 @@ void sinsp_parser::parse_timerfd_create_exit(sinsp_evt *evt)
 		// Populate the new fdi
 		//
 		fdi.m_type = SCAP_FD_TIMERFD;
+		fdi.m_name = "";
+
+		//
+		// Add the fd to the table.
+		//
+		evt->m_fdinfo = evt->m_tinfo->add_fd(retval, &fdi);
+	}
+}
+
+void sinsp_parser::parse_bpf_exit(sinsp_evt* evt)
+{
+	sinsp_evt_param *parinfo;
+	int64_t retval;
+
+	//
+	// Extract the return value
+	//
+	parinfo = evt->get_param(0);
+	retval = *(int64_t *)parinfo->m_val;
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+
+	if(evt->m_tinfo == nullptr)
+	{
+		return;
+	}
+
+	//
+	// Check if the syscall was successful
+	//
+	if(retval >= 0)
+	{
+		sinsp_fdinfo_t fdi;
+
+		//
+		// Populate the new fdi
+		//
+		fdi.m_type = SCAP_FD_BPF;
+		fdi.m_name = "";
+
+		//
+		// Add the fd to the table.
+		//
+		evt->m_fdinfo = evt->m_tinfo->add_fd(retval, &fdi);
+	}
+}
+
+void sinsp_parser::parse_userfaultfd_exit(sinsp_evt* evt)
+{
+	sinsp_evt_param *parinfo;
+	int64_t retval;
+
+	//
+	// Extract the return value
+	//
+	parinfo = evt->get_param(0);
+	retval = *(int64_t *)parinfo->m_val;
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+
+	if(evt->m_tinfo == nullptr)
+	{
+		return;
+	}
+
+	//
+	// Check if the syscall was successful
+	//
+	if(retval >= 0)
+	{
+		sinsp_fdinfo_t fdi;
+
+		//
+		// Populate the new fdi
+		//
+		fdi.m_type = SCAP_FD_USERFAULTFD;
+		fdi.m_name = "";
+
+		//
+		// Add the fd to the table.
+		//
+		evt->m_fdinfo = evt->m_tinfo->add_fd(retval, &fdi);
+	}
+}
+
+void sinsp_parser::parse_io_uring_setup_exit(sinsp_evt* evt)
+{
+	sinsp_evt_param *parinfo;
+	int64_t retval;
+
+	//
+	// Extract the return value
+	//
+	parinfo = evt->get_param(0);
+	retval = *(int64_t *)parinfo->m_val;
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+
+	if(evt->m_tinfo == nullptr)
+	{
+		return;
+	}
+
+	//
+	// Check if the syscall was successful
+	//
+	if(retval >= 0)
+	{
+		sinsp_fdinfo_t fdi;
+
+		//
+		// Populate the new fdi
+		//
+		fdi.m_type = SCAP_FD_IOURING;
 		fdi.m_name = "";
 
 		//

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -121,6 +121,9 @@ private:
 	void parse_dup_exit(sinsp_evt* evt);
 	void parse_signalfd_exit(sinsp_evt* evt);
 	void parse_timerfd_create_exit(sinsp_evt* evt);
+	void parse_bpf_exit(sinsp_evt* evt);
+	void parse_userfaultfd_exit(sinsp_evt* evt);
+	void parse_io_uring_setup_exit(sinsp_evt* evt);
 	void parse_inotify_init_exit(sinsp_evt* evt);
 	void parse_getrlimit_setrlimit_exit(sinsp_evt* evt);
 	void parse_prlimit_exit(sinsp_evt* evt);

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -119,12 +119,7 @@ private:
 	void parse_getcwd_exit(sinsp_evt* evt);
 	void parse_shutdown_exit(sinsp_evt* evt);
 	void parse_dup_exit(sinsp_evt* evt);
-	void parse_signalfd_exit(sinsp_evt* evt);
-	void parse_timerfd_create_exit(sinsp_evt* evt);
-	void parse_bpf_exit(sinsp_evt* evt);
-	void parse_userfaultfd_exit(sinsp_evt* evt);
-	void parse_io_uring_setup_exit(sinsp_evt* evt);
-	void parse_inotify_init_exit(sinsp_evt* evt);
+	void parse_single_param_fd_exit(sinsp_evt* evt, scap_fd_type type);
 	void parse_getrlimit_setrlimit_exit(sinsp_evt* evt);
 	void parse_prlimit_exit(sinsp_evt* evt);
 	void parse_select_poll_epollwait_enter(sinsp_evt *evt);

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -456,3 +456,47 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path)
 		FAIL();
 	}
 }
+
+TEST_F(sinsp_with_test_input, creates_fd_generic)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_E, 3, -1, NULL, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_X, 1, 5);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "signalfd");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "s");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "5");
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_E, 2, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_X, 1, 6);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "timerfd");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "t");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "6");
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_E, 1, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, 7);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "inotify");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "i");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "7");
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_E, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_X, 1, 8);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "bpf");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "b");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "8");
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_USERFAULTFD_E, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_USERFAULTFD_X, 2, 9, 0);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "userfaultfd");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "u");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "9");
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_IO_URING_SETUP_E, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_IO_URING_SETUP_X, 8, 10, 0, 0, 0, 0, 0, 0, 0);
+	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "io_uring");
+	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "r");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "10");
+}

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -477,7 +477,7 @@ TEST_F(sinsp_with_test_input, creates_fd_generic)
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "6");
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_E, 1, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, 7);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, 7);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "inotify");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "i");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "7");

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -341,6 +341,9 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
+	case SCAP_FD_BPF:
+	case SCAP_FD_USERFAULTFD:
+	case SCAP_FD_IOURING:
 		newfdi->m_name = fdi->info.fname;
 
 		if(newfdi->m_name == USER_EVT_DEVICE_NAME)
@@ -1313,6 +1316,9 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 	case SCAP_FD_INOTIFY:
 	case SCAP_FD_TIMERFD:
 	case SCAP_FD_NETLINK:
+	case SCAP_FD_BPF:
+	case SCAP_FD_USERFAULTFD:
+	case SCAP_FD_IOURING:
 		strlcpy(dst->info.fname, src->m_name.c_str(), sizeof(dst->info.fname));
 		break;
 	default:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-savefile
/area libscap
/area libsinsp

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Moreover, properly state in EF_CREATES_FD and EF_DESTROYS_FD flags docs, that when used, a parser MUST always be created.
Practically, added parser for:
* bpf
* userfaultfd
* io_uring_setup

exit events.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: properly parse and add to sinsp state FDs coming from bpf, userfaultfd and io_uring_setup events.
```
