### PR TITLE
Don't use a global variable for the ring buffer size

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1548,7 +1548,8 @@ int32_t scap_bpf_load(
 		//
 		// Map the ring buffer
 		//
-		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_buffer_size, bpf_args->buffer_bytes_dim);
+		dev->m_buffer = perf_event_mmap(handle, pmu_fd, &dev->m_mmap_size, bpf_args->buffer_bytes_dim);
+		dev->m_buffer_size = bpf_args->buffer_bytes_dim;
 		if(dev->m_buffer == MAP_FAILED)
 		{
 			return SCAP_FAILURE;
@@ -1722,7 +1723,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	struct scap_bpf_engine_params *params = oargs->engine_params;
 	strlcpy(bpf_probe_buf, params->bpf_probe, SCAP_MAX_PATH_SIZE);
 
-	if(check_and_set_buffer_bytes_dim(engine.m_handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(engine.m_handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -158,7 +158,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	uint64_t schema_version = 0;
 
 	unsigned long single_buffer_dim = params->buffer_bytes_dim;
-	if(check_and_set_buffer_bytes_dim(handle->m_lasterr, single_buffer_dim) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(handle->m_lasterr, single_buffer_dim) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -307,7 +307,8 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error mapping the ring buffer for device %s. (If you get memory allocation errors try to reduce the buffer dimension)", filename);
 			return SCAP_FAILURE;
 		}
-		dev->m_buffer_size = mapped_len;
+		dev->m_buffer_size = single_buffer_dim;
+		dev->m_mmap_size = mapped_len;
 
 		//
 		// Map the ppm_ring_buffer_info that contains the buffer pointers

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -97,7 +97,7 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
-	if(check_and_set_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -892,6 +892,8 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 	{
 		return SCAP_FAILURE;
 	}
+
+	handle->m_dev_set.m_devs[0].m_mmap_size = 2 * handle->m_dev_set.m_devs[0].m_buffer_size;
 
 	// Set close-on-exec for the fd
 #ifndef _WIN32

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -41,7 +41,7 @@ int ud_shm_open(const char *name, int flag, mode_t mode);
 ///////////////////////////////////////////////////////////////////////////////
 int32_t udig_alloc_ring(void* ring_id, 
 	uint8_t** ring, 
-	uint32_t *ringsize,
+	unsigned long *ringsize,
 	char *error)
 {
 	int* ring_fd = (int*)ring_id;
@@ -62,7 +62,7 @@ int32_t udig_alloc_ring(void* ring_id,
 			return SCAP_FAILURE;
 		}
 
-		*ringsize = (uint32_t)rstat.st_size;
+		*ringsize = rstat.st_size;
 	}
 	else
 	{
@@ -97,7 +97,7 @@ int32_t udig_alloc_ring(void* ring_id,
 		}
 	}
 
-	if(check_and_set_buffer_bytes_dim(error, (unsigned long)*ringsize) != SCAP_SUCCESS)
+	if(check_and_set_buffer_bytes_dim(error, *ringsize) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -342,7 +342,7 @@ int32_t udig_begin_capture(struct scap_engine_handle engine, char *error)
 ///////////////////////////////////////////////////////////////////////////////
 int32_t udig_alloc_ring(HANDLE* ring_handle,
 	uint8_t** ring,
-	uint32_t* ringsize,
+	unsigned long* ringsize,
 	char* error)
 {
 	*ring_handle = NULL;
@@ -369,7 +369,7 @@ int32_t udig_alloc_ring(HANDLE* ring_handle,
 		MEMORY_BASIC_INFORMATION info;
 		SIZE_T szBufferSize = VirtualQueryEx(GetCurrentProcess(), pdbuf, &info, sizeof(info));
 
-		*ringsize = (uint32_t)info.RegionSize;
+		*ringsize = info.RegionSize;
 
 		UnmapViewOfFile(pdbuf);
 	}

--- a/userspace/libscap/ringbuffer/devset.c
+++ b/userspace/libscap/ringbuffer/devset.c
@@ -58,10 +58,10 @@ void devset_free(struct scap_device_set *devset)
 		{
 #ifdef _DEBUG
 			int ret;
-			ret = munmap(dev->m_buffer, dev->m_buffer_size);
+			ret = munmap(dev->m_buffer, dev->m_mmap_size);
 			ASSERT(ret == 0);
 #else
-			munmap(dev->m_buffer, dev->m_buffer_size);
+			munmap(dev->m_buffer, dev->m_mmap_size);
 #endif
 		}
 

--- a/userspace/libscap/ringbuffer/devset.h
+++ b/userspace/libscap/ringbuffer/devset.h
@@ -31,7 +31,8 @@ typedef struct scap_device
 	int m_fd;
 	int m_bufinfo_fd; // used by udig
 	char* m_buffer;
-	unsigned long m_buffer_size; // used by udig
+	unsigned long m_buffer_size;
+	unsigned long m_mmap_size; // generally 2 * m_buffer_size, but bpf does weird things
 	uint32_t m_lastreadsize;
 	char* m_sn_next_event; // Pointer to the next event available for scap_next
 	uint32_t m_sn_len; // Number of bytes available in the buffer pointed by m_sn_next_event

--- a/userspace/libscap/ringbuffer/ringbuffer.c
+++ b/userspace/libscap/ringbuffer/ringbuffer.c
@@ -22,10 +22,7 @@ limitations under the License.
 #include <scap.h>
 #include "../../../driver/ppm_ringbuffer.h"
 
-/* Dimension of a single per-CPU buffer in bytes. */
-unsigned long global_buffer_bytes_dim;
-
-int32_t check_and_set_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_dim)
+int32_t check_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_dim)
 {
 	/* If you face some memory allocation issues, please remember that:
 	 *
@@ -65,6 +62,5 @@ int32_t check_and_set_buffer_bytes_dim(char* last_err, unsigned long buf_bytes_d
 		return SCAP_FAILURE;
 	}
 
-	global_buffer_bytes_dim = buf_bytes_dim;
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -23,13 +23,11 @@ limitations under the License.
 #include "barrier.h"
 #include "sleep.h"
 
-extern unsigned long global_buffer_bytes_dim;
-
 /* Check buffer dimension in bytes. 
  * Our 2 eBPF probes require that this number is a power of 2! Right now we force this
  * constraint to all our drivers (also the kernel module and udig) just for conformity.
  */
-int32_t check_and_set_buffer_bytes_dim(char* error, unsigned long buf_bytes_dim);
+int32_t check_buffer_bytes_dim(char* error, unsigned long buf_bytes_dim);
 
 
 #ifndef GET_BUF_POINTERS
@@ -42,7 +40,7 @@ static inline void ringbuffer_get_buf_pointers(scap_device* dev, uint64_t* phead
 
 	if(*ptail > *phead)
 	{
-		*pread_size = global_buffer_bytes_dim - *ptail + *phead;
+		*pread_size = dev->m_buffer_size - *ptail + *phead;
 	}
 	else
 	{
@@ -72,13 +70,13 @@ static inline void ringbuffer_advance_tail(struct scap_device* dev)
 	//
 	mem_barrier();
 
-	if(ttail < global_buffer_bytes_dim)
+	if(ttail < dev->m_buffer_size)
 	{
 		dev->m_bufinfo->tail = ttail;
 	}
 	else
 	{
-		dev->m_bufinfo->tail = ttail - global_buffer_bytes_dim;
+		dev->m_bufinfo->tail = ttail - dev->m_buffer_size;
 	}
 
 	dev->m_lastreadsize = 0;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -571,7 +571,7 @@ struct udig_ring_buffer_status {
 
 typedef struct ppm_ring_buffer_info ppm_ring_buffer_info;
 
-int32_t udig_alloc_ring(void* ring_id, uint8_t** ring, uint32_t *ringsize, char *error);
+int32_t udig_alloc_ring(void* ring_id, uint8_t** ring, unsigned long *ringsize, char *error);
 int32_t udig_alloc_ring_descriptors(void* ring_descs_id,
 	struct ppm_ring_buffer_info** ring_info,
 	struct udig_ring_buffer_status** ring_status,


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

/area libscap-engine-bpf

> /area libscap-engine-gvisor

/area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Remove the global variable introduced by https://github.com/falcosecurity/libs/pull/584

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
