### PR TITLE
fix(userspace/libsinsp): do proper checks on syscall.type filtercheck

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3921,10 +3921,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		{
 			uint8_t* evname;
 			uint16_t etype = evt->m_pevt->type;
-			enum ppm_event_flags flags = g_infotables.m_event_info[etype].flags;
-
-			if(etype == PPME_SCHEDSWITCH_6_E ||
-				(flags & EC_INTERNAL) || (flags & EF_SKIPPARSERESET))
+			if(!sinsp::is_syscall_event(etype))
 			{
 				return NULL;
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Mentioning the description, the `syscall.type` filtercheck should work as:
```
For system call events, the name of the system call (e.g. 'open').
Unset for other events  (e.g. switch or internal events). 
Use this field instead of evt.type if you need to make sure that
the filtered/printed value is actually a system call. 
```

However, given the recent event flag cleanup, this is not guaranteed to work as expected if not relying on the formal `sinsp::is_syscall_event` API.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
