### PR TITLE
update(userspace/libsinsp): rely on proc root

### DIFF
--- a/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
+++ b/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
@@ -2,7 +2,7 @@ import pytest
 from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events
 
-sinsp_filters = ["-f", "evt.type=setuid"]
+sinsp_filters = ["-f", "evt.type=setuid", "-E"]
 
 containers = [
     {

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -83,6 +83,7 @@ Options:
   -s <path>, --scap_file <path>   			 Scap file
   -d <dim>, --buffer_dim <dim>               Dimension in bytes that every per-CPU buffer will have.
   -o <fields>, --output-fields-json <fields>    [JSON support only, can also use without -j] Output fields string (see <filter> for supported display fields) that overwrites JSON default output fields for all events. * at the beginning prints JSON keys with null values, else no null fields are printed.
+  -E, --exclude-users                        Don't create the user/group tables
 )";
 	cout << usage << endl;
 }
@@ -102,12 +103,13 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 		{"scap_file", required_argument, 0, 's'},
 		{"buffer_dim", required_argument, 0, 'd'},
 		{"output-fields-json", required_argument, 0, 'o'},
+		{"exclude-users", no_argument, 0, 'E'},
 		{0, 0, 0, 0}};
 
 	int op;
 	int long_index = 0;
 	while((op = getopt_long(argc, argv,
-				"hf:jab:mks:d:o:",
+				"hf:jab:mks:d:o:E",
 				long_options, &long_index)) != -1)
 	{
 		switch(op)
@@ -145,6 +147,9 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 			output_fields_json = optarg;
 			json_dump_init(inspector);
 			json_dump_reinit_evt_formatter(inspector);
+			break;
+		case 'E':
+			inspector.set_import_users(false);
 			break;
 		default:
 			break;

--- a/userspace/libsinsp/procfs_utils.h
+++ b/userspace/libsinsp/procfs_utils.h
@@ -34,14 +34,11 @@ class ns_helper
 {
 public:
 	ns_helper(const std::string& host_root);
-	~ns_helper();
 
 	bool can_read_host_init_ns_mnt() const
 	{
 		return !m_cannot_read_host_init_ns_mnt;
 	}
-
-	const char* get_host_init_ns_mnt() const { return m_host_init_ns_mnt; }
 
 	//! Return true if not in the host init mount namespace
 	bool in_own_ns_mnt(int64_t pid) const;
@@ -53,16 +50,8 @@ public:
 
 private:
 	const std::string& m_host_root;
-	char* m_host_init_ns_mnt{nullptr};
 	bool m_cannot_read_host_init_ns_mnt{false};
-
-private:
-	//
-	// NOTE: at the time of writing 16 would have been enough, being
-	// the format `mnt:[<unsigned>]`, but the only call to `ns_get_name`
-	// I could find in the kernel was using a buffer of 50, so 50 it is.
-	//
-	static constexpr const std::size_t NS_MNT_SIZE{50};
+	int64_t m_host_init_root_inode{-1};
 };
 
 } // namespace procfs_utils

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -354,19 +354,7 @@ scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &co
 
 	scap_userinfo *retval{nullptr};
 
-	//
-	// When a container is running with a specific user and this
-	// get called with 0, it's too early to make an attempt.
-	// As a downside we won't load users for containers running as
-	// root, but we will load them if e.g.docker exec -u <specific-user>.
-	//
-	if (uid == 0)
-	{
-		return retval;
-	}
-
 #if defined HAVE_PWD_H && defined HAVE_FGET__ENT
-
 	if(!m_ns_helper->in_own_ns_mnt(pid))
 	{
 		return retval;
@@ -485,17 +473,6 @@ scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &
 			"adding container [%s] group: %d", container_id.c_str(), gid);
 
 	scap_groupinfo *retval{nullptr};
-
-	//
-	// When a container is running with a specific user and this
-	// get called with 0, it's too early to make an attempt.
-	// As a downside we won't load users for containers running as
-	// root, but we will load them if e.g.docker exec -u <specific-user>.
-	//
-	if(gid == 0)
-	{
-		return retval;
-	}
 
 #if defined HAVE_GRP_H && defined HAVE_FGET__ENT
 	if(!m_ns_helper->in_own_ns_mnt(pid))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**
/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Instead of checking /proc/<pid>/ns/mnt, just check /proc/<pid>/root inode. The mount namespace gets created before the process actually gets into that namespace, so it was flaky and we also had a workaround getting it to work only for containers being created with non-root user.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): rely on proc root for user and group container lookup
```
