### PR TITLE
Drop sinsp_usergroup_manager::load_from_container

### DIFF
--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -86,6 +86,8 @@ def test_container_root_user(run_containers: dict):
 
     container_id = get_container_id(app_container)
 
+    app_container.exec_run("sh -c ls", user='nginx')
+
     expected_events = [
         {
             'container.id': get_container_id(run_containers['nginx']),
@@ -98,6 +100,14 @@ def test_container_root_user(run_containers: dict):
             'user.homedir': '/root',
             'group.gid': 0,
             'group.name': 'root'
+        }, {
+            'container.id': container_id,
+            'evt.category': 'process',
+            'evt.type': 'execve',
+            'proc.exe': 'sh',
+            'proc.cmdline': 'sh -c ls',
+            'user.name': 'nginx',
+            'group.name': 'nginx',
         }
     ]
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -168,7 +168,6 @@ string sinsp_container_manager::container_to_json(const sinsp_container_info& co
 	container["is_pod_sandbox"] = container_info.m_is_pod_sandbox;
 	container["lookup_state"] = static_cast<int>(container_info.get_lookup_status());
 	container["created_time"] = static_cast<Json::Value::Int64>(container_info.m_created_time);
-	container["lowerdir"] = container_info.m_overlayfs_root;
 
 	Json::Value mounts = Json::arrayValue;
 

--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -126,15 +126,6 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 	// This is in Nanoseconds(in CRI API). Need to convert it to seconds.
 	container.m_created_time = static_cast<int64_t>(resp_container.created_at() / ONE_SECOND_IN_NS );
 
-	for(const auto &pair : resp_container.annotations())
-	{
-		if (pair.first == "io.kubernetes.cri-o.MountPoint")
-		{
-			container.m_overlayfs_root = pair.second;
-		}
-	}
-
-
 	for(const auto &pair : resp_container.labels())
 	{
 		if(pair.second.length() <= sinsp_container_info::m_container_label_max_length)

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -873,17 +873,6 @@ bool docker_async_source::parse(const docker_lookup_request& request, sinsp_cont
 
 	container.m_size_rw_bytes = root["SizeRw"].asInt64();
 
-	try
-	{
-		auto lowerdir = root["GraphDriver"]["Data"]["LowerDir"].asString();
-		container.m_overlayfs_root = lowerdir.substr(lowerdir.find_last_of(':') + 1);
-
-	}
-	catch (const std::exception &)
-	{
-		container.m_overlayfs_root = "";
-	}
-
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"docker_async (%s): parse returning true",
 			request.container_id.c_str());

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -336,11 +336,6 @@ public:
 	int64_t m_created_time;
 
 	/**
-	 * Root of the overlayfs, fetched from container runtime (lowerdir)
-	 */
-	std::string m_overlayfs_root;
-
-	/**
 	 * The max container label length value. This is static because it is 
 	 * universal across all instances and needs to be set once only.
 	 */

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5219,12 +5219,6 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 			container_info->m_created_time = created_time.asInt64();
 		}
 
-		const Json::Value& lowerdir = container["lowerdir"];
-		if(check_json_val_is_convertible(lowerdir, Json::stringValue, "lowerdir"))
-		{
-			container_info->m_overlayfs_root = lowerdir.asString();
-		}
-
 #if !defined(MINIMAL_BUILD) && !defined(_WIN32)
 		libsinsp::container_engine::docker_async_source::parse_json_mounts(container["Mounts"], container_info->m_mounts);
 #endif

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -145,10 +145,6 @@ void sinsp_usergroup_manager::subscribe_container_mgr()
 		m_inspector->m_container_manager.subscribe_on_remove_container([&](const sinsp_container_info &cinfo) -> void {
 			delete_container_users_groups(cinfo);
 		});
-
-		m_inspector->m_container_manager.subscribe_on_new_container([&](const sinsp_container_info&cinfo, sinsp_threadinfo *tinfo) -> void {
-		        load_from_container(cinfo.m_id, cinfo.m_overlayfs_root);
-	       });
 	}
 }
 
@@ -756,51 +752,5 @@ void sinsp_usergroup_manager::notify_group_changed(const scap_groupinfo *group, 
 
 #ifndef _WIN32
 	m_inspector->m_pending_state_evts.push(cevt);
-#endif
-}
-
-void sinsp_usergroup_manager::load_from_container(const std::string &container_id, const std::string &overlayfs_root)
-{
-	if (!m_import_users)
-	{
-		return;
-	}
-
-	if (overlayfs_root.empty())
-	{
-		// Avoid loading from host
-		return;
-	}
-
-	if(m_userlist.find(container_id) != m_userlist.end())
-	{
-		// userlist for this container already exists
-		return;
-	}
-
-#if defined HAVE_PWD_H && defined HAVE_FGET__ENT
-	auto passwd_in_container = overlayfs_root + "/etc/passwd";
-	auto pwd_file = fopen(passwd_in_container.c_str(), "r");
-	if(pwd_file)
-	{
-		while(auto p = fgetpwent(pwd_file))
-		{
-			add_user(container_id, p->pw_uid, p->pw_gid, p->pw_name, p->pw_dir, p->pw_shell, true);
-		}
-		fclose(pwd_file);
-	}
-#endif
-
-#if defined HAVE_GRP_H && defined HAVE_FGET__ENT
-	auto group_in_container = overlayfs_root + "/etc/group";
-	auto grp_file = fopen(group_in_container.c_str(), "r");
-	if(grp_file)
-	{
-		while(auto g = fgetgrent(grp_file))
-		{
-			add_group(container_id, g->gr_gid, g->gr_name, true);
-		}
-		fclose(grp_file);
-	}
 #endif
 }

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -126,7 +126,6 @@ public:
 	bool rm_user(const std::string &container_id, uint32_t uid, bool notify = false);
 	bool rm_group(const std::string &container_id, uint32_t gid, bool notify = false);
 
-	void load_from_container(const std::string &container_id, const std::string &overlayfs_root);
 	bool clear_host_users_groups();
 
 	//


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
`sinsp_usergroup_manager::load_from_container` isn't quite reliable, actually interfering with the mechanism accessing through proc. Drop it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
