### PR TITLE
fix(scap): use strerror_r return value

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #pragma once
 
+#include "scap_const.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,26 +102,6 @@ struct iovec;
 //
 #define SCAP_MINIMUM_DRIVER_API_VERSION PPM_API_VERSION(3, 0, 0)
 #define SCAP_MINIMUM_DRIVER_SCHEMA_VERSION PPM_API_VERSION(2, 0, 0)
-
-//
-// Return types
-//
-#define SCAP_SUCCESS 0
-#define SCAP_FAILURE 1
-#define SCAP_TIMEOUT -1
-#define SCAP_ILLEGAL_INPUT 3
-#define SCAP_NOTFOUND 4
-#define SCAP_INPUT_TOO_SMALL 5
-#define SCAP_EOF 6
-#define SCAP_UNEXPECTED_BLOCK 7
-#define SCAP_VERSION_MISMATCH 8
-#define SCAP_NOT_SUPPORTED 9
-#define SCAP_FILTERED_EVENT 10
-
-//
-// Last error string size for `scap_open...` methods.
-//
-#define SCAP_LASTERR_SIZE 256
 
 // 
 // This is the dimension we used before introducing the variable buffer size.

--- a/userspace/libscap/scap_const.h
+++ b/userspace/libscap/scap_const.h
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+//
+// Return types
+//
+#define SCAP_SUCCESS 0
+#define SCAP_FAILURE 1
+#define SCAP_TIMEOUT -1
+#define SCAP_ILLEGAL_INPUT 3
+#define SCAP_NOTFOUND 4
+#define SCAP_INPUT_TOO_SMALL 5
+#define SCAP_EOF 6
+#define SCAP_UNEXPECTED_BLOCK 7
+#define SCAP_VERSION_MISMATCH 8
+#define SCAP_NOT_SUPPORTED 9
+#define SCAP_FILTERED_EVENT 10
+
+//
+// Last error string size for `scap_open...` methods.
+//
+#define SCAP_LASTERR_SIZE 256
+

--- a/userspace/libscap/strerror.c
+++ b/userspace/libscap/strerror.c
@@ -15,11 +15,22 @@ limitations under the License.
 
 */
 
+/* ensure we're getting the XSI definition of strerror_r, not the GNU one */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200112L
+#endif
+
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE
+#endif
+
 #include <errno.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
-#include "scap.h"
+#include "scap_const.h"
 
 #ifdef _WIN32
 #define strerror_r(errnum, buf, size) strerror_s(buf, size, errnum)
@@ -37,8 +48,11 @@ int32_t scap_errprintf_unchecked(char *buf, int errnum, const char* fmt, ...)
 
 	if (errnum > 0 && len < SCAP_LASTERR_SIZE - 1)
 	{
-		char err_buf[SCAP_LASTERR_SIZE] = "unknown error";
-		strerror_r(errnum, err_buf, sizeof(err_buf));
+		char err_buf[SCAP_LASTERR_SIZE];
+		if(strerror_r(errnum, err_buf, sizeof(err_buf)) < 0)
+		{
+			snprintf(err_buf, sizeof(err_buf), "Unknown error %d", errnum);
+		}
 		snprintf(buf + len, SCAP_LASTERR_SIZE - len, ": %s", err_buf);
 	}
 


### PR DESCRIPTION
    We're forcing the XSI-compliant version. It's complicated:
    https://linux.die.net/man/3/strerror_r

    Since the `_POSIX_C_SOURCE` and `_GNU_SOURCE` are fairly
    fundamental, play it ultra safe and don't include scap.h with these
    two set to a potentially different value from the rest of the code.

    This is a good excuse to introduce scap_const.h, which only contains
    a few `#define`s used all over the place. I'd expect many of the
    `#include "scap.h"` occurrences are for these constants only
    so we might be able to speed up rebuilds a  bit.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
