### PR TITLE
container users and groups from process root

### DIFF
--- a/test/e2e/containers/sinsp.Dockerfile
+++ b/test/e2e/containers/sinsp.Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:buster
 
+ENV HOST_ROOT /host
+
 RUN apt-get update && \
     apt-get install -y \
     libcurl4 \

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -141,12 +141,12 @@ def validate_event(expected_fields: dict, event: dict) -> bool:
 
         expected = expected_fields[k]
 
-        if isinstance(expected, str) or expected is None:
-            if expected == event[k]:
+        if isinstance(expected, SinspField):
+            if expected.compare(str(event[k])):
                 continue
             return False
 
-        if not expected.compare(str(event[k])):
+        if expected != event[k]:
             return False
 
     return True

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -202,8 +202,10 @@ def container_spec(image: str = 'sinsp-example:latest', args: list = [], env: di
         A dictionary describing how to run the sinsp-example container
     """
     mounts = [
-        docker.types.Mount("/dev", "/dev", type="bind",
-                           consistency="delegated", read_only=True)
+        docker.types.Mount("/host/dev", "/dev", type="bind",
+                           consistency="delegated", read_only=True),
+        docker.types.Mount("/host/proc", "/proc", type="bind",
+                           consistency="delegated", read_only=True),
     ]
 
     return {
@@ -212,6 +214,8 @@ def container_spec(image: str = 'sinsp-example:latest', args: list = [], env: di
         'mounts': mounts,
         'env': env,
         'privileged': True,
+        'pid_mode': 'host',
+        'network_mode': 'host',
         'init_wait': 2,
         'post_validation': sinsp_validation,
     }

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -66,6 +66,7 @@ def run_containers(request, docker_client: docker.client.DockerClient):
         additional_wait = container.get('init_wait', 0)
         post_validation = container.get('post_validation', None)
         stop_signal = container.get('signal', None)
+        user = container.get('user', '')
 
         handle = docker_client.containers.run(
             image,
@@ -74,7 +75,8 @@ def run_containers(request, docker_client: docker.client.DockerClient):
             detach=True,
             privileged=privileged,
             mounts=mounts,
-            environment=environment
+            environment=environment,
+            user=user
         )
 
         containers[name] = handle

--- a/test/e2e/tests/conftest.py
+++ b/test/e2e/tests/conftest.py
@@ -67,6 +67,8 @@ def run_containers(request, docker_client: docker.client.DockerClient):
         post_validation = container.get('post_validation', None)
         stop_signal = container.get('signal', None)
         user = container.get('user', '')
+        pid_mode = container.get('pid_mode', '')
+        network_mode = container.get('network_mode', '')
 
         handle = docker_client.containers.run(
             image,
@@ -76,7 +78,9 @@ def run_containers(request, docker_client: docker.client.DockerClient):
             privileged=privileged,
             mounts=mounts,
             environment=environment,
-            user=user
+            user=user,
+            pid_mode=pid_mode,
+            network_mode=network_mode,
         )
 
         containers[name] = handle

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -53,7 +53,7 @@ def test_db_program_spawned_process(run_containers: dict):
         },
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=/bin/ls args=NULL tid=\d+\(ls\) pid=\d+\(ls\) ptid=\d+\(mysqld\) .* tty=0 pgid=1\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=/bin/ls args=NULL tid=\d+\(ls\) pid=\d+\(ls\) ptid=\d+\(mysqld\) .* tty=0 pgid=1\(systemd\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -27,7 +27,7 @@ def test_run_shell_untrusted(run_containers: dict):
     expected_events = [
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=\/tmp\/falco-event-generator\d+\/httpd args=--loglevel.info.run.\^helper.RunShell\$. tid=\d+\(httpd\) pid=\d+\(httpd\) ptid=\d+\(event-generator\) .* tty=0 pgid=\d+\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=\/tmp\/falco-event-generator\d+\/httpd args=--loglevel.info.run.\^helper.RunShell\$. tid=\d+\(httpd\) pid=\d+\(httpd\) ptid=\d+\(event-generator\) .* tty=0 pgid=\d+\(systemd\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
@@ -39,7 +39,7 @@ def test_run_shell_untrusted(run_containers: dict):
         },
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=bash args=-c.ls > \/dev\/null. tid=\d+\(bash\) pid=\d+\(bash\) ptid=\d+\(httpd\) .* tty=0 pgid=\d+\(sinsp-example\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=bash args=-c.ls > \/dev\/null. tid=\d+\(bash\) pid=\d+\(bash\) ptid=\d+\(httpd\) .* tty=0 pgid=\d+\(systemd\) loginuid=-1 flags=1\(EXE_WRITABLE\) cap_inheritable=0 cap_permitted=3FFFFFFFFF cap_effective=3FFFFFFFFF $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -27,7 +27,7 @@ def test_system_user_interactive(run_containers: dict):
     expected_events = [
         {
             "container.id": generator_id,
-            "evt.args": SinspField.regex_field(r'^res=0 exe=\/bin\/login args=NULL tid=\d+\(login\) pid=\d+\(login\) ptid=\d+\(event-generator\) .* pgid=\d+\(sinsp-example\) loginuid=-1 flags=0 cap_inheritable=0 cap_permitted=0 cap_effective=0 $'),
+            "evt.args": SinspField.regex_field(r'^res=0 exe=\/bin\/login args=NULL tid=\d+\(login\) pid=\d+\(login\) ptid=\d+\(event-generator\) .* pgid=\d+\(systemd\) loginuid=-1 flags=0 cap_inheritable=0 cap_permitted=0 cap_effective=0 $'),
             "evt.category": "process",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),

--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -3,33 +3,38 @@ from sinspqa import sinsp
 from sinspqa.sinsp import assert_events
 from sinspqa.docker import get_container_id
 
-sinsp_filters = ["-f", "evt.category=process and not container.id=host"]
+sinsp_args = [
+    "-f", "evt.category=process and not container.id=host",
+    "-o", "%container.id %evt.args %evt.category %evt.type %proc.cmdline %proc.exe %user.uid %user.name %group.gid %group.name"
+]
 
 containers = [
     {
         'sinsp': sinsp_container,
-        'nginx': {
-            'image': 'nginx:1.14-alpine',
+        'app': {
+            'image': 'hashicorp/http-echo:alpine',
+            'args': ['-text=hello'],
+            'user': '11:100'
         }
-    } for sinsp_container in sinsp.generate_specs(args=sinsp_filters)
+    } for sinsp_container in sinsp.generate_specs(args=sinsp_args)
 ]
 
 ids = [ sinsp.generate_id(c['sinsp']) for c in containers ]
 
 @pytest.mark.parametrize("run_containers", containers, indirect=True, ids=ids)
 def test_exec_in_container(run_containers: dict):
-    nginx_container = run_containers['nginx']
+    app_container = run_containers['app']
     sinsp_container = run_containers['sinsp']
 
-    container_id = get_container_id(nginx_container)
+    container_id = get_container_id(app_container)
 
-    nginx_container.exec_run("sleep 5")
-    nginx_container.exec_run("sh -c ls")
+    app_container.exec_run("sleep 5")
+    app_container.exec_run("sh -c ls")
 
     expected_events = [
         {
             'container.id': container_id,
-            'evt.args': 'filename=/usr/sbin/nginx ',
+            'evt.args': 'filename=/http-echo ',
             'evt.category': 'process',
             'evt.type': 'execve',
             'proc.exe': 'runc',
@@ -38,8 +43,12 @@ def test_exec_in_container(run_containers: dict):
             'container.id': container_id,
             'evt.category': 'process',
             'evt.type': 'execve',
-            'proc.exe': 'nginx',
-            'proc.cmdline': 'nginx -g daemon off;'
+            'proc.exe': '/http-echo',
+            'proc.cmdline': 'http-echo -text=hello',
+            'user.uid': 11,
+            'user.name': 'operator',
+            'group.gid': 100,
+            'group.name': 'users',
         }, {
             'container.id': container_id,
             'evt.category': 'process',

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -123,6 +123,10 @@ set(SINSP_SOURCES
 	sinsp_ppm_sc.cpp
 	sinsp_tp.cpp)
 
+if(NOT WIN32)
+	list(APPEND SINSP_SOURCES procfs_utils.cpp)
+endif()
+
 if(WITH_CHISEL)
 	list(APPEND SINSP_SOURCES
 		../chisel/chisel_api.cpp
@@ -180,7 +184,6 @@ if(NOT MINIMAL_BUILD)
 		container_engine/mesos.cpp
 		container_engine/rkt.cpp
 		container_engine/bpm.cpp
-		procfs_utils.cpp
 		runc.cpp)
 	endif()
 

--- a/userspace/libsinsp/procfs_utils.cpp
+++ b/userspace/libsinsp/procfs_utils.cpp
@@ -74,7 +74,7 @@ libsinsp::procfs_utils::ns_helper::ns_helper(const std::string& host_root):
 {
 	// (try to) init m_host_init_ns_mnt
 	char buf[NS_MNT_SIZE] = {0};
-	if(-1 == readlink((m_host_root + "/proc/1/ns/mnt").c_str(), buf, NS_MNT_SIZE))
+	if(-1 == readlink((m_host_root + "/proc/1/ns/mnt").c_str(), buf, NS_MNT_SIZE - 1))
 	{
 		g_logger.format(sinsp_logger::SEV_WARNING,
 				"Cannot read host init ns/mnt");
@@ -107,7 +107,7 @@ bool libsinsp::procfs_utils::ns_helper::in_own_ns_mnt(int64_t pid) const
 	std::string path = m_host_root + "/proc/" + std::to_string(pid) + "/ns/mnt";
 
 	char proc_ns_mnt[NS_MNT_SIZE] = {0};
-	if(-1 == readlink(path.c_str(), proc_ns_mnt, NS_MNT_SIZE))
+	if(-1 == readlink(path.c_str(), proc_ns_mnt, NS_MNT_SIZE-1))
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"Cannot read process ns/mnt");

--- a/userspace/libsinsp/procfs_utils.cpp
+++ b/userspace/libsinsp/procfs_utils.cpp
@@ -77,7 +77,7 @@ libsinsp::procfs_utils::ns_helper::ns_helper(const std::string& host_root):
 	if(-1 == readlink((m_host_root + "/proc/1/ns/mnt").c_str(), buf, NS_MNT_SIZE - 1))
 	{
 		g_logger.format(sinsp_logger::SEV_WARNING,
-				"Cannot read host init ns/mnt");
+				"Cannot read host init ns/mnt: %d", errno);
 		m_cannot_read_host_init_ns_mnt = true;
 	}
 	else

--- a/userspace/libsinsp/procfs_utils.cpp
+++ b/userspace/libsinsp/procfs_utils.cpp
@@ -15,9 +15,11 @@ limitations under the License.
 
 */
 #include "procfs_utils.h"
+#include "logger.h"
 
-#include <string>
-#include "sinsp.h"
+#include <cstring>
+#include <sstream>
+#include <unistd.h>
 
 int libsinsp::procfs_utils::get_userns_root_uid(std::istream& uid_map)
 {
@@ -62,4 +64,61 @@ std::string libsinsp::procfs_utils::get_systemd_cgroup(std::istream& cgroups)
 	}
 
 	return "";
+}
+
+//
+// ns_helper
+//
+libsinsp::procfs_utils::ns_helper::ns_helper(const std::string& host_root):
+	m_host_root(host_root)
+{
+	// (try to) init m_host_init_ns_mnt
+	char buf[NS_MNT_SIZE] = {0};
+	if(-1 == readlink((m_host_root + "/proc/1/ns/mnt").c_str(), buf, NS_MNT_SIZE))
+	{
+		g_logger.format(sinsp_logger::SEV_WARNING,
+				"Cannot read host init ns/mnt");
+		m_cannot_read_host_init_ns_mnt = true;
+	}
+	else
+	{
+		auto size = strlen(buf) + 1;
+		m_host_init_ns_mnt = (char*)malloc(size);
+		strncpy(m_host_init_ns_mnt, buf, size);
+	}
+}
+
+libsinsp::procfs_utils::ns_helper::~ns_helper()
+{
+	if(m_host_init_ns_mnt)
+	{
+		free(m_host_init_ns_mnt);
+		m_host_init_ns_mnt = nullptr;
+	}
+}
+
+bool libsinsp::procfs_utils::ns_helper::in_own_ns_mnt(int64_t pid) const
+{
+	if(m_host_init_ns_mnt == nullptr)
+	{
+		return false;
+	}
+
+	std::string path = m_host_root + "/proc/" + std::to_string(pid) + "/ns/mnt";
+
+	char proc_ns_mnt[NS_MNT_SIZE] = {0};
+	if(-1 == readlink(path.c_str(), proc_ns_mnt, NS_MNT_SIZE))
+	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"Cannot read process ns/mnt");
+		return false;
+	}
+
+	if(0 == strncmp(m_host_init_ns_mnt, proc_ns_mnt, NS_MNT_SIZE))
+	{
+		// Still in the host namespace
+		return false;
+	}
+
+	return true;
 }

--- a/userspace/libsinsp/procfs_utils.h
+++ b/userspace/libsinsp/procfs_utils.h
@@ -27,5 +27,43 @@ int get_userns_root_uid(std::istream& uid_map);
  */
 std::string get_systemd_cgroup(std::istream& cgroups);
 
-}
-}
+/**
+ * @brief Access container data through proc
+ */
+class ns_helper
+{
+public:
+	ns_helper(const std::string& host_root);
+	~ns_helper();
+
+	bool can_read_host_init_ns_mnt() const
+	{
+		return !m_cannot_read_host_init_ns_mnt;
+	}
+
+	const char* get_host_init_ns_mnt() const { return m_host_init_ns_mnt; }
+
+	//! Return true if not in the host init mount namespace
+	bool in_own_ns_mnt(int64_t pid) const;
+
+	std::string get_pid_root(int64_t pid) const
+	{
+		return m_host_root + "/proc/" + std::to_string(pid) + "/root";
+	}
+
+private:
+	const std::string& m_host_root;
+	char* m_host_init_ns_mnt{nullptr};
+	bool m_cannot_read_host_init_ns_mnt{false};
+
+private:
+	//
+	// NOTE: at the time of writing 16 would have been enough, being
+	// the format `mnt:[<unsigned>]`, but the only call to `ns_get_name`
+	// I could find in the kernel was using a buffer of 50, so 50 it is.
+	//
+	static constexpr const std::size_t NS_MNT_SIZE{50};
+};
+
+} // namespace procfs_utils
+} // namespace libsinsp

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -71,6 +71,7 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 	m_external_event_processor(),
 	m_evt(this),
 	m_lastevent_ts(0),
+	m_host_root(scap_get_host_root()),
 	m_container_manager(this, static_container, static_id, static_name, static_image),
 	m_usergroup_manager(this),
 	m_suppressed_comms(),

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1150,6 +1150,9 @@ public:
 
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
+	const std::string& get_host_root() const { return m_host_root; }
+	void set_host_root(const std::string& s) { m_host_root = s; }
+
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);
 	void set_mode(scap_mode_t value)
@@ -1263,6 +1266,8 @@ private:
 	scap_test_input_data *m_test_input_data = nullptr;
 
 	sinsp_network_interfaces* m_network_interfaces;
+
+	std::string m_host_root;
 
 public:
 	sinsp_thread_manager* m_thread_manager;

--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -115,6 +115,8 @@ protected:
 		m_host_root += "/host";
 
 		ASSERT_EQ(mkdir(m_host_root.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+		m_inspector.set_host_root(m_host_root);
+
 		std::string etc = m_host_root + "/etc";
 		ASSERT_EQ(mkdir(etc.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
 
@@ -146,7 +148,6 @@ TEST_F(usergroup_manager_host_root_test, host_root_lookup)
 	std::string container_id{""};
 
 	sinsp_usergroup_manager mgr(&m_inspector);
-	sinsp_usergroup_manager::s_host_root = m_host_root;
 
 	mgr.add_user(container_id, 0, 0, nullptr, nullptr, nullptr);
 	auto* user = mgr.get_user(container_id, 0);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -505,8 +505,21 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 	scap_userinfo *user = m_inspector->m_usergroup_manager.get_user(m_container_id, uid);
 	if (!user)
 	{
-		// this can fail if import_user is disabled
-		user = m_inspector->m_usergroup_manager.add_user(m_container_id, uid, m_group.gid, NULL, NULL, NULL, m_inspector->is_live());
+		// these can fail if import_user is disabled
+		if(m_container_id.empty())
+		{
+			user = m_inspector->m_usergroup_manager.add_user(m_container_id, uid, m_group.gid, NULL, NULL, NULL, m_inspector->is_live());
+		}
+		else if(uid != 0)
+		{
+			//
+			// When a container is running with a specific user and this
+			// get called with 0, it's too early to make an attempt.
+			// As a downside we won't load users for containers running as
+			// root, but we will load them if e.g.docker exec -u <specific-user>.
+			//
+			user = m_inspector->m_usergroup_manager.add_container_user(m_container_id, m_pid, uid, m_inspector->is_live());
+		}
 	}
 
 	if (user)
@@ -528,8 +541,21 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 	scap_groupinfo *group = m_inspector->m_usergroup_manager.get_group(m_container_id, gid);
 	if (!group)
 	{
-		// this can fail if import_user is disabled
-		group = m_inspector->m_usergroup_manager.add_group(m_container_id, gid, NULL, m_inspector->is_live());
+		// these can fail if import_user is disabled
+		if(m_container_id.empty())
+		{
+			group = m_inspector->m_usergroup_manager.add_group(m_container_id, gid, NULL, m_inspector->is_live());
+		}
+		else if(gid != 0)
+		{
+			//
+			// When a container is running with a specific user and this
+			// get called with 0, it's too early to make an attempt.
+			// As a downside we won't load users for containers running as
+			// root, but we will load them if e.g.docker exec -u <specific-user>.
+			//
+			group = m_inspector->m_usergroup_manager.add_container_group(m_container_id, m_pid, gid, m_inspector->is_live());
+		}
 	}
 
 	if (group)

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -282,7 +282,7 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 	scap_userinfo *usr = get_user(container_id, uid);
 	if (!usr)
 	{
-		bool do_notify{false};
+		bool inserted{false};
 		if (name)
 		{
 			usr = userinfo_map_insert(
@@ -292,7 +292,7 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 				name,
 				home,
 				shell);
-			do_notify = true;
+			inserted = true;
 		}
 		else if (container_id.empty())
 		{
@@ -308,12 +308,12 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 					p->pw_name,
 					p->pw_dir,
 					p->pw_shell);
-				do_notify = true;
+				inserted = true;
 			}
 #endif
 		}
 
-		if (notify && do_notify)
+		if (notify && inserted)
 		{
 			notify_user_changed(usr, container_id);
 		}
@@ -418,11 +418,11 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 	scap_groupinfo *gr = get_group(container_id, gid);
 	if (!gr)
 	{
-		bool do_notify{false};
+		bool inserted{false};
 		if (name)
 		{
 			gr = groupinfo_map_insert(m_grouplist[container_id], gid, name);
-			do_notify = true;
+			inserted = true;
 		}
 		else if (container_id.empty())
 		{
@@ -432,12 +432,12 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 			if (g)
 			{
 				gr = groupinfo_map_insert(m_grouplist[container_id], g->gr_gid, g->gr_name);
-				do_notify = true;
+				inserted = true;
 			}
 #endif
 		}
 
-		if (notify && do_notify)
+		if (notify && inserted)
 		{
 			notify_group_changed(gr, container_id, true);
 		}

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -116,6 +116,10 @@ public:
 
 	scap_userinfo *add_user(const std::string &container_id, uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify = false);
 	scap_groupinfo *add_group(const std::string &container_id, uint32_t gid, const char *name, bool notify = false);
+
+	scap_userinfo *add_container_user(const std::string &container_id, int64_t pid, uint32_t uid, bool notify = false);
+	scap_groupinfo *add_container_group(const std::string &container_id, int64_t pid, uint32_t gid, bool notify = false);
+
 	bool rm_user(const std::string &container_id, uint32_t uid, bool notify = false);
 	bool rm_group(const std::string &container_id, uint32_t gid, bool notify = false);
 
@@ -140,8 +144,23 @@ private:
 	void notify_user_changed(const scap_userinfo *user, const std::string &container_id, bool added = true);
 	void notify_group_changed(const scap_groupinfo *group, const std::string &container_id, bool added = true);
 
-	std::unordered_map<std::string, std::unordered_map<uint32_t, scap_userinfo>> m_userlist;
-	std::unordered_map<std::string, std::unordered_map<uint32_t, scap_groupinfo>> m_grouplist;
+	using userinfo_map = std::unordered_map<uint32_t, scap_userinfo>;
+	using groupinfo_map = std::unordered_map<uint32_t, scap_groupinfo>;
+
+	scap_userinfo *userinfo_map_insert(
+		userinfo_map &map,
+		uint32_t uid,
+		uint32_t gid,
+		const char *name,
+		const char *home,
+		const char *shell);
+	scap_groupinfo *groupinfo_map_insert(
+		groupinfo_map &map,
+		uint32_t gid,
+		const char *name);
+
+	std::unordered_map<std::string, userinfo_map> m_userlist;
+	std::unordered_map<std::string, groupinfo_map> m_grouplist;
 	uint64_t m_last_flush_time_ns;
 	sinsp *m_inspector;
 };

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -21,10 +21,14 @@ limitations under the License.
 #include <unordered_map>
 #include <string>
 #include "container_info.h"
+#include "procfs_utils.h"
 #include "scap.h"
 
 class sinsp;
 class sinsp_evt;
+#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+namespace libsinsp { namespace procfs_utils { class ns_helper; }}
+#endif
 
 /*
  * Basic idea:
@@ -131,10 +135,6 @@ public:
 	//
 	bool m_import_users;
 
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
-	static std::string s_host_root;
-#endif
-
 private:
 	bool user_to_sinsp_event(const scap_userinfo *user, sinsp_evt* evt, const std::string &container_id, uint16_t ev_type);
 	bool group_to_sinsp_event(const scap_groupinfo *group, sinsp_evt* evt, const std::string &container_id, uint16_t ev_type);
@@ -163,6 +163,17 @@ private:
 	std::unordered_map<std::string, groupinfo_map> m_grouplist;
 	uint64_t m_last_flush_time_ns;
 	sinsp *m_inspector;
+
+#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+	const std::string &m_host_root;
+	std::unique_ptr<libsinsp::procfs_utils::ns_helper> m_ns_helper;
+#endif
+#ifdef HAVE_PWD_H
+	struct passwd *__getpwuid(uint32_t uid);
+#endif
+#ifdef HAVE_GRP_H
+	struct group *__getgrgid(uint32_t gid);
+#endif
 };
 
 #endif // FALCOSECURITY_LIBS_USER_H


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Introduce `add_container_user` and `add_container_group`.
Those are called by `sinsp_threadinfo` `set_user` / `set_group` and load the information from /proc/<pid>/root/etc.
For that to work, the process running sinsp has to be privileged and in the host pid namespace.
For more information see `man 5 proc`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
