### PR TITLE
fix(driver): use `extract__egid` instread of `extract__euid` helper

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -203,7 +203,7 @@ int BPF_PROG(t1_fork_x,
 
 	/* Parameter 18: gid (type: PT_UINT32) */
 	u32 egid = 0;
-	extract__euid(task, &egid);
+	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 
 	/* Parameter 19: vtid (type: PT_PID) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -201,7 +201,7 @@ int BPF_PROG(t1_vfork_x,
 
 	/* Parameter 18: gid (type: PT_UINT32) */
 	u32 egid = 0;
-	extract__euid(task, &egid);
+	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 
 	/* Parameter 19: vtid (type: PT_PID) */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR fixes some typos, we need to extract the `gid` instead of the `uid`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
