### PR TITLE
new(libsinsp): `sinsp_repair_state_sc_set` ppm sc API

### DIFF
--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -190,18 +190,28 @@ set<ppm_sc_code> names_to_sc_set(const std::unordered_set<std::string>& syscalls
 set<ppm_event_code> sc_set_to_event_set(const set<ppm_sc_code> &ppm_sc_of_interest);
 
 /*!
-  * \brief [Experimental] Enforce sinsp state `ppm_sc` set conditioned by filter `ppm_sc` set.
-  * This has a resource-conscious effect in that the driver only subscribes to a set of `ppm_sc`
-  * that is effectively needed for the absolute minimum sinsp state build-up and
-  * life-cycle management.
+  * \brief [Experimental]
+  * Enforce minimum sinsp state `ppm_sc` set conditioned by filter `ppm_sc` set.
   * 
-  * In addition, this option can be used to "repair" a custom set of user defined `ppm_sc`
-  * to ensure Falco runs correctly.
+  * Use Cases:
   * 
-  * TODO @incertum create new e2e test format to model sinsp state dependencies.
+  * (1) Resourceful minimal sinsp state enforcement. The driver only activates a set of `ppm_sc`
+  *     that is needed based on the current `ppm_sc` configuration from filter(s).
+  * 
+  * (2) "repair" a custom set of user defined `ppm_sc` to ensure the agent runs correctly.
+  *     This setting is useful for cases where the end user takes advantage of complete default
+  *     sinsp state enforcement override, but still would like to rely on some safety minimal sinsp
+  *     state enforcement mechanisms.
+  * 
+  * `sinsp_repair_state_sc_set` is a more resourceful alternative to the default `sinsp_state_sc_set`
+  * option as it takes the filter `ppm_sc` set into consideration when selecting the effective set of
+  * `ppm_sc` that needs to be activated in addition to the filter `ppm_sc` set.
+  * 
+  * todo: possibly extend e2e tests.
   *
   * @param ppm_sc_set set of `ppm_sc` from filter(s)
   * @return sinsp state compliant set of `ppm_sc` conditioned by set of `ppm_sc` from filter(s)
+  *         -> the returned set includes the set of `ppm_sc` from filter(s)
 */
 set<ppm_sc_code> sinsp_repair_state_sc_set(const set<ppm_sc_code>& ppm_sc_set);
 

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -189,6 +189,23 @@ set<ppm_sc_code> names_to_sc_set(const std::unordered_set<std::string>& syscalls
  */
 set<ppm_event_code> sc_set_to_event_set(const set<ppm_sc_code> &ppm_sc_of_interest);
 
+/*!
+  * \brief [Experimental] Enforce sinsp state `ppm_sc` set conditioned by filter `ppm_sc` set.
+  * This has a resource-conscious effect in that the driver only subscribes to a set of `ppm_sc`
+  * that is effectively needed for the absolute minimum sinsp state build-up and
+  * life-cycle management.
+  * 
+  * In addition, this option can be used to "repair" a custom set of user defined `ppm_sc`
+  * to ensure Falco runs correctly.
+  * 
+  * TODO @incertum create new e2e test format to model sinsp state dependencies.
+  *
+  * @param ppm_sc_set set of `ppm_sc` from filter(s)
+  * @return sinsp state compliant set of `ppm_sc` conditioned by set of `ppm_sc` from filter(s)
+*/
+set<ppm_sc_code> sinsp_repair_state_sc_set(const set<ppm_sc_code>& ppm_sc_set);
+
+
 /*=============================== PPM_SC set related (sinsp_events_ppm_sc.cpp) ===============================*/
 
 /*=============================== PPME set related (sinsp_events.cpp) ===============================*/

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -385,5 +385,8 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_repair_state_sc_set(c
 		repaired_sinsp_state_sc_set.insert(PPM_SC_CLOSE);
 	}
 
+	/* Enforce proc exit tp as safety even if enforced elsewhere. */
+	repaired_sinsp_state_sc_set.insert(PPM_SC_SCHED_PROCESS_EXIT);
+
 	return repaired_sinsp_state_sc_set;
 }

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -21,9 +21,9 @@ limitations under the License.
 /*
  * Repair base syscalls flags.
  */
-#define PPM_ADAPTIVE_SC_NETWORK_BASE (1 << 0)
-#define PPM_ADAPTIVE_SC_NETWORK_BIND (1 << 1)
-#define PPM_ADAPTIVE_SC_FD_CLOSE (1 << 2)
+#define PPM_REPAIR_STATE_SC_NETWORK_BASE (1 << 0)
+#define PPM_REPAIR_STATE_SC_NETWORK_BIND (1 << 1)
+#define PPM_REPAIR_STATE_SC_FD_CLOSE (1 << 2)
 
 
 libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_state_sc_set()
@@ -326,21 +326,21 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_repair_state_sc_set(c
 	uint32_t flags = 0;
 	if (!libsinsp::events::net_sc_set().intersect(ppm_sc_set).empty())
 	{
-		flags |= PPM_ADAPTIVE_SC_NETWORK_BASE;
-		flags |= PPM_ADAPTIVE_SC_FD_CLOSE;
+		flags |= PPM_REPAIR_STATE_SC_NETWORK_BASE;
+		flags |= PPM_REPAIR_STATE_SC_FD_CLOSE;
 	}
 
 	static libsinsp::events::set<ppm_sc_code> accept_listen_sc_set = {PPM_SC_ACCEPT, PPM_SC_ACCEPT4, PPM_SC_LISTEN};
 	if (!accept_listen_sc_set.intersect(ppm_sc_set).empty())
 	{
-		flags |= PPM_ADAPTIVE_SC_NETWORK_BIND;
+		flags |= PPM_REPAIR_STATE_SC_NETWORK_BIND;
 	}
 
 	if (!libsinsp::events::file_sc_set().intersect(ppm_sc_set).empty() ||
 		!libsinsp::events::io_sc_set().intersect(ppm_sc_set).empty() ||
 		!libsinsp::events::io_other_sc_set().intersect(ppm_sc_set).empty())
 	{
-		flags |= PPM_ADAPTIVE_SC_FD_CLOSE;
+		flags |= PPM_REPAIR_STATE_SC_FD_CLOSE;
 	}
 
 	/* These syscalls are used to build up or modify info of the basic process (tinfo) struct.
@@ -369,16 +369,16 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_repair_state_sc_set(c
 		PPM_SC_SETUID32,
 	};
 
-	if ((flags & PPM_ADAPTIVE_SC_NETWORK_BASE))
+	if ((flags & PPM_REPAIR_STATE_SC_NETWORK_BASE))
 	{
 		repaired_sinsp_state_sc_set.insert(PPM_SC_SOCKET);
 		repaired_sinsp_state_sc_set.insert(PPM_SC_GETSOCKOPT);
 	}
-	if ((flags & PPM_ADAPTIVE_SC_NETWORK_BIND))
+	if ((flags & PPM_REPAIR_STATE_SC_NETWORK_BIND))
 	{
 		repaired_sinsp_state_sc_set.insert(PPM_SC_BIND);
 	}
-	if ((flags & PPM_ADAPTIVE_SC_FD_CLOSE))
+	if ((flags & PPM_REPAIR_STATE_SC_FD_CLOSE))
 	{
 		repaired_sinsp_state_sc_set.insert(PPM_SC_CLOSE);
 	}

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -333,9 +333,7 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_repair_state_sc_set(c
 	static libsinsp::events::set<ppm_sc_code> accept_listen_sc_set = {PPM_SC_ACCEPT, PPM_SC_ACCEPT4, PPM_SC_LISTEN};
 	if (!accept_listen_sc_set.intersect(ppm_sc_set).empty())
 	{
-		flags |= PPM_ADAPTIVE_SC_NETWORK_BASE;
 		flags |= PPM_ADAPTIVE_SC_NETWORK_BIND;
-		flags |= PPM_ADAPTIVE_SC_FD_CLOSE;
 	}
 
 	if (!libsinsp::events::file_sc_set().intersect(ppm_sc_set).empty() ||
@@ -388,5 +386,6 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_repair_state_sc_set(c
 	/* Enforce proc exit tp as safety even if enforced elsewhere. */
 	repaired_sinsp_state_sc_set.insert(PPM_SC_SCHED_PROCESS_EXIT);
 
-	return repaired_sinsp_state_sc_set;
+	/* Merge input sc set with sinsp_state_sc_set and return a complete "repaired" set. */
+	return repaired_sinsp_state_sc_set.merge(ppm_sc_set);
 }

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -162,3 +162,58 @@ TEST(interesting_syscalls, event_set_to_sc_set_generic_events)
 	ASSERT_TRUE(sc_set.contains(PPM_SC_INIT_MODULE));
 	ASSERT_TRUE(sc_set.contains(PPM_SC_READLINKAT));
 }
+
+TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
+{
+    libsinsp::events::set<ppm_sc_code> truth;
+    libsinsp::events::set<ppm_sc_code> input_sc_set;
+    libsinsp::events::set<ppm_sc_code> sc_set;
+
+    truth = libsinsp::events::names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
+        "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
+		"setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+    truth = libsinsp::events::names_to_sc_set({
+        "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "connect",
+        "execve", "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect", "accept", "accept4"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+    truth = libsinsp::events::names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "close", "connect", "execve", "execveat",
+        "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+    truth = libsinsp::events::names_to_sc_set({
+        "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "execve",
+        "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "accept", "accept4"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+    truth = libsinsp::events::names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
+        "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
+		"setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+    truth = libsinsp::events::names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "close", "execve", "execveat", "fchdir", "fork", "open", "openat", "openat2",
+        "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::names_to_sc_set({"open", "openat", "openat2"});
+    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
+
+}

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -169,10 +169,12 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     libsinsp::events::set<ppm_sc_code> input_sc_set;
     libsinsp::events::set<ppm_sc_code> sc_set;
 
+    /* todo: @incertum update / revisit once names_to_sc_set is refactored featuring new tp names as well. */
     truth = libsinsp::events::names_to_sc_set({
         "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
         "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
-		"setuid", "setuid32", "vfork"});
+        "setuid", "setuid32", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
@@ -180,7 +182,8 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     truth = libsinsp::events::names_to_sc_set({
         "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "connect",
         "execve", "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect", "accept", "accept4"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
@@ -188,7 +191,8 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     truth = libsinsp::events::names_to_sc_set({
         "capset", "chdir", "chroot", "clone", "clone3", "close", "connect", "execve", "execveat",
         "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
@@ -196,7 +200,8 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     truth = libsinsp::events::names_to_sc_set({
         "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "execve",
         "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "accept", "accept4"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
@@ -204,14 +209,17 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     truth = libsinsp::events::names_to_sc_set({
         "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
         "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
-		"setuid", "setuid32", "vfork"});
+        "setuid", "setuid32", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
     truth = libsinsp::events::names_to_sc_set({
-        "capset", "chdir", "chroot", "clone", "clone3", "close", "execve", "execveat", "fchdir", "fork", "open", "openat", "openat2",
-        "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"});
+        "capset", "chdir", "chroot", "clone", "clone3", "close", "execve", "execveat", "fchdir", "fork",
+        "open", "openat", "openat2", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"})\
+        .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"open", "openat", "openat2"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -176,7 +176,7 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
         "setuid", "setuid32", "vfork"})\
         .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
-    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
     truth = libsinsp::events::names_to_sc_set({
@@ -185,7 +185,7 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
         "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
         .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect", "accept", "accept4"});
-    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
     truth = libsinsp::events::names_to_sc_set({
@@ -194,7 +194,7 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
         "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
         .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect"});
-    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
     truth = libsinsp::events::names_to_sc_set({
@@ -203,7 +203,7 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
         "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
         .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"execve", "accept", "accept4"});
-    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
     truth = libsinsp::events::names_to_sc_set({
@@ -221,7 +221,7 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
         "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"})\
         .merge({PPM_SC_SCHED_PROCESS_EXIT});
     input_sc_set = libsinsp::events::names_to_sc_set({"open", "openat", "openat2"});
-    sc_set = sinsp_repair_state_sc_set(input_sc_set).merge(input_sc_set);
+    sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
 }


### PR DESCRIPTION
Signed-off-by: Melissa Kilby <melissa.kilby.oss@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Edited 2023-02-16:

Thanks to refactors in https://github.com/falcosecurity/libs/pull/877 and https://github.com/falcosecurity/libs/pull/854 stars have aligned to build out the adaptive base syscalls enforcement option based on the event types defined in the filter.

Why is this option needed?

Clients can now enable more resourceful kernel tracing in that only syscalls that are needed for sinsp state build-up and life-cycle management are subscribed to in addition to the syscalls defined in the filter string. In short, this new option is sinsp state compliant - conditioned by filter events / current configuration. This option can accomplish large cost savings, especially when the client needs to feature different modes of monitoring according to a cost budget. All configurations are supported, e.g. the most minimal configuration possible is solely monitoring spawned processes nothing else.

Integration proposal:
- Introduce as "experimental"
- Create new e2e test format to verify validity in addition to the new unit tests
- If successful, feature as stable API


Example:

```
sudo ./libsinsp/examples/sinsp-example -b driver/bpf/probe.o -f "(evt.type in (execve, execveat, connect, accept))" -o "*%proc.exepath %proc.cmdline %proc.exe_ino" -x
-- Filter event types names: accept, connect, execve, execveat
-- Try to open: 'bpf' engine.
-- Option adaptive base syscalls set
-- (25) syscalls activated in total: accept, accept4, bind, capset, chdir, chroot, clone, clone3, close, connect, execve, execveat, fchdir, fork, getsockopt, setgid, setpgid, setresgid, setresgid32, setresuid, setresuid32, setsid, setuid, socket, vfork
driver/bpf/probe.o
-- Engine 'bpf' correctly opened.
-- Start capture
```


**Which issue(s) this PR fixes**:

Inability to customize libs clients and run agents in a more cost saving mode.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): feature adaptive base syscalls option in ppm sc API
```
