### PR TITLE
chore(driver): support external skeleton build for modern bpf

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ make ProbeSkeleton
 
 > __Please note__: these are not the requirements to use the BPF probe but to build it from source!
 
+As you have seen the modern bpf probe has strict requirements to be built that maybe are not easy to satisfy on old machines. The workaround you can use is to build the probe skeleton on a recent machine and than link it during the building phase on an older machine. To do that you have to use the cmake variable `MODERN_BPF_SKEL_DIR`. Supposing you have built the skeleton under the directory `/tmp/skel-dir`, you should use the option in this way:
+
+```bash
+cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_SKEL_DIR="/tmp/skel-dir" -DBUILD_LIBSCAP_GVISOR=OFF .. 
+```
+
 ### gVisor support
 
 Libscap contains additional library functions to allow integration with system call events coming from [gVisor](https://gvisor.dev).

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -120,7 +120,7 @@ add_custom_command(
 )
 
 ## Generate the skeleton file
-set(BPF_SKEL_FILE ${SKEL_DIR}/${UNIQUE_BPF_O_FILE_NAME}.skel.h)
+set(BPF_SKEL_FILE ${MODERN_BPF_SKEL_DIR}/${UNIQUE_BPF_O_FILE_NAME}.skel.h)
 add_custom_command(
     OUTPUT ${BPF_SKEL_FILE}
     COMMAND bash -c "${BPFTOOL_EXE} gen skeleton ${UNIQUE_BPF_O_FILE} > ${BPF_SKEL_FILE}"

--- a/userspace/libpman/CMakeLists.txt
+++ b/userspace/libpman/CMakeLists.txt
@@ -12,12 +12,11 @@ set(PMAN_SOURCES
 set(PMAN_PRIVATE_INCLUDES
     "${ZLIB_INCLUDE}"
     "${LIBBPF_INCLUDE}"
+    "${MODERN_BPF_SKEL_DIR}"
     "${LIBELF_INCLUDE}"
-    "${SKEL_DIR}"
     "${LIBSCAP_DIR}/driver/" ## ppm_enum and tables
     "${LIBSCAP_DIR}/userspace/libscap" ## scap-stats struct
     "${LIBSCAP_DIR}/driver/modern_bpf/" ## bpf-shared structs
-    "./include"
 )
 
 set(PMAN_PUBLIC_INCLUDES
@@ -31,9 +30,11 @@ set(PMAN_LINK_LIBRARIES
     scap_event_schema
 )
 
-set(PMAN_DEPENDENCIES
-    ProbeSkeleton
-)
+if(USE_BUNDLED_MODERN_BPF)
+    set(PMAN_DEPENDENCIES
+        ProbeSkeleton
+    )
+endif()
 
 if(USE_BUNDLED_LIBBPF)
     list(APPEND
@@ -45,7 +46,7 @@ endif()
 add_library(pman ${PMAN_SOURCES})
 
 target_include_directories(pman
-    INTERFACE
+    PUBLIC
     ${PMAN_PUBLIC_INCLUDES}
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -21,17 +21,15 @@ if(RESULT STREQUAL NOTFOUND)
 endif()
 
 if(NOT MODERN_BPF_SKEL_DIR)
-  message(STATUS "USE_BUNDLED_MODERN_BPF: ON")
   # Directory in which the BPF skeleton will be built
   set(MODERN_BPF_SKEL_DIR "${CMAKE_BINARY_DIR}/skel_dir")
   file(MAKE_DIRECTORY ${MODERN_BPF_SKEL_DIR})
   # Build the BPF skeleton as custom target.
   add_subdirectory(${LIBSCAP_DIR}/driver/modern_bpf ${CMAKE_BINARY_DIR}/driver/modern_bpf)
 else()
-  message(STATUS "USE_BUNDLED_MODERN_BPF: OFF")
   set(USE_BUNDLED_MODERN_BPF OFF)
 endif()
-message(STATUS "using modern BPF skel_dir: ${MODERN_BPF_SKEL_DIR}")
+message(STATUS "USE_BUNDLED_MODERN_BPF: ${USE_BUNDLED_MODERN_BPF}, using skeleton dir: ${MODERN_BPF_SKEL_DIR}")
 
 # Build `libpman` library.
 add_subdirectory(${LIBSCAP_DIR}/userspace/libpman ${CMAKE_BINARY_DIR}/libpman)

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -7,6 +7,8 @@ option(BUILD_MODERN_BPF_TEST "Build tests for modern BPF" OFF)
 # They should be used only on local machines because they print output and they could be verbose.
 option(BUILD_ENHANCED_MODERN_BPF_TEST "Build enhanced tests for modern BPF" OFF)
 
+option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)
+
 # Add to libpman all functions related to the testing phase
 if(BUILD_MODERN_BPF_TEST)
   add_definitions(-DTEST_HELPERS)
@@ -18,12 +20,18 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "problem with libbpf.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 
-# Directory in which the BPF skeleton will be built
-set(SKEL_DIR "${CMAKE_BINARY_DIR}/skel_dir")
-file(MAKE_DIRECTORY ${SKEL_DIR})
-
-# Build the BPF skeleton as custom target.
-add_subdirectory(${LIBSCAP_DIR}/driver/modern_bpf ${CMAKE_BINARY_DIR}/driver/modern_bpf)
+if(NOT MODERN_BPF_SKEL_DIR)
+  message(STATUS "USE_BUNDLED_MODERN_BPF: ON")
+  # Directory in which the BPF skeleton will be built
+  set(MODERN_BPF_SKEL_DIR "${CMAKE_BINARY_DIR}/skel_dir")
+  file(MAKE_DIRECTORY ${MODERN_BPF_SKEL_DIR})
+  # Build the BPF skeleton as custom target.
+  add_subdirectory(${LIBSCAP_DIR}/driver/modern_bpf ${CMAKE_BINARY_DIR}/driver/modern_bpf)
+else()
+  message(STATUS "USE_BUNDLED_MODERN_BPF: OFF")
+  set(USE_BUNDLED_MODERN_BPF OFF)
+endif()
+message(STATUS "using modern BPF skel_dir: ${MODERN_BPF_SKEL_DIR}")
 
 # Build `libpman` library.
 add_subdirectory(${LIBSCAP_DIR}/userspace/libpman ${CMAKE_BINARY_DIR}/libpman)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR allows us to build the modern bpf skeleton on another machine and to include it inside another build flow, an example is the CI job in the PR... we craft the skeleton on an ubuntu 22.04 machine where we have all the toolchain and then we port the skeleton into a centos7 container to have a lower GLIBC version inside the `scap-open` executable

> NOTE: the CI job and the docker image will be removed before merging the PR I use them to test the correct behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
