### PR TITLE
chore(userspace): manage not bundled libelf dependency adding a custom target

### DIFF
--- a/cmake/modules/libelf.cmake
+++ b/cmake/modules/libelf.cmake
@@ -5,6 +5,9 @@ option(USE_BUNDLED_LIBELF "Enable building of the bundled libelf" ${USE_BUNDLED_
 
 if(LIBELF_INCLUDE)
     # we already have LIBELF
+    # We add a custom target, in this way we can always depend on `libelf`
+    # without distinguishing between "bundled" and "not-bundled" case
+    add_custom_target(libelf)
 elseif(NOT USE_BUNDLED_LIBELF)
     find_path(LIBELF_INCLUDE elf.h PATH_SUFFIXES elf)
     find_library(LIBELF_LIB NAMES libelf.a libelf.so)
@@ -13,6 +16,9 @@ elseif(NOT USE_BUNDLED_LIBELF)
     else()
         message(FATAL_ERROR "Couldn't find system libelf")
     endif()
+    # We add a custom target, in this way we can always depend on `libelf`
+    # without distinguishing between "bundled" and "not-bundled" case
+    add_custom_target(libelf)
 else()
     set(LIBELF_SRC "${PROJECT_BINARY_DIR}/libelf-prefix/src")
     set(LIBELF_INCLUDE "${LIBELF_SRC}/libelf/libelf")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR should solve issues when not using bundled dependencies, for example here we allow other libraries to depend on `libelf` even if it is not bundled, in this way we don't have to manage the bundled case in a different way

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
