### PR TITLE
fix(ci): properly build HEAD instead of merge commits in ci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       libscap_changed: ${{ steps.filter.outputs.libscap }}
       libsinsp_changed: ${{ steps.filter.outputs.libsinsp }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -53,6 +55,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps ⛓️
         run: |
@@ -79,6 +82,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps ⛓️
         run: |
@@ -102,6 +106,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and test 🏗️🧪
         run: |
@@ -117,6 +122,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run aarch64 build 🏎️
@@ -142,6 +148,8 @@ jobs:
     steps:
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run s390x build 🏗️
@@ -172,6 +180,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps ⛓️
         run: |
@@ -210,6 +219,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run aarch64 build 🏎️
@@ -241,6 +251,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: uraimo/run-on-arch-action@v2.2.0
         name: Run s390x build 🏗️
@@ -351,6 +362,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps ⛓️
         run: |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

NOPE

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

We discovered that actions/checkout in gh actions is actually building a "fake" merge commit.
To disable the behavior, we needed to follow: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
