### PR TITLE
fix(userspace/libsinsp): set current time in procinfo metaevent

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1108,7 +1108,7 @@ void sinsp::get_procs_cpu_from_driver(uint64_t ts)
 	{
 		m_meinfo.m_cur_procinfo_evt = -1;
 
-		m_meinfo.m_piscapevt->ts = m_next_flush_time_ns - (ONE_SECOND_IN_NS + 1);
+		m_meinfo.m_piscapevt->ts = ts;
 		add_meta_event_callback(&schedule_next_threadinfo_evt, &m_meinfo);
 		schedule_next_threadinfo_evt(this, &m_meinfo);
 	}


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The current timestamp is generally obtained by using the timestamp of the last event received (not super reliable for plugins, but that's out of scope for this PR). Metaevents, which are generated internally by the libraries (and not by the kernel drivers), usually use the last event timestamp in order to break the assumption that events are received with `next()` with a monotonic timestamp.

Now, when creating creating `PPME_PROCINFO_E` metaevents, the event timestamp is set to be _before_ the actual current time. With the old formula, we would have cases such as:
```
Last event timestamp: 1667494534022352346
m_next_flush_time_ns: 1667494535000000000
Metaevent timestamp:  1667494533999999999
```
As visible, the timestamp for the metaevent (which will be fetched at the subsequent invocation of `sinsp::next()`) is lower than the timestamp of the last fetched event. This makes sense, as the `m_next_flush_time_ns - (ONE_SECOND_IN_NS + 1)` formula does not provide any guarantee of having a result bigger then the last event timestamp.

This breaks some features/logics based on the monotomic event time assumption. In general, this assumption is mostly used to compute time differences efficiently inside libsinsp. For instance, this bug was catched by observing that the `sinsp_chisel::do_timeout` method to run mistakenly. 


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
