### PR TITLE
fix(driver): reduce the wait time to `500` us

### DIFF
--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -126,8 +126,8 @@ static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_
 	pman_consume_first_from_buffers((void**)pevent, pcpuid);
 	if((*pevent) == NULL)
 	{
-		/* Sleep 500 ms */
-		usleep(5*100000);
+		/* Sleep 500 us */
+		usleep(500);
 		return SCAP_TIMEOUT;
 	}
 	return SCAP_SUCCESS;

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -934,7 +934,7 @@ void print_stats()
 
 	scap_stats s;
 	printf("\n---------------------- STATS -----------------------\n");
-	printf("Events captured: %" PRIu64 "\n", g_nevts);
+	printf("Events correctly captured (SCAP_SUCCESS): %" PRIu64 "\n", g_nevts);
 	scap_get_stats(g_h, &s);
 	printf("Seen by driver: %" PRIu64 "\n", s.n_evts);
 	printf("Time elapsed: %ld s\n", tval_result.tv_sec);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Reduce the time to wait when the buffer is full to `500 us` instead of `500 ms`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
