### PR TITLE
fix(userspace/libsinsp): make sinsp_evt initialization consistent

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -62,28 +62,51 @@ extern sinsp_evttables g_infotables;
 // sinsp_evt implementation
 ///////////////////////////////////////////////////////////////////////////////
 sinsp_evt::sinsp_evt() :
-	m_pevt_storage(NULL),
-	m_paramstr_storage(256), m_resolved_paramstr_storage(1024)
+		m_inspector(NULL),
+		m_pevt(NULL),
+		m_poriginal_evt(NULL),
+		m_pevt_storage(NULL),
+		m_cpuid(0),
+		m_evtnum(0),
+		m_flags(EF_NONE),
+		m_params_loaded(false),
+		m_info(NULL),
+		m_paramstr_storage(256),
+		m_resolved_paramstr_storage(1024),
+		m_tinfo(NULL),
+		m_fdinfo(NULL),
+		m_fdinfo_name_changed(false),
+		m_iosize(0),
+		m_errorcode(0),
+		m_rawbuf_str_len(0),
+		m_filtered_out(false),
+		m_event_info_table(g_infotables.m_event_info)
 {
-	m_flags = EF_NONE;
-	m_tinfo = NULL;
-#ifdef _DEBUG
-	m_filtered_out = false;
-#endif
-	m_event_info_table = g_infotables.m_event_info;
+
 }
 
 sinsp_evt::sinsp_evt(sinsp *inspector) :
-	m_pevt_storage(NULL),
-	m_paramstr_storage(1024), m_resolved_paramstr_storage(1024)
+		m_inspector(inspector),
+		m_pevt(NULL),
+		m_poriginal_evt(NULL),
+		m_pevt_storage(NULL),
+		m_cpuid(0),
+		m_evtnum(0),
+		m_flags(EF_NONE),
+		m_params_loaded(false),
+		m_info(NULL),
+		m_paramstr_storage(1024),
+		m_resolved_paramstr_storage(1024),
+		m_tinfo(NULL),
+		m_fdinfo(NULL),
+		m_fdinfo_name_changed(false),
+		m_iosize(0),
+		m_errorcode(0),
+		m_rawbuf_str_len(0),
+		m_filtered_out(false),
+		m_event_info_table(g_infotables.m_event_info)
 {
-	m_inspector = inspector;
-	m_flags = EF_NONE;
-	m_tinfo = NULL;
-#ifdef _DEBUG
-	m_filtered_out = false;
-#endif
-	m_event_info_table = g_infotables.m_event_info;
+	
 }
 
 sinsp_evt::~sinsp_evt()

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -415,14 +415,12 @@ private:
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_poriginal_evt = NULL;
-		m_evtnum = 0;
 	}
 	inline void init()
 	{
 		init_keep_threadinfo();
 		m_tinfo_ref.reset();
 		m_tinfo = NULL;
-		m_evtnum = 0;
 	}
 	inline void init(uint8_t* evdata, uint16_t cpuid)
 	{
@@ -435,7 +433,6 @@ private:
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_cpuid = cpuid;
-		m_evtnum = 0;
 		m_poriginal_evt = NULL;
 	}
 	inline void init(scap_evt *scap_event,
@@ -448,7 +445,6 @@ private:
 		m_tinfo_ref.reset(); // we don't own the threadinfo so don't try to manage its lifetime
 		m_tinfo = threadinfo;
 		m_fdinfo = fdinfo;
-		m_evtnum = 0;
 	}
 	inline void load_params()
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1247,7 +1247,13 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		get_procs_cpu_from_driver(ts);
 	}
 
-	// this is used by things like the k8s and mesos clients
+	//
+	// Store a couple of values that we'll need later inside the event.
+	// These are potentially used both for parsing the event for internal
+	// state management, and for managing the k8s and mesos clients.
+	//
+	m_nevts++;
+	evt->m_evtnum = m_nevts;
 	m_lastevent_ts = ts;
 
 	if (m_automatic_threadtable_purging)
@@ -1394,10 +1400,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 #else
 	m_parser->process_event(evt);
 #endif
-
-	// set the event number
-	m_nevts++;
-	evt->m_evtnum = m_nevts;
 
 	//
 	// If needed, dump the event to file


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The changes of https://github.com/falcosecurity/libs/pull/639 and https://github.com/falcosecurity/libs/pull/655 polished the `sinsp_evt` initialization by setting the evt number to 0, which however causes some troubles in case some parts of the inspector's state management logic rely on that value (e.g. plugin field extraction). This PRs fixes this by introducing proper constructors for that class, and reverting the changes of the previous two PRs.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
