### PR TITLE
new(modern_probe): Add access()

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -128,6 +128,7 @@
 #define EPOLL_CREATE_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define EPOLL_CREATE1_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define EPOLL_CREATE1_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define ACCESS_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(access_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: mode (type: PT_UINT32) */
-	unsigned long mode = (u32)extract__syscall_argument(regs, 1);
+	int mode = (int)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, (u32)access_flags_to_scap(mode));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -60,8 +60,8 @@ int BPF_PROG(access_x,
         auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: pathname (type: PT_FSPATH) */
-	unsigned long mode = (u32)extract__syscall_argument(regs, 0);
-	auxmap__store_u32_param(auxmap, (u32)access_flags_to_scap(mode));
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -16,12 +16,12 @@ int BPF_PROG(access_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, ACCESS_E_SIZE))
-        {
-                return 0;
-        }
+	if(!ringbuf__reserve_space(&ringbuf, ACCESS_E_SIZE))
+	{
+		return 0;
+	}
 
-        ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_ACCESS_E);
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_ACCESS_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -37,7 +37,6 @@ int BPF_PROG(access_e,
 }
 
 /*=============================== ENTER EVENT ===========================*/
-
 
 /*=============================== EXIT EVENT ===========================*/
 
@@ -56,8 +55,8 @@ int BPF_PROG(access_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-        /* Parameter 1: res (type: PT_ERRNO) */
-        auxmap__store_s64_param(auxmap, ret);
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: pathname (type: PT_FSPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 0);
@@ -65,7 +64,7 @@ int BPF_PROG(access_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-       auxmap__finalize_event_header(auxmap);
+	auxmap__finalize_event_header(auxmap);
 
 	auxmap__submit_event(auxmap);
 
@@ -73,4 +72,3 @@ int BPF_PROG(access_x,
 }
 
 /*=============================== EXIT EVENT ===========================*/
-

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(access_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_ACCESS_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: mode (type: PT_UINT32) */
+	unsigned long mode = (u32)extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, (u32)access_flags_to_scap(mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(access_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_ACCESS_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+        /* Parameter 1: res (type: PT_ERRNO) */
+        auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: pathname (type: PT_FSPATH) */
+	unsigned long mode = (u32)extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, (u32)access_flags_to_scap(mode));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/
+

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -65,6 +65,8 @@ int BPF_PROG(access_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+       auxmap__finalize_event_header(auxmap);
+
 	auxmap__submit_event(auxmap);
 
 	return 0;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(access_x,
         auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: pathname (type: PT_FSPATH) */
-	unsigned long mode = (u32)extract__syscall_argument(regs, 1);
+	unsigned long mode = (u32)extract__syscall_argument(regs, 0);
 	auxmap__store_u32_param(auxmap, (u32)access_flags_to_scap(mode));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -15,23 +15,23 @@ int BPF_PROG(access_e,
 	     struct pt_regs *regs,
 	     long id)
 {
-	struct auxiliary_map *auxmap = auxmap__get();
-	if(!auxmap)
-	{
-		return 0;
-	}
+	struct ringbuf_struct ringbuf;
+        if(!ringbuf__reserve_space(&ringbuf, ACCESS_E_SIZE))
+        {
+                return 0;
+        }
 
-	auxmap__preload_event_header(auxmap, PPME_SYSCALL_ACCESS_E);
+        ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_ACCESS_E);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: mode (type: PT_UINT32) */
 	unsigned long mode = (u32)extract__syscall_argument(regs, 1);
-	auxmap__store_u32_param(auxmap, (u32)access_flags_to_scap(mode));
+	ringbuf__store_u32(&ringbuf, (u32)access_flags_to_scap(mode));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	auxmap__submit_event(auxmap);
+	ringbuf__submit_event(&ringbuf);
 
 	return 0;
 }

--- a/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
@@ -1,0 +1,40 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_access
+
+TEST(SyscallEnter, accessE)
+{
+	auto evt_test = get_syscall_event_test(__NR_access, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t _mode = W_OK;
+	const char *_pathname = "./mock_file";
+	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, _pathname, _mode));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	//evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
@@ -10,9 +10,9 @@ TEST(SyscallEnter, accessE)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	int32_t _mode = W_OK;
-	const char *_pathname = "./mock_file";
-	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, _pathname, _mode));
+	int32_t mode = W_OK;
+	char pathname[] = "//**null-file-path**//";
+	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, pathname, mode));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -27,14 +27,15 @@ TEST(SyscallEnter, accessE)
 
 	evt_test->parse_event();
 
-	//evt_test->assert_header();
+	evt_test->assert_header();
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	// Here we have no parameters to assert.
+        /* Parameter 1: mode (type: PT_UINT32)*/
+        evt_test->assert_numeric_param(1, (uint32_t)mode);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	evt_test->assert_num_params_pushed(0);
+	evt_test->assert_num_params_pushed(1);
 }
 #endif

--- a/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
@@ -31,8 +31,8 @@ TEST(SyscallEnter, accessE)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-        /* Parameter 1: mode (type: PT_UINT32)*/
-        evt_test->assert_numeric_param(1, (uint32_t)PPM_W_OK);
+	/* Parameter 1: mode (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_W_OK);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
+++ b/test/modern_bpf/test_suites/syscall_enter_suite/access_e.cpp
@@ -32,7 +32,7 @@ TEST(SyscallEnter, accessE)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
         /* Parameter 1: mode (type: PT_UINT32)*/
-        evt_test->assert_numeric_param(1, (uint32_t)mode);
+        evt_test->assert_numeric_param(1, (uint32_t)PPM_W_OK);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
@@ -34,9 +34,6 @@ TEST(SyscallExit, accessX)
 	/* Parameter 1: res (type: PT_ERRNO)*/
 	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
-	/* Parameter 2: pathname (type: PT_CHARBUF) */
-	evt_test->assert_charbuf_param(2, _pathname);
-
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	evt_test->assert_num_params_pushed(2);

--- a/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_access
+TEST(SyscallExit, accessX)
+{
+	auto evt_test = get_syscall_event_test(__NR_access, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* _pathname = "testfile";
+	const int32_t _mode = W_OK;
+	access(_pathname, _mode);
+	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, _pathname, _mode));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: pathname (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, _pathname);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
@@ -9,10 +9,9 @@ TEST(SyscallExit, accessX)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	const char* _pathname = "testfile";
-	const int32_t _mode = W_OK;
-	access(_pathname, _mode);
-	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, _pathname, _mode));
+	int32_t mode = W_OK;
+	char pathname[] = "//**null-file-path**//";
+	assert_syscall_state(SYSCALL_FAILURE, "access", syscall(__NR_access, pathname, mode));
 	int64_t errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
+++ b/test/modern_bpf/test_suites/syscall_exit_suite/access_x.cpp
@@ -34,6 +34,9 @@ TEST(SyscallExit, accessX)
 	/* Parameter 1: res (type: PT_ERRNO)*/
 	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
+	/* Parameter 2: path (type: PT_FSPATH)*/
+	evt_test->assert_charbuf_param(2, pathname);
+
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	evt_test->assert_num_params_pushed(2);

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -181,6 +181,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_EPOLL_CREATE_X] = "epoll_create_x",
 	[PPME_SYSCALL_EPOLL_CREATE1_E] = "epoll_create1_e",
 	[PPME_SYSCALL_EPOLL_CREATE1_X] = "epoll_create1_x",
+	[PPME_SYSCALL_ACCESS_E] = "access_e",
+	[PPME_SYSCALL_ACCESS_X] = "access_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
Add modern probe for access() system call.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

#723 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
