### PR TITLE
update: avoid owning event pointer offset in scap test engine

### DIFF
--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -25,7 +25,6 @@ struct test_input_engine
 {
 	char* m_lasterr;
 	struct scap_test_input_data *m_data;
-	size_t m_event_index;
 };
 
 typedef struct test_input_engine test_input_engine;
@@ -56,13 +55,13 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 	test_input_engine *engine = handle.m_handle;
 	scap_test_input_data *data = engine->m_data;
 
-	if (engine->m_event_index >= data->event_count)
+	if (!data->events || data->event_count == 0)
 	{
 		return SCAP_EOF;
 	}
-	
-	*pevent = data->events[engine->m_event_index];
-	engine->m_event_index++;
+
+	*pevent = *(data->events++);
+	data->event_count--;
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -130,9 +130,10 @@ protected:
 		event->ts = ts;
 		event->tid = tid;
 
+		uint64_t evtoffset = m_events.size() - m_test_data->event_count;
 		m_events.push_back(event);
-		m_test_data->events = m_events.data();
-		m_test_data->event_count = m_events.size();
+		m_test_data->events = m_events.data() + evtoffset;
+		m_test_data->event_count = m_events.size() - evtoffset;
 		m_last_recorded_timestamp = ts;
 
 		return event;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The libscap's test engine currently accepts a pointer to an event array, and then stores an internal offset index of that array to proceed with the event generation. This approach limits the degrees of freedom of the engine users, such as the sinsp tests, because they need to provide an increasingly-larger array every time they want to change/add events at runtime between one `next` call and another.

This PR fixes this by moving the pointer ownership to the caller. The test engine will iterate through the event array using pointer arithmetic and always dereferencing the head left-most element, and by decrementing the size count. Both the pointer and the size count can be manipulated from the caller.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
