### PR TITLE
chore(libscap): Check handle for NULL in scap API

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1230,11 +1230,6 @@ int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
 //
 int32_t scap_stop_capture(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->stop_capture(handle->m_engine);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1061,7 +1061,7 @@ scap_os_platform scap_get_os_platform(scap_t* handle)
 
 uint32_t scap_get_ndevs(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle && handle->m_vtable)
 	{
 		return handle->m_vtable->get_n_devs(handle->m_engine);
 	}
@@ -1081,7 +1081,7 @@ int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT uint32_
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle && handle->m_vtable)
 	{
 		return handle->m_vtable->get_max_buf_used(handle->m_engine);
 	}
@@ -1091,6 +1091,11 @@ uint64_t scap_max_buf_used(scap_t* handle)
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 {
 	int32_t res = SCAP_FAILURE;
+	if(handle == NULL)
+	{
+		return res;
+	}
+
 	if(handle->m_vtable)
 	{
 		res = handle->m_vtable->next(handle->m_engine, pevent, pcpuid);
@@ -1131,6 +1136,11 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 //
 scap_threadinfo* scap_get_proc_table(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return NULL;
+	}
+
 	return handle->m_proclist.m_proclist;
 }
 
@@ -1139,6 +1149,11 @@ scap_threadinfo* scap_get_proc_table(scap_t* handle)
 //
 int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	stats->n_evts = 0;
 	stats->n_drops = 0;
 	stats->n_drops_buffer = 0;
@@ -1230,6 +1245,11 @@ int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
 //
 int32_t scap_stop_capture(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->stop_capture(handle->m_engine);
@@ -1250,6 +1270,11 @@ int32_t scap_stop_capture(scap_t* handle)
 //
 int32_t scap_start_capture(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->start_capture(handle->m_engine);
@@ -1267,6 +1292,11 @@ int32_t scap_start_capture(scap_t* handle)
 
 int32_t scap_enable_tracers_capture(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
@@ -1283,6 +1313,11 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 
 int32_t scap_stop_dropping_mode(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
@@ -1299,6 +1334,11 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
@@ -1318,6 +1358,11 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 //
 scap_addrlist* scap_get_ifaddr_list(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return NULL;
+	}
+
 	return handle->m_addrlist;
 }
 
@@ -1326,6 +1371,11 @@ scap_addrlist* scap_get_ifaddr_list(scap_t* handle)
 //
 scap_userlist* scap_get_user_list(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return NULL;
+	}
+
 	return handle->m_userlist;
 }
 
@@ -1334,7 +1384,7 @@ scap_userlist* scap_get_user_list(scap_t* handle)
 //
 const scap_machine_info* scap_get_machine_info(scap_t* handle)
 {
-	if(handle->m_machine_info.num_cpus != (uint32_t)-1)
+	if(handle && handle->m_machine_info.num_cpus != (uint32_t)-1)
 	{
 		return (const scap_machine_info*)&handle->m_machine_info;
 	}
@@ -1349,6 +1399,11 @@ const scap_machine_info* scap_get_machine_info(scap_t* handle)
 
 int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
@@ -1365,6 +1420,11 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 
 int64_t scap_get_readfile_offset(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return -1;
+	}
+
 	if(handle->m_vtable->savefile_ops)
 	{
 		return handle->m_vtable->savefile_ops->get_readfile_offset(handle->m_engine);
@@ -1378,6 +1438,11 @@ int64_t scap_get_readfile_offset(scap_t* handle)
 
 static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t ppm_sc)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	switch(op)
 	{
 	case SCAP_EVENTMASK_SET:
@@ -1400,11 +1465,6 @@ static int32_t scap_handle_eventmask(scap_t* handle, uint32_t op, uint32_t ppm_s
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
-	if (handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "manipulating eventmasks not supported on this scap mode");
 	return SCAP_FAILURE;
 #endif // HAS_CAPTURE
@@ -1432,6 +1492,11 @@ uint32_t scap_event_get_dump_flags(scap_t* handle)
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
@@ -1448,6 +1513,11 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
@@ -1508,6 +1578,11 @@ bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_
 
 struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return NULL;
+	}
+
 #if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return NULL;
@@ -1524,12 +1599,17 @@ struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 
 void scap_set_refresh_proc_table_when_saving(scap_t* handle, bool refresh)
 {
+	if(handle == NULL)
+	{
+		return;
+	}
+
 	handle->refresh_proc_table_when_saving = refresh;
 }
 
 uint64_t scap_ftell(scap_t *handle)
 {
-	if(handle->m_vtable->savefile_ops)
+	if(handle && handle->m_vtable->savefile_ops)
 	{
 		return handle->m_vtable->savefile_ops->ftell_capture(handle->m_engine);
 	}
@@ -1541,7 +1621,7 @@ uint64_t scap_ftell(scap_t *handle)
 
 void scap_fseek(scap_t *handle, uint64_t off)
 {
-	if(handle->m_vtable->savefile_ops)
+	if(handle && handle->m_vtable->savefile_ops)
 	{
 		handle->m_vtable->savefile_ops->fseek_capture(handle->m_engine, off);
 	}
@@ -1549,6 +1629,11 @@ void scap_fseek(scap_t *handle, uint64_t off)
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
@@ -1566,6 +1651,11 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 #ifdef CYGWING_AGENT
 wh_t* scap_get_wmi_handle(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return NULL;
+	}
+
 	return handle->m_whh;
 }
 #endif
@@ -1582,6 +1672,11 @@ bool scap_get_bpf_enabled(scap_t *handle)
 
 int32_t scap_suppress_events_comm(scap_t *handle, const char *comm)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	// If the comm is already present in the list, do nothing
 	uint32_t i;
 	for(i=0; i<handle->m_num_suppressed_comms; i++)
@@ -1608,6 +1703,11 @@ int32_t scap_suppress_events_comm(scap_t *handle, const char *comm)
 
 bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 {
+	if(handle == NULL)
+	{
+		return false;
+	}
+
 	scap_tid *stid;
 	HASH_FIND_INT64(handle->m_suppressed_tids, &tid, stid);
 
@@ -1616,6 +1716,11 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
@@ -1632,6 +1737,11 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 {
+	if(handle == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
@@ -1681,10 +1791,20 @@ bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long requ
 
 uint64_t scap_get_driver_api_version(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return 0;
+	}
+
 	return handle->m_api_version;
 }
 
 uint64_t scap_get_driver_schema_version(scap_t* handle)
 {
+	if(handle == NULL)
+	{
+		return 0;
+	}
+
 	return handle->m_schema_version;
 }

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1061,7 +1061,7 @@ scap_os_platform scap_get_os_platform(scap_t* handle)
 
 uint32_t scap_get_ndevs(scap_t* handle)
 {
-	if(handle && handle->m_vtable)
+	if(handle->m_vtable)
 	{
 		return handle->m_vtable->get_n_devs(handle->m_engine);
 	}
@@ -1081,7 +1081,7 @@ int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT uint32_
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
-	if(handle && handle->m_vtable)
+	if(handle->m_vtable)
 	{
 		return handle->m_vtable->get_max_buf_used(handle->m_engine);
 	}
@@ -1091,11 +1091,6 @@ uint64_t scap_max_buf_used(scap_t* handle)
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 {
 	int32_t res = SCAP_FAILURE;
-	if(handle == NULL)
-	{
-		return res;
-	}
-
 	if(handle->m_vtable)
 	{
 		res = handle->m_vtable->next(handle->m_engine, pevent, pcpuid);
@@ -1136,11 +1131,6 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 //
 scap_threadinfo* scap_get_proc_table(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return NULL;
-	}
-
 	return handle->m_proclist.m_proclist;
 }
 
@@ -1149,11 +1139,6 @@ scap_threadinfo* scap_get_proc_table(scap_t* handle)
 //
 int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	stats->n_evts = 0;
 	stats->n_drops = 0;
 	stats->n_drops_buffer = 0;
@@ -1270,11 +1255,6 @@ int32_t scap_stop_capture(scap_t* handle)
 //
 int32_t scap_start_capture(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->start_capture(handle->m_engine);
@@ -1292,11 +1272,6 @@ int32_t scap_start_capture(scap_t* handle)
 
 int32_t scap_enable_tracers_capture(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
@@ -1313,11 +1288,6 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 
 int32_t scap_stop_dropping_mode(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
@@ -1334,11 +1304,6 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
@@ -1358,11 +1323,6 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 //
 scap_addrlist* scap_get_ifaddr_list(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return NULL;
-	}
-
 	return handle->m_addrlist;
 }
 
@@ -1371,11 +1331,6 @@ scap_addrlist* scap_get_ifaddr_list(scap_t* handle)
 //
 scap_userlist* scap_get_user_list(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return NULL;
-	}
-
 	return handle->m_userlist;
 }
 
@@ -1384,7 +1339,7 @@ scap_userlist* scap_get_user_list(scap_t* handle)
 //
 const scap_machine_info* scap_get_machine_info(scap_t* handle)
 {
-	if(handle && handle->m_machine_info.num_cpus != (uint32_t)-1)
+	if(handle->m_machine_info.num_cpus != (uint32_t)-1)
 	{
 		return (const scap_machine_info*)&handle->m_machine_info;
 	}
@@ -1399,11 +1354,6 @@ const scap_machine_info* scap_get_machine_info(scap_t* handle)
 
 int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
@@ -1420,11 +1370,6 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 
 int64_t scap_get_readfile_offset(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return -1;
-	}
-
 	if(handle->m_vtable->savefile_ops)
 	{
 		return handle->m_vtable->savefile_ops->get_readfile_offset(handle->m_engine);
@@ -1492,11 +1437,6 @@ uint32_t scap_event_get_dump_flags(scap_t* handle)
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
@@ -1513,11 +1453,6 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
@@ -1578,11 +1513,6 @@ bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_
 
 struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return NULL;
-	}
-
 #if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return NULL;
@@ -1599,17 +1529,12 @@ struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 
 void scap_set_refresh_proc_table_when_saving(scap_t* handle, bool refresh)
 {
-	if(handle == NULL)
-	{
-		return;
-	}
-
 	handle->refresh_proc_table_when_saving = refresh;
 }
 
 uint64_t scap_ftell(scap_t *handle)
 {
-	if(handle && handle->m_vtable->savefile_ops)
+	if(handle->m_vtable->savefile_ops)
 	{
 		return handle->m_vtable->savefile_ops->ftell_capture(handle->m_engine);
 	}
@@ -1621,7 +1546,7 @@ uint64_t scap_ftell(scap_t *handle)
 
 void scap_fseek(scap_t *handle, uint64_t off)
 {
-	if(handle && handle->m_vtable->savefile_ops)
+	if(handle->m_vtable->savefile_ops)
 	{
 		handle->m_vtable->savefile_ops->fseek_capture(handle->m_engine, off);
 	}
@@ -1629,11 +1554,6 @@ void scap_fseek(scap_t *handle, uint64_t off)
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
@@ -1651,11 +1571,6 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 #ifdef CYGWING_AGENT
 wh_t* scap_get_wmi_handle(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return NULL;
-	}
-
 	return handle->m_whh;
 }
 #endif
@@ -1672,11 +1587,6 @@ bool scap_get_bpf_enabled(scap_t *handle)
 
 int32_t scap_suppress_events_comm(scap_t *handle, const char *comm)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	// If the comm is already present in the list, do nothing
 	uint32_t i;
 	for(i=0; i<handle->m_num_suppressed_comms; i++)
@@ -1703,11 +1613,6 @@ int32_t scap_suppress_events_comm(scap_t *handle, const char *comm)
 
 bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 {
-	if(handle == NULL)
-	{
-		return false;
-	}
-
 	scap_tid *stid;
 	HASH_FIND_INT64(handle->m_suppressed_tids, &tid, stid);
 
@@ -1716,11 +1621,6 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
@@ -1737,11 +1637,6 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 {
-	if(handle == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
@@ -1791,20 +1686,10 @@ bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long requ
 
 uint64_t scap_get_driver_api_version(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return 0;
-	}
-
 	return handle->m_api_version;
 }
 
 uint64_t scap_get_driver_schema_version(scap_t* handle)
 {
-	if(handle == NULL)
-	{
-		return 0;
-	}
-
 	return handle->m_schema_version;
 }


### PR DESCRIPTION
/kind cleanup
/area libscap

The API is very inconsistent about checking for NULL. Most of the time the handle is unchecked. There was one specific function which was checked, but then new code got added before the check: https://github.com/draios/agent-libs/commit/d98fb0761bc454230ca1f069cc393d0f0ff286ca#diff-c478647d3c515b80e0b8377839cfdb4936cf1b1f5999a89b56a72ccf42f76e04R2557

This new code ended up breaking a test which relied on the check. Rather than fix that one function, I thought the ideal fix would be to consistently check the handle for NULL at the top of each API function.

```release-note
NONE
```
Signed-off-by: Nathan Baker <nathan.baker@sysdig.com>
