### PR TITLE
chore(libs): move strlcpy definition in libscap module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,18 +71,6 @@ endif()
 
 set(LIBS_PACKAGE_NAME "falcosecurity")
 
-include(CheckSymbolExists)
-check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
-
-if(HAVE_STRLCPY)
-	message(STATUS "Existing strlcpy found, will *not* use local definition")
-else()
-	message(STATUS "No strlcpy found, will use local definition")
-endif()
-
-configure_file(userspace/common/common_config.h.in ${PROJECT_BINARY_DIR}/common/common_config.h)
-include_directories(${PROJECT_BINARY_DIR}/common)
-
 include(CompilerFlags)
 
 option(WITH_CHISEL "Include chisel implementation" OFF)

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -10,6 +10,18 @@ option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system
 
 include(ExternalProject)
 
+include(CheckSymbolExists)
+check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
+
+if(HAVE_STRLCPY)
+	message(STATUS "Existing strlcpy found, will *not* use local definition")
+else()
+	message(STATUS "No strlcpy found, will use local definition")
+endif()
+
+configure_file(${LIBSCAP_DIR}/userspace/common/common_config.h.in ${PROJECT_BINARY_DIR}/common/common_config.h)
+include_directories(${PROJECT_BINARY_DIR}/common)
+
 add_definitions(-DPLATFORM_NAME="${CMAKE_SYSTEM_NAME}")
 
 get_filename_component(DRIVER_CONFIG_DIR ${CMAKE_BINARY_DIR}/driver/src ABSOLUTE)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The HAVE_STRCPY have been moved to a common target in https://github.com/falcosecurity/libs/pull/659, however that currently happens inside CMakeLists, which is not included by all project. This caused projects based on top of libs to fail compilation due to the common_config.h not being generated. This PR fixes this by moving the cmake definitions inside the libscap.cmake module.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
