### PR TITLE
fix(userspace): split is_unused from is_skip_parse_reset event checks

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -245,7 +245,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_EXECVE_16_E */{"execve", EC_PROCESS | EC_SYSCALL, EF_MODIFIES_STATE | EF_OLD_VERSION, 0},
 	/* PPME_SYSCALL_EXECVE_16_X */{"execve", EC_PROCESS | EC_SYSCALL, EF_MODIFIES_STATE | EF_OLD_VERSION, 16, {{"res", PT_ERRNO, PF_DEC}, {"exe", PT_CHARBUF, PF_NA}, {"args", PT_BYTEBUF, PF_NA}, {"tid", PT_PID, PF_DEC}, {"pid", PT_PID, PF_DEC}, {"ptid", PT_PID, PF_DEC}, {"cwd", PT_CHARBUF, PF_NA}, {"fdlimit", PT_UINT64, PF_DEC}, {"pgft_maj", PT_UINT64, PF_DEC}, {"pgft_min", PT_UINT64, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC}, {"comm", PT_CHARBUF, PF_NA}, {"cgroups", PT_BYTEBUF, PF_NA}, {"env", PT_BYTEBUF, PF_NA} } },
 	/* PPME_SIGNALDELIVER_E */ {"signaldeliver", EC_SIGNAL | EC_TRACEPOINT, EF_NONE, 3, {{"spid", PT_PID, PF_DEC}, {"dpid", PT_PID, PF_DEC}, {"sig", PT_SIGTYPE, PF_DEC} } },
-	/* PPME_SIGNALDELIVER_X */ {"signaldeliver", EC_SIGNAL | EC_TRACEPOINT, EF_UNUSED, 0 },
+	/* PPME_SIGNALDELIVER_X */ {"signaldeliver", EC_UNKNOWN, EF_UNUSED, 0 },
 	/* PPME_PROCINFO_E */{"procinfo", EC_INTERNAL | EC_METAEVENT, EF_SKIPPARSERESET, 2, {{"cpu_usr", PT_UINT64, PF_DEC}, {"cpu_sys", PT_UINT64, PF_DEC} } },
 	/* PPME_PROCINFO_X */{"NA2", EC_UNKNOWN, EF_UNUSED, 0},
 	/* PPME_SYSCALL_GETDENTS_E */{"getdents", EC_FILE | EC_SYSCALL, EF_USES_FD, 1, {{"fd", PT_FD, PF_NA} } },

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -960,7 +960,6 @@ public:
 
 	/**
 	 * @brief If the event type has one of the following flags return true:
-	 * - `EF_SKIPPARSERESET`
 	 * - `EF_UNUSED`
 	 * 
 	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
@@ -970,7 +969,21 @@ public:
 	{
 		ASSERT(event_type < PPM_EVENT_MAX);
 		enum ppm_event_flags flags = g_infotables.m_event_info[event_type].flags;
-		return (flags & (EF_SKIPPARSERESET | EF_UNUSED));
+		return (flags & EF_UNUSED);
+	}
+
+	/**
+	 * @brief If the event type has one of the following flags return true:
+	 * - `EF_SKIPPARSERESET`
+	 * 
+	 * @param event_type type of event we want to check (must be less than `PPM_EVENT_MAX`)
+	 * @return true if the event type has at least one of these flags.
+	 */
+	static inline bool is_skip_parse_reset_event(uint16_t event_type)
+	{
+		ASSERT(event_type < PPM_EVENT_MAX);
+		enum ppm_event_flags flags = g_infotables.m_event_info[event_type].flags;
+		return (flags & EF_SKIPPARSERESET);
 	}
 
 	/**

--- a/userspace/libsinsp/test/public_sinsp_API/event_related.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/event_related.cpp
@@ -10,9 +10,6 @@ TEST(events, check_unused_events)
 	/* `PPME_SCHEDSWITCH_6_X` has the `EF_UNUSED` flag */
 	ASSERT_EQ(sinsp::is_unused_event(PPME_SCHEDSWITCH_6_X), true);
 
-	/* `PPME_DROP_E` has the `EF_SKIPPARSERESET` flag */
-	ASSERT_EQ(sinsp::is_unused_event(PPME_DROP_E), true);
-
 	/* `PPME_SYSCALL_QUOTACTL_E` has no flags in this set */
 	ASSERT_EQ(sinsp::is_unused_event(PPME_SYSCALL_QUOTACTL_E), false);
 }

--- a/userspace/libsinsp/test/sinsp.ut.cpp
+++ b/userspace/libsinsp/test/sinsp.ut.cpp
@@ -607,11 +607,6 @@ TEST_F(sinsp_with_test_input, check_event_category)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_NOTIFICATION_E, 2, 0, "data");
 	ASSERT_EQ(evt->get_category(), EC_OTHER);
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "other");
-
-	/* Check that `EC_UNKNOWN` category is not considered */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_NOTIFICATION_X, 0);
-	ASSERT_EQ(evt->get_category(), EC_UNKNOWN);
-	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "unknown");
 }
 
 // test user tracking with setuid

--- a/userspace/libsinsp/test/table/event_table.cpp
+++ b/userspace/libsinsp/test/table/event_table.cpp
@@ -3,10 +3,10 @@
 
 /* These numbers must be updated when we add new events */
 #define SYSCALL_EVENTS_NUM 328
-#define TRACEPOINT_EVENTS_NUM 7
+#define TRACEPOINT_EVENTS_NUM 6
 #define METAEVENTS_NUM 19
 #define PLUGIN_EVENTS_NUM 1
-#define UNKNOWN_EVENTS_NUM 19
+#define UNKNOWN_EVENTS_NUM 20
 
 /* Check if the events category is correct in our event table.
  * This test will not pass if we forget to update the event table


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

EF_UNUSED and EF_SKIPPARSERESET have two distinct semantics, and checks for those flags should be split in the two `sinsp::is_unused()` and `sinsp::is_skip_parse_reset()` methods.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
