### PR TITLE
chore(userspace/libscap): let the g_buffer_bytes_dim file missing be properly managed during the API version check

### DIFF
--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -91,7 +91,7 @@ static int32_t enforce_into_kmod_buffer_bytes_dim(scap_t *handle, unsigned long 
 			// let the issue be gracefully managed during the api version check against the driver.
 			return SCAP_SUCCESS;
 		}
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open '%s': %s. Please ensure the kernel module is already loaded.", file_name, scap_strerror(handle, errno));
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open '%s': %s.", file_name, scap_strerror(handle, errno));
 		return SCAP_FAILURE;
 	}
 

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -84,8 +84,9 @@ static int32_t enforce_into_kmod_buffer_bytes_dim(scap_t *handle, unsigned long 
 	FILE *read_file = fopen(file_name, "r");
 	if(read_file == NULL)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "unable to open '%s': %s. Please ensure the kernel module is already loaded.", file_name, scap_strerror(handle, errno));
-		return SCAP_FAILURE;
+		// It is most probably a wrong API version of the driver;
+		// let the issue be gracefully managed during the api version check against the driver.
+		return SCAP_SUCCESS;
 	}
 
 	unsigned long kernel_buf_bytes_dim = 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap-engine-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When an user with an old driver runs Falco 0.33, Falco shows the wrong error message:
> Error: unable to open '/sys/module/falco/parameters/g_buffer_bytes_dim': Errno 2. Please ensure the kernel module is already loaded.

(See: https://github.com/falcosecurity/falco/issues/2280)
It should instead fail during the driver API/schema version check.
This patch allows the correct message to be displayed by the users, by faking "everything's good" behavior when `g_buffer_bytes_dim` file is missing.
Note: if the file is missing BUT the driver is the new one, it is a super odd behavior but in any case, it is not a real issue because kmod has an internal default value.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
