### PR TITLE
fix(driver): avoid kmod buffer corruption in case of `len>max_arg_size`

### DIFF
--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -168,6 +168,7 @@ unsigned long ppm_copy_from_user(void *to, const void __user *from, unsigned lon
  * 2. the terminator is found. (the `\0` is computed in the overall length)
  * 3. we have read `n` bytes. (in this case, we don't have the `\0` but it's ok we will add it in the caller)
  */
+/// TODO: we need to change the return value to `int` and the third param from `unsigned long n` to 'uint32_t n`
 long ppm_strncpy_from_user(char *to, const char __user *from, unsigned long n)
 {
 	long string_length = 0;
@@ -730,6 +731,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 			}
 			else
 			{
+				/* WARNING: `strlcpy` could return a `len` greater than `max_arg_size` */
 				len = (int)strlcpy(args->buffer + args->arg_data_offset,
 								(const char *)(syscall_arg_t)val,
 								max_arg_size);
@@ -738,6 +740,11 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 			/* Make sure the string is null-terminated */
 			if (likely(len > 0))
 			{
+				if(len > max_arg_size)
+				{
+					len = max_arg_size;
+				}
+
 				if(*(char *)(args->buffer + args->arg_data_offset + (len-1)) != '\0')
 				{
 					/* If we have not reached the `max_arg_size` we can put a new char with

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -719,66 +719,65 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 	case PT_CHARBUF:
 	case PT_FSPATH:
 	case PT_FSRELPATH:
-		if (likely(val != 0)) {
-#ifdef WDIG // strlcpy does not exist on Windows, where in any case we only have 
-			 // userlevel capture, so we default to ppm_strncpy_from_user
-			fromuser = true;
-#endif
-			if(fromuser)
-			{
-				len = ppm_strncpy_from_user(args->buffer + args->arg_data_offset,
-					(const char __user *)(syscall_arg_t)val, max_arg_size);
-
-				if(unlikely(len < 0))
-				{
-					len = 0;
-					break;
-				}
-				/* Two possible cases here:
-				 *
-				 * 1. `len < max_arg_size`, the terminator is always there, and `len` takes it into account,
-				 *    so we need to do nothing. We just push a `\0` to an empty byte to avoid an if
-				 *    case.
-				 *
-				 * 2. `len == max_arg_size`, the terminator is not there but we cannot push an additional
-				 *    char for this reason we overwrite the last char and we don't increment `len`.
-				 */
-				*(char *)(args->buffer + args->arg_data_offset + max_arg_size - 1) = '\0';
-			}
-			else
-			{
-				len = (int)strlcpy(args->buffer + args->arg_data_offset,
-								(const char *)(syscall_arg_t)val,
-								max_arg_size);
-				/* WARNING: `strlcpy` returns the length of the string it tries to create
-				 * so `len` could also be greater than `max_arg_size`, but please note that the copied
-				 * charbuf is at max `max_arg_size` (where the last byte is used for the `\0`).
-				 * The copied string is always `\0` terminated but the returned `len` doesn't
-				 * take into consideration the `\0` like `strlen()` function.
-				 *
-				 * Two possible cases here:
-				 *
-				 * 1. `len < max_arg_size`, the terminator is always there, but `len` doesn't take it into account,
-				 *    so we need to increment the `len`. Note that if the source string has exactly `max_arg_size`
-				 *    characters the returned `len` is `max_arg_size-1` so we need to do `len++` to obtain the copied size.
-				 *
-				 * 2. `len >= max_arg_size`, the source string is greater than `max_arg_size`. `strlcpy` copied
-				 *    `max_arg_size - 1` and added the `\0` at the end, so our final copied `len` is `max_arg_size` we have just
-				 *    to resize it and we have done.
-				 */
-				if(++len >= max_arg_size)
-				{
-					len = max_arg_size;
-				}
-			}
+		if(unlikely(val == 0))
+		{
+			/* Send an empty param when we have a null pointer `val==0` */
+			len = 0;
 			break;
 		}
-		/* Send an empty param in all these cases:
-		 * - we have a null pointer `val==0`.
-		 * - we have read `0` bytes.
-		 * - we faced an error while reading.
-		 */
-		len = 0;
+
+#ifdef WDIG // strlcpy does not exist on Windows, where in any case we only have 
+			// userlevel capture, so we default to ppm_strncpy_from_user
+		fromuser = true;
+#endif
+
+		if(fromuser)
+		{
+			len = ppm_strncpy_from_user(args->buffer + args->arg_data_offset,
+				(const char __user *)(syscall_arg_t)val, max_arg_size);
+
+			if(unlikely(len < 0))
+			{
+				len = 0;
+				break;
+			}
+			/* Two possible cases here:
+			 *
+			 * 1. `len < max_arg_size`, the terminator is always there, and `len` takes it into account,
+			 *    so we need to do nothing. We just push a `\0` to an empty byte to avoid an if
+			 *    case.
+			 *
+			 * 2. `len == max_arg_size`, the terminator is not there but we cannot push an additional
+			 *    char for this reason we overwrite the last char and we don't increment `len`.
+			 */
+			*(char *)(args->buffer + args->arg_data_offset + max_arg_size - 1) = '\0';
+		}
+		else
+		{
+			len = (int)strlcpy(args->buffer + args->arg_data_offset,
+							(const char *)(syscall_arg_t)val,
+							max_arg_size);
+			/* WARNING: `strlcpy` returns the length of the string it tries to create
+			 * so `len` could also be greater than `max_arg_size`, but please note that the copied
+			 * charbuf is at max `max_arg_size` (where the last byte is used for the `\0`).
+			 * The copied string is always `\0` terminated but the returned `len` doesn't
+			 * take into consideration the `\0` like `strlen()` function.
+			 *
+			 * Two possible cases here:
+			 *
+			 * 1. `len < max_arg_size`, the terminator is always there, but `len` doesn't take it into account,
+			 *    so we need to increment the `len`. Note that if the source string has exactly `max_arg_size`
+			 *    characters the returned `len` is `max_arg_size-1` so we need to do `len++` to obtain the copied size.
+			 *
+			 * 2. `len >= max_arg_size`, the source string is greater than `max_arg_size`. `strlcpy` copied
+			 *    `max_arg_size - 1` and added the `\0` at the end, so our final copied `len` is `max_arg_size` we have just
+			 *    to resize it and we have done.
+			 */
+			if(++len >= max_arg_size)
+			{
+				len = max_arg_size;
+			}
+		}
 		break;
 
 	case PT_BYTEBUF:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR fixes a bug introduced here: https://github.com/falcosecurity/libs/pull/574
In that commit we relied on the fact that `strlcpy` could return at max `max_arg_size` but this is not the truth, so this fix adds a check to ensure `len<=max_arg_size`.
Without this check bad things could happen, if `len>max_arg_size` we could cause buffer corruption when we do `args->arg_data_size -= len;` here :point_down: 
https://github.com/falcosecurity/libs/blob/b4e9f97a3a30eabd45d737274a101070141d5512/driver/ppm_events.c#L1002

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
