### PR TITLE
chore(userspace/libsinsp): move new `enforce_X_ppm_sc` near to `enforce_sinsp_state_ppm_sc`

### DIFF
--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -833,6 +833,7 @@ public:
 	sinsp_parser* get_parser();
 
 	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
+
 	/*!
 		\brief Mark desired syscall as (un)interesting, enabling or disabling its collection.
 		This method receives a `ppm_sc` code, not a syscall system code, the same ppm_code
@@ -891,7 +892,10 @@ public:
 	*/
 	std::unordered_set<uint32_t> enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 
+	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
+
 	/*=============================== Tracepoint set related ===============================*/
+
 	/*!
 		\brief Provide the minimum set of tracepoints required by `libsinsp` state collection.
 		If you call it without arguments it returns a new set with just these tracepoints
@@ -902,6 +906,7 @@ public:
 	*/
 	std::unordered_set<uint32_t> enforce_sinsp_state_tracepoints(std::unordered_set<uint32_t> tp_of_interest = {});
 
+	/*=============================== Tracepoint set related ===============================*/
 
 	bool setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -832,6 +832,7 @@ public:
 
 	sinsp_parser* get_parser();
 
+	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
 	/*!
 		\brief Mark desired syscall as (un)interesting, enabling or disabling its collection.
 		This method receives a `ppm_sc` code, not a syscall system code, the same ppm_code
@@ -855,6 +856,42 @@ public:
 	*/
 	std::unordered_set<uint32_t> enforce_sinsp_state_ppm_sc(std::unordered_set<uint32_t> ppm_sc_of_interest = {});
 
+	/*!
+	  \brief Enforce simple set of syscalls with all the security-valuable syscalls.
+	  It has same effect of old `simple_consumer` mode.
+	  Does enforce minimum sinsp state set.
+	*/
+	std::unordered_set<uint32_t> enforce_simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+
+	/*!
+	  \brief Enforce passed set of syscalls with the ones
+	  valuable for IO.
+	  Does not enforce minimum sinsp state set.
+	*/
+	std::unordered_set<uint32_t> enforce_io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+
+	/*!
+	  \brief Enforce passed set of syscalls with the ones
+	  valuable for networking.
+	  Does not enforce minimum sinsp state set.
+	*/
+	std::unordered_set<uint32_t> enforce_net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+
+	/*!
+	  \brief Enforce passed set of syscalls with the ones
+	  valuable for process state tracking.
+	  Does not enforce minimum sinsp state set.
+	*/
+	std::unordered_set<uint32_t> enforce_proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+
+	/*!
+	  \brief Enforce passed set of syscalls with the ones
+	  valuable for system state tracking (signals, memory...)
+	  Does not enforce minimum sinsp state set.
+	*/
+	std::unordered_set<uint32_t> enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
+
+	/*=============================== Tracepoint set related ===============================*/
 	/*!
 		\brief Provide the minimum set of tracepoints required by `libsinsp` state collection.
 		If you call it without arguments it returns a new set with just these tracepoints
@@ -944,37 +981,6 @@ public:
 	const sinsp_plugin_manager* get_plugin_manager();
 
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
-
-	/*!
-	  \brief Enforce simple set of syscalls with all the security-valuable syscalls.
-	  It has same effect of old `simple_consumer` mode.
-	  Does enforce minimum sinsp state set.
-	*/
-	std::unordered_set<uint32_t> enforce_simple_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
-	/*!
-	  \brief Enforce passed set of syscalls with the ones
-	  valuable for IO.
-	  Does not enforce minimum sinsp state set.
-	*/
-	std::unordered_set<uint32_t> enforce_io_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
-	/*!
-	  \brief Enforce passed set of syscalls with the ones
-	  valuable for networking.
-	  Does not enforce minimum sinsp state set.
-	*/
-	std::unordered_set<uint32_t> enforce_net_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
-	/*!
-	  \brief Enforce passed set of syscalls with the ones
-	  valuable for process state tracking.
-	  Does not enforce minimum sinsp state set.
-	*/
-	std::unordered_set<uint32_t> enforce_proc_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
-	/*!
-	  \brief Enforce passed set of syscalls with the ones
-	  valuable for system state tracking (signals, memory...)
-	  Does not enforce minimum sinsp state set.
-	*/
-	std::unordered_set<uint32_t> enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
