### PR TITLE
new(bpf, modern_bpf): introduce `socketcall` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ Right now our drivers officially support the following architectures:
 | ----------- |----------------------------------------------------------------------------------------------| ---------- | ---------------- |
 | **x86_64**  | >= 2.6                                                                                       | >= 4.14    | WIP 👷           |
 | **aarch64** | >= [3.16](https://github.com/torvalds/linux/commit/055b1212d141f1f398fca548f8147787c0b6253f) | >= 4.17    | WIP 👷           |
-| **s390x**   | >= 2.6                                                                                       | ❌         | WIP 👷            |
-
->**Please note**: BPF has some issues with architectures like `s390x`! Some helpers like `bpf_probe_read()` and `bpf_probe_read_str()` are broken on archs with overlapping address ranges.
+| **s390x**   | >= 2.6                                                                                       | >= [5.5](https://github.com/torvalds/linux/commit/6ae08ae3dea) | WIP 👷            |
 
 **For a list of supported syscalls through specific events, please refer to [_report_](./driver/report.md).**
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2873,6 +2873,7 @@ FILLER(sys_accept4_e, true)
 	/*
 	 * push the flags into the ring.
 	 * XXX we don't support flags yet and so we just return zero
+	 *     If implemented, special handling for SYS_ACCEPT socketcall is needed.
 	 */
 	res = bpf_val_to_ring(data, 0);
 

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -677,6 +677,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_bind;
 #endif
 
+#ifdef __NR_listen
+	case SYS_LISTEN:
+		return __NR_listen;
+#endif
+
 #ifdef __NR_connect
 	case SYS_CONNECT:
 		return __NR_connect;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -707,6 +707,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_getsockopt;
 #endif
 
+#ifdef __NR_setsockopt
+	case SYS_SETSOCKOPT:
+		return __NR_setsockopt;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -659,6 +659,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_socket;
 #endif
 
+#ifdef __NR_socketpair
+	case SYS_SOCKETPAIR:
+		return __NR_socketpair;
+#endif
+
 	case SYS_ACCEPT:
 #if defined(CONFIG_S390) && defined(__NR_accept4)
 		return __NR_accept4;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -668,6 +668,16 @@ static __always_inline long convert_network_syscalls(void *ctx)
 	case SYS_CONNECT:
 		return __NR_connect;
 #endif
+
+#ifdef __NR_recvmmsg
+	case SYS_RECVMMSG:
+		return __NR_recvmmsg;
+#endif
+
+#ifdef __NR_sendmmsg
+	case SYS_SENDMMSG:
+		return __NR_sendmmsg;
+#endif
 	default:
 		break;
 	}

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -687,9 +687,19 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_connect;
 #endif
 
+#ifdef __NR_recv
+	case SYS_RECV:
+		return __NR_recv;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;
+#endif
+
+#ifdef __NR_send
+	case SYS_SEND:
+		return __NR_send;
 #endif
 
 #ifdef __NR_sendmmsg

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -702,6 +702,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_getpeername;
 #endif
 
+#ifdef __NR_getsockopt
+	case SYS_GETSOCKOPT:
+		return __NR_getsockopt;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -712,6 +712,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_recvfrom;
 #endif
 
+#ifdef __NR_recvmsg
+	case SYS_RECVMSG:
+		return __NR_recvmsg;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -687,6 +687,16 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_connect;
 #endif
 
+#ifdef __NR_getsockname
+	case SYS_GETSOCKNAME:
+		return __NR_getsockname;
+#endif
+
+#ifdef __NR_getpeername
+	case SYS_GETPEERNAME:
+		return __NR_getpeername;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -678,6 +678,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;
 #endif
+
+#ifdef __NR_shutdown
+	case SYS_SHUTDOWN:
+		return __NR_shutdown;
+#endif
 	default:
 		break;
 	}

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -659,6 +659,19 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_socket;
 #endif
 
+	case SYS_ACCEPT:
+#if defined(CONFIG_S390) && defined(__NR_accept4)
+		return __NR_accept4;
+#elif defined(__NR_ACCEPT)
+		return __NR_accept;
+#endif
+		break;
+
+#ifdef __NR_accept4
+	case SYS_ACCEPT4:
+		return __NR_accept4;
+#endif
+
 #ifdef __NR_bind
 	case SYS_BIND:
 		return __NR_bind;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -692,6 +692,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_recv;
 #endif
 
+#ifdef __NR_recvfrom
+	case SYS_RECVFROM:
+		return __NR_recvfrom;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -722,6 +722,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_send;
 #endif
 
+#ifdef __NR_sendto
+	case SYS_SENDTO:
+		return __NR_sendto;
+#endif
+
 #ifdef __NR_sendmmsg
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -727,6 +727,11 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		return __NR_sendto;
 #endif
 
+#ifdef __NR_sendmsg
+	case SYS_SENDMSG:
+		return __NR_sendmsg;
+#endif
+
 #ifdef __NR_sendmmsg
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -51,6 +51,13 @@ BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)
 	if (id < 0 || id >= SYSCALL_TABLE_SIZE)
 		return 0;
 
+#if defined(CAPTURE_SOCKETCALL) && defined(BPF_SUPPORTS_RAW_TRACEPOINTS)
+	if(id == __NR_socketcall)
+	{
+		id = convert_network_syscalls(ctx);
+	}
+#endif
+
 	enabled = is_syscall_interesting(id);
 	if (!enabled)
 	{
@@ -98,6 +105,13 @@ BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 	id = bpf_syscall_get_nr(ctx);
 	if (id < 0 || id >= SYSCALL_TABLE_SIZE)
 		return 0;
+
+#if defined(CAPTURE_SOCKETCALL) && defined(BPF_SUPPORTS_RAW_TRACEPOINTS)
+	if(id == __NR_socketcall)
+	{
+		id = convert_network_syscalls(ctx);
+	}
+#endif
 
 	enabled = is_syscall_interesting(id);
 	if (!enabled)

--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -65,6 +65,21 @@ or GPL2.txt for full copies of the license.
 #endif
 
 ///////////////////////////////
+// CAPTURE_SOCKETCALL
+///////////////////////////////
+
+/* There are architectures that used history socketcall to multiplex
+ * the network system calls.  Even if architectures, like s390x, has
+ * direct support for those network system calls, kernel version header
+ * dependencies in libc prevent using them.
+ *
+ * For details, see also https://sourceware.org/pipermail/libc-alpha/2022-September/142108.html
+ */
+#if defined(CONFIG_S390)
+	#define CAPTURE_SOCKETCALL
+#endif
+
+///////////////////////////////
 // CAPTURE_SCHED_PROC_EXEC 
 ///////////////////////////////
 
@@ -167,6 +182,13 @@ or GPL2.txt for full copies of the license.
 	#define CAPTURE_PAGE_FAULTS 
 #endif
 
+///////////////////////////////
+// CAPTURE_SOCKETCALL
+///////////////////////////////
+
+#if defined(__TARGET_ARCH_s390)
+	#define CAPTURE_SOCKETCALL
+#endif
 
 #else /* Userspace */
 
@@ -217,6 +239,14 @@ or GPL2.txt for full copies of the license.
 
 #if defined(__aarch64__)
 	#define CAPTURE_SCHED_PROC_EXEC 
+#endif
+
+///////////////////////////////
+// CAPTURE_SOCKETCALL
+///////////////////////////////
+
+#if defined(__s390x__)
+	#define CAPTURE_SOCKETCALL
 #endif
 
 #endif /* UDIG */

--- a/driver/main.c
+++ b/driver/main.c
@@ -1767,7 +1767,7 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	}
 
 	// Check if syscall is interesting for the consumer
-	if (event_datap->category == PPMC_SYSCALL)
+	if (event_datap->category == PPMC_SYSCALL && event_datap->event_info.syscall_data.id != event_datap->socketcall_syscall)
 	{
 		table_index = event_datap->event_info.syscall_data.id - SYSCALL_TABLE_ID0;
 		if (!test_bit(table_index, consumer->syscalls_mask))

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -388,10 +388,10 @@
  * https://github.com/torvalds/linux/commit/a9beb86ae6e55bd92f38453c8623de60b8e5a308
  */
 #define SO_RCVTIMEO 20
-#define SO_RCVTIMEO_OLD	20
+#define SO_RCVTIMEO_OLD 20
 #define SO_RCVTIMEO_NEW 66
 #define SO_SNDTIMEO 21
-#define SO_SNDTIMEO_OLD	21
+#define SO_SNDTIMEO_OLD 21
 #define SO_SNDTIMEO_NEW 67
 
 /* Security levels - as per NRL IPv6 - don't actually do anything */
@@ -722,7 +722,7 @@
 
 /* `/include/uapi/asm-generic/mman-common.h` from kernel source tree. */
 
-#define MLOCK_ONFAULT	0x01		/* Lock pages in range after they are faulted in, do not prefault */
+#define MLOCK_ONFAULT 0x01 /* Lock pages in range after they are faulted in, do not prefault */
 
 //////////////////////////
 // mlockall flags
@@ -730,9 +730,9 @@
 
 /* `/include/uapi/asm-generic/mman.h` from kernel source tree. */
 
-#define MCL_CURRENT	1		/* lock all current mappings */
-#define MCL_FUTURE	2		/* lock all future mappings */
-#define MCL_ONFAULT	4		/* lock all pages that are faulted in */
+#define MCL_CURRENT 1 /* lock all current mappings */
+#define MCL_FUTURE 2  /* lock all future mappings */
+#define MCL_ONFAULT 4 /* lock all pages that are faulted in */
 
 /*=============================== FLAGS ===========================*/
 
@@ -1371,5 +1371,30 @@
 #define SPLICE_F_ALL (SPLICE_F_MOVE|SPLICE_F_NONBLOCK|SPLICE_F_MORE|SPLICE_F_GIFT)
 
 /*=============================== SPLICE SYSCALL =============================*/
+
+/*=============================== SOCKETCALL CODES ===========================*/
+
+#define SYS_SOCKET 1	  /* sys_socket(2)		*/
+#define SYS_BIND 2	  /* sys_bind(2)			*/
+#define SYS_CONNECT 3	  /* sys_connect(2)		*/
+#define SYS_LISTEN 4	  /* sys_listen(2)		*/
+#define SYS_ACCEPT 5	  /* sys_accept(2)		*/
+#define SYS_GETSOCKNAME 6 /* sys_getsockname(2)		*/
+#define SYS_GETPEERNAME 7 /* sys_getpeername(2)		*/
+#define SYS_SOCKETPAIR 8  /* sys_socketpair(2)		*/
+#define SYS_SEND 9	  /* sys_send(2)			*/
+#define SYS_RECV 10	  /* sys_recv(2)			*/
+#define SYS_SENDTO 11	  /* sys_sendto(2)		*/
+#define SYS_RECVFROM 12	  /* sys_recvfrom(2)		*/
+#define SYS_SHUTDOWN 13	  /* sys_shutdown(2)		*/
+#define SYS_SETSOCKOPT 14 /* sys_setsockopt(2)		*/
+#define SYS_GETSOCKOPT 15 /* sys_getsockopt(2)		*/
+#define SYS_SENDMSG 16	  /* sys_sendmsg(2)		*/
+#define SYS_RECVMSG 17	  /* sys_recvmsg(2)		*/
+#define SYS_ACCEPT4 18	  /* sys_accept4(2)		*/
+#define SYS_RECVMMSG 19	  /* sys_recvmmsg(2)		*/
+#define SYS_SENDMMSG 20	  /* sys_sendmmsg(2)		*/
+
+/*=============================== SOCKETCALL CODES ===========================*/
 
 #endif /* __MISSING_DEFINITIONS_H__ */

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -47,6 +47,19 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_socket;
 #endif
 
+	case SYS_ACCEPT:
+#if defined(__TARGET_ARCH_s390) && defined(__NR_accept4)
+		return __NR_accept4;
+#elif defined(__NR_ACCEPT)
+		return __NR_accept;
+#endif
+		break;
+
+#ifdef __NR_accept4
+	case SYS_ACCEPT4:
+		return __NR_accept4;
+#endif
+
 #ifdef __NR_bind
 	case SYS_BIND:
 		return __NR_bind;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -95,6 +95,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_getsockopt;
 #endif
 
+#ifdef __NR_setsockopt
+	case SYS_SETSOCKOPT:
+		return __NR_setsockopt;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -56,6 +56,16 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 	case SYS_CONNECT:
 		return __NR_connect;
 #endif
+
+#ifdef __NR_recvmmsg
+	case SYS_RECVMMSG:
+		return __NR_recvmmsg;
+#endif
+
+#ifdef __NR_sendmmsg
+	case SYS_SENDMMSG:
+		return __NR_sendmmsg;
+#endif
 	default:
 		break;
 	}

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -90,6 +90,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_getpeername;
 #endif
 
+#ifdef __NR_getsockopt
+	case SYS_GETSOCKOPT:
+		return __NR_getsockopt;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -80,6 +80,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_recv;
 #endif
 
+#ifdef __NR_recvfrom
+	case SYS_RECVFROM:
+		return __NR_recvfrom;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -75,9 +75,19 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_connect;
 #endif
 
+#ifdef __NR_recv
+	case SYS_RECV:
+		return __NR_recv;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;
+#endif
+
+#ifdef __NR_send
+	case SYS_SEND:
+		return __NR_send;
 #endif
 
 #ifdef __NR_sendmmsg

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -115,6 +115,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_sendto;
 #endif
 
+#ifdef __NR_sendmsg
+	case SYS_SENDMSG:
+		return __NR_sendmsg;
+#endif
+
 #ifdef __NR_sendmmsg
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -65,6 +65,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_bind;
 #endif
 
+#ifdef __NR_listen
+	case SYS_LISTEN:
+		return __NR_listen;
+#endif
+
 #ifdef __NR_connect
 	case SYS_CONNECT:
 		return __NR_connect;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -100,6 +100,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_recvfrom;
 #endif
 
+#ifdef __NR_recvmsg
+	case SYS_RECVMSG:
+		return __NR_recvmsg;
+#endif
+
 #ifdef __NR_recvmmsg
 	case SYS_RECVMMSG:
 		return __NR_recvmmsg;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -110,6 +110,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_send;
 #endif
 
+#ifdef __NR_sendto
+	case SYS_SENDTO:
+		return __NR_sendto;
+#endif
+
 #ifdef __NR_sendmmsg
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -47,6 +47,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_socket;
 #endif
 
+#ifdef __NR_socketpair
+	case SYS_SOCKETPAIR:
+		return __NR_socketpair;
+#endif
+
 	case SYS_ACCEPT:
 #if defined(__TARGET_ARCH_s390) && defined(__NR_accept4)
 		return __NR_accept4;

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -66,6 +66,11 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 	case SYS_SENDMMSG:
 		return __NR_sendmmsg;
 #endif
+
+#ifdef __NR_shutdown
+	case SYS_SHUTDOWN:
+		return __NR_shutdown;
+#endif
 	default:
 		break;
 	}

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -75,6 +75,16 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		return __NR_connect;
 #endif
 
+#ifdef __NR_getsockname
+	case SYS_GETSOCKNAME:
+		return __NR_getsockname;
+#endif
+
+#ifdef __NR_getpeername
+	case SYS_GETPEERNAME:
+		return __NR_getpeername;
+#endif
+
 #ifdef __NR_recv
 	case SYS_RECV:
 		return __NR_recv;

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
@@ -16,6 +16,15 @@ int BPF_PROG(sys_enter,
 	     struct pt_regs *regs,
 	     long syscall_id)
 {
+
+#ifdef CAPTURE_SOCKETCALL
+	/* we convert it here in this way the syscall will be treated exactly as the original one */
+	if(syscall_id == __NR_socketcall)
+	{
+		syscall_id = convert_network_syscalls(regs);
+	}
+#endif
+
 	/* The `syscall-id` can refer to both 64-bit and 32-bit architectures.
 	 * Right now we filter only 64-bit syscalls, all the 32-bit syscalls
 	 * will be dropped with `syscalls_dispatcher__check_32bit_syscalls`.

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -16,7 +16,15 @@ int BPF_PROG(sys_exit,
 	     struct pt_regs *regs,
 	     long ret)
 {
-	u32 syscall_id = syscalls_dispatcher__get_syscall_id(regs);
+	u32 syscall_id = extract__syscall_id(regs);
+
+#ifdef CAPTURE_SOCKETCALL
+	/* we convert it here in this way the syscall will be treated exactly as the original one */
+	if(syscall_id == __NR_socketcall)
+	{
+		syscall_id = convert_network_syscalls(regs);
+	}
+#endif
 
 	/* The `syscall-id` can refer to both 64-bit and 32-bit architectures.
 	 * Right now we filter only 64-bit syscalls, all the 32-bit syscalls

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -75,12 +75,16 @@ int BPF_PROG(accept_x,
 	{
 		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
 
+		/* Collect parameters at the beginning to  manage socketcalls */
+		unsigned long args[1];
+		extract__network_args(args, 1, regs);
+
 		/* Perform some computations to get queue information. */
 		/* If the syscall is successful the `sockfd` will be >= 0. We want
 		 * to extract information from the listening socket, not from the
 		 * new one.
 		 */
-		s32 sockfd = (s32)extract__syscall_argument(regs, 0);
+		s32 sockfd = (s32)args[0];
 		struct file *file = NULL;
 		file = extract__file_struct_from_fd(sockfd);
 		struct socket *socket = BPF_CORE_READ(file, private_data);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -78,12 +78,16 @@ int BPF_PROG(accept4_x,
 	{
 		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
 
+		/* Collect parameters at the beginning to  manage socketcalls */
+		unsigned long args[1];
+		extract__network_args(args, 1, regs);
+
 		/* Perform some computations to get queue information. */
 		/* If the syscall is successful the `sockfd` will be >= 0. We want
 		 * to extract information from the listening socket, not from the
 		 * new one.
 		 */
-		s32 sockfd = (s32)extract__syscall_argument(regs, 0);
+		s32 sockfd = (s32)args[0];
 		struct file *file = NULL;
 		file = extract__file_struct_from_fd(sockfd);
 		struct socket *socket = BPF_CORE_READ(file, private_data);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -27,6 +27,7 @@ int BPF_PROG(accept4_e,
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
 	/// TODO: we don't support flags yet and so we just return zero.
+	///    If implemented, special handling for SYS_ACCEPT socketcall is needed.
 	u32 flags = 0;
 	ringbuf__store_u32(&ringbuf, flags);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -25,8 +25,12 @@ int BPF_PROG(bind_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to easily manage socketcalls */
+	unsigned long args[1];
+	extract__network_args(args, 1, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	s32 fd = (s32)args[0];
 	ringbuf__store_s64(&ringbuf, (s64)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -54,13 +58,16 @@ int BPF_PROG(bind_x,
 	auxmap__preload_event_header(auxmap, PPME_SOCKET_BIND_X);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
+	/* Collect parameters at the beginning to easily manage socketcalls */
+	unsigned long args[3];
+	extract__network_args(args, 3, regs);
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR) */
-	unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
-	u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+	unsigned long sockaddr_ptr = args[1];
+	u16 addrlen = (u16)args[2];
 	auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -23,13 +23,16 @@ int BPF_PROG(connect_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	unsigned long args[3];
+	extract__network_args(args, 3, regs);
+
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	s32 socket_fd = (s32)args[0];
 	auxmap__store_s64_param(auxmap, (s64)socket_fd);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR)*/
-	unsigned long sockaddr_ptr = extract__syscall_argument(regs, 1);
-	u16 addrlen = (u16)extract__syscall_argument(regs, 2);
+	unsigned long sockaddr_ptr = args[1];
+	u16 addrlen = (u16)args[2];
 	auxmap__store_sockaddr_param(auxmap, sockaddr_ptr, addrlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -60,10 +63,13 @@ int BPF_PROG(connect_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	unsigned long args[1];
+	extract__network_args(args, 1, regs);
+
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	s32 socket_fd = (s32)args[0];
 
 	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
 	/* We need a valid sockfd to extract source data.*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
@@ -6,7 +6,6 @@
  */
 
 #include <helpers/interfaces/fixed_size_event.h>
-#include <helpers/interfaces/syscalls_dispatcher.h>
 
 /*=============================== ENTER EVENT ===========================*/
 
@@ -60,7 +59,7 @@ int BPF_PROG(generic_x,
 
 	/* Parameter 1: ID (type: PT_SYSCALLID) */
 	/* This is the PPM_SC code obtained from the syscall id. */
-	ringbuf__store_u16(&ringbuf, maps__get_ppm_sc(syscalls_dispatcher__get_syscall_id(regs)));
+	ringbuf__store_u16(&ringbuf, maps__get_ppm_sc(extract__syscall_id(regs)));
 
 	/*=============================== COLLECT PARAMETERS ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -24,13 +24,17 @@ int BPF_PROG(listen_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to  manage socketcalls */
+	unsigned long args[2];
+	extract__network_args(args, 2, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	s32 fd = (s32)args[0];
 	ringbuf__store_s64(&ringbuf, (s64)fd);
 
 	/* Parameter 2: backlog (type: PT_UINT32) */
 	/// TODO: This should be an `int` not a `uint32_t`
-	u32 backlog = (u32)extract__syscall_argument(regs, 1);
+	u32 backlog = (u32)args[1];
 	ringbuf__store_u32(&ringbuf, backlog);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -25,12 +25,16 @@ int BPF_PROG(recvfrom_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to  manage socketcalls */
+	unsigned long args[3];
+	extract__network_args(args, 3, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	s32 socket_fd = (s32)args[0];
 	ringbuf__store_s64(&ringbuf, (s64)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)extract__syscall_argument(regs, 2);
+	u32 size = (u32)args[2];
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -78,12 +82,16 @@ int BPF_PROG(recvfrom_x,
 			bytes_to_read = ret;
 		}
 
+		/* Collect parameters at the beginning to manage socketcalls */
+		unsigned long args[2];
+		extract__network_args(args, 2, regs);
+
 		/* Parameter 2: data (type: PT_BYTEBUF) */
-		unsigned long received_data_pointer = extract__syscall_argument(regs, 1);
+		unsigned long received_data_pointer = args[1];
 		auxmap__store_bytebuf_param(auxmap, received_data_pointer, bytes_to_read, USER);
 
 		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
-		u32 socket_fd = (u32)extract__syscall_argument(regs, 0);
+		u32 socket_fd = (u32)args[0];
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -25,8 +25,12 @@ int BPF_PROG(recvmsg_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to manage socketcalls */
+	unsigned long args[1];
+	extract__network_args(args, 1, regs);
+
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	s32 fd = (s32)args[0];
 	ringbuf__store_s64(&ringbuf, (s64)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -78,12 +82,16 @@ int BPF_PROG(recvmsg_x,
 			bytes_to_read = ret;
 		}
 
+		/* Collect parameters at the beginning to manage socketcalls */
+		unsigned long args[2];
+		extract__network_args(args, 2, regs);
+
 		/* Parameter 3: data (type: PT_BYTEBUF) */
-		unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+		unsigned long msghdr_pointer = args[1];
 		auxmap__store_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
 
 		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
-		u32 socket_fd = (u32)extract__syscall_argument(regs, 0);
+		u32 socket_fd = (u32)args[0];
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -23,12 +23,16 @@ int BPF_PROG(sendmsg_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to manage socketcalls */
+	unsigned long args[2];
+	extract__network_args(args, 2, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	s32 socket_fd = (s32)args[0];
 	auxmap__store_s64_param(auxmap, (s64)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+	unsigned long msghdr_pointer = args[1];
 	auxmap__store_iovec_size_param(auxmap, msghdr_pointer);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE)*/
@@ -94,7 +98,11 @@ int BPF_PROG(sendmsg_x,
 			bytes_to_read = ret;
 		}
 
-		unsigned long msghdr_pointer = extract__syscall_argument(regs, 1);
+		/* Collect parameters at the beginning to manage socketcalls */
+		unsigned long args[2];
+		extract__network_args(args, 2, regs);
+
+		unsigned long msghdr_pointer = args[1];
 		auxmap__store_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -23,12 +23,16 @@ int BPF_PROG(sendto_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to manage socketcalls */
+	unsigned long args[3];
+	extract__network_args(args, 3, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)extract__syscall_argument(regs, 0);
+	s32 socket_fd = (s32)args[0];
 	auxmap__store_s64_param(auxmap, (s64)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)extract__syscall_argument(regs, 2);
+	u32 size = (u32)args[2];
 	auxmap__store_u32_param(auxmap, size);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE)*/
@@ -93,8 +97,12 @@ int BPF_PROG(sendto_x,
 			bytes_to_read = ret;
 		}
 
+		/* Collect parameters at the beginning to manage socketcalls */
+		unsigned long args[2];
+		extract__network_args(args, 2, regs);
+
 		/* Parameter 2: data (type: PT_BYTEBUF) */
-		unsigned long sent_data_pointer = extract__syscall_argument(regs, 1);
+		unsigned long sent_data_pointer = args[1];
 		auxmap__store_bytebuf_param(auxmap, sent_data_pointer, bytes_to_read, USER);
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -53,24 +53,28 @@ int BPF_PROG(setsockopt_x,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to manage socketcalls */
+	unsigned long args[5];
+	extract__network_args(args, 5, regs);
+
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	s32 fd = (s32)args[0];
 	auxmap__store_s64_param(auxmap, (s64)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
-	int level = (int)extract__syscall_argument(regs, 1);
+	int level = (int)args[1];
 	auxmap__store_u8_param(auxmap, sockopt_level_to_scap(level));
 
 	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
-	int optname = (int)extract__syscall_argument(regs, 2);
+	int optname = (int)args[2];
 	auxmap__store_u8_param(auxmap, sockopt_optname_to_scap(level, optname));
 
 	/* Parameter 5: optval (type: PT_DYN) */
-	unsigned long optval = extract__syscall_argument(regs, 3);
-	u16 optlen = (u16)extract__syscall_argument(regs, 4);
+	unsigned long optval = args[3];
+	u16 optlen = (u16)args[4];
 	auxmap__store_sockopt_param(auxmap, level, optname, optlen, optval);
 
 	/* Parameter 6: optlen (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -24,12 +24,16 @@ int BPF_PROG(shutdown_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning to easily manage socketcalls */
+	unsigned long args[2];
+	extract__network_args(args, 2, regs);
+
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	s32 fd = (s32)args[0];
 	ringbuf__store_s64(&ringbuf, (s64)fd);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
-	int how = (s32)extract__syscall_argument(regs, 1);
+	int how = (s32)args[1];
 	ringbuf__store_u8(&ringbuf, (u8)shutdown_how_to_scap(how));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -24,19 +24,23 @@ int BPF_PROG(socket_e,
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
+	/* Collect parameters at the beginning so we can easily manage socketcalls */
+	unsigned long args[3];
+	extract__network_args(args, 3, regs);
+
 	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
 	/* why to send 32 bits if we need only 8 bits? */
-	u8 domain = (u8)extract__syscall_argument(regs, 0);
+	u8 domain = (u8)args[0];
 	ringbuf__store_u32(&ringbuf, (u32)socket_family_to_scap(domain));
 
 	/* Parameter 2: type (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 type = (u32)extract__syscall_argument(regs, 1);
+	u32 type = (u32)args[1];
 	ringbuf__store_u32(&ringbuf, type);
 
 	/* Parameter 3: proto (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 proto = (u32)extract__syscall_argument(regs, 2);
+	u32 proto = (u32)args[2];
 	ringbuf__store_u32(&ringbuf, proto);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -2056,7 +2056,12 @@ int f_sys_setsockopt_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Get all the five arguments */
-	syscall_get_arguments_deprecated(current, args->regs, 0, 5, val);
+	if (!args->is_socketcall)
+		syscall_get_arguments_deprecated(current, args->regs, 0, 5, val);
+#ifndef UDIG
+	else
+		memcpy(val, args->socketcall_args, 5*sizeof(syscall_arg_t));
+#endif
 
 	/* Parameter 2: fd (type: PT_FD) */
 	fd = (s32)val[0];
@@ -2089,7 +2094,14 @@ int f_sys_getsockopt_x(struct event_filler_arguments *args)
 	uint32_t optlen = 0;
 	s32 fd = 0;
 	syscall_arg_t val[5] = {0};
-	syscall_get_arguments_deprecated(current, args->regs, 0, 5, val);
+
+	/* Get all the five arguments */
+	if (!args->is_socketcall)
+		syscall_get_arguments_deprecated(current, args->regs, 0, 5, val);
+#ifndef UDIG
+	else
+		memcpy(val, args->socketcall_args, 5*sizeof(syscall_arg_t));
+#endif
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = (int64_t)(long)syscall_get_return_value(current, args->regs);

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -153,11 +153,6 @@ event_test::event_test(ppm_tp_code tp_code):
 	m_tp_set[tp_code] = 1;
 }
 
-void event_test::set_event_type(enum ppm_event_type type)
-{
-	m_event_type = type;
-}
-
 /* This constructor must be used with syscalls events */
 event_test::event_test(int syscall_id, int event_direction):
 	m_tp_set(TP_VAL_MAX, 0)

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -153,6 +153,11 @@ event_test::event_test(ppm_tp_code tp_code):
 	m_tp_set[tp_code] = 1;
 }
 
+void event_test::set_event_type(enum ppm_event_type type)
+{
+	m_event_type = type;
+}
+
 /* This constructor must be used with syscalls events */
 event_test::event_test(int syscall_id, int event_direction):
 	m_tp_set(TP_VAL_MAX, 0)

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -582,6 +582,8 @@ public:
 	 */
 	void assert_fd_list(int param_num, struct fd_poll* expected_fds, int32_t nfds);
 
+	void set_event_type(enum ppm_event_type type);
+
 private:
 	ppm_event_code m_event_type;	  /* type of the event we want to assert in this test. */
 	std::vector<struct param> m_event_params; /* all the params of the event (len+value). */

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -582,8 +582,6 @@ public:
 	 */
 	void assert_fd_list(int param_num, struct fd_poll* expected_fds, int32_t nfds);
 
-	void set_event_type(enum ppm_event_type type);
-
 private:
 	ppm_event_code m_event_type;	  /* type of the event we want to assert in this test. */
 	std::vector<struct param> m_event_params; /* all the params of the event (len+value). */

--- a/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
@@ -1,7 +1,8 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_socket) && defined(__NR_close)
+#if defined(__NR_socket) && defined(__NR_clone3) && defined(__NR_wait4)
 
+#include <linux/sched.h>
 #include <sys/socket.h>
 
 TEST(SyscallEnter, socketE)
@@ -15,15 +16,44 @@ TEST(SyscallEnter, socketE)
 	int domain = AF_INET;
 	int type = SOCK_RAW;
 	int protocol = PF_INET;
-	int32_t socket_fd = syscall(__NR_socket, domain, type, protocol);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket_fd", socket_fd, NOT_EQUAL, -1);
-	syscall(__NR_close, socket_fd);
+
+	/* Here we need to call the `socket` from a child because the main process throws a `socket`
+	 * syscall to calibrate the socket file options if we are using the bpf probe.
+	 */
+	struct clone_args cl_args = {0};
+	cl_args.flags = CLONE_FILES;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* In this way in the father we know if the call was successful or not. */
+		if(syscall(__NR_socket, domain, type, protocol) == -1)
+		{
+			exit(EXIT_FAILURE);
+		}
+		else
+		{
+			exit(EXIT_SUCCESS);
+		}
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+	/* Catch the child before doing anything else. */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "The socket call failed while it should be successful..." << std::endl;
+	}
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence();
+	evt_test->assert_event_presence(ret_pid);
 
 	if(HasFatalFailure())
 	{

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -785,3 +785,54 @@ TEST(SyscallEnter, socketcall_recvmsgE)
 	evt_test->assert_num_params_pushed(1);
 }
 #endif
+
+#ifdef __NR_getsockopt
+
+#include <netdb.h>
+
+TEST(SyscallEnter, socketcall_getsockoptE)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int socket_fd = 0;
+	int level = 0;
+	int option_name = 0;
+	int option_value = 0;
+	socklen_t option_len = 0;
+
+	unsigned long args[5] = {0};
+	args[0] = socket_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -1,6 +1,8 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_socketcall) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
+#ifdef __NR_socketcall
+
+#if defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
 
 #include <sys/socket.h>
 #include <linux/net.h>
@@ -887,3 +889,5 @@ TEST(SyscallEnter, socketcall_setsockoptE)
 	evt_test->assert_num_params_pushed(0);
 }
 #endif
+
+#endif /* __NR_socketcall */

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -325,6 +325,8 @@ TEST(SyscallEnter, socketcall_acceptE)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, ENTER_EVENT);
+	if(evt_test->is_kmod_engine())
+		GTEST_SKIP() << "[acceptE] kmod socketcall implementation is event based (rather syscall) " << std::endl;
 #else
 	auto evt_test = get_syscall_event_test(__NR_accept, ENTER_EVENT);
 #endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -1,0 +1,99 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_socketcall
+
+#include <sys/socket.h>
+#include <linux/net.h>
+
+TEST(SyscallEnter, socketcall_socketE)
+{
+	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
+	auto evt_test = get_syscall_event_test();
+
+	evt_test->set_event_type(PPME_SOCKET_SOCKET_E);
+
+	evt_test->enable_capture();
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	unsigned long args[3] = {0};
+	args[0] = AF_INET;
+	args[1] = SOCK_RAW;
+	args[2] = PF_INET;
+
+	syscall(__NR_socketcall, SYS_SOCKET, args);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_SOCKET_E);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)args[0]);
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)args[1]);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)args[2]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+TEST(SyscallEnter, socketcall_bindE)
+{
+	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
+	auto evt_test = get_syscall_event_test();
+
+	evt_test->set_event_type(PPME_SOCKET_BIND_E);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	unsigned long args[3] = {0};
+	args[0] = 47;
+	args[1] = 0;
+	args[2] = 0;
+
+	syscall(__NR_socketcall, SYS_BIND, args);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_BIND_E);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)args[0]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -535,3 +535,59 @@ TEST(SyscallEnter, socketcall_recvfromE)
 	evt_test->assert_num_params_pushed(2);
 }
 #endif
+
+#ifdef __NR_socketpair
+
+#include <sys/socket.h>
+
+TEST(SyscallEnter, socketcall_socketpairE)
+{
+	auto evt_test = get_syscall_event_test(__NR_socketpair, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	int32_t* fds = NULL;
+
+	unsigned long args[4] = {0};
+	args[0] = domain;
+	args[1] = type;
+	args[2] = protocol;
+	args[3] = (unsigned long)fds;
+	assert_syscall_state(SYSCALL_FAILURE, "socketpair", syscall(__NR_socketcall, SYS_SOCKETPAIR, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_LOCAL);
+
+	/* Parameter 2: type (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)type);
+
+	/* Parameter 3: proto (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)protocol);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -1,18 +1,16 @@
 #include "../../event_class/event_class.h"
 
-#ifdef __NR_socketcall
+#if defined(__NR_socketcall) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
 
 #include <sys/socket.h>
 #include <linux/net.h>
 
 TEST(SyscallEnter, socketcall_socketE)
 {
-	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
-	auto evt_test = get_syscall_event_test();
-
-	evt_test->set_event_type(PPME_SOCKET_SOCKET_E);
+	auto evt_test = get_syscall_event_test(__NR_socket, ENTER_EVENT);
 
 	evt_test->enable_capture();
+
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	unsigned long args[3] = {0};
@@ -20,13 +18,15 @@ TEST(SyscallEnter, socketcall_socketE)
 	args[1] = SOCK_RAW;
 	args[2] = PF_INET;
 
-	syscall(__NR_socketcall, SYS_SOCKET, args);
+	int socket_fd = syscall(__NR_socketcall, SYS_SOCKET, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "socketcall socket", socket_fd, NOT_EQUAL, -1);
+	syscall(__NR_close, socket_fd);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_SOCKET_E);
+	evt_test->assert_event_presence();
 
 	if(HasFatalFailure())
 	{
@@ -40,7 +40,7 @@ TEST(SyscallEnter, socketcall_socketE)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
-	evt_test->assert_numeric_param(1, (uint32_t)args[0]);
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_INET);
 
 	/* Parameter 2: type (type: PT_UINT32) */
 	evt_test->assert_numeric_param(2, (uint32_t)args[1]);
@@ -55,10 +55,7 @@ TEST(SyscallEnter, socketcall_socketE)
 
 TEST(SyscallEnter, socketcall_bindE)
 {
-	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
-	auto evt_test = get_syscall_event_test();
-
-	evt_test->set_event_type(PPME_SOCKET_BIND_E);
+	auto evt_test = get_syscall_event_test(__NR_bind, ENTER_EVENT);
 
 	evt_test->enable_capture();
 
@@ -69,13 +66,13 @@ TEST(SyscallEnter, socketcall_bindE)
 	args[1] = 0;
 	args[2] = 0;
 
-	syscall(__NR_socketcall, SYS_BIND, args);
+	assert_syscall_state(SYSCALL_FAILURE, "socketcall bind", syscall(__NR_socketcall, SYS_BIND, args));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_BIND_E);
+	evt_test->assert_event_presence();
 
 	if(HasFatalFailure())
 	{
@@ -96,4 +93,58 @@ TEST(SyscallEnter, socketcall_bindE)
 	evt_test->assert_num_params_pushed(1);
 }
 
+TEST(SyscallEnter, socketcall_connectE)
+{
+	auto evt_test = get_syscall_event_test(__NR_connect, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = 12;
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+	unsigned long args[3] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)&server_addr;
+	args[2] = sizeof(server_addr);
+	assert_syscall_state(SYSCALL_FAILURE, "socketcall connect", syscall(__NR_socketcall, SYS_CONNECT, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR)*/
+	/* Modern BPF returns addr_info even if the syscall fails other drivers return an empty param. */
+	if(evt_test->is_modern_bpf_engine())
+	{
+		evt_test->assert_addr_info_inet_param(2, PPM_AF_INET, IPV4_SERVER, IPV4_PORT_SERVER_STRING);
+	}
+	else
+	{
+		evt_test->assert_empty_param(2);
+		evt_test->assert_num_params_pushed(2);
+		GTEST_SKIP() << "[CONNECT_E]: what we receive is correct but we need to reimplement it, see the code" << std::endl;
+	}
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
 #endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -740,3 +740,48 @@ TEST(SyscallEnter, socketcall_sendmsgE)
 	evt_test->assert_num_params_pushed(3);
 }
 #endif
+
+#ifdef __NR_recvmsg
+TEST(SyscallEnter, socketcall_recvmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	int flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = flags;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmsg", syscall(__NR_socketcall, SYS_RECVMSG, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -179,6 +179,7 @@ TEST(SyscallEnter, socketcall_connectE)
 
 	evt_test->assert_num_params_pushed(2);
 }
+#endif
 
 #ifdef __NR_recvmmsg
 TEST(SyscallEnter, socketcall_recvmmsgE)
@@ -429,6 +430,4 @@ TEST(SyscallEnter, socketcall_accept4E)
 
 	evt_test->assert_num_params_pushed(1);
 }
-#endif
-
 #endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -591,3 +591,71 @@ TEST(SyscallEnter, socketcall_socketpairE)
 	evt_test->assert_num_params_pushed(3);
 }
 #endif
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallEnter, socketcall_sendtoE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+
+	unsigned long args[6] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)sent_data;
+	args[2] = sizeof(sent_data);
+	args[3] = sendto_flags;
+	args[4] = (unsigned long)&server_addr;
+	args[5] = sizeof(server_addr);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", syscall(__NR_socketcall, SYS_SENDTO, args), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
+
+	/* Parameter 3: addr (type: PT_SOCKADDR)*/
+	/* The client performs a `sendto` to the server so the src_ipv4 is the client one. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -433,3 +433,49 @@ TEST(SyscallEnter, socketcall_accept4E)
 	evt_test->assert_num_params_pushed(1);
 }
 #endif
+
+#ifdef __NR_listen
+TEST(SyscallEnter, socketcall_listenE)
+{
+	auto evt_test = get_syscall_event_test(__NR_listen, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t socket_fd = 2;
+	int backlog = 3;
+
+	unsigned long args[2] = {0};
+	args[0] = socket_fd;
+	args[1] = backlog;
+	assert_syscall_state(SYSCALL_FAILURE, "listen", syscall(__NR_socketcall, SYS_LISTEN, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)socket_fd);
+
+	/* Parameter 2: backlog (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)backlog);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -5,6 +5,9 @@
 #include <sys/socket.h>
 #include <linux/net.h>
 
+#if defined(__NR_clone3) && defined(__NR_wait4)
+#include <linux/sched.h>
+
 TEST(SyscallEnter, socketcall_socketE)
 {
 	auto evt_test = get_syscall_event_test(__NR_socket, ENTER_EVENT);
@@ -18,15 +21,43 @@ TEST(SyscallEnter, socketcall_socketE)
 	args[1] = SOCK_RAW;
 	args[2] = PF_INET;
 
-	int socket_fd = syscall(__NR_socketcall, SYS_SOCKET, args);
-	assert_syscall_state(SYSCALL_SUCCESS, "socketcall socket", socket_fd, NOT_EQUAL, -1);
-	syscall(__NR_close, socket_fd);
+	/* Here we need to call the `socket` from a child because the main process throws a `socket`
+	 * syscall to calibrate the socket file options if we are using the bpf probe.
+	 */
+	struct clone_args cl_args = {0};
+	cl_args.flags = CLONE_FILES;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* In this way in the father we know if the call was successful or not. */
+		if(syscall(__NR_socketcall, SYS_SOCKET, args) == -1)
+		{
+			exit(EXIT_FAILURE);
+		}
+		else
+		{
+			exit(EXIT_SUCCESS);
+		}
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+	/* Catch the child before doing anything else. */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "The 'socketcall socket' failed while it should be successful..." << std::endl;
+	}
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence();
+	evt_test->assert_event_presence(ret_pid);
 
 	if(HasFatalFailure())
 	{
@@ -52,6 +83,7 @@ TEST(SyscallEnter, socketcall_socketE)
 
 	evt_test->assert_num_params_pushed(3);
 }
+#endif
 
 TEST(SyscallEnter, socketcall_bindE)
 {
@@ -101,7 +133,7 @@ TEST(SyscallEnter, socketcall_connectE)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	int32_t mock_fd = 12;
+	int32_t mock_fd = -1;
 	struct sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 	unsigned long args[3] = {0};

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -274,4 +274,47 @@ TEST(SyscallEnter, socketcall_sendmmsgE)
 }
 #endif
 
+TEST(SyscallEnter, socketcall_shutdownE)
+{
+	auto evt_test = get_syscall_event_test(__NR_shutdown, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t invalid_fd = -1;
+	int how = SHUT_RD;
+
+	unsigned long args[2] = {0};
+	args[0] = invalid_fd;
+	args[1] = how;
+	assert_syscall_state(SYSCALL_FAILURE, "shutdown", syscall(__NR_socketcall, SYS_SHUTDOWN, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
+
+	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(2, (uint8_t)PPM_SHUT_RD);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
 #endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -659,3 +659,84 @@ TEST(SyscallEnter, socketcall_sendtoE)
 	evt_test->assert_num_params_pushed(3);
 }
 #endif
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendmsg)
+
+TEST(SyscallEnter, socketcall_sendmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[3];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
+	char sent_data_3[THIRD_MESSAGE_LEN] = "hey! there is a third message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	iov[2].iov_base = sent_data_3;
+	iov[2].iov_len = sizeof(sent_data_3);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)&send_msg;
+	args[2] = sendmsg_flags;
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", syscall(__NR_socketcall, SYS_SENDMSG, args), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)client_socket_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
+
+	/* Parameter 3: addr (type: PT_SOCKADDR)*/
+	/* The client performs a `sendmsg` to the server so the src_ipv4 is the client one. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -836,3 +836,54 @@ TEST(SyscallEnter, socketcall_getsockoptE)
 	evt_test->assert_num_params_pushed(0);
 }
 #endif
+
+#ifdef __NR_setsockopt
+
+#include <netdb.h>
+
+TEST(SyscallEnter, socketcall_setsockoptE)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int socket_fd = 0;
+	int level = 0;
+	int option_name = 0;
+	const void* option_value = NULL;
+	socklen_t option_len = 0;
+
+	unsigned long args[5] = {0};
+	args[0] = socket_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -479,3 +479,59 @@ TEST(SyscallEnter, socketcall_listenE)
 	evt_test->assert_num_params_pushed(2);
 }
 #endif
+
+#ifdef __NR_recvfrom
+
+TEST(SyscallEnter, socketcall_recvfromE)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvfrom, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+
+	unsigned long args[6] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)received_data;
+	args[2] = received_data_len;
+	args[3] = flags;
+	args[4] = (unsigned long)src_addr;
+	args[5] = (unsigned long)addrlen;
+
+	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_socketcall, SYS_RECVFROM, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)mock_fd);
+
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)received_data_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -179,4 +179,99 @@ TEST(SyscallEnter, socketcall_connectE)
 
 	evt_test->assert_num_params_pushed(2);
 }
+
+#ifdef __NR_recvmmsg
+TEST(SyscallEnter, socketcall_recvmmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	struct timespec *timeout = NULL;
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = vlen;
+	args[3] = flags;
+	args[4] = (unsigned long)timeout;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmmsg", syscall(__NR_socketcall, SYS_RECVMMSG, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif
+
+#ifdef __NR_sendmmsg
+TEST(SyscallEnter, socketcall_sendmmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = vlen;
+	args[3] = flags;
+	assert_syscall_state(SYSCALL_FAILURE, "sendmmsg", syscall(__NR_socketcall, SYS_SENDMMSG, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif
+
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
@@ -1,7 +1,8 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_socket) && defined(__NR_close)
+#if defined(__NR_socket) && defined(__NR_clone3) && defined(__NR_wait4)
 
+#include <linux/sched.h>
 #include <sys/socket.h>
 
 TEST(SyscallExit, socketX)
@@ -12,18 +13,50 @@ TEST(SyscallExit, socketX)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	int domain = AF_INET;
-	int type = SOCK_RAW;
-	int protocol = PF_INET;
-	int32_t socket_fd = syscall(__NR_socket, domain, type, protocol);
-	assert_syscall_state(SYSCALL_SUCCESS, "socket_fd", socket_fd, NOT_EQUAL, -1);
-	syscall(__NR_close, socket_fd);
+	int domain = -1;
+	int type = -1;
+	int protocol = -1;
+
+	/* Here we need to call the `socket` from a child because the main process throws a `socket`
+	 * syscall to calibrate the socket file options if we are using the bpf probe.
+	 */
+	struct clone_args cl_args = {0};
+	cl_args.flags = CLONE_FILES;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* In this way in the father we know if the call was successful or not. */
+		if(syscall(__NR_socket, domain, type, protocol) == -1)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		else
+		{
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+	/* Catch the child before doing anything else. */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "The socket call is successful while it should fail..." << std::endl;
+	}
+
+	/* This is the errno value we expect from the `socket` call. */
+	int64_t errno_value = -EINVAL;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence();
+	evt_test->assert_event_presence(ret_pid);
 
 	if(HasFatalFailure())
 	{
@@ -37,7 +70,7 @@ TEST(SyscallExit, socketX)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO)*/
-	evt_test->assert_numeric_param(1, (int64_t)socket_fd);
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -966,3 +966,231 @@ TEST(SyscallExit, socketcall_listenX)
 	evt_test->assert_num_params_pushed(1);
 }
 #endif
+
+#ifdef __NR_recvfrom
+
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallExit, socketcall_recvfromX_no_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t recvfrom_flags = 0;
+	/// TODO: if we use `struct sockaddr_in* src_addr = NULL` kernel module and old bpf are not able to get correct data.
+	/// Fixing them means changing how we retrieve network data, so it would be quite a big change.
+	struct sockaddr_in src_addr = {0};
+	socklen_t addrlen = sizeof(src_addr);
+
+	unsigned long args[6] = {0};
+	args[0] = connected_socket_fd;
+	args[1] = (unsigned long)received_data;
+	args[2] = received_data_len;
+	args[3] = recvfrom_flags;
+	args[4] = (unsigned long)&src_addr;
+	args[5] = (unsigned long)&addrlen;
+
+	int64_t received_bytes = syscall(__NR_socketcall, SYS_RECVFROM, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)received_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, received_bytes);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvfrom` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+TEST(SyscallExit, socketcall_recvfromX_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t recvfrom_flags = 0;
+	struct sockaddr_in src_addr = {0};
+	socklen_t addrlen = sizeof(src_addr);
+
+	unsigned long args[6] = {0};
+	args[0] = connected_socket_fd;
+	args[1] = (unsigned long)received_data;
+	args[2] = received_data_len;
+	args[3] = recvfrom_flags;
+	args[4] = (unsigned long)&src_addr;
+	args[5] = (unsigned long)&addrlen;
+
+	int64_t received_bytes = syscall(__NR_socketcall, SYS_RECVFROM, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)MAX_RECV_BUF_SIZE);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs a 'recvfrom` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif
+
+TEST(SyscallExit, socketcall_recvfromX_fail)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvfrom, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char received_data[MAX_RECV_BUF_SIZE];
+	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
+	uint32_t flags = 0;
+	struct sockaddr *src_addr = NULL;
+	socklen_t *addrlen = NULL;
+
+	unsigned long args[6] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)received_data;
+	args[2] = received_data_len;
+	args[3] = flags;
+	args[4] = (unsigned long)src_addr;
+	args[5] = (unsigned long)addrlen;
+
+	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_socketcall, SYS_RECVFROM, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(3);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -331,4 +331,586 @@ TEST(SyscallExit, socketcall_shutdownX)
 
 	evt_test->assert_num_params_pushed(1);
 }
+
+#if defined(__NR_accept) || defined(__s390x__)
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+TEST(SyscallExit, socketcall_acceptX_INET)
+{
+#ifdef __s390x__
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+#else
+	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
+#endif
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	unsigned long args[3] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)NULL;
+	args[2] = (unsigned long)NULL;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, socketcall_acceptX_INET6)
+{
+#ifdef __s390x__
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+#else
+	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
+#endif
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in6 client_addr = {0};
+	struct sockaddr_in6 server_addr = {0};
+	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	unsigned long args[3] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)NULL;
+	args[2] = (unsigned long)NULL;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet6_param(2, PPM_AF_INET6, IPV6_CLIENT, IPV6_SERVER, IPV6_PORT_CLIENT_STRING, IPV6_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, socketcall_acceptX_UNIX)
+{
+#ifdef __s390x__
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+#else
+	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
+#endif
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_un client_addr = {0};
+	struct sockaddr_un server_addr = {0};
+	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	unsigned long args[3] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)NULL;
+	args[2] = (unsigned long)NULL;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_CLIENT, 0);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif /* __NR_unlinkat */
+
+TEST(SyscallExit, socketcall_acceptX_failure)
+{
+#ifdef __s390x__
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+#else
+	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
+#endif
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+
+	unsigned long args[3] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)addr;
+	args[2] = (unsigned long)addrlen;
+	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_socketcall, SYS_ACCEPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif
+#endif /* __NR_accept || __s390x__ */
+
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+TEST(SyscallExit, socketcall_accept4X_INET)
+{
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)addr;
+	args[2] = (unsigned long)addrlen;
+	args[3] = flags;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT4, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, socketcall_accept4X_INET6)
+{
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in6 client_addr = {0};
+	struct sockaddr_in6 server_addr = {0};
+	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)addr;
+	args[2] = (unsigned long)addrlen;
+	args[3] = flags;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT4, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_inet6_param(2, PPM_AF_INET6, IPV6_CLIENT, IPV6_SERVER, IPV6_PORT_CLIENT_STRING, IPV6_PORT_SERVER_STRING);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#ifdef __NR_unlinkat
+TEST(SyscallExit, socketcall_accept4X_UNIX)
+{
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_un client_addr = {0};
+	struct sockaddr_un server_addr = {0};
+	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)addr;
+	args[2] = (unsigned long)addrlen;
+	args[3] = flags;
+	int connected_socket_fd = syscall(__NR_socketcall, SYS_ACCEPT4, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+	syscall(__NR_unlinkat, 0, UNIX_CLIENT, 0);
+	syscall(__NR_unlinkat, 0, UNIX_SERVER, 0);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)connected_socket_fd);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The server performs an `accept` so the `client` is the src. */
+	evt_test->assert_tuple_unix_param(2, PPM_AF_UNIX, UNIX_SERVER);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	/* we expect 0 elements in the queue so 0%. */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	/* we expect 0 elements. */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif /* __NR_unlinkat */
+
+TEST(SyscallExit, socketcall_accept4X_failure)
+{
+	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct sockaddr *addr = NULL;
+	socklen_t *addrlen = NULL;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)addr;
+	args[2] = (unsigned long)addrlen;
+	args[3] = flags;
+	assert_syscall_state(SYSCALL_FAILURE, "accept4", syscall(__NR_socketcall, SYS_ACCEPT4, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(2);
+
+	/* Parameter 3: queuepct (type: PT_UINT8) */
+	evt_test->assert_numeric_param(3, (uint8_t)0);
+
+	/* Parameter 4: queuelen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0);
+
+	/* Parameter 5: queuemax (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+#endif
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1194,3 +1194,128 @@ TEST(SyscallExit, socketcall_recvfromX_fail)
 }
 
 #endif
+
+#if defined(__NR_socketpair) && defined(__NR_close)
+
+#include <sys/socket.h>
+
+TEST(SyscallExit, socketcall_socketpairX_success)
+{
+	auto evt_test = get_syscall_event_test(__NR_socketpair, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	int32_t fd[2];
+
+	unsigned long args[4] = {0};
+	args[0] = domain;
+	args[1] = type;
+	args[2] = protocol;
+	args[3] = (unsigned long)fd;
+	assert_syscall_state(SYSCALL_SUCCESS, "socketpair", syscall(__NR_socketcall, SYS_SOCKETPAIR, args), NOT_EQUAL, -1);
+	syscall(__NR_close, fd[0]);
+	syscall(__NR_close, fd[1]);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: fd1 (type: PT_FD)*/
+	evt_test->assert_numeric_param(2, (int64_t)fd[0]);
+
+	/* Parameter 3: fd2 (type: PT_FD)*/
+	evt_test->assert_numeric_param(3, (int64_t)fd[1]);
+
+	/* Parameter 4: source (type: PT_UINT64)*/
+	/* Here we have a kernel pointer, we don't know the exact value. */
+	evt_test->assert_numeric_param(4, (uint64_t)0, NOT_EQUAL);
+
+	/* Parameter 5: peer (type: PT_UINT64)*/
+	/* Here we have a kernel pointer, we don't know the exact value. */
+	evt_test->assert_numeric_param(5, (uint64_t)0, NOT_EQUAL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+TEST(SyscallExit, socketcall_socketpairX_failure)
+{
+	auto evt_test = get_syscall_event_test(__NR_socketpair, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int domain = PF_LOCAL;
+	int type = SOCK_STREAM;
+	int protocol = 0;
+	int32_t* fd = NULL;
+
+	unsigned long args[4] = {0};
+	args[0] = domain;
+	args[1] = type;
+	args[2] = protocol;
+	args[3] = (unsigned long)fd;
+	assert_syscall_state(SYSCALL_SUCCESS, "socketpair", syscall(__NR_socketcall, SYS_SOCKETPAIR, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd1 (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)-1);
+
+	/* Parameter 3: fd2 (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)-1);
+
+	/* Parameter 4: source (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)0);
+
+	/* Parameter 5: peer (type: PT_UINT64) */
+	evt_test->assert_numeric_param(5, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -195,6 +195,7 @@ TEST(SyscallExit, socketcall_connectX)
 
 	evt_test->assert_num_params_pushed(2);
 }
+#endif
 
 #ifdef __NR_recvmmsg
 TEST(SyscallExit, socketcall_recvmmsgX)
@@ -912,5 +913,4 @@ TEST(SyscallExit, socketcall_accept4X_failure)
 
 	evt_test->assert_num_params_pushed(5);
 }
-#endif
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -341,6 +341,8 @@ TEST(SyscallExit, socketcall_acceptX_INET)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+	if(evt_test->is_kmod_engine())
+		GTEST_SKIP() << "[acceptX] kmod socketcall implementation is event based (rather syscall) " << std::endl;
 #else
 	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
 #endif
@@ -415,6 +417,8 @@ TEST(SyscallExit, socketcall_acceptX_INET6)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+	if(evt_test->is_kmod_engine())
+		GTEST_SKIP() << "[acceptX] kmod socketcall implementation is event based (rather syscall) " << std::endl;
 #else
 	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
 #endif
@@ -490,6 +494,8 @@ TEST(SyscallExit, socketcall_acceptX_UNIX)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+	if(evt_test->is_kmod_engine())
+		GTEST_SKIP() << "[acceptX] kmod socketcall implementation is event based (rather syscall) " << std::endl;
 #else
 	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
 #endif
@@ -567,6 +573,8 @@ TEST(SyscallExit, socketcall_acceptX_failure)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
+	if(evt_test->is_kmod_engine())
+		GTEST_SKIP() << "[acceptX] kmod socketcall implementation is event based (rather syscall) " << std::endl;
 #else
 	auto evt_test = get_syscall_event_test(__NR_accept, EXIT_EVENT);
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1,0 +1,50 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_socketcall
+
+#include <sys/socket.h>
+#include <linux/net.h>
+
+TEST(SyscallExit, socketcall_socketX)
+{
+	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
+	auto evt_test = get_syscall_event_test();
+
+	evt_test->set_event_type(PPME_SOCKET_SOCKET_X);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	unsigned long args[3] = {0};
+	args[0] = AF_INET;
+	args[1] = SOCK_RAW;
+	args[2] = PF_INET;
+
+	int ret = syscall(__NR_socketcall, SYS_SOCKET, &args);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_SOCKET_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)ret);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1319,3 +1319,191 @@ TEST(SyscallExit, socketcall_socketpairX_failure)
 }
 
 #endif
+
+#ifdef __NR_sendto
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+/* By default `snaplen` is 80 bytes.
+ * No `snaplen` because here we don't hit the 80 bytes so we don't have to truncate the message.
+ */
+TEST(SyscallExit, socketcall_sendtoX_no_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+
+	unsigned long args[6] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)sent_data;
+	args[2] = sizeof(sent_data);
+	args[3] = sendto_flags;
+	args[4] = (unsigned long)&server_addr;
+	args[5] = sizeof(server_addr);
+	int64_t sent_bytes = syscall(__NR_socketcall, SYS_SENDTO, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+/* Here we need to truncate our message since it is greater than `snaplen` */
+TEST(SyscallExit, socketcall_sendtoX_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+
+	unsigned long args[6] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)sent_data;
+	args[2] = sizeof(sent_data);
+	args[3] = sendto_flags;
+	args[4] = (unsigned long)&server_addr;
+	args[5] = sizeof(server_addr);
+	int64_t sent_bytes = syscall(__NR_socketcall, SYS_SENDTO, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+TEST(SyscallExit, socketcall_sendtoX_fail)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	char* sent_data = NULL;
+	size_t len = 0;
+	uint32_t sendto_flags = 0;
+	struct sockaddr* dest_addr = NULL;
+	socklen_t addrlen = 0;
+
+	unsigned long args[6] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)sent_data;
+	args[2] = len;
+	args[3] = sendto_flags;
+	args[4] = (unsigned long)dest_addr;
+	args[5] = addrlen;
+	assert_syscall_state(SYSCALL_FAILURE, "sendto", syscall(__NR_socketcall, SYS_SENDTO, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif /* __NR_sendto */

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1712,3 +1712,266 @@ TEST(SyscallExit, socketcall_sendmsgX_fail)
 }
 
 #endif /* __NR_sendmsg */
+
+#ifdef __NR_recvmsg
+
+#if defined(__NR_accept4) && defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown) && defined(__NR_sendto)
+
+TEST(SyscallExit, socketcall_recvmsgX_no_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	struct msghdr recv_msg;
+	struct iovec iov[2];
+	memset(&recv_msg, 0, sizeof(recv_msg));
+	memset(iov, 0, sizeof(iov));
+	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_namelen = sizeof(client_addr);
+	char data_1[MAX_RECV_BUF_SIZE];
+	char data_2[MAX_RECV_BUF_SIZE];
+	iov[0].iov_base = data_1;
+	iov[0].iov_len = MAX_RECV_BUF_SIZE;
+	iov[1].iov_base = data_2;
+	iov[1].iov_len = MAX_RECV_BUF_SIZE;
+	recv_msg.msg_iov = iov;
+	recv_msg.msg_iovlen = 2;
+	uint32_t recvmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = connected_socket_fd;
+	args[1] = (unsigned long)&recv_msg;
+	args[2] = recvmsg_flags;
+	int64_t received_bytes = syscall(__NR_socketcall, SYS_RECVMSG, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvmsg (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)received_bytes);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)received_bytes);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(3, NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+
+	if(evt_test->is_modern_bpf_engine())
+	{
+		/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+		evt_test->assert_tuple_inet_param(4, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+	}
+	else
+	{
+		/// TODO: same as `recvfrom` the kernel code tries to get information from userspace structs
+		///  but these could be empty so this is not the correct way to retrieve information we have to
+		///  change it.
+		evt_test->assert_empty_param(4);
+		evt_test->assert_num_params_pushed(4);
+		GTEST_SKIP() << "[RECVMSG_X]: what we receive is correct but we need to reimplement it, see the code" << std::endl;
+	}
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+
+TEST(SyscallExit, socketcall_recvmsgX_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* The server accepts the connection and receives the message */
+	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, NULL, NULL, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "accept4 (server)", connected_socket_fd, NOT_EQUAL, -1);
+
+	struct msghdr recv_msg;
+	struct iovec iov[2];
+	memset(&recv_msg, 0, sizeof(recv_msg));
+	memset(iov, 0, sizeof(iov));
+	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_namelen = sizeof(client_addr);
+	char data_1[MAX_RECV_BUF_SIZE];
+	char data_2[MAX_RECV_BUF_SIZE];
+	iov[0].iov_base = data_1;
+	iov[0].iov_len = MAX_RECV_BUF_SIZE;
+	iov[1].iov_base = data_2;
+	iov[1].iov_len = MAX_RECV_BUF_SIZE;
+	recv_msg.msg_iov = iov;
+	recv_msg.msg_iovlen = 2;
+	uint32_t recvmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = connected_socket_fd;
+	args[1] = (unsigned long)&recv_msg;
+	args[2] = recvmsg_flags;
+	int64_t received_bytes = syscall(__NR_socketcall, SYS_RECVMSG, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "recvmsg (server)", received_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, connected_socket_fd, 2);
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, connected_socket_fd);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)FULL_MESSAGE_LEN);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)FULL_MESSAGE_LEN);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(3, FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	if(evt_test->is_modern_bpf_engine())
+	{
+		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+		/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+		evt_test->assert_tuple_inet_param(4, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+	}
+	else
+	{
+		/// TODO: same as `recvfrom` the kernel code tries to get information from userspace structs
+		///  but these could be empty so this is not the correct way to retrieve information we have to
+		///  change it.
+		evt_test->assert_empty_param(4);
+		evt_test->assert_num_params_pushed(4);
+		GTEST_SKIP() << "[RECVMSG_X]: what we receive is correct but we need to reimplement it, see the code" << std::endl;
+	}
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif
+
+TEST(SyscallExit, socketcall_recvmsgX_fail)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	int flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = flags;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmsg", syscall(__NR_socketcall, SYS_RECVMSG, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)0);
+
+	/* Parameter 3: data (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(3);
+
+	/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_empty_param(4);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1,6 +1,8 @@
 #include "../../event_class/event_class.h"
 
-#if defined(__NR_socketcall) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
+#ifdef __NR_socketcall
+
+#if defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
 
 #include <sys/socket.h>
 #include <linux/net.h>
@@ -2898,3 +2900,5 @@ TEST(SyscallExit, socketcall_setsockoptX_ZERO_OPTLEN)
 }
 
 #endif
+
+#endif /* __NR_socketcall */

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1975,3 +1975,473 @@ TEST(SyscallExit, socketcall_recvmsgX_fail)
 }
 
 #endif
+
+#ifdef __NR_getsockopt
+
+#include <netdb.h>
+#include <time.h>
+
+#if defined(__NR_socket) && defined(__NR_setsockopt) && defined(__NR_close)
+TEST(SyscallExit, socketcall_getsockoptX_success)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t socketfd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", socketfd, NOT_EQUAL, -1);
+
+	/* This option allow us to reuse the same address. */
+	int32_t setsockopt_option_value = 1;
+	socklen_t setsockopt_option_len = sizeof(setsockopt_option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = socketfd;
+	args[1] = SOL_SOCKET;
+	args[2] = SO_REUSEADDR;
+	args[3] = (unsigned long)&setsockopt_option_value;
+	args[4] = setsockopt_option_len;
+	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args), NOT_EQUAL, -1);
+
+	/* Check if we are able to get the right option just set */
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_REUSEADDR;
+	/* just a fake value that should be overwritten by the real value */
+	int32_t option_value = 14;
+	socklen_t option_len = sizeof(int32_t);
+
+	args[0] = socketfd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_SUCCESS, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, socketfd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)socketfd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_REUSEADDR);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT32, &setsockopt_option_value, setsockopt_option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)setsockopt_option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+#endif
+
+TEST(SyscallExit, socketcall_getsockoptX_SO_RCVTIMEO)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_RCVTIMEO;
+	struct timeval option_value = {0};
+	option_value.tv_sec = 5;
+	option_value.tv_usec = 10;
+	socklen_t option_len = sizeof(struct timeval);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_RCVTIMEO);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	uint64_t total_timeval = option_value.tv_sec * SEC_FACTOR + option_value.tv_usec * USEC_FACTOR;
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_TIMEVAL, &total_timeval, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_getsockoptX_SO_COOKIE)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_COOKIE;
+	uint64_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_COOKIE);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT64, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_getsockoptX_SO_PASSCRED)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_PASSCRED);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT32, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_getsockoptX_UNKNOWN_OPTION)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = -1; /* this is an unknown option. */
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_getsockoptX_SOL_UNKNOWN)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_getsockoptX_ZERO_OPTLEN)
+{
+	auto evt_test = get_syscall_event_test(__NR_getsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 0;
+	socklen_t option_len = 0;
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = (unsigned long)&option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "getsockopt", syscall(__NR_socketcall, SYS_GETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1507,3 +1507,208 @@ TEST(SyscallExit, socketcall_sendtoX_fail)
 }
 
 #endif /* __NR_sendto */
+
+#ifdef __NR_sendmsg
+
+#if defined(__NR_connect) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_close) && defined(__NR_setsockopt) && defined(__NR_shutdown)
+
+/* By default `snaplen` is 80 bytes.
+ * No `snaplen` because here we don't hit the 80 bytes so we don't have to truncate the message.
+ */
+TEST(SyscallExit, socketcall_sendmsgX_no_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[2];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 2;
+	uint32_t sendmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)&send_msg;
+	args[2] = sendmsg_flags;
+	int64_t sent_bytes = syscall(__NR_socketcall, SYS_SENDMSG, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, NO_SNAPLEN_MESSAGE, sent_bytes);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+/* Here we need to truncate our message since it is greater than `snaplen` */
+TEST(SyscallExit, socketcall_sendmsgX_snaplen)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	struct msghdr send_msg;
+	struct iovec iov[3];
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_namelen = sizeof(server_addr);
+	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
+	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
+	char sent_data_3[THIRD_MESSAGE_LEN] = "hey! there is a third message here.";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	iov[1].iov_base = sent_data_2;
+	iov[1].iov_len = sizeof(sent_data_2);
+	iov[2].iov_base = sent_data_3;
+	iov[2].iov_len = sizeof(sent_data_3);
+	send_msg.msg_iov = iov;
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)&send_msg;
+	args[2] = sendmsg_flags;
+	int64_t sent_bytes = syscall(__NR_socketcall, SYS_SENDMSG, args);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendmsg (client)", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+TEST(SyscallExit, socketcall_sendmsgX_fail)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr* send_msg = NULL;
+	uint32_t sendmsg_flags = 0;
+
+	unsigned long args[3] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)&send_msg;
+	args[2] = sendmsg_flags;
+	assert_syscall_state(SYSCALL_FAILURE, "sendmsg", syscall(__NR_socketcall, SYS_SENDMSG, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif /* __NR_sendmsg */

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -922,3 +922,47 @@ TEST(SyscallExit, socketcall_accept4X_failure)
 	evt_test->assert_num_params_pushed(5);
 }
 #endif
+
+#ifdef __NR_listen
+TEST(SyscallExit, socketcall_listenX)
+{
+	auto evt_test = get_syscall_event_test(__NR_listen, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t socket_fd = 2;
+	int backlog = 3;
+
+	unsigned long args[2] = {0};
+	args[0] = socket_fd;
+	args[1] = backlog;
+	assert_syscall_state(SYSCALL_FAILURE, "listen", syscall(__NR_socketcall, SYS_LISTEN, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1,33 +1,31 @@
 #include "../../event_class/event_class.h"
 
-#ifdef __NR_socketcall
+#if defined(__NR_socketcall) && defined(__NR_socket) && defined(__NR_bind) && defined(__NR_connect)
 
 #include <sys/socket.h>
 #include <linux/net.h>
 
 TEST(SyscallExit, socketcall_socketX)
 {
-	/* RIGHT NOW we enable all the syscalls, we create a dedicated helper IMHO */
-	auto evt_test = get_syscall_event_test();
-
-	evt_test->set_event_type(PPME_SOCKET_SOCKET_X);
+	auto evt_test = get_syscall_event_test(__NR_socket, EXIT_EVENT);
 
 	evt_test->enable_capture();
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	unsigned long args[3] = {0};
-	args[0] = AF_INET;
-	args[1] = SOCK_RAW;
-	args[2] = PF_INET;
+	args[0] = -1;
+	args[1] = -1;
+	args[2] = -1;
 
-	int ret = syscall(__NR_socketcall, SYS_SOCKET, &args);
+	assert_syscall_state(SYSCALL_FAILURE, "socketcall socket", syscall(__NR_socketcall, SYS_SOCKET, args));
+	int64_t errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence(CURRENT_PID, PPME_SOCKET_SOCKET_X);
+	evt_test->assert_event_presence();
 
 	if(HasFatalFailure())
 	{
@@ -41,10 +39,124 @@ TEST(SyscallExit, socketcall_socketX)
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO)*/
-	evt_test->assert_numeric_param(1, (int64_t)ret);
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	evt_test->assert_num_params_pushed(1);
+}
+
+TEST(SyscallExit, socketcall_bindX)
+{
+	auto evt_test = get_syscall_event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
+	evt_test->server_reuse_address_port(server_socket_fd);
+
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	unsigned long args[3] = {0};
+	args[0] = server_socket_fd;
+	args[1] = (unsigned long)&server_addr;
+	args[2] = sizeof(server_addr);
+
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_socketcall, SYS_BIND, args), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, server_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: addr (type: PT_SOCKADDR) */
+	evt_test->assert_addr_info_inet_param(2, PPM_AF_INET, IPV4_SERVER, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, socketcall_connectX)
+{
+	auto evt_test = get_syscall_event_test(__NR_connect, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t client_socket_fd = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
+	evt_test->client_reuse_address_port(client_socket_fd);
+
+	struct sockaddr_in client_addr;
+	evt_test->client_fill_sockaddr_in(&client_addr);
+
+	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+
+	/* Now we associate the client socket with the server address. */
+	struct sockaddr_in server_addr;
+	evt_test->server_fill_sockaddr_in(&server_addr);
+
+	/* With `SOCK_DGRAM` the `connect` will not perform a connection this is why the syscall doesn't fail. */
+	unsigned long args[3] = {0};
+	args[0] = client_socket_fd;
+	args[1] = (unsigned long)&server_addr;
+	args[2] = sizeof(server_addr);
+	assert_syscall_state(SYSCALL_SUCCESS, "socketcall connect (client)", syscall(__NR_socketcall, SYS_CONNECT, args), NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
+	/* The client performs a `connect` so the client is the src. */
+	evt_test->assert_tuple_inet_param(2, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
 }
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -5,6 +5,9 @@
 #include <sys/socket.h>
 #include <linux/net.h>
 
+#if defined(__NR_clone3) && defined(__NR_wait4)
+#include <linux/sched.h>
+
 TEST(SyscallExit, socketcall_socketX)
 {
 	auto evt_test = get_syscall_event_test(__NR_socket, EXIT_EVENT);
@@ -18,14 +21,46 @@ TEST(SyscallExit, socketcall_socketX)
 	args[1] = -1;
 	args[2] = -1;
 
-	assert_syscall_state(SYSCALL_FAILURE, "socketcall socket", syscall(__NR_socketcall, SYS_SOCKET, args));
-	int64_t errno_value = -errno;
+	/* Here we need to call the `socket` from a child because the main process throws a `socket`
+	 * syscall to calibrate the socket file options if we are using the bpf probe.
+	 */
+	struct clone_args cl_args = {0};
+	cl_args.flags = CLONE_FILES;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* In this way in the father we know if the call was successful or not. */
+		if(syscall(__NR_socketcall, SYS_SOCKET, args) == -1)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		else
+		{
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+	/* Catch the child before doing anything else. */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "The 'socketcall socket' is successful while it should fail..." << std::endl;
+	}
+
+	/* This is the errno value we expect from the `socket` call. */
+	int64_t errno_value = -EINVAL;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence();
+	evt_test->assert_event_presence(ret_pid);
 
 	if(HasFatalFailure())
 	{
@@ -45,6 +80,7 @@ TEST(SyscallExit, socketcall_socketX)
 
 	evt_test->assert_num_params_pushed(1);
 }
+#endif
 
 TEST(SyscallExit, socketcall_bindX)
 {

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -2445,3 +2445,456 @@ TEST(SyscallExit, socketcall_getsockoptX_ZERO_OPTLEN)
 }
 
 #endif
+
+#ifdef __NR_setsockopt
+
+#include <netdb.h>
+#include <time.h>
+
+TEST(SyscallExit, socketcall_setsockoptX_SO_ERROR)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_ERROR;
+	int32_t option_value = 14;
+	socklen_t option_len = sizeof(int32_t);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_ERROR);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	/* In case of `PPM_SOCKOPT_IDX_ERRNO` we receive the negative `option_value`*/
+	int64_t negative_option_value = -option_value;
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_ERRNO, &negative_option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_SO_RCVTIMEO)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_RCVTIMEO;
+	struct timeval option_value = {0};
+	option_value.tv_sec = 5;
+	option_value.tv_usec = 10;
+	socklen_t option_len = sizeof(struct timeval);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_RCVTIMEO);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	uint64_t total_timeval = option_value.tv_sec * SEC_FACTOR + option_value.tv_usec * USEC_FACTOR;
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_TIMEVAL, &total_timeval, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_SO_COOKIE)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_COOKIE;
+	uint64_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_COOKIE);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT64, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_SO_PASSCRED)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_SO_PASSCRED);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UINT32, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_UNKNOWN_OPTION)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = SOL_SOCKET;
+	int32_t option_name = -1; /* this is an unknown option. */
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_SOL_SOCKET);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_SOL_UNKNOWN)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 16;
+	socklen_t option_len = sizeof(option_value);
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+TEST(SyscallExit, socketcall_setsockoptX_ZERO_OPTLEN)
+{
+	auto evt_test = get_syscall_event_test(__NR_setsockopt, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	int32_t level = 7; /* Unknown level. */
+	int32_t option_name = SO_PASSCRED;
+	uint32_t option_value = 0;
+	socklen_t option_len = 0;
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = level;
+	args[2] = option_name;
+	args[3] = (unsigned long)&option_value;
+	args[4] = option_len;
+	assert_syscall_state(SYSCALL_FAILURE, "setsockopt", syscall(__NR_socketcall, SYS_SETSOCKOPT, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(3, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
+	evt_test->assert_numeric_param(4, (uint8_t)PPM_SOCKOPT_LEVEL_UNKNOWN);
+
+	/* Parameter 5: optval (type: PT_DYN) */
+	evt_test->assert_setsockopt_val(5, PPM_SOCKOPT_IDX_UNKNOWN, &option_value, option_len);
+
+	/* Parameter 6: optlen (type: PT_UINT32) */
+	evt_test->assert_numeric_param(6, (uint32_t)option_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -195,4 +195,99 @@ TEST(SyscallExit, socketcall_connectX)
 
 	evt_test->assert_num_params_pushed(2);
 }
+
+#ifdef __NR_recvmmsg
+TEST(SyscallExit, socketcall_recvmmsgX)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	struct timespec *timeout = NULL;
+
+	unsigned long args[5] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = vlen;
+	args[3] = flags;
+	args[4] = (unsigned long)timeout;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmmsg", syscall(__NR_socketcall, SYS_RECVMMSG, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif
+
+#ifdef __NR_sendmmsg
+TEST(SyscallExit, socketcall_sendmmsgX)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+
+	unsigned long args[4] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)msg;
+	args[2] = vlen;
+	args[3] = flags;
+	assert_syscall_state(SYSCALL_FAILURE, "sendmmsg", syscall(__NR_socketcall, SYS_SENDMMSG, args));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif
+
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

**What this PR does / why we need it**:

Add `socketcall` handling to enable capturing of network syscall events on `s390x`. See #810 for details.

**Which issue(s) this PR fixes**:

Fixes the BPF part in: #810 
Depends-on: #809 

**Special notes for your reviewer**:

I took an approach similar to the `kmod` driver to extract the socket call and its arguments. Arguments are stored and looked up in/from a BPF map. This becomes then transparent to the actual filler implementations.

Note that this PR includes and is depending on #809, so for review please focus on the just the [last commit](https://github.com/falcosecurity/libs/pull/811/commits/af390de09adf9975a0c50065ea5e80d0cb53f381).

cc: @FedeDP @Andreagit97 @Molter73 

@Andreagit97 The `modern-bpf` version of `socketcall` handling is not yet finalized and like to briefly discuss my approach in #810.

**Does this PR introduce a user-facing change?**:

This should be transparent.

```release-note
`new(bpf, modern_bpf): introduce `socketcall` handling`
```
