### PR TITLE
fix(userspace/libscap): fixed loading of ebpf probe with offline CPUs

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1564,7 +1564,7 @@ int32_t scap_bpf_load(
 
 	if(online_cpu != handle->m_dev_set.m_ndevs)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "processors online: %d, expected: %d", j, handle->m_dev_set.m_ndevs);
+		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "processors online: %d, expected: %d", online_cpu, handle->m_dev_set.m_ndevs);
 		return SCAP_FAILURE;
 	}
 
@@ -1786,7 +1786,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	}
 
 	//
-	// Find out how many devices we have to open, which equals to the number of CPUs
+	// Find out how many devices we have to open, which equals to the number of online CPUs
 	//
 	ssize_t num_cpus = sysconf(_SC_NPROCESSORS_CONF);
 	if(num_cpus == -1)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf

**Does this PR require a change in the driver versions?**

NOPE

**What this PR does / why we need it**:

Revert a bug introduced in #374: use same code used by kmod engine to properly load all CPUs and online CPUs, to be later able to properly count online CPUs.

**Which issue(s) this PR fixes**:

Fixes #720 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libscap): fixed loading of ebpf probe with offline CPUs
```
