### PR TITLE
new(bpf-driver): Introduce `bpf_probe_read_user` and `bpf_probe_read_kernel` variants

### DIFF
--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -72,7 +72,7 @@ static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
 static int (*bpf_probe_read_str)(void *dst, u64 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)
+#if defined(USE_BPF_PROBE_KERNEL_USER_VARIANTS)
 static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_user;
 static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =

--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -71,6 +71,14 @@ static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
 	(void *)BPF_FUNC_xdp_adjust_head;
 static int (*bpf_probe_read_str)(void *dst, u64 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
+static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_user;
+static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_kernel;
+static int (*bpf_probe_read_user_str)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_user_str;
+static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_kernel_str;
 static u64 (*bpf_get_current_task)(void) =
 	(void *)BPF_FUNC_get_current_task;
 static int (*bpf_skb_load_bytes)(void *ctx, int off, void *to, int len) =

--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -71,6 +71,8 @@ static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
 	(void *)BPF_FUNC_xdp_adjust_head;
 static int (*bpf_probe_read_str)(void *dst, u64 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)
 static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_user;
 static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =
@@ -79,6 +81,17 @@ static int (*bpf_probe_read_user_str)(void *dst, u32 size, const void *unsafe_pt
 	(void *)BPF_FUNC_probe_read_user_str;
 static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_kernel_str;
+#else
+static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read;
+static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read;
+static int (*bpf_probe_read_user_str)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_str;
+static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_ptr) =
+	(void *)BPF_FUNC_probe_read_str;
+#endif
+
 static u64 (*bpf_get_current_task)(void) =
 	(void *)BPF_FUNC_get_current_task;
 static int (*bpf_skb_load_bytes)(void *ctx, int off, void *to, int len) =

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -474,9 +474,9 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 }
 
 static __always_inline int unix_socket_path(char *dest, const char *user_ptr, size_t size) {
-	int res = bpf_probe_read_user_str(dest,
-				     size,
-				     user_ptr);
+	int res = bpf_probe_read_kernel_str(dest,
+				            size,
+				            user_ptr);
 	/*
   	 * Extract from: https://man7.org/linux/man-pages/man7/unix.7.html
 	 * an abstract socket address is distinguished (from a
@@ -487,9 +487,9 @@ static __always_inline int unix_socket_path(char *dest, const char *user_ptr, si
 	 */
 	if (res == 1) {
 		dest[0] = '@';
-		res = bpf_probe_read_user_str(dest + 1,
-					      size - 1, // account for '@'
-					      user_ptr + 1);
+		res = bpf_probe_read_kernel_str(dest + 1,
+					        size - 1, // account for '@'
+					        user_ptr + 1);
 		res++; // account for '@'
 	}
 	return res;

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -659,8 +659,8 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 				 * From kernel 3.13 we can take both ipv4 and ipv6 info from here
 				 * https://elixir.bootlin.com/linux/v3.13/source/include/net/sock.h#L164
 				 */
-				bpf_probe_read(&sip, sizeof(sip), &sk->__sk_common.skc_daddr);
-				bpf_probe_read(&sport, sizeof(sport), &sk->__sk_common.skc_dport);
+				bpf_probe_read_kernel(&sip, sizeof(sip), &sk->__sk_common.skc_daddr);
+				bpf_probe_read_kernel(&sport, sizeof(sport), &sk->__sk_common.skc_dport);
 				sport = ntohs(sport);
 				dip = ((struct sockaddr_in *)sock_address)->sin_addr.s_addr;
 				dport = ntohs(((struct sockaddr_in *)sock_address)->sin_port);
@@ -716,9 +716,9 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 			struct sockaddr_in6 *usrsockaddr_in6 = (struct sockaddr_in6 *)usrsockaddr;
 
 			if (is_inbound) {
-				bpf_probe_read(&in6, sizeof(in6), &sk->__sk_common.skc_v6_daddr);
+				bpf_probe_read_kernel(&in6, sizeof(in6), &sk->__sk_common.skc_v6_daddr);
 				sip6 = in6.in6_u.u6_addr8;
-				bpf_probe_read(&sport, sizeof(sport), &sk->__sk_common.skc_dport);
+				bpf_probe_read_kernel(&sport, sizeof(sport), &sk->__sk_common.skc_dport);
 				sport = ntohs(sport);
 				dip6 = ((struct sockaddr_in6 *)sock_address)->sin6_addr.s6_addr;
 				dport = ntohs(((struct sockaddr_in6 *)sock_address)->sin6_port);

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -923,7 +923,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 					 * we send an empty param `len=0`.
 					 */
 					volatile u16 read_size = dpi_lookahead_size;
-					int rc;
+					int rc = 0;
 
 					rc = __bpf_read_val_into(data, curoff_bounded, val, read_size, mem);
 					if (rc)
@@ -949,7 +949,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 			if(!data->curarg_already_on_frame)
 			{
 				volatile u16 read_size = len;
-				int rc;
+				int rc = 0;
 
 				curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
 				if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -873,16 +873,18 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_CHARBUF:
 	case PT_FSPATH:
 	case PT_FSRELPATH: {
-		if (!data->curarg_already_on_frame) 
+		if (!data->curarg_already_on_frame)
 		{
-			int res;
-			/* Return `res<0` only in case of error. */ 
-			res = (mem == KERNEL) ? bpf_probe_read_kernel_str(&data->buf[curoff_bounded],
-							PPM_MAX_ARG_SIZE,
-							(const void *)val)
-					      : bpf_probe_read_user_str(&data->buf[curoff_bounded],
-							PPM_MAX_ARG_SIZE,
-							(const void *)val);
+			int res = -1;
+
+			if (val)
+				/* Return `res<0` only in case of error. */
+				res = (mem == KERNEL) ? bpf_probe_read_kernel_str(&data->buf[curoff_bounded],
+								PPM_MAX_ARG_SIZE,
+								(const void *)val)
+						      : bpf_probe_read_user_str(&data->buf[curoff_bounded],
+								PPM_MAX_ARG_SIZE,
+								(const void *)val);
 			if(res >= 0)
 			{
 				len = res;

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -273,7 +273,7 @@ static __always_inline bool bpf_getsockname(struct socket *sock,
 static __always_inline int bpf_addr_to_kernel(void *uaddr, int ulen,
 					      struct sockaddr *kaddr)
 {
-	int len = _READ(ulen);
+	int len = _READ_USER(ulen);
 	if (len < 0 || len > sizeof(struct sockaddr_storage))
 		return -EINVAL;
 	if (len == 0)

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -264,9 +264,9 @@ static __always_inline bool bpf_getsockname(struct socket *sock,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 			if (len > 0)
-				bpf_probe_read_user(sunaddr, ((len - 1) & 0xff) + 1, addr->name);
+				bpf_probe_read_kernel(sunaddr, ((len - 1) & 0xff) + 1, addr->name);
 #else
-			bpf_probe_read_user(sunaddr, len, addr->name);
+			bpf_probe_read_kernel(sunaddr, len, addr->name);
 #endif
 		}
 

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -282,7 +282,8 @@ static __always_inline bool bpf_getsockname(struct socket *sock,
 static __always_inline int bpf_addr_to_kernel(void *uaddr, int ulen,
 					      struct sockaddr *kaddr)
 {
-	int len = _READ_USER(ulen);
+	int len = ulen & 0xfff;	/* required by BPF verifier */
+
 	if (len < 0 || len > sizeof(struct sockaddr_storage))
 		return -EINVAL;
 	if (len == 0)

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1114,7 +1114,6 @@ static __always_inline enum read_memory param_type_to_mem(enum ppm_param_type ty
 	case PT_FSPATH:
 	case PT_FSRELPATH:
 	case PT_BYTEBUF:
-	{
 		/* Those types typically read memory from user space pointers.
 		 * If not, explicit use the respective helper with the _mem()
 		 * suffix to specify the memory to read from.
@@ -1122,11 +1121,8 @@ static __always_inline enum read_memory param_type_to_mem(enum ppm_param_type ty
 		 * See also the usage below in the helpers.
 		 */
 		return USER;
-	}
 	default:
-	{
 		return KERNEL;
-	}
 	}
 }
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2561,7 +2561,11 @@ FILLER(proc_startupdate_3, true)
 		switch (data->state->tail_ctx.evt_type)
 		{
 		case PPME_SYSCALL_CLONE_20_X:
+#ifdef CONFIG_S390
+			flags = bpf_syscall_get_argument(data, 1);
+#else
 			flags = bpf_syscall_get_argument(data, 0);
+#endif
 			break;
 		
 		case PPME_SYSCALL_CLONE3_X:

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -12,6 +12,7 @@ or GPL2.txt for full copies of the license.
 #include "../systype_compat.h"
 #include "../ppm_flag_helpers.h"
 #include "../ppm_version.h"
+#include "bpf_helpers.h"
 
 #include <linux/tty.h>
 #include <linux/audit.h>
@@ -511,11 +512,11 @@ static __always_inline int bpf_poll_parse_fds(struct filler_data *data,
 	val = bpf_syscall_get_argument(data, 0);
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 	if (read_size)
-		if (bpf_probe_read(fds,
-				   ((read_size - 1) & SCRATCH_SIZE_MAX) + 1,
-				   (void *)val))
+		if (bpf_probe_read_user(fds,
+					((read_size - 1) & SCRATCH_SIZE_MAX) + 1,
+					 (void *)val))
 #else
-	if (bpf_probe_read(fds, read_size & SCRATCH_SIZE_MAX, (void *)val))
+	if (bpf_probe_read_user(fds, read_size & SCRATCH_SIZE_MAX, (void *)val))
 #endif
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -627,13 +628,13 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 	if (copylen)
-		if (bpf_probe_read((void *)iov,
-				   ((copylen - 1) & SCRATCH_SIZE_MAX) + 1,
-				   (void *)iovsrc))
+		if (bpf_probe_read_user((void *)iov,
+					((copylen - 1) & SCRATCH_SIZE_MAX) + 1,
+					(void *)iovsrc))
 #else
-	if (bpf_probe_read((void *)iov,
-			   copylen & SCRATCH_SIZE_MAX,
-			   (void *)iovsrc))
+	if (bpf_probe_read_user((void *)iov,
+				copylen & SCRATCH_SIZE_MAX,
+				(void *)iovsrc))
 #endif
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -686,13 +687,13 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (to_read)
-					if (bpf_probe_read(&data->buf[off_bounded],
-							   ((to_read - 1) & SCRATCH_SIZE_HALF) + 1,
-							   iov[j].iov_base))
+					if (bpf_probe_read_user(&data->buf[off_bounded],
+								((to_read - 1) & SCRATCH_SIZE_HALF) + 1,
+								iov[j].iov_base))
 #else
-				if (bpf_probe_read(&data->buf[off_bounded],
-						   to_read & SCRATCH_SIZE_HALF,
-						   iov[j].iov_base))
+				if (bpf_probe_read_user(&data->buf[off_bounded],
+							to_read & SCRATCH_SIZE_HALF,
+							iov[j].iov_base))
 #endif
 					return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -798,7 +799,7 @@ static __always_inline int timespec_parse(struct filler_data *data,
 	u64 longtime;
 	struct timespec ts;
 
-	if (bpf_probe_read(&ts, sizeof(ts), (void *)val))
+	if (bpf_probe_read_user(&ts, sizeof(ts), (void *)val))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	longtime = ((u64)ts.tv_sec) * 1000000000 + ts.tv_nsec;
@@ -852,7 +853,7 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 {
 	long val;
 
-	bpf_probe_read(&val, sizeof(val), &mm->rss_stat.count[member]);
+	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
 	if (val < 0)
 		val = 0;
 
@@ -883,7 +884,7 @@ FILLER(sys_brk_munmap_mmap_x, true)
 
 	task = (struct task_struct *)bpf_get_current_task();
 	mm = NULL;
-	bpf_probe_read(&mm, sizeof(mm), &task->mm);
+	bpf_probe_read_kernel(&mm, sizeof(mm), &task->mm);
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring_type(data, retval, PT_UINT64);
@@ -1083,7 +1084,7 @@ FILLER(sys_getrlimit_setrlrimit_x, true)
 		struct rlimit rl;
 
 		val = bpf_syscall_get_argument(data, 1);
-		if (bpf_probe_read(&rl, sizeof(rl), (void *)val))
+		if (bpf_probe_read_user(&rl, sizeof(rl), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		cur = rl.rlim_cur;
@@ -1229,7 +1230,7 @@ FILLER(sys_socketpair_x, true)
 
 	if (retval >= 0) {
 		val = bpf_syscall_get_argument(data, 3);
-		if (bpf_probe_read(fds, 2 * sizeof(int), (void *)val))
+		if (bpf_probe_read_user(fds, 2 * sizeof(int), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		struct socket *sock = bpf_sockfd_lookup(data, fds[0]);
@@ -1278,7 +1279,7 @@ static int __always_inline parse_sockopt(struct filler_data *data, int level, in
 			/* If there is an error while reading `bpf_probe_read` performs
 			 * a `memset` so no need to check return value.
 			 */
-			bpf_probe_read(&val32, sizeof(val32), optval);
+			bpf_probe_read_user(&val32, sizeof(val32), optval);
 			return bpf_val_to_ring_dyn(data, (s64)-val32, PT_ERRNO, PPM_SOCKOPT_IDX_ERRNO);
 #endif
 
@@ -1300,12 +1301,12 @@ static int __always_inline parse_sockopt(struct filler_data *data, int level, in
 #if (defined(SO_SNDTIMEO_NEW) && !defined(SO_SNDTIMEO)) || (defined(SO_SNDTIMEO_NEW) && (SO_SNDTIMEO_NEW != SO_SNDTIMEO))
 		case SO_SNDTIMEO_NEW:
 #endif
-			bpf_probe_read(&tv, sizeof(tv), optval);
+			bpf_probe_read_user(&tv, sizeof(tv), optval);
 			return bpf_val_to_ring_dyn(data, tv.tv_sec * SECOND_IN_NS + tv.tv_usec * USECOND_IN_NS, PT_RELTIME, PPM_SOCKOPT_IDX_TIMEVAL);
 
 #ifdef SO_COOKIE
 		case SO_COOKIE:
-			bpf_probe_read(&val64, sizeof(val64), optval);
+			bpf_probe_read_user(&val64, sizeof(val64), optval);
 			return bpf_val_to_ring_dyn(data, val64, PT_UINT64, PPM_SOCKOPT_IDX_UINT64);
 #endif
 
@@ -1435,7 +1436,7 @@ static int __always_inline parse_sockopt(struct filler_data *data, int level, in
 #ifdef SO_INCOMING_CPU
 		case SO_INCOMING_CPU:
 #endif
-			bpf_probe_read(&val32, sizeof(val32), optval);
+			bpf_probe_read_user(&val32, sizeof(val32), optval);
 			return bpf_val_to_ring_dyn(data, val32, PT_UINT32, PPM_SOCKOPT_IDX_UINT32);
 
 		default:
@@ -1506,7 +1507,7 @@ FILLER(sys_getsockopt_x, true)
 	int optlen = 0;
 	unsigned long optlen_pointer = bpf_syscall_get_argument(data, 4);
 	/* if the read fails it internally calls memeset(0) so we are ok */
-	bpf_probe_read(&optlen, sizeof(optlen), (void*)optlen_pointer);
+	bpf_probe_read_user(&optlen, sizeof(optlen), (void*)optlen_pointer);
 	res = parse_sockopt(data, level, optname, (void*)optval, optlen);
 	CHECK_RES(res);
 
@@ -1858,9 +1859,9 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
 
-	int res = bpf_probe_read_str(&buf[off_bounded],
-				     SCRATCH_SIZE_HALF,
-				     subsys_name);
+	int res = bpf_probe_read_kernel_str(&buf[off_bounded],
+					    SCRATCH_SIZE_HALF,
+					    subsys_name);
 	if (res == -EFAULT)
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -1907,9 +1908,9 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 				return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 			}
 
-			res = bpf_probe_read_str(&buf[off_bounded],
-						 SCRATCH_SIZE_HALF,
-						 cgroup_path[k]);
+			res = bpf_probe_read_kernel_str(&buf[off_bounded],
+							SCRATCH_SIZE_HALF,
+							cgroup_path[k]);
 			if (res > 1)
 			{
 				off += res - 1;
@@ -2000,7 +2001,7 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 			return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 		}
 
-		len = bpf_probe_read_str(&data->buf[off & SCRATCH_SIZE_HALF], SCRATCH_SIZE_HALF, arg);
+		len = bpf_probe_read_user_str(&data->buf[off & SCRATCH_SIZE_HALF], SCRATCH_SIZE_HALF, arg);
 		if (len == -EFAULT)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -2306,11 +2307,11 @@ FILLER(proc_startupdate, true)
 				args_len = ARGS_ENV_SIZE_MAX;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-			if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+			if (bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 						((args_len - 1) & SCRATCH_SIZE_HALF) + 1,
 						(void *)arg_start))
 #else
-			if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+			if (bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 						args_len & SCRATCH_SIZE_HALF,
 						(void *)arg_start))
 #endif
@@ -2349,9 +2350,9 @@ FILLER(proc_startupdate, true)
 	if (args_len) {
 		int exe_len;
 
-		exe_len = bpf_probe_read_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						SCRATCH_SIZE_HALF,
-						&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
+		exe_len = bpf_probe_read_kernel_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						    SCRATCH_SIZE_HALF,
+						    &data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
 
 		if (exe_len == -EFAULT)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
@@ -2566,7 +2567,7 @@ FILLER(proc_startupdate_3, true)
 		case PPME_SYSCALL_CLONE3_X:
 #ifdef __NR_clone3
 			flags = bpf_syscall_get_argument(data, 0);
-			if (bpf_probe_read(&cl_args, sizeof(struct clone_args), (void *)flags)) 
+			if (bpf_probe_read_user(&cl_args, sizeof(struct clone_args), (void *)flags)) 
 			{
 				return PPM_FAILURE_INVALID_USER_MEMORY;
 			}
@@ -2678,13 +2679,13 @@ FILLER(proc_startupdate_3, true)
 					env_len = ARGS_ENV_SIZE_MAX;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-				if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						   ((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
-						   (void *)env_start))
+				if (bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+							  ((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
+							  (void *)env_start))
 #else
-				if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						   env_len & SCRATCH_SIZE_HALF,
-						   (void *)env_start))
+				if (bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+							  env_len & SCRATCH_SIZE_HALF,
+							  (void *)env_start))
 #endif
 					env_len = 0;
 				else
@@ -3149,7 +3150,7 @@ FILLER(sys_openat2_e, true)
 	 * how: we get the data structure, and put its fields in the buffer one by one
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	if (bpf_probe_read(&how, sizeof(struct open_how), (void *)val)) {
+	if (bpf_probe_read_user(&how, sizeof(struct open_how), (void *)val)) {
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
 	flags = open_flags_to_scap(how.flags);
@@ -3227,7 +3228,7 @@ FILLER(sys_openat2_x, true)
 	 * how: we get the data structure, and put its fields in the buffer one by one
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	if (bpf_probe_read(&how, sizeof(struct open_how), (void *)val)) {
+	if (bpf_probe_read_user(&how, sizeof(struct open_how), (void *)val)) {
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
 	flags = open_flags_to_scap(how.flags);
@@ -3312,7 +3313,7 @@ FILLER(sys_io_uring_setup_x, true)
 	/* if the call fails we don't care since `bpf_probe_read` under the hood memsets
 	 * the destination memory to `0`
 	 */
-	bpf_probe_read(&params, sizeof(struct io_uring_params), (void *)params_pointer);
+	bpf_probe_read_user(&params, sizeof(struct io_uring_params), (void *)params_pointer);
 
 	sq_entries = params.sq_entries;
 	cq_entries = params.cq_entries;
@@ -3803,7 +3804,7 @@ FILLER(sys_prlimit_x, true)
 	 */
 	if (retval >= 0) {
 		val = bpf_syscall_get_argument(data, 2);
-		if (bpf_probe_read(&rl, sizeof(rl), (void *)val)) {
+		if (bpf_probe_read_user(&rl, sizeof(rl), (void *)val)) {
 			newcur = -1;
 			newmax = -1;
 		} else {
@@ -3816,7 +3817,7 @@ FILLER(sys_prlimit_x, true)
 	}
 
 	val = bpf_syscall_get_argument(data, 3);
-	if (bpf_probe_read(&rl, sizeof(rl), (void *)val)) {
+	if (bpf_probe_read_user(&rl, sizeof(rl), (void *)val)) {
 		oldcur = -1;
 		oldmax = -1;
 	} else {
@@ -4078,7 +4079,7 @@ FILLER(sys_recvfrom_x, true)
 		val = bpf_syscall_get_argument(data, 5);
 
 		if (usrsockaddr && val != 0) {
-			if (bpf_probe_read(&addrlen, sizeof(addrlen),
+			if (bpf_probe_read_user(&addrlen, sizeof(addrlen),
 					   (void *)val))
 				return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -4165,7 +4166,7 @@ FILLER(sys_recvmsg_x, true)
 	 * Retrieve the message header
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	if (bpf_probe_read(&mh, sizeof(mh), (void *)val))
+	if (bpf_probe_read_user(&mh, sizeof(mh), (void *)val))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	/*
@@ -4204,7 +4205,7 @@ FILLER(sys_recvmsg_x_2, true)
 		 * Retrieve the message header
 		 */
 		val = bpf_syscall_get_argument(data, 1);
-		if (bpf_probe_read(&mh, sizeof(mh), (void *)val))
+		if (bpf_probe_read_user(&mh, sizeof(mh), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		/*
@@ -4269,7 +4270,7 @@ FILLER(sys_sendmsg_e, true)
 	 * Retrieve the message header
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	if (bpf_probe_read(&mh, sizeof(mh), (void *)val))
+	if (bpf_probe_read_user(&mh, sizeof(mh), (void *)val))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	/*
@@ -4342,7 +4343,7 @@ FILLER(sys_sendmsg_x, true)
 	 * data
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	if (bpf_probe_read(&mh, sizeof(mh), (void *)val))
+	if (bpf_probe_read_user(&mh, sizeof(mh), (void *)val))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	iov = (const struct iovec *)mh.msg_iov;
@@ -4438,7 +4439,7 @@ FILLER(sys_pipe_x, true)
 	s32 pipefd[2] = {-1, -1};
 	/* This is a pointer to the vector with the 2 file descriptors. */
 	unsigned long fd_vector_pointer = bpf_syscall_get_argument(data, 0);
-	if(bpf_probe_read(pipefd, sizeof(pipefd), (void *)fd_vector_pointer))
+	if(bpf_probe_read_user(pipefd, sizeof(pipefd), (void *)fd_vector_pointer))
 	{
 		pipefd[0] = -1;
 		pipefd[1] = -1;
@@ -4604,7 +4605,7 @@ FILLER(sys_ppoll_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 3);
 	if (val != (unsigned long)NULL)
-		if (bpf_probe_read(&val, sizeof(val), (void *)val))
+		if (bpf_probe_read_user(&val, sizeof(val), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 	res = bpf_val_to_ring_type(data, val, PT_SIGSET);
@@ -4650,7 +4651,7 @@ FILLER(sys_semop_x, true)
 			struct sembuf sops = {0, 0, 0};
 
 			if (nsops--)
-				if (bpf_probe_read(&sops, sizeof(sops),
+				if (bpf_probe_read_user(&sops, sizeof(sops),
 						   (void *)&ptr[j]))
 					return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -5256,7 +5257,7 @@ FILLER(sys_quotactl_x, true)
 	 * dqblk fields if present
 	 */
 	if (cmd == PPM_Q_GETQUOTA || cmd == PPM_Q_SETQUOTA) {
-		if (bpf_probe_read(&dqblk, sizeof(dqblk),
+		if (bpf_probe_read_user(&dqblk, sizeof(dqblk),
 				   (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
@@ -5328,7 +5329,7 @@ FILLER(sys_quotactl_x, true)
 	 * dqinfo fields if present
 	 */
 	if (cmd == PPM_Q_GETINFO || cmd == PPM_Q_SETINFO) {
-		if (bpf_probe_read(&dqinfo, sizeof(dqinfo),
+		if (bpf_probe_read_user(&dqinfo, sizeof(dqinfo),
 				   (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
@@ -5367,7 +5368,7 @@ FILLER(sys_quotactl_x, true)
 	if (cmd == PPM_Q_GETFMT) {
 		u32 tmp;
 
-		if (bpf_probe_read(&tmp, sizeof(tmp), (void *)val))
+		if (bpf_probe_read_user(&tmp, sizeof(tmp), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 		quota_fmt_out = quotactl_fmt_to_scap(tmp);
 	}
@@ -5492,7 +5493,7 @@ static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, u16 r
 	case PPM_PTRACE_PEEKUSR:
 		idx = PPM_PTRACE_IDX_UINT64;
 		type = PT_UINT64;
-		if (bpf_probe_read(&dst, sizeof(long), (void *)val))
+		if (bpf_probe_read_user(&dst, sizeof(long), (void *)val))
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
 		break;
@@ -6053,13 +6054,13 @@ FILLER(sched_prog_exec, false)
 
 	/* `bpf_probe_read()` returns 0 in case of success. */
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-	int correctly_read = bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						((args_len - 1) & SCRATCH_SIZE_HALF) + 1,
-						(void *)arg_start);
+	int correctly_read = bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						 ((args_len - 1) & SCRATCH_SIZE_HALF) + 1,
+						 (void *)arg_start);
 #else						
-	int correctly_read = bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-					    args_len & SCRATCH_SIZE_HALF,
-					    (void *)arg_start);
+	int correctly_read = bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						 args_len & SCRATCH_SIZE_HALF,
+						 (void *)arg_start);
 #endif /* BPF_FORBIDS_ZERO_ACCESS */
 
 	/* If there was something to read and we read it correctly, update all
@@ -6070,9 +6071,9 @@ FILLER(sched_prog_exec, false)
 		data->buf[(data->state->tail_ctx.curoff + args_len - 1) & SCRATCH_SIZE_MAX] = 0;
 
 		/* We need the len of the second param `exe`. */
-		int exe_len = bpf_probe_read_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						 SCRATCH_SIZE_HALF,
-						 &data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
+		int exe_len = bpf_probe_read_kernel_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						      SCRATCH_SIZE_HALF,
+						      &data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
 
 		if(exe_len == -EFAULT)
 		{
@@ -6081,6 +6082,7 @@ FILLER(sched_prog_exec, false)
 
 		/* Parameter 2: exe (type: PT_CHARBUF) */
 		data->curarg_already_on_frame = true;
+		/** XXX: memory from mm ... kernel */
 		res = __bpf_val_to_ring(data, 0, exe_len, PT_CHARBUF, -1, false);
 		if(res != PPM_SUCCESS)
 		{
@@ -6089,6 +6091,7 @@ FILLER(sched_prog_exec, false)
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 		data->curarg_already_on_frame = true;
+		/** XXX: memory from mm ... kernel */
 		res = __bpf_val_to_ring(data, 0, args_len - exe_len, PT_BYTEBUF, -1, false);
 		if(res != PPM_SUCCESS)
 		{
@@ -6264,11 +6267,11 @@ FILLER(sched_prog_exec_3, false)
 		}
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-		if(bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+		if(bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 				  ((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
 				  (void *)env_start))
 #else
-		if(bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+		if(bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 				  env_len & SCRATCH_SIZE_HALF,
 				  (void *)env_start))
 #endif /* BPF_FORBIDS_ZERO_ACCESS */
@@ -6283,6 +6286,7 @@ FILLER(sched_prog_exec_3, false)
 
 	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
 	data->curarg_already_on_frame = true;
+	/* XXX: memory from mm ... kernel */
 	res = __bpf_val_to_ring(data, 0, env_len, PT_BYTEBUF, -1, false);
 	if(res != PPM_SUCCESS)
 	{
@@ -6467,9 +6471,9 @@ FILLER(sched_prog_fork, false)
 	}
 
 	/* `bpf_probe_read()` returns 0 in case of success. */
-	int correctly_read = bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-					    args_len & SCRATCH_SIZE_HALF,
-					    (void *)arg_start);
+	int correctly_read = bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						 args_len & SCRATCH_SIZE_HALF,
+						 (void *)arg_start);
 
 	/* If there was something to read and we read it correctly, update all
 	 * the offsets, otherwise push empty params to userspace.
@@ -6479,9 +6483,9 @@ FILLER(sched_prog_fork, false)
 		data->buf[(data->state->tail_ctx.curoff + args_len - 1) & SCRATCH_SIZE_MAX] = 0;
 
 		/* We need the len of the second param `exe`. */
-		int exe_len = bpf_probe_read_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-						 SCRATCH_SIZE_HALF,
-						 &data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
+		int exe_len = bpf_probe_read_kernel_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						      SCRATCH_SIZE_HALF,
+						      &data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]);
 
 		if(exe_len == -EFAULT)
 		{

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2243,7 +2243,7 @@ static __always_inline bool get_exe_upper_layer(struct inode *inode)
 		
 		// Pointer arithmetics due to unexported ovl_inode struct
 		// warning: this works if and only if the dentry pointer is placed right after the inode struct
-		bpf_probe_read(&upper_dentry, sizeof(upper_dentry), vfs_inode + sizeof(struct inode));
+		bpf_probe_read_kernel(&upper_dentry, sizeof(upper_dentry), vfs_inode + sizeof(struct inode));
 
 		if(upper_dentry)
 		{

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3566,7 +3566,7 @@ FILLER(sys_fsconfig_x, true)
 
 	/* Parameter 4: key (type: PT_CHARBUF) */
 	unsigned long key_pointer = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, key_pointer);
+	res = bpf_val_to_ring_mem(data, key_pointer, USER);
 	CHECK_RES(res);
 
 	int aux = bpf_syscall_get_argument(data, 4);
@@ -3594,11 +3594,11 @@ FILLER(sys_fsconfig_x, true)
 		/* Since `value` is NULL we send two empty params. */
 
 		/* Parameter 5: value_bytebuf (type: PT_BYTEBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 
 		/* Parameter 6: value_charbuf (type: PT_CHARBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 		break;
 
@@ -3610,11 +3610,11 @@ FILLER(sys_fsconfig_x, true)
 		 */
 
 		/* Parameter 5: value_bytebuf (type: PT_BYTEBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 
 		/* Parameter 6: value_charbuf (type: PT_CHARBUF) */
-		res = bpf_val_to_ring(data, value_pointer);
+		res = bpf_val_to_ring_mem(data, value_pointer, USER);
 		CHECK_RES(res);
 		break;
 
@@ -3624,22 +3624,22 @@ FILLER(sys_fsconfig_x, true)
 		 */
 
 		/* Parameter 5: value_bytebuf (type: PT_BYTEBUF) */
-		res = __bpf_val_to_ring(data, value_pointer, aux, PT_BYTEBUF, -1, true);
+		res = __bpf_val_to_ring(data, value_pointer, aux, PT_BYTEBUF, -1, true, USER);
 		CHECK_RES(res);
 
 		/* Parameter 6: value_charbuf (type: PT_CHARBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 
 		break;
 
 	default:
 		/* Parameter 5: value_bytebuf (type: PT_BYTEBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 
 		/* Parameter 6: value_charbuf (type: PT_CHARBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_val_to_ring_mem(data, 0, KERNEL);
 		CHECK_RES(res);
 		break;
 	}

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1992,7 +1992,7 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 
 	#pragma unroll
 	for (j = 0; j < FAILED_ARGS_ENV_ITEMS_MAX; ++j) {
-		arg = _READ(argv[j]);
+		arg = _READ_USER(argv[j]);
 		if (!arg)
 			break;
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2679,13 +2679,13 @@ FILLER(proc_startupdate_3, true)
 					env_len = ARGS_ENV_SIZE_MAX;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-				if (bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-							  ((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
-							  (void *)env_start))
+				if (bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+							((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
+							(void *)env_start))
 #else
-				if (bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
-							  env_len & SCRATCH_SIZE_HALF,
-							  (void *)env_start))
+				if (bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+							env_len & SCRATCH_SIZE_HALF,
+							(void *)env_start))
 #endif
 					env_len = 0;
 				else
@@ -6265,11 +6265,11 @@ FILLER(sched_prog_exec_3, false)
 		}
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
-		if(bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+		if(bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 				  ((env_len - 1) & SCRATCH_SIZE_HALF) + 1,
 				  (void *)env_start))
 #else
-		if(bpf_probe_read_kernel(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+		if(bpf_probe_read_user(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
 				  env_len & SCRATCH_SIZE_HALF,
 				  (void *)env_start))
 #endif /* BPF_FORBIDS_ZERO_ACCESS */

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -16,10 +16,16 @@ or GPL2.txt for full copies of the license.
 #include "types.h"
 #include "builtins.h"
 
-#define _READ(P) ({ typeof(P) _val;				\
-		    memset(&_val, 0, sizeof(_val));		\
-		    bpf_probe_read(&_val, sizeof(_val), &P);	\
-		    _val;					\
+#define _READ(P) ({ typeof(P) _val;					\
+		    memset(&_val, 0, sizeof(_val));			\
+		    bpf_probe_read_kernel(&_val, sizeof(_val), &P);	\
+		    _val;						\
+		 })
+#define _READ_KERNEL(P) _READ(P)
+#define _READ_USER(P) ({ typeof(P) _val;				\
+			 memset(&_val, 0, sizeof(_val));		\
+			 bpf_probe_read_user(&_val, sizeof(_val), &P);	\
+			 _val;						\
 		 })
 
 #ifdef BPF_DEBUG

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -17,13 +17,11 @@ or GPL2.txt for full copies of the license.
 #include "builtins.h"
 
 #define _READ(P) ({ typeof(P) _val;					\
-		    memset(&_val, 0, sizeof(_val));			\
 		    bpf_probe_read_kernel(&_val, sizeof(_val), &P);	\
 		    _val;						\
 		 })
 #define _READ_KERNEL(P) _READ(P)
 #define _READ_USER(P) ({ typeof(P) _val;				\
-			 memset(&_val, 0, sizeof(_val));		\
 			 bpf_probe_read_user(&_val, sizeof(_val), &P);	\
 			 _val;						\
 		 })

--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -27,7 +27,7 @@ or GPL2.txt for full copies of the license.
 
 #ifdef __KERNEL__ /* Kernel module - BPF probe */
 
-#include <linux/version.h>
+#include "ppm_version.h"
 
 ///////////////////////////////
 // CAPTURE_SCHED_PROC_FORK 
@@ -136,7 +136,8 @@ or GPL2.txt for full copies of the license.
 // USE_BPF_PROBE_KERNEL_USER_VARIANTS
 ///////////////////////////////
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)) || \
+    (defined(PPM_RHEL_RELEASE_CODE) && (PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 5)))
 	#define USE_BPF_PROBE_KERNEL_USER_VARIANTS
 #endif
 

--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -137,8 +137,8 @@ or GPL2.txt for full copies of the license.
 ///////////////////////////////
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)) || \
-    (defined(PPM_RHEL_RELEASE_CODE) && (PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 5)))
-	#define USE_BPF_PROBE_KERNEL_USER_VARIANTS
+	((PPM_RHEL_RELEASE_CODE > 0) && (PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 5)))
+		#define USE_BPF_PROBE_KERNEL_USER_VARIANTS
 #endif
 
 #elif defined(__USE_VMLINUX__) /* modern BPF probe */

--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -132,6 +132,14 @@ or GPL2.txt for full copies of the license.
 	#define CAPTURE_PAGE_FAULTS
 #endif
 
+///////////////////////////////
+// USE_BPF_PROBE_KERNEL_USER_VARIANTS
+///////////////////////////////
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)
+	#define USE_BPF_PROBE_KERNEL_USER_VARIANTS
+#endif
+
 #elif defined(__USE_VMLINUX__) /* modern BPF probe */
 
 ///////////////////////////////


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

tbd

**What this PR does / why we need it**:

This PR introduces the `bpf_probe_read_user` and `bpf_probe_read_kernel` variants to correctly read memory either from kernel or user space. This PR would also be the base to enable the BPF driver for the `s390x` architecture as well. Please note that for `s390x` there is yet another issue to be solved (here and in modern-bpf as well): [new(bpf, modern-bpf): Add socketcall support ](https://github.com/falcosecurity/libs/issues/810)

**Which issue(s) this PR fixes**:

Fixes #497 

**Special notes for your reviewer**:

This PR evolved over the last couple of weeks and months. And I think it's time to open to obtain feedback and thoughts from you. There is some more testing required along the way and I also look forward towards the shared driver test cases being worked on. 

There are basically three areas that where the user and kernel bpf probe read variants are introduced:
1. Direct calls are replaced.
2. Helper routines to be adjusted which also affects the `ringbuffer` routines
3. `_READ()` macro
The commits are structured in the way to introduce and then adjust helper occurrences, e.g., by adding information from where to read memory (similar as in modern-bpf-driver).

cc: @Andreagit97, @FedeDP , @Molter73 

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(bpf-driver): Introduce `bpf_probe_read_user` and `bpf_probe_read_kernel` variants
```
