### PR TITLE
Add const_expr_visitor, use it when compiling/cloning/stringing

### DIFF
--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -51,7 +51,7 @@ private:
   \brief This is the class that compiles the filters.
 */
 class SINSP_PUBLIC sinsp_filter_compiler:
-	private libsinsp::filter::ast::expr_visitor
+	private libsinsp::filter::ast::const_expr_visitor
 {
 public:
 	/*!
@@ -94,7 +94,7 @@ public:
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<gen_event_filter_factory> factory,
-		libsinsp::filter::ast::expr* fltast,
+		const libsinsp::filter::ast::expr* fltast,
 		bool ttable_only=false);
 
 	/*!
@@ -108,16 +108,16 @@ public:
 	const libsinsp::filter::ast::pos_info& get_pos() const { return m_pos; }
 
 private:
-	void visit(libsinsp::filter::ast::and_expr*) override;
-	void visit(libsinsp::filter::ast::or_expr*) override;
-	void visit(libsinsp::filter::ast::not_expr*) override;
-	void visit(libsinsp::filter::ast::value_expr*) override;
-	void visit(libsinsp::filter::ast::list_expr*) override;
-	void visit(libsinsp::filter::ast::unary_check_expr*) override;
-	void visit(libsinsp::filter::ast::binary_check_expr*) override;
+	void visit(const libsinsp::filter::ast::and_expr*) override;
+	void visit(const libsinsp::filter::ast::or_expr*) override;
+	void visit(const libsinsp::filter::ast::not_expr*) override;
+	void visit(const libsinsp::filter::ast::value_expr*) override;
+	void visit(const libsinsp::filter::ast::list_expr*) override;
+	void visit(const libsinsp::filter::ast::unary_check_expr*) override;
+	void visit(const libsinsp::filter::ast::binary_check_expr*) override;
 	void check_ttable_only(std::string& field, gen_event_filter_check *check);
-	cmpop str_to_cmpop(std::string& str);
-	std::string create_filtercheck_name(std::string& name, std::string& arg);
+	cmpop str_to_cmpop(const std::string& str);
+	std::string create_filtercheck_name(const std::string& name, const std::string& arg);
 	gen_event_filter_check* create_filtercheck(std::string& field);
 
 	libsinsp::filter::ast::pos_info m_pos;
@@ -128,7 +128,7 @@ private:
 	sinsp_filter* m_filter;
 	std::vector<std::string> m_field_values;
 	std::unique_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
-	libsinsp::filter::ast::expr* m_flt_ast;
+	const libsinsp::filter::ast::expr* m_flt_ast;
 	std::shared_ptr<gen_event_filter_factory> m_factory;
 
 	friend class sinsp_evt_formatter;

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -86,24 +86,24 @@ void string_visitor::visit_logical_op(const char *op, const std::vector<std::uni
 	m_str += ")";
 }
 
-void string_visitor::visit(and_expr* e)
+void string_visitor::visit(const and_expr* e)
 {
 	visit_logical_op("and", e->children);
 }
 
-void string_visitor::visit(or_expr* e)
+void string_visitor::visit(const or_expr* e)
 {
 	visit_logical_op("or", e->children);
 }
 
-void string_visitor::visit(not_expr* e)
+void string_visitor::visit(const not_expr* e)
 {
 	m_str += "not ";
 
 	e->child->accept(this);
 }
 
-void string_visitor::visit(value_expr* e)
+void string_visitor::visit(const value_expr* e)
 {
 	if(escape_next_value)
 	{
@@ -117,7 +117,7 @@ void string_visitor::visit(value_expr* e)
 	escape_next_value = false;
 }
 
-void string_visitor::visit(list_expr* e)
+void string_visitor::visit(const list_expr* e)
 {
 	bool first = true;
 
@@ -135,7 +135,7 @@ void string_visitor::visit(list_expr* e)
 
 	m_str += ")";
 }
-void string_visitor::visit(unary_check_expr* e)
+void string_visitor::visit(const unary_check_expr* e)
 {
 	m_str += e->field;
 
@@ -148,7 +148,7 @@ void string_visitor::visit(unary_check_expr* e)
 	m_str += e->op;
 }
 
-void string_visitor::visit(binary_check_expr* e)
+void string_visitor::visit(const binary_check_expr* e)
 {
 	m_str += e->field;
 
@@ -171,7 +171,7 @@ const std::string& string_visitor::as_string()
 	return m_str;
 }
 
-std::string libsinsp::filter::ast::as_string(ast::expr *e)
+std::string libsinsp::filter::ast::as_string(const ast::expr *e)
 {
 	string_visitor sv;
 
@@ -180,13 +180,13 @@ std::string libsinsp::filter::ast::as_string(ast::expr *e)
 	return sv.as_string();
 }
 
-std::unique_ptr<expr> libsinsp::filter::ast::clone(expr* e)
-{  
-    struct clone_visitor: public expr_visitor
-    {   
+std::unique_ptr<expr> libsinsp::filter::ast::clone(const expr* e)
+{
+    struct clone_visitor: public const_expr_visitor
+    {
         std::unique_ptr<expr> m_last_node;
 
-        void visit(and_expr* e) override
+        void visit(const and_expr* e) override
         {
             std::vector<std::unique_ptr<expr>> children;
             for (auto &c: e->children)
@@ -197,7 +197,7 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(expr* e)
             m_last_node = and_expr::create(children, e->get_pos());
         }
 
-        void visit(or_expr* e) override
+        void visit(const or_expr* e) override
         {
             std::vector<std::unique_ptr<expr>> children;
             for (auto &c: e->children)
@@ -208,29 +208,29 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(expr* e)
             m_last_node = or_expr::create(children, e->get_pos());
         }
 
-        void visit(not_expr* e) override
+        void visit(const not_expr* e) override
         {
             e->child->accept(this);
             m_last_node = not_expr::create(std::move(m_last_node), e->get_pos());
         }
 
-        void visit(binary_check_expr* e) override
+        void visit(const binary_check_expr* e) override
         {
             e->value->accept(this);
             m_last_node = binary_check_expr::create(e->field, e->arg, e->op, std::move(m_last_node), e->get_pos());
         }
 
-        void visit(unary_check_expr* e) override
+        void visit(const unary_check_expr* e) override
         {
             m_last_node = unary_check_expr::create(e->field, e->arg, e->op, e->get_pos());
         }
 
-        void visit(value_expr* e) override
+        void visit(const value_expr* e) override
         {
             m_last_node = value_expr::create(e->value, e->get_pos());
         }
 
-        void visit(list_expr* e) override
+        void visit(const list_expr* e) override
         {
             m_last_node = list_expr::create(e->values, e->get_pos());
         }

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -98,6 +98,21 @@ struct SINSP_PUBLIC expr_visitor
 };
 
 /*!
+    \brief an AST visitor that does not change the ast.
+*/
+struct SINSP_PUBLIC const_expr_visitor
+{
+    virtual ~const_expr_visitor() = default;
+    virtual void visit(const and_expr*) = 0;
+    virtual void visit(const or_expr*) = 0;
+    virtual void visit(const not_expr*) = 0;
+    virtual void visit(const value_expr*) = 0;
+    virtual void visit(const list_expr*) = 0;
+    virtual void visit(const unary_check_expr*) = 0;
+    virtual void visit(const binary_check_expr*) = 0;
+};
+
+/*!
     \brief Base implementation for AST visitors, that traverses
     the tree without doing anything. This way, subclasses can
     avoid overriding empty methods if they are not interested
@@ -133,17 +148,17 @@ private:
     \brief A visitor that builds a string as it traverses the
     ast. Used to convert to strings.
 */
-struct SINSP_PUBLIC string_visitor: public expr_visitor
+struct SINSP_PUBLIC string_visitor: public const_expr_visitor
 {
 public:
 	virtual ~string_visitor() = default;
-	virtual void visit(and_expr*) override;
-	virtual void visit(or_expr*) override;
-	virtual void visit(not_expr*) override;
-	virtual void visit(value_expr*) override;
-	virtual void visit(list_expr*) override;
-	virtual void visit(unary_check_expr*) override;
-	virtual void visit(binary_check_expr*) override;
+	virtual void visit(const and_expr*) override;
+	virtual void visit(const or_expr*) override;
+	virtual void visit(const not_expr*) override;
+	virtual void visit(const value_expr*) override;
+	virtual void visit(const list_expr*) override;
+	virtual void visit(const unary_check_expr*) override;
+	virtual void visit(const binary_check_expr*) override;
 
 	const std::string& as_string();
 
@@ -166,6 +181,7 @@ class SINSP_PUBLIC expr
 public:
     virtual ~expr() = default;
     virtual void accept(expr_visitor*) = 0;
+    virtual void accept(const_expr_visitor*) const = 0;
     virtual bool is_equal(const expr* other) const = 0;
 
     const pos_info& get_pos() const { return m_pos; }
@@ -190,6 +206,11 @@ struct SINSP_PUBLIC and_expr: expr
     explicit and_expr(std::vector<std::unique_ptr<expr>> &c): children(std::move(c)) { }
 
     void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
     {
         v->visit(this);
     };
@@ -235,6 +256,11 @@ struct SINSP_PUBLIC or_expr: expr
         v->visit(this);
     };
 
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const or_expr*>(other);
@@ -276,6 +302,11 @@ struct SINSP_PUBLIC not_expr: expr
         v->visit(this);
     };
 
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const not_expr*>(other);
@@ -300,6 +331,11 @@ struct SINSP_PUBLIC value_expr: expr
     explicit value_expr(const std::string& v): value(v) { }
 
     void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
     {
         v->visit(this);
     };
@@ -332,6 +368,11 @@ struct SINSP_PUBLIC list_expr: expr
         v->visit(this);
     };
 
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const list_expr*>(other);
@@ -359,6 +400,11 @@ struct SINSP_PUBLIC unary_check_expr: expr
         const std::string& o): field(f), arg(a), op(o) { }
 
     void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
     {
         v->visit(this);
     };
@@ -400,6 +446,11 @@ struct SINSP_PUBLIC binary_check_expr: expr
         v->visit(this);
     };
 
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const binary_check_expr*>(other);
@@ -429,14 +480,14 @@ struct SINSP_PUBLIC binary_check_expr: expr
 	\brief Return a string representation of an AST.
 	\return A string representation of an AST.
 */
-std::string as_string(ast::expr *e);
+std::string as_string(const ast::expr *e);
 
 /*!
 	\brief Creates a deep clone of a filter AST
 	\return The newly created cloned AST. Comparing the return value
     with the input parameter returns true
 */
-std::unique_ptr<expr> clone(expr* e);
+std::unique_ptr<expr> clone(const expr* e);
 
 }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In some cases, we want to ensure that a visitor does *not* change the ast. This includes cases where the ast pointer used by the visitor is read-only.

To support these use cases, add a const_expr_visitor interface where all the visit() methods take a const argument.

Also add variants of accept() that take const_expr_visitor arguments and call the const_expr_visitors visit() method.

Compiling, cloning, and stringifying asts are all cases that should not change the underlying ast, so switch those to use const_expr_visitor instead of expr_visitor.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Add a const AST visitor variant that does not change the ast. Modify ast compiler, clone, stringify to use the const variant.
```
