### PR TITLE
update(modern_bpf_engine): add a check on the minimum kernel version

### DIFF
--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -123,7 +123,7 @@ static int32_t check_minimum_kernel_version(char* last_err)
 	{
 		if(last_err != NULL)
 		{
-			snprintf(last_err, SCAP_LASTERR_SIZE, "unable to get major, minor, patch with sscanf: %s", strerror(errno));
+			snprintf(last_err, SCAP_LASTERR_SIZE, "unable to parse info.release '%s'. %s", info.release, strerror(errno));
 		}
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1708,6 +1708,26 @@ int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 #endif
 }
 
+bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
+							uint32_t required_major, uint32_t required_minor, uint32_t required_patch)
+{
+	if(current_major != required_major)
+	{
+		return false;
+	}
+
+	if(current_minor < required_minor)
+	{
+		return false;
+	}
+	if(current_minor == required_minor && current_patch < required_patch)
+	{
+		return false;
+	}
+
+	return true;
+}
+
 bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version)
 {
 	unsigned long driver_major = PPM_API_VERSION_MAJOR(driver_api_version);
@@ -1717,24 +1737,7 @@ bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long requ
 	unsigned long required_minor = PPM_API_VERSION_MINOR(required_api_version);
 	unsigned long required_patch = PPM_API_VERSION_PATCH(required_api_version);
 
-	if(driver_major != required_major)
-	{
-		// major numbers disagree
-		return false;
-	}
-
-	if(driver_minor < required_minor)
-	{
-		// driver's minor version is < ours
-		return false;
-	}
-	if(driver_minor == required_minor && driver_patch < required_patch)
-	{
-		// driver's minor versions match and patch level is < ours
-		return false;
-	}
-
-	return true;
+	return scap_apply_semver_check(driver_major, driver_minor, driver_patch, required_major, required_minor, required_patch);
 }
 
 uint64_t scap_get_driver_api_version(scap_t* handle)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1134,6 +1134,12 @@ int32_t scap_set_statsd_port(scap_t* handle, uint16_t port);
 bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version);
 
 /**
+ * Apply the `semver` checks on current and required versions.
+ */  
+bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
+							uint32_t required_major, uint32_t required_minor, uint32_t required_patch);
+
+/**
  * Get API version supported by the driver
  */
 uint64_t scap_get_driver_api_version(scap_t* handle);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

/area libscap

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR adds:
* a new API in scap to compute the `semver` check
* a new check in the modern probe engine to ensure that we are on a supported kernel

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(modern_bpf_engine): add a check on the minimum kernel version
```
