### PR TITLE
chore(ci): add a driverkit job in CI to test drivers build against multiple kernelreleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,40 @@ jobs:
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DBUILD_LIBSCAP_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
             make scap-open
             make bpf_test
+  
+  # paths-filter:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     driver_changed: ${{ steps.filter.outputs.driver }}
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: dorny/paths-filter@v2
+  #     id: filter
+  #     with:
+  #       filters: |
+  #         driver:
+  #           - 'driver/**'
+            
+  build-libs-driverkit:
+    name: build-libs-driverkit
+    runs-on: ubuntu-latest
+    # needs: paths-filter
+    container:
+      image: falcosecurity/driverkit:master
+    # if: needs.paths-filter.outputs.driver_changed == 'true'  
+    steps:
+      - name: Test driver build on linux 2.6.32 
+        run: |
+          driverkit docker --kernelrelease 2.6.32-754.el6.x86_64 --target centos --output-module /tmp/libs.ko --driverversion $GITHUB_SHA --loglevel debug
+          
+      - name: Test driver build on linux 3.x
+        run: |
+          driverkit docker --kernelrelease 3.10.0-957.el7.x86_64 --target centos --output-module /tmp/libs.ko --driverversion $GITHUB_SHA --loglevel debug
+    
+      - name: Test driver build on linux 4.x
+        run: |
+          driverkit docker --kernelrelease 4.18.0-373.el8.x86_64 --target centos --output-module /tmp/libs.ko --output-probe=/tmp/libs.o --driverversion $GITHUB_SHA --loglevel debug
+     
+      - name: Test driver build on linux 5.x
+        run: |
+          driverkit docker --kernelrelease 5.19.12-arch1-1 --target arch --output-module /tmp/libs.ko --output-probe=/tmp/libs.o --driverversion $GITHUB_SHA --loglevel debug  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: paths-filter
     container:
-      image: falcosecurity/driverkit:master
+      image: falcosecurity/driverkit:v0.10.0
     if: needs.paths-filter.outputs.driver_changed == 'true'
     steps:
       - name: Test driver build on linux 2.6.32 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      driver_changed: ${{ steps.filter.outputs.driver }}
+      libscap_changed: ${{ steps.filter.outputs.libscap }}
+      libsinsp_changed: ${{ steps.filter.outputs.libsinsp }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          driver:
+            - 'driver/**'
+          libscap:
+            - 'userspace/libscap/**'
+          libsinsp:
+            - 'userspace/libsinsp/**'
+
   build-libs-linux-amd64:
     name: build-libs-linux-amd64 😁
     strategy:
@@ -142,6 +161,8 @@ jobs:
   build-and-test-modern-bpf-x86:
     name: build-and-test-modern-bpf-x86 😇 (bundled_deps)
     runs-on: ubuntu-22.04
+    needs: paths-filter
+    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️
@@ -178,6 +199,8 @@ jobs:
   build-modern-bpf-arm64:
     name: build-modern-bpf-arm64 🙃 (system_deps)
     runs-on: ubuntu-22.04
+    needs: paths-filter
+    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️
@@ -207,6 +230,8 @@ jobs:
   build-modern-bpf-s390x:
     name: build-modern-bpf-s390x 😁 (system_deps)
     runs-on: ubuntu-22.04
+    needs: paths-filter
+    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️
@@ -232,19 +257,6 @@ jobs:
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DBUILD_LIBSCAP_MODERN_BPF=ON -DBUILD_MODERN_BPF_TEST=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
             make scap-open
             make bpf_test
-  
-  paths-filter:
-    runs-on: ubuntu-latest
-    outputs:
-      driver_changed: ${{ steps.filter.outputs.driver }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        filters: |
-          driver:
-            - 'driver/**'
             
   build-libs-driverkit:
     name: build-libs-driverkit
@@ -252,7 +264,7 @@ jobs:
     needs: paths-filter
     container:
       image: falcosecurity/driverkit:master
-    if: needs.paths-filter.outputs.driver_changed == 'true'  
+    if: needs.paths-filter.outputs.driver_changed == 'true'
     steps:
       - name: Test driver build on linux 2.6.32 
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: paths-filter
     container:
-      image: falcosecurity/driverkit:v0.10.0
+      image: falcosecurity/driverkit:v0.10.1
     if: needs.paths-filter.outputs.driver_changed == 'true'
     steps:
       - name: Test driver build on linux 2.6.32 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
     
       - name: Test driver build on linux 4.x
         run: |
-          driverkit docker --kernelrelease 4.18.0-373.el8.x86_64 --target centos --output-module /tmp/libs.ko --output-probe=/tmp/libs.o --driverversion $GITHUB_SHA --loglevel debug
+          driverkit docker --kernelrelease 4.18.0-305.25.1.el8_4.x86_64 --target centos --output-module /tmp/libs.ko --output-probe=/tmp/libs.o --driverversion $GITHUB_SHA --loglevel debug
      
       - name: Test driver build on linux 5.x
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI Build
 on:
   pull_request:
   push:
+    branches:
+      - master
+      - 'release/**'
   workflow_dispatch:
 
 jobs:
@@ -162,7 +165,7 @@ jobs:
     name: build-and-test-modern-bpf-x86 😇 (bundled_deps)
     runs-on: ubuntu-22.04
     needs: paths-filter
-    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
+    if: needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️
@@ -200,7 +203,7 @@ jobs:
     name: build-modern-bpf-arm64 🙃 (system_deps)
     runs-on: ubuntu-22.04
     needs: paths-filter
-    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
+    if: needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️
@@ -231,7 +234,7 @@ jobs:
     name: build-modern-bpf-s390x 😁 (system_deps)
     runs-on: ubuntu-22.04
     needs: paths-filter
-    if: needs.paths-filter.outputs.driver_changed == 'true' && needs.paths-filter.outputs.libscap_changed == 'true'
+    if: needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'
     steps:
 
       - name: Checkout Libs ⤵️

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,26 +233,26 @@ jobs:
             make scap-open
             make bpf_test
   
-  # paths-filter:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     driver_changed: ${{ steps.filter.outputs.driver }}
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: dorny/paths-filter@v2
-  #     id: filter
-  #     with:
-  #       filters: |
-  #         driver:
-  #           - 'driver/**'
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      driver_changed: ${{ steps.filter.outputs.driver }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          driver:
+            - 'driver/**'
             
   build-libs-driverkit:
     name: build-libs-driverkit
     runs-on: ubuntu-latest
-    # needs: paths-filter
+    needs: paths-filter
     container:
       image: falcosecurity/driverkit:master
-    # if: needs.paths-filter.outputs.driver_changed == 'true'  
+    if: needs.paths-filter.outputs.driver_changed == 'true'  
     steps:
       - name: Test driver build on linux 2.6.32 
         run: |


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

no.

**What this PR does / why we need it**:

Adds a new github action to test the build of kmod and eBPF probe against multiple kernel releases, leveraging driverkit docker image.

TODO: 

- [x] Switch to a driverkit tag once driverkit 0.10.0 is released
- [ ] Upload CentOS kernel headers to https://download.falco.org/?prefix=fixtures/ and add a `--kernelurls` option to the builds (i've collected the headers, we just need an admin that can push them on downloads.falco.org :) )
- [x] Add the path filter to only run the ci when driver/ folder is changed
- [x] Add the path filter also for modernbpf probe jobs (driver/** and userspace/libscap/**)
- [ ] Once this PR is merged, open a PR on test-infra to mark the new job as required 
- [x] rebase on top of libs master to fix ci
- [x] Only trigger on pushes against master or release branches

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
