### PR TITLE
fix(userspace/chisel): revert 29635fb3f11a2d067082bc7545d59996c053d20e.

### DIFF
--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -474,7 +474,14 @@ void chisel_table::process_event(sinsp_evt* evt)
 		else
 		{
 			// todo: Do something better here. For now, only support single-value extracted fields
+			// Set the val in the m_premerge_fld_pointers; note: at this stage,
+			// m_fld_pointers points to m_premerge_fld_pointers.
+			// This is only used to eventually compute the field len for BYTE_BUF
+			pfld->m_val = m_premerge_extractors[j]->m_check->m_extracted_values[0].ptr;
+			// Compute len
+			// NOTE: this internally uses m_fld_pointers thus the m_val must be already set, as above.
 			pfld->m_len = get_field_len(j);
+			// Finally, create the buffer copy and store it to val.
 			pfld->m_val = m_buffer->copy(m_premerge_extractors[j]->m_check->m_extracted_values[0].ptr, pfld->m_len);
 			pfld->m_cnt = 1;
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp


**Does this PR require a change in the driver versions?**

NOPE.

**What this PR does / why we need it**:

Reverts a chisels patch that causes segfault.
Moreover, added some comments to make it explicit why the code is there.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/chisel): fixed segfault
```
