### PR TITLE
tests: allow user to pass arguments with a space

### DIFF
--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -160,7 +160,15 @@ int open_engine(int argc, char** argv)
 			abort_if_already_configured(&oargs);
 			oargs.engine_name = BPF_ENGINE;
 			bpf_params.buffer_bytes_dim = buffer_bytes_dim;
-			if(optarg == NULL)
+			/* This should handle cases where we pass arguments with the space:
+			 * `-b ./path/to/probe`. Without this `if` case we can accept arguments
+			 * only in this format `-b./path/to/probe`
+			 */
+			if(optarg == NULL && optind < argc && argv[optind][0] != '-')
+			{
+				bpf_params.bpf_probe = argv[optind++];
+			}
+			else if(optarg == NULL)
 			{
 				bpf_params.bpf_probe = strncat(cwd, BPF_PROBE_DEFAULT_PATH, FILENAME_MAX - strlen(cwd));
 			}
@@ -196,7 +204,11 @@ int open_engine(int argc, char** argv)
 			abort_if_already_configured(&oargs);
 			oargs.engine_name = KMOD_ENGINE;
 			kmod_params.buffer_bytes_dim = buffer_bytes_dim;
-			if(optarg == NULL)
+			if(optarg == NULL && optind < argc && argv[optind][0] != '-')
+			{
+				kmod_path = argv[optind++];
+			}
+			else if(optarg == NULL)
 			{
 				kmod_path = strncat(cwd, KMOD_DEFAULT_PATH, FILENAME_MAX - strlen(cwd));
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

No

**What this PR does / why we need it**:

This PR allows us to pass arguments to the test executable with a space, for example, before this patch we can pass arguments only in the following way `-b./path/to/probe` now we can do also something like `-b ./path/to/probe`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
