### PR TITLE
Fix user and group data for uid/gid 0 being reported as <NA>

### DIFF
--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -58,6 +58,7 @@ set(E2E_CONTAINERS
 	sinsp-e2e-tester
 	curl
 	generator
+	http-hello
 )
 
  add_custom_target(e2e-cleanup

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -531,8 +531,8 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 	{
 		m_user.uid = uid;
 		m_user.gid = m_group.gid;
-		strlcpy(m_user.name, "<NA>", sizeof(m_user.name));
-		strlcpy(m_user.homedir, "<NA>", sizeof(m_user.homedir));
+		strlcpy(m_user.name, (uid == 0) ? "root" : "<NA>", sizeof(m_user.name));
+		strlcpy(m_user.homedir, (uid == 0) ? "/root" : "<NA>", sizeof(m_user.homedir));
 		strlcpy(m_user.shell, "<NA>", sizeof(m_user.shell));
 	}
 }
@@ -566,7 +566,7 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 	else
 	{
 		m_group.gid = gid;
-		strlcpy(m_group.name, "<NA>", sizeof(m_group.name));
+		strlcpy(m_group.name, (gid == 0) ? "root" : "<NA>", sizeof(m_group.name));
 	}
 	// Force-sync user.gid and group id
 	m_user.gid = m_group.gid;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Container events with uid / gid `0` have `<NA>`  for name and homedir. Set a fallback for those.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): uid/gid 0 fallback to `root` in case of missing data from sinsp_usergroup_manager
```
