### PR TITLE
fix(libsinsp, libscap): fix compiler warning about uninitialized var

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -321,7 +321,7 @@ static int32_t load_elf_maps_section(struct bpf_engine *handle, struct bpf_map_d
 				     int maps_shndx, Elf *elf, Elf_Data *symbols,
 				     int strtabidx, int *nr_maps)
 {
-	Elf_Data *data_maps;
+	Elf_Data *data_maps = NULL;
 	GElf_Sym *sym;
 	Elf_Scn *scn;
 	int i;

--- a/userspace/libsinsp/tracers.cpp
+++ b/userspace/libsinsp/tracers.cpp
@@ -549,7 +549,7 @@ inline void sinsp_tracerparser::delete_char(char* p)
 inline void sinsp_tracerparser::parse_simple(char* evtstr)
 {
 	char* p = evtstr;
-	uint32_t delta;
+	uint32_t delta = 0;
 
 	//
 	// Extract the type


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp
/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix warnings if you compile with `-DBUILD_WARNINGS_AS_ERRORS`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
