### PR TITLE
update(driver): update syscalls tables.

### DIFF
--- a/driver/report.md
+++ b/driver/report.md
@@ -40,8 +40,8 @@ Syscalls that are not mapped to any event, are instead mapped to the `generic` o
 | dup                     | ✔         |
 | dup2                    | ✔         |
 | dup3                    | ✔         |
-| epoll_create            | ❌        |
-| epoll_create1           | ❌        |
+| epoll_create            | ✔         |
+| epoll_create1           | ✔         |
 | epoll_ctl               | ❌        |
 | epoll_ctl_old           | ❌        |
 | epoll_pwait             | ❌        |


### PR DESCRIPTION
This PR updates the list of supported syscalls from the latest kernel. Do not edit this PR.

/area driver

```release-note
NONE
```
