### PR TITLE
build(.github): enable CI workflow on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI Build
 on:
   pull_request:
-    branches: [master]
   push:
-    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This change solves two issues:
 - Run the CI on PR based on branches other than `master` (that's legit, for example  :point_right: https://github.com/falcosecurity/libs/pull/611)
 - Let maintainers use the CI for testing their code by pushing to a branch ( otherwise maintainers are forced to open dummy PRs like this :point_right: https://github.com/falcosecurity/libs/pull/618) 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
