### PR TITLE
Fix kmod build error

### DIFF
--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -22,8 +22,8 @@ limitations under the License.
 #include <errno.h>
 #include <sys/mman.h>
 
-#include "kmod.h"
 #define SCAP_HANDLE_T struct kmod_engine
+#include "kmod.h"
 #include "scap.h"
 #include "driver_config.h"
 #include "../../driver/ppm_ringbuffer.h"

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -31,10 +31,7 @@ limitations under the License.
 #include "unixid.h"
 
 #include "scap.h"
-#include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
-#include "scap_engines.h"
-#include "engine/kmod/kmod.h"
 #include "strerror.h"
 
 

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -28,7 +28,6 @@ limitations under the License.
 #include "engine_handle.h"
 #include "scap_vtable.h"
 #include "ringbuffer/devset.h"
-#include "engine/kmod/kmod.h"
 
 #include "settings.h"
 #include "plugin_info.h"

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -21,10 +21,7 @@ limitations under the License.
 #include <string.h>
 
 #include "scap.h"
-#include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
-#include "scap_engines.h"
-#include "engine/kmod/kmod.h"
 
 int32_t scap_getpid_global(scap_t* handle, int64_t* pid)
 {

--- a/userspace/libscap/win32/scap_procs.c
+++ b/userspace/libscap/win32/scap_procs.c
@@ -21,10 +21,7 @@ limitations under the License.
 #include <string.h>
 
 #include "scap.h"
-#include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
-#include "scap_engines.h"
-#include "engine/kmod/kmod.h"
 
 #include <io.h>
 #define R_OK 4


### PR DESCRIPTION
SCAP_HANDLE_T must be defined before including scap_open.h (which gets included from kmod.h)

Also, remove a few unnecessary `#include`s; in particular, including engine internal headers shouldn't be needed (any more; it was a temporary measure during the engine refactor)

```
/draios/falco-libs/userspace/libscap/engine/kmod/scap_kmod.c:26:0: error: "SCAP_HANDLE_T" redefined [-Werror]
 #define SCAP_HANDLE_T struct kmod_engine
 ^
In file included from /draios/falco-libs/userspace/libscap/engine/kmod/kmod.h:21:0,
                 from /draios/falco-libs/userspace/libscap/engine/kmod/scap_kmod.c:25:
/draios/falco-libs/userspace/libscap/scap_open.h:24:0: note: this is the location of the previous definition
 #define SCAP_HANDLE_T void
 ^
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

/area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
