### PR TITLE
fix(driver-modern-bpf): fix execve USER vs MEMORY reads + cleanup + enforce upper bounds in push__bytebuf

### DIFF
--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -257,7 +257,11 @@ static __always_inline u16 push__charbuf(u8 *data, u64 *payload_pos, unsigned lo
 static __always_inline u16 push__bytebuf(u8 *data, u64 *payload_pos, unsigned long bytebuf_pointer, u16 len_to_read, enum read_memory mem)
 {
 	u16 total_len = 0;
-	if (len_to_read > ARGS_ENV_SIZE_MAX)
+	if (len_to_read < 1)
+	{
+		return 0;
+	}
+	else if (len_to_read > ARGS_ENV_SIZE_MAX)
 	{
 		total_len = ARGS_ENV_SIZE_MAX;
 	}

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -89,9 +89,6 @@ enum read_memory
 /* Paramater maximum size */
 #define MAX_PARAM_SIZE MAX_EVENT_SIZE - 1
 
-/* ARGS or ENV maximum size */
-#define ARGS_ENV_SIZE_MAX 4096
-
 /* Helper used to please the verifier during reading
  * operations like `bpf_probe_read_str()`.
  */
@@ -256,40 +253,25 @@ static __always_inline u16 push__charbuf(u8 *data, u64 *payload_pos, unsigned lo
  */
 static __always_inline u16 push__bytebuf(u8 *data, u64 *payload_pos, unsigned long bytebuf_pointer, u16 len_to_read, enum read_memory mem)
 {
-	u16 total_len = 0;
-	if (len_to_read < 1)
-	{
-		return 0;
-	}
-	else if (len_to_read > ARGS_ENV_SIZE_MAX)
-	{
-		total_len = ARGS_ENV_SIZE_MAX;
-	}
-	else
-	{
-		total_len = len_to_read;
-	}
-
 	if(mem == KERNEL)
 	{
 		if(bpf_probe_read_kernel(&data[SAFE_ACCESS(*payload_pos)],
-						      total_len,
+						      len_to_read,
 						      (void *)bytebuf_pointer) != 0)
 		{
 			return 0;
 		}
-
 	}
 	else
 	{
 		if(bpf_probe_read_user(&data[SAFE_ACCESS(*payload_pos)],
-						    total_len,
+						    len_to_read,
 						    (void *)bytebuf_pointer) != 0)
 		{
 			return 0;
 		}
 	}
 
-	*payload_pos += total_len;
-	return total_len;
+	*payload_pos += len_to_read;
+	return len_to_read;
 }

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -254,24 +254,24 @@ static __always_inline u16 push__charbuf(u8 *data, u64 *payload_pos, unsigned lo
 static __always_inline u16 push__bytebuf(u8 *data, u64 *payload_pos, unsigned long bytebuf_pointer, u16 len_to_read, enum read_memory mem)
 {
 
-	int written_bytes = 0;
-
 	if(mem == KERNEL)
 	{
-		written_bytes = bpf_probe_read_kernel(&data[SAFE_ACCESS(*payload_pos)],
+		if(bpf_probe_read_kernel(&data[SAFE_ACCESS(*payload_pos)],
 						      len_to_read,
-						      (char *)bytebuf_pointer);
+						      (void *)bytebuf_pointer) != 0)
+		{
+			return 0;
+		}
+
 	}
 	else
 	{
-		written_bytes = bpf_probe_read_user(&data[SAFE_ACCESS(*payload_pos)],
+		if(bpf_probe_read_user(&data[SAFE_ACCESS(*payload_pos)],
 						    len_to_read,
-						    (char *)bytebuf_pointer);
-	}
-
-	if(written_bytes != 0)
-	{
-		return 0;
+						    (void *)bytebuf_pointer) != 0)
+		{
+			return 0;
+		}
 	}
 
 	*payload_pos += len_to_read;

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -334,7 +334,11 @@ static __always_inline u16 auxmap__store_charbuf_param(struct auxiliary_map *aux
  */
 static __always_inline u16 auxmap__store_bytebuf_param(struct auxiliary_map *auxmap, unsigned long bytebuf_pointer, unsigned long len_to_read, enum read_memory mem)
 {
-	u16 bytebuf_len = push__bytebuf(auxmap->data, &auxmap->payload_pos, bytebuf_pointer, len_to_read, mem);
+	u16 bytebuf_len = 0;
+	if (len_to_read > 0)
+	{
+		bytebuf_len = push__bytebuf(auxmap->data, &auxmap->payload_pos, bytebuf_pointer, len_to_read, mem);
+	}
 	/* If we are not able to push anything with `push__bytebuf`
 	 * `bytebuf_len` will be equal to `0` so we will send an
 	 * empty param to userspace.

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -79,7 +79,7 @@ int BPF_PROG(execve_x,
 		/* We need to extract the len of `exe` arg so we can undestand
 		 * the overall length of the remaining args.
 		 */
-		u16 exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, KERNEL);
+		u16 exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		/* Here we read the whole array starting from the pointer to the first
@@ -87,7 +87,7 @@ int BPF_PROG(execve_x,
 		 * since we know the total len we read it as a `bytebuf`.
 		 * The `\0` after every argument are preserved.
 		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, total_args_len - exe_arg_len, KERNEL);
+		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, total_args_len - exe_arg_len, USER);
 	}
 	else
 	{
@@ -203,7 +203,7 @@ int BPF_PROG(t1_execve_x,
 		 * since we know the total len we read it as a `bytebuf`.
 		 * The `\0` after every argument are preserved.
 		 */
-		auxmap__store_bytebuf_param(auxmap, env_start_pointer, total_env_len, KERNEL);
+		auxmap__store_bytebuf_param(auxmap, env_start_pointer, total_env_len, USER);
 	}
 	else
 	{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Reproduce bug and verify fix:

Currently in `driver-modern-bpf` we do not get some execve data, for example:

```
sudo ./libsinsp/examples/sinsp-example --modern_bpf -f "evt.dir=< and (evt.type=execve or evt.type=execveat)" -o "* %proc.cmdline %proc.exepath %proc.name %proc.env"
```
Current master:

```
{"proc.cmdline":"git","proc.env":"","proc.exepath":"/usr/bin/git","proc.name":"git"}
```

After reverting KERNEL reads to `bpf_probe_read` or `bpf_probe_read_str` everything seems to be fixed again (this PR):

```
{"proc.cmdline":"git status","proc.env":"LONG REDACTED STRING","proc.exepath":"/usr/bin/git","proc.name":"git"}
```

> Checked in some other projects and distinguishing between KERNEL and USER reads is best practice. However, I also noticed that while `_user` bpf helpers are used, the `_kernel` helpers are not used and instead the global ones are used. Therefore, I suspect it is the actual bpf helpers causing issues here. No idea what it could be.

Edited: Actual issue was some wrong USER vs MEMORY reads attribution in execve filler.

CC folks who touched `modern_bpf` so far: @Andreagit97 @hbrueckner @Molter73 @FedeDP @jasondellaluce @leogr 


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
