### PR TITLE
wip: new(userspace/libscap,userspace/libsinsp): allow to pass kmod name as kmod engine param

### DIFF
--- a/userspace/libscap/engine/kmod/kmod.h
+++ b/userspace/libscap/engine/kmod/kmod.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 struct kmod_engine
 {
+	char *m_name;
 	struct scap_device_set m_dev_set;
 	char* m_lasterr;
 	interesting_tp_set open_tp_set;

--- a/userspace/libscap/engine/kmod/kmod_public.h
+++ b/userspace/libscap/engine/kmod/kmod_public.h
@@ -25,6 +25,7 @@ extern "C"
 	struct scap_kmod_engine_params
 	{
 		unsigned long buffer_bytes_dim; ///< Dimension of a single per-CPU buffer in bytes. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
+		const char *kmod_name; ///< Name of the kmod
 	};
 
 #ifdef __cplusplus

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -163,7 +163,8 @@ void open_engine(sinsp& inspector)
 
 	if(!engine_string.compare(KMOD_ENGINE))
 	{
-		inspector.open_kmod(buffer_bytes_dim, ppm_sc, tp_set);
+		// Use default kmod name
+		inspector.open_kmod("", buffer_bytes_dim, ppm_sc, tp_set);
 	}
 	else if(!engine_string.compare(BPF_ENGINE))
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -490,7 +490,7 @@ scap_open_args sinsp::factory_open_args(const char* engine_name, scap_mode_t sca
 	return oargs;
 }
 
-void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_kmod(const std::string& kmod_name, unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	scap_open_args oargs = factory_open_args(KMOD_ENGINE, SCAP_MODE_LIVE);
 
@@ -501,6 +501,7 @@ void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const std::unordere
 	/* Engine-specific args. */
 	struct scap_kmod_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
+	params.kmod_name = kmod_name.data();
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -218,7 +218,7 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	virtual void open_kmod(const std::string& kmod_name = "", unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	virtual void open_udig();
 	virtual void open_nodriver();


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-kmod
/area libsinsp

**Does this PR require a change in the driver versions?**

Nope

**What this PR does / why we need it**:

Allow libs consumers to customize at startup time the kmod name, instead of setting it through cmake variable `SCAP_KERNEL_MODULE_NAME`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #617 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(userspace): allow to programmatically customize kmod name at startup time
```
