### PR TITLE
fix: unify dropping management in modern bpf probe

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -195,6 +195,9 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap)
 		return;
 	}
 
+	/* This counts the event seen by the drivers even if they are dropped because the buffer is full. */
+	counter->n_evts++;
+
 	if(auxmap->payload_pos > MAX_EVENT_SIZE)
 	{
 		counter->n_drops_max_event_size++;
@@ -208,10 +211,6 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap)
 	if(err)
 	{
 		counter->n_drops_buffer++;
-	}
-	else
-	{
-		counter->n_evts++;
 	}
 }
 

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -99,6 +99,9 @@ static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf
 		return 0;
 	}
 
+	/* This counts the event seen by the drivers even if they are dropped because the buffer is full. */
+	counter->n_evts++;
+
 	/* If we are not able to reserve space we stop here
 	 * the event collection.
 	 */
@@ -109,7 +112,6 @@ static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf
 		return 0;
 	}
 
-	counter->n_evts++;
 	ringbuf->data = space;
 	ringbuf->reserved_event_size = event_size;
 	return 1;

--- a/userspace/libpman/src/capture.c
+++ b/userspace/libpman/src/capture.c
@@ -120,6 +120,7 @@ int pman_get_scap_stats(void *scap_stats_struct)
 		stats->n_evts += cnt_map.n_evts;
 		stats->n_drops_buffer += cnt_map.n_drops_buffer;
 		stats->n_drops_scratch_map += cnt_map.n_drops_max_event_size;
+		stats->n_drops += (cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size);
 	}
 	return 0;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR carries 2 fixes:
* allow computing the sum of all drops (full ring buffer + event too large) like in all our drivers.
* unify the logic between our drivers. In our drivers `n_evts` is the number of events that the driver should send to userspace according to its configuration. So this counter includes also the number of drops (for example due to full buffers). Before this patch, the modern probe didn't consider drops inside the `n_evts`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
