### PR TITLE
new(libsinps): add a new API in sinsp to obtain the events associated with a set of `ppm_sc`

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1179,10 +1179,7 @@ int scap_get_modifies_state_ppm_sc(OUT uint32_t ppm_sc_array[PPM_SC_MAX])
 	/* Clear the array before using it.
 	 * This is not necessary but just to be future-proof.
 	 */
-	for(int ppm_sc = 0; ppm_sc < PPM_SC_MAX; ppm_sc++)
-	{
-		ppm_sc_array[ppm_sc] = 0;
-	}
+	memset(ppm_sc_array, 0, sizeof(*ppm_sc_array) * PPM_SC_MAX);
 
 #ifdef __linux__
 	// Collect EF_MODIFIES_STATE events
@@ -1224,10 +1221,7 @@ int scap_get_events_from_ppm_sc(IN uint32_t ppm_sc_array[PPM_SC_MAX], OUT uint32
 	/* Clear the array before using it.
 	 * This is not necessary but just to be future-proof.
 	 */
-	for(int event_num = 0; event_num < PPM_EVENT_MAX; event_num++)
-	{
-		events_array[event_num] = 0;
-	}
+	memset(events_array, 0, sizeof(*events_array) * PPM_EVENT_MAX);
 
 #ifdef __linux__
 	for(int ppm_code = 0; ppm_code< PPM_SC_MAX; ppm_code++)
@@ -1262,10 +1256,7 @@ int scap_get_modifies_state_tracepoints(OUT uint32_t tp_array[TP_VAL_MAX])
 	/* Clear the array before using it.
 	 * This is not necessary but just to be future-proof.
 	 */
-	for(int tp_num = 0; tp_num < TP_VAL_MAX; tp_num++)
-	{
-		tp_array[tp_num] = 0;
-	}
+	memset(tp_array, 0, sizeof(*tp_array) * TP_VAL_MAX);
 
 	tp_array[SYS_ENTER] = 1;
 	tp_array[SYS_EXIT] = 1;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1169,11 +1169,19 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 	return SCAP_SUCCESS;
 }
 
-int scap_get_modifies_state_ppm_sc(uint32_t* ppm_sc_array)
+int scap_get_modifies_state_ppm_sc(OUT uint32_t ppm_sc_array[PPM_SC_MAX])
 {
 	if(ppm_sc_array == NULL)
 	{
 		return SCAP_FAILURE;
+	}
+
+	/* Clear the array before using it.
+	 * This is not necessary but just to be future-proof.
+	 */
+	for(int ppm_sc = 0; ppm_sc < PPM_SC_MAX; ppm_sc++)
+	{
+		ppm_sc_array[ppm_sc] = 0;
 	}
 
 #ifdef __linux__
@@ -1206,11 +1214,19 @@ int scap_get_modifies_state_ppm_sc(uint32_t* ppm_sc_array)
 	return SCAP_SUCCESS;
 }
 
-int scap_get_events_from_ppm_sc(IN uint32_t * ppm_sc_array, OUT uint32_t* events_array)
+int scap_get_events_from_ppm_sc(IN uint32_t ppm_sc_array[PPM_SC_MAX], OUT uint32_t events_array[PPM_EVENT_MAX])
 {
 	if(ppm_sc_array == NULL || events_array == NULL)
 	{
 		return SCAP_FAILURE;
+	}
+
+	/* Clear the array before using it.
+	 * This is not necessary but just to be future-proof.
+	 */
+	for(int event_num = 0; event_num < PPM_EVENT_MAX; event_num++)
+	{
+		events_array[event_num] = 0;
 	}
 
 #ifdef __linux__
@@ -1236,11 +1252,19 @@ int scap_get_events_from_ppm_sc(IN uint32_t * ppm_sc_array, OUT uint32_t* events
 	return SCAP_SUCCESS;
 }
 
-int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
+int scap_get_modifies_state_tracepoints(OUT uint32_t tp_array[TP_VAL_MAX])
 {
 	if(tp_array == NULL)
 	{
 		return SCAP_FAILURE;
+	}
+
+	/* Clear the array before using it.
+	 * This is not necessary but just to be future-proof.
+	 */
+	for(int tp_num = 0; tp_num < TP_VAL_MAX; tp_num++)
+	{
+		tp_array[tp_num] = 0;
 	}
 
 	tp_array[SYS_ENTER] = 1;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1206,6 +1206,36 @@ int scap_get_modifies_state_ppm_sc(uint32_t* ppm_sc_array)
 	return SCAP_SUCCESS;
 }
 
+int scap_get_events_from_ppm_sc(IN uint32_t * ppm_sc_array, OUT uint32_t* events_array)
+{
+	if(ppm_sc_array == NULL || events_array == NULL)
+	{
+		return SCAP_FAILURE;
+	}
+
+#ifdef __linux__
+	for(int ppm_code = 0; ppm_code< PPM_SC_MAX; ppm_code++)
+	{
+		if(!ppm_sc_array[ppm_code])
+		{
+			continue;
+		}
+		
+		/* If we arrive here we want to know the events associated with this ppm_code. */
+		for(int syscall_nr = 0; syscall_nr < SYSCALL_TABLE_SIZE; syscall_nr++)
+		{
+			struct syscall_evt_pair pair = g_syscall_table[syscall_nr];
+			if(pair.ppm_sc == ppm_code)
+			{
+				events_array[pair.enter_event_type] = 1;
+				events_array[pair.exit_event_type] = 1;
+			}
+		}
+	}
+#endif
+	return SCAP_SUCCESS;
+}
+
 int scap_get_modifies_state_tracepoints(uint32_t* tp_array)
 {
 	if(tp_array == NULL)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -839,6 +839,11 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats);
 int scap_get_modifies_state_ppm_sc(uint32_t * ppm_sc_array);
 
 /*!
+  \brief Take an array of `ppm_sc` as input and provide the associated array of events as output.
+*/
+int scap_get_events_from_ppm_sc(IN uint32_t* ppm_sc_array, OUT uint32_t* events_array);
+
+/*!
   \brief Returns the set of minimum tracepoints required by `libsinsp` state.
 */
 int scap_get_modifies_state_tracepoints(uint32_t * tp_array);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -836,17 +836,17 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats);
 /*!
   \brief Returns the set of ppm_sc whose events have EF_MODIFIES_STATE flag or whose syscall have UF_NEVER_DROP flag.
 */
-int scap_get_modifies_state_ppm_sc(uint32_t * ppm_sc_array);
+int scap_get_modifies_state_ppm_sc(OUT uint32_t ppm_sc_array[PPM_SC_MAX]);
 
 /*!
   \brief Take an array of `ppm_sc` as input and provide the associated array of events as output.
 */
-int scap_get_events_from_ppm_sc(IN uint32_t* ppm_sc_array, OUT uint32_t* events_array);
+int scap_get_events_from_ppm_sc(IN uint32_t ppm_sc_array[PPM_SC_MAX], OUT uint32_t events_array[PPM_EVENT_MAX]);
 
 /*!
   \brief Returns the set of minimum tracepoints required by `libsinsp` state.
 */
-int scap_get_modifies_state_tracepoints(uint32_t * tp_array);
+int scap_get_modifies_state_tracepoints(OUT uint32_t tp_array[TP_VAL_MAX]);
 
 /*!
   \brief This function can be used to temporarily interrupt event capture.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -892,6 +892,16 @@ public:
 	*/
 	std::unordered_set<uint32_t> enforce_sys_ppm_sc_set(std::unordered_set<uint32_t> ppm_sc_set = {});
 
+	/**
+	 * @brief When you want to retrieve the events associated with a particular `ppm_sc` you have to
+	 * pass a single-element set, with just the specific `ppm_sc`. On the other side, you want all the events
+	 * associated with a set of `ppm_sc` you have to pass the entire set of `ppm_sc`.
+	 * 
+	 * @param ppm_sc_set set of `ppm_sc` from which you want to obtain information
+	 * @return set of events associated with the provided `ppm_sc` set.
+	 */
+	std::unordered_set<uint32_t> get_event_set_from_ppm_sc_set(const std::unordered_set<uint32_t> &ppm_sc_of_interest);
+
 	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
 
 	/*=============================== Tracepoint set related ===============================*/

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -201,3 +201,32 @@ std::unordered_set<uint32_t> sinsp::enforce_sys_ppm_sc_set(std::unordered_set<ui
 	}
 	return ppm_sc_set;
 }
+
+std::unordered_set<uint32_t> sinsp::get_event_set_from_ppm_sc_set(const std::unordered_set<uint32_t> &ppm_sc_set)
+{
+	std::vector<uint32_t> events_array(PPM_EVENT_MAX, 0);
+	std::vector<uint32_t> ppm_sc_array(PPM_SC_MAX, 0);
+	std::unordered_set<uint32_t> events_set;
+
+	/* Fill the `ppm_sc_array` with the syscalls we are interested in. */
+	for (auto itr = ppm_sc_set.begin(); itr != ppm_sc_set.end(); itr++)
+	{
+		ppm_sc_array[*itr] = 1;
+	}
+
+	if(scap_get_events_from_ppm_sc(ppm_sc_array.data(), events_array.data()) != SCAP_SUCCESS)
+	{
+		throw sinsp_exception("`ppm_sc_array` or `events_array` is an unexpected NULL vector!");
+	}
+
+	for(uint32_t event_num = 0; event_num < PPM_EVENT_MAX; event_num++)
+	{
+		/* True means it is associated with a `ppm_sc` */
+		if(events_array[event_num])
+		{
+			events_set.insert(event_num);
+		}
+	}
+
+	return events_set;
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR introduces a new API in sinps that can be used to obtain the set of events associated with a set of `ppm_sc`. The typical use case is when Falco needs to understand if all the events used in the rule are considered in our set of interesting `ppm_sc`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(libsinps): add a new API in sinsp to obtain the events associated with a set of `ppm_sc`
```
