### PR TITLE
fix(userspace/libsinsp): use self instead of inspector's usergroup_manager

### DIFF
--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -617,7 +617,7 @@ void sinsp_usergroup_manager::load_from_container(const std::string &container_i
 	{
 		while(auto p = fgetpwent(pwd_file))
 		{
-			m_inspector->m_usergroup_manager.add_user(container_id, p->pw_uid, p->pw_gid, p->pw_name, p->pw_dir, p->pw_shell, true);
+			add_user(container_id, p->pw_uid, p->pw_gid, p->pw_name, p->pw_dir, p->pw_shell, true);
 		}
 		fclose(pwd_file);
 	}
@@ -631,7 +631,7 @@ void sinsp_usergroup_manager::load_from_container(const std::string &container_i
 	{
 		while(auto g = fgetgrent(grp_file))
 		{
-			m_inspector->m_usergroup_manager.add_group(container_id, g->gr_gid, g->gr_name, true);
+			add_group(container_id, g->gr_gid, g->gr_name, true);
 		}
 		fclose(grp_file);
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
In sinsp_usergroup_manager::load_from_container, don't use the inspector's usergroup_manager instance.
Mind that in a real scenario the usergroup_manager gets created by the inspector, so it would be the same instance actually.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
