### PR TITLE
fix: dequeue_next_key breaks async_key_value_source TTL mechanism

### DIFF
--- a/userspace/libsinsp/async/async_key_value_source.tpp
+++ b/userspace/libsinsp/async/async_key_value_source.tpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include <string>
 #include <utility>
 #include <vector>
+#include <tuple>
 
 namespace libsinsp
 {
@@ -149,15 +150,15 @@ void async_key_value_source<key_type, value_type>::run()
 			run_impl();
 		}
 	}
-
 }
 
 template<typename key_type, typename value_type>
 bool async_key_value_source<key_type, value_type>::lookup_delayed(
-		const key_type& key,
-		value_type& value,
-		std::chrono::milliseconds delay,
-		const callback_handler& handler)
+	const key_type& key,
+	value_type& value,
+	std::chrono::milliseconds delay,
+	const callback_handler& handler,
+	const ttl_expired_handler& ttl_expired)
 {
 	std::unique_lock<std::mutex> guard(m_mutex);
 
@@ -167,7 +168,7 @@ bool async_key_value_source<key_type, value_type>::lookup_delayed(
 		m_thread = std::thread(&async_key_value_source::run, this);
 	}
 
-	typename value_map::iterator itr = m_value_map.find(key);
+	auto itr = m_value_map.find(key);
 	bool request_complete;
 
 	if (itr == m_value_map.end())
@@ -233,6 +234,7 @@ bool async_key_value_source<key_type, value_type>::lookup_delayed(
 	{
 		// Set the callback to fill the value later
 		itr->second.m_callback = handler;
+		itr->second.m_ttl_callback = ttl_expired;
 	}
 
 	return request_complete;
@@ -241,10 +243,29 @@ bool async_key_value_source<key_type, value_type>::lookup_delayed(
 template<typename key_type, typename value_type>
 bool async_key_value_source<key_type, value_type>::lookup(
 	const key_type& key,
+	value_type& value)
+{
+	return lookup_delayed(key, value, std::chrono::milliseconds::zero(),
+			      callback_handler(), ttl_expired_handler());
+}
+
+template<typename key_type, typename value_type>
+bool async_key_value_source<key_type, value_type>::lookup(
+	const key_type& key,
 	value_type& value,
 	const callback_handler& handler)
 {
-	return lookup_delayed(key, value, std::chrono::milliseconds::zero(), handler);
+	return lookup_delayed(key, value, std::chrono::milliseconds::zero(), handler, ttl_expired_handler());
+}
+
+template<typename key_type, typename value_type>
+bool async_key_value_source<key_type, value_type>::lookup(
+	const key_type& key,
+	value_type& value,
+	const callback_handler& handler,
+	const ttl_expired_handler& ttl_expired)
+{
+	return lookup_delayed(key, value, std::chrono::milliseconds::zero(), handler, ttl_expired);
 }
 
 template<typename key_type, typename value_type>
@@ -259,14 +280,26 @@ bool async_key_value_source<key_type, value_type>::dequeue_next_key(key_type& ke
 		auto now = std::chrono::steady_clock::now();
 		if(top_element.first < now)
 		{
-			key_found = true;
 			key = std::move(top_element.second);
 			m_request_queue.pop();
 			m_request_set.erase(key);
 
-			if(value_ptr)
+			// The value associated to the key may have been removed because
+			// of TTL expired.
+			auto itr = m_value_map.find(key);
+			if(itr != m_value_map.end())
 			{
-				*value_ptr = m_value_map[key].m_value;
+				key_found = true;
+				if(value_ptr)
+				{
+					*value_ptr = m_value_map[key].m_value;
+				}
+			}
+			else
+			{
+				g_logger.log("async_key_value_source: Key not found when"
+					"retrieving value, TTL expired",
+					sinsp_logger::SEV_DEBUG);
 			}
 		}
 		else
@@ -298,7 +331,7 @@ void async_key_value_source<key_type, value_type>::store_value(
 {
 	std::lock_guard<std::mutex> guard(m_mutex);
 
-	typename value_map::iterator itr = m_value_map.find(key);
+	auto itr = m_value_map.find(key);
 	if(itr == m_value_map.end())
 	{
 		g_logger.log("async_key_value_source: Key not found when storing value",
@@ -351,7 +384,7 @@ void async_key_value_source<key_type, value_type>::prune_stale_requests()
 {
 	// Avoid both iterating over and modifying the map by saving a list
 	// of keys to prune.
-	std::vector<key_type> keys_to_prune;
+	std::vector<std::pair<key_type, ttl_expired_handler>> keys_to_prune;
 
 	for(auto i = m_value_map.begin();
 	    !m_terminate && (i != m_value_map.end());
@@ -365,7 +398,7 @@ void async_key_value_source<key_type, value_type>::prune_stale_requests()
 
 		if(age_ms > m_ttl_ms)
 		{
-			keys_to_prune.push_back(i->first);
+			keys_to_prune.emplace_back(i->first, i->second.m_ttl_callback);
 		}
 	}
 
@@ -373,7 +406,13 @@ void async_key_value_source<key_type, value_type>::prune_stale_requests()
 	    !m_terminate && (i != keys_to_prune.end());
 	    ++i)
 	{
-		m_value_map.erase(*i);
+		key_type key = i->first;
+		ttl_expired_handler ttl_expired_callback = i->second;
+		if(ttl_expired_callback)
+		{
+			ttl_expired_callback(key);
+		}
+		m_value_map.erase(key);
 	}
 }
 

--- a/userspace/libsinsp/container_engine/container_async_source.h
+++ b/userspace/libsinsp/container_engine/container_async_source.h
@@ -43,10 +43,12 @@ public:
 	container_async_source(uint64_t max_wait_ms, uint64_t ttl_ms, container_cache_interface* cache);
 	virtual ~container_async_source() {}
 
-	/// convenience method with default callback
+	// convenience method with default callback
+	bool lookup(const key_type& key, sinsp_container_info& value);
+
 	bool lookup(const key_type& key,
 		    sinsp_container_info& value,
-		    const callback_handler& handler = callback_handler());
+		    const callback_handler& handler);
 
 	bool lookup_sync(const key_type& key, sinsp_container_info& value);
 

--- a/userspace/libsinsp/container_engine/container_async_source.tpp
+++ b/userspace/libsinsp/container_engine/container_async_source.tpp
@@ -34,24 +34,24 @@ container_async_source<key_type>::container_async_source(uint64_t max_wait_ms, u
 
 template<typename key_type>
 bool container_async_source<key_type>::lookup(const key_type& key,
+					      sinsp_container_info& value)
+{
+    return parent_type::lookup(
+        key,
+        value,
+        std::bind(
+            &container_async_source::source_callback,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2));
+}
+
+template<typename key_type>
+bool container_async_source<key_type>::lookup(const key_type& key,
 					      sinsp_container_info& value,
 					      const callback_handler& handler)
 {
-	if(handler)
-	{
-		return parent_type::lookup(key, value, handler);
-	}
-	else
-	{
-		return parent_type::lookup(
-			key,
-			value,
-			std::bind(
-				&container_async_source::source_callback,
-				this,
-				std::placeholders::_1,
-				std::placeholders::_2));
-	}
+	return parent_type::lookup(key, value, handler);
 }
 
 template<typename key_type>

--- a/userspace/libsinsp/test/async_key_value_source.ut.cpp
+++ b/userspace/libsinsp/test/async_key_value_source.ut.cpp
@@ -17,37 +17,78 @@ limitations under the License.
 
 #include <async/async_key_value_source.h>
 #include <gtest/gtest.h>
+#include <chrono>
+#include <cassert>
+#include <atomic>
+#include <condition_variable>
 #include <cstdlib>
+#include <iostream>
+#include <limits>
 #include <memory>
+#include <thread>
+namespace
+{
 
-class test_key_value_source : public libsinsp::async_key_value_source<std::string, uint64_t> {
+struct result
+{
+	uint64_t val = 0;
+	int retries = 0;
+};
+
+class test_key_value_source : public libsinsp::async_key_value_source<std::string, result>
+{
 public:
-	test_key_value_source(uint64_t delay_sec, uint64_t wait_response_ms) :
-		async_key_value_source<std::string, uint64_t>(wait_response_ms, UINT64_MAX),
-		m_delay_sec(delay_sec)
-	{}
+	test_key_value_source(uint64_t delay_ms, uint64_t wait_response_ms, uint64_t ttl_ms = std::numeric_limits<uint64_t>::max(), short num_failures = 0, short backoff_ms = 10):
+		async_key_value_source<std::string, result>(wait_response_ms, ttl_ms),
+		m_delay_ms(delay_ms),
+		m_num_failures(num_failures),
+		m_backoff_ms(backoff_ms)
+	{
+		assert(m_num_failures >= 0);
+		assert(backoff_ms >= 0);
+	}
 
 	virtual ~test_key_value_source()
 	{
 		stop();
 	}
 
+	bool next_key(std::string& key)
+	{
+		return dequeue_next_key(key);
+	}
+
 	void run_impl()
 	{
 		std::string key;
+		result res;
 
-		while(dequeue_next_key(key))
+		while(dequeue_next_key(key, &res))
 		{
-			if(m_delay_sec > 0)
+			if(m_delay_ms > 0)
 			{
-				sleep(m_delay_sec);
+				std::this_thread::sleep_for(std::chrono::milliseconds(m_delay_ms));
 			}
-			store_value(key, (uint64_t) atoi(key.c_str()));
+			if(res.retries < m_num_failures)
+			{
+				res.retries++;
+				// Simulate failures, re-enqueue the key after m_backoff_ms milliseconds
+				defer_lookup(key,
+					     &res,
+					     std::chrono::milliseconds(m_backoff_ms));
+			}
+			else
+			{
+				res.val = (uint64_t)atoi(key.c_str());
+				store_value(key, res);
+			}
 		}
 	}
 
 protected:
-	uint64_t m_delay_sec;
+	uint64_t m_delay_ms;
+	short m_num_failures;
+	short m_backoff_ms;
 };
 
 TEST(async_key_value_source_test, no_lookup)
@@ -58,47 +99,105 @@ TEST(async_key_value_source_test, no_lookup)
 TEST(async_key_value_source_test, basic)
 {
 	std::unique_ptr<test_key_value_source> t(new test_key_value_source(0, UINT64_MAX));
-	uint64_t value;
+	result res;
 
-	while(!t->lookup("1", value))
+	while(!t->lookup("1", res))
 	{
-		sleep(1);
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	ASSERT_EQ(1, value);
+	ASSERT_EQ(1, res.val);
 }
 
 TEST(async_key_value_source_test, long_delay_lookups)
 {
-	std::unique_ptr<test_key_value_source> t(new test_key_value_source(5, UINT64_MAX));
-	uint64_t value;
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(500, UINT64_MAX));
+	result res;
 
-	while(!t->lookup("1", value))
+	while(!t->lookup("1", res))
 	{
-		sleep(1);
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	ASSERT_EQ(1, value);
+	ASSERT_EQ(1, res.val);
 }
 
 TEST(async_key_value_source_test, basic_nowait)
 {
 	std::unique_ptr<test_key_value_source> t(new test_key_value_source(0, 0));
-	uint64_t value;
+	result res;
 
-	while(!t->lookup("1", value))
+	while(!t->lookup("1", res))
 	{
-		sleep(1);
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	ASSERT_EQ(1, value);
+	ASSERT_EQ(1, res.val);
 }
 
 TEST(async_key_value_source_test, long_delay_lookups_nowait)
 {
-	std::unique_ptr<test_key_value_source> t(new test_key_value_source(5, 0));
-	uint64_t value;
+	std::unique_ptr<test_key_value_source> t(new test_key_value_source(500, 0));
+	result res;
 
-	while(!t->lookup("1", value))
+	while(!t->lookup("1", res))
 	{
-		sleep(1);
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	ASSERT_EQ(1, value);
+	ASSERT_EQ(1, res.val);
 }
+
+TEST(async_key_value_source_test, async)
+{
+	uint64_t ttl_ms = std::numeric_limits<uint64_t>::max();
+	short num_failures = 3;
+	test_key_value_source t(0, 0, ttl_ms, num_failures);
+	result res;
+	std::condition_variable cv;
+	std::mutex cv_m;
+
+	bool done = false;
+	t.lookup("1", res, [&cv, &done](const std::string& key, const result& res)
+		 {
+	            ASSERT_EQ(1, res.val);
+	            ASSERT_EQ(3, res.retries);
+                done = true;
+                cv.notify_all(); });
+	std::unique_lock<std::mutex> lk(cv_m);
+	if(!cv.wait_for(lk, std::chrono::milliseconds(100), [&done]()
+			{ return done; }))
+		FAIL() << "Timeout expired while waiting for result";
+}
+
+TEST(async_key_value_source_test, async_ttl_expired)
+{
+	uint64_t ttl_ms = 10;
+	short num_failures = 3;
+	short backoff_ms = 6;
+	test_key_value_source t(0, 0, ttl_ms, num_failures, backoff_ms);
+	result res;
+	std::condition_variable cv;
+	std::mutex cv_m;
+
+	bool done = false;
+	t.lookup(
+		"1", res,
+		[&cv, &done](const std::string& key, const result& res)
+		{
+			FAIL() << "unexpected callback for key: " << key;
+			done = true;
+			cv.notify_all();
+		},
+		[&cv, &done](const std::string& key)
+		{
+			ASSERT_EQ("1", key);
+			done = true;
+			cv.notify_all();
+		});
+	std::unique_lock<std::mutex> lk(cv_m);
+	if(!cv.wait_for(lk, std::chrono::milliseconds(100), [&done]()
+			{ return done; }))
+		FAIL() << "Timeout expired while waiting for result";
+	// Verify that no keys are left in the queue.
+	std::string key;
+	ASSERT_FALSE(t.next_key(key));
+}
+
+} // namespace

--- a/userspace/libsinsp/test/container_info.ut.cpp
+++ b/userspace/libsinsp/test/container_info.ut.cpp
@@ -41,11 +41,12 @@ TEST(sinsp_container_lookup_test, default_values)
 	ASSERT_EQ(500, lookup.delay());
 }
 
-TEST(sinsp_container_lookup_test, custom)
+TEST_P(sinsp_container_lookup_test, delays_match)
 {
-	short max_retry = 5;
-	short max_delay_ms = 1000;
-	std::vector<short> expected_delays{125, 250, 500, 1000, 1000};
+	short max_retry;
+	short max_delay_ms;
+	std::vector<short> expected_delays;
+	std::tie(max_retry, max_delay_ms, expected_delays) = GetParam();
 	auto lookup = sinsp_container_lookup(max_retry, max_delay_ms);
 	lookup.set_status(sinsp_container_lookup::state::STARTED);
 	for(size_t i = 0; i < expected_delays.size(); i++)
@@ -56,3 +57,10 @@ TEST(sinsp_container_lookup_test, custom)
 		ASSERT_EQ(expected_delays[i], lookup.delay());
 	}
 }
+
+INSTANTIATE_TEST_CASE_P(sinsp_container_lookup,
+			 sinsp_container_lookup_test,
+			 ::testing::Values(
+				 std::tuple<short, short, std::vector<short>>{3, 500, {125, 250, 500}},
+				 std::tuple<short, short, std::vector<short>>{5, 1000, {125, 250, 500, 1000, 1000}},
+				 std::tuple<short, short, std::vector<short>>{2, 1, {1, 1}}));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

`async_key_value_source` provides a TTL mechanism, the problem is that when `dequeue_next_key` is invoked, there is no check for the existence of the key in `m_value_map`. If the value was pruned due to TTL expiration it gets put back by [std::map::operator[]](https://cplusplus.com/reference/map/map/operator[]/), which creates a new `lookup_request`. This may lead to an infinite loop, in case the TTL always expires.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: make sure that dequeue_next_key does not put back expired values in async_key_value_source
```
