### PR TITLE
new(libsinsp,engines): add support for variable shared buffer dimension 

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2938,7 +2938,7 @@ MODULE_INFO(api_version, PPM_API_CURRENT_VERSION_STRING);
 MODULE_INFO(schema_version, PPM_SCHEMA_CURRENT_VERSION_STRING);
 
 module_param(per_cpu_buffer_dim, ulong, 0644);
-MODULE_PARM_DESC(per_cpu_buffer_dim, "This is the dimension of a single per-CPU buffer");
+MODULE_PARM_DESC(per_cpu_buffer_dim, "This is the dimension of a single per-CPU buffer. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.");
 module_param(max_consumers, uint, 0444);
 MODULE_PARM_DESC(max_consumers, "Maximum number of consumers that can simultaneously open the devices");
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)

--- a/driver/main.c
+++ b/driver/main.c
@@ -2962,7 +2962,7 @@ static int set_g_per_cpu_buffer_dim(const char *val, const struct kernel_param *
 	   (dim & (dim - 1)) != 0 ||
 	   dim < 128 * PAGE_SIZE)
 	{
-		pr_err("the specified per-CPU ring buffer dimension (%lu) is not allowed! Please use a power of 2 and a multiple of the actual page_size (%d)!\n", dim, PAGE_SIZE);
+		pr_err("the specified per-CPU ring buffer dimension (%lu) is not allowed! Please use a power of 2 and a multiple of the actual page_size (%lu)!\n", dim, PAGE_SIZE);
 		return -EINVAL;
 	}
 	return param_set_ulong(val, kp);

--- a/driver/main.c
+++ b/driver/main.c
@@ -208,6 +208,7 @@ static const struct file_operations g_ppm_fops = {
 LIST_HEAD(g_consumer_list);
 static DEFINE_MUTEX(g_consumer_mutex);
 static u32 g_tracepoints_attached; // list of attached tracepoints; bitmask using ppm_tp.h enum
+static unsigned long per_cpu_buffer_dim = 0; // dimension of a single per-CPU buffer. We initialize it to `0` but this must be set by userspace before opening the buffers.
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
 static struct tracepoint *tp_sys_enter;
@@ -1240,23 +1241,6 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 		       PAGE_SIZE);
 
 		/*
-		 * Enforce ring buffer size
-		 */
-		if (RING_BUF_SIZE < 2 * PAGE_SIZE) {
-			pr_err("Ring buffer size too small (%ld bytes, must be at least %ld bytes\n",
-			       (long)RING_BUF_SIZE,
-			       (long)PAGE_SIZE);
-			ret = -EIO;
-			goto cleanup_mmap;
-		}
-
-		if (RING_BUF_SIZE / PAGE_SIZE * PAGE_SIZE != RING_BUF_SIZE) {
-			pr_err("Ring buffer size is not a multiple of the page size\n");
-			ret = -EIO;
-			goto cleanup_mmap;
-		}
-
-		/*
 		 * Retrieve the ring structure for this CPU
 		 */
 		ring = per_cpu_ptr(consumer->ring_buffers, ring_no);
@@ -1288,7 +1272,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
 
 			ret = 0;
 			goto cleanup_mmap;
-		} else if (length == RING_BUF_SIZE * 2) {
+		}
+		else if(length == per_cpu_buffer_dim * 2)
+		{
 			long mlength;
 
 			/*
@@ -1875,16 +1861,16 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	if (ttail > head)
 		freespace = ttail - head - 1;
 	else
-		freespace = RING_BUF_SIZE + ttail - head - 1;
+		freespace = per_cpu_buffer_dim + ttail - head - 1;
 
-	usedspace = RING_BUF_SIZE - freespace - 1;
-	delta_from_end = RING_BUF_SIZE + (2 * PAGE_SIZE) - head - 1;
+	usedspace = per_cpu_buffer_dim - freespace - 1;
+	delta_from_end = per_cpu_buffer_dim + (2 * PAGE_SIZE) - head - 1;
 
-	ASSERT(freespace <= RING_BUF_SIZE);
-	ASSERT(usedspace <= RING_BUF_SIZE);
-	ASSERT(ttail <= RING_BUF_SIZE);
-	ASSERT(head <= RING_BUF_SIZE);
-	ASSERT(delta_from_end < RING_BUF_SIZE + (2 * PAGE_SIZE));
+	ASSERT(freespace <= per_cpu_buffer_dim);
+	ASSERT(usedspace <= per_cpu_buffer_dim);
+	ASSERT(ttail <= per_cpu_buffer_dim);
+	ASSERT(head <= per_cpu_buffer_dim);
+	ASSERT(delta_from_end < per_cpu_buffer_dim + (2 * PAGE_SIZE));
 	ASSERT(delta_from_end > (2 * PAGE_SIZE) - 1);
 #ifdef _HAS_SOCKETCALL
 	/*
@@ -2072,20 +2058,20 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 
 		next = head + event_size;
 
-		if (unlikely(next >= RING_BUF_SIZE)) {
+		if (unlikely(next >= per_cpu_buffer_dim)) {
 			/*
 			 * If something has been written in the cushion space at the end of
 			 * the buffer, copy it to the beginning and wrap the head around.
 			 * Note, we don't check that the copy fits because we assume that
 			 * filler_callback failed if the space was not enough.
 			 */
-			if (next > RING_BUF_SIZE) {
+			if (next > per_cpu_buffer_dim) {
 				memcpy(ring->buffer,
-				ring->buffer + RING_BUF_SIZE,
-				next - RING_BUF_SIZE);
+				ring->buffer + per_cpu_buffer_dim,
+				next - per_cpu_buffer_dim);
 			}
 
-			next -= RING_BUF_SIZE;
+			next -= per_cpu_buffer_dim;
 		}
 
 		/*
@@ -2116,10 +2102,10 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	}
 
 	if (MORE_THAN_ONE_SECOND_AHEAD(ns, ring->last_print_time + 1) && !(drop_flags & UF_ATOMIC)) {
-		vpr_info("consumer:%p CPU:%d, use:%d%%, ev:%llu, dr_buf:%llu, dr_buf_clone_fork_e:%llu, dr_buf_clone_fork_x:%llu, dr_buf_execve_e:%llu, dr_buf_execve_x:%llu, dr_buf_connect_e:%llu, dr_buf_connect_x:%llu, dr_buf_open_e:%llu, dr_buf_open_x:%llu, dr_buf_dir_file_e:%llu, dr_buf_dir_file_x:%llu, dr_buf_other_e:%llu, dr_buf_other_x:%llu, dr_pf:%llu, pr:%llu, cs:%llu\n",
+		vpr_info("consumer:%p CPU:%d, use:%lu, ev:%llu, dr_buf:%llu, dr_buf_clone_fork_e:%llu, dr_buf_clone_fork_x:%llu, dr_buf_execve_e:%llu, dr_buf_execve_x:%llu, dr_buf_connect_e:%llu, dr_buf_connect_x:%llu, dr_buf_open_e:%llu, dr_buf_open_x:%llu, dr_buf_dir_file_e:%llu, dr_buf_dir_file_x:%llu, dr_buf_other_e:%llu, dr_buf_other_x:%llu, dr_pf:%llu, pr:%llu, cs:%llu\n",
 			   consumer->consumer_id,
 		       smp_processor_id(),
-		       (usedspace * 100) / RING_BUF_SIZE,
+		       (usedspace * 100) / per_cpu_buffer_dim,
 		       ring_info->n_evts,
 		       ring_info->n_drops_buffer,
 		       ring_info->n_drops_buffer_clone_fork_enter,
@@ -2460,13 +2446,13 @@ static int init_ring_buffer(struct ppm_ring_buffer_context *ring)
 	 * Note how we allocate 2 additional pages: they are used as additional overflow space for
 	 * the event data generation functions, so that they always operate on a contiguous buffer.
 	 */
-	ring->buffer = vmalloc(RING_BUF_SIZE + 2 * PAGE_SIZE);
+	ring->buffer = vmalloc(per_cpu_buffer_dim + 2 * PAGE_SIZE);
 	if (ring->buffer == NULL) {
 		pr_err("Error allocating ring memory\n");
 		goto init_ring_err;
 	}
 
-	for (j = 0; j < RING_BUF_SIZE + 2 * PAGE_SIZE; j++)
+	for (j = 0; j < per_cpu_buffer_dim + 2 * PAGE_SIZE; j++)
 		ring->buffer[j] = 0;
 
 	/*
@@ -2484,7 +2470,7 @@ static int init_ring_buffer(struct ppm_ring_buffer_context *ring)
 	reset_ring_buffer(ring);
 	atomic_set(&ring->preempt_count, 0);
 
-	pr_info("CPU buffer initialized, size=%d\n", RING_BUF_SIZE);
+	pr_info("CPU buffer initialized, size=%lu\n", per_cpu_buffer_dim);
 
 	return 1;
 
@@ -2951,6 +2937,8 @@ MODULE_INFO(build_commit, DRIVER_COMMIT);
 MODULE_INFO(api_version, PPM_API_CURRENT_VERSION_STRING);
 MODULE_INFO(schema_version, PPM_SCHEMA_CURRENT_VERSION_STRING);
 
+module_param(per_cpu_buffer_dim, ulong, 0644);
+MODULE_PARM_DESC(per_cpu_buffer_dim, "This is the dimension of a single per-CPU buffer");
 module_param(max_consumers, uint, 0444);
 MODULE_PARM_DESC(max_consumers, "Maximum number of consumers that can simultaneously open the devices");
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -17,11 +17,6 @@
  */
 #define AUXILIARY_MAP_SIZE 128 * 1024
 
-/* The actual dimension of every single ringbuf is 8 MB.
- * Right now, this macro is used only by the userspace.
- */
-#define SINGLE_RINGBUF_DIMENSION 8 * 1024 * 1024
-
 /**
  * @brief General settings shared among all the CPUs.
  *

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -76,6 +76,7 @@ struct ppm_consumer_t {
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
 	uint16_t statsd_port;
+	unsigned long per_cpu_buffer_dim; /* Every consumer will have is per-CPU buffer dim. */
 	DECLARE_BITMAP(events_mask, PPM_EVENT_MAX);
 };
 #endif // UDIG

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -76,7 +76,7 @@ struct ppm_consumer_t {
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
 	uint16_t statsd_port;
-	unsigned long per_cpu_buffer_dim; /* Every consumer will have is per-CPU buffer dim. */
+	unsigned long buffer_bytes_dim; /* Every consumer will have its per-CPU buffer dim in bytes. */
 	DECLARE_BITMAP(events_mask, PPM_EVENT_MAX);
 };
 #endif // UDIG

--- a/driver/ppm_ringbuffer.h
+++ b/driver/ppm_ringbuffer.h
@@ -12,7 +12,22 @@ or GPL2.txt for full copies of the license.
 
 #ifdef __KERNEL__
 #include <linux/types.h>
+#else
+#include <stdbool.h>
 #endif
+
+/* This method validates the per-CPU buffer bytes dimension:
+ * The single buffer dimension must be:
+ * - greater than `2 * PAGE_SIZE`.
+ * - a multiple of the system PAGE_SIZE.
+ * - a power of 2.
+ * 
+ * Returns true if the buffer has a valid dimension.
+ */
+static inline bool validate_buffer_bytes_dim(unsigned long buf_bytes_dim, unsigned long page_size)
+{
+	return ((buf_bytes_dim > (2 * page_size)) && ((buf_bytes_dim % page_size) == 0) && ((buf_bytes_dim & (buf_bytes_dim - 1)) == 0));
+}
 
 /*
  * This gets mapped to user level, so we want to keep it as clean as possible

--- a/driver/ppm_ringbuffer.h
+++ b/driver/ppm_ringbuffer.h
@@ -14,9 +14,6 @@ or GPL2.txt for full copies of the license.
 #include <linux/types.h>
 #endif
 
-static const __u32 RING_BUF_SIZE = 8 * 1024 * 1024;
-static const __u32 MIN_USERSPACE_READ_SIZE = 128 * 1024;
-
 /*
  * This gets mapped to user level, so we want to keep it as clean as possible
  */

--- a/test/modern_bpf/start_tests.cpp
+++ b/test/modern_bpf/start_tests.cpp
@@ -83,7 +83,6 @@ int main(int argc, char** argv)
 
 cleanup_tests:
 	print_teardown_test_message();
-	pman_detach_all_programs();
 	pman_close_probe();
 	std::cout << "* BPF probe correctly detached! Bye!" << std::endl;
 	return ret;

--- a/test/modern_bpf/start_tests.cpp
+++ b/test/modern_bpf/start_tests.cpp
@@ -4,10 +4,8 @@
 #include <string>
 #include <chrono>
 #include <libpman.h>
+#include <scap.h>
 #include <gtest/gtest.h>
-
-/* Dimension of every single ring buffer in these tests is 8 MB. */
-#define RINGBUF_BYTES_DIMENSION 8 * 1024 * 1024
 
 void print_setup_phase_message()
 {
@@ -55,7 +53,7 @@ int main(int argc, char** argv)
 	::testing::InitGoogleTest(&argc, argv);
 
 	/* Configure and load BPF probe. */
-	ret = pman_init_state(libbpf_verbosity, RINGBUF_BYTES_DIMENSION);
+	ret = pman_init_state(libbpf_verbosity, DEFAULT_DRIVER_BUFFER_BYTES_DIM);
 	ret = ret ?: pman_open_probe();
 	ret = ret ?: pman_prepare_ringbuf_array_before_loading();
 	ret = ret ?: pman_prepare_maps_before_loading();

--- a/test/modern_bpf/start_tests.cpp
+++ b/test/modern_bpf/start_tests.cpp
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 
 /* Dimension of every single ring buffer in these tests is 8 MB. */
-#define SINGLE_RINGBUF_DIMENSION 8 * 1024 * 1024
+#define RINGBUF_BYTES_DIMENSION 8 * 1024 * 1024
 
 void print_setup_phase_message()
 {
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 	::testing::InitGoogleTest(&argc, argv);
 
 	/* Configure and load BPF probe. */
-	ret = pman_init_state(libbpf_verbosity, SINGLE_RINGBUF_DIMENSION);
+	ret = pman_init_state(libbpf_verbosity, RINGBUF_BYTES_DIMENSION);
 	ret = ret ?: pman_open_probe();
 	ret = ret ?: pman_prepare_ringbuf_array_before_loading();
 	ret = ret ?: pman_prepare_maps_before_loading();

--- a/test/modern_bpf/start_tests.cpp
+++ b/test/modern_bpf/start_tests.cpp
@@ -6,6 +6,9 @@
 #include <libpman.h>
 #include <gtest/gtest.h>
 
+/* Dimension of every single ring buffer in these tests is 8 MB. */
+#define SINGLE_RINGBUF_DIMENSION 8 * 1024 * 1024
+
 void print_setup_phase_message()
 {
 	std::cout << std::endl;
@@ -52,7 +55,7 @@ int main(int argc, char** argv)
 	::testing::InitGoogleTest(&argc, argv);
 
 	/* Configure and load BPF probe. */
-	ret = pman_set_libbpf_configuration(libbpf_verbosity);
+	ret = pman_init_state(libbpf_verbosity, SINGLE_RINGBUF_DIMENSION);
 	ret = ret ?: pman_open_probe();
 	ret = ret ?: pman_prepare_ringbuf_array_before_loading();
 	ret = ret ?: pman_prepare_maps_before_loading();

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -39,15 +39,16 @@ extern "C"
 	/////////////////////////////
 
 	/**
-	 * @brief Set libbpf inital configurations:
-	 * - libbpf strict mode.
-	 * - libbpf logging function according to the verbosity.
+	 * @brief Set `libpman` initial state:
+	 * - set `libbpf` strict mode.
+	 * - set `libbpf` logging function according to the verbosity.
 	 * - set available number of CPUs.
+	 * - set dimension of a single per-CPU ring buffer.
 	 *
 	 * @param verbosity use `true` if you want to activate libbpf verbosity.
 	 * @return `0` on success, `-1` in case of error.
 	 */
-	int pman_set_libbpf_configuration(bool verbosity);
+	int pman_init_state(bool verbosity, uint64_t single_buf_dim);
 
 	/**
 	 * @brief Return the number of available CPUs on the system, not the

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -46,9 +46,10 @@ extern "C"
 	 * - set dimension of a single per-CPU ring buffer.
 	 *
 	 * @param verbosity use `true` if you want to activate libbpf verbosity.
+	 * @param buf_bytes_dim dimension of a single per-CPU buffer in bytes.
 	 * @return `0` on success, `-1` in case of error.
 	 */
-	int pman_init_state(bool verbosity, uint64_t single_buf_dim);
+	int pman_init_state(bool verbosity, unsigned long buf_bytes_dim);
 
 	/**
 	 * @brief Return the number of available CPUs on the system, not the

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -44,7 +44,7 @@ static void setup_libbpf_logging(bool verbosity)
 	}
 }
 
-int pman_init_state(bool verbosity, uint64_t single_buf_dim)
+int pman_init_state(bool verbosity, uint64_t buf_bytes_dim)
 {
 
 	/* `LIBBPF_STRICT_ALL` turns on all supported strict features
@@ -65,7 +65,7 @@ int pman_init_state(bool verbosity, uint64_t single_buf_dim)
 	}
 
 	/* Set the dimension of a single per-CPU ring buffer. */
-	g_state.single_ringbuf_dimension = single_buf_dim;
+	g_state.buffer_bytes_dim = buf_bytes_dim;
 	return 0;
 }
 

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -44,7 +44,7 @@ static void setup_libbpf_logging(bool verbosity)
 	}
 }
 
-int pman_init_state(bool verbosity, uint64_t buf_bytes_dim)
+int pman_init_state(bool verbosity, unsigned long buf_bytes_dim)
 {
 
 	/* `LIBBPF_STRICT_ALL` turns on all supported strict features

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -44,7 +44,7 @@ static void setup_libbpf_logging(bool verbosity)
 	}
 }
 
-int pman_set_libbpf_configuration(bool verbosity)
+int pman_init_state(bool verbosity, uint64_t single_buf_dim)
 {
 
 	/* `LIBBPF_STRICT_ALL` turns on all supported strict features
@@ -56,13 +56,16 @@ int pman_set_libbpf_configuration(bool verbosity)
 	/* Set libbpf verbosity. */
 	setup_libbpf_logging(verbosity);
 
-	/* Set available number of CPUs inside the internal state. */
+	/* Set the available number of CPUs inside the internal state. */
 	g_state.n_cpus = libbpf_num_possible_cpus();
 	if(g_state.n_cpus <= 0)
 	{
 		pman_print_error("no available cpus");
 		return -1;
 	}
+
+	/* Set the dimension of a single per-CPU ring buffer. */
+	g_state.single_ringbuf_dimension = single_buf_dim;
 	return 0;
 }
 

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -117,23 +117,6 @@ static int create_first_ringbuffer_map()
 		goto clean_create_first_ringbuffer_map;
 	}
 
-	/* create the ringbuf manager with the first map. */
-	/* Each data page is mapped twice to allow "virtual"
-	 * continuous read of samples wrapping around the end of ring
-	 * buffer area:
-	 * 
-	 * ------------------------------------------------------
-	 * | meta pages |  real data pages  |  same data pages  |
-	 * ------------------------------------------------------
-	 * |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
-	 * ------------------------------------------------------
-	 * |            | TA             DA | TA             DA |
-	 * ------------------------------------------------------
-	 *                               ^^^^^^^
-	 *                                  |
-	 * Here, no need to worry about special handling of wrapped-around
-	 * data due to double-mapped data pages.
-	 */
 	g_state.rb_manager = ring_buffer__new(ringbuf_map_fd, NULL, NULL, NULL);
 	if(!g_state.rb_manager)
 	{

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -118,6 +118,22 @@ static int create_first_ringbuffer_map()
 	}
 
 	/* create the ringbuf manager with the first map. */
+	/* Each data page is mapped twice to allow "virtual"
+	 * continuous read of samples wrapping around the end of ring
+	 * buffer area:
+	 * 
+	 * ------------------------------------------------------
+	 * | meta pages |  real data pages  |  same data pages  |
+	 * ------------------------------------------------------
+	 * |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
+	 * ------------------------------------------------------
+	 * |            | TA             DA | TA             DA |
+	 * ------------------------------------------------------
+	 *                               ^^^^^^^
+	 *                                  |
+	 * Here, no need to worry about special handling of wrapped-around
+	 * data due to double-mapped data pages.
+	 */
 	g_state.rb_manager = ring_buffer__new(ringbuf_map_fd, NULL, NULL, NULL);
 	if(!g_state.rb_manager)
 	{

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -31,7 +31,7 @@ limitations under the License.
 static int ringbuf_array_set_inner_map()
 {
 	int err = 0;
-	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 	if(inner_map_fd < 0)
 	{
 		pman_print_error("failed to create the dummy inner map");
@@ -103,7 +103,7 @@ static int create_first_ringbuffer_map()
 	}
 
 	/* create the first ringbuf map. */
-	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 	if(ringbuf_map_fd <= 0)
 	{
 		pman_print_error("failed to create the first ringbuf map");
@@ -157,7 +157,7 @@ static int create_remaining_ringbuffer_maps()
 	 */
 	for(index = 1; index < g_state.n_cpus; index++)
 	{
-		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, SINGLE_RINGBUF_DIMENSION, NULL);
+		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
 		if(ringbuf_map_fd <= 0)
 		{
 			sprintf(error_message, "failed to create the ringbuf map for CPU %d", index);

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -31,7 +31,7 @@ limitations under the License.
 static int ringbuf_array_set_inner_map()
 {
 	int err = 0;
-	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
+	int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
 	if(inner_map_fd < 0)
 	{
 		pman_print_error("failed to create the dummy inner map");
@@ -103,7 +103,7 @@ static int create_first_ringbuffer_map()
 	}
 
 	/* create the first ringbuf map. */
-	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
+	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
 	if(ringbuf_map_fd <= 0)
 	{
 		pman_print_error("failed to create the first ringbuf map");
@@ -156,7 +156,7 @@ static int create_remaining_ringbuffer_maps()
 	 */
 	for(index = 1; index < g_state.n_cpus; index++)
 	{
-		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.single_ringbuf_dimension, NULL);
+		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
 		if(ringbuf_map_fd <= 0)
 		{
 			sprintf(error_message, "failed to create the ringbuf map for CPU %d", index);

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -121,7 +121,7 @@ static int create_first_ringbuffer_map()
 	g_state.rb_manager = ring_buffer__new(ringbuf_map_fd, NULL, NULL, NULL);
 	if(!g_state.rb_manager)
 	{
-		pman_print_error("failed to instantiate the ringbuf manager");
+		pman_print_error("failed to instantiate the ringbuf manager. (If you get memory allocation errors try to reduce the buffer dimension)");
 		goto clean_create_first_ringbuffer_map;
 	}
 	return 0;

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -34,7 +34,7 @@ struct internal_state
 	unsigned long* cons_pos;	/* every ringbuf has a consumer position. */
 	unsigned long* prod_pos;	/* every ringbuf has a producer position. */
 	int32_t inner_ringbuf_map_fd;	/* inner map used to configure the ringbuf array before loading phase. */
-	uint64_t buffer_bytes_dim; /* dimension of a single per-CPU ringbuffer in bytes. */
+	unsigned long buffer_bytes_dim; /* dimension of a single per-CPU ringbuffer in bytes. */
 };
 
 extern struct internal_state g_state;

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -34,6 +34,7 @@ struct internal_state
 	unsigned long* cons_pos;	/* every ringbuf has a consumer position. */
 	unsigned long* prod_pos;	/* every ringbuf has a producer position. */
 	int32_t inner_ringbuf_map_fd;	/* inner map used to configure the ringbuf array before loading phase. */
+	uint64_t single_ringbuf_dimension; /* dimension of a single per-CPU ringbuffer. */
 };
 
 extern struct internal_state g_state;

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -34,7 +34,7 @@ struct internal_state
 	unsigned long* cons_pos;	/* every ringbuf has a consumer position. */
 	unsigned long* prod_pos;	/* every ringbuf has a producer position. */
 	int32_t inner_ringbuf_map_fd;	/* inner map used to configure the ringbuf array before loading phase. */
-	uint64_t single_ringbuf_dimension; /* dimension of a single per-CPU ringbuffer. */
+	uint64_t buffer_bytes_dim; /* dimension of a single per-CPU ringbuffer in bytes. */
 };
 
 extern struct internal_state g_state;

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -159,7 +159,8 @@ endif()
 
 add_library(scap_engine_util
 	scap_engine_util.c
-	ringbuffer/devset.c)
+	ringbuffer/devset.c
+	ringbuffer/ringbuffer.c)
 
 target_link_libraries(scap scap_engine_util)
 

--- a/userspace/libscap/engine/bpf/bpf_public.h
+++ b/userspace/libscap/engine/bpf/bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_bpf_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 		const char* bpf_probe;	    ///<  The path to the BPF probe object file.
 	};
 

--- a/userspace/libscap/engine/bpf/bpf_public.h
+++ b/userspace/libscap/engine/bpf/bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_bpf_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
+		unsigned long buffer_bytes_dim; ///< Dimension of a single per-CPU buffer in bytes. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 		const char* bpf_probe;	    ///<  The path to the BPF probe object file.
 	};
 

--- a/userspace/libscap/engine/bpf/bpf_public.h
+++ b/userspace/libscap/engine/bpf/bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_bpf_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 		const char* bpf_probe;	    ///<  The path to the BPF probe object file.
 	};
 

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -835,22 +835,6 @@ cleanup:
 
 static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, uint64_t buf_num_pages)
 {
-   /* Each data page is mapped twice to allow "virtual"
-	* continuous read of samples wrapping around the end of ring
-	* buffer area:
-	* 
-	* ------------------------------------------------------
-	* | meta pages |  real data pages  |  same data pages  |
-	* ------------------------------------------------------
-	* |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
-	* ------------------------------------------------------
-	* |            | TA             DA | TA             DA |
-	* ------------------------------------------------------
-	*                               ^^^^^^^
-	*                                  |
-	* Here, no need to worry about special handling of wrapped-around
-	* data due to double-mapped data pages.
-	*/
 	int page_size = getpagesize();
 	int ring_size = page_size * buf_num_pages;
 	int header_size = page_size;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -841,6 +841,9 @@ static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, 
 	int total_size = ring_size * 2 + header_size;
 	char buf[SCAP_LASTERR_SIZE] = {0};
 
+	/* This variable is not used in BPF right now, but just to be future proof we set it. */
+	set_per_cpu_buffer_dim(ring_size);
+
 	*size = 0;
 
 	//

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1725,6 +1725,12 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	struct scap_bpf_engine_params *params = oargs->engine_params;
 	strlcpy(bpf_probe_buf, params->bpf_probe, SCAP_MAX_PATH_SIZE);
 
+	/* Validate the number of buffer pages. */
+	if(check_per_cpu_buffer_num_pages(engine.m_handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
+	{
+		return SCAP_FAILURE;
+	}
+
 	//
 	// Find out how many devices we have to open, which equals to the number of CPUs
 	//

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1726,7 +1726,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	strlcpy(bpf_probe_buf, params->bpf_probe, SCAP_MAX_PATH_SIZE);
 
 	/* Validate the number of buffer pages. */
-	if(check_per_cpu_buffer_num_pages(engine.m_handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
+	if(check_buffer_num_pages(engine.m_handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -835,6 +835,22 @@ cleanup:
 
 static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, uint64_t buf_num_pages)
 {
+   /* Each data page is mapped twice to allow "virtual"
+	* continuous read of samples wrapping around the end of ring
+	* buffer area:
+	* 
+	* ------------------------------------------------------
+	* | meta pages |  real data pages  |  same data pages  |
+	* ------------------------------------------------------
+	* |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
+	* ------------------------------------------------------
+	* |            | TA             DA | TA             DA |
+	* ------------------------------------------------------
+	*                               ^^^^^^^
+	*                                  |
+	* Here, no need to worry about special handling of wrapped-around
+	* data due to double-mapped data pages.
+	*/
 	int page_size = getpagesize();
 	int ring_size = page_size * buf_num_pages;
 	int header_size = page_size;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -850,7 +850,7 @@ static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, 
 	void *tmp = mmap(NULL, total_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 	if(tmp == MAP_FAILED)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (1): %s", scap_strerror_r(buf, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (1): %s. (If you get memory allocation errors try to reduce the buffer dimension)", scap_strerror_r(buf, errno));
 		return MAP_FAILED;
 	}
 
@@ -858,7 +858,7 @@ static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, 
 	void *p1 = mmap(tmp + ring_size, ring_size + header_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, 0);
 	if(p1 == MAP_FAILED)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (2): %s", scap_strerror_r(buf, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (2): %s. (If you get memory allocation errors try to reduce the buffer dimension)", scap_strerror_r(buf, errno));
 		munmap(tmp, total_size);
 		return MAP_FAILED;
 	}
@@ -869,7 +869,7 @@ static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, 
 	void *p2 = mmap(tmp, ring_size + header_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, 0);
 	if(p2 == MAP_FAILED)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (3): %s", scap_strerror_r(buf, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "mmap (3): %s. (If you get memory allocation errors try to reduce the buffer dimension)", scap_strerror_r(buf, errno));
 		munmap(tmp, total_size);
 		return MAP_FAILED;
 	}

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1548,7 +1548,8 @@ int32_t scap_bpf_load(
 		//
 		// Map the ring buffer
 		//
-		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size, bpf_args->buffer_bytes_dim);
+		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_mmap_size, bpf_args->buffer_bytes_dim);
+		dev->m_buffer_size = bpf_args->buffer_bytes_dim;
 		if(dev->m_buffer == MAP_FAILED)
 		{
 			return SCAP_FAILURE;
@@ -1722,7 +1723,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	struct scap_bpf_engine_params *params = oargs->engine_params;
 	strlcpy(bpf_probe_buf, params->bpf_probe, SCAP_MAX_PATH_SIZE);
 
-	if(check_and_set_buffer_bytes_dim(engine.m_handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(engine.m_handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -109,8 +109,6 @@ static void free_handle(struct scap_engine_handle engine)
 
 # define UINT32_MAX (4294967295U)
 
-static const int BUF_SIZE_PAGES = 2048;
-
 /* Recommended log buffer size. 
  * Taken from libbpf source code: https://github.com/libbpf/libbpf/blob/67a4b1464349345e483df26ed93f8d388a60cee1/src/bpf.h#L201
  */
@@ -835,13 +833,13 @@ cleanup:
 	return res;
 }
 
-static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size)
+static void *perf_event_mmap(struct bpf_engine *handle, int fd, uint32_t *size, uint64_t buf_num_pages)
 {
 	int page_size = getpagesize();
-	int ring_size = page_size * BUF_SIZE_PAGES;
+	int ring_size = page_size * buf_num_pages;
 	int header_size = page_size;
 	int total_size = ring_size * 2 + header_size;
-	char buf[SCAP_LASTERR_SIZE];
+	char buf[SCAP_LASTERR_SIZE] = {0};
 
 	*size = 0;
 
@@ -1433,6 +1431,7 @@ int32_t scap_bpf_load(
 	int online_cpu;
 	int j;
 	char buf[SCAP_LASTERR_SIZE];
+	struct scap_bpf_engine_params* bpf_args = oargs->engine_params;
 
 	if(set_runtime_params(handle) != SCAP_SUCCESS)
 	{
@@ -1549,7 +1548,7 @@ int32_t scap_bpf_load(
 		//
 		// Map the ring buffer
 		//
-		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size);
+		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size, bpf_args->buffer_num_pages);
 		if(dev->m_buffer == MAP_FAILED)
 		{
 			return SCAP_FAILURE;

--- a/userspace/libscap/engine/kmod/kmod_public.h
+++ b/userspace/libscap/engine/kmod/kmod_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_kmod_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
+		unsigned long buffer_bytes_dim; ///< Dimension of a single per-CPU buffer in bytes. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/kmod/kmod_public.h
+++ b/userspace/libscap/engine/kmod/kmod_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_kmod_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/kmod/kmod_public.h
+++ b/userspace/libscap/engine/kmod/kmod_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_kmod_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -290,6 +290,24 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 		// (for subsequent devices it's a no-op thanks to the check above)
 		handle->m_schema_version = schema_version;
 
+
+	   /* Each data page is mapped twice to allow "virtual"
+		* continuous read of samples wrapping around the end of ring
+		* buffer area:
+		* 
+		* ------------------------------------------------------
+		* | meta pages |  real data pages  |  same data pages  |
+		* ------------------------------------------------------
+		* |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
+		* ------------------------------------------------------
+		* |            | TA             DA | TA             DA |
+		* ------------------------------------------------------
+		*                               ^^^^^^^
+		*                                  |
+		* Here, no need to worry about special handling of wrapped-around
+		* data due to double-mapped data pages.
+		*/
+
 		//
 		// Map the ring buffer
 		//

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -290,24 +290,6 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 		// (for subsequent devices it's a no-op thanks to the check above)
 		handle->m_schema_version = schema_version;
 
-
-	   /* Each data page is mapped twice to allow "virtual"
-		* continuous read of samples wrapping around the end of ring
-		* buffer area:
-		* 
-		* ------------------------------------------------------
-		* | meta pages |  real data pages  |  same data pages  |
-		* ------------------------------------------------------
-		* |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
-		* ------------------------------------------------------
-		* |            | TA             DA | TA             DA |
-		* ------------------------------------------------------
-		*                               ^^^^^^^
-		*                                  |
-		* Here, no need to worry about special handling of wrapped-around
-		* data due to double-mapped data pages.
-		*/
-
 		//
 		// Map the ring buffer
 		//

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -158,7 +158,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	uint64_t schema_version = 0;
 
 	unsigned long single_buffer_dim = params->buffer_bytes_dim;
-	if(check_and_set_buffer_bytes_dim(handle->m_lasterr, single_buffer_dim) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(handle->m_lasterr, single_buffer_dim) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -307,7 +307,8 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer for device %s. (If you get memory allocation errors try to reduce the buffer dimension)", filename);
 			return SCAP_FAILURE;
 		}
-		dev->m_buffer_size = mapped_len;
+		dev->m_buffer_size = single_buffer_dim;
+		dev->m_mmap_size = mapped_len;
 
 		//
 		// Map the ppm_ring_buffer_info that contains the buffer pointers

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -305,7 +305,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			// we cleanup this fd and then we let scap_close() take care of the other ones
 			close(dev->m_fd);
 
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer for device %s", filename);
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer for device %s. (If you get memory allocation errors try to reduce the buffer dimension)", filename);
 			return SCAP_FAILURE;
 		}
 		dev->m_buffer_size = mapped_len;
@@ -326,7 +326,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			munmap(dev->m_buffer, mapped_len);
 			close(dev->m_fd);
 
-			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer info for device %s", filename);
+			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer info for device %s. (If you get memory allocation errors try to reduce the buffer dimension)", filename);
 			return SCAP_FAILURE;
 		}
 		dev->m_bufinfo_size = sizeof(struct ppm_ring_buffer_info);

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -76,16 +76,16 @@ static uint32_t get_max_consumers()
 
 static int32_t enforce_into_kmod_single_buffer_dim(scap_t *handle, unsigned long buffer_dim)
 {
-	FILE *pfile = fopen("/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_per_cpu_buffer_dim", "w");
+	FILE *pfile = fopen("/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_buffer_bytes_dim", "w");
 	if(pfile == NULL)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open the 'g_per_cpu_buffer_dim' parameter file: %s", scap_strerror(handle, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open the 'g_buffer_bytes_dim' parameter file: %s", scap_strerror(handle, errno));
 		return SCAP_FAILURE;
 	}
 
 	if(fprintf(pfile, "%lu", buffer_dim) < 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to write into /sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_per_cpu_buffer_dim: %s", scap_strerror(handle, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to write into /sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_buffer_bytes_dim: %s", scap_strerror(handle, errno));
 		fclose(pfile);
 		return SCAP_FAILURE;
 	}
@@ -158,7 +158,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	uint64_t schema_version = 0;
 
 	/* Validate the number of buffer pages. */
-	if(check_per_cpu_buffer_num_pages(handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
+	if(check_buffer_num_pages(handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -74,18 +74,18 @@ static uint32_t get_max_consumers()
 	return 0;
 }
 
-static int32_t enforce_into_kmod_single_buffer_dim(scap_t *handle, unsigned long bpf_dim)
+static int32_t enforce_into_kmod_single_buffer_dim(scap_t *handle, unsigned long buffer_dim)
 {
-	FILE *pfile = fopen("/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/per_cpu_buffer_dim", "w");
+	FILE *pfile = fopen("/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_per_cpu_buffer_dim", "w");
 	if(pfile == NULL)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open the 'per_cpu_buffer_dim' parameter file: %s", scap_strerror(handle, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open the 'g_per_cpu_buffer_dim' parameter file: %s", scap_strerror(handle, errno));
 		return SCAP_FAILURE;
 	}
 
-	if(fprintf(pfile, "%lu", bpf_dim) < 0)
+	if(fprintf(pfile, "%lu", buffer_dim) < 0)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/per_cpu_buffer_dim: %s", scap_strerror(handle, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "/sys/module/" SCAP_KERNEL_MODULE_NAME "/parameters/g_per_cpu_buffer_dim: %s", scap_strerror(handle, errno));
 		fclose(pfile);
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_modern_bpf_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_modern_bpf_engine_params
 	{
-		uint64_t single_buffer_dim; ///<  dim of a single shared buffer. Usually, we have one buffer for every online CPU.
+		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -25,7 +25,7 @@ extern "C"
 
 	struct scap_modern_bpf_engine_params
 	{
-		uint64_t buffer_num_pages; ///< Number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
+		unsigned long buffer_bytes_dim; ///< Dimension of a single per-CPU buffer in bytes. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -196,7 +196,7 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	bool libbpf_verbosity = false;
 
 	/* Validate the number of buffer pages. */
-	if(check_per_cpu_buffer_num_pages(handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
+	if(check_buffer_num_pages(handle->m_lasterr, params->buffer_num_pages) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -97,6 +97,9 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
+	/* Set the dimension of the per-cpu buffer. */
+	set_per_cpu_buffer_dim((unsigned long)*ringsize);
+
 	//
 	// Map the ring. This is a multi-step process because we want to map two
 	// consecutive copies of the same memory to reuse the driver fillers, which

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -97,8 +97,10 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
-	/* Set the dimension of the per-cpu buffer. */
-	set_per_cpu_buffer_dim((unsigned long)*ringsize);
+	if(check_and_set_buffer_bytes_dim(error, (unsigned long)*ringsize) != SCAP_SUCCESS)
+	{
+		return SCAP_FAILURE;
+	}
 
 	//
 	// Map the ring. This is a multi-step process because we want to map two

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -97,7 +97,7 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
-	if(check_and_set_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -892,6 +892,8 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 	{
 		return SCAP_FAILURE;
 	}
+
+	handle->m_dev_set.m_devs[0].m_mmap_size = 2 * handle->m_dev_set.m_devs[0].m_buffer_size;
 
 	// Set close-on-exec for the fd
 #ifndef _WIN32

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -41,7 +41,7 @@ int ud_shm_open(const char *name, int flag, mode_t mode);
 ///////////////////////////////////////////////////////////////////////////////
 int32_t udig_alloc_ring(void* ring_id, 
 	uint8_t** ring, 
-	uint32_t *ringsize,
+	unsigned long *ringsize,
 	char *error)
 {
 	int* ring_fd = (int*)ring_id;
@@ -62,7 +62,7 @@ int32_t udig_alloc_ring(void* ring_id,
 			return SCAP_FAILURE;
 		}
 
-		*ringsize = (uint32_t)rstat.st_size;
+		*ringsize = rstat.st_size;
 	}
 	else
 	{
@@ -97,7 +97,7 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
-	if(check_and_set_buffer_bytes_dim(error, (unsigned long)*ringsize) != SCAP_SUCCESS)
+	if(check_and_set_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -342,7 +342,7 @@ int32_t udig_begin_capture(struct scap_engine_handle engine, char *error)
 ///////////////////////////////////////////////////////////////////////////////
 int32_t udig_alloc_ring(HANDLE* ring_handle,
 	uint8_t** ring,
-	uint32_t* ringsize,
+	unsigned long* ringsize,
 	char* error)
 {
 	*ring_handle = NULL;
@@ -369,7 +369,7 @@ int32_t udig_alloc_ring(HANDLE* ring_handle,
 		MEMORY_BASIC_INFORMATION info;
 		SIZE_T szBufferSize = VirtualQueryEx(GetCurrentProcess(), pdbuf, &info, sizeof(info));
 
-		*ringsize = (uint32_t)info.RegionSize;
+		*ringsize = info.RegionSize;
 
 		UnmapViewOfFile(pdbuf);
 	}

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -58,6 +58,7 @@ uint64_t num_events = UINT64_MAX; /* max number of events to catch. */
 int evt_type = -1;		  /* event type to print. */
 bool ppm_sc_is_set = 0;
 bool tp_is_set = 0;
+uint64_t buffer_num_pages = 2048; /* This should generate a 8 MB buffer. */
 
 /* Generic global variables. */
 scap_open_args oargs = {.engine_name = UNKNOWN_ENGINE};			    /* scap oargs used in `scap_open`. */
@@ -603,6 +604,7 @@ void print_help()
 	printf("'%s <ppm_sc_code>': enable only requested syscall (this is our internal ppm syscall code not the system syscall code). Can be passed multiple times.\n", PPM_SC_OPTION);
 	printf("'%s <num_events>': number of events to catch before terminating. (default: UINT64_MAX)\n", NUM_EVENTS_OPTION);
 	printf("'%s <event_type>': every event of this type will be printed to console. (default: -1, no print)\n", EVENT_TYPE_OPTION);
+	printf("'%s <num_pages>': number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. (default: 2048 pages)\n", BUFFER_OPTION);
 	printf("\n------> VALIDATION OPTIONS\n");
 	printf("'%s': validation checks.\n", VALIDATION_OPTION);
 	printf("\n------> PRINT OPTIONS\n");
@@ -688,6 +690,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = KMOD_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			kmod_params.buffer_num_pages = buffer_num_pages;
 			oargs.engine_params = &kmod_params;
 		}
 		if(!strcmp(argv[i], BPF_OPTION))
@@ -700,12 +703,14 @@ void parse_CLI_options(int argc, char** argv)
 			oargs.engine_name = BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
 			bpf_params.bpf_probe = argv[++i];
+			bpf_params.buffer_num_pages = buffer_num_pages;
 			oargs.engine_params = &bpf_params;
 		}
 		if(!strcmp(argv[i], MODERN_BPF_OPTION))
 		{
 			oargs.engine_name = MODERN_BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			modern_bpf_params.buffer_num_pages = buffer_num_pages;
 			oargs.engine_params = &modern_bpf_params;
 		}
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
@@ -732,7 +737,7 @@ void parse_CLI_options(int argc, char** argv)
 				printf("\nYou need to specify also the number of pages! Bye!\n");
 				exit(EXIT_FAILURE);
 			}
-			uint64_t buffer_num_pages = strtoul(argv[++i], NULL, 10);
+			buffer_num_pages = strtoul(argv[++i], NULL, 10);
 			kmod_params.buffer_num_pages = buffer_num_pages;
 			bpf_params.buffer_num_pages = buffer_num_pages;
 			modern_bpf_params.buffer_num_pages = buffer_num_pages;

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -36,6 +36,7 @@ limitations under the License.
 #define PPM_SC_OPTION "--ppm_sc"
 #define NUM_EVENTS_OPTION "--num_events"
 #define EVENT_TYPE_OPTION "--evt_type"
+#define BUFFER_OPTION "--pages"
 
 /* PRINT */
 #define VALIDATION_OPTION "--validate_syscalls"
@@ -48,6 +49,8 @@ extern const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
 
 /* Engine params */
 struct scap_bpf_engine_params bpf_params = {0};
+struct scap_kmod_engine_params kmod_params = {0};
+struct scap_modern_bpf_engine_params modern_bpf_params = {0};
 struct scap_savefile_engine_params savefile_params = {0};
 
 /* Configuration variables set through CLI. */
@@ -685,6 +688,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = KMOD_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			oargs.engine_params = &kmod_params;
 		}
 		if(!strcmp(argv[i], BPF_OPTION))
 		{
@@ -695,7 +699,6 @@ void parse_CLI_options(int argc, char** argv)
 			}
 			oargs.engine_name = BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
-
 			bpf_params.bpf_probe = argv[++i];
 			oargs.engine_params = &bpf_params;
 		}
@@ -703,6 +706,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = MODERN_BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
+			oargs.engine_params = &modern_bpf_params;
 		}
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
 		{
@@ -713,7 +717,6 @@ void parse_CLI_options(int argc, char** argv)
 			}
 			oargs.engine_name = SAVEFILE_ENGINE;
 			oargs.mode = SCAP_MODE_CAPTURE;
-
 			savefile_params.fname = argv[++i];
 			oargs.engine_params = &savefile_params;
 		}
@@ -722,6 +725,18 @@ void parse_CLI_options(int argc, char** argv)
 
 		/*=============================== CONFIGURATIONS ===========================*/
 
+		if(!strcmp(argv[i], BUFFER_OPTION))
+		{
+			if(!(i + 1 < argc))
+			{
+				printf("\nYou need to specify also the number of pages! Bye!\n");
+				exit(EXIT_FAILURE);
+			}
+			uint64_t buffer_num_pages = strtoul(argv[++i], NULL, 10);
+			kmod_params.buffer_num_pages = buffer_num_pages;
+			bpf_params.buffer_num_pages = buffer_num_pages;
+			modern_bpf_params.buffer_num_pages = buffer_num_pages;
+		}
 		if(!strcmp(argv[i], TP_OPTION))
 		{
 			if(!(i + 1 < argc))

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -58,7 +58,7 @@ uint64_t num_events = UINT64_MAX; /* max number of events to catch. */
 int evt_type = -1;		  /* event type to print. */
 bool ppm_sc_is_set = 0;
 bool tp_is_set = 0;
-uint64_t buffer_num_pages = 2048; /* This should generate a 8 MB buffer. */
+uint64_t buffer_num_pages = 2048; /* This will generate a 8 MB buffer in systems with a page size of 4 KB. */
 
 /* Generic global variables. */
 scap_open_args oargs = {.engine_name = UNKNOWN_ENGINE};			    /* scap oargs used in `scap_open`. */

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -36,7 +36,7 @@ limitations under the License.
 #define PPM_SC_OPTION "--ppm_sc"
 #define NUM_EVENTS_OPTION "--num_events"
 #define EVENT_TYPE_OPTION "--evt_type"
-#define BUFFER_OPTION "--pages"
+#define BUFFER_OPTION "--buffer_dim"
 
 /* PRINT */
 #define VALIDATION_OPTION "--validate_syscalls"
@@ -58,7 +58,7 @@ uint64_t num_events = UINT64_MAX; /* max number of events to catch. */
 int evt_type = -1;		  /* event type to print. */
 bool ppm_sc_is_set = 0;
 bool tp_is_set = 0;
-uint64_t buffer_num_pages = 2048; /* This will generate a 8 MB buffer in systems with a page size of 4 KB. */
+unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
 
 /* Generic global variables. */
 scap_open_args oargs = {.engine_name = UNKNOWN_ENGINE};			    /* scap oargs used in `scap_open`. */
@@ -604,7 +604,7 @@ void print_help()
 	printf("'%s <ppm_sc_code>': enable only requested syscall (this is our internal ppm syscall code not the system syscall code). Can be passed multiple times.\n", PPM_SC_OPTION);
 	printf("'%s <num_events>': number of events to catch before terminating. (default: UINT64_MAX)\n", NUM_EVENTS_OPTION);
 	printf("'%s <event_type>': every event of this type will be printed to console. (default: -1, no print)\n", EVENT_TYPE_OPTION);
-	printf("'%s <num_pages>': number of pages of a single per CPU buffer. The overall buffer dimension is: `buffer_num_pages * page_dim`. (default: 2048 pages)\n", BUFFER_OPTION);
+	printf("'%s <dim>': dimension in bytes of a single per CPU buffer.\n", BUFFER_OPTION);
 	printf("\n------> VALIDATION OPTIONS\n");
 	printf("'%s': validation checks.\n", VALIDATION_OPTION);
 	printf("\n------> PRINT OPTIONS\n");
@@ -690,7 +690,7 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			oargs.engine_name = KMOD_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
-			kmod_params.buffer_num_pages = buffer_num_pages;
+			kmod_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &kmod_params;
 		}
 		if(!strcmp(argv[i], BPF_OPTION))
@@ -703,14 +703,14 @@ void parse_CLI_options(int argc, char** argv)
 			oargs.engine_name = BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
 			bpf_params.bpf_probe = argv[++i];
-			bpf_params.buffer_num_pages = buffer_num_pages;
+			bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &bpf_params;
 		}
 		if(!strcmp(argv[i], MODERN_BPF_OPTION))
 		{
 			oargs.engine_name = MODERN_BPF_ENGINE;
 			oargs.mode = SCAP_MODE_LIVE;
-			modern_bpf_params.buffer_num_pages = buffer_num_pages;
+			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &modern_bpf_params;
 		}
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
@@ -734,13 +734,13 @@ void parse_CLI_options(int argc, char** argv)
 		{
 			if(!(i + 1 < argc))
 			{
-				printf("\nYou need to specify also the number of pages! Bye!\n");
+				printf("\nYou need to specify also the dimension of buffer in bytes! Bye!\n");
 				exit(EXIT_FAILURE);
 			}
-			buffer_num_pages = strtoul(argv[++i], NULL, 10);
-			kmod_params.buffer_num_pages = buffer_num_pages;
-			bpf_params.buffer_num_pages = buffer_num_pages;
-			modern_bpf_params.buffer_num_pages = buffer_num_pages;
+			buffer_bytes_dim = strtoul(argv[++i], NULL, 10);
+			kmod_params.buffer_bytes_dim = buffer_bytes_dim;
+			bpf_params.buffer_bytes_dim = buffer_bytes_dim;
+			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 		}
 		if(!strcmp(argv[i], TP_OPTION))
 		{

--- a/userspace/libscap/ringbuffer/devset.c
+++ b/userspace/libscap/ringbuffer/devset.c
@@ -58,10 +58,10 @@ void devset_free(struct scap_device_set *devset)
 		{
 #ifdef _DEBUG
 			int ret;
-			ret = munmap(dev->m_buffer, dev->m_buffer_size);
+			ret = munmap(dev->m_buffer, dev->m_mmap_size);
 			ASSERT(ret == 0);
 #else
-			munmap(dev->m_buffer, dev->m_buffer_size);
+			munmap(dev->m_buffer, dev->m_mmap_size);
 #endif
 		}
 

--- a/userspace/libscap/ringbuffer/devset.h
+++ b/userspace/libscap/ringbuffer/devset.h
@@ -31,7 +31,8 @@ typedef struct scap_device
 	int m_fd;
 	int m_bufinfo_fd; // used by udig
 	char* m_buffer;
-	unsigned long m_buffer_size; // used by udig
+	unsigned long m_buffer_size;
+	unsigned long m_mmap_size; // generally 2 * m_buffer_size, but bpf does weird things
 	uint32_t m_lastreadsize;
 	char* m_sn_next_event; // Pointer to the next event available for scap_next
 	uint32_t m_sn_len; // Number of bytes available in the buffer pointed by m_sn_next_event

--- a/userspace/libscap/ringbuffer/devset.h
+++ b/userspace/libscap/ringbuffer/devset.h
@@ -31,7 +31,7 @@ typedef struct scap_device
 	int m_fd;
 	int m_bufinfo_fd; // used by udig
 	char* m_buffer;
-	uint32_t m_buffer_size; // used by udig
+	unsigned long m_buffer_size; // used by udig
 	uint32_t m_lastreadsize;
 	char* m_sn_next_event; // Pointer to the next event available for scap_next
 	uint32_t m_sn_len; // Number of bytes available in the buffer pointed by m_sn_next_event

--- a/userspace/libscap/ringbuffer/ringbuffer.c
+++ b/userspace/libscap/ringbuffer/ringbuffer.c
@@ -1,0 +1,19 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+/* Dimension of a single per-CPU buffer. */
+unsigned long per_cpu_buffer_dim;

--- a/userspace/libscap/ringbuffer/ringbuffer.c
+++ b/userspace/libscap/ringbuffer/ringbuffer.c
@@ -20,8 +20,6 @@ limitations under the License.
 #include <math.h>
 #include <scap.h>
 
-#define MAX_ALLOWED_VALUES 12
-
 /* Dimension of a single per-CPU buffer. */
 unsigned long per_cpu_buffer_dim;
 
@@ -30,10 +28,22 @@ void set_per_cpu_buffer_dim(unsigned long buf_dim)
 	per_cpu_buffer_dim = buf_dim;
 }
 
-int32_t check_per_cpu_buffer_num_pages(char* last_err, unsigned long buf_num_pages)
+int32_t check_buffer_num_pages(char* last_err, unsigned long buf_num_pages)
 {
-	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
-	int allowed_num_pages_values[MAX_ALLOWED_VALUES] = {pow(2, 7), pow(2, 8), pow(2, 9), pow(2, 10), pow(2, 11), pow(2, 12), pow(2, 13), pow(2, 14), pow(2, 15), pow(2, 16), pow(2, 17), pow(2, 18)};
+	int allowed_num_pages_values[] = {
+		1 << 7,
+		1 << 8,
+		1 << 9,
+		1 << 10,
+		1 << 11,
+		1 << 12,
+		1 << 13,
+		1 << 14,
+		1 << 15,
+		1 << 16,
+		1 << 17,
+		1 << 18,
+	};
 	bool found = false;
 
 	/* If you face some memory allocation issues, please remember that:
@@ -55,7 +65,7 @@ int32_t check_per_cpu_buffer_num_pages(char* last_err, unsigned long buf_num_pag
 	 * data due to double-mapped data pages.
 	 */
 
-	for(int i = 0; i < MAX_ALLOWED_VALUES; i++)
+	for(int i = 0; i < sizeof(allowed_num_pages_values) / sizeof(allowed_num_pages_values[0]); i++)
 	{
 		if(allowed_num_pages_values[i] == buf_num_pages)
 		{

--- a/userspace/libscap/ringbuffer/ringbuffer.c
+++ b/userspace/libscap/ringbuffer/ringbuffer.c
@@ -15,5 +15,62 @@ limitations under the License.
 
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include <scap.h>
+
+#define MAX_ALLOWED_VALUES 12
+
 /* Dimension of a single per-CPU buffer. */
 unsigned long per_cpu_buffer_dim;
+
+void set_per_cpu_buffer_dim(unsigned long buf_dim)
+{
+	per_cpu_buffer_dim = buf_dim;
+}
+
+int32_t check_per_cpu_buffer_num_pages(char* last_err, unsigned long buf_num_pages)
+{
+	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
+	int allowed_num_pages_values[MAX_ALLOWED_VALUES] = {pow(2, 7), pow(2, 8), pow(2, 9), pow(2, 10), pow(2, 11), pow(2, 12), pow(2, 13), pow(2, 14), pow(2, 15), pow(2, 16), pow(2, 17), pow(2, 18)};
+	bool found = false;
+
+	/* If you face some memory allocation issues, please remember that:
+	 *
+	 * Each data page is mapped twice to allow "virtual"
+	 * continuous read of samples wrapping around the end of ring
+	 * buffer area:
+	 *
+	 * ------------------------------------------------------
+	 * | meta pages |  real data pages  |  same data pages  |
+	 * ------------------------------------------------------
+	 * |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
+	 * ------------------------------------------------------
+	 * |            | TA             DA | TA             DA |
+	 * ------------------------------------------------------
+	 *                               ^^^^^^^
+	 *                                  |
+	 * Here, no need to worry about special handling of wrapped-around
+	 * data due to double-mapped data pages.
+	 */
+
+	for(int i = 0; i < MAX_ALLOWED_VALUES; i++)
+	{
+		if(allowed_num_pages_values[i] == buf_num_pages)
+		{
+			found = true;
+			break;
+		}
+	}
+
+	if(!found)
+	{
+		if(last_err != NULL)
+		{
+			snprintf(last_err, SCAP_LASTERR_SIZE, "Allowed page numbers are all the powers of 2 from 128 pages (2^7) to 256 Kpages (2^18): '%lu' is not a valid value", buf_num_pages);
+		}
+		return SCAP_FAILURE;
+	}
+	return SCAP_SUCCESS;
+}

--- a/userspace/libscap/ringbuffer/ringbuffer.c
+++ b/userspace/libscap/ringbuffer/ringbuffer.c
@@ -22,10 +22,7 @@ limitations under the License.
 #include <scap.h>
 #include "../../../driver/ppm_ringbuffer.h"
 
-/* Dimension of a single per-CPU buffer in bytes. */
-unsigned long global_buffer_bytes_dim;
-
-int32_t check_and_set_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_dim)
+int32_t check_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_dim)
 {
 	/* If you face some memory allocation issues, please remember that:
 	 *
@@ -65,6 +62,5 @@ int32_t check_and_set_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_d
 		return SCAP_FAILURE;
 	}
 
-	global_buffer_bytes_dim = buf_bytes_dim;
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -23,13 +23,11 @@ limitations under the License.
 #include "barrier.h"
 #include "sleep.h"
 
-extern unsigned long global_buffer_bytes_dim;
-
 /* Check buffer dimension in bytes. 
  * Our 2 eBPF probes require that this number is a power of 2! Right now we force this
  * constraint to all our drivers (also the kernel module and udig) just for conformity.
  */
-int32_t check_and_set_buffer_bytes_dim(char* error, unsigned long buf_bytes_dim);
+int32_t check_buffer_bytes_dim(char* error, unsigned long buf_bytes_dim);
 
 
 #ifndef GET_BUF_POINTERS
@@ -42,7 +40,7 @@ static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead
 
 	if(*ptail > *phead)
 	{
-		*pread_size = global_buffer_bytes_dim - *ptail + *phead;
+		*pread_size = dev->m_buffer_size - *ptail + *phead;
 	}
 	else
 	{
@@ -72,13 +70,13 @@ static inline void ringbuffer_advance_tail(struct scap_device* dev)
 	//
 	mem_barrier();
 
-	if(ttail < global_buffer_bytes_dim)
+	if(ttail < dev->m_buffer_size)
 	{
 		dev->m_bufinfo->tail = ttail;
 	}
 	else
 	{
-		dev->m_bufinfo->tail = ttail - global_buffer_bytes_dim;
+		dev->m_bufinfo->tail = ttail - dev->m_buffer_size;
 	}
 
 	dev->m_lastreadsize = 0;

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -28,8 +28,11 @@ extern unsigned long per_cpu_buffer_dim;
 /* Set the dimension of a single per-CPU buffer. */
 void set_per_cpu_buffer_dim(unsigned long buf_dim);
 
-/* Check buffer number of pages. */
-int32_t check_per_cpu_buffer_num_pages(char* error, unsigned long buf_num_pages);
+/* Check buffer number of pages. 
+ * Our 2 eBPF probes require that this number is a power of 2! Right now we force this
+ * constraint to all our drivers (also the kernel module) just for conformity.
+ */
+int32_t check_buffer_num_pages(char* error, unsigned long buf_num_pages);
 
 
 #ifndef GET_BUF_POINTERS

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "barrier.h"
 #include "sleep.h"
 
-static unsigned long per_cpu_buffer_dim;
+extern unsigned long per_cpu_buffer_dim;
 
 static inline void set_per_cpu_buffer_dim(unsigned long buf_dim)
 {

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -25,10 +25,12 @@ limitations under the License.
 
 extern unsigned long per_cpu_buffer_dim;
 
-static inline void set_per_cpu_buffer_dim(unsigned long buf_dim)
-{
-	per_cpu_buffer_dim = buf_dim;
-}
+/* Set the dimension of a single per-CPU buffer. */
+void set_per_cpu_buffer_dim(unsigned long buf_dim);
+
+/* Check buffer number of pages. */
+int32_t check_per_cpu_buffer_num_pages(char* error, unsigned long buf_num_pages);
+
 
 #ifndef GET_BUF_POINTERS
 #define GET_BUF_POINTERS ringbuffer_get_buf_pointers

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -23,6 +23,13 @@ limitations under the License.
 #include "barrier.h"
 #include "sleep.h"
 
+static unsigned long per_cpu_buffer_dim;
+
+static inline void set_per_cpu_buffer_dim(unsigned long buf_dim)
+{
+	per_cpu_buffer_dim = buf_dim;
+}
+
 #ifndef GET_BUF_POINTERS
 #define GET_BUF_POINTERS ringbuffer_get_buf_pointers
 static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead, uint64_t* ptail, uint64_t* pread_size)
@@ -33,7 +40,7 @@ static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead
 
 	if(*ptail > *phead)
 	{
-		*pread_size = RING_BUF_SIZE - *ptail + *phead;
+		*pread_size = per_cpu_buffer_dim - *ptail + *phead;
 	}
 	else
 	{
@@ -63,13 +70,13 @@ static inline void ringbuffer_advance_tail(struct scap_device* dev)
 	//
 	mem_barrier();
 
-	if(ttail < RING_BUF_SIZE)
+	if(ttail < per_cpu_buffer_dim)
 	{
 		dev->m_bufinfo->tail = ttail;
 	}
 	else
 	{
-		dev->m_bufinfo->tail = ttail - RING_BUF_SIZE;
+		dev->m_bufinfo->tail = ttail - per_cpu_buffer_dim;
 	}
 
 	dev->m_lastreadsize = 0;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1225,6 +1225,16 @@ int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
 	return SCAP_SUCCESS;
 }
 
+unsigned long scap_get_system_page_size()
+{
+	long page_size = sysconf(_SC_PAGESIZE);
+	if(page_size <= 0)
+	{
+		return SCAP_FAILURE;
+	}
+	return page_size;
+}
+
 //
 // Stop capturing the events
 //

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1227,11 +1227,15 @@ int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
 
 unsigned long scap_get_system_page_size()
 {
-	long page_size = sysconf(_SC_PAGESIZE);
+	long page_size = 0;
+#ifdef __linux__
+	page_size = sysconf(_SC_PAGESIZE);
 	if(page_size <= 0)
 	{
 		return SCAP_FAILURE;
 	}
+#endif
+	/// TODO: if needed we have to implement how to recover the page size in not Linux systems
 	return page_size;
 }
 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -121,6 +121,11 @@ struct iovec;
 //
 #define SCAP_LASTERR_SIZE 256
 
+// 
+// This is the dimension we used before introducing the variable buffer size.
+//
+#define DEFAULT_DRIVER_BUFFER_BYTES_DIM 8 * 1024 * 1024
+
 /*!
   \brief Statistics about an in progress capture
 */
@@ -842,6 +847,11 @@ int scap_get_modifies_state_ppm_sc(uint32_t * ppm_sc_array);
   \brief Returns the set of minimum tracepoints required by `libsinsp` state.
 */
 int scap_get_modifies_state_tracepoints(uint32_t * tp_array);
+
+/*!
+  \brief Get the system page size.
+*/
+unsigned long scap_get_system_page_size();
 
 /*!
   \brief This function can be used to temporarily interrupt event capture.

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -571,7 +571,7 @@ struct udig_ring_buffer_status {
 
 typedef struct ppm_ring_buffer_info ppm_ring_buffer_info;
 
-int32_t udig_alloc_ring(void* ring_id, uint8_t** ring, uint32_t *ringsize, char *error);
+int32_t udig_alloc_ring(void* ring_id, uint8_t** ring, unsigned long *ringsize, char *error);
 int32_t udig_alloc_ring_descriptors(void* ring_descs_id,
 	struct ppm_ring_buffer_info** ring_info,
 	struct udig_ring_buffer_status** ring_status,

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -50,7 +50,7 @@ string filter_string = "";
 string file_path = "";
 string bpf_path = "";
 string output_fields_json = "";
-uint64_t num_pages = 0;
+uint64_t num_pages = 2048; /* This will generate a 8 MB buffer in systems with a page size of 4 KB. */
 
 sinsp_evt* get_event(sinsp& inspector);
 

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -50,7 +50,7 @@ string filter_string = "";
 string file_path = "";
 string bpf_path = "";
 string output_fields_json = "";
-uint64_t buffer_dim = 0;
+uint64_t num_pages = 0;
 
 sinsp_evt* get_event(sinsp& inspector);
 
@@ -81,7 +81,7 @@ Options:
   -m, --modern_bpf               			 modern BPF probe.
   -k, --kmod								 Kernel module
   -s <path>, --scap_file <path>   			 Scap file
-  -d <dim>, --buffer_dim <dim>               Buffer dimension.
+  -p <#pages>, --pages <#pages>              Number of pages that every per-CPU buffer will have.
   -o <fields>, --output-fields-json <fields>    [JSON support only, can also use without -j] Output fields string (see <filter> for supported display fields) that overwrites JSON default output fields for all events. * at the beginning prints JSON keys with null values, else no null fields are printed.
 )";
 	cout << usage << endl;
@@ -100,14 +100,14 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 		{"modern_bpf", no_argument, 0, 'm'},
 		{"kmod", no_argument, 0, 'k'},
 		{"scap_file", required_argument, 0, 's'},
-		{"buffer_dim", required_argument, 0, 'd'},
+		{"pages", required_argument, 0, 'p'},
 		{"output-fields-json", required_argument, 0, 'o'},
 		{0, 0, 0, 0}};
 
 	int op;
 	int long_index = 0;
 	while((op = getopt_long(argc, argv,
-				"hf:jae:b:d:s:o:",
+				"hf:jae:b:p:s:o:",
 				long_options, &long_index)) != -1)
 	{
 		switch(op)
@@ -138,8 +138,8 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 			engine_string = SAVEFILE_ENGINE;
 			file_path = optarg;
 			break;
-		case 'd':
-			buffer_dim = strtoul(optarg, NULL, 10);
+		case 'p':
+			num_pages = strtoul(optarg, NULL, 10);
 			break;
 		case 'o':
 			output_fields_json = optarg;
@@ -163,7 +163,7 @@ void open_engine(sinsp& inspector)
 
 	if(!engine_string.compare(KMOD_ENGINE))
 	{
-		inspector.open_kmod(buffer_dim, ppm_sc, tp_set);
+		inspector.open_kmod(num_pages, ppm_sc, tp_set);
 	}
 	else if(!engine_string.compare(BPF_ENGINE))
 	{
@@ -176,7 +176,7 @@ void open_engine(sinsp& inspector)
 		{
 			std::cerr << bpf_path << std::endl;
 		}
-		inspector.open_bpf(buffer_dim, bpf_path.c_str(), ppm_sc, tp_set);
+		inspector.open_bpf(num_pages, bpf_path.c_str(), ppm_sc, tp_set);
 	}
 	else if(!engine_string.compare(SAVEFILE_ENGINE))
 	{
@@ -189,7 +189,7 @@ void open_engine(sinsp& inspector)
 	}
 	else if(!engine_string.compare(MODERN_BPF_ENGINE))
 	{
-		inspector.open_modern_bpf(buffer_dim, ppm_sc, tp_set);
+		inspector.open_modern_bpf(num_pages, ppm_sc, tp_set);
 	}
 	else
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -504,6 +504,44 @@ void sinsp::fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<
 	}
 }
 
+/*=============================== INTERESTING TRACEPOINTS/SYSCALLS ===============================*/
+
+/*=============================== BUFFER DIMENSION VALIDATION ===============================*/
+
+static void validate_driver_buffer_num_pages(uint64_t driver_buffer_num_pages)
+{
+	std::unordered_set<uint32_t> allowed_dimensions;
+	
+	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
+	for(int i = 7; i <= 18; i++)
+	{
+		uint32_t val = 1<<i;
+		allowed_dimensions.insert(val);
+	}
+
+	if(allowed_dimensions.find(driver_buffer_num_pages) == allowed_dimensions.end())
+	{
+		std::ostringstream os;
+		os << "Allowed page numbers are all the powers of 2 from 128 pages (2^7) to 256 Kpages (2^18): {";
+		auto itr = allowed_dimensions.begin();
+		while(itr != allowed_dimensions.end())
+		{
+			os << *itr;
+			if(++itr != allowed_dimensions.end())
+			{
+				os << ", ";
+			}
+		}
+		
+		os << "}";
+		throw sinsp_exception("Chosen number of pages (" + std::to_string(driver_buffer_num_pages) +") is not valid. " + os.str());
+	}
+}
+
+/*=============================== BUFFER DIMENSION VALIDATION ===============================*/
+
+/*=============================== OPEN METHODS ===============================*/
+
 void sinsp::open_common(scap_open_args* oargs)
 {
 	char error[SCAP_LASTERR_SIZE] = {0};
@@ -544,8 +582,11 @@ scap_open_args sinsp::factory_open_args(const char* engine_name, scap_mode_t sca
 	return oargs;
 }
 
-void sinsp::open_kmod(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
+	/* Validate buffer dim. */
+	validate_driver_buffer_num_pages(driver_buffer_num_pages);
+
 	scap_open_args oargs = factory_open_args(KMOD_ENGINE, SCAP_MODE_LIVE);
 
 	/* Set interesting syscalls and tracepoints. */
@@ -554,28 +595,31 @@ void sinsp::open_kmod(uint64_t buffer_dimension, const std::unordered_set<uint32
 
 	/* Engine-specific args. */
 	struct scap_kmod_engine_params params;
-	params.single_buffer_dim = buffer_dimension;
+	params.buffer_num_pages = driver_buffer_num_pages;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }
 
-/* We cannot trust the client to validate arguments we need to do it here. */
-void sinsp::open_bpf(uint64_t buffer_dimension, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
+	/* Validate buffer dim. */
+	validate_driver_buffer_num_pages(driver_buffer_num_pages);
+
+	/* Validate the BPF path. */
 	if(!bpf_path)
 	{
 		throw sinsp_exception("When you use the 'BPF' engine you need to provide a path to the bpf object file.");
 	}
 
 	scap_open_args oargs = factory_open_args(BPF_ENGINE, SCAP_MODE_LIVE);
-	
+
 	/* Set interesting syscalls and tracepoints. */
 	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
 	fill_tp_of_interest(&oargs, tp_of_interest);
 
 	/* Engine-specific args. */
 	struct scap_bpf_engine_params params;
-	params.single_buffer_dim = buffer_dimension;
+	params.buffer_num_pages = driver_buffer_num_pages;
 	params.bpf_probe = bpf_path;
 	oargs.engine_params = &params;
 	open_common(&oargs);
@@ -667,8 +711,11 @@ void sinsp::open_gvisor(std::string config_path, std::string root_path)
 	set_get_procs_cpu_from_driver(false);
 }
 
-void sinsp::open_modern_bpf(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
+	/* Validate buffer dim. */
+	validate_driver_buffer_num_pages(driver_buffer_num_pages);
+
 	scap_open_args oargs = factory_open_args(MODERN_BPF_ENGINE, SCAP_MODE_LIVE);
 
 	/* Set interesting syscalls and tracepoints. */
@@ -677,7 +724,7 @@ void sinsp::open_modern_bpf(uint64_t buffer_dimension, const std::unordered_set<
 
 	/* Engine-specific args. */
 	struct scap_modern_bpf_engine_params params;
-	params.single_buffer_dim = buffer_dimension;
+	params.buffer_num_pages = driver_buffer_num_pages;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }
@@ -692,6 +739,8 @@ void sinsp::open_test_input(scap_test_input_data* data)
 
 	set_get_procs_cpu_from_driver(false);
 }
+
+/*=============================== OPEN METHODS ===============================*/
 
 std::string sinsp::generate_gvisor_config(std::string socket_path)
 {

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/stat.h>
@@ -505,8 +504,6 @@ void sinsp::fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<
 	}
 }
 
-/*=============================== INTERESTING TRACEPOINTS/SYSCALLS ===============================*/
-
 /*=============================== OPEN METHODS ===============================*/
 
 void sinsp::open_common(scap_open_args* oargs)
@@ -549,7 +546,7 @@ scap_open_args sinsp::factory_open_args(const char* engine_name, scap_mode_t sca
 	return oargs;
 }
 
-void sinsp::open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	scap_open_args oargs = factory_open_args(KMOD_ENGINE, SCAP_MODE_LIVE);
 
@@ -559,12 +556,12 @@ void sinsp::open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set
 
 	/* Engine-specific args. */
 	struct scap_kmod_engine_params params;
-	params.buffer_num_pages = driver_buffer_num_pages;
+	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }
 
-void sinsp::open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_bpf(const char* bpf_path, unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	/* Validate the BPF path. */
 	if(!bpf_path)
@@ -580,7 +577,7 @@ void sinsp::open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, con
 
 	/* Engine-specific args. */
 	struct scap_bpf_engine_params params;
-	params.buffer_num_pages = driver_buffer_num_pages;
+	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.bpf_probe = bpf_path;
 	oargs.engine_params = &params;
 	open_common(&oargs);
@@ -672,7 +669,7 @@ void sinsp::open_gvisor(std::string config_path, std::string root_path)
 	set_get_procs_cpu_from_driver(false);
 }
 
-void sinsp::open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	scap_open_args oargs = factory_open_args(MODERN_BPF_ENGINE, SCAP_MODE_LIVE);
 
@@ -682,7 +679,7 @@ void sinsp::open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unorder
 
 	/* Engine-specific args. */
 	struct scap_modern_bpf_engine_params params;
-	params.buffer_num_pages = driver_buffer_num_pages;
+	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/stat.h>
@@ -510,7 +511,8 @@ void sinsp::fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<
 
 static void validate_driver_buffer_num_pages(uint64_t driver_buffer_num_pages)
 {
-	std::unordered_set<uint32_t> allowed_dimensions;
+	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
+	std::unordered_set<double> allowed_dimensions = {pow(2,7), pow(2,8), pow(2,9), pow(2,10), pow(2,11), pow(2,12), pow(2,13), pow(2,14), pow(2,15), pow(2,16), pow(2,17), pow(2,18)};
 	
    /* If you face some memory allocation issues, please remember that:
 	*
@@ -530,13 +532,6 @@ static void validate_driver_buffer_num_pages(uint64_t driver_buffer_num_pages)
 	* Here, no need to worry about special handling of wrapped-around
 	* data due to double-mapped data pages.
 	*/
-
-	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
-	for(int i = 7; i <= 18; i++)
-	{
-		uint32_t val = 1<<i;
-		allowed_dimensions.insert(val);
-	}
 
 	if(allowed_dimensions.find(driver_buffer_num_pages) == allowed_dimensions.end())
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -512,6 +512,25 @@ static void validate_driver_buffer_num_pages(uint64_t driver_buffer_num_pages)
 {
 	std::unordered_set<uint32_t> allowed_dimensions;
 	
+   /* If you face some memory allocation issues, please remember that:
+	*
+	* Each data page is mapped twice to allow "virtual"
+	* continuous read of samples wrapping around the end of ring
+	* buffer area:
+	* 
+	* ------------------------------------------------------
+	* | meta pages |  real data pages  |  same data pages  |
+	* ------------------------------------------------------
+	* |            | 1 2 3 4 5 6 7 8 9 | 1 2 3 4 5 6 7 8 9 |
+	* ------------------------------------------------------
+	* |            | TA             DA | TA             DA |
+	* ------------------------------------------------------
+	*                               ^^^^^^^
+	*                                  |
+	* Here, no need to worry about special handling of wrapped-around
+	* data due to double-mapped data pages.
+	*/
+
 	/* Allowed page numbers are all the power of 2 from 128(2^7) pages to 256Kpages(2^18) */
 	for(int i = 7; i <= 18; i++)
 	{

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -219,14 +219,14 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	void open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	void open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_bpf(const char* bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_udig();
 	void open_nodriver();
-	void open_savefile(const std::string &filename, int fd);
+	void open_savefile(const std::string &filename, int fd = 0);
 	void open_plugin(std::string plugin_name, std::string plugin_open_params);
 	void open_gvisor(std::string config_path, std::string root_path);
-	void open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_test_input(scap_test_input_data *data);
 
 	scap_open_args factory_open_args(const char* engine, scap_mode_t scap_mode);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -219,14 +219,14 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	void open_kmod(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	void open_bpf(uint64_t buffer_dimension, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_kmod(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_bpf(uint64_t driver_buffer_num_pages, const char* bpf_path, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_udig();
 	void open_nodriver();
 	void open_savefile(const std::string &filename, int fd);
 	void open_plugin(std::string plugin_name, std::string plugin_open_params);
 	void open_gvisor(std::string config_path, std::string root_path);
-	void open_modern_bpf(uint64_t buffer_dimension, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	void open_modern_bpf(uint64_t driver_buffer_num_pages, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	void open_test_input(scap_test_input_data *data);
 
 	scap_open_args factory_open_args(const char* engine, scap_mode_t scap_mode);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

/area libpman

/area libsinsp

**Does this PR require a change in the driver versions?**

/version driver-API-version-major

But we have already bumped it here https://github.com/falcosecurity/libs/pull/492

**What this PR does / why we need it**:

As previously discussed [here](https://github.com/falcosecurity/libs/pull/414#issue-1277253587 ) and in various other issues this PR introduces the possibility of choosing the dimension of the shared buffers (between userspace/kernel) at initialization time. The rationale here is:
* `libsinsp` receives the number of pages that every single per-CPU buffer must have through the specific engine `open_` method.
* `libsinsp` validates the number of pages that must be a power of 2, right now the allowed values are the following:
```c
{262144, 131072, 65536, 32768, 16384, 8192, 4096, 2048, 1024, 512, 256, 128}
```
* every engine receives this number of pages through the `scap_open_args`, it multiplies it by the effective size of the page and uses the obtained size (`number_of_pages` * `page_size`) to initialize the per-CPU buffers


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This PR is just the https://github.com/falcosecurity/libs/pull/576 reopened

**Does this PR introduce a user-facing change?**:


```release-note
new(libsinsp,engines): add support for variable shared buffer dimension 
```
