### PR TITLE
fix: set max retries to 5 when using CRI only

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_op_bcontains.ut.cpp
 	filter_compiler.ut.cpp
 	user.ut.cpp
+	container_info.ut.cpp
 	"${PUBLIC_SINSP_API_SUITE}"
 	"${TABLE_SUITE}"
 )

--- a/userspace/libsinsp/test/container_info.ut.cpp
+++ b/userspace/libsinsp/test/container_info.ut.cpp
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "container_info.h"
+#include <gtest/gtest.h>
+#include <tuple>
+#include <vector>
+
+class sinsp_container_lookup_test : public ::testing::TestWithParam<std::tuple<short, short, std::vector<short>>>
+{
+};
+
+TEST(sinsp_container_lookup_test, default_values)
+{
+	sinsp_container_lookup lookup;
+	lookup.set_status(sinsp_container_lookup::state::STARTED);
+	EXPECT_TRUE(lookup.first_attempt());
+	// Loop until retry attempt are exausted.
+	int actual_retries = 0;
+	while(lookup.should_retry() && actual_retries < 4)
+	{
+		lookup.attempt_increment();
+		actual_retries++;
+	}
+	ASSERT_EQ(3, actual_retries);
+	ASSERT_EQ(3, lookup.retry_no());
+	ASSERT_EQ(500, lookup.delay());
+}
+
+TEST(sinsp_container_lookup_test, custom)
+{
+	short max_retry = 5;
+	short max_delay_ms = 1000;
+	std::vector<short> expected_delays{125, 250, 500, 1000, 1000};
+	auto lookup = sinsp_container_lookup(max_retry, max_delay_ms);
+	lookup.set_status(sinsp_container_lookup::state::STARTED);
+	for(size_t i = 0; i < expected_delays.size(); i++)
+	{
+		ASSERT_EQ(i == 0, lookup.first_attempt());
+		lookup.attempt_increment();
+		ASSERT_EQ(i < (expected_delays.size() - 1), lookup.should_retry());
+		ASSERT_EQ(expected_delays[i], lookup.delay());
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This change makes sure that 5 maximum retries to retrieve container information are used with CRI only. It puts back the number of retries to 3 for all the other container runtimes.
It also adjusts the maximum time to complete all their attempts to take into account the increased of retries.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: make sure that 5 maximum attempts to resolve container information are used with CRI only, and adjust the maximum time for all the retries.
```
