### PR TITLE
fix(savefile-engine): skip unreferenced FD block

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -1531,12 +1531,6 @@ static int32_t scap_read_fdlist(scap_reader_t* r, uint32_t block_length, uint32_
 		// Identify the process descriptor
 		//
 		HASH_FIND_INT64(proclist->m_proclist, &tid, tinfo);
-		if(tinfo == NULL)
-		{
-			snprintf(error, SCAP_LASTERR_SIZE, "corrupted trace file. FD block references TID %"PRIu64", which doesn't exist.",
-					 tid);
-			return SCAP_FAILURE;
-		}
 	}
 	else
 	{
@@ -1556,6 +1550,14 @@ static int32_t scap_read_fdlist(scap_reader_t* r, uint32_t block_length, uint32_
 		//
 		if(proclist->m_proc_callback == NULL)
 		{
+			if(tinfo == NULL)
+			{
+				//
+				// We have the fdinfo but no associated tid, skip it
+				//
+				continue;
+			}
+
 			//
 			// Parsed successfully. Allocate the new entry and copy the temp one into into it.
 			//


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area libscap-engine-savefile

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
If new threads come between `scap_write_proclist` and `scap_write_fdlist`, we could have fdlist entries without their TID counterpart in the proclist: silently skip them.
It would be nice to have a warning, but there aren't any in scap so I won't risk adding one.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Relates to https://github.com/falcosecurity/libs/pull/473

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```