### PR TITLE
chore(userspace): link static `libelf` when using `BUNDLED_DEPS`

### DIFF
--- a/cmake/modules/find_static_library.cmake
+++ b/cmake/modules/find_static_library.cmake
@@ -1,0 +1,26 @@
+# This function must be used to retrieve a static library. This could be useful
+# if we want to obtain a unique executable linked with only static libraries.
+# - `LIB_NAME` is the full name of the library (for example `elf`)
+# - `OUT` is the full path of the library that should be passed to `target_link_libraries`
+
+function(find_static_library LIB_NAME OUT)
+
+  if(UNIX)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  endif()
+
+  find_library(FOUND_${LIB_NAME}_STATIC ${LIB_NAME})
+
+  if(FOUND_${LIB_NAME}_STATIC)
+    get_filename_component(ABS_FILE ${FOUND_${LIB_NAME}_STATIC} ABSOLUTE)
+  else()
+    message(SEND_ERROR "Unable to find library ${LIB_NAME}")
+  endif()
+
+  set(${OUT}
+      ${ABS_FILE}
+      PARENT_SCOPE)
+
+endfunction()

--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -31,6 +31,10 @@ else()
         UPDATE_COMMAND ""
     )
     message(STATUS "Using bundled libbpf: include'${LIBBPF_INCLUDE}', lib: ${LIBBPF_LIB}")
+    install(FILES "${LIBBPF_LIB}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
+            COMPONENT "libs-deps")
+    install(DIRECTORY "${LIBBPF_INCLUDE}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}"
+            COMPONENT "libs-deps")
 endif()
 
 include_directories(${LIBBPF_INCLUDE})

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -44,6 +44,10 @@ list(APPEND LIBSCAP_LIBS
 	"${PROJECT_BINARY_DIR}/libscap/engine/savefile/libscap_engine_savefile.a"
 	"${PROJECT_BINARY_DIR}/libscap/engine/source_plugin/libscap_engine_source_plugin.a"
 	"${PROJECT_BINARY_DIR}/libscap/engine/udig/libscap_engine_udig.a"
+if(BUILD_LIBSCAP_MODERN_BPF)
+	"${PROJECT_BINARY_DIR}/libscap/engine/modern_bpf/libscap_engine_modern_bpf.a"
+	"${PROJECT_BINARY_DIR}/libpman/libpman.a"
+endif()
 )
 install(FILES ${LIBSCAP_LIBS} DESTINATION "${CMAKE_INSTALL_LIBDIR}/${LIBS_PACKAGE_NAME}"
 			COMPONENT "scap" OPTIONAL)

--- a/userspace/libpman/CMakeLists.txt
+++ b/userspace/libpman/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(find_static_library)
 
 set(PMAN_SOURCES
     src/capture.c
@@ -23,11 +24,17 @@ set(PMAN_PUBLIC_INCLUDES
     "./include"
 )
 
+set(LIBELF "elf")
+# With `BUNDLED_DEPS`, we enforce the usage of a static library
+if(USE_BUNDLED_DEPS)
+    find_static_library("elf" LIBELF)
+endif()
+
 set(PMAN_PRIVATE_LINK_LIBRARIES
     "${LIBBPF_LIB}"
     "${ZLIB_LIB}"
     scap_event_schema
-    elf
+    ${LIBELF}
 )
 
 set(PMAN_DEPENDENCIES

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -30,6 +30,8 @@ endif()
 
 include(ExternalProject)
 
+include(find_static_library)
+
 if(WIN32 OR NOT MINIMAL_BUILD)
 	include(zlib)
 endif()

--- a/userspace/libscap/engine/bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/bpf/CMakeLists.txt
@@ -1,5 +1,12 @@
 include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
 add_library(scap_engine_bpf scap_bpf.c)
 if(NOT MINIMAL_BUILD)
-target_link_libraries(scap_engine_bpf scap_event_schema scap_engine_util elf)
+
+set(LIBELF "elf")
+# With `BUNDLED_DEPS`, we enforce the usage of a static library
+if(USE_BUNDLED_DEPS)
+    find_static_library("elf" LIBELF)
+endif()
+
+target_link_libraries(scap_engine_bpf scap_event_schema scap_engine_util ${LIBELF})
 endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR ensures that `libelf` is statically linked when we build with `BUNDLED_DEPS`.  `BUNDLED_DEPS` are used when we build for example tar packages so we prefer to have always static libraries in order to ship the package without system dependencies

Moreover this PR adds `libbpf` as a cmake component since we don't want to use this folder during the packaging phase with `cpack`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
