### PR TITLE
add filter execution statistics to be analyzed by the clients

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1429,7 +1429,7 @@ bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT vector<extract_value
 			}
 		}
 
-		// Shallow-copy the cached values to values
+		// Shallow-copy the m_cached values to values
 		values = m_extraction_cache_entry->m_res;
 
 		return !m_extraction_cache_entry->m_res.empty();
@@ -1442,6 +1442,7 @@ bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT vector<extract_value
 
 bool sinsp_filter_check::compare(gen_event *evt)
 {
+	m_hits++;
 	if(m_cache_metrics != NULL)
 	{
 		m_cache_metrics->m_num_eval++;
@@ -1464,12 +1465,23 @@ bool sinsp_filter_check::compare(gen_event *evt)
 			}
 		}
 
+		if (m_eval_cache_entry->m_res)
+		{
+			m_matched_true++;
+		}
+		m_cached++;
 
 		return m_eval_cache_entry->m_res;
 	}
 	else
 	{
-		return compare((sinsp_evt *) evt);
+		auto res = compare((sinsp_evt *) evt);
+		if (res)
+		{
+			m_matched_true++;
+		}
+
+		return res;
 	}
 }
 

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -62,14 +62,61 @@ void gen_event_filter_expression::add_check(gen_event_filter_check* chk)
 	m_checks.push_back(chk);
 }
 
+std::string std::to_string(boolop b)
+{
+	switch (b)
+	{
+	case BO_NONE:
+		return "NONE";
+	case BO_NOT:
+		return "NOT";
+	case BO_OR:
+		return "OR";
+	case BO_AND:
+		return "AND";
+	case BO_ORNOT:
+		return "OR_NOT";
+	case BO_ANDNOT:
+		return "AND_NOT";
+	};
+	return "<unset>";
+}
+
+std::string std::to_string(cmpop c)
+{
+	switch (c)
+	{
+	case CO_NONE: return "NONE";
+	case CO_EQ: return "EQ";
+	case CO_NE: return "NE";
+	case CO_LT: return "LT";
+	case CO_LE: return "LE";
+	case CO_GT: return "GT";
+	case CO_GE: return "GE";
+	case CO_CONTAINS: return "CONTAINS";
+	case CO_IN: return "IN";
+	case CO_EXISTS: return "EXISTS";
+	case CO_ICONTAINS: return "ICONTAINS";
+	case CO_STARTSWITH: return "STARTSWITH";
+	case CO_GLOB: return "GLOB";
+	case CO_PMATCH: return "PMATCH";
+	case CO_ENDSWITH: return "ENDSWITH";
+	case CO_INTERSECTS: return "INTERSECTS";
+	case CO_BCONTAINS: return "BCONTAINS";
+	case CO_BSTARTSWITH: return "BSTARTSWITH";
+	}
+	return "<unset>";
+};
+
 bool gen_event_filter_expression::compare(gen_event *evt)
 {
-	uint32_t j;
-	uint32_t size = (uint32_t)m_checks.size();
 	bool res = true;
-	gen_event_filter_check* chk = NULL;
 
-	for(j = 0; j < size; j++)
+	gen_event_filter_check* chk = nullptr;
+	++m_hits;
+
+	auto size = m_checks.size();
+	for(size_t j = 0; j < size; j++)
 	{
 		chk = m_checks[j];
 		ASSERT(chk != NULL);
@@ -128,7 +175,10 @@ bool gen_event_filter_expression::compare(gen_event *evt)
 		}
 	}
  done:
-
+	if (res)
+	{
+		m_matched_true++;
+	}
 	return res;
 }
 

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -59,6 +59,12 @@ enum boolop
 	BO_ANDNOT = 5,
 };
 
+namespace std
+{
+std::string to_string(cmpop);
+std::string to_string(boolop);
+}
+
 enum evt_src
 {
 	ESRC_NONE = 0,
@@ -101,6 +107,10 @@ public:
 
 	boolop m_boolop;
 	cmpop m_cmpop;
+
+	size_t m_hits = 0;
+	size_t m_cached = 0;
+	size_t m_matched_true = 0;
 
 	virtual int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) = 0;
 	virtual void add_filter_value(const char* str, uint32_t len, uint32_t i = 0 ) = 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**


>/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Add stat fields to `gen_event_filter_check` to maintain filters exec statistics.
This will help clients to analyze the performance of the filters and make runtime decisions for the checks optimization/rearrangements.  
the statistics may look this way:
```
    rule:{ name: Linux Kernel Module Injection Detected, src: syscall, types: [230, 231, 292, 293]}
            * NONE, 45941 0, LT, (6)
            [
                = NONE, 45941 45941, evt.type EQ (1)[ execve ]
                = AND, 45941 45941, evt.dir EQ (1)[ < ]
                = AND, 24288 0, evt.arg EQ (1)[ 0 ]
                = AND, 20877 20877, container.id NE (1)[ host ]
                = AND, 20877 20877, proc.name EQ (1)[ insmod ]
                = AND_NOT, 0 0, proc.args IN (1)[  ]
            ]
```
here we can see that if we move the check `= AND, 20877 20877, proc.name EQ (1)[ insmod ]` to the first place we will cut ~200K unnecessary extractions/comparisons.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
