### PR TITLE
fix(userspace/libsinsp): set event number consistently

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -415,6 +415,7 @@ private:
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_poriginal_evt = NULL;
+		m_evtnum = 0;
 	}
 	inline void init()
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1308,11 +1308,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		get_procs_cpu_from_driver(ts);
 	}
 
-	//
-	// Store a couple of values that we'll need later inside the event.
-	//
-	m_nevts++;
-	evt->m_evtnum = m_nevts;
+	// this is used by things like the k8s and mesos clients
 	m_lastevent_ts = ts;
 
 	if (m_automatic_threadtable_purging)
@@ -1459,6 +1455,10 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 #else
 	m_parser->process_event(evt);
 #endif
+
+	// set the event number
+	m_nevts++;
+	evt->m_evtnum = m_nevts;
 
 	//
 	// If needed, dump the event to file


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This fixes a regression that prevented evt numbers to be properly set. This commit caused the issue: https://github.com/falcosecurity/libs/commit/2c68faef0c42ad37c841c31a9f89efaee0d0c0e5

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
