### PR TITLE
cleanup(libsinsp,libscap): remove error-prone string functions (even if used safely)

### DIFF
--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -1,3 +1,5 @@
+
+#include "../../../userspace/common/strlcpy.h"
 #include "event_class.h"
 #include <time.h>
 
@@ -309,10 +311,7 @@ void event_test::client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sun_family = AF_UNIX;
 
-	if(strncpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH) == NULL)
-	{
-		FAIL() << "'strncpy (client)' must not fail." << std::endl;
-	}
+	strlcpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH);
 }
 
 void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path)
@@ -320,10 +319,7 @@ void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sun_family = AF_UNIX;
 
-	if(strncpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH) == NULL)
-	{
-		FAIL() << "'strncpy (server)' must not fail." << std::endl;
-	}
+	strlcpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH);
 }
 
 void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr)
@@ -535,16 +531,11 @@ void event_test::assert_cgroup_param(int param_num)
 
 	for(int index = 0; index < CGROUP_NUMBER; index++)
 	{
-		/* 'strcpy()' takes also the '\0'. */
-		strcpy(cgroup_string, m_event_params[m_current_param].valptr + total_len);
-		/* 'strlen()' does not include the terminating null byte '\0'. */
-		total_len += strlen(cgroup_string) + 1;
+		total_len += strlcpy(cgroup_string, m_event_params[m_current_param].valptr + total_len, sizeof(cgroup_string));
+		total_len += 1;
+
 		prefix_len = strlen(cgroup_prefix_array[index]);
-		strncpy(cgroup_prefix, cgroup_string, prefix_len);
-		/* add the NULL terminator.
-		 * Pay attention to buffer overflow if you change the `MAX_CGROUP_PREFIX_LEN`.
-		 */
-		cgroup_prefix[prefix_len] = '\0';
+		strlcpy(cgroup_prefix, cgroup_string, prefix_len);
 		ASSERT_STREQ(cgroup_prefix, cgroup_prefix_array[index]) << VALUE_NOT_CORRECT << m_current_param;
 	}
 	assert_param_len(total_len);

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -531,11 +531,11 @@ void event_test::assert_cgroup_param(int param_num)
 
 	for(int index = 0; index < CGROUP_NUMBER; index++)
 	{
-		total_len += strlcpy(cgroup_string, m_event_params[m_current_param].valptr + total_len, sizeof(cgroup_string));
-		total_len += 1;
+		strlcpy(cgroup_string, m_event_params[m_current_param].valptr + total_len, MAX_CGROUP_STRING_LEN);
+		total_len += strlen(cgroup_string) + 1;
 
 		prefix_len = strlen(cgroup_prefix_array[index]);
-		strlcpy(cgroup_prefix, cgroup_string, prefix_len);
+		strlcpy(cgroup_prefix, cgroup_string, prefix_len + 1);
 		ASSERT_STREQ(cgroup_prefix, cgroup_prefix_array[index]) << VALUE_NOT_CORRECT << m_current_param;
 	}
 	assert_param_len(total_len);

--- a/test/modern_bpf/event_class/network_utils.h
+++ b/test/modern_bpf/event_class/network_utils.h
@@ -43,7 +43,7 @@
 /*=============================== UNIX ===========================*/
 
 /* Max length socket unix path. */
-#define MAX_SUN_PATH 108
+#define MAX_SUN_PATH 109
 
 /* Unix Client: the `xyzxe-` prefix is used to avoid name collisions */
 #define UNIX_CLIENT "/tmp/xyzxe-client"

--- a/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/connect_e.cpp
@@ -128,8 +128,8 @@ TEST(SyscallEnter, connectE_UNIX)
 	evt_test->assert_num_params_pushed(2);
 }
 
-/* This is long 109 chars, so no null terminator will be put inside the `sun_path` during the socket call.
- * The BPF prog can read at least `108` chars so instead of the `*`, it will put the `\0`.
+/* This is 109 chars long, so no null terminator will be put inside the `sun_path` during the socket call.
+ * The BPF prog can read at most `108` chars so instead of the `*`, it will put the `\0`.
  */
 #define UNIX_LONG_PATH "/unix_socket/test/too_long/too_long/too_long/too_long/unix_socket/test/too_long/too_long/too_long/too_longgg*"
 #define EXPECTED_UNIX_LONG_PATH "/unix_socket/test/too_long/too_long/too_long/too_long/unix_socket/test/too_long/too_long/too_long/too_longgg"

--- a/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/open_by_handle_at_x.cpp
@@ -1,3 +1,4 @@
+#include "../../../../userspace/common/strlcpy.h"
 #include "../../event_class/event_class.h"
 #include <sys/mount.h>
 
@@ -86,7 +87,7 @@ void do___open_by_handle_atX_success(int *open_by_handle_fd, int *dirfd, char *f
 	 */
 	if(use_mountpoint)
 	{
-		strcpy(fspath, dir_name);
+		strlcpy(fspath, dir_name, MAX_FSPATH_LEN);
 	}
 	else
 	{

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #endif
 #include <json/json.h>
 
+#include "../common/strlcpy.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "chisel.h"
@@ -170,7 +171,7 @@ uint32_t lua_cbacks::rawval_to_lua_stack(lua_State *ls, uint8_t* rawval, ppm_par
 
 				if(NULL == inet_ntop(AF_INET6, ip->m_b, address, 100))
 				{
-					strcpy(address, "<NA>");
+					strlcpy(address, "<NA>", sizeof(address));
 				}
 
 				strlcpy(ch->m_lua_fld_storage,
@@ -980,14 +981,14 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 					// Now convert the raw sip/cip to strings
 					if(NULL == inet_ntop(af, sip, sipbuf, sizeof(sipbuf)))
 					{
-						strcpy(sipbuf, "<NA>");
+						strlcpy(sipbuf, "<NA>", sizeof(sipbuf));
 					}
 
 					if(cip)
 					{
 						if(NULL == inet_ntop(af, cip, cipbuf, sizeof(cipbuf)))
 						{
-							strcpy(cipbuf, "<NA>");
+							strlcpy(cipbuf, "<NA>", sizeof(cipbuf));
 						}
 					}
 

--- a/userspace/libpman/src/capture.c
+++ b/userspace/libpman/src/capture.c
@@ -50,7 +50,7 @@ int pman_print_stats()
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{
-			sprintf(error_message, "unbale to get the counter map for CPU %d", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unbale to get the counter map for CPU %d", index);
 			pman_print_error((const char *)error_message);
 			goto clean_print_stats;
 		}
@@ -98,7 +98,7 @@ int pman_get_scap_stats(void *scap_stats_struct)
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{
-			sprintf(error_message, "unbale to get the counter map for CPU %d", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unbale to get the counter map for CPU %d", index);
 			pman_print_error((const char *)error_message);
 			goto clean_print_stats;
 		}
@@ -129,7 +129,7 @@ int pman_get_n_tracepoint_hit(long *n_events_per_cpu)
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{
-			sprintf(error_message, "unbale to get the counter map for CPU %d", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unbale to get the counter map for CPU %d", index);
 			pman_print_error((const char *)error_message);
 			goto clean_print_stats;
 		}

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -98,7 +98,7 @@ static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog
 	bpf_prog = bpf_object__find_program_by_name(g_state.skel->obj, bpf_prog_name);
 	if(!bpf_prog)
 	{
-		sprintf(error_message, "unable to find BPF program '%s'", bpf_prog_name);
+		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to find BPF program '%s'", bpf_prog_name);
 		pman_print_error((const char*)error_message);
 		goto clean_add_program_to_tail_table;
 	}
@@ -106,14 +106,14 @@ static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog
 	bpf_prog_fd = bpf_program__fd(bpf_prog);
 	if(bpf_prog_fd <= 0)
 	{
-		sprintf(error_message, "unable to get the fd for BPF program '%s'", bpf_prog_name);
+		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to get the fd for BPF program '%s'", bpf_prog_name);
 		pman_print_error((const char*)error_message);
 		goto clean_add_program_to_tail_table;
 	}
 
 	if(bpf_map_update_elem(tail_table_fd, &key, &bpf_prog_fd, BPF_ANY))
 	{
-		sprintf(error_message, "unable to update the tail table with BPF program '%s'", bpf_prog_name);
+		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to update the tail table with BPF program '%s'", bpf_prog_name);
 		pman_print_error((const char*)error_message);
 		goto clean_add_program_to_tail_table;
 	}

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -160,14 +160,14 @@ static int create_remaining_ringbuffer_maps()
 		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
 		if(ringbuf_map_fd <= 0)
 		{
-			sprintf(error_message, "failed to create the ringbuf map for CPU %d", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to create the ringbuf map for CPU %d", index);
 			pman_print_error((const char *)error_message);
 			goto clean_create_remaining_ringbuffer_maps;
 		}
 
 		if(bpf_map_update_elem(ringubuf_array_fd, &index, &ringbuf_map_fd, BPF_ANY))
 		{
-			sprintf(error_message, "failed to add the ringbuf map for CPU %d into the array", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU %d into the array", index);
 			pman_print_error((const char *)error_message);
 			goto clean_create_remaining_ringbuffer_maps;
 		}
@@ -175,7 +175,7 @@ static int create_remaining_ringbuffer_maps()
 		/* add the new ringbuf map into the manager. */
 		if(ring_buffer__add(g_state.rb_manager, ringbuf_map_fd, NULL, NULL))
 		{
-			sprintf(error_message, "failed to add the ringbuf map for CPU %d into the manager", index);
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU %d into the manager", index);
 			pman_print_error((const char *)error_message);
 			goto clean_create_remaining_ringbuffer_maps;
 		}

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -547,7 +547,7 @@ static int32_t load_tracepoint(struct bpf_engine* handle, const char *event, str
 	}
 
 	handle->m_bpf_progs[handle->m_bpf_prog_cnt].fd = fd;
-	strncpy(handle->m_bpf_progs[handle->m_bpf_prog_cnt].name, full_event, NAME_MAX);
+	strlcpy(handle->m_bpf_progs[handle->m_bpf_prog_cnt].name, full_event, NAME_MAX);
 	handle->m_bpf_prog_cnt++;
 
 	if(memcmp(event, "filler/", sizeof("filler/") - 1) == 0)
@@ -598,9 +598,7 @@ static int32_t load_tracepoint(struct bpf_engine* handle, const char *event, str
 	}
 	else
 	{
-		strcpy(buf, "/sys/kernel/debug/tracing/events/");
-		strcat(buf, event);
-		strcat(buf, "/id");
+		snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/events/%s/id", event);
 
 		efd = open(buf, O_RDONLY, 0);
 		if(efd < 0)

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -29,6 +29,7 @@ struct iovec {
 };
 #endif
 
+#include "../common/strlcpy.h"
 #include "savefile.h"
 #include "scap.h"
 #include "scap-int.h"
@@ -2182,7 +2183,7 @@ static int32_t scap_savefile_restart_capture(scap_t* handle)
 	{
 		char error[SCAP_LASTERR_SIZE];
 		snprintf(error, SCAP_LASTERR_SIZE, "could not restart capture: %s", scap_getlasterr(handle));
-		strncpy(handle->m_lasterr, error, SCAP_LASTERR_SIZE);
+		strlcpy(handle->m_lasterr, error, SCAP_LASTERR_SIZE);
 	}
 	return res;
 }

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -21,6 +21,7 @@ limitations under the License.
 #include <scap.h>
 #include <arpa/inet.h>
 #include <sys/time.h>
+#include "../../../common/strlcpy.h"
 
 #define SYSCALL_NAME_MAX_LEN 40
 #define UNKNOWN_ENGINE "unknown"
@@ -170,9 +171,9 @@ void print_sorted_syscalls(char string_vector[SYSCALL_TABLE_SIZE][SYSCALL_NAME_M
 			/* swapping strings if they are not in the lexicographical order */
 			if(strcmp(string_vector[i], string_vector[j]) > 0)
 			{
-				strcpy(temp, string_vector[i]);
-				strcpy(string_vector[i], string_vector[j]);
-				strcpy(string_vector[j], temp);
+				strlcpy(temp, string_vector[i], SYSCALL_NAME_MAX_LEN);
+				strlcpy(string_vector[i], string_vector[j], SYSCALL_NAME_MAX_LEN);
+				strlcpy(string_vector[j], temp, SYSCALL_NAME_MAX_LEN);
 			}
 		}
 	}
@@ -201,7 +202,7 @@ void print_UF_NEVER_DROP_syscalls()
 
 			if(g_syscall_table[syscall_nr].flags & UF_NEVER_DROP)
 			{
-				strcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name);
+				strlcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name, SYSCALL_NAME_MAX_LEN);
 			}
 		}
 	}
@@ -227,7 +228,7 @@ void print_EF_MODIFIES_STATE_syscalls()
 			int enter_event = g_syscall_table[syscall_nr].enter_event_type;
 			if(g_event_info[enter_event].flags & EF_MODIFIES_STATE)
 			{
-				strcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name);
+				strlcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name, SYSCALL_NAME_MAX_LEN);
 			}
 		}
 	}
@@ -256,7 +257,7 @@ void print_sinsp_modifies_state_syscalls()
 			{
 				continue;
 			}
-			strcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name);
+			strlcpy(str[interesting_syscall++], g_syscall_info_table[ppm_sc].name, SYSCALL_NAME_MAX_LEN);
 		}
 	}
 
@@ -452,7 +453,7 @@ void print_ipv4(int starting_index)
 {
 	char ipv4_string[50];
 	uint8_t* ipv4 = (uint8_t*)(valptr + starting_index);
-	sprintf(ipv4_string, "%d.%d.%d.%d", ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
+	snprintf(ipv4_string, sizeof(ipv4_string), "%d.%d.%d.%d", ipv4[0], ipv4[1], ipv4[2], ipv4[3]);
 	printf("- ipv4: %s\n", ipv4_string);
 }
 

--- a/userspace/libscap/windows_hal.c
+++ b/userspace/libscap/windows_hal.c
@@ -23,6 +23,7 @@ limitations under the License.
 #include <iphlpapi.h>
 
 #include "../common/types.h"
+#include "../common/strlcpy.h"
 #define DRAGENT_WIN_HAL_C_ONLY
 #include "win_hal/win_hal_public.h"
 #include "scap.h"
@@ -268,7 +269,7 @@ int32_t scap_create_userlist_windows(scap_t* handle)
 		}
 		else
 		{
-			strcpy(handle->m_userlist->users[j].name, "NA");
+			strlcpy(handle->m_userlist->users[j].name, "NA", WH_MAX_PATH_SIZE+1);
 		}
 
 		//
@@ -290,7 +291,7 @@ int32_t scap_create_userlist_windows(scap_t* handle)
 	// Only one fake group, since windows doesn't have unix groups
 	//
 	handle->m_userlist->groups[0].gid = 0;
-	strcpy(handle->m_userlist->groups[0].name, "NA");
+	strlcpy(handle->m_userlist->groups[0].name, "NA", WH_MAX_PATH_SIZE + 1);
 
 	return SCAP_SUCCESS;
 }
@@ -576,7 +577,7 @@ static int32_t addprocess_windows(wh_procinfo* wpi, scap_t* handle, char* error)
 			switch(wfd->type)
 			{
 			case WH_FD_FILE:
-				strncpy(fdi->info.fname, 
+				strlcpy(fdi->info.fname, 
 					wfd->info.fname + 4, // the +4 removes the "\\?\" from the beginning of the string
 					SCAP_MAX_PATH_SIZE - 1);
 				fdi->info.fname[SCAP_MAX_PATH_SIZE - 1] = 0;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -238,7 +238,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 	for(j = 0; j < srclen; j += 8 * sizeof(uint16_t))
 	{
 		k = 0;
-		k += sprintf(row + k, "\n\t0x%.4x:", j);
+		k += snprintf(row + k, sizeof(row) - k, "\n\t0x%.4x:", j);
 
 		ptr = &src[j];
 		num_chunks = 0;
@@ -248,11 +248,11 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 
 			if(ptr == src + srclen - 1)
 			{
-				k += sprintf(row + k, " %.2x", *(((uint8_t*)&chunk) + 1));
+				k += snprintf(row + k, sizeof(row) - k, " %.2x", *(((uint8_t*)&chunk) + 1));
 			}
 			else
 			{
-				k += sprintf(row + k, " %.4x", chunk);
+				k += snprintf(row + k, sizeof(row) - k, " %.4x", chunk);
 			}
 
 			num_chunks++;
@@ -295,7 +295,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 			truncated = true;
 			break;
 		}
-		strcpy(dst + l, row);
+		strlcpy(dst + l, row, dstlen - l);
 		l += row_len;
 	}
 

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1040,7 +1040,7 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 
 			if(NULL == inet_ntop(AF_INET6, rawval, address, INET6_ADDRSTRLEN))
 			{
-				strcpy(address, "<NA>");
+				strlcpy(address, "<NA>", INET6_ADDRSTRLEN);
 			}
 
 			strlcpy(m_getpropertystr_storage, address, sizeof(m_getpropertystr_storage));
@@ -1097,7 +1097,7 @@ char* sinsp_filter_check::tostring(sinsp_evt* evt)
 			res += rawval_to_string(val.ptr, m_field->m_type, m_field->m_print_format, val.len);
 		}
 		res += ")";
-		strncpy(m_getpropertystr_storage, res.c_str(), sizeof(m_getpropertystr_storage) - 1);
+		strlcpy(m_getpropertystr_storage, res.c_str(), sizeof(m_getpropertystr_storage));
 		return m_getpropertystr_storage;
 	}
 	return rawval_to_string(m_extracted_values[0].ptr, m_field->m_type, m_field->m_print_format, m_extracted_values[0].len);

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5189,28 +5189,31 @@ uint8_t* sinsp_filter_check_tracer::extract_args(sinsp_partial_tracer* pae, OUT 
 	}
 
 	char* p = m_storage;
+	size_t storage_len = 0;
 
 	for(nameit = pae->m_argnames.begin(), valit = pae->m_argvals.begin(),
 		namesit = pae->m_argnamelens.begin(), valsit = pae->m_argvallens.begin();
 		nameit != pae->m_argnames.end();
 		++nameit, ++namesit, ++valit, ++valsit)
 	{
-		strcpy(p, *nameit);
-		p += (*namesit);
-		*p++ = '=';
+		strlcpy(p + storage_len, *nameit, m_storage_size - storage_len);
+		storage_len += (*namesit);
+		m_storage[storage_len] = '=';
+		storage_len++;
 
-		memcpy(p, *valit, (*valsit));
-		p += (*valsit);
-		*p++ = ',';
+		memcpy(p + storage_len, *valit, (*valsit));
+		storage_len += (*valsit);
+		m_storage[storage_len] = ',';
+		storage_len++;
 	}
 
-	if(p != m_storage)
+	if (storage_len == 0)
 	{
-		*--p = 0;
+		m_storage[0] = '\0';
 	}
 	else
 	{
-		*p = 0;
+		m_storage[storage_len - 1] = '\0';
 	}
 
 	RETURN_EXTRACT_CSTR(m_storage);
@@ -5886,28 +5889,31 @@ inline uint8_t* sinsp_filter_check_evtin::extract_tracer(sinsp_evt *evt, sinsp_p
 		}
 
 		char* p = m_storage;
+		size_t storage_len = 0;
 
 		for(nameit = pae->m_argnames.begin(), valit = pae->m_argvals.begin(),
 			namesit = pae->m_argnamelens.begin(), valsit = pae->m_argvallens.begin();
 			nameit != pae->m_argnames.end();
 			++nameit, ++namesit, ++valit, ++valsit)
 		{
-			strcpy(p, *nameit);
-			p += (*namesit);
-			*p++ = ':';
+			strlcpy(p + storage_len, *nameit, m_storage_size - storage_len);
+			storage_len += (*namesit);
+			m_storage[storage_len] = ':';
+			storage_len++;
 
-			memcpy(p, *valit, (*valsit));
-			p += (*valsit);
-			*p++ = ',';
+			memcpy(p + storage_len, *valit, (*valsit));
+			storage_len += (*valsit);
+			m_storage[storage_len] = ',';
+			storage_len++;
 		}
 
-		if(p != m_storage)
+		if (storage_len == 0)
 		{
-			*--p = 0;
+			m_storage[0] = '\0';
 		}
 		else
 		{
-			*p = 0;
+			m_storage[storage_len - 1] = '\0';
 		}
 
 		RETURN_EXTRACT_CSTR(m_storage);

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -35,10 +35,11 @@ sinsp_ipv4_ifinfo::sinsp_ipv4_ifinfo(uint32_t addr, uint32_t netmask, uint32_t b
 	m_name = name;
 }
 
-void sinsp_ipv4_ifinfo::convert_to_string(char * dest, const uint32_t addr)
+void sinsp_ipv4_ifinfo::convert_to_string(char * dest, size_t len, const uint32_t addr)
 {
-	sprintf(
+	snprintf(
 		dest,
+		len,
 		"%d.%d.%d.%d",
 		(addr & 0xFF),
 		((addr & 0xFF00) >> 8),
@@ -49,7 +50,7 @@ void sinsp_ipv4_ifinfo::convert_to_string(char * dest, const uint32_t addr)
 string sinsp_ipv4_ifinfo::address() const
 {
 	char str_addr[16];
-	convert_to_string(str_addr, m_addr);
+	convert_to_string(str_addr, sizeof(str_addr), m_addr);
 	return string(str_addr);
 }
 
@@ -60,9 +61,9 @@ string sinsp_ipv4_ifinfo::to_string() const
 	char s_netmask[16];
 	char s_bcast[16];
 
-	convert_to_string(str_addr, m_addr);
-	convert_to_string(s_netmask, m_netmask);
-	convert_to_string(s_bcast, m_bcast);
+	convert_to_string(str_addr, sizeof(str_addr), m_addr);
+	convert_to_string(s_netmask, sizeof(str_addr), m_netmask);
+	convert_to_string(s_bcast, sizeof(str_addr), m_bcast);
 	snprintf(s, sizeof(s), "%s inet %s netmask %s broadcast %s", m_name.c_str(), str_addr, s_netmask, s_bcast);
 	return string(s);
 }

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -43,7 +43,7 @@ public:
 	uint32_t m_bcast;
 	string m_name;
 private:
-	static void convert_to_string(char * dest, const uint32_t addr);
+	static void convert_to_string(char * dest, size_t len, const uint32_t addr);
 };
 
 //

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -54,10 +54,11 @@ sinsp_ipv4_ifinfo make_ipv4_localhost()
 }
 
 
-void convert_to_string(char* dest, uint32_t addr)
+void convert_to_string(char* dest, size_t len, uint32_t addr)
 {
-	sprintf(
+	snprintf(
 		dest, 
+		len,
 		"%d.%d.%d.%d", 
 		(addr & 0xFF),
 		((addr & 0xFF00) >> 8),
@@ -69,7 +70,7 @@ void convert_to_string(char* dest, uint32_t addr)
 
 #define EXPECT_ADDR_EQ(dotted_notation,addr) {\
 	char buf[17];\
-	convert_to_string(buf,addr);\
+	convert_to_string(buf,17,addr);\
 	EXPECT_STREQ(dotted_notation,buf);\
 };
 

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -70,7 +70,7 @@ void convert_to_string(char* dest, size_t len, uint32_t addr)
 
 #define EXPECT_ADDR_EQ(dotted_notation,addr) {\
 	char buf[17];\
-	convert_to_string(buf,17,addr);\
+	convert_to_string(buf, sizeof(buf), addr);\
 	EXPECT_STREQ(dotted_notation,buf);\
 };
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1934,7 +1934,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 			 */
 			if(strncmp(parinfo->m_val, "<NA>", 5) == 0)
 			{
-				strncpy(fullpath, "<NA>", 5);
+				strlcpy(fullpath, "<NA>", 5);
 			}
 			else
 			{
@@ -1996,7 +1996,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 			   sdir.compare("<UNKNOWN>") == 0)
 			{
 				/* we copy also the string terminator `\0`. */
-				strncpy(fullpath, "<NA>", 5);
+				strlcpy(fullpath, "<NA>", 5);
 			} 
 			/* (3) In this case we have already obtained the `exepath` and it is `sdir`, we just need
 			 * to sanitize it. 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -517,9 +517,9 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 	{
 		m_user.uid = uid;
 		m_user.gid = m_group.gid;
-		strcpy(m_user.name, "<NA>");
-		strcpy(m_user.homedir, "<NA>");
-		strcpy(m_user.shell, "<NA>");
+		strlcpy(m_user.name, "<NA>", sizeof(m_user.name));
+		strlcpy(m_user.homedir, "<NA>", sizeof(m_user.homedir));
+		strlcpy(m_user.shell, "<NA>", sizeof(m_user.shell));
 	}
 }
 
@@ -539,7 +539,7 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 	else
 	{
 		m_group.gid = gid;
-		strcpy(m_group.name, "<NA>");
+		strlcpy(m_group.name, "<NA>", sizeof(m_group.name));
 	}
 	// Force-sync user.gid and group id
 	m_user.gid = m_group.gid;
@@ -562,9 +562,9 @@ void sinsp_threadinfo::set_loginuser(uint32_t loginuid)
 	{
 		m_loginuser.uid = loginuid;
 		m_loginuser.gid = m_group.gid;
-		strcpy(m_loginuser.name, "<NA>");
-		strcpy(m_loginuser.homedir, "<NA>");
-		strcpy(m_loginuser.shell, "<NA>");
+		strlcpy(m_loginuser.name, "<NA>", sizeof(m_loginuser.name));
+		strlcpy(m_loginuser.homedir, "<NA>", sizeof(m_loginuser.homedir));
+		strlcpy(m_loginuser.shell, "<NA>", sizeof(m_loginuser.shell));
 	}
 }
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -757,7 +757,7 @@ bool sinsp_utils::concatenate_paths(char* target,
 {
 	if(targetlen < (len1 + len2 + 1))
 	{
-		strcpy(target, "/PATH_TOO_LONG");
+		strlcpy(target, "/PATH_TOO_LONG", targetlen);
 		return false;
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp
/area libscap
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

I would like to remove all usage of functions such as `strcpy`, `sprintf`, `strncpy` even if they are used safely. For copying strings we have a safer alternative called `strlcpy` (see the original [whitepaper](https://www.usenix.org/legacy/publications/library/proceedings/usenix99/full_papers/millert/millert.pdf) from 1999). It is way too easy to mess up when using the standard libc functions. Indeed, the main falco repo already removed that function usage via a `banned.h` header. I would also like to have that (in another PR) in libs as well.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Q: Why is there one commit per file?
A: Because sometimes the modifications aren't trivial and if something may be off it's easy to remove that by reverting a commit instead of having a big block of stuff

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
