### PR TITLE
fix: handle capset_x missing thread_info

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5749,7 +5749,7 @@ void sinsp_parser::parse_capset_exit(sinsp_evt *evt)
 	retval = *(int64_t *)parinfo->m_val;
 	ASSERT(parinfo->m_len == sizeof(int64_t));
 
-	if(retval < 0)
+	if(retval < 0 || evt->m_tinfo == nullptr)
 	{
 		return;
 	}


### PR DESCRIPTION
Signed-off-by: Adnan Ali <adduali1310@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area libsinsp


<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds a safety check to validate if thread information is available before trying to dereference it when parsing the capset_exit event.
Should be a straightforward change and follows other such checks within the code file as mentioned in the issue.

**Which issue(s) this PR fixes**:
Fixes #817 


**Does this PR introduce a user-facing change?**:
NONE

