### PR TITLE
new(driver): implement generic events support in modern bpf probe

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -20,6 +20,8 @@
 /// want to touch scap tables.
 
 /* Syscall events */
+#define GENERIC_E_SIZE HEADER_LEN + sizeof(uint16_t) * 2 + PARAM_LEN * 2
+#define GENERIC_X_SIZE HEADER_LEN + sizeof(uint16_t) + PARAM_LEN
 #define MKDIR_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define OPEN_BY_HANDLE_AT_E_SIZE HEADER_LEN
 #define CLOSE_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -50,6 +50,15 @@ static __always_inline u8 maps__get_event_num_params(u32 event_id)
 
 /*=============================== EVENT NUM PARAMS TABLE ===========================*/
 
+/*=============================== PPM_SC TABLE ===========================*/
+
+static __always_inline u16 maps__get_ppm_sc(u16 syscall_id)
+{
+	return g_ppm_sc_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
+}
+
+/*=============================== PPM_SC TABLE ===========================*/
+
 /*=============================== AUXILIARY MAPS ===========================*/
 
 static __always_inline struct auxiliary_map *maps__get_auxiliary_map()

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -25,10 +25,16 @@
  */
 
 /**
- * @brief Take as input the `ppm_event_type` enum and return the number
+ * @brief Take as input the `ppm_event_type` enum and returns the number
  * of parameters for that event.
  */
 __weak const volatile uint8_t g_event_params_table[PPM_EVENT_MAX];
+
+/**
+ * @brief Take as input the `syscall_id` and returns the PPM_SC_CODE
+ * associated with the syscall.
+ */
+__weak const volatile uint16_t g_ppm_sc_table[SYSCALL_TABLE_SIZE];
 
 /**
  * @brief Actual probe API version

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/syscalls_dispatcher.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(generic_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, GENERIC_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_GENERIC_E);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	ringbuf__store_u16(&ringbuf, maps__get_ppm_sc(id));
+
+	/* Parameter 2: nativeID (type: PT_UINT16) */
+	ringbuf__store_u16(&ringbuf, id);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(generic_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, GENERIC_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_GENERIC_X);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	ringbuf__store_u16(&ringbuf, maps__get_ppm_sc(syscalls_dispatcher__get_syscall_id(regs)));
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -146,6 +146,15 @@ event_test::event_test(int syscall_id, int event_direction):
 	{
 		m_tp_set[SYS_EXIT] = 1;
 		m_event_type = g_syscall_table[syscall_id].exit_event_type;
+
+		/* We need this patch to set the right event, the syscall table will
+		 * always return `PPME_GENERIC_E`.
+		 */
+		if(m_event_type == PPME_GENERIC_E)
+		{
+			m_event_type = PPME_GENERIC_X;
+		}
+
 		if(is_bpf_engine())
 		{
 			/* The bpf engine retrieves syscall params from sys_enter tracepoints

--- a/test/drivers/test_suites/syscall_enter_suite/generic_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/generic_e.cpp
@@ -1,0 +1,45 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_uname
+TEST(SyscallEnter, genericE)
+{
+	/* We use `uname` syscall because it is defined on all architectures
+	 * and is a very simple syscall.
+	 */
+	auto evt_test = get_syscall_event_test(__NR_uname, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "uname", syscall(__NR_uname, NULL));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* this is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_UNAME);
+
+	/* Parameter 2: nativeID (type: PT_UINT16) */
+	evt_test->assert_numeric_param(2, (uint16_t)__NR_uname);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/generic_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/generic_x.cpp
@@ -1,0 +1,42 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_uname
+TEST(SyscallExit, genericX)
+{
+	/* We use `uname` syscall because it is defined on all architectures
+	 * and is a very simple syscall.
+	 */
+	auto evt_test = get_syscall_event_test(__NR_uname, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "uname", syscall(__NR_uname, NULL));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* this is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (int16_t)PPM_SC_UNAME);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -22,6 +22,8 @@ limitations under the License.
 
 /* For every event here we have the name of the corresponding bpf program. */
 static const char* event_prog_names[PPM_EVENT_MAX] = {
+	[PPME_GENERIC_E] = "generic_e",
+	[PPME_GENERIC_X] = "generic_x",
 	[PPME_SYSCALL_MKDIR_2_E] = "mkdir_e",
 	[PPME_SYSCALL_MKDIR_2_X] = "mkdir_x",
 	[PPME_SYSCALL_OPEN_E] = "open_e",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR allows us to send generic events (`PPME_GENERIC_E` and `PPME_GENERIC_X`) for not implemented syscalls like in the old drivers

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
