### PR TITLE
new(libsinsp,libscap): add a new generable event API

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1246,6 +1246,23 @@ int scap_get_events_from_ppm_sc(IN uint32_t ppm_sc_array[PPM_SC_MAX], OUT uint32
 	return SCAP_SUCCESS;
 }
 
+bool scap_is_generable_event(uint16_t event_type)
+{
+	ASSERT(event_type < PPM_EVENT_MAX);
+
+#ifdef __linux__
+	for(int syscall_nr = 0; syscall_nr < SYSCALL_TABLE_SIZE; syscall_nr++)
+	{
+		struct syscall_evt_pair pair = g_syscall_table[syscall_nr];
+		if(pair.enter_event_type == event_type || pair.exit_event_type == event_type)
+		{
+			return true;
+		}
+	}
+#endif
+	return false;
+}
+
 int scap_get_modifies_state_tracepoints(OUT uint32_t tp_array[TP_VAL_MAX])
 {
 	if(tp_array == NULL)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -849,6 +849,11 @@ int scap_get_modifies_state_ppm_sc(OUT uint32_t ppm_sc_array[PPM_SC_MAX]);
 int scap_get_events_from_ppm_sc(IN uint32_t ppm_sc_array[PPM_SC_MAX], OUT uint32_t events_array[PPM_EVENT_MAX]);
 
 /*!
+  \brief Return true if the event is generable by the live system instrumentation.
+*/
+bool scap_is_generable_event(uint16_t event_type);
+
+/*!
   \brief Returns the set of minimum tracepoints required by `libsinsp` state.
 */
 int scap_get_modifies_state_tracepoints(OUT uint32_t tp_array[TP_VAL_MAX]);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -963,11 +963,12 @@ public:
 	 * - `EF_SKIPPARSERESET`
 	 * - `EF_UNUSED`
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has at least one of these flags.
 	 */
 	static inline bool is_unused_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_flags flags = g_infotables.m_event_info[event_type].flags;
 		return (flags & (EF_SKIPPARSERESET | EF_UNUSED));
 	}
@@ -975,11 +976,12 @@ public:
 	/**
 	 * @brief Return true if the event has the `EF_OLD_VERSION` flag
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EF_OLD_VERSION` flag.
 	 */
 	static inline bool is_old_version_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_flags flags = g_infotables.m_event_info[event_type].flags;
 		return (flags & EF_OLD_VERSION);
 	}
@@ -987,11 +989,12 @@ public:
 	/**
 	 * @brief Return true if the event belongs to the `EC_SYSCALL` category
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EC_SYSCALL` category.
 	 */
 	static inline bool is_syscall_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_category category = g_infotables.m_event_info[event_type].category;
 		return (category & EC_SYSCALL);
 	}
@@ -999,11 +1002,12 @@ public:
 	/**
 	 * @brief Return true if the event belongs to the `EC_TRACEPOINT` category
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EC_TRACEPOINT` category.
 	 */
 	static inline bool is_tracepoint_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_category category = g_infotables.m_event_info[event_type].category;
 		return (category & EC_TRACEPOINT);
 	}
@@ -1011,11 +1015,12 @@ public:
 	/**
 	 * @brief Return true if the event belongs to the `EC_METAEVENT` category
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EC_METAEVENT` category.
 	 */
 	static inline bool is_metaevent(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_category category = g_infotables.m_event_info[event_type].category;
 		return (category & EC_METAEVENT);
 	}
@@ -1023,11 +1028,12 @@ public:
 	/**
 	 * @brief Return true if the event belongs to the `EC_UNKNOWN` category
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EC_UNKNOWN` category.
 	 */
 	static inline bool is_unknown_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_category category = g_infotables.m_event_info[event_type].category;
 		/* Please note this is not an `&` but an `==` if one event has 
 		 * the `EC_UNKNOWN` category, it must have only this category!
@@ -1038,13 +1044,26 @@ public:
 	/**
 	 * @brief Return true if the event belongs to the `EC_PLUGIN` category
 	 * 
-	 * @param event_type type of event we want to check
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
 	 * @return true if the event type has the `EC_PLUGIN` category.
 	 */
 	static inline bool is_plugin_event(uint16_t event_type)
 	{
+		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_category category = g_infotables.m_event_info[event_type].category;
 		return (category & EC_PLUGIN);
+	}
+
+	/**
+	 * @brief Return true if the event is generable by the live system instrumentation.
+	 * 
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
+	 * @return true if the event is generable by the live system.
+	 */
+	static inline bool is_generable_event(uint16_t event_type)
+	{
+		ASSERT(event_type < PPM_EVENT_MAX);
+		return scap_is_generable_event(event_type);
 	}
 
 	/*=============================== Events related ===============================*/


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR adds a new sinsp API to get if the event is generated by the system during live capture.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
