### PR TITLE
Fix vtid/vpid fields in CLONE_20_X event built by sched_proc_fork

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -7064,14 +7064,14 @@ cgroups_error:
 	}
 
 	/* Parameter 19: vtid (type: PT_PID) */
-	res = val_to_ring(args, task_pid_vnr(child), 0, false, 0);
+	res = val_to_ring(args, task_pid_nr_ns(child, pidns), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
 	}
 
 	/* Parameter 20: vpid (type: PT_PID) */
-	res = val_to_ring(args, task_tgid_vnr(child), 0, false, 0);
+	res = val_to_ring(args, task_tgid_nr_ns(child, pidns), 0, false, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;


### PR DESCRIPTION
New sched_proc_fork tracepoint handler was created, to compensate for lack of sys_exit tracepoint generated when clone/fork system calls return to the child process.  The new sched_proc_fork handler builds the CLONE_20_X event which would have been built by the missing sys_exit tracepoint.

Two of the fields in the CLONE_20_X are vtid and vpid, the thread ID and process ID of the running thread, IN THE LOCAL PID NAMESPACE of that thread.  The new sched_proc_fork handler has a bug -- it uses the convenience functions task_pid_vnr() and task_tgid_vnr() to retrieve the vtid and vpid; but those functions assume the PID namespace of the executing thread, which in the case of the sched_proc_fork handler, is the parent thread, not the child thread.

Solution is to use task_pid_nr_ns() and task_tgid_nr_ns(), explicitly specifying the PID namespace associated with the child thread.

Signed-off-by: Joseph Pittman <joseph.pittman@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
CLONE_20_X events, generated by ARM/zLinux-specific sched_proc_fork tracepoint handler, reports incorrect vtid/vpid.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
