### PR TITLE
fix(modern_bpf): add some CO-RE relocations

### DIFF
--- a/driver/modern_bpf/helpers/base/read_from_task.h
+++ b/driver/modern_bpf/helpers/base/read_from_task.h
@@ -15,7 +15,7 @@
  */
 static __always_inline struct task_struct *get_current_task()
 {
-	if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf))
+	if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf)
 	{
 		return (struct task_struct *)bpf_get_current_task_btf();
 	}
@@ -33,7 +33,7 @@ static __always_inline struct task_struct *get_current_task()
 #define READ_TASK_FIELD(src, a, ...)                                                            \
 	({                                                                                      \
 		___type((src), a, ##__VA_ARGS__) __r;                                           \
-		if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf)) \
+		if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf) \
 		{                                                                               \
 			__r = ___arrow((src), a, ##__VA_ARGS__);                                \
 		}                                                                               \
@@ -65,7 +65,7 @@ static __always_inline struct task_struct *get_current_task()
  */
 #define READ_TASK_FIELD_INTO(dst, src, a, ...)                                                  \
 	({                                                                                      \
-		if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf)) \
+		if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf) \
 		{                                                                               \
 			*dst = ___arrow((src), a, ##__VA_ARGS__);                               \
 		}                                                                               \

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -1279,10 +1279,25 @@ static __always_inline u16 store_cgroup_subsys(struct auxiliary_map *auxmap, str
 static __always_inline void auxmap__store_cgroups_param(struct auxiliary_map *auxmap, struct task_struct *task)
 {
 	uint16_t total_croups_len = 0;
-	total_croups_len += store_cgroup_subsys(auxmap, task, cpuset_cgrp_id);
-	total_croups_len += store_cgroup_subsys(auxmap, task, cpu_cgrp_id);
-	total_croups_len += store_cgroup_subsys(auxmap, task, cpuacct_cgrp_id);
-	total_croups_len += store_cgroup_subsys(auxmap, task, io_cgrp_id);
-	total_croups_len += store_cgroup_subsys(auxmap, task, memory_cgrp_id);
+	if(bpf_core_enum_value_exists(enum cgroup_subsys_id, cpuset_cgrp_id))
+	{
+		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, cpuset_cgrp_id));
+	}
+	if(bpf_core_enum_value_exists(enum cgroup_subsys_id, cpu_cgrp_id))
+	{
+		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, cpu_cgrp_id));
+	}
+	if(bpf_core_enum_value_exists(enum cgroup_subsys_id, cpuacct_cgrp_id))
+	{
+		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, cpuacct_cgrp_id));
+	}
+	if(bpf_core_enum_value_exists(enum cgroup_subsys_id, io_cgrp_id))
+	{
+		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, io_cgrp_id));
+	}
+	if(bpf_core_enum_value_exists(enum cgroup_subsys_id, memory_cgrp_id))
+	{
+		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, memory_cgrp_id));
+	}
 	push__param_len(auxmap->data, &auxmap->lengths_pos, total_croups_len);
 }


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

enum `cgroup_subsys_id`, defined in [include/linux/cgroup-defs.h](https://github.com/torvalds/linux/blob/87066fdd2e30fe9dd531125d95257c118a74617e/include/linux/cgroup-defs.h#L43-L47), can differ depending on which cgroup features are enabled during kernel compilation (see [include/linux/cgroup_subsys.h](https://github.com/torvalds/linux/blob/87066fdd2e30fe9dd531125d95257c118a74617e/include/linux/cgroup_subsys.h) for details). So, to know the actual integer value of the `cgroup_subsys_id::...` we need the CO-RE helper macros `bpf_core_enum_value()` and `bpf_core_enum_value_exists`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
