### PR TITLE
fix(driver/modern_bpf): fix params order in modern probe network functions

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -777,19 +777,19 @@ static __always_inline void auxmap__store_socktuple_param(struct auxiliary_map *
 		if(direction == OUTBOUND)
 		{
 			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_local);
-			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_remote);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_local));
+			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_remote);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_remote));
 		}
 		else
 		{
 			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_remote);
-			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_local);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_remote));
+			push__u32(auxmap->data, &auxmap->payload_pos, ipv4_local);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_local));
 		}
 
-		final_param_len = FAMILY_SIZE + IPV4_SIZE + IPV4_SIZE + PORT_SIZE + PORT_SIZE;
+		final_param_len = FAMILY_SIZE + IPV4_SIZE + PORT_SIZE + IPV4_SIZE + PORT_SIZE;
 		break;
 	}
 
@@ -820,18 +820,18 @@ static __always_inline void auxmap__store_socktuple_param(struct auxiliary_map *
 		if(direction == OUTBOUND)
 		{
 			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_local);
-			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_remote);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_local));
+			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_remote);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_remote));
 		}
 		else
 		{
 			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_remote);
-			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_local);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_remote));
+			push__ipv6(auxmap->data, &auxmap->payload_pos, ipv6_local);
 			push__u16(auxmap->data, &auxmap->payload_pos, ntohs(port_local));
 		}
-		final_param_len = FAMILY_SIZE + IPV6_SIZE + IPV6_SIZE + PORT_SIZE + PORT_SIZE;
+		final_param_len = FAMILY_SIZE + IPV6_SIZE + PORT_SIZE + IPV6_SIZE + PORT_SIZE;
 		break;
 	}
 

--- a/test/modern_bpf/event_class/event_class.cpp
+++ b/test/modern_bpf/event_class/event_class.cpp
@@ -607,17 +607,17 @@ void event_test::assert_tuple_inet_param(int param_num, uint8_t desired_family, 
 	/* Assert src ipv4. */
 	assert_ipv4_string(desired_src_ipv4, 1, SOURCE);
 
-	/* Assert dest ipv4. */
-	assert_ipv4_string(desired_dest_ipv4, 5, DEST);
-
 	/* Assert src port. */
-	assert_port_string(desired_src_port, 9, SOURCE);
+	assert_port_string(desired_src_port, 5, SOURCE);
+
+	/* Assert dest ipv4. */
+	assert_ipv4_string(desired_dest_ipv4, 7, DEST);
 
 	/* Assert dest port. */
 	assert_port_string(desired_dest_port, 11, DEST);
 
-	/* Assert (family + ipv4_src + ipv4_dest + port_src + port_dest) */
-	assert_param_len(FAMILY_SIZE + IPV4_SIZE + IPV4_SIZE + PORT_SIZE + PORT_SIZE);
+	/* Assert (family + ipv4_src + port_src + ipv4_dest + port_dest) */
+	assert_param_len(FAMILY_SIZE + IPV4_SIZE + PORT_SIZE + IPV4_SIZE + PORT_SIZE);
 }
 
 void event_test::assert_tuple_inet6_param(int param_num, uint8_t desired_family, const char* desired_src_ipv6, const char* desired_dest_ipv6,
@@ -631,17 +631,17 @@ void event_test::assert_tuple_inet6_param(int param_num, uint8_t desired_family,
 	/* Assert src ipv6. */
 	assert_ipv6_string(desired_src_ipv6, 1, SOURCE);
 
-	/* Assert dest ipv6. */
-	assert_ipv6_string(desired_dest_ipv6, 17, DEST);
-
 	/* Assert src port. */
-	assert_port_string(desired_src_port, 33, SOURCE);
+	assert_port_string(desired_src_port, 17, SOURCE);
+
+	/* Assert dest ipv6. */
+	assert_ipv6_string(desired_dest_ipv6, 19, DEST);
 
 	/* Assert dest port. */
 	assert_port_string(desired_dest_port, 35, DEST);
 
-	/* Assert (family + ipv6_src + ipv6_dest + port_src + port_dest)*/
-	assert_param_len(FAMILY_SIZE + IPV6_SIZE + IPV6_SIZE + PORT_SIZE + PORT_SIZE);
+	/* Assert (family + ipv6_src + port_src + ipv6_dest + port_dest)*/
+	assert_param_len(FAMILY_SIZE + IPV6_SIZE + PORT_SIZE + IPV6_SIZE + PORT_SIZE);
 }
 
 void event_test::assert_tuple_unix_param(int param_num, uint8_t desired_family, const char* desired_path)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**


**What this PR does / why we need it**:

This PR fixes an issue in the modern bpf probe. In the other 2 drivers (current bpf, kernel module) in network functions, we send the socket_tuple in the following way:

```
- ip
- port
- ip
- port
```

For some reason (:man_artist:) in the modern probe, I've chosen another other 

```
- ip
- ip
- port
- port
``` 

This PR updates the modern probe to use the first order like other drivers:

```
- ip
- port
- ip
- port
```

I've fixed also tests to follow this new order

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(driver/modern_bpf): fix params order in modern probe network functions
```
