### PR TITLE
fix(gvisor): skip invalid/untraceable sandboxes at startup

### DIFF
--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -372,6 +372,14 @@ uint32_t engine::get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos)
 	for(const auto &sandbox : sandboxes)
 	{
 		runsc::result procfs_res = runsc::trace_procfs(m_root_path, sandbox);
+
+		// We may be unable to read procfs for several reasons, e.g. the pause container on k8s or a sandbox that was
+		// being removed
+		if (procfs_res.error != 0)
+		{
+			continue;
+		}
+
 		for(const auto &line : procfs_res.output)
 		{
 			// skip first line of the output and empty lines

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -287,11 +287,10 @@ int32_t engine::start_capture()
 		runsc::result trace_create_res = runsc::trace_create(m_root_path, m_trace_session_path, sandbox, true);
 		if(trace_create_res.error)
 		{
-			snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot create session for sandbox %s", sandbox.c_str());
-			return SCAP_FAILURE;
+			// some sandboxes may not be traced, we can skip them safely
+			continue;
 		}
 	}
-
 
 	// Catch all sandboxes that might have been created in the meantime
 	runsc::result new_sandboxes_res = runsc::list(m_root_path);
@@ -320,8 +319,8 @@ int32_t engine::start_capture()
 		runsc::result trace_create_res = runsc::trace_create(m_root_path, m_trace_session_path, sandbox, false);
 		if(trace_create_res.error)
 		{
-			snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot create session for sandbox %s", sandbox.c_str());
-			return SCAP_FAILURE;
+			// some sandboxes may not be traced, we can skip them safely
+			continue;
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap-engine-gvisor



<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
no

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

There are several cases in which we could find invalid sandboxes, e.g.:
1. race condition between stopping and querying them
2. on k8s, the pause container

In those cases Falco should not crash, but rather not trace those sandboxes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The `continue` may look redundant, but I wanted to be explicit when skipping over an error.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(gvisor): skip invalid/untraceable sandboxes at startup
```
