### PR TITLE
fix(userspace/libsinsp): properly load users and groups from pre-existing containers on init

### DIFF
--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -876,11 +876,7 @@ bool docker_async_source::parse(const docker_lookup_request& request, sinsp_cont
 	try
 	{
 		auto lowerdir = root["GraphDriver"]["Data"]["LowerDir"].asString();
-		while (lowerdir.find_first_of(':') != std::string::npos)
-		{
-			lowerdir = lowerdir.substr(lowerdir.find_first_of(':') + 1);
-		}
-		container.m_overlayfs_root = lowerdir;
+		container.m_overlayfs_root = lowerdir.substr(lowerdir.find_last_of(':') + 1);
 
 	}
 	catch (const std::exception &)

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -876,7 +876,12 @@ bool docker_async_source::parse(const docker_lookup_request& request, sinsp_cont
 	try
 	{
 		auto lowerdir = root["GraphDriver"]["Data"]["LowerDir"].asString();
-		container.m_overlayfs_root = lowerdir.substr(lowerdir.find_first_of(':') + 1);
+		while (lowerdir.find_first_of(':') != std::string::npos)
+		{
+			lowerdir = lowerdir.substr(lowerdir.find_first_of(':') + 1);
+		}
+		container.m_overlayfs_root = lowerdir;
+
 	}
 	catch (const std::exception &)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -546,7 +546,7 @@ void sinsp::open_common(scap_open_args* oargs)
 	oargs->import_users = m_usergroup_manager.m_import_users;
 	// We need to subscribe to container manager notifiers before
 	// scap starts scanning proc.
-	m_usergroup_manager.init();
+	m_usergroup_manager.subscribe_container_mgr();
 
 	add_suppressed_comms(oargs);
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -401,8 +401,6 @@ void sinsp::init()
 	//
 	m_thread_manager->fix_sockets_coming_from_proc();
 
-	m_usergroup_manager.init();
-
 	// If we are in capture, this is already called by consume_initialstate_events
 	if (!is_capture() && m_external_event_processor)
 	{
@@ -546,6 +544,9 @@ void sinsp::open_common(scap_open_args* oargs)
 		oargs->proc_callback_context = this;
 	}
 	oargs->import_users = m_usergroup_manager.m_import_users;
+	// We need to subscribe to container manager notifiers beore
+	// scap starts scanning proc.
+	m_usergroup_manager.init();
 
 	add_suppressed_comms(oargs);
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -544,7 +544,7 @@ void sinsp::open_common(scap_open_args* oargs)
 		oargs->proc_callback_context = this;
 	}
 	oargs->import_users = m_usergroup_manager.m_import_users;
-	// We need to subscribe to container manager notifiers beore
+	// We need to subscribe to container manager notifiers before
 	// scap starts scanning proc.
 	m_usergroup_manager.init();
 

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -127,7 +127,7 @@ sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp *inspector) :
 #endif
 }
 
-void sinsp_usergroup_manager::init()
+void sinsp_usergroup_manager::subscribe_container_mgr()
 {
 	if (m_import_users)
 	{

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -139,6 +139,11 @@ void sinsp_usergroup_manager::init()
 		m_inspector->m_container_manager.subscribe_on_new_container([&](const sinsp_container_info&cinfo, sinsp_threadinfo *tinfo) -> void {
 		        load_from_container(cinfo.m_id, cinfo.m_overlayfs_root);
 	       });
+
+		for (auto &c : *m_inspector->m_container_manager.get_containers())
+		{
+			load_from_container(c.second->m_id, c.second->m_overlayfs_root);
+		}
 	}
 }
 
@@ -231,6 +236,10 @@ bool sinsp_usergroup_manager::clear_host_users_groups()
 
 scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify)
 {
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"adding user: container: %s, name: %s",
+			container_id.c_str(), name);
+
 	if (!m_import_users)
 	{
 		return nullptr;
@@ -310,6 +319,9 @@ bool sinsp_usergroup_manager::rm_user(const string &container_id, uint32_t uid, 
 
 scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, uint32_t gid, const char *name, bool notify)
 {
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"adding group: container: %s, name: %s",
+			container_id.c_str(), name);
 	if (!m_import_users)
 	{
 		return nullptr;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -298,6 +298,9 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 
 bool sinsp_usergroup_manager::rm_user(const string &container_id, uint32_t uid, bool notify)
 {
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"removing user: container: %s, uid: %d",
+			container_id.c_str(), uid);
 	bool res = false;
 	scap_userinfo *usr = get_user(container_id, uid);
 	if (usr)
@@ -364,6 +367,9 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 
 bool sinsp_usergroup_manager::rm_group(const string &container_id, uint32_t gid, bool notify)
 {
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"removing group: container: %s, gid: %d",
+			container_id.c_str(), gid);
 	bool res = false;
 	scap_groupinfo *gr = get_group(container_id, gid);
 	if (gr)

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -139,11 +139,6 @@ void sinsp_usergroup_manager::init()
 		m_inspector->m_container_manager.subscribe_on_new_container([&](const sinsp_container_info&cinfo, sinsp_threadinfo *tinfo) -> void {
 		        load_from_container(cinfo.m_id, cinfo.m_overlayfs_root);
 	       });
-
-		for (auto &c : *m_inspector->m_container_manager.get_containers())
-		{
-			load_from_container(c.second->m_id, c.second->m_overlayfs_root);
-		}
 	}
 }
 

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -61,9 +61,9 @@ class sinsp_usergroup_manager
 public:
 	explicit sinsp_usergroup_manager(sinsp* inspector);
 
-	// Do not call init() in capture mode, because
+	// Do not call subscribe_container_mgr() in capture mode, because
 	// events shall not be sent as they will be loaded from capture file.
-	void init();
+	void subscribe_container_mgr();
 
 	void dump_users_groups(scap_dumper_t* dumper);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR allows us to properly load users and groups from pre-existing containers on init 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): properly load users and groups from pre-existing containers on init
```
