### PR TITLE
Remove refresh_proc_table_when_saving from scap_t

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -73,7 +73,6 @@ struct scap
 	scap_machine_info m_machine_info;
 	scap_userlist* m_userlist;
 	struct ppm_proclist_info* m_driver_procinfo;
-	bool refresh_proc_table_when_saving;
 	uint32_t m_fd_lookup_limit;
 	uint8_t m_cgroup_version;
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -197,8 +197,6 @@ scap_t* scap_open_live_int(char *error, int32_t *rc, scap_open_args* oargs)
 		handle->m_userlist = NULL;
 	}
 
-	handle->refresh_proc_table_when_saving = true;
-
 	handle->m_suppressed_comms = NULL;
 	handle->m_num_suppressed_comms = 0;
 	handle->m_suppressed_tids = NULL;
@@ -352,8 +350,6 @@ scap_t* scap_open_udig_int(char *error, int32_t *rc,
 		handle->m_userlist = NULL;
 	}
 
-	handle->refresh_proc_table_when_saving = true;
-
 	handle->m_suppressed_comms = NULL;
 	handle->m_num_suppressed_comms = 0;
 	handle->m_suppressed_tids = NULL;
@@ -444,8 +440,6 @@ scap_t* scap_open_test_input_int(char *error, int32_t *rc, scap_open_args *oargs
 	//
 	handle->m_mode = SCAP_MODE_LIVE;
 
-	handle->refresh_proc_table_when_saving = true;
-
 	handle->m_suppressed_comms = NULL;
 	handle->m_num_suppressed_comms = 0;
 	handle->m_suppressed_tids = NULL;
@@ -525,8 +519,6 @@ scap_t* scap_open_gvisor_int(char *error, int32_t *rc, scap_open_args *oargs)
 
 	// XXX - interface list initialization and user list initalization goes here if necessary
 
-	handle->refresh_proc_table_when_saving = true;
-
 	handle->m_suppressed_comms = NULL;
 	handle->m_num_suppressed_comms = 0;
 	handle->m_suppressed_tids = NULL;
@@ -602,7 +594,6 @@ scap_t* scap_open_offline_int(scap_open_args* oargs, int* rc, char* error)
 	handle->m_userlist = NULL;
 	handle->m_machine_info.num_cpus = (uint32_t)-1;
 	handle->m_driver_procinfo = NULL;
-	handle->refresh_proc_table_when_saving = true;
 	handle->m_fd_lookup_limit = 0;
 #if CYGWING_AGENT || _WIN32
 	handle->m_whh = NULL;
@@ -736,8 +727,6 @@ scap_t* scap_open_nodriver_int(char *error, int32_t *rc,
 		handle->m_userlist = NULL;
 	}
 
-	handle->refresh_proc_table_when_saving = true;
-
 	//
 	// Create the process list
 	//
@@ -806,7 +795,6 @@ scap_t* scap_open_plugin_int(char *error, int32_t *rc, scap_open_args* oargs)
 	handle->m_machine_info.reserved4 = 0;
 	handle->m_driver_procinfo = NULL;
 	handle->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP; // fd lookup is limited here because is very expensive
-	handle->refresh_proc_table_when_saving = true;
 
 	if((*rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
 	{
@@ -1586,11 +1574,6 @@ struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 
 	return handle->m_driver_procinfo;
 #endif	// HAS_CAPTURE
-}
-
-void scap_set_refresh_proc_table_when_saving(scap_t* handle, bool refresh)
-{
-	handle->refresh_proc_table_when_saving = refresh;
 }
 
 uint64_t scap_ftell(scap_t *handle)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -1097,7 +1097,6 @@ void scap_proc_free_table(scap_t* handle);
 void scap_free_device_table(scap_t* handle);
 void scap_refresh_iflist(scap_t* handle);
 void scap_refresh_proc_table(scap_t* handle);
-void scap_set_refresh_proc_table_when_saving(scap_t* handle, bool refresh);
 uint64_t scap_ftell(scap_t *handle);
 void scap_fseek(scap_t *handle, uint64_t off);
 int32_t scap_enable_tracers_capture(scap_t* handle);

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -983,6 +983,7 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 
 	if(scap_setup_dump(handle, res, fname) != SCAP_SUCCESS)
 	{
+		free(res);
 		res = NULL;
 	}
 

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -962,7 +962,7 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 	// between opening the handle and starting the dump
 	//
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
-	if(handle->m_mode != SCAP_MODE_CAPTURE && handle->refresh_proc_table_when_saving && !skip_proc_scan)
+	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
 	{
 		proc_entry_callback tcb = handle->m_proclist.m_proc_callback;
 		handle->m_proclist.m_proc_callback = NULL;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -233,11 +233,6 @@ void sinsp::add_protodecoders()
 void sinsp::filter_proc_table_when_saving(bool filter)
 {
 	m_filter_proc_table_when_saving = filter;
-
-	if(m_h != NULL)
-	{
-		scap_set_refresh_proc_table_when_saving(m_h, !filter);
-	}
 }
 
 void sinsp::enable_tracers_capture()
@@ -482,8 +477,6 @@ void sinsp::open_common(scap_open_args* oargs)
 	{
 		throw scap_open_exception(error, scap_rc);
 	}
-
-	scap_set_refresh_proc_table_when_saving(m_h, !m_filter_proc_table_when_saving);
 
 	init();
 }


### PR DESCRIPTION
All the juggling we do with refresh_proc_table_when_saving can be simplified to the point where we remove the flag completely from libscap (and leave the corresponding flag in sinsp since it has multiple meanings)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

OSS Sysdig does allow clearing this flag, but only when reading a capture file, i.e. when it does nothing anyway. I'm not aware of any other users that touch refresh_proc_table_when_saving. If there are any, please let me know if I broke your stuff.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
