### PR TITLE
fix(userspace): check that the actual kernel version is greater than the required one

### DIFF
--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -187,16 +187,22 @@ static int32_t check_minimum_kernel_version(char* last_err)
 		return SCAP_FAILURE;
 	}
 
-	if(!scap_apply_semver_check(major, minor, patch, REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_PATCH))
+	if(major > REQUIRED_MAJOR)
 	{
-		if(last_err != NULL)
-		{
-			snprintf(last_err, SCAP_LASTERR_SIZE, "Actual kernel version is: '%d.%d.%d' while the minimum required is: '%d.%d.%d'\n", major, minor, patch, REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_PATCH);
-		}
-		return SCAP_FAILURE;
+		return SCAP_SUCCESS;
 	}
 
-	return SCAP_SUCCESS;
+	if(major == REQUIRED_MAJOR && minor > REQUIRED_MINOR)
+	{
+		return SCAP_SUCCESS;
+	}
+
+	if(major == REQUIRED_MAJOR && minor == REQUIRED_MINOR && patch >= REQUIRED_PATCH)
+	{
+		return SCAP_SUCCESS;
+	}
+	snprintf(last_err, SCAP_LASTERR_SIZE, "Actual kernel version is: '%d.%d.%d' while the minimum required is: '%d.%d.%d'\n", major, minor, patch, REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_PATCH);
+	return SCAP_FAILURE;
 }
 
 /*=============================== UTILS ===============================*/


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

We need to check that the actual kernel version is greater than the required one, we don't need to apply a semver check!

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
