### PR TITLE
new(userspace/libsinsp): provide multiple default sets for ppm_sc of interest

### DIFF
--- a/userspace/libscap/syscall_info_table.c
+++ b/userspace/libscap/syscall_info_table.c
@@ -323,8 +323,8 @@ const struct ppm_syscall_desc g_syscall_info_table[PPM_SC_MAX] = {
 	/*PPM_SC_STIME*/ { EC_TIME, (enum ppm_event_flags)(EF_NONE), "stime" },
 	/*PPM_SC__LLSEEK*/	{ EC_FILE, (enum ppm_event_flags)(EF_NONE), "llseek" },
 	/*PPM_SC_WAITPID*/ { EC_WAIT, (enum ppm_event_flags)(EF_NONE), "waitpid" },
-	/*PPM_SC_PREAD64*/ { EC_FILE, (enum ppm_event_flags)(EF_NONE), "pread64" },
-	/*PPM_SC_PWRITE64*/ { EC_FILE, (enum ppm_event_flags)(EF_NONE), "pwrite64" },
+	/*PPM_SC_PREAD64*/ { EC_IO_READ, (enum ppm_event_flags)(EF_NONE), "pread64" },
+	/*PPM_SC_PWRITE64*/ { EC_IO_WRITE, (enum ppm_event_flags)(EF_NONE), "pwrite64" },
 	/*PPM_SC_ARCH_PRCTL*/ { EC_PROCESS, (enum ppm_event_flags)(EF_NONE), "arch_prctl" },
 	/*PPM_SC_SHMAT*/ { EC_IPC, (enum ppm_event_flags)(EF_NONE), "shmat" },
 	/*PPM_SC_SIGRETURN*/ { EC_SIGNAL, (enum ppm_event_flags)(EF_NONE), "sigreturn" }, /* return from signal handler and cleanup stack frame */

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -119,7 +119,8 @@ set(SINSP_SOURCES
 	user_event.cpp
 	value_parser.cpp
 	user.cpp
-	gvisor_config.cpp)
+	gvisor_config.cpp
+	sinsp_ppm_sc.cpp)
 
 if(WITH_CHISEL)
 	list(APPEND SINSP_SOURCES

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -452,44 +452,6 @@ void sinsp::set_import_users(bool import_users)
 	m_usergroup_manager.m_import_users = import_users;
 }
 
-void sinsp::mark_ppm_sc_of_interest(uint32_t ppm_sc, bool enable)
-{
-	/* This API must be used only after the initialization phase. */
-	if (!m_inited)
-	{
-		throw sinsp_exception("you cannot use this method before opening the inspector!");
-	}
-	if (ppm_sc >= PPM_SC_MAX || ppm_sc < 0)
-	{
-		throw sinsp_exception("inexistent ppm_sc code: " + std::to_string(ppm_sc));
-	}
-	int ret = scap_set_eventmask(m_h, ppm_sc, enable);
-	if (ret != SCAP_SUCCESS)
-	{
-		throw sinsp_exception(scap_getlasterr(m_h));
-	}
-}
-
-std::unordered_set<uint32_t> sinsp::enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t> ppm_sc_of_interest)
-{
-	std::vector<uint32_t> minimum_syscalls(PPM_SC_MAX, 0);
-	
-	/* Should never happen but just to be sure. */
-	if(scap_get_modifies_state_ppm_sc(minimum_syscalls.data()) != SCAP_SUCCESS)
-	{
-		throw sinsp_exception("'minimum_syscalls' is an unexpected NULL vector!");
-	}
-
-	for(int ppm_sc = 0; ppm_sc < PPM_SC_MAX; ppm_sc++)
-	{
-		if(minimum_syscalls[ppm_sc])
-		{
-			ppm_sc_of_interest.insert(ppm_sc);
-		}
-	}
-	return ppm_sc_of_interest;
-}
-
 std::unordered_set<uint32_t> sinsp::enforce_sinsp_state_tracepoints(std::unordered_set<uint32_t> tp_of_interest)
 {
 	std::vector<uint32_t> minimum_tracepoints(TP_VAL_MAX, 0);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -946,35 +946,35 @@ public:
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
 	/*!
-	  \brief Simple set of syscalls with all the security-valuable syscalls.
+	  \brief Enforce simple set of syscalls with all the security-valuable syscalls.
 	  It has same effect of old `simple_consumer` mode.
 	  Does enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+	std::unordered_set<uint32_t> enforce_simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Enrich passed set of syscalls with the ones
+	  \brief Enforce passed set of syscalls with the ones
 	  valuable for IO.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+	std::unordered_set<uint32_t> enforce_io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Enrich passed set of syscalls with the ones
+	  \brief Enforce passed set of syscalls with the ones
 	  valuable for networking.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+	std::unordered_set<uint32_t> enforce_net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Enrich passed set of syscalls with the ones
+	  \brief Enforce passed set of syscalls with the ones
 	  valuable for process state tracking.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+	std::unordered_set<uint32_t> enforce_proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Enrich passed set of syscalls with the ones
+	  \brief Enforce passed set of syscalls with the ones
 	  valuable for system state tracking (signals, memory...)
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+	std::unordered_set<uint32_t> enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -945,10 +945,31 @@ public:
 
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
+	/*!
+	  \brief Simple set of syscalls that enforce minimum sinsp state set,
+	  plus some valuable syscalls.
+	  It has same effect of old `simple_consumer` mode.
+	*/
 	std::unordered_set<uint32_t> simple_ppm_sc_set();
+	/*!
+	  \brief Set of syscalls valuable for IO.
+	  Does not enforce minimum sinsp state set.
+	*/
 	std::unordered_set<uint32_t> io_ppm_sc_set();
+	/*!
+	  \brief Set of syscalls valuable for networking.
+	  Does not enforce minimum sinsp state set.
+	*/
 	std::unordered_set<uint32_t> net_ppm_sc_set();
+	/*!
+	  \brief Set of syscalls valuable for process state tracking.
+	  Does not enforce minimum sinsp state set.
+	*/
 	std::unordered_set<uint32_t> proc_ppm_sc_set();
+	/*!
+	  \brief Set of syscalls valuable for system state tracking (signals, memory...)
+	  Does not enforce minimum sinsp state set.
+	*/
 	std::unordered_set<uint32_t> sys_ppm_sc_set();
 
 VISIBILITY_PROTECTED

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -945,6 +945,12 @@ public:
 
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
+	std::unordered_set<uint32_t> simple_ppm_sc_set();
+	std::unordered_set<uint32_t> io_ppm_sc_set();
+	std::unordered_set<uint32_t> net_ppm_sc_set();
+	std::unordered_set<uint32_t> proc_ppm_sc_set();
+	std::unordered_set<uint32_t> sys_ppm_sc_set();
+
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);
 	void set_mode(scap_mode_t value)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -946,31 +946,35 @@ public:
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
 	/*!
-	  \brief Simple set of syscalls that enforce minimum sinsp state set,
-	  plus some valuable syscalls.
+	  \brief Simple set of syscalls with all the security-valuable syscalls.
 	  It has same effect of old `simple_consumer` mode.
+	  Does enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> simple_ppm_sc_set();
+	std::unordered_set<uint32_t> simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Set of syscalls valuable for IO.
+	  \brief Enrich passed set of syscalls with the ones
+	  valuable for IO.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> io_ppm_sc_set();
+	std::unordered_set<uint32_t> io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Set of syscalls valuable for networking.
+	  \brief Enrich passed set of syscalls with the ones
+	  valuable for networking.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> net_ppm_sc_set();
+	std::unordered_set<uint32_t> net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Set of syscalls valuable for process state tracking.
+	  \brief Enrich passed set of syscalls with the ones
+	  valuable for process state tracking.
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> proc_ppm_sc_set();
+	std::unordered_set<uint32_t> proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 	/*!
-	  \brief Set of syscalls valuable for system state tracking (signals, memory...)
+	  \brief Enrich passed set of syscalls with the ones
+	  valuable for system state tracking (signals, memory...)
 	  Does not enforce minimum sinsp state set.
 	*/
-	std::unordered_set<uint32_t> sys_ppm_sc_set();
+	std::unordered_set<uint32_t> sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -17,7 +17,45 @@ limitations under the License.
 
 #include <sinsp.h>
 
-std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
+void sinsp::mark_ppm_sc_of_interest(uint32_t ppm_sc, bool enable)
+{
+	/* This API must be used only after the initialization phase. */
+	if (!m_inited)
+	{
+		throw sinsp_exception("you cannot use this method before opening the inspector!");
+	}
+	if (ppm_sc >= PPM_SC_MAX)
+	{
+		throw sinsp_exception("inexistent ppm_sc code: " + std::to_string(ppm_sc));
+	}
+	int ret = scap_set_eventmask(m_h, ppm_sc, enable);
+	if (ret != SCAP_SUCCESS)
+	{
+		throw sinsp_exception(scap_getlasterr(m_h));
+	}
+}
+
+std::unordered_set<uint32_t> sinsp::enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t> ppm_sc_of_interest)
+{
+	std::vector<uint32_t> minimum_syscalls(PPM_SC_MAX, 0);
+
+	/* Should never happen but just to be sure. */
+	if(scap_get_modifies_state_ppm_sc(minimum_syscalls.data()) != SCAP_SUCCESS)
+	{
+		throw sinsp_exception("'minimum_syscalls' is an unexpected NULL vector!");
+	}
+
+	for(int ppm_sc = 0; ppm_sc < PPM_SC_MAX; ppm_sc++)
+	{
+		if(minimum_syscalls[ppm_sc])
+		{
+			ppm_sc_of_interest.insert(ppm_sc);
+		}
+	}
+	return ppm_sc_of_interest;
+}
+
+std::unordered_set<uint32_t> sinsp::enforce_simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
 	auto simple_set = enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t>{
 		PPM_SC_ACCEPT,
@@ -111,7 +149,7 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set(std::unordered_set<uint32_
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
+std::unordered_set<uint32_t> sinsp::enforce_io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
@@ -126,7 +164,7 @@ std::unordered_set<uint32_t> sinsp::io_ppm_sc_set(std::unordered_set<uint32_t> p
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
+std::unordered_set<uint32_t> sinsp::enforce_net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
@@ -138,7 +176,7 @@ std::unordered_set<uint32_t> sinsp::net_ppm_sc_set(std::unordered_set<uint32_t> 
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
+std::unordered_set<uint32_t> sinsp::enforce_proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
@@ -150,7 +188,7 @@ std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set(std::unordered_set<uint32_t>
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
+std::unordered_set<uint32_t> sinsp::enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -1,0 +1,164 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <sinsp.h>
+
+std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
+{
+	return std::unordered_set<uint32_t>{
+		PPM_SC_ACCEPT,
+		PPM_SC_ACCEPT4,
+		PPM_SC_BIND,
+		PPM_SC_BPF,
+		PPM_SC_CAPSET,
+		PPM_SC_CHDIR,
+		PPM_SC_CHMOD,
+		PPM_SC_CHROOT,
+		PPM_SC_CLONE,
+		PPM_SC_CLONE3,
+		PPM_SC_CLOSE,
+		PPM_SC_CONNECT,
+		PPM_SC_COPY_FILE_RANGE, // REMOVE?
+		PPM_SC_CREAT,
+		PPM_SC_DUP,
+		PPM_SC_DUP2,
+		PPM_SC_DUP3,
+		PPM_SC_EVENTFD,
+		PPM_SC_EVENTFD2,
+		PPM_SC_EXECVE,
+		PPM_SC_EXECVEAT,
+		PPM_SC_FCHDIR,
+		PPM_SC_FCHMOD,
+		PPM_SC_FCHMODAT,
+		PPM_SC_FCNTL, // 64 TOO?
+		PPM_SC_FLOCK,
+		PPM_SC_FORK,
+		PPM_SC_GETSOCKOPT, // do we need this?
+		PPM_SC_INOTIFY_INIT,
+		PPM_SC_INOTIFY_INIT1,
+		PPM_SC_IOCTL,
+		PPM_SC_IO_URING_SETUP,
+		PPM_SC_KILL,
+		PPM_SC_LINK,
+		PPM_SC_LINKAT,
+		PPM_SC_LISTEN,
+		PPM_SC_MKDIR,
+		PPM_SC_MKDIRAT,
+		PPM_SC_MOUNT,
+		PPM_SC_OPEN,
+		PPM_SC_OPEN_BY_HANDLE_AT,
+		PPM_SC_OPENAT,
+		PPM_SC_OPENAT2,
+		PPM_SC_PIPE,
+		PPM_SC_PIPE2,
+		PPM_SC_PRLIMIT64,
+		PPM_SC_PTRACE,
+		PPM_SC_QUOTACTL,
+		PPM_SC_RECVFROM,
+		PPM_SC_RECVMSG,
+		PPM_SC_RENAME,
+		PPM_SC_RENAMEAT,
+		PPM_SC_RENAMEAT2,
+		PPM_SC_RMDIR,
+		PPM_SC_SECCOMP,
+		PPM_SC_SENDMSG,
+		PPM_SC_SENDTO,
+		PPM_SC_SETGID, // 32?
+		PPM_SC_SETNS,
+		PPM_SC_SETPGID,	  // 32?
+		PPM_SC_SETRESGID, // 32?
+		PPM_SC_SETRESUID, // 32?
+		PPM_SC_SETRLIMIT,
+		PPM_SC_SETSID,
+		PPM_SC_SETUID,
+		PPM_SC_SHUTDOWN,
+		PPM_SC_SIGNALFD,
+		PPM_SC_SIGNALFD4,
+		PPM_SC_SOCKET,
+		PPM_SC_SOCKETPAIR,
+		PPM_SC_SYMLINK,
+		PPM_SC_SYMLINKAT,
+		PPM_SC_TGKILL,
+		PPM_SC_TIMERFD_CREATE,
+		PPM_SC_TKILL,
+		PPM_SC_UMOUNT,
+		PPM_SC_UMOUNT2,
+		PPM_SC_UNLINK,
+		PPM_SC_UNLINKAT,
+		PPM_SC_UNSHARE,
+		PPM_SC_USERFAULTFD,
+		PPM_SC_VFORK,
+	};
+}
+
+std::unordered_set<uint32_t> sinsp::io_ppm_sc_set()
+{
+	std::unordered_set<uint32_t> ppm_sc_set;
+	for(int i = 0; i < PPM_SC_MAX; i++)
+	{
+		if(g_infotables.m_syscall_info_table[i].category == EC_IO_READ ||
+		   g_infotables.m_syscall_info_table[i].category == EC_IO_WRITE ||
+		   g_infotables.m_syscall_info_table[i].category == EC_IO_OTHER ||
+		   g_infotables.m_syscall_info_table[i].category == EC_FILE)
+		{
+			ppm_sc_set.insert(i);
+		}
+	}
+	return ppm_sc_set;
+}
+
+std::unordered_set<uint32_t> sinsp::net_ppm_sc_set()
+{
+	std::unordered_set<uint32_t> ppm_sc_set;
+	for(int i = 0; i < PPM_SC_MAX; i++)
+	{
+		if(g_infotables.m_syscall_info_table[i].category == EC_NET)
+		{
+			ppm_sc_set.insert(i);
+		}
+	}
+	return ppm_sc_set;
+}
+
+std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set()
+{
+	std::unordered_set<uint32_t> ppm_sc_set;
+	for(int i = 0; i < PPM_SC_MAX; i++)
+	{
+		if(g_infotables.m_syscall_info_table[i].category == EC_PROCESS)
+		{
+			ppm_sc_set.insert(i);
+		}
+	}
+	return ppm_sc_set;
+}
+
+std::unordered_set<uint32_t> sinsp::sys_ppm_sc_set()
+{
+	std::unordered_set<uint32_t> ppm_sc_set;
+	for(int i = 0; i < PPM_SC_MAX; i++)
+	{
+		if(g_infotables.m_syscall_info_table[i].category == EC_SYSTEM ||
+		   g_infotables.m_syscall_info_table[i].category == EC_MEMORY ||
+		   g_infotables.m_syscall_info_table[i].category == EC_SIGNAL ||
+		   g_infotables.m_syscall_info_table[i].category == EC_OTHER)
+		{
+			ppm_sc_set.insert(i);
+		}
+	}
+	return ppm_sc_set;
+}

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -17,9 +17,9 @@ limitations under the License.
 
 #include <sinsp.h>
 
-std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
+std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
-	return enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t>{
+	auto simple_set = enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t>{
 		PPM_SC_ACCEPT,
 		PPM_SC_ACCEPT4,
 		PPM_SC_BIND,
@@ -107,11 +107,12 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 		PPM_SC_USERFAULTFD,
 		PPM_SC_VFORK,
 	});
+	ppm_sc_set.insert(simple_set.begin(), simple_set.end());
+	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::io_ppm_sc_set()
+std::unordered_set<uint32_t> sinsp::io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
-	std::unordered_set<uint32_t> ppm_sc_set;
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
 		if(g_infotables.m_syscall_info_table[i].category == EC_IO_READ ||
@@ -125,9 +126,8 @@ std::unordered_set<uint32_t> sinsp::io_ppm_sc_set()
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::net_ppm_sc_set()
+std::unordered_set<uint32_t> sinsp::net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
-	std::unordered_set<uint32_t> ppm_sc_set;
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
 		if(g_infotables.m_syscall_info_table[i].category == EC_NET)
@@ -138,9 +138,8 @@ std::unordered_set<uint32_t> sinsp::net_ppm_sc_set()
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set()
+std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
-	std::unordered_set<uint32_t> ppm_sc_set;
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
 		if(g_infotables.m_syscall_info_table[i].category == EC_PROCESS)
@@ -151,15 +150,13 @@ std::unordered_set<uint32_t> sinsp::proc_ppm_sc_set()
 	return ppm_sc_set;
 }
 
-std::unordered_set<uint32_t> sinsp::sys_ppm_sc_set()
+std::unordered_set<uint32_t> sinsp::sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set)
 {
-	std::unordered_set<uint32_t> ppm_sc_set;
 	for(int i = 0; i < PPM_SC_MAX; i++)
 	{
 		if(g_infotables.m_syscall_info_table[i].category == EC_SYSTEM ||
 		   g_infotables.m_syscall_info_table[i].category == EC_MEMORY ||
-		   g_infotables.m_syscall_info_table[i].category == EC_SIGNAL ||
-		   g_infotables.m_syscall_info_table[i].category == EC_OTHER)
+		   g_infotables.m_syscall_info_table[i].category == EC_SIGNAL)
 		{
 			ppm_sc_set.insert(i);
 		}

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 
 std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 {
-	return std::unordered_set<uint32_t>{
+	return enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t>{
 		PPM_SC_ACCEPT,
 		PPM_SC_ACCEPT4,
 		PPM_SC_BIND,
@@ -32,7 +32,6 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 		PPM_SC_CLONE3,
 		PPM_SC_CLOSE,
 		PPM_SC_CONNECT,
-		PPM_SC_COPY_FILE_RANGE, // REMOVE?
 		PPM_SC_CREAT,
 		PPM_SC_DUP,
 		PPM_SC_DUP2,
@@ -44,10 +43,11 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 		PPM_SC_FCHDIR,
 		PPM_SC_FCHMOD,
 		PPM_SC_FCHMODAT,
-		PPM_SC_FCNTL, // 64 TOO?
+		PPM_SC_FCNTL,
+		PPM_SC_FCNTL64,
 		PPM_SC_FLOCK,
 		PPM_SC_FORK,
-		PPM_SC_GETSOCKOPT, // do we need this?
+		PPM_SC_GETSOCKOPT,
 		PPM_SC_INOTIFY_INIT,
 		PPM_SC_INOTIFY_INIT1,
 		PPM_SC_IOCTL,
@@ -77,14 +77,18 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 		PPM_SC_SECCOMP,
 		PPM_SC_SENDMSG,
 		PPM_SC_SENDTO,
-		PPM_SC_SETGID, // 32?
+		PPM_SC_SETGID,
+		PPM_SC_SETGID32,
 		PPM_SC_SETNS,
-		PPM_SC_SETPGID,	  // 32?
-		PPM_SC_SETRESGID, // 32?
-		PPM_SC_SETRESUID, // 32?
+		PPM_SC_SETPGID,
+		PPM_SC_SETRESGID,
+		PPM_SC_SETRESGID32,
+		PPM_SC_SETRESUID,
+		PPM_SC_SETRESUID32,
 		PPM_SC_SETRLIMIT,
 		PPM_SC_SETSID,
 		PPM_SC_SETUID,
+		PPM_SC_SETUID32,
 		PPM_SC_SHUTDOWN,
 		PPM_SC_SIGNALFD,
 		PPM_SC_SIGNALFD4,
@@ -102,7 +106,7 @@ std::unordered_set<uint32_t> sinsp::simple_ppm_sc_set()
 		PPM_SC_UNSHARE,
 		PPM_SC_USERFAULTFD,
 		PPM_SC_VFORK,
-	};
+	});
 }
 
 std::unordered_set<uint32_t> sinsp::io_ppm_sc_set()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

> /area libsinsp


**What this PR does / why we need it**:

Provide a `simple_ppm_sc_set` that is basically the same as previous simple consumer mode. Moreover, leveraging syscall_info_table categories, provide more default sets to be used in different environments.

Moreover in syscall_info_table, a couple of categories were fixed. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
