### PR TITLE
new(modern_bpf): change `sys_enter` and `sys_exit` prog names

### DIFF
--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
@@ -12,7 +12,7 @@
  * TP_PROTO(struct pt_regs *regs, long id),
  */
 SEC("tp_btf/sys_enter")
-int BPF_PROG(dispatch_syscall_enter_events,
+int BPF_PROG(sys_enter,
 	     struct pt_regs *regs,
 	     long syscall_id)
 {

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -12,7 +12,7 @@
  * TP_PROTO(struct pt_regs *regs, long ret),
  */
 SEC("tp_btf/sys_exit")
-int BPF_PROG(dispatch_syscall_exit_events,
+int BPF_PROG(sys_exit,
 	     struct pt_regs *regs,
 	     long ret)
 {

--- a/userspace/libpman/src/programs.c
+++ b/userspace/libpman/src/programs.c
@@ -26,15 +26,15 @@ limitations under the License.
 int pman_attach_syscall_enter_dispatcher()
 {
 	/* The program is already attached. */
-	if(g_state.skel->links.dispatch_syscall_enter_events != NULL)
+	if(g_state.skel->links.sys_enter != NULL)
 	{
 		return 0;
 	}
 
-	g_state.skel->links.dispatch_syscall_enter_events = bpf_program__attach(g_state.skel->progs.dispatch_syscall_enter_events);
-	if(!g_state.skel->links.dispatch_syscall_enter_events)
+	g_state.skel->links.sys_enter = bpf_program__attach(g_state.skel->progs.sys_enter);
+	if(!g_state.skel->links.sys_enter)
 	{
-		pman_print_error("failed to attach the 'dispatch_syscall_enter_events' program");
+		pman_print_error("failed to attach the 'sys_enter' program");
 		return errno;
 	}
 	return 0;
@@ -43,15 +43,15 @@ int pman_attach_syscall_enter_dispatcher()
 int pman_attach_syscall_exit_dispatcher()
 {
 	/* The program is already attached. */
-	if(g_state.skel->links.dispatch_syscall_exit_events != NULL)
+	if(g_state.skel->links.sys_exit != NULL)
 	{
 		return 0;
 	}
 
-	g_state.skel->links.dispatch_syscall_exit_events = bpf_program__attach(g_state.skel->progs.dispatch_syscall_exit_events);
-	if(!g_state.skel->links.dispatch_syscall_exit_events)
+	g_state.skel->links.sys_exit = bpf_program__attach(g_state.skel->progs.sys_exit);
+	if(!g_state.skel->links.sys_exit)
 	{
-		pman_print_error("failed to attach the 'dispatch_syscall_exit_events' program");
+		pman_print_error("failed to attach the 'sys_exit' program");
 		return errno;
 	}
 	return 0;
@@ -108,23 +108,23 @@ int pman_attach_all_programs()
 
 int pman_detach_syscall_enter_dispatcher()
 {
-	if(g_state.skel->links.dispatch_syscall_enter_events && bpf_link__destroy(g_state.skel->links.dispatch_syscall_enter_events))
+	if(g_state.skel->links.sys_enter && bpf_link__destroy(g_state.skel->links.sys_enter))
 	{
-		pman_print_error("failed to detach the 'dispatch_syscall_enter_events' program");
+		pman_print_error("failed to detach the 'sys_enter' program");
 		return errno;
 	}
-	g_state.skel->links.dispatch_syscall_enter_events = NULL;
+	g_state.skel->links.sys_enter = NULL;
 	return 0;
 }
 
 int pman_detach_syscall_exit_dispatcher()
 {
-	if(g_state.skel->links.dispatch_syscall_exit_events && bpf_link__destroy(g_state.skel->links.dispatch_syscall_exit_events))
+	if(g_state.skel->links.sys_exit && bpf_link__destroy(g_state.skel->links.sys_exit))
 	{
-		pman_print_error("failed to detach the 'dispatch_syscall_exit_events' program");
+		pman_print_error("failed to detach the 'sys_exit' program");
 		return errno;
 	}
-	g_state.skel->links.dispatch_syscall_exit_events = NULL;
+	g_state.skel->links.sys_exit = NULL;
 	return 0;
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR changes the names of some BPF programs to allow better debugging with BPFTOOL, the max length of a bpf prog name before the truncation is `16`. We should try to use short names :) 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
