### PR TITLE
cleanup(userspace/libscap): scap_open should not start capture.

### DIFF
--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -1015,6 +1015,8 @@ int main(int argc, char** argv)
 
 	gettimeofday(&tval_start, NULL);
 
+	scap_start_capture(g_h);
+
 	while(g_nevts != num_events)
 	{
 		res = scap_next(g_h, &ev, &cpuid);
@@ -1050,6 +1052,7 @@ int main(int argc, char** argv)
 		g_nevts++;
 	}
 
+	scap_stop_capture(g_h);
 	print_stats();
 	scap_close(g_h);
 	return EXIT_SUCCESS;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -243,17 +243,6 @@ scap_t* scap_open_live_int(char *error, int32_t *rc, scap_open_args* oargs)
 		snprintf(error, SCAP_LASTERR_SIZE, "scap_open_live_int() error creating the process list: %s. Make sure you have root credentials.", proc_scan_err);
 		return NULL;
 	}
-
-	//
-	// Now that /proc parsing has been done, start the capture
-	//
-	if((*rc = scap_start_capture(handle)) != SCAP_SUCCESS)
-	{
-		snprintf(error, SCAP_LASTERR_SIZE, "%s", handle->m_lasterr);
-		scap_close(handle);
-		return NULL;
-	}
-
 	return handle;
 }
 
@@ -468,12 +457,6 @@ scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *oargs
 		scap_close(handle);
 		return NULL;
 	}
-
-	if(handle->m_vtable->start_capture(handle->m_engine) != SCAP_SUCCESS)
-	{
-		scap_close(handle);
-		return NULL;
-	}
 	return handle;
 }
 #else
@@ -546,13 +529,6 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *oargs)
 
 	if ((*rc = scap_proc_scan_vtable(error, handle)) != SCAP_SUCCESS)
 	{
-		scap_close(handle);
-		return NULL;
-	}
-
-	if(handle->m_vtable->start_capture(handle->m_engine) != SCAP_SUCCESS)
-	{
-		snprintf(error, SCAP_LASTERR_SIZE, "error while starting capture: %s", handle->m_lasterr);
 		scap_close(handle);
 		return NULL;
 	}

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -294,10 +294,12 @@ int main(int argc, char** argv)
 		}
 	}
 
+	inspector.start_capture();
 	while(!g_interrupted)
 	{
 		dump(inspector);
 	}
+	inspector.stop_capture();
 
 	// Cleanup JSON formatters
 	delete default_formatter;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

NOPE

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Right now, `scap_open` does also start driver capture. `scap_close` instead, is not stopping the capture.
I think the best way is to allow consumers to open scap without starting any capture; therefore this PR forces consumers to manually call `scap_start_capture()` and `scap_stop_capture()`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(userspace/libscap): `scap_open` won't autostart the capture anymore. Instead, consumers should manually start it.
```
