### PR TITLE
feat(libs): Add new return code for filtered events(3/3)

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1115,7 +1115,7 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 		if(suppressed)
 		{
 			handle->m_num_suppressed_evts++;
-			return SCAP_TIMEOUT;
+			return SCAP_FILTERED_EVENT;
 		}
 		else
 		{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1513,7 +1513,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		if(!(m_isinternal_events_enabled && (cat & EC_INTERNAL)))
 		{
 			*puevt = evt;
-			return SCAP_TIMEOUT;
+			return SCAP_FILTERED_EVENT;
 		}
 	}
 


### PR DESCRIPTION
Ref #490

Now that the return code is in place (step 1) and handled in all the major libsinsp clients (step 2), it's time to actually start returning the code.

There should be no user-visible effect of this change. Rather, by providing additional information to the client, the caller should be able to better react to the behavior of the library. This change only affects clients using userspace filtering / suppression.

Signed-off-by: Nathan Baker <nathan.baker@sysdig.com>

/kind feature
/area libscap
/area libsinsp

```release-note
new(libs): new return code from `scap::next` and `sinsp::next` which must be handled by the caller.
```
