### PR TITLE
fix(libscap): consistently remove the newline character from cgroups read from proc

### DIFF
--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -454,6 +454,12 @@ int32_t scap_proc_fill_cgroups(scap_t *handle, struct scap_threadinfo* tinfo, co
 			{
 				cgroup = subsys_list;
 				subsys_list = default_subsys_list; // force-set a default subsys list
+
+				size_t cgroup_len = strlen(cgroup);
+				if (cgroup_len != 0 && cgroup[cgroup_len - 1] == '\n')
+				{
+					cgroup[cgroup_len - 1] = '\0';
+				}
 			} else
 			{
 				// skip cgroups like this:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

When going through the `/proc` directory in search of information for existing processes, there is an inconsistency in how the cgroup lines are captured. For cgroups v1, the newline character is discarded by this line: https://github.com/falcosecurity/libs/blob/0fedd768602c39ab9d07bfee73bbd46d0acc836c/userspace/libscap/linux/scap_procs.c#L466 

However, cgroup v2 uses the read string as is: https://github.com/falcosecurity/libs/blob/0fedd768602c39ab9d07bfee73bbd46d0acc836c/userspace/libscap/linux/scap_procs.c#L455

Ultimately, this would not be such a big deal, except when you find a system that uses cgroups v2 with a container runtime like non-systemd docker: https://github.com/falcosecurity/libs/blob/0fedd768602c39ab9d07bfee73bbd46d0acc836c/userspace/libsinsp/container_engine/docker/docker_linux.cpp#L28

In this case, the string read for a process is of the form:
```
0::/../fcc594bda3b650387bfb0147d777adf34fba42223cbcd92ad1c12813f67e98f9\n
```

Which after going through `scap_proc_fill_cgroups` puts `/../fcc594bda3b650387bfb0147d777adf34fba42223cbcd92ad1c12813f67e98f9\n` as the cgroup, then when calling `match_one_container_id` [here](https://github.com/falcosecurity/libs/blob/0fedd768602c39ab9d07bfee73bbd46d0acc836c/userspace/libsinsp/runc.cpp#L41) with the previously shown prefix and suffix attempts to extract `fcc594bda3b650387bfb0147d777adf34fba42223cbcd92ad1c12813f67e98f9\n` as the container id and fails because the string is 65 characters in length.

This behavior has been observed and fixed on a [Garden Linux](https://github.com/gardenlinux/gardenlinux) v934.1 VM running on GCP.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Fix an issue where container IDs might not be properly acquired from the `/proc` directory.
```
