### PR TITLE
Fix neglect-to-remove bug in sinsp automatic threadtable purging logic

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1262,10 +1262,13 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		// Delayed removal of threads from the thread table, so that
 		// things like exit() or close() can be parsed.
 		//
-		if(m_tid_to_remove != -1)
+		// Note: remove_thread() may itself identify another thread that
+		// needs removal.
+		while (m_tid_to_remove != -1)
 		{
-			remove_thread(m_tid_to_remove, false);
+			uint64_t remove_tid = m_tid_to_remove;
 			m_tid_to_remove = -1;
+			remove_thread(remove_tid, false);
 		}
 
 		if(!is_capture())


### PR DESCRIPTION
Various sinsp logic sets m_tid_to_remove, to record the fact that a thread has been identified as ready-to-be-removed from the threadtable.  And if automatic threadtable purging is configured, sinsp::next() takes care of removing these threads by calling remove_thread(), then clearing m_tid_to_remove.

But remove_thread() may itself set m_tid_to_remove in certain situations. The current sinsp::next() logic loses track of this request; as a result, these threads will languish in the threadtable until the next remove_inactive_threads() interval, default value 20 minutes.

This fix changes the sinsp::next() logic to recognize and handle the case where remove_thread() records a thread for removal.

Signed-off-by: Joseph Pittman <joseph.pittman@sysdig.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Fix sinsp automatic threadtable purging logic, which loses track of a thread to remove, in the case where removal of one thread results in the detection of another thread which also needs removal.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: timely removal of terminated threads
```
