### PR TITLE
fix(scap): Fix Windows build warnings

### DIFF
--- a/userspace/libscap/engine/udig/udig.h
+++ b/userspace/libscap/engine/udig/udig.h
@@ -27,8 +27,4 @@ struct udig_engine
 
 	char* m_lasterr;
 	bool m_udig_capturing;
-#ifdef _WIN32
-	HANDLE m_win_buf_handle;
-	HANDLE m_win_descs_handle;
-#endif
 };

--- a/userspace/libscap/ringbuffer/devset.h
+++ b/userspace/libscap/ringbuffer/devset.h
@@ -20,6 +20,19 @@ limitations under the License.
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#define INVALID_FD NULL
+#define INVALID_MAPPING NULL
+#else // !_WIN32
+#include <sys/mman.h>
+#include <unistd.h>
+#define INVALID_FD (-1)
+#define INVALID_MAPPING MAP_FAILED
+#endif // !_WIN32
+
+#include "scap_assert.h"
+
 //
 // Read buffer timeout constants
 //
@@ -39,8 +52,13 @@ struct udig_ring_buffer_status;
 //
 typedef struct scap_device
 {
+#ifdef _WIN32
+	HANDLE m_fd;
+	HANDLE m_bufinfo_fd; // used by udig
+#else
 	int m_fd;
 	int m_bufinfo_fd; // used by udig
+#endif
 	char* m_buffer;
 	unsigned long m_buffer_size;
 	unsigned long m_mmap_size; // generally 2 * m_buffer_size, but bpf does weird things
@@ -68,4 +86,41 @@ struct scap_device_set
 };
 
 int32_t devset_init(struct scap_device_set *devset, size_t num_devs, char *lasterr);
+void devset_close_device(struct scap_device *dev);
 void devset_free(struct scap_device_set *devset);
+
+#ifndef _WIN32
+static inline void devset_munmap(void* addr, size_t size)
+{
+	if(addr != INVALID_MAPPING)
+	{
+		int ret = munmap(addr, size);
+		ASSERT(ret == 0);
+		(void) ret;
+	}
+}
+
+static inline void devset_close(int fd)
+{
+	if(fd != INVALID_FD)
+	{
+		close(fd);
+	}
+}
+#else // _WIN32
+static inline void devset_munmap(void* addr, size_t size)
+{
+	if(addr != INVALID_MAPPING)
+	{
+		UnmapViewOfFile(addr);
+	}
+}
+
+static inline void devset_close(HANDLE fd)
+{
+	if(fd != INVALID_FD)
+	{
+		CloseHandle(fd);
+	}
+}
+#endif // _WIN32

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -64,7 +64,6 @@ struct iovec;
 #include "../../driver/ppm_events_public.h"
 #ifdef _WIN32
 #include <time.h>
-#define MAP_FAILED (void*)-1
 #endif
 
 #include "plugin_info.h"


### PR DESCRIPTION
```
D:\a\libs\libs\userspace\libscap\ringbuffer\../scap.h(67,1): warning C4005: 'MAP_FAILED': macro redefinition [D:\a\libs\libs\build\libscap\scap_engine_util.vcxproj]
D:\a\libs\libs\userspace\libscap\ringbuffer\devset.c(11): message : see previous definition of 'MAP_FAILED' [D:\a\libs\libs\build\libscap\scap_engine_util.vcxproj]
D:\a\libs\libs\userspace\libscap\ringbuffer\devset.c(20,20): warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data [D:\a\libs\libs\build\libscap\scap_engine_util.vcxproj]
D:\a\libs\libs\userspace\libscap\ringbuffer\devset.c(75,4): warning C4013: 'close' undefined; assuming extern returning int [D:\a\libs\libs\build\libscap\scap_engine_util.vcxproj]
```

This change is more involved than the minimum fix, since it moves some of the responsibilities from udig to devset (including abstracting over the HANDLE/fd types and close vs CloseHandle).

`udig`'s m_win_*_handle fields were effectively replacements of `int m_fd` and `m_bufinfo_fd`, so make these fields use the `HANDLE` type on Windows and remove the two udig engine fields.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
