### PR TITLE
fix(driver/kmod): fixed tracepoint detach to avoid dmesg errors.

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -598,7 +598,6 @@ static int ppm_release(struct inode *inode, struct file *filp)
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
 			tracepoint_synchronize_unregister();
 #endif
-			g_tracepoints_attached = 0;
 
 			/*
 			 * Reset tracepoint counter
@@ -744,7 +743,18 @@ static int force_tp_set(u32 new_tp_set, u32 max_val)
 			}
 			else
 			{
-				pr_err("can't create the %s tracepoint\n", tp_names[idx]);
+				pr_err("can't attach the %s tracepoint\n", tp_names[idx]);
+			}
+		}
+		else
+		{
+			if (ret == 0)
+			{
+				g_tracepoints_attached &= ~(1 << idx);
+			}
+			else
+			{
+				pr_err("can't detach the %s tracepoint\n", tp_names[idx]);
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**What this PR does / why we need it**:

Avoid some dmesg errors by keeping `g_tracepoints_attached` in sync with real values.
Extracted from #582 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
