### PR TITLE
fix(userspace/libsinsp): avoid having compile time conditionals in public headers

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -247,15 +247,22 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 		{
 			uint16_t chunk = htons(*(uint16_t*)ptr);
 
+			int ret;
 			if(ptr == src + srclen - 1)
 			{
-				k += snprintf(row + k, sizeof(row) - k, " %.2x", *(((uint8_t*)&chunk) + 1));
+				ret = snprintf(row + k, sizeof(row) - k, " %.2x", *(((uint8_t*)&chunk) + 1));
 			}
 			else
 			{
-				k += snprintf(row + k, sizeof(row) - k, " %.4x", chunk);
+				ret = snprintf(row + k, sizeof(row) - k, " %.4x", chunk);
+			}
+			if (ret < 0 || ret >= sizeof(row) - k)
+			{
+				dst[0] = 0;
+				return 0;
 			}
 
+			k += ret;
 			num_chunks++;
 			ptr += sizeof(uint16_t);
 		}

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -26,9 +26,7 @@ limitations under the License.
 
 class sinsp;
 class sinsp_evt;
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
 namespace libsinsp { namespace procfs_utils { class ns_helper; }}
-#endif
 
 /*
  * Basic idea:
@@ -64,6 +62,7 @@ class sinsp_usergroup_manager
 {
 public:
 	explicit sinsp_usergroup_manager(sinsp* inspector);
+	~sinsp_usergroup_manager();
 
 	// Do not call subscribe_container_mgr() in capture mode, because
 	// events shall not be sent as they will be loaded from capture file.
@@ -164,16 +163,9 @@ private:
 	uint64_t m_last_flush_time_ns;
 	sinsp *m_inspector;
 
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+
 	const std::string &m_host_root;
-	std::unique_ptr<libsinsp::procfs_utils::ns_helper> m_ns_helper;
-#endif
-#ifdef HAVE_PWD_H
-	struct passwd *__getpwuid(uint32_t uid);
-#endif
-#ifdef HAVE_GRP_H
-	struct group *__getgrgid(uint32_t gid);
-#endif
+	libsinsp::procfs_utils::ns_helper *m_ns_helper;
 };
 
 #endif // FALCOSECURITY_LIBS_USER_H


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Having conditionals in public headers is not good: clients of libs will find that their linked libsinsp sees a `sizeof(foo)` different from what client sees including the headers, unless the macro is manually defined for client too.

In our case, Falco was seeing different sizes for usergroup_manager class than sinsp, because it hadn't got `HAVE_PWD_H` and `HAVE_GRP_H` defined. Therefore a SIGABRT was killing it (see https://github.com/falcosecurity/falco/pull/2302).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
