### PR TITLE
Sync changes for 0.9.2: gvisor bugfixes

### DIFF
--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -372,6 +372,14 @@ uint32_t engine::get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos)
 	for(const auto &sandbox : sandboxes)
 	{
 		runsc::result procfs_res = runsc::trace_procfs(m_root_path, sandbox);
+
+		// We may be unable to read procfs for several reasons, e.g. the pause container on k8s or a sandbox that was
+		// being removed
+		if (procfs_res.error != 0)
+		{
+			continue;
+		}
+
 		for(const auto &line : procfs_res.output)
 		{
 			// skip first line of the output and empty lines

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -287,11 +287,10 @@ int32_t engine::start_capture()
 		runsc::result trace_create_res = runsc::trace_create(m_root_path, m_trace_session_path, sandbox, true);
 		if(trace_create_res.error)
 		{
-			snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot create session for sandbox %s", sandbox.c_str());
-			return SCAP_FAILURE;
+			// some sandboxes may not be traced, we can skip them safely
+			continue;
 		}
 	}
-
 
 	// Catch all sandboxes that might have been created in the meantime
 	runsc::result new_sandboxes_res = runsc::list(m_root_path);
@@ -320,8 +319,8 @@ int32_t engine::start_capture()
 		runsc::result trace_create_res = runsc::trace_create(m_root_path, m_trace_session_path, sandbox, false);
 		if(trace_create_res.error)
 		{
-			snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot create session for sandbox %s", sandbox.c_str());
-			return SCAP_FAILURE;
+			// some sandboxes may not be traced, we can skip them safely
+			continue;
 		}
 	}
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -592,6 +592,7 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *oargs)
 
 	if(handle->m_vtable->start_capture(handle->m_engine) != SCAP_SUCCESS)
 	{
+		snprintf(error, SCAP_LASTERR_SIZE, "error while starting capture: %s", handle->m_lasterr);
 		scap_close(handle);
 		return NULL;
 	}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1787,6 +1787,7 @@ int32_t scap_proc_scan_vtable(char *error, scap_t *handle)
 	res = handle->m_vtable->get_threadinfos(handle->m_engine, &n_tinfos, &tinfos);
 	if (res != SCAP_SUCCESS)
 	{
+		snprintf(error, SCAP_LASTERR_SIZE, "cannot get system thread information: %s", handle->m_lasterr);
 		return res;
 	}
 


### PR DESCRIPTION
This PR updates the 0.9.2 release branch with the gVisor bugfixes.

```release-note
fix(gvisor): prevent libscap crashes by skipping invalid/untraceable sandboxes at startup
fix(libscap,gvisor): fix error handling at capture start and proc scan in some cases
```
