### PR TITLE
 fix(sinsp-example): parse cli options missing -m

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -107,7 +107,7 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 	int op;
 	int long_index = 0;
 	while((op = getopt_long(argc, argv,
-				"hf:jae:b:d:s:o:",
+				"hf:jab:mks:d:o:",
 				long_options, &long_index)) != -1)
 	{
 		switch(op)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area libsinsp

**Does this PR require a change in the driver versions?**
None

**What this PR does / why we need it**:
sinsp-example cannot run with --modern_bpf option

**Which issue(s) this PR fixes**:
[#756](https://github.com/falcosecurity/libs/issues/756)

```release-note
NONE
```
