### PR TITLE
update(userspace/libsinsp): k8s filterchecks documentation desc

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -7351,7 +7351,7 @@ const filtercheck_field_info sinsp_filter_check_k8s_fields[] =
 sinsp_filter_check_k8s::sinsp_filter_check_k8s()
 {
 	m_info.m_name = "k8s";
-	m_info.m_desc = "Kubernetes related context. Available when configured to fetch k8s meta-data from API Server.";
+	m_info.m_desc = "Kubernetes related context. When configured to fetch from the API server, all fields are available. Otherwise, only the `k8s.pod.*` and `k8s.ns.name` fields are populated with data gathered from the container runtime.";
 	m_info.m_fields = sinsp_filter_check_k8s_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_k8s_fields) / sizeof(sinsp_filter_check_k8s_fields[0]);
 	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp


**Does this PR require a change in the driver versions?**

no

**What this PR does / why we need it**:

This is needed to advise our users that they can still have k8s metadata without the full k8s support (ref **https://github.com/falcosecurity/libs/pull/15).**
The message will be rendered on the official Falco documentation :point_down: , once a new version is out.

https://falco.org/docs/rules/supported-fields/#field-class-k8s


**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
