### PR TITLE
fix(driver): extend modern bpf test framework to all drivers (part 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
           sudo ./libscap/examples/01-open/scap-open --kmod --num_events 0
           sudo rmmod scap
 
-  build-and-test-modern-bpf-x86:
-    name: build-and-test-modern-bpf-x86 😇 (bundled_deps)
+  test-drivers-x86:
+    name: test-drivers-x86 😇 (bundled_deps)
     runs-on: ubuntu-22.04
     needs: paths-filter
     if: needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'
@@ -232,11 +232,22 @@ jobs:
           mkdir -p build
           cd build && cmake -DUSE_BUNDLED_DEPS=ON -DENABLE_DRIVERS_TESTS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_BPF=True -DBUILD_LIBSCAP_GVISOR=OFF ../
           make drivers_test
+          make driver bpf
 
       - name: Run drivers_test with modern bpf 🏎️
         run: |
           cd build
           sudo ./test/drivers/drivers_test -m
+
+      - name: Run drivers_test with bpf 🏎️
+        run: |
+          cd build
+          sudo ./test/drivers/drivers_test -b
+
+      - name: Run drivers_test with kmod 🏎️
+        run: |
+          cd build
+          sudo ./test/drivers/drivers_test -k
 
   build-modern-bpf-arm64:
     name: build-modern-bpf-arm64 🙃 (system_deps)
@@ -266,7 +277,6 @@ jobs:
             .github/install-deps.sh
             mkdir -p build
             cd build && cmake -DUSE_BUNDLED_DEPS=OFF -DENABLE_DRIVERS_TESTS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_LIBSCAP_GVISOR=OFF ../
-            make scap-open
             make drivers_test
 
   build-modern-bpf-s390x:

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1038,6 +1038,23 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	return PPM_SUCCESS;
 }
 
+static __always_inline int bpf_push_empty_param(struct filler_data *data)
+{
+	/* This is not so necessary but just keep it for compliance with other helpers */
+	if (data->state->tail_ctx.curarg >= PPM_MAX_EVENT_PARAMS) {
+		bpf_printk("invalid curarg: %d\n", data->state->tail_ctx.curarg);
+		return PPM_FAILURE_BUG;
+	}
+
+	/* We push 0 in the length array */
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, 0);
+	data->curarg_already_on_frame = false;
+
+	/* We increment the current argument */
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
 static __always_inline int bpf_val_to_ring(struct filler_data *data,
 					   unsigned long val)
 {

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2380,14 +2380,14 @@ FILLER(proc_startupdate, true)
 		/*
 		 * exe
 		 */
-		res = bpf_val_to_ring_type(data, (unsigned long)&empty, PT_CHARBUF);
+		res = bpf_push_empty_param(data);
 		if (res != PPM_SUCCESS)
 			return res;
 
 		/*
 		 * Args
 		 */
-		res = bpf_val_to_ring_type(data, 0, PT_BYTEBUF);
+		res = bpf_push_empty_param(data);
 		if (res != PPM_SUCCESS)
 			return res;
 	}
@@ -2424,7 +2424,7 @@ FILLER(proc_startupdate, true)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+	res = bpf_push_empty_param(data);
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -4396,7 +4396,7 @@ FILLER(sys_sendmsg_x, true)
 	if(retval < 0)
 	{
 		/* Parameter 2: data (type: PT_BYTEBUF) */
-		return bpf_val_to_ring(data, 0);
+		return bpf_push_empty_param(data);
 	}
 
 	/*
@@ -5308,7 +5308,7 @@ FILLER(sys_quotactl_x, true)
 		if (res != PPM_SUCCESS)
 			return res;
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+		res = bpf_push_empty_param(data);
 		if (res != PPM_SUCCESS)
 			return res;
 	}
@@ -6159,14 +6159,14 @@ FILLER(sched_prog_exec, false)
 	else
 	{
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+		res = bpf_push_empty_param(data);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
 		}
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		res = bpf_val_to_ring_type(data, 0, PT_BYTEBUF);
+		res = bpf_push_empty_param(data);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
@@ -6202,7 +6202,7 @@ FILLER(sched_prog_exec, false)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+	res = bpf_push_empty_param(data);
 	if(res != PPM_SUCCESS)
 	{
 		return res;
@@ -6568,14 +6568,14 @@ FILLER(sched_prog_fork, false)
 	else
 	{
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+		res = bpf_push_empty_param(data);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
 		}
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		res = bpf_val_to_ring_type(data, 0, PT_BYTEBUF);
+		res = bpf_push_empty_param(data);
 		if(res != PPM_SUCCESS)
 		{
 			return res;
@@ -6611,7 +6611,7 @@ FILLER(sched_prog_fork, false)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = bpf_val_to_ring_type(data, 0, PT_CHARBUF);
+	res = bpf_push_empty_param(data);
 	if(res != PPM_SUCCESS)
 	{
 		return res;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4227,11 +4227,11 @@ FILLER(sys_recvmsg_x, true)
 		CHECK_RES(res);
 
 		/* Parameter 3: data (type: PT_BYTEBUF) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_push_empty_param(data);
 		CHECK_RES(res);
 
 		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
-		return bpf_val_to_ring(data, 0);
+		return bpf_push_empty_param(data);
 	}
 
 	/*

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3830,26 +3830,14 @@ FILLER(sys_sendfile_x, true)
 
 FILLER(sys_prlimit_e, true)
 {
-	unsigned long val;
-	u8 ppm_resource;
-	int res;
+	/* Parameter 1: pid (type: PT_PID) */
+	pid_t pid = (s32)bpf_syscall_get_argument(data, 0);
+	int res = bpf_val_to_ring(data, (s64)pid);
+	CHECK_RES(res);
 
-	/*
-	 * pid
-	 */
-	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
-
-	/*
-	 * resource
-	 */
-	val = bpf_syscall_get_argument(data, 1);
-	ppm_resource = rlimit_resource_to_scap(val);
-	res = bpf_val_to_ring(data, ppm_resource);
-
-	return res;
+	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
+	unsigned long resource = bpf_syscall_get_argument(data, 1);
+	return bpf_val_to_ring(data, rlimit_resource_to_scap(resource));
 }
 
 FILLER(sys_prlimit_x, true)

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
@@ -61,15 +61,15 @@ int BPF_PROG(getsockopt_x,
 	auxmap__store_s64_param(auxmap, (s64)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
-	u8 level = (u8)extract__syscall_argument(regs, 1);
+	int level = extract__syscall_argument(regs, 1);
 	auxmap__store_u8_param(auxmap, sockopt_level_to_scap(level));
 
 	/* Parameter 4: optname (type: PT_ENUMFLAGS8) */
-	u8 optname = (u8)extract__syscall_argument(regs, 2);
+	int optname = extract__syscall_argument(regs, 2);
 	auxmap__store_u8_param(auxmap, sockopt_optname_to_scap(level, optname));
 
 	/* `optval` and `optlen` will be the ones provided by the user if the syscall fails
-	 * otherwise they will be directly extracted from the socket.
+	 * otherwise they will refer to the real socket data since the kernel populated them.
 	 */
 
 	/* Parameter 5: optval (type: PT_DYN) */

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -36,7 +36,7 @@ or GPL2.txt for full copies of the license.
 
 typedef u64 nanoseconds;
 
-/* This is an auxiliary `__kernel_timex_timeval` struct we use in setsockopt
+/* This is an auxiliary struct we use in setsockopt
  * when `__kernel_timex_timeval` struct is not defined.
  */
 struct __aux_timeval {

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -641,6 +641,34 @@ done:
 }
 #endif // UDIG
 
+int push_empty_param(struct event_filler_arguments *args)
+{
+	u16 *psize = (u16 *)(args->buffer + args->curarg * sizeof(u16));
+
+	if (unlikely(args->curarg >= args->nargs))
+	{
+#ifndef UDIG
+		pr_err("(%u)val_to_ring: too many arguments for event #%u, type=%u, curarg=%u, nargs=%u tid:%u\n",
+			smp_processor_id(),
+			args->nevents,
+			(u32)args->event_type,
+			args->curarg,
+			args->nargs,
+			current->pid);
+		memory_dump(args->buffer - sizeof(struct ppm_evt_hdr), 32);
+#endif
+		ASSERT(0);
+		return PPM_FAILURE_BUG;
+	}
+
+	/* We push 0 in the length array */
+	*psize = 0;
+
+	/* We increment the current argument */
+	args->curarg++;
+	return PPM_SUCCESS;
+}
+
 /*
  * NOTES:
  * - val_len is ignored for everything other than PT_BYTEBUF.

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -107,6 +107,7 @@ extern const struct ppm_event_entry g_ppm_events[];
  * Functions
  */
 int32_t dpi_lookahead_init(void);
+int32_t push_empty_param(struct event_filler_arguments *args);
 int32_t val_to_ring(struct event_filler_arguments *args, u64 val, u32 val_len, bool fromuser, u8 dyn_idx);
 u16 pack_addr(struct sockaddr *usrsockaddr, int ulen, char *targetbuf, u16 targetbufsize);
 u16 fd_to_socktuple(int fd, struct sockaddr *usrsockaddr, int ulen, bool use_userdata, bool is_inbound, char *targetbuf, u16 targetbufsize);

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -965,7 +965,7 @@ int f_proc_startupdate(struct event_filler_arguments *args)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = val_to_ring(args, 0, 0, false, 0);
+	res = push_empty_param(args);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -2749,7 +2749,7 @@ int f_sys_sendmsg_x(struct event_filler_arguments *args)
 	if(retval < 0)
 	{
 		/* Parameter 2: data (type: PT_BYTEBUF) */
-		res = val_to_ring(args, 0, 0, false, 0);
+		res = push_empty_param(args);
 		CHECK_RES(res);
 
 		return add_sentinel(args);
@@ -6879,7 +6879,7 @@ int f_sched_prog_exec(struct event_filler_arguments *args)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = val_to_ring(args, 0, 0, false, 0);
+	res = push_empty_param(args);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;
@@ -7249,7 +7249,7 @@ int f_sched_prog_fork(struct event_filler_arguments *args)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
-	res = val_to_ring(args, 0, 0, false, 0);
+	res = push_empty_param(args);
 	if(unlikely(res != PPM_SUCCESS))
 	{
 		return res;

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -5871,56 +5871,49 @@ int f_sys_sendfile_x(struct event_filler_arguments *args)
 
 int f_sys_quotactl_e(struct event_filler_arguments *args)
 {
-	unsigned long val;
-	int res;
-	uint32_t id;
-	uint8_t quota_fmt;
-	uint16_t cmd;
+	unsigned long val = 0;
+	int res = 0;
+	uint32_t id = 0;
+	uint8_t quota_fmt = 0;
+	uint32_t cmd = 0;
+	uint16_t scap_cmd = 0;
 
-	/*
-	 * extract cmd
-	 */
+	/* Parameter 1: cmd (type: PT_FLAGS16) */
 	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
-	cmd = quotactl_cmd_to_scap(val);
-	res = val_to_ring(args, cmd, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	cmd = (uint32_t)val;
+	scap_cmd = quotactl_cmd_to_scap(cmd);
+	res = val_to_ring(args, scap_cmd, 0, false, 0);
+	CHECK_RES(res);
 
-	/*
-	 * extract type
-	 */
-	res = val_to_ring(args, quotactl_type_to_scap(val), 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	/* Parameter 2: type (type: PT_FLAGS8) */
+	res = val_to_ring(args, quotactl_type_to_scap(cmd), 0, false, 0);
+	CHECK_RES(res);
 
-	/*
-	 *  extract id
-	 */
-	id = 0;
+	/* Parameter 3: id (type: PT_UINT32) */
 	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
-	if ((cmd == PPM_Q_GETQUOTA) ||
-		 (cmd == PPM_Q_SETQUOTA) ||
-		 (cmd == PPM_Q_XGETQUOTA) ||
-		 (cmd == PPM_Q_XSETQLIM)) {
-		/*
-		 * in this case id represent an userid or groupid so add it
-		 */
-		id = val;
+	id = (u32)val;
+	if ((scap_cmd != PPM_Q_GETQUOTA) &&
+		 (scap_cmd != PPM_Q_SETQUOTA) &&
+		 (scap_cmd != PPM_Q_XGETQUOTA) &&
+		 (scap_cmd != PPM_Q_XSETQLIM))
+	{
+		/* In this case `id` don't represent a `userid` or a `groupid` */
+		res = val_to_ring(args, 0, 0, false, 0);
 	}
-	res = val_to_ring(args, id, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	else
+	{
+		res = val_to_ring(args, id, 0, false, 0);
+	}
+	CHECK_RES(res);
 
-	/*
-	 * extract quota_fmt from id
-	 */
+	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
 	quota_fmt = PPM_QFMT_NOT_USED;
-	if (cmd == PPM_Q_QUOTAON)
-		quota_fmt = quotactl_fmt_to_scap(val);
-
+	if(scap_cmd == PPM_Q_QUOTAON)
+	{
+		quota_fmt = quotactl_fmt_to_scap(id);
+	}
 	res = val_to_ring(args, quota_fmt, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	CHECK_RES(res);
 
 	return add_sentinel(args);
 }

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -2865,11 +2865,11 @@ int f_sys_recvmsg_x(struct event_filler_arguments *args)
 		CHECK_RES(res);
 
 		/* Parameter 3: data (type: PT_BYTEBUF) */
-		res = val_to_ring(args, 0, 0, false, 0);
+		res = push_empty_param(args);
 		CHECK_RES(res);
 
 		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
-		res = val_to_ring(args, 0, 0, false, 0);
+		res = push_empty_param(args);
 		CHECK_RES(res);
 
 		return add_sentinel(args);

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -4137,29 +4137,20 @@ int f_sys_getrlimit_setrlrimit_x(struct event_filler_arguments *args)
 
 int f_sys_prlimit_e(struct event_filler_arguments *args)
 {
-	u8 ppm_resource;
-	unsigned long val;
-	int res;
+	unsigned long val = 0;
+	int res = 0;
+	pid_t pid = 0;
 
-	/*
-	 * pid
-	 */
+	/* Parameter 1: pid (type: PT_PID) */
 	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	pid = (s32)val;
+	res = val_to_ring(args, (s64)pid, 0, false, 0);
+	CHECK_RES(res);
 
-	res = val_to_ring(args, val, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
-
-	/*
-	 * resource
-	 */
+	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
 	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
-
-	ppm_resource = rlimit_resource_to_scap(val);
-
-	res = val_to_ring(args, (uint64_t)ppm_resource, 0, false, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	res = val_to_ring(args, rlimit_resource_to_scap(val), 0, false, 0);
+	CHECK_RES(res);
 
 	return add_sentinel(args);
 }

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -22,6 +22,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/futex.h>
 #include <linux/ptrace.h>
 #include <linux/capability.h>
+#include <linux/eventpoll.h>
 #include "ppm.h"
 #ifdef __NR_io_uring_register
 #include <uapi/linux/io_uring.h>

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -155,6 +155,11 @@ event_test::event_test(int syscall_id, int event_direction):
 			m_event_type = PPME_GENERIC_X;
 		}
 
+		/* This logic is not needed by architectures that require the `CAPTURE_SCHED_PROC_FORK`
+		 * workaround, since `CAPTURE_SCHED_PROC_FORK` requires `BPF_RAW_TRACEPOINTS` and so
+		 * kernel versions >= 4.17
+		 */		
+#ifndef CAPTURE_SCHED_PROC_FORK  
 		if(is_bpf_engine())
 		{
 			/* The bpf engine retrieves syscall params from sys_enter tracepoints
@@ -171,6 +176,7 @@ event_test::event_test(int syscall_id, int event_direction):
 				m_tp_set[SCHED_PROC_FORK] = 1;
 			}
 		}
+#endif			
 	}
 
 	m_current_param = 0;

--- a/test/drivers/test_suites/syscall_enter_suite/prlimit64_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/prlimit64_e.cpp
@@ -14,7 +14,8 @@ TEST(SyscallEnter, prlimit64E)
 
 	struct rlimit* old_rlimit = NULL;
 	struct rlimit* new_rlimit = NULL;
-	pid_t pid = ::getpid();
+	/* We need to put the pid to `-1` otherwise the syscall won't fail on some machines. */
+	pid_t pid = -1;
 	int resource = RLIMIT_NOFILE;
 	assert_syscall_state(SYSCALL_FAILURE, "prlimit64", syscall(__NR_prlimit64, pid, resource, &new_rlimit, &old_rlimit));
 

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -189,6 +189,11 @@ TEST(SyscallExit, clone3X_child)
 #else
 	evt_test->assert_event_presence(ret_pid);
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
@@ -233,6 +233,11 @@ TEST(SyscallExit, cloneX_child)
 #else
 	evt_test->assert_event_presence(ret_pid);
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
@@ -178,6 +178,11 @@ TEST(SyscallExit, forkX_child)
 #else
 	evt_test->assert_event_presence(ret_pid);
 
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
 	evt_test->parse_event();
 
 	evt_test->assert_header();

--- a/test/drivers/test_suites/syscall_exit_suite/mlock2_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/mlock2_x.cpp
@@ -3,6 +3,7 @@
 #ifdef __NR_mlock2
 
 #include <sys/mman.h>
+#include <asm-generic/mman-common.h>
 
 TEST(SyscallExit, mlock2X)
 {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR belongs to the https://github.com/falcosecurity/libs/pull/783 series. It fixes some differences between the 3 drivers. It tries also to simplify code paths where possible.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I've to check the CI part, but I've tested it locally on the following machines:
* 5.11.0-051100 (x86)
* 5.15.0-1023 (x86)
* 4.14.276 (x86)
* 4.14.276 (aarch64)
* 5.15.0-1019 (aarch64)
* 5.11.0-051100 (s390x)
* 5.15.0-56-generic (s390x)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
