### PR TITLE
update(driver): add a backoff in case of modern probe timeout

### DIFF
--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
@@ -26,6 +26,7 @@ struct scap;
 struct modern_bpf_engine
 {
 	size_t m_num_cpus;
+	unsigned long m_retry_us;
 	char* m_lasterr;
 };
 


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR reduces the number of timeouts in the modern bpf probe

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
