### PR TITLE
fix(userspace/libsinsp): avoid exception failure on unknown k8s node name

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2253,10 +2253,18 @@ void sinsp::validate_k8s_node_name()
 
 		if(!found)
 		{
-			throw sinsp_exception(
+			// todo(jasondellaluce): we used to throw an exception here, however
+			// at this point we have no guarantee on whether the provided node
+			// name is wrong or if there was a failure in the k8s client event
+			// parsing logic. As such, it's unsafe to throw an exception that
+			// can potentially terminate the libs consumer. For now, we stick
+			// to error-level logging, however this is an issue we may want to
+			// further investigate in the future.
+			// see: https://github.com/falcosecurity/falco/issues/2358
+			g_logger.log(
 				"Failing to enrich events with Kubernetes metadata: "
 				"node name does not correspond to a node in the cluster: "
-				+ *m_k8s_node_name);
+				+ *m_k8s_node_name, sinsp_logger::SEV_ERROR);
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When a node name is passed to the k8s client filtering, we throw an exception in case the node name is not found in the reconstructed k8s cluster state. However, this does not distinguish bad node names from unexpected/unpredictable parsing errors during the k8s cluster stare reconstruction. Since an exception can be blocking and cause consumers like Falco to terminate, the best option we have from a security/availability perspective is to log with error level instead of throwing an exception.

Of course, this is a workaround and not a concrete long-term solution. Here, we are giving priority to security and availability of the libs consumer over ease of troubleshooting in case k8s metadata ends up being not available. Since we now have libs logging in Falco (which we didn't have when first introducing this check), I think this is an acceptable tradeoff.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/2358

**Special notes for your reviewer**:

Open to discussion for better workarounds.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
