### PR TITLE
cleanup(driver):  cleanup nested lookups

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1725,10 +1725,9 @@ static __always_inline int bpf_ppm_get_tty(struct task_struct *task)
 	struct signal_struct *sig;
 	struct tty_struct *tty;
 	struct tty_driver *driver;
-	int major;
-	int minor_start;
-	int index;
-	int tty_nr = 0;
+	int major = 0;
+	int minor_start = 0;
+	int index = 0;
 
 	sig = _READ(task->signal);
 	if (!sig)
@@ -1738,18 +1737,15 @@ static __always_inline int bpf_ppm_get_tty(struct task_struct *task)
 	if (!tty)
 		return 0;
 
-	index = _READ(tty->index);
-
 	driver = _READ(tty->driver);
 	if (!driver)
 		return 0;
 
+	index = _READ(tty->index);
 	major = _READ(driver->major);
 	minor_start = _READ(driver->minor_start);
 
-	tty_nr = new_encode_dev(MKDEV(major, minor_start) + index);
-
-	return tty_nr;
+	return new_encode_dev(MKDEV(major, minor_start) + index);
 }
 
 static __always_inline struct pid *bpf_task_pid(struct task_struct *task)

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -587,10 +587,8 @@ static __always_inline void extract__egid(struct task_struct *task, u32 *egid)
 // EXECVE FLAGS EXTRACTION
 ////////////////////////
 
-static __always_inline bool extract__exe_upper_layer(struct task_struct *task)
+static __always_inline bool extract__exe_upper_layer(struct inode *inode)
 {
-	struct inode *inode = BPF_CORE_READ(task, mm, exe_file, f_inode);
-
 	unsigned long sb_magic = BPF_CORE_READ(inode, i_sb, s_magic);
 
 	if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -475,12 +475,34 @@ static __always_inline unsigned long extract__vm_swap(struct mm_struct *mm)
  */
 static __always_inline u32 exctract__tty(struct task_struct *task)
 {
-	int index;
-	int major;
-	int minor_start;
-	READ_TASK_FIELD_INTO(&index, task, signal, tty, index);
-	READ_TASK_FIELD_INTO(&major, task, signal, tty, driver, major);
-	READ_TASK_FIELD_INTO(&minor_start, task, signal, tty, driver, minor_start);
+	struct signal_struct *signal;
+	struct tty_struct *tty;
+	struct tty_driver *driver;
+	int major = 0;
+	int minor_start = 0;
+	int index = 0;
+
+	BPF_CORE_READ_INTO(&signal, task, signal);
+	if (!signal)
+	{
+		return 0;
+	}
+
+	BPF_CORE_READ_INTO(&tty, signal, tty);
+	if (!tty)
+	{
+		return 0;
+	}
+
+	BPF_CORE_READ_INTO(&driver, tty, driver);
+	if (!driver)
+	{
+		return 0;
+	}
+
+	BPF_CORE_READ_INTO(&index, tty, index);
+	BPF_CORE_READ_INTO(&major, driver, major);
+	BPF_CORE_READ_INTO(&minor_start, driver, minor_start);
 	return encode_dev(MKDEV(major, minor_start) + index);
 }
 

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -482,6 +482,10 @@ static __always_inline u32 exctract__tty(struct task_struct *task)
 	int minor_start = 0;
 	int index = 0;
 
+	/* Direct access of fields w/ READ_TASK_FIELD_INTO or READ_TASK_FIELD can
+	cause issues for tty extraction. Adopt approach of incremental lookups and
+	checks similar to driver-bpf */
+
 	BPF_CORE_READ_INTO(&signal, task, signal);
 	if (!signal)
 	{

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -175,9 +175,10 @@ int BPF_PROG(t1_sched_p_exec,
 	auxmap__store_s32_param(auxmap, (s32)loginuid);
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	/// TODO: still to implement! See what we do in the old probe.
+	/// TODO: we still have to manage `exe_writable` flag.
 	u32 flags = 0;
-	if(extract__exe_upper_layer(task))
+	struct inode *exe_inode = extract__exe_inode_from_task(task);
+	if(extract__exe_upper_layer(exe_inode))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}
@@ -194,8 +195,6 @@ int BPF_PROG(t1_sched_p_exec,
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
-
-	struct inode *exe_inode = extract__exe_inode_from_task(task);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
 	u64 ino = 0;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -239,9 +239,10 @@ int BPF_PROG(t1_execve_x,
 	auxmap__store_s32_param(auxmap, (s32)loginuid);
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	/// TODO: still to implement! See what we do in the old probe.
+	/// TODO: we still have to manage `exe_writable` flag.
 	u32 flags = 0;
-	if(extract__exe_upper_layer(task))
+	struct inode *exe_inode = extract__exe_inode_from_task(task);
+	if(extract__exe_upper_layer(exe_inode))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}
@@ -258,8 +259,6 @@ int BPF_PROG(t1_execve_x,
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
-
-	struct inode *exe_inode = extract__exe_inode_from_task(task);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
 	u64 ino = 0;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -258,7 +258,8 @@ int BPF_PROG(t1_execveat_x,
 	/* Parameter 20: flags (type: PT_FLAGS32) */
 	/// TODO: we still have to manage `exe_writable` flag.
 	u32 flags = 0;
-	if(extract__exe_upper_layer(task))
+	struct inode *exe_inode = extract__exe_inode_from_task(task);
+	if(extract__exe_upper_layer(exe_inode))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}
@@ -275,8 +276,6 @@ int BPF_PROG(t1_execveat_x,
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
-
-	struct inode *exe_inode = extract__exe_inode_from_task(task);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
 	u64 ino = 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

During additional modern_bpf tests (lucky me ... again) noticed that for a bespoke distro and kernel release running in a VM, the tty lookup caused the VM to freeze (no ssh possible anymore and couldn't kill the binary, had to force reload the VM). Never noticed such issues before when running modern_bpf on my Linux boxes etc.
Proposing to perform incremental lookups in `exctract__tty` and checks for each step - exactly like it's done in the old eBPF probe. With these changes everything now seems to work fine in the bespoke VM.

In addition, while here, super minor optimizations.

@Andreagit97 and @hbrueckner would it make sense to carefully re-audit over the next couple of weeks if (as a precaution) some other lookups could benefit from such incremental lookups and checks?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
