### PR TITLE
new(modern_bpf):  [EXPERIMENTAL] support variable number of ring buffers and online CPUs

### DIFF
--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -139,7 +139,7 @@ struct
 
 /**
  * @brief For every CPU on the system we have a counter
- * map where we store the number of events correcty pushed
+ * map where we store the number of events correctly pushed
  * and the number of events dropped.
  */
 struct
@@ -154,9 +154,7 @@ struct
 /*=============================== RINGBUF MAP ===============================*/
 
 /**
- * @brief We will have a ringbuf map for every CPU on the system.
- * The dimension of the single ringbuf and the number of
- * ringbuf maps are set in userspace.
+ * @brief We use this map to let the verifier understand the content of our array of maps (`ringbuf_maps`)
  */
 struct ringbuf_map
 {
@@ -164,8 +162,9 @@ struct ringbuf_map
 };
 
 /**
- * @brief This array of maps will contain a ringbuf map for every CPU
- * on the system.
+ * @brief This array of maps will contain a variable number of ring buffers
+ * according to the user-provided configuration. It could also contain only
+ * one buffer shared between all CPUs. 
  */
 struct
 {

--- a/userspace/libpman/src/capture.c
+++ b/userspace/libpman/src/capture.c
@@ -40,7 +40,12 @@ int pman_enable_capture(bool *tp_set)
 
 int pman_disable_capture()
 {
-	return pman_detach_all_programs();
+	/* If we fail at initialization time the BPF skeleton is not initialized */
+	if(g_state.skel)
+	{
+		return pman_detach_all_programs();
+	}
+	return 0;
 }
 
 #ifdef TEST_HELPERS

--- a/userspace/libpman/src/capture.c
+++ b/userspace/libpman/src/capture.c
@@ -66,7 +66,7 @@ int pman_print_stats()
 		return errno;
 	}
 
-	for(int index = 0; index < g_state.n_cpus; index++)
+	for(int index = 0; index < g_state.n_possible_cpus; index++)
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{
@@ -114,7 +114,10 @@ int pman_get_scap_stats(void *scap_stats_struct)
 	 * - stats->n_preemptions
 	 */
 
-	for(int index = 0; index < g_state.n_cpus; index++)
+	/* We always take statistics from all the CPUs, even if some of them are not online. 
+	 * If the CPU is not online the counter map will be empty.
+	 */
+	for(int index = 0; index < g_state.n_possible_cpus; index++)
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{
@@ -146,7 +149,10 @@ int pman_get_n_tracepoint_hit(long *n_events_per_cpu)
 		return errno;
 	}
 
-	for(int index = 0; index < g_state.n_cpus; index++)
+	/* We always take statistics from all the CPUs, even if some of them are not online. 
+	 * If the CPU is not online the counter map will be empty.
+	 */
+	for(int index = 0; index < g_state.n_possible_cpus; index++)
 	{
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0)
 		{

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -40,22 +40,23 @@ int pman_load_probe()
 
 void pman_close_probe()
 {
-	if(!g_state.cons_pos)
+	if(g_state.cons_pos)
 	{
 		free(g_state.cons_pos);
 	}
 
-	if(!g_state.prod_pos)
+	if(g_state.prod_pos)
 	{
 		free(g_state.prod_pos);
 	}
 
-	if(!g_state.skel)
+	if(g_state.skel)
 	{
+		bpf_probe__detach(g_state.skel);
 		bpf_probe__destroy(g_state.skel);
 	}
 
-	if(!g_state.rb_manager)
+	if(g_state.rb_manager)
 	{
 		ring_buffer__free(g_state.rb_manager);
 	}

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -244,7 +244,8 @@ int pman_fill_extra_event_prog_tail_table()
 
 static int size_auxiliary_maps()
 {
-	if(bpf_map__set_max_entries(g_state.skel->maps.auxiliary_maps, g_state.n_cpus))
+	/* We always allocate auxiliary maps from all the CPUs, even if some of them are not online. */
+	if(bpf_map__set_max_entries(g_state.skel->maps.auxiliary_maps, g_state.n_possible_cpus))
 	{
 		pman_print_error("unable to set max entries for 'auxiliary_maps'");
 		return errno;
@@ -254,7 +255,8 @@ static int size_auxiliary_maps()
 
 static int size_counter_maps()
 {
-	if(bpf_map__set_max_entries(g_state.skel->maps.counter_maps, g_state.n_cpus))
+	/* We always allocate counter maps from all the CPUs, even if some of them are not online. */
+	if(bpf_map__set_max_entries(g_state.skel->maps.counter_maps, g_state.n_possible_cpus))
 	{
 		pman_print_error(" unable to set max entries for 'counter_maps'");
 		return errno;

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -26,6 +26,8 @@ limitations under the License.
 
 #include "ringbuffer_definitions.h"
 
+/* Utility functions object loading */
+
 /* This must be done to please the verifier! At load-time, the verifier must know the
  * size of a map inside the array.
  */
@@ -55,7 +57,11 @@ static int ringbuf_array_set_inner_map()
 
 static int ringbuf_array_set_max_entries()
 {
-	if(bpf_map__set_max_entries(g_state.skel->maps.ringbuf_maps, g_state.n_cpus))
+	/* We always allocate a number of entries equal to the available CPUs.
+	 * This doesn't mean that we allocate a ring buffer for every available CPU,
+	 * it means only that every CPU will have an associated entry.
+	 */
+	if(bpf_map__set_max_entries(g_state.skel->maps.ringbuf_maps, g_state.n_possible_cpus))
 	{
 		pman_print_error("unable to set max entries for the ringbuf_array");
 		return errno;
@@ -66,8 +72,8 @@ static int ringbuf_array_set_max_entries()
 static int allocate_consumer_producer_positions()
 {
 	g_state.ringbuf_pos = 0;
-	g_state.cons_pos = (unsigned long *)calloc(g_state.n_cpus, sizeof(unsigned long));
-	g_state.prod_pos = (unsigned long *)calloc(g_state.n_cpus, sizeof(unsigned long));
+	g_state.cons_pos = (unsigned long *)calloc(g_state.n_required_buffers, sizeof(unsigned long));
+	g_state.prod_pos = (unsigned long *)calloc(g_state.n_required_buffers, sizeof(unsigned long));
 	if(g_state.cons_pos == NULL || g_state.prod_pos == NULL)
 	{
 		pman_print_error("failed to alloc memory for cons_pos and prod_pos");
@@ -76,6 +82,7 @@ static int allocate_consumer_producer_positions()
 	return 0;
 }
 
+/* Before loading */
 int pman_prepare_ringbuf_array_before_loading()
 {
 	int err;
@@ -86,14 +93,84 @@ int pman_prepare_ringbuf_array_before_loading()
 	return err;
 }
 
-static int create_first_ringbuffer_map()
+static bool is_cpu_online(uint16_t cpu_id)
+{
+	/* CPU 0 is always online */
+	if(cpu_id == 0)
+	{
+		return true;
+	}
+
+	char filename[FILENAME_MAX];
+	int online = 0;
+	snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/online", cpu_id);
+	FILE *fp = fopen(filename, "r");
+	if(fp == NULL)
+	{
+		/* When missing NUMA properties, CPUs do not expose online information.
+		 * Fallback at considering them online if we can at least reach their folder.
+		 * This is useful for example for raspPi devices.
+		 * See: https://github.com/kubernetes/kubernetes/issues/95039
+		 */
+		snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/", cpu_id);
+		if(access(filename, F_OK) == 0)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	fscanf(fp, "%d", &online);
+	return online == 1;
+}
+
+/* After loading */
+int pman_finalize_ringbuf_array_after_loading()
 {
 	int ringubuf_array_fd = -1;
-	int ringbuf_map_fd = -1;
-	int index = 0;
+	char error_message[MAX_ERROR_MESSAGE_LEN];
+	int *ringbufs_fds = (int *)calloc(g_state.n_required_buffers, sizeof(int));
+	bool success = false;
 
 	/* We don't need anymore the inner map, close it. */
 	close(g_state.inner_ringbuf_map_fd);
+
+	/* Create ring buffer maps. */
+	for(int i = 0; i < g_state.n_required_buffers; i++)
+	{
+		ringbufs_fds[i] = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
+		if(ringbufs_fds[i] <= 0)
+		{
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to create the ringbuf map for CPU '%d'. (If you get memory allocation errors try to reduce the buffer dimension)", i);
+			pman_print_error((const char *)error_message);
+			goto clean_percpu_ring_buffers;
+		}
+	}
+
+	/* Create the ringbuf manager */
+	g_state.rb_manager = ring_buffer__new(ringbufs_fds[0], NULL, NULL, NULL);
+	if(!g_state.rb_manager)
+	{
+		pman_print_error("failed to instantiate the ringbuf manager.");
+		goto clean_percpu_ring_buffers;
+	}
+
+	/* Add all remaining buffers into the manager.
+	 * We start from 1 because the first one is
+	 * used to instantiate the manager.
+	 */
+	for(int i = 1; i < g_state.n_required_buffers; i++)
+	{
+		if(ring_buffer__add(g_state.rb_manager, ringbufs_fds[i], NULL, NULL))
+		{
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU %d into the manager", i);
+			pman_print_error((const char *)error_message);
+			goto clean_percpu_ring_buffers;
+		}
+	}
 
 	/* `ringbuf_array` is a maps array, every map inside it is a `BPF_MAP_TYPE_RINGBUF`. */
 	ringubuf_array_fd = bpf_map__fd(g_state.skel->maps.ringbuf_maps);
@@ -103,103 +180,56 @@ static int create_first_ringbuffer_map()
 		return errno;
 	}
 
-	/* create the first ringbuf map. */
-	ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
-	if(ringbuf_map_fd <= 0)
+	/* We need to associate every CPU to the right ring buffer */
+	int ringbuf_id = 0;
+	int reached = 0;
+	for(int i = 0; i < g_state.n_possible_cpus; i++)
 	{
-		pman_print_error("failed to create the first ringbuf map");
-		goto clean_create_first_ringbuffer_map;
+		/* If we want to allocate only buffers for online CPUs and the CPU is online, fill its
+		 * ring buffer array entry, otherwise we can go on with the next online CPU
+		 */
+		if(g_state.allocate_online_only && !is_cpu_online(i))
+		{
+			continue;
+		}
+
+		if(bpf_map_update_elem(ringubuf_array_fd, &i, &ringbufs_fds[ringbuf_id], BPF_ANY))
+		{
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU '%d' to ringbuf '%d'", i, ringbuf_id);
+			pman_print_error((const char *)error_message);
+			goto clean_percpu_ring_buffers;
+		}
+
+		if(++reached == g_state.cpus_for_each_buffer)
+		{
+			/* we need to switch to the next buffer */
+			reached = 0;
+			ringbuf_id++;
+		}
+	}
+	success = true;
+
+clean_percpu_ring_buffers:
+	for(int i = 0; i < g_state.n_required_buffers; i++)
+	{
+		if(ringbufs_fds[i])
+		{
+			close(ringbufs_fds[i]);
+		}
+	}
+	free(ringbufs_fds);
+
+	if(success)
+	{
+		return 0;
 	}
 
-	/* add the first ringbuf map into the array. */
-	if(bpf_map_update_elem(ringubuf_array_fd, &index, &ringbuf_map_fd, BPF_ANY))
-	{
-		pman_print_error("failed to add the first ringbuf map into the array");
-		goto clean_create_first_ringbuffer_map;
-	}
-
-	g_state.rb_manager = ring_buffer__new(ringbuf_map_fd, NULL, NULL, NULL);
-	if(!g_state.rb_manager)
-	{
-		pman_print_error("failed to instantiate the ringbuf manager. (If you get memory allocation errors try to reduce the buffer dimension)");
-		goto clean_create_first_ringbuffer_map;
-	}
-	return 0;
-
-clean_create_first_ringbuffer_map:
-	close(ringbuf_map_fd);
 	close(ringubuf_array_fd);
-	return errno;
-}
-
-static int create_remaining_ringbuffer_maps()
-{
-	int ringubuf_array_fd = -1;
-	int ringbuf_map_fd = -1;
-	char error_message[MAX_ERROR_MESSAGE_LEN];
-
-	/* the first ringbuf map is already inserted into the array.
-	 * See `create_first_ringbuffer_map()` function.
-	 */
-	int index = 1;
-
-	/* get the ringbuf_array with a map already in it. */
-	ringubuf_array_fd = bpf_map__fd(g_state.skel->maps.ringbuf_maps);
-	if(ringubuf_array_fd <= 0)
+	if(g_state.rb_manager)
 	{
-		pman_print_error("failed to get a not empty ringubuf_array");
-		return errno;
+		ring_buffer__free(g_state.rb_manager);
 	}
-
-	/* for all CPUs add the rinugbuf map into the array and add it also
-	 * into the ringbuf manager. Please note: we have already initialized the
-	 * the ringbuf_array and the manager with the map for the CPU `0`.
-	 */
-	for(index = 1; index < g_state.n_cpus; index++)
-	{
-		ringbuf_map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, g_state.buffer_bytes_dim, NULL);
-		if(ringbuf_map_fd <= 0)
-		{
-			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to create the ringbuf map for CPU %d", index);
-			pman_print_error((const char *)error_message);
-			goto clean_create_remaining_ringbuffer_maps;
-		}
-
-		if(bpf_map_update_elem(ringubuf_array_fd, &index, &ringbuf_map_fd, BPF_ANY))
-		{
-			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU %d into the array", index);
-			pman_print_error((const char *)error_message);
-			goto clean_create_remaining_ringbuffer_maps;
-		}
-
-		/* add the new ringbuf map into the manager. */
-		if(ring_buffer__add(g_state.rb_manager, ringbuf_map_fd, NULL, NULL))
-		{
-			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU %d into the manager", index);
-			pman_print_error((const char *)error_message);
-			goto clean_create_remaining_ringbuffer_maps;
-		}
-	}
-	return 0;
-
-clean_create_remaining_ringbuffer_maps:
-	close(ringbuf_map_fd);
-	close(ringubuf_array_fd);
 	return errno;
-}
-
-/* Create all the ringbuffer maps inside the ringbuffer_array and assign
- * them to the manager. Note, the first ringbuffer map is separated from
- * the others because we first need to create the ringbuffer manager with
- * just one map `ring_buffer__new`. After having instanciating the manager
- * we can add to it all the other maps with `ring_buffer__add`.
- */
-int pman_finalize_ringbuf_array_after_loading()
-{
-	int err;
-	err = create_first_ringbuffer_map();
-	err = err ?: create_remaining_ringbuffer_maps();
-	return err;
 }
 
 static inline void *ringbuf__get_first_ring_event(struct ring *r, int pos)
@@ -209,7 +239,7 @@ static inline void *ringbuf__get_first_ring_event(struct ring *r, int pos)
 	void *sample = NULL;
 
 	/* If the consumer reaches the producer update the producer position to
-	 * get the newly collected events. 
+	 * get the newly collected events.
 	 */
 	if(g_state.cons_pos[pos] >= g_state.prod_pos[pos])
 	{
@@ -238,7 +268,7 @@ static inline void *ringbuf__get_first_ring_event(struct ring *r, int pos)
 	return sample;
 }
 
-static void ringbuf__consume_first_event(struct ring_buffer *rb, struct ppm_evt_hdr **event_ptr, int16_t *cpu_id)
+static void ringbuf__consume_first_event(struct ring_buffer *rb, struct ppm_evt_hdr **event_ptr, int16_t *buffer_id)
 {
 	uint64_t min_ts = 0xffffffffffffffffLL;
 	struct ppm_evt_hdr *tmp_pointer = NULL;
@@ -273,15 +303,15 @@ static void ringbuf__consume_first_event(struct ring_buffer *rb, struct ppm_evt_
 	}
 
 	*event_ptr = tmp_pointer;
-	*cpu_id = tmp_ring;
+	*buffer_id = tmp_ring;
 	g_state.last_ring_read = tmp_ring;
 	g_state.last_event_size = tmp_cons_increment;
 }
 
-/* This API must be used if we want to get the first event according to its timestamp */
-void pman_consume_first_from_buffers(void **event_ptr, int16_t *cpu_id)
+/* Consume */
+void pman_consume_first_event(void **event_ptr, int16_t *buffer_id)
 {
-	ringbuf__consume_first_event(g_state.rb_manager, (struct ppm_evt_hdr **)event_ptr, cpu_id);
+	ringbuf__consume_first_event(g_state.rb_manager, (struct ppm_evt_hdr **)event_ptr, buffer_id);
 }
 
 #ifdef TEST_HELPERS
@@ -292,7 +322,7 @@ void pman_consume_first_from_buffers(void **event_ptr, int16_t *cpu_id)
  */
 static bool pman_is_ringbuffer_full(int ring_num, unsigned long threshold)
 {
-	if(ring_num < 0 || ring_num >= g_state.n_cpus)
+	if(ring_num < 0 || ring_num >= g_state.n_possible_cpus)
 	{
 		return -1;
 	}
@@ -317,7 +347,7 @@ bool pman_are_all_ringbuffers_full(unsigned long threshold)
 	int attempt = 0;
 
 	/* Performs 3 attempts just to be sure that all the buffers are empty. */
-	while(pos < g_state.n_cpus)
+	while(pos < g_state.n_possible_cpus)
 	{
 		if(!pman_is_ringbuffer_full(pos, threshold))
 		{
@@ -326,7 +356,7 @@ bool pman_are_all_ringbuffers_full(unsigned long threshold)
 
 		pos++;
 
-		if(pos == g_state.n_cpus && attempt != 2)
+		if(pos == g_state.n_possible_cpus && attempt != 2)
 		{
 			printf("Stable, attempt %d\n", attempt);
 			pos = 0;

--- a/userspace/libpman/src/state.c
+++ b/userspace/libpman/src/state.c
@@ -22,16 +22,21 @@ limitations under the License.
 #include <unistd.h>
 #include "state.h"
 
-struct internal_state g_state;
+struct internal_state g_state = {};
 
 void pman_print_error(const char* error_message)
 {
 	if(!error_message)
 	{
-		fprintf(stderr, "libpman: No specific message available (errno: %d | message: %s)\n", errno, strerror(errno));
+		return;
+	}
+
+	if(errno != 0)
+	{
+		fprintf(stderr, "libpman: %s (errno: %d | message: %s)\n", error_message, errno, strerror(errno));
 	}
 	else
 	{
-		fprintf(stderr, "libpman: %s (errno: %d | message: %s)\n", error_message, errno, strerror(errno));
+		fprintf(stderr, "libpman: %s\n", error_message);
 	}
 }

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -29,14 +29,18 @@ struct internal_state
 {
 	struct bpf_probe* skel;		/* bpf skeleton with all programs and maps. */
 	struct ring_buffer* rb_manager; /* ring_buffer manager with all per-CPU ringbufs. */
-	int16_t n_cpus;			/* number of system available CPUs. */
+	int16_t n_possible_cpus;			/* number of possible system CPUs (online and not). */
+	int16_t n_interesting_cpus;			/* according to userspace configuration we can consider only online CPUs or all available CPUs. */
+	bool allocate_online_only;      /* If true we allocate ring buffers only for online CPUs */
+	uint32_t n_required_buffers;	/* number of ring buffers we need to allocate */
+	uint16_t cpus_for_each_buffer;	/* Users want a ring buffer every `cpus_for_each_buffer` CPUs */
 	int ringbuf_pos;		/* actual ringbuf we are considering. */
 	unsigned long* cons_pos;	/* every ringbuf has a consumer position. */
 	unsigned long* prod_pos;	/* every ringbuf has a producer position. */
 	int32_t inner_ringbuf_map_fd;	/* inner map used to configure the ringbuf array before loading phase. */
 	unsigned long buffer_bytes_dim; /* dimension of a single per-CPU ringbuffer in bytes. */
-	int last_ring_read; /* Last ring from which we have correctly read an event. Could be `-1` if there were no successful reads. */
-	unsigned long last_event_size; /* Last event correctly read. Could be `0` if there were no successful reads. */
+	int last_ring_read;		/* Last ring from which we have correctly read an event. Could be `-1` if there were no successful reads. */
+	unsigned long last_event_size;	/* Last event correctly read. Could be `0` if there were no successful reads. */
 };
 
 extern struct internal_state g_state;

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -16,6 +16,7 @@ limitations under the License.
 #include <stdint.h>
 
 #define MODERN_BPF_ENGINE "modern_bpf"
+#define DEFAULT_CPU_FOR_EACH_BUFFER 1
 
 #ifdef __cplusplus
 extern "C"
@@ -24,7 +25,9 @@ extern "C"
 
 	struct scap_modern_bpf_engine_params
 	{
-		unsigned long buffer_bytes_dim; ///< Dimension of a single per-CPU buffer in bytes. Please note: this buffer will be mapped twice in the process virtual memory, so pay attention to its size.
+		uint16_t cpus_for_each_buffer;	///< [EXPERIMENTAL] We will allocate a ring buffer every `cpus_for_each_buffer` CPUs. `0` is a special value and means a single ring buffer shared between all the CPUs.
+		bool allocate_online_only; ///< [EXPERIMENTAL] Allocate ring buffers only for online CPUs. The number of ring buffers allocated changes according to the `cpus_for_each_buffer` param. Please note: this buffer will be mapped twice both kernel and userspace-side, so pay attention to its size.
+		unsigned long buffer_bytes_dim; ///< Dimension of a ring buffer in bytes. The number of ring buffers allocated changes according to the `cpus_for_each_buffer` param. Please note: this buffer will be mapped twice both kernel and userspace-side, so pay attention to its size.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
@@ -26,8 +26,7 @@ struct scap;
 
 struct modern_bpf_engine
 {
-	size_t m_num_cpus;
-	unsigned long m_retry_us;
-	char* m_lasterr;
-	interesting_tp_set open_tp_set;
+	unsigned long m_retry_us; /* Microseconds to wait if all ring buffers are empty */
+	char* m_lasterr; /* Last error caught by the engine */
+	interesting_tp_set open_tp_set; /* Interesting tracepoints */
 };

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -40,7 +40,7 @@ limitations under the License.
 #define BUFFER_OPTION "--buffer_dim"
 #define SIMPLE_SET_OPTION "--simple_set"
 #define CPUS_FOR_EACH_BUFFER_MODE "--cpus_for_buf"
-#define ALLOCATE_ONLINE_ONLY_MODE "--online_only"
+#define ALL_AVAILABLE_CPUS_MODE "--available_cpus"
 
 /* PRINT */
 #define VALIDATION_OPTION "--validate_syscalls"
@@ -711,7 +711,9 @@ void print_help()
 	printf("'%s <num_events>': number of events to catch before terminating. (default: UINT64_MAX)\n", NUM_EVENTS_OPTION);
 	printf("'%s <event_type>': every event of this type will be printed to console. (default: -1, no print)\n", EVENT_TYPE_OPTION);
 	printf("'%s <dim>': dimension in bytes of a single per CPU buffer.\n", BUFFER_OPTION);
+	printf("[MODERN PROBE ONLY, EXPERIMENTAL]\n");
 	printf("'%s <cpus_for_each_buffer>': allocate a ring buffer for every `cpus_for_each_buffer` CPUs.\n", CPUS_FOR_EACH_BUFFER_MODE);
+	printf("'%s': allocate ring buffers for all available CPUs. Default: allocate ring buffers for online CPUs only.\n", ALL_AVAILABLE_CPUS_MODE);
 	printf("\n------> VALIDATION OPTIONS\n");
 	printf("'%s': validation checks.\n", VALIDATION_OPTION);
 	printf("\n------> PRINT OPTIONS\n");
@@ -820,7 +822,7 @@ void parse_CLI_options(int argc, char** argv)
 			oargs.mode = SCAP_MODE_LIVE;
 			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			modern_bpf_params.cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER;
-			modern_bpf_params.allocate_online_only = false;
+			modern_bpf_params.allocate_online_only = true;
 			oargs.engine_params = &modern_bpf_params;
 		}
 		if(!strcmp(argv[i], SCAP_FILE_OPTION))
@@ -905,9 +907,9 @@ void parse_CLI_options(int argc, char** argv)
 			modern_bpf_params.cpus_for_each_buffer = atoi(argv[++i]);
 		}
 		/* This should be used only with the modern probe */
-		if(!strcmp(argv[i], ALLOCATE_ONLINE_ONLY_MODE))
+		if(!strcmp(argv[i], ALL_AVAILABLE_CPUS_MODE))
 		{
-			modern_bpf_params.allocate_online_only = true;
+			modern_bpf_params.allocate_online_only = false;
 		}
 
 

--- a/userspace/libscap/test/CMakeLists.txt
+++ b/userspace/libscap/test/CMakeLists.txt
@@ -22,6 +22,12 @@ set(LIBSCAP_UNIT_TESTS_SOURCES
     scap_event.ut.cpp
 )
 
+# Modern BPF is supported only on kernel versions >= 5.8.
+# To compile these tests you need to use the Cmake option `BUILD_LIBSCAP_MODERN_BPF=On`
+if(BUILD_LIBSCAP_MODERN_BPF)
+	list(APPEND LIBSCAP_UNIT_TESTS_SOURCES ./test_suites/engines/modern_bpf/modern_bpf.cpp)
+endif()
+
 if (BUILD_LIBSCAP_GVISOR)
 	list(APPEND LIBSCAP_UNIT_TESTS_SOURCES scap_gvisor_parsers.ut.cpp)
 	include_directories(../engine/gvisor)

--- a/userspace/libscap/test/README.md
+++ b/userspace/libscap/test/README.md
@@ -1,0 +1,20 @@
+# Scap tests
+
+## Compile tests
+
+```bash
+cmake -DUSE_BUNDLED_DEPS=On -DBUILD_BPF=True -DCREATE_TEST_TARGETS=On -DBUILD_LIBSCAP_GVISOR=Off ..
+make unit-test-libscap
+```
+
+You can add tests for specific engines using their Cmake options:
+- `-DBUILD_LIBSCAP_MODERN_BPF=On`
+- `-BUILD_LIBSCAP_GVISOR=On`
+
+## Run tests
+
+From the build directory:
+
+```bash
+sudo ./libscap/test/unit-test-libscap
+```

--- a/userspace/libscap/test/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/userspace/libscap/test/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -1,0 +1,386 @@
+#include "scap.h"
+#include <gtest/gtest.h>
+#include <unordered_set>
+#include <syscall.h>
+
+/* We are supposing that if we overcome this threshold, all buffers are full */
+#define MAX_ITERATIONS 300
+
+scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, uint16_t cpus_for_each_buffer, bool online_only, std::unordered_set<uint32_t> tp_set = {}, std::unordered_set<uint32_t> ppm_sc_set = {})
+{
+	struct scap_open_args oargs = {
+		.engine_name = MODERN_BPF_ENGINE,
+		.mode = SCAP_MODE_LIVE,
+	};
+
+	/* If empty we fill with all tracepoints */
+	if(tp_set.empty())
+	{
+		for(int i = 0; i < TP_VAL_MAX; i++)
+		{
+			oargs.tp_of_interest.tp[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto tp : tp_set)
+		{
+			oargs.tp_of_interest.tp[tp] = 1;
+		}
+	}
+
+	/* If empty we fill with all syscalls */
+	if(ppm_sc_set.empty())
+	{
+		for(int i = 0; i < PPM_SC_MAX; i++)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto ppm_sc : ppm_sc_set)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[ppm_sc] = 1;
+		}
+	}
+
+	struct scap_modern_bpf_engine_params modern_bpf_params = {
+		.cpus_for_each_buffer = cpus_for_each_buffer,
+		.allocate_online_only = online_only,
+		.buffer_bytes_dim = buffer_dim,
+	};
+	oargs.engine_params = &modern_bpf_params;
+
+	return scap_open(&oargs, error_buf, rc);
+}
+
+void check_event_is_not_overwritten(scap_t* h)
+{
+	/* Start the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to start the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* When the number of events is fixed for `MAX_ITERATIONS` we consider all the buffers full, this is just an approximation */
+	scap_stats stats = {};
+	uint64_t last_num_events = 0;
+	uint16_t iterations = 0;
+
+	while(iterations < MAX_ITERATIONS || stats.n_drops == 0)
+	{
+		ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS) << "unable to get stats: " << scap_getlasterr(h) << std::endl;
+		if(last_num_events == (stats.n_evts - stats.n_drops))
+		{
+			iterations++;
+		}
+		else
+		{
+			iterations = 0;
+			last_num_events = (stats.n_evts - stats.n_drops);
+		}
+	}
+
+	/* Stop the capture */
+	ASSERT_EQ(scap_stop_capture(h), SCAP_SUCCESS) << "unable to stop the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* The idea here is to check if an event is overwritten while we still have a pointer to it.
+	 * Again this is only an approximation, we don't know if new events will be written in the buffer
+	 * under test...
+	 *
+	 * We call `scap_next` keeping the pointer to the event.
+	 * An event pointer becomes invalid when we call another `scap_next`, but until that moment it should be valid!
+	 */
+	scap_evt* evt = NULL;
+	uint16_t buffer_id;
+
+	/* The first 'scap_next` could return a `SCAP_TIMEOUT` according to the chosen `buffer_mode` so we ignore it. */
+	scap_next(h, &evt, &buffer_id);
+
+	ASSERT_EQ(scap_next(h, &evt, &buffer_id), SCAP_SUCCESS) << "unable to get an event with `scap_next`: " << scap_getlasterr(h) << std::endl;
+
+	last_num_events = 0;
+	iterations = 0;
+
+	/* We save some event info to check if they are still valid after some new events */
+	uint64_t prev_ts = evt->ts;
+	uint64_t prev_tid = evt->tid;
+	uint32_t prev_len = evt->len;
+	uint16_t prev_type = evt->type;
+	uint32_t prev_nparams = evt->nparams;
+
+	/* Start again the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to restart the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* We use the same approximation as before */
+	while(iterations < MAX_ITERATIONS)
+	{
+		ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS) << "unable to get stats: " << scap_getlasterr(h) << std::endl;
+		if(last_num_events == (stats.n_evts - stats.n_drops))
+		{
+			iterations++;
+		}
+		else
+		{
+			iterations = 0;
+			last_num_events = (stats.n_evts - stats.n_drops);
+		}
+	}
+
+	/* We check if the previously collected event is still valid */
+	ASSERT_EQ(prev_ts, evt->ts) << "different timestamp" << std::endl;
+	ASSERT_EQ(prev_tid, evt->tid) << "different thread id" << std::endl;
+	ASSERT_EQ(prev_len, evt->len) << "different event len" << std::endl;
+	ASSERT_EQ(prev_type, evt->type) << "different event type" << std::endl;
+	ASSERT_EQ(prev_nparams, evt->nparams) << "different num params" << std::endl;
+}
+
+TEST(modern_bpf, open_engine)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* we want 1 ring buffer for each CPU */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine: " << error_buffer << std::endl;
+	scap_close(h);
+}
+
+TEST(modern_bpf, empty_buffer_dim)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 0, 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is 0, we should fail: " << error_buffer << std::endl;
+	/* In case of failure the `scap_close(h)` is already called in the vtable `init` method */
+}
+
+TEST(modern_bpf, wrong_buffer_dim)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* ring buffer dim is not a multiple of PAGE_SIZE */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 + 4 * 4096, 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is not a multiple of the page size, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, not_enough_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_possible_CPUs + 1, false);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater than the system possible CPUs, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, not_enough_online_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_online_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_online_CPUs + 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater than the system online CPUs, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, one_buffer_per_possible_CPU)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer << std::endl;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+	uint32_t num_expected_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_expected_rings, num_possible_CPUs) << "we should have a ring buffer for every possible CPU!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, one_buffer_every_two_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 2, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer every 2 CPUs: " << error_buffer << std::endl;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+	uint32_t num_expected_rings = num_possible_CPUs / 2;
+	if(num_possible_CPUs % 2 != 0)
+	{
+		num_expected_rings++;
+	}
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, num_expected_rings) << "we should have one ring buffer every 2 CPUs!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, one_buffer_shared_between_all_possible_CPUs_with_special_value)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* `0` is a special value that means one single shared ring buffer */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, 1) << "we should have only one ring buffer shared between all CPUs!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+/* In this test we don't need to check for buffer corruption with `check_event_is_not_overwritten`
+ * we have already done it in the previous test `one_buffer_shared_between_all_CPUs_with_special_value`.
+ */
+TEST(modern_bpf, one_buffer_shared_between_all_online_CPUs_with_explicit_CPUs_number)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_possible_CPUs, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, 1) << "we should have only one ring buffer shared between all CPUs!" << std::endl;
+
+	scap_close(h);
+}
+
+#if defined(__NR_close) && defined(__NR_openat) && defined(__NR_listen) && defined(__NR_accept4) && defined(__NR_getegid) && defined(__NR_getgid) && defined(__NR_geteuid) && defined(__NR_getuid) && defined(__NR_bind) && defined(__NR_connect) && defined(__NR_sendto) && defined(__NR_sendmsg) && defined(__NR_recvmsg) && defined(__NR_recvfrom) && defined(__NR_socket) && defined(__NR_socketpair)
+
+/* Number of events we want to assert */
+#define EVENTS_TO_ASSERT 32
+
+void check_event_order(scap_t* h)
+{
+	uint32_t events_to_assert[EVENTS_TO_ASSERT] = {PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X, PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X, PPME_SOCKET_ACCEPT4_5_E, PPME_SOCKET_ACCEPT4_5_X, PPME_SYSCALL_GETEGID_E, PPME_SYSCALL_GETEGID_X, PPME_SYSCALL_GETGID_E, PPME_SYSCALL_GETGID_X, PPME_SYSCALL_GETEUID_E, PPME_SYSCALL_GETEUID_X, PPME_SYSCALL_GETUID_E, PPME_SYSCALL_GETUID_X, PPME_SOCKET_BIND_E, PPME_SOCKET_BIND_X, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X, PPME_SOCKET_SENDTO_E, PPME_SOCKET_SENDTO_X, PPME_SOCKET_SENDMSG_E, PPME_SOCKET_SENDMSG_X, PPME_SOCKET_RECVMSG_E, PPME_SOCKET_RECVMSG_X, PPME_SOCKET_RECVFROM_E, PPME_SOCKET_RECVFROM_X, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X, PPME_SOCKET_SOCKETPAIR_E, PPME_SOCKET_SOCKETPAIR_X};
+
+	/* Start the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to start the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* 1. Generate a `close` event pair */
+	syscall(__NR_close, -1);
+
+	/* 2. Generate an `openat` event pair */
+	syscall(__NR_openat, 0, "/**mock_path**/", 0, 0);
+
+	/* 3. Generate a `listen` event pair */
+	syscall(__NR_listen, -1, -1);
+
+	/* 4. Generate an `accept4` event pair */
+	syscall(__NR_accept4, -1, NULL, NULL, 0);
+
+	/* 5. Generate a `getegid` event pair */
+	syscall(__NR_getegid);
+
+	/* 6. Generate a `getgid` event pair */
+	syscall(__NR_getgid);
+
+	/* 7. Generate a `geteuid` event pair */
+	syscall(__NR_geteuid);
+
+	/* 8. Generate a `getuid` event pair */
+	syscall(__NR_getuid);
+
+	/* 9. Generate a `bind` event pair */
+	syscall(__NR_bind, -1, NULL, 0);
+
+	/* 10. Generate a `connect` event pair */
+	syscall(__NR_connect, -1, NULL, 0);
+
+	/* 11. Generate a `sendto` event pair */
+	syscall(__NR_sendto, -1, NULL, 0, 0, NULL, 0);
+
+	/* 12. Generate a `sendmsg` event pair */
+	syscall(__NR_sendmsg, -1, NULL, 0);
+
+	/* 13. Generate a `recvmsg` event pair */
+	syscall(__NR_recvmsg, -1, NULL, 0);
+
+	/* 14. Generate a `recvmsg` event pair */
+	syscall(__NR_recvfrom, -1, NULL, 0, 0, NULL, 0);
+
+	/* 15. Generate a `socket` event pair */
+	syscall(__NR_socket, 0, 0, 0);
+
+	/* 16. Generate a `socketpair` event pair */
+	syscall(__NR_socketpair, 0, 0, 0, 0);
+
+	/* Stop the capture */
+	ASSERT_EQ(scap_stop_capture(h), SCAP_SUCCESS) << "unable to stop the capture: " << scap_getlasterr(h) << std::endl;
+
+	scap_evt* evt = NULL;
+	uint16_t buffer_id = 0;
+	int ret = 0;
+	uint64_t acutal_pid = getpid();
+	/* if we hit 5 consecutive timeouts it means that all buffers are empty (approximation) */
+	uint16_t timeouts = 0;
+
+	for(int i = 0; i < EVENTS_TO_ASSERT; i++)
+	{
+		while(true)
+		{
+			ret = scap_next(h, &evt, &buffer_id);
+			if(ret == SCAP_SUCCESS)
+			{
+				timeouts = 0;
+				if(evt->tid == acutal_pid && evt->type == events_to_assert[i])
+				{
+					/* We found our event */
+					break;
+				}
+			}
+			else if(ret == SCAP_TIMEOUT)
+			{
+				timeouts++;
+				if(timeouts == 5)
+				{
+					FAIL() << "we didn't find event '" << events_to_assert[i] << "' at position '" << i << "'" << std::endl;
+				}
+			}
+		}
+	}
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_per_online_CPU)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 1, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_every_two_online_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 2, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer every 2 CPUs: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_shared_between_all_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}
+#endif

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -194,7 +194,7 @@ void open_engine(sinsp& inspector)
 	}
 	else if(!engine_string.compare(MODERN_BPF_ENGINE))
 	{
-		inspector.open_modern_bpf(buffer_bytes_dim, ppm_sc, tp_set);
+		inspector.open_modern_bpf(buffer_bytes_dim, DEFAULT_CPU_FOR_EACH_BUFFER, true, ppm_sc, tp_set);
 	}
 	else
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -606,7 +606,7 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	set_get_procs_cpu_from_driver(false);
 }
 
-void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
+void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus_for_each_buffer, bool online_only, const std::unordered_set<uint32_t> &ppm_sc_of_interest, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	scap_open_args oargs = factory_open_args(MODERN_BPF_ENGINE, SCAP_MODE_LIVE);
 
@@ -617,6 +617,8 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, const std::un
 	/* Engine-specific args. */
 	struct scap_modern_bpf_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
+	params.cpus_for_each_buffer = cpus_for_each_buffer;
+	params.allocate_online_only = online_only;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -223,7 +223,11 @@ public:
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
-	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
+	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
+	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
+	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.
+	 */
+	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
 	virtual void open_test_input(scap_test_input_data *data);
 
 	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);


### PR DESCRIPTION
I want to highlight that these features are experimental, which means they could change over libs releases. More in general all the modern probe is still experimental so don't expect to have a stable interface at least for this release :)

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libscap-engine-modern-bpf

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

The way in which the modern probe references memory is a little bit different from the old BPF probe.
Usually, we ask our drivers to open an 8 MB buffer for every CPU, so the kernel allocates 8 MB, and then the userspace map this memory 2 times in order to efficiently read collected events. This is not completely true in the modern BPF probe. When we ask to allocate 8 MB, the kernel under the hood maps this dimension 2 times (https://github.com/torvalds/linux/blob/5a41237ad1d4b62008f93163af1d9b1da90729d8/kernel/bpf/ringbuf.c#L107-L123), in this way both kernel and user-space implementations are simplified and they are also more efficient. Then the userspace will map the entire 16 MB exposed by the kernel. So, in the end, the virtual space of the process will be the same with modern and old BPF, what changes is the referenced memory since in one case we have only 8 MB while in the other we have 16 MB!

Here we have an example just to be surer explicit: we have 8 available CPUs and we allocate a 1 GB ring buffer for each one:

```
PID    USER      PR  NI    VIRT    RES    SHR  S     %CPU       %MEM     TIME+ COMMAND   
32257 root      20   0     16,0g  16,0g  16,0g S      3,0       51,6     0:01.31 scap-open (with modern bpf) 
32647 root      20   0     16,1g   8,1g   8,1g S      1,7       26,2     0:01.73 scap-open (with old probe)
```

This could become an issue if we have many CPUs or if we want buffer greater than 8 MB. This is the reason behind this patch!
Now the modern bpf engine exposes 2 new params:

* `cpus_for_each_buffer`,  allows users to specify how many CPUs they want to associate with a ring buffer. For example, `cpus_for_each_buffer = 1` means that we want a ring buffer for every CPU, so like today, `cpus_for_each_buffer = 2` means that we want a ring buffer every 2 CPUs, so a ring buffer will be shared between 2 CPUs. `0` is a special value and means that we want only a ring buffer shared between all the CPUs.
The rule is: `cpus_for_each_buffer` must `>=0` and `<=max_possible_CPUs_in_the_system`. 
`cpus_for_each_buffer=0` and `cpus_for_each_buffer=max_possible_CPUs_in_the_system` do exactly the same thing, 0 is just a simpler way to specify it without knowing the available CPU of our system.
* `allocate_online_only` allows user to allocate ring buffers only for online CPUs. Before this patch, the modern probe allocated a ring buffer for every available CPU and not for online CPUs! This param can be used in combination with `cpus_for_each_buffer` so also in this case we can associate more than one CPU to a ring buffer.



I think that these 2 new parameters could offer great flexibility to the end user.  
Let's consider a final example to clarify the solution. Let's imagine we have a system with `8` CPUs. With the old probe, we will have an 8 MB buffer for every CPU (therefore a total of 64 MB). With the modern probe, we have different ways to obtain the same referenced memory:
* a 4 MB ring buffer for every CPU
* an 8 MB ring buffer for every CPU pair
* a 32 MB ring buffer shared between all the 8 CPUs

Which is the best solution really depends on your system load, but now you have the power to find the optimal solution for your deployment

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
 
The PR seems huge but most of the lines are due to tests or comments :) 

**Does this PR introduce a user-facing change?**:

```release-note
new(modern_bpf):  support variable number of ring buffers and online CPUs
```
