### PR TITLE
feat: Add new return code for filtered events (4/3)

### DIFF
--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -17,7 +17,8 @@ enum event_return
 {
 	EVENT_RETURN_TIMEOUT,
 	EVENT_RETURN_EOF,
-	EVENT_RETURN_NONE
+	EVENT_RETURN_NONE,
+	EVENT_RETURN_FILTERED
 };
 
 class event_processor

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1279,6 +1279,20 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 				return SCAP_TIMEOUT;
 
 			}
+			else if(res == SCAP_FILTERED_EVENT)
+			{
+				// This will happen if SCAP has filtered the event in userspace (tid suppression).
+				// A valid event was read from the driver, but we are choosing to not report it to
+				// the client at the client's request.
+				// However, we still need to return here so that the client doesn't time out the
+				// request.
+				if(m_external_event_processor)
+				{
+					m_external_event_processor->process_event(NULL, libsinsp::EVENT_RETURN_FILTERED);
+					*puevt = NULL;
+					return res;
+				}
+			}
 			else
 			{
 				m_lasterr = scap_getlasterr(m_h);


### PR DESCRIPTION
Apologies for the improper fraction. I missed some analysis earlier.

/kind feature
/area libsinsp

Signed-off-by: Nathan Baker <nathan.baker@sysdig.com>

```release-note
Clients of libsinsp who are using external event processors will see EVENT_RETURN_FILTERED if using userspace filtering / tid suppression.
```
