### PR TITLE
fix(userspace/libsinsp): respect m_import_users for container user/group

### DIFF
--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -333,6 +333,11 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, uin
 
 scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &container_id, int64_t pid, uint32_t uid, bool notify)
 {
+	if(!m_import_users)
+	{
+		return nullptr;
+	}
+
 	ASSERT(!container_id.empty());
 	ASSERT(uid != 0);
 
@@ -456,6 +461,11 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, u
 
 scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &container_id, int64_t pid, uint32_t gid, bool notify)
 {
+	if(!m_import_users)
+	{
+		return nullptr;
+	}
+
 	ASSERT(!container_id.empty());
 	ASSERT(gid != 0);
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Container user / group detection doesn't respect sinsp `set_import_users`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
This would affect `sysdig` `-E/--exclude-users`

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): respect set_import_users for container user and group
```
