### PR TITLE
fix(driver): fix some verifier issues in the modern probe

### DIFF
--- a/driver/modern_bpf/helpers/base/read_from_task.h
+++ b/driver/modern_bpf/helpers/base/read_from_task.h
@@ -15,7 +15,8 @@
  */
 static __always_inline struct task_struct *get_current_task()
 {
-	if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf)
+	if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf)
+		&& (bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf))
 	{
 		return (struct task_struct *)bpf_get_current_task_btf();
 	}
@@ -33,7 +34,8 @@ static __always_inline struct task_struct *get_current_task()
 #define READ_TASK_FIELD(src, a, ...)                                                            \
 	({                                                                                      \
 		___type((src), a, ##__VA_ARGS__) __r;                                           \
-		if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf) \
+		if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf) \
+			&& (bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf)) \
 		{                                                                               \
 			__r = ___arrow((src), a, ##__VA_ARGS__);                                \
 		}                                                                               \
@@ -65,7 +67,8 @@ static __always_inline struct task_struct *get_current_task()
  */
 #define READ_TASK_FIELD_INTO(dst, src, a, ...)                                                  \
 	({                                                                                      \
-		if(bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf) \
+		if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf) \
+			&& (bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf) == BPF_FUNC_get_current_task_btf)) \
 		{                                                                               \
 			*dst = ___arrow((src), a, ##__VA_ARGS__);                               \
 		}                                                                               \

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -126,7 +126,7 @@ static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf
  * @param event_type type of the event that we are storing into the ringbuf.
  * @param event_size exact size of the fixed-size event.
  */
-static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf, u32 event_type, u32 event_size)
+static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf, u32 event_type)
 {
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)ringbuf->data;
 	u8 nparams = maps__get_event_num_params(event_type);
@@ -134,7 +134,7 @@ static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *r
 	hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
 	hdr->type = event_type;
 	hdr->nparams = nparams;
-	hdr->len = event_size;
+	hdr->len = ringbuf->reserved_event_size;
 
 	ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(u16);
 	ringbuf->lengths_pos = sizeof(struct ppm_evt_hdr);

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(sched_proc_exit,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_PROCEXIT_1_E, PROC_EXIT_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_PROCEXIT_1_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -23,7 +23,7 @@ int BPF_PROG(sched_switch,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SCHEDSWITCH_6_E, SCHED_SWITCH_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SCHEDSWITCH_6_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(accept_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT_5_E, ACCEPT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT_5_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(accept4_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT4_5_E, ACCEPT4_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_ACCEPT4_5_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(bind_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_BIND_E, BIND_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_BIND_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(bpf_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_E, BPF_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(bpf_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_X, BPF_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_BPF_2_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(capset_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_E, CAPSET_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -48,7 +48,7 @@ int BPF_PROG(capset_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_X, CAPSET_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CAPSET_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(chdir_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHDIR_E, CHDIR_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHDIR_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(chmod_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHMOD_E, CHMOD_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHMOD_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(chroot_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHROOT_E, CHROOT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHROOT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(clone_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLONE_20_E, CLONE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLONE_20_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(clone3_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLONE3_E, CLONE3_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLONE3_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(close_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_E, CLOSE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(close_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_X, CLOSE_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CLOSE_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(copy_file_range_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_E, COPY_FILE_RANGE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -58,7 +58,7 @@ int BPF_PROG(copy_file_range_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_X, COPY_FILE_RANGE_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_COPY_FILE_RANGE_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(dup_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_E, DUP_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(dup_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_X, DUP_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP_1_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(dup2_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_E, DUP2_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(dup2_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_X, DUP2_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP2_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(dup3_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_E, DUP3_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(dup3_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_X, DUP3_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_DUP3_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(epoll_create_e,
 	       return 0;
        }
 
-       ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE_E, EPOLL_CREATE_E_SIZE);
+       ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE_E);
 
        /*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(epoll_create_x,
 	       return 0;
        }
 
-       ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE_X, EPOLL_CREATE_X_SIZE);
+       ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE_X);
 
        /*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(epoll_create1_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE1_E, EPOLL_CREATE1_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE1_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(epoll_create1_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE1_X, EPOLL_CREATE1_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EPOLL_CREATE1_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
@@ -22,7 +22,7 @@ int BPF_PROG(eventfd_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EVENTFD_E, EVENTFD_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EVENTFD_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -57,7 +57,7 @@ int BPF_PROG(eventfd_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EVENTFD_X, EVENTFD_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_EVENTFD_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(fchdir_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_E, FCHDIR_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(fchdir_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_X, FCHDIR_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHDIR_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(fchmod_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_E, FCHMOD_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -49,7 +49,7 @@ int BPF_PROG(fchmod_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_X, FCHMOD_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMOD_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(fchmodat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMODAT_E, FCHMODAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHMODAT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -20,6 +20,7 @@ int BPF_PROG(fcntl_e,
 		return 0;
 	}
 
+	/// TODO: we can remove the size from here.
 	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_E, FCNTL_E_SIZE);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -20,8 +20,7 @@ int BPF_PROG(fcntl_e,
 		return 0;
 	}
 
-	/// TODO: we can remove the size from here.
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_E, FCNTL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -55,7 +54,7 @@ int BPF_PROG(fcntl_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_X, FCNTL_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCNTL_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(flock_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_E, FLOCK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(flock_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_X, FLOCK_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FLOCK_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(fork_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FORK_20_E, FORK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FORK_20_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(fsconfig_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FSCONFIG_E, FSCONFIG_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FSCONFIG_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
@@ -22,7 +22,7 @@ int BPF_PROG(inotify_init_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_INOTIFY_INIT_E, INOTIFY_INIT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_INOTIFY_INIT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -56,7 +56,7 @@ int BPF_PROG(inotify_init_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_INOTIFY_INIT_X, INOTIFY_INIT_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_INOTIFY_INIT_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(ioctl_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_E, IOCTL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -58,7 +58,7 @@ int BPF_PROG(ioctl_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_X, IOCTL_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_IOCTL_3_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(kill_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_E, KILL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(kill_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_X, KILL_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_KILL_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(link_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_LINK_2_E, LINK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_LINK_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(linkat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_LINKAT_2_E, LINKAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_LINKAT_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(listen_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_E, LISTEN_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -55,7 +55,7 @@ int BPF_PROG(listen_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_X, LISTEN_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_LISTEN_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(mkdir_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MKDIR_2_E, MKDIR_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MKDIR_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(mkdirat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MKDIRAT_E, MKDIRAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MKDIRAT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(mount_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MOUNT_E, MOUNT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MOUNT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(open_by_handle_at_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, OPEN_BY_HANDLE_AT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
@@ -22,7 +22,7 @@ int BPF_PROG(pipe_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PIPE_E, PIPE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PIPE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(pipe_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PIPE_X, PIPE_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PIPE_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(prlimit64_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PRLIMIT_E, PRLIMIT64_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PRLIMIT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(prlimit64_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PRLIMIT_X, PRLIMIT64_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PRLIMIT_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(ptrace_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PTRACE_E, PTRACE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_PTRACE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(quotactl_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_QUOTACTL_E, QUOTACTL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_QUOTACTL_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(recvfrom_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVFROM_E, RECVFROM_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVFROM_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(recvmsg_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVMSG_E, RECVMSG_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVMSG_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(rename_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAME_E, RENAME_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAME_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(renameat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAMEAT_E, RENAMEAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAMEAT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(renameat2_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAMEAT2_E, RENAMEAT2_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RENAMEAT2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(rmdir_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RMDIR_2_E, RMDIR_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_RMDIR_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(seccomp_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_E, SECCOMP_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(seccomp_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_X, SECCOMP_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SECCOMP_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setgid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETGID_E, SETGID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETGID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(setgid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETGID_X, SETGID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETGID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setns_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETNS_E, SETNS_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETNS_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(setns_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETNS_X, SETNS_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETNS_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setpgid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETPGID_E, SETPGID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETPGID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(setpgid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETPGID_X, SETPGID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETPGID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setresgid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESGID_E, SETRESGID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESGID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -58,7 +58,7 @@ int BPF_PROG(setresgid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESGID_X, SETRESGID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESGID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setresuid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESUID_E, SETRESUID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESUID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -58,7 +58,7 @@ int BPF_PROG(setresuid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESUID_X, SETRESUID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRESUID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setrlimit.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setrlimit.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setrlimit_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRLIMIT_E, SETRLIMIT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRLIMIT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(setrlimit_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRLIMIT_X, SETRLIMIT_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETRLIMIT_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setsid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETSID_E, SETSID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETSID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -48,7 +48,7 @@ int BPF_PROG(setsid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETSID_X, SETSID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETSID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(setsockopt_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SETSOCKOPT_E, SETSOCKOPT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SETSOCKOPT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(setuid_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETUID_E, SETUID_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETUID_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(setuid_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETUID_X, SETUID_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SETUID_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(shutdown_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_E, SHUTDOWN_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(shutdown_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_X, SHUTDOWN_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SHUTDOWN_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
@@ -22,7 +22,7 @@ int BPF_PROG(signalfd_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SIGNALFD_E, SIGNALFD_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SIGNALFD_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -64,7 +64,7 @@ int BPF_PROG(signalfd_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SIGNALFD_X, SIGNALFD_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SIGNALFD_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(socket_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_E, SOCKET_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -61,7 +61,7 @@ int BPF_PROG(socket_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_X, SOCKET_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKET_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(socketpair_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_E, SOCKETPAIR_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -61,7 +61,7 @@ int BPF_PROG(socketpair_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_X, SOCKETPAIR_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SOCKETPAIR_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(symlink_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SYMLINK_E, SYMLINK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SYMLINK_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(symlinkat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SYMLINKAT_E, SYMLINKAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SYMLINKAT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(tgkill_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_E, TGKILL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -58,7 +58,7 @@ int BPF_PROG(tgkill_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_X, TGKILL_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TGKILL_X);
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO)*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/timerfd_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/timerfd_create.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(timerfd_create_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TIMERFD_CREATE_E, TIMERFD_CREATE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TIMERFD_CREATE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(timerfd_create_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TIMERFD_CREATE_X, TIMERFD_CREATE_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TIMERFD_CREATE_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(tkill_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_E, TKILL_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -54,7 +54,7 @@ int BPF_PROG(tkill_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_X, TKILL_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_TKILL_X);
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO)*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
@@ -22,7 +22,7 @@ int BPF_PROG(umount2_e,
 	}
 
 	/// TODO: This event should be called `PPME_SYSCALL_UMOUNT2_E`.
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UMOUNT_E, UMOUNT2_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UMOUNT_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(unlink_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNLINK_2_E, UNLINK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNLINK_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(unlinkat_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNLINKAT_2_E, UNLINKAT_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNLINKAT_2_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(unshare_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_E, UNSHARE_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -50,7 +50,7 @@ int BPF_PROG(unshare_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_X, UNSHARE_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_UNSHARE_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
@@ -20,7 +20,7 @@ int BPF_PROG(userfaultfd_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_USERFAULTFD_E, USERFAULTFD_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_USERFAULTFD_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -48,7 +48,7 @@ int BPF_PROG(userfaultfd_x,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_USERFAULTFD_X, USERFAULTFD_X_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_USERFAULTFD_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(vfork_e,
 		return 0;
 	}
 
-	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_VFORK_20_E, VFORK_E_SIZE);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_VFORK_20_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR presents 2 patches:

* (1° commit): `bpf_core_enum_value(enum bpf_func_id, BPF_FUNC_get_current_task_btf)` cannot be used if `BPF_FUNC_get_current_task_btf` is not defined in the kernel for this reason we first need to check is existence with `bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task_btf)`

* (2° commit and 3° commit) Some kernels like `5.8.18` and `5.9.16` don't work with the actual ringbuf approach. The actual approach doesn't check if we are overcoming the ringbuf `reserved_size` this is because recent kernel verifiers `>=5.10` are able to keep track of the free space without the programmer's help. Unfortunately, this is not true on old kernels, for this reason, we need to help the verifier with this `CHECK_RINGBUF_SPACE` macro

> __Please note__:  I've changed the signature of `ringbuf__store_event_header` since passing the `event_size` is no more necessary, for this reason, I've changed a lot of files but in the end, the fix is straightforward :)  I suggest reviewing it commit by commit

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(driver): fix some verifier issues in the modern probe
```
