### PR TITLE
fix(libsinsp): display invalid pids as <NA>

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2142,6 +2142,14 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 	return NULL;
 }
 
+// Some syscall sources, such as the gVisor integration, cannot match events to host PIDs and TIDs.
+// The event will retain the PID field which is consistent with the rest of sinsp logic, but it won't represent
+// a real PID and so it should not be displayed to the user.
+inline bool should_extract_xid(int64_t xid)
+{
+	return xid >= -1 && xid <= UINT32_MAX;
+}
+
 uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
@@ -2158,9 +2166,17 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	switch(m_field_id)
 	{
 	case TYPE_TID:
-		m_u64val = evt->get_tid();
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_s64val = evt->get_tid();
+		if (!should_extract_xid(m_s64val))
+		{
+			return NULL;
+		}
+		RETURN_EXTRACT_VAR(m_s64val);
 	case TYPE_PID:
+		if (!should_extract_xid(tinfo->m_pid))
+		{
+			return NULL;
+		}
 		RETURN_EXTRACT_VAR(tinfo->m_pid);
 	case TYPE_SID:
 		RETURN_EXTRACT_VAR(tinfo->m_sid);
@@ -2341,6 +2357,10 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	case TYPE_PPID:
 		if(tinfo->is_main_thread())
 		{
+			if (!should_extract_xid(tinfo->m_ptid))
+			{
+				return NULL;
+			}
 			RETURN_EXTRACT_VAR(tinfo->m_ptid);
 		}
 		else
@@ -2349,6 +2369,10 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 
 			if(mt != NULL)
 			{
+				if (!should_extract_xid(mt->m_ptid))
+				{
+					return NULL;
+				}
 				RETURN_EXTRACT_VAR(mt->m_ptid);
 			}
 			else
@@ -2416,7 +2440,11 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 					return NULL;
 				}
 			}
-
+			
+			if (!should_extract_xid(mt->m_pid))
+			{
+				return NULL;
+			}
 			RETURN_EXTRACT_VAR(mt->m_pid);
 		}
 	case TYPE_ANAME:

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -624,3 +624,52 @@ TEST_F(sinsp_with_test_input, setuid_setgid)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_X, 1, (int64_t) -1);
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "600");
 }
+
+// Falco libs allow pid over 32bit, those are used to hold extra values in the high bits.
+// For example, this is used in gVisor to save the sandbox ID.
+// These PIDs are not meaningful to the user and should not be displayed
+TEST_F(sinsp_with_test_input, pid_over_32bit)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+
+	uint64_t parent_pid = 1, parent_tid = 1;
+	uint64_t child_pid = 0x0000000100000010, child_tid = 0x0000000100000010;
+	uint64_t child_vpid = 2, child_vtid = 2;
+	uint64_t child2_pid = 0x0000000100000100, child2_tid = 0x0000000100000100;
+	uint64_t child2_vpid = 3, child2_vtid = 3;
+	scap_const_sized_buffer empty_bytebuf = {.buf = nullptr, .size = 0};
+
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
+	std::vector<std::string> cgroups = {"cpuset=/", "cpu=/user.slice", "cpuacct=/user.slice", "io=/user.slice", "memory=/user.slice/user-1000.slice/session-1.scope", "devices=/user.slice", "freezer=/", "net_cls=/", "perf_event=/", "net_prio=/", "hugetlb=/", "pids=/user.slice/user-1000.slice/session-1.scope", "rdma=/", "misc=/"};
+	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	std::vector<std::string> env = {"SHELL=/bin/bash", "PWD=/home/user", "HOME=/home/user"};
+	std::string envv = test_utils::to_null_delimited(env);
+	std::vector<std::string> args = {"--help"};
+	std::string argsv = test_utils::to_null_delimited(args);
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", 1024, 0, 68633, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", 1024, 0, 1, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
+	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
+
+	ASSERT_FALSE(field_exists(evt, "proc.pid"));
+	ASSERT_FALSE(field_exists(evt, "thread.tid"));
+	ASSERT_EQ(get_field_as_string(evt, "proc.vpid"), "2");
+	ASSERT_EQ(get_field_as_string(evt, "thread.vtid"), "2");
+
+	// spawn a child process to verify ppid/apid
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_E, 0);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, child2_tid, "/bin/test-exe", empty_bytebuf, child_pid, child_tid, child_tid, "", 1024, 0, 68633, 12088, 7208, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
+	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "/bin/test-exe", empty_bytebuf, child2_pid, child2_tid, child_tid, "", 1024, 0, 1, 12088, 3764, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child2_vpid, child2_vtid);
+	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe2");
+	evt = add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe2", scap_const_sized_buffer{argsv.data(), argsv.size()}, child2_tid, child2_pid, child_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe2", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, child_pid, 1000, 1);
+
+	ASSERT_FALSE(field_exists(evt, "proc.pid"));
+	ASSERT_FALSE(field_exists(evt, "thread.tid"));
+	ASSERT_FALSE(field_exists(evt, "proc.ppid"));
+	ASSERT_FALSE(field_exists(evt, "proc.apid[1]"));
+	ASSERT_EQ(get_field_as_string(evt, "proc.vpid"), "3");
+	ASSERT_EQ(get_field_as_string(evt, "thread.vtid"), "3");
+}

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -244,6 +244,14 @@ protected:
 		return ret;
 	}
 
+	bool field_exists(sinsp_evt *evt, const std::string& field_name)
+	{
+		std::unique_ptr<sinsp_filter_check> chk(g_filterlist.new_filter_check_from_fldname(field_name, &m_inspector, false));
+		chk->parse_field_name(field_name.c_str(), true, false);
+		std::vector<extract_value_t> values;
+		return chk->extract(evt, values);
+	}
+
 	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name)
 	{
 		std::unique_ptr<sinsp_filter_check> chk(g_filterlist.new_filter_check_from_fldname(field_name, &m_inspector, false));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Sometimes PIDs do not necessarily indicate host PIDs. This is true if we're monitoring sandboxes which do not map to a real kernel, such as gVisor. In order to maintain internal state consinstency sinsp will hold a PID that is larger than an actual one for those processes which acts as a unique identifier. However, those are not meant to be consumed by users.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): display invalid PIDs as <NA>
```
