### PR TITLE
Remove CYGWING_AGENT and HAS_CAPTURE from libscap

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -19,12 +19,6 @@ option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system
 
 option(BUILD_LIBSCAP_MODERN_BPF "Enable modern bpf probe" OFF)
 
-if(NOT MSVC)
-	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-		add_definitions(-DHAS_CAPTURE)
-	endif()
-endif()
-
 include(ExternalProject)
 
 if(WIN32 OR NOT MINIMAL_BUILD)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -691,15 +691,6 @@ scap_t* scap_open_plugin_int(char *error, int32_t *rc, scap_open_args* oargs)
 
 scap_t* scap_open(scap_open_args* oargs, char *error, int32_t *rc)
 {
-
-#ifdef CYGWING_AGENT
-	if(oargs->mode == SCAP_MODE_LIVE)
-	{
-		snprintf(error,	SCAP_LASTERR_SIZE, "libscap: live mode currently not supported on Windows.");
-		*rc = SCAP_NOT_SUPPORTED;
-		return NULL;
-	}
-#endif
 	const char* engine_name = oargs->engine_name;
 	/* At the end of the `v-table` work we can use just one function
 	 * with an internal switch that selects the right vtable! For the moment
@@ -891,16 +882,12 @@ uint32_t scap_get_ndevs(scap_t* handle)
 	return 1;
 }
 
-#if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT)
-
 int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT uint32_t* len)
 {
 	// engines do not even necessarily have a concept of a buffer
 	// that you read events from
 	return SCAP_NOT_SUPPORTED;
 }
-
-#endif // HAS_CAPTURE
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
@@ -1139,7 +1126,7 @@ int32_t scap_stop_capture(scap_t* handle)
 		return handle->m_vtable->stop_capture(handle->m_engine);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+#if !defined(HAS_CAPTURE)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1159,7 +1146,7 @@ int32_t scap_start_capture(scap_t* handle)
 		return handle->m_vtable->start_capture(handle->m_engine);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+#if !defined(HAS_CAPTURE)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1175,7 +1162,7 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
 	}
-#if defined(HAS_CAPTURE) && ! defined(CYGWING_AGENT) && ! defined(_WIN32)
+#if defined(HAS_CAPTURE) && ! defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_enable_tracers_capture not supported on this scap mode");
 	ASSERT(false);
 	return SCAP_FAILURE;
@@ -1191,7 +1178,7 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
 	}
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_stop_dropping_mode not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1207,7 +1194,7 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
 	}
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1258,7 +1245,7 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+#if !defined(HAS_CAPTURE)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1392,7 +1379,7 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+#if !defined(HAS_CAPTURE)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1408,7 +1395,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT)
+#if !defined(HAS_CAPTURE)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1463,7 +1450,7 @@ bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_
 
 struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 {
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return NULL;
 #else
@@ -1504,7 +1491,7 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1563,7 +1550,7 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
 	return SCAP_FAILURE;
 #else
@@ -1579,7 +1566,7 @@ int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(CYGWING_AGENT) || defined(_WIN32)
+#if !defined(HAS_CAPTURE) || defined(_WIN32)
 	snprintf(handle->m_lasterr,
 	         SCAP_LASTERR_SIZE,
 	         "scap_set_statsd_port not supported on %s", PLATFORM_NAME);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1126,14 +1126,9 @@ int32_t scap_stop_capture(scap_t* handle)
 		return handle->m_vtable->stop_capture(handle->m_engine);
 	}
 
-#if !defined(HAS_CAPTURE)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "cannot stop offline live captures");
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	ASSERT(false);
 	return SCAP_FAILURE;
-#endif // HAS_CAPTURE
 }
 
 //
@@ -1146,14 +1141,9 @@ int32_t scap_start_capture(scap_t* handle)
 		return handle->m_vtable->start_capture(handle->m_engine);
 	}
 
-#if !defined(HAS_CAPTURE)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "cannot start offline live captures");
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	ASSERT(false);
 	return SCAP_FAILURE;
-#endif // HAS_CAPTURE
 }
 
 int32_t scap_enable_tracers_capture(scap_t* handle)
@@ -1162,14 +1152,10 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
 	}
-#if defined(HAS_CAPTURE) && ! defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_enable_tracers_capture not supported on this scap mode");
+
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	ASSERT(false);
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_enable_tracers_capture not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#endif
 }
 
 int32_t scap_stop_dropping_mode(scap_t* handle)
@@ -1178,14 +1164,10 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
 	}
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_stop_dropping_mode not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_stop_dropping_mode not supported on this scap mode");
+
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	ASSERT(false);
 	return SCAP_FAILURE;
-#endif
 }
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
@@ -1194,14 +1176,10 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
 	}
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_start_dropping_mode not supported on this scap mode");
+
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	ASSERT(false);
 	return SCAP_FAILURE;
-#endif
 }
 
 //
@@ -1245,13 +1223,8 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
 	}
 
-#if !defined(HAS_CAPTURE)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "setting snaplen not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif
 }
 
 int64_t scap_get_readfile_offset(scap_t* handle)
@@ -1299,13 +1272,9 @@ static int32_t scap_handle_ppm_sc_mask(scap_t* handle, uint32_t op, uint32_t ppm
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_EVENTMASK, op, ppm_sc);
 	}
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "eventmask not supported on %s", PLATFORM_NAME);
+
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "manipulating eventmasks not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif // HAS_CAPTURE
 }
 
 int32_t scap_clear_ppm_sc_mask(scap_t* handle) {
@@ -1338,22 +1307,18 @@ static int32_t scap_handle_tpmask(scap_t* handle, uint32_t op, uint32_t tp)
 		return SCAP_FAILURE;
 	}
 
-	if(handle->m_vtable)
-	{
-		return handle->m_vtable->configure(handle->m_engine, SCAP_TPMASK, op, tp);
-	}
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "tpmask not supported on %s", PLATFORM_NAME);
-	return SCAP_FAILURE;
-#else
 	if (handle == NULL)
 	{
 		return SCAP_FAILURE;
 	}
 
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "manipulating tpmask not supported on this scap mode");
+	if(handle->m_vtable)
+	{
+		return handle->m_vtable->configure(handle->m_engine, SCAP_TPMASK, op, tp);
+	}
+
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#endif // HAS_CAPTURE
 }
 
 int32_t scap_set_tpmask(scap_t* handle, uint32_t tp, bool enabled) {
@@ -1379,13 +1344,8 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
 	}
 
-#if !defined(HAS_CAPTURE)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "setting snaplen not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif
 }
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle)
@@ -1395,13 +1355,8 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
 	}
 
-#if !defined(HAS_CAPTURE)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "setting snaplen not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif // HAS_CAPTURE
 }
 
 const char* scap_get_host_root()
@@ -1450,18 +1405,19 @@ bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_
 
 struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
 {
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
-	return NULL;
-#else
-	int res = handle->m_vtable->get_threadlist(handle->m_engine, &handle->m_driver_procinfo, handle->m_lasterr);
-	if(res != SCAP_SUCCESS)
+	if(handle->m_vtable)
 	{
-		return NULL;
+		int res = handle->m_vtable->get_threadlist(handle->m_engine, &handle->m_driver_procinfo, handle->m_lasterr);
+		if(res != SCAP_SUCCESS)
+		{
+			return NULL;
+		}
+
+		return handle->m_driver_procinfo;
 	}
 
-	return handle->m_driver_procinfo;
-#endif	// HAS_CAPTURE
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
+	return NULL;
 }
 
 uint64_t scap_ftell(scap_t *handle)
@@ -1491,13 +1447,8 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "getting n_tracepoint_hit not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif
 }
 
 bool scap_check_current_engine(scap_t *handle, const char* engine_name)
@@ -1550,13 +1501,8 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "live capture not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_set_fullcapture_port_range not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif
 }
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
@@ -1566,17 +1512,8 @@ int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
 	}
 
-#if !defined(HAS_CAPTURE) || defined(_WIN32)
-	snprintf(handle->m_lasterr,
-	         SCAP_LASTERR_SIZE,
-	         "scap_set_statsd_port not supported on %s", PLATFORM_NAME);
+	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-#else
-	snprintf(handle->m_lasterr,
-		 SCAP_LASTERR_SIZE,
-		 "scap_set_statsd_port not supported on this scap mode");
-	return SCAP_FAILURE;
-#endif
 }
 
 bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -963,7 +963,7 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 	// so we don't lose information about processes created in the interval
 	// between opening the handle and starting the dump
 	//
-#if defined(HAS_CAPTURE) && !defined(_WIN32)
+#ifdef __linux__
 	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
 	{
 		proc_entry_callback tcb = handle->m_proclist.m_proc_callback;


### PR DESCRIPTION
In most places, `HAS_CAPTURE` is only used to determine a better error message in a situation that shouldn't ever happen anyway (no handle->m_vtable).

In the last place, it's an elaborate replacement for `__linux__` (which should be cleaned up anyway but let it live for now).

`CYGWING_AGENT` is historical cruft, shouldn't be needed any more (including sinsp, but this PR does not touch it)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
