### PR TITLE
fix(sinsp): Get CRI image metadata both from image and imageRef

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -154,6 +154,15 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 		// name stays at its default "<NA>" value.
 	}
 
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"cri (%s): after parse_containerd: repo=%s tag=%s image=%s digest=%s",
+			container.m_id.c_str(),
+			container.m_imagerepo.c_str(),
+			container.m_imagetag.c_str(),
+			container.m_image.c_str(),
+			container.m_imagedigest.c_str());
+
+
 	if(s_cri_extra_queries)
 	{
 		if(!container.m_container_ip)
@@ -163,6 +172,14 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 		if(container.m_imageid.empty())
 		{
 			container.m_imageid = m_cri->get_container_image_id(resp_container.image_ref());
+			g_logger.format(sinsp_logger::SEV_DEBUG,
+					"cri (%s): after get_container_image_id: repo=%s tag=%s image=%s digest=%s",
+					container.m_id.c_str(),
+					container.m_imagerepo.c_str(),
+					container.m_imagetag.c_str(),
+					container.m_image.c_str(),
+					container.m_imagedigest.c_str());
+
 		}
 	}
 

--- a/userspace/libsinsp/cri.cpp
+++ b/userspace/libsinsp/cri.cpp
@@ -118,6 +118,12 @@ bool cri_interface::parse_cri_image(const runtime::v1alpha2::ContainerStatus &st
 	std::string image_name = status.image().image();
 	bool get_tag_from_image = false;
 	auto digest_start = image_ref.find("sha256:");
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"cri (%s): parse_cri_image: image_ref=%s, digest_start=%d",
+			container.m_id.c_str(),
+			image_ref.c_str(), digest_start);
+
 	switch (digest_start)
 	{
 	case 0: // sha256:digest
@@ -134,6 +140,11 @@ bool cri_interface::parse_cri_image(const runtime::v1alpha2::ContainerStatus &st
 		}
 	}
 
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"cri (%s): parse_cri_image: have_digest=%d image_name=%s",
+			container.m_id.c_str(),
+			have_digest, image_name.c_str());
+
 	string hostname, port, digest;
 	sinsp_utils::split_container_image(image_name,
 					   hostname,
@@ -145,6 +156,12 @@ bool cri_interface::parse_cri_image(const runtime::v1alpha2::ContainerStatus &st
 
 	if(get_tag_from_image)
 	{
+		g_logger.format(sinsp_logger::SEV_DEBUG,
+				"cri (%s): parse_cri_image: tag=%s, pulling tag from %s",
+				container.m_id.c_str(),
+				container.m_imagetag.c_str(),
+				status.image().image().c_str());
+
 		string digest2, repo;
 		sinsp_utils::split_container_image(status.image().image(),
 						   hostname,
@@ -168,6 +185,15 @@ bool cri_interface::parse_cri_image(const runtime::v1alpha2::ContainerStatus &st
 	{
 		container.m_imagedigest = digest;
 	}
+
+	g_logger.format(sinsp_logger::SEV_DEBUG,
+			"cri (%s): parse_cri_image: repo=%s tag=%s image=%s digest=%s",
+			container.m_id.c_str(),
+			container.m_imagerepo.c_str(),
+			container.m_imagetag.c_str(),
+			container.m_image.c_str(),
+			container.m_imagedigest.c_str());
+
 	return true;
 }
 


### PR DESCRIPTION
    With the different CRI runtimes and the different ways to start
    a container, it's not always trivial to find all the image metadata
    (id, repo, tag, digest).

    When running a container as `host/image@sha256:digest`, we have to
    fetch the tag from the `Image` field, not `ImageRef`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
