### PR TITLE
tests(userspace/libscap): move libscap tests into `test` folder and add engine specific tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,9 @@ jobs:
             KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
             make run-unit-tests
 
-  # This job checks that we correctly run `scap-open` for all the 3 drivers.
-  test-scap-open-x86:
-    name: test-scap-open-x86 😆 (bundled_deps)
+  # This job run all engine tests and scap-open
+  test-scap-x86:
+    name: test-scap-x86 😆 (bundled_deps)
     runs-on: ubuntu-22.04
     needs: paths-filter
     if: needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'
@@ -186,9 +186,10 @@ jobs:
       - name: Build scap-open and drivers 🏗️
         run: |
           mkdir -p build
-          cd build && cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DBUILD_LIBSCAP_GVISOR=OFF -DBUILD_BPF=True -DCREATE_TEST_TARGETS=Off ../
+          cd build && cmake -DUSE_BUNDLED_DEPS=On -DBUILD_DRIVER=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DBUILD_BPF=On -DBUILD_LIBSCAP_GVISOR=Off -DCREATE_TEST_TARGETS=On -DENABLE_LIBSCAP_TESTS=On ../
           make scap-open
           make driver bpf
+          make libscap_test
 
       - name: Run scap-open with modern bpf 🏎️
         run: |
@@ -206,6 +207,11 @@ jobs:
           sudo insmod ./driver/scap.ko
           sudo ./libscap/examples/01-open/scap-open --kmod --num_events 0
           sudo rmmod scap
+
+      - name: Run libscap_test 🏎️
+        run: |
+          cd build
+          sudo ./test/libscap/libscap_test
 
   test-drivers-x86:
     name: test-drivers-x86 😇 (bundled_deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(MINIMAL_BUILD "Produce a minimal build with only the essential features (
 option(MUSL_OPTIMIZED_BUILD "Enable if you want a musl optimized build" OFF)
 option(USE_BUNDLED_DRIVER "Use the driver/ subdirectory in the build process (only available in Linux)" ON)
 option(ENABLE_DRIVERS_TESTS "Enable driver tests (bpf, kernel module, modern bpf)" OFF)
+option(ENABLE_LIBSCAP_TESTS "Enable libscap unit tests" OFF)
 
 include(GNUInstallDirs)
 
@@ -98,5 +99,9 @@ if(CREATE_TEST_TARGETS AND NOT WIN32)
 
 	if(ENABLE_DRIVERS_TESTS)
 		add_subdirectory(test/drivers)
+	endif()
+	
+	if(ENABLE_LIBSCAP_TESTS)
+		add_subdirectory(test/libscap)
 	endif()
 endif()

--- a/test/libscap/CMakeLists.txt
+++ b/test/libscap/CMakeLists.txt
@@ -1,0 +1,91 @@
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+message(STATUS "Libscap unit tests build enabled")
+
+# find_package(Threads)
+
+set(LIBSCAP_TESTS_SOURCES "")
+
+set(LIBSCAP_TESTS_INCLUDE
+  PRIVATE
+  "${GTEST_INCLUDE}"
+  "${CMAKE_CURRENT_SOURCE_DIR}" # for test helpers <helpers/...>
+  "${CMAKE_SOURCE_DIR}/userspace/libscap" # this is for libscap includes
+)
+
+set(LIBSCAP_TESTS_LIBRARIES
+	"${GTEST_LIB}"
+	"${GTEST_MAIN_LIB}"
+	# "${CMAKE_THREAD_LIBS_INIT}"
+	scap
+)
+
+set(LIBSCAP_TESTS_DEPENDENCIES
+	gtest
+	scap
+)
+
+# Add `gcov` to needed libraries
+if (CMAKE_BUILD_TYPE STREQUAL "Coverage")
+	list(APPEND LIBSCAP_TESTS_LIBRARIES gcov)
+endif()
+
+# Engine-specific tests
+if(BUILD_DRIVER)
+	file(GLOB_RECURSE KMOD_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/engines/kmod/*.cpp")
+	list(APPEND LIBSCAP_TESTS_SOURCES ${KMOD_TEST_SUITE})
+	# Set `driver` target as a dependency
+	list(APPEND LIBSCAP_TESTS_DEPENDENCIES driver)
+endif()
+
+if(BUILD_BPF)
+	file(GLOB_RECURSE BPF_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/engines/bpf/*.cpp")
+	list(APPEND LIBSCAP_TESTS_SOURCES ${BPF_TEST_SUITE})
+	# Set `bpf` target as a dependency
+	list(APPEND LIBSCAP_TESTS_DEPENDENCIES bpf)
+endif()
+
+if(BUILD_LIBSCAP_MODERN_BPF)
+	file(GLOB_RECURSE MODERN_BPF_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/engines/modern_bpf/*.cpp")
+	list(APPEND LIBSCAP_TESTS_SOURCES ${MODERN_BPF_TEST_SUITE})
+endif()
+
+if(BUILD_LIBSCAP_GVISOR)
+	include(protobuf)
+	file(GLOB_RECURSE GVISOR_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/engines/gvisor/*.cpp")
+	list(APPEND LIBSCAP_TESTS_SOURCES ${GVISOR_TEST_SUITE})
+	list(APPEND LIBSCAP_TESTS_INCLUDE "${CMAKE_BINARY_DIR}/libscap")
+
+	# include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
+	# include_directories(../engine/gvisor)
+	# include_directories(${CMAKE_CURRENT_BINARY_DIR}/../engine/gvisor)
+endif()
+
+# Helpers are not engine-specific so we always include them
+file(GLOB_RECURSE LIBSCAP_TESTS_UTILS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/helpers/*cpp")
+list(APPEND LIBSCAP_TESTS_SOURCES ${LIBSCAP_TESTS_UTILS_SOURCES})
+
+add_executable(libscap_test ${LIBSCAP_TESTS_SOURCES})
+target_include_directories(libscap_test ${LIBSCAP_TESTS_INCLUDE})
+target_link_libraries(libscap_test ${LIBSCAP_TESTS_LIBRARIES})
+add_dependencies(libscap_test ${LIBSCAP_TESTS_DEPENDENCIES})
+
+# ## Probably we can remove these
+# add_custom_target(run-libscap_test
+# 	DEPENDS ${RUN_LIBSCAP_TESTS_DEPENDENCIES}
+# 	COMMAND libscap_test
+# )

--- a/test/libscap/CMakeLists.txt
+++ b/test/libscap/CMakeLists.txt
@@ -16,26 +16,32 @@
 
 message(STATUS "Libscap unit tests build enabled")
 
-# find_package(Threads)
+if(NOT DEFINED DRIVER_NAME)
+	set(DRIVER_NAME "scap")
+endif()
 
-set(LIBSCAP_TESTS_SOURCES "")
+# Create a libscap_test_var.h file with some variables used by our tests
+# for example the kmod path or the bpf path.
+configure_file (
+    "${CMAKE_CURRENT_SOURCE_DIR}/libscap_test_var.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/libscap_test_var.h"
+)
 
 set(LIBSCAP_TESTS_INCLUDE
   PRIVATE
   "${GTEST_INCLUDE}"
   "${CMAKE_CURRENT_SOURCE_DIR}" # for test helpers <helpers/...>
   "${CMAKE_SOURCE_DIR}/userspace/libscap" # this is for libscap includes
+  "${CMAKE_CURRENT_BINARY_DIR}" # used to include `libscap_test_var.h`
 )
+
+# Needed by gtest
+find_package(Threads)
 
 set(LIBSCAP_TESTS_LIBRARIES
 	"${GTEST_LIB}"
 	"${GTEST_MAIN_LIB}"
-	# "${CMAKE_THREAD_LIBS_INIT}"
-	scap
-)
-
-set(LIBSCAP_TESTS_DEPENDENCIES
-	gtest
+	"${CMAKE_THREAD_LIBS_INIT}"
 	scap
 )
 
@@ -43,6 +49,19 @@ set(LIBSCAP_TESTS_DEPENDENCIES
 if (CMAKE_BUILD_TYPE STREQUAL "Coverage")
 	list(APPEND LIBSCAP_TESTS_LIBRARIES gcov)
 endif()
+
+set(LIBSCAP_TESTS_DEPENDENCIES
+	gtest
+	scap
+)
+
+# Generic libscap test suite, always compiled
+file(GLOB_RECURSE GENERIC_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/generic/*.cpp")
+set(LIBSCAP_TESTS_SOURCES ${GENERIC_TEST_SUITE})
+
+# Helpers are not engine-specific so we always include them
+file(GLOB_RECURSE LIBSCAP_TESTS_UTILS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/helpers/*cpp")
+list(APPEND LIBSCAP_TESTS_SOURCES ${LIBSCAP_TESTS_UTILS_SOURCES})
 
 # Engine-specific tests
 if(BUILD_DRIVER)
@@ -68,24 +87,16 @@ if(BUILD_LIBSCAP_GVISOR)
 	include(protobuf)
 	file(GLOB_RECURSE GVISOR_TEST_SUITE "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/engines/gvisor/*.cpp")
 	list(APPEND LIBSCAP_TESTS_SOURCES ${GVISOR_TEST_SUITE})
-	list(APPEND LIBSCAP_TESTS_INCLUDE "${CMAKE_BINARY_DIR}/libscap")
-
-	# include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
-	# include_directories(../engine/gvisor)
-	# include_directories(${CMAKE_CURRENT_BINARY_DIR}/../engine/gvisor)
+	list(APPEND LIBSCAP_TESTS_INCLUDE "${CMAKE_BINARY_DIR}/libscap/engine/gvisor") # Used for <pkg/sentry/...> includes
 endif()
 
-# Helpers are not engine-specific so we always include them
-file(GLOB_RECURSE LIBSCAP_TESTS_UTILS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/helpers/*cpp")
-list(APPEND LIBSCAP_TESTS_SOURCES ${LIBSCAP_TESTS_UTILS_SOURCES})
+# Summary logs
+message(STATUS "LIBSCAP_TESTS_SOURCES: ${LIBSCAP_TESTS_SOURCES}")
+message(STATUS "LIBSCAP_TESTS_INCLUDE: ${LIBSCAP_TESTS_INCLUDE}")
+message(STATUS "LIBSCAP_TESTS_LIBRARIES: ${LIBSCAP_TESTS_LIBRARIES}")
+message(STATUS "LIBSCAP_TESTS_DEPENDENCIES: ${LIBSCAP_TESTS_DEPENDENCIES}")
 
 add_executable(libscap_test ${LIBSCAP_TESTS_SOURCES})
 target_include_directories(libscap_test ${LIBSCAP_TESTS_INCLUDE})
 target_link_libraries(libscap_test ${LIBSCAP_TESTS_LIBRARIES})
 add_dependencies(libscap_test ${LIBSCAP_TESTS_DEPENDENCIES})
-
-# ## Probably we can remove these
-# add_custom_target(run-libscap_test
-# 	DEPENDS ${RUN_LIBSCAP_TESTS_DEPENDENCIES}
-# 	COMMAND libscap_test
-# )

--- a/test/libscap/README.md
+++ b/test/libscap/README.md
@@ -1,0 +1,22 @@
+# Scap tests
+
+## Compile tests
+
+```bash
+cmake -DUSE_BUNDLED_DEPS=On -DCREATE_TEST_TARGETS=On -DBUILD_BPF=Off -DBUILD_DRIVER=Off -DBUILD_LIBSCAP_GVISOR=Off -DENABLE_LIBSCAP_TESTS=On ..
+make unit-test-libscap
+```
+
+You can add tests for specific engines using their Cmake options:
+- `-DBUILD_LIBSCAP_MODERN_BPF=On`
+- `-DBUILD_LIBSCAP_GVISOR=On`
+- `-DBUILD_BPF=ON` (this will require `make bpf` before running tests)
+- `-DBUILD_DRIVER=ON` (this will require `make driver` before running tests)
+
+## Run tests
+
+From the build directory:
+
+```bash
+sudo ./test/libscap/libscap_test
+```

--- a/test/libscap/README.md
+++ b/test/libscap/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 cmake -DUSE_BUNDLED_DEPS=On -DCREATE_TEST_TARGETS=On -DBUILD_BPF=Off -DBUILD_DRIVER=Off -DBUILD_LIBSCAP_GVISOR=Off -DENABLE_LIBSCAP_TESTS=On ..
-make unit-test-libscap
+make libscap_test
 ```
 
 You can add tests for specific engines using their Cmake options:

--- a/test/libscap/helpers/engines.cpp
+++ b/test/libscap/helpers/engines.cpp
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+#include <syscall.h>
+#include <scap.h>
+
+/* We are supposing that if we overcome this threshold, all buffers are full.
+ * Probably this threshold is too low, but it depends on the machine's workload.
+ * We are running in CI so it is better to be conservative even if tests becomes
+ * not so reliable...
+ */
+#define MAX_ITERATIONS 300
+
+/* Number of events we want to assert */
+#define EVENTS_TO_ASSERT 32
+
+void check_event_is_not_overwritten(scap_t* h)
+{
+	/* Start the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to start the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* When the number of events is fixed for `MAX_ITERATIONS` we consider all the buffers full, this is just an approximation */
+	scap_stats stats = {};
+	uint64_t last_num_events = 0;
+	uint16_t iterations = 0;
+
+	while(iterations < MAX_ITERATIONS || stats.n_drops == 0)
+	{
+		ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS) << "unable to get stats: " << scap_getlasterr(h) << std::endl;
+		if(last_num_events == (stats.n_evts - stats.n_drops))
+		{
+			iterations++;
+		}
+		else
+		{
+			iterations = 0;
+			last_num_events = (stats.n_evts - stats.n_drops);
+		}
+	}
+
+	/* Stop the capture */
+	ASSERT_EQ(scap_stop_capture(h), SCAP_SUCCESS) << "unable to stop the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* The idea here is to check if an event is overwritten while we still have a pointer to it.
+	 * Again this is only an approximation, we don't know if new events will be written in the buffer
+	 * under test...
+	 *
+	 * We call `scap_next` keeping the pointer to the event.
+	 * An event pointer becomes invalid when we call another `scap_next`, but until that moment it should be valid!
+	 */
+	scap_evt* evt = NULL;
+	uint16_t buffer_id;
+
+	/* The first 'scap_next` could return a `SCAP_TIMEOUT` according to the chosen `buffer_mode` so we ignore it. */
+	scap_next(h, &evt, &buffer_id);
+
+	ASSERT_EQ(scap_next(h, &evt, &buffer_id), SCAP_SUCCESS) << "unable to get an event with `scap_next`: " << scap_getlasterr(h) << std::endl;
+
+	last_num_events = 0;
+	iterations = 0;
+
+	/* We save some event info to check if they are still valid after some new events */
+	uint64_t prev_ts = evt->ts;
+	uint64_t prev_tid = evt->tid;
+	uint32_t prev_len = evt->len;
+	uint16_t prev_type = evt->type;
+	uint32_t prev_nparams = evt->nparams;
+
+	/* Start again the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to restart the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* We use the same approximation as before */
+	while(iterations < MAX_ITERATIONS)
+	{
+		ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS) << "unable to get stats: " << scap_getlasterr(h) << std::endl;
+		if(last_num_events == (stats.n_evts - stats.n_drops))
+		{
+			iterations++;
+		}
+		else
+		{
+			iterations = 0;
+			last_num_events = (stats.n_evts - stats.n_drops);
+		}
+	}
+
+	/* We check if the previously collected event is still valid */
+	ASSERT_EQ(prev_ts, evt->ts) << "different timestamp" << std::endl;
+	ASSERT_EQ(prev_tid, evt->tid) << "different thread id" << std::endl;
+	ASSERT_EQ(prev_len, evt->len) << "different event len" << std::endl;
+	ASSERT_EQ(prev_type, evt->type) << "different event type" << std::endl;
+	ASSERT_EQ(prev_nparams, evt->nparams) << "different num params" << std::endl;
+}
+
+#if defined(__NR_close) && defined(__NR_openat) && defined(__NR_listen) && defined(__NR_accept4) && defined(__NR_getegid) && defined(__NR_getgid) && defined(__NR_geteuid) && defined(__NR_getuid) && defined(__NR_bind) && defined(__NR_connect) && defined(__NR_sendto) && defined(__NR_sendmsg) && defined(__NR_recvmsg) && defined(__NR_recvfrom) && defined(__NR_socket) && defined(__NR_socketpair)
+
+void check_event_order(scap_t* h)
+{
+	uint32_t events_to_assert[EVENTS_TO_ASSERT] = {PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X, PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X, PPME_SOCKET_ACCEPT4_5_E, PPME_SOCKET_ACCEPT4_5_X, PPME_SYSCALL_GETEGID_E, PPME_SYSCALL_GETEGID_X, PPME_SYSCALL_GETGID_E, PPME_SYSCALL_GETGID_X, PPME_SYSCALL_GETEUID_E, PPME_SYSCALL_GETEUID_X, PPME_SYSCALL_GETUID_E, PPME_SYSCALL_GETUID_X, PPME_SOCKET_BIND_E, PPME_SOCKET_BIND_X, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X, PPME_SOCKET_SENDTO_E, PPME_SOCKET_SENDTO_X, PPME_SOCKET_SENDMSG_E, PPME_SOCKET_SENDMSG_X, PPME_SOCKET_RECVMSG_E, PPME_SOCKET_RECVMSG_X, PPME_SOCKET_RECVFROM_E, PPME_SOCKET_RECVFROM_X, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X, PPME_SOCKET_SOCKETPAIR_E, PPME_SOCKET_SOCKETPAIR_X};
+
+	/* Start the capture */
+	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to start the capture: " << scap_getlasterr(h) << std::endl;
+
+	/* 1. Generate a `close` event pair */
+	syscall(__NR_close, -1);
+
+	/* 2. Generate an `openat` event pair */
+	syscall(__NR_openat, 0, "/**mock_path**/", 0, 0);
+
+	/* 3. Generate a `listen` event pair */
+	syscall(__NR_listen, -1, -1);
+
+	/* 4. Generate an `accept4` event pair */
+	syscall(__NR_accept4, -1, NULL, NULL, 0);
+
+	/* 5. Generate a `getegid` event pair */
+	syscall(__NR_getegid);
+
+	/* 6. Generate a `getgid` event pair */
+	syscall(__NR_getgid);
+
+	/* 7. Generate a `geteuid` event pair */
+	syscall(__NR_geteuid);
+
+	/* 8. Generate a `getuid` event pair */
+	syscall(__NR_getuid);
+
+	/* 9. Generate a `bind` event pair */
+	syscall(__NR_bind, -1, NULL, 0);
+
+	/* 10. Generate a `connect` event pair */
+	syscall(__NR_connect, -1, NULL, 0);
+
+	/* 11. Generate a `sendto` event pair */
+	syscall(__NR_sendto, -1, NULL, 0, 0, NULL, 0);
+
+	/* 12. Generate a `sendmsg` event pair */
+	syscall(__NR_sendmsg, -1, NULL, 0);
+
+	/* 13. Generate a `recvmsg` event pair */
+	syscall(__NR_recvmsg, -1, NULL, 0);
+
+	/* 14. Generate a `recvmsg` event pair */
+	syscall(__NR_recvfrom, -1, NULL, 0, 0, NULL, 0);
+
+	/* 15. Generate a `socket` event pair */
+	syscall(__NR_socket, 0, 0, 0);
+
+	/* 16. Generate a `socketpair` event pair */
+	syscall(__NR_socketpair, 0, 0, 0, 0);
+
+	/* Stop the capture */
+	ASSERT_EQ(scap_stop_capture(h), SCAP_SUCCESS) << "unable to stop the capture: " << scap_getlasterr(h) << std::endl;
+
+	scap_evt* evt = NULL;
+	uint16_t buffer_id = 0;
+	int ret = 0;
+	uint64_t acutal_pid = getpid();
+	/* if we hit 5 consecutive timeouts it means that all buffers are empty (approximation) */
+	uint16_t timeouts = 0;
+
+	for(int i = 0; i < EVENTS_TO_ASSERT; i++)
+	{
+		while(true)
+		{
+			ret = scap_next(h, &evt, &buffer_id);
+			if(ret == SCAP_SUCCESS)
+			{
+				timeouts = 0;
+				if(evt->tid == acutal_pid && evt->type == events_to_assert[i])
+				{
+					/* We found our event */
+					break;
+				}
+			}
+			else if(ret == SCAP_TIMEOUT)
+			{
+				timeouts++;
+				if(timeouts == 5)
+				{
+					FAIL() << "we didn't find event '" << events_to_assert[i] << "' at position '" << i << "'" << std::endl;
+				}
+			}
+		}
+	}
+}
+
+#else
+
+void check_event_order(scap_t* h)
+{
+	GTEST_SKIP() << "Some syscalls required by the test are not defined" << std::endl;
+}
+#endif

--- a/test/libscap/helpers/engines.cpp
+++ b/test/libscap/helpers/engines.cpp
@@ -90,11 +90,11 @@ void check_event_is_not_overwritten(scap_t* h)
 	ASSERT_EQ(prev_nparams, evt->nparams) << "different num params" << std::endl;
 }
 
-#if defined(__NR_close) && defined(__NR_openat) && defined(__NR_listen) && defined(__NR_accept4) && defined(__NR_getegid) && defined(__NR_getgid) && defined(__NR_geteuid) && defined(__NR_getuid) && defined(__NR_bind) && defined(__NR_connect) && defined(__NR_sendto) && defined(__NR_sendmsg) && defined(__NR_recvmsg) && defined(__NR_recvfrom) && defined(__NR_socket) && defined(__NR_socketpair)
+#if defined(__NR_close) && defined(__NR_openat) && defined(__NR_listen) && defined(__NR_accept4) && defined(__NR_getegid) && defined(__NR_getgid) && defined(__NR_geteuid) && defined(__NR_getuid) && defined(__NR_bind) && defined(__NR_connect) && defined(__NR_sendto) && defined(__NR_getsockopt) && defined(__NR_recvmsg) && defined(__NR_recvfrom) && defined(__NR_socket) && defined(__NR_socketpair)
 
 void check_event_order(scap_t* h)
 {
-	uint32_t events_to_assert[EVENTS_TO_ASSERT] = {PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X, PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X, PPME_SOCKET_ACCEPT4_5_E, PPME_SOCKET_ACCEPT4_5_X, PPME_SYSCALL_GETEGID_E, PPME_SYSCALL_GETEGID_X, PPME_SYSCALL_GETGID_E, PPME_SYSCALL_GETGID_X, PPME_SYSCALL_GETEUID_E, PPME_SYSCALL_GETEUID_X, PPME_SYSCALL_GETUID_E, PPME_SYSCALL_GETUID_X, PPME_SOCKET_BIND_E, PPME_SOCKET_BIND_X, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X, PPME_SOCKET_SENDTO_E, PPME_SOCKET_SENDTO_X, PPME_SOCKET_SENDMSG_E, PPME_SOCKET_SENDMSG_X, PPME_SOCKET_RECVMSG_E, PPME_SOCKET_RECVMSG_X, PPME_SOCKET_RECVFROM_E, PPME_SOCKET_RECVFROM_X, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X, PPME_SOCKET_SOCKETPAIR_E, PPME_SOCKET_SOCKETPAIR_X};
+	uint32_t events_to_assert[EVENTS_TO_ASSERT] = {PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X, PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X, PPME_SOCKET_LISTEN_E, PPME_SOCKET_LISTEN_X, PPME_SOCKET_ACCEPT4_5_E, PPME_SOCKET_ACCEPT4_5_X, PPME_SYSCALL_GETEGID_E, PPME_SYSCALL_GETEGID_X, PPME_SYSCALL_GETGID_E, PPME_SYSCALL_GETGID_X, PPME_SYSCALL_GETEUID_E, PPME_SYSCALL_GETEUID_X, PPME_SYSCALL_GETUID_E, PPME_SYSCALL_GETUID_X, PPME_SOCKET_BIND_E, PPME_SOCKET_BIND_X, PPME_SOCKET_CONNECT_E, PPME_SOCKET_CONNECT_X, PPME_SOCKET_SENDTO_E, PPME_SOCKET_SENDTO_X, PPME_SOCKET_GETSOCKOPT_E, PPME_SOCKET_GETSOCKOPT_X, PPME_SOCKET_RECVMSG_E, PPME_SOCKET_RECVMSG_X, PPME_SOCKET_RECVFROM_E, PPME_SOCKET_RECVFROM_X, PPME_SOCKET_SOCKET_E, PPME_SOCKET_SOCKET_X, PPME_SOCKET_SOCKETPAIR_E, PPME_SOCKET_SOCKETPAIR_X};
 
 	/* Start the capture */
 	ASSERT_EQ(scap_start_capture(h), SCAP_SUCCESS) << "unable to start the capture: " << scap_getlasterr(h) << std::endl;
@@ -132,8 +132,8 @@ void check_event_order(scap_t* h)
 	/* 11. Generate a `sendto` event pair */
 	syscall(__NR_sendto, -1, NULL, 0, 0, NULL, 0);
 
-	/* 12. Generate a `sendmsg` event pair */
-	syscall(__NR_sendmsg, -1, NULL, 0);
+	/* 12. Generate a `getsockopt` event pair */
+	syscall(__NR_getsockopt, -1, 0, 0, NULL, NULL);
 
 	/* 13. Generate a `recvmsg` event pair */
 	syscall(__NR_recvmsg, -1, NULL, 0);

--- a/test/libscap/helpers/engines.h
+++ b/test/libscap/helpers/engines.h
@@ -1,0 +1,5 @@
+#include <scap.h>
+
+void check_event_is_not_overwritten(scap_t* h);
+
+void check_event_order(scap_t* h);

--- a/test/libscap/libscap_test_var.h.in
+++ b/test/libscap/libscap_test_var.h.in
@@ -1,0 +1,10 @@
+#pragma once
+
+// Absolute path to the kernel module file
+#define LIBSCAP_TEST_KERNEL_MODULE_PATH "${CMAKE_BINARY_DIR}/driver/scap.ko"
+
+// Kernel module name
+#define LIBSCAP_TEST_KERNEL_MODULE_NAME "${DRIVER_NAME}"
+
+// Absolute path to the bpf probe .o file
+#define LIBSCAP_TEST_BPF_PROBE_PATH "${CMAKE_BINARY_DIR}/driver/bpf/probe.o"

--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -1,0 +1,101 @@
+#include <scap.h>
+#include <gtest/gtest.h>
+#include <unordered_set>
+#include <helpers/engines.h>
+
+#define BPF_PROBE_PATH "./driver/bpf/probe.o"
+
+scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* name, std::unordered_set<uint32_t> tp_set = {}, std::unordered_set<uint32_t> ppm_sc_set = {})
+{
+	struct scap_open_args oargs = {
+		.engine_name = BPF_ENGINE,
+		.mode = SCAP_MODE_LIVE,
+	};
+
+	/* If empty we fill with all tracepoints */
+	if(tp_set.empty())
+	{
+		for(int i = 0; i < TP_VAL_MAX; i++)
+		{
+			oargs.tp_of_interest.tp[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto tp : tp_set)
+		{
+			oargs.tp_of_interest.tp[tp] = 1;
+		}
+	}
+
+	/* If empty we fill with all syscalls */
+	if(ppm_sc_set.empty())
+	{
+		for(int i = 0; i < PPM_SC_MAX; i++)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto ppm_sc : ppm_sc_set)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[ppm_sc] = 1;
+		}
+	}
+
+	struct scap_bpf_engine_params bpf_params = {
+		.buffer_bytes_dim = buffer_dim,
+		.bpf_probe = name,
+	};
+	oargs.engine_params = &bpf_params;
+
+	return scap_open(&oargs, error_buf, rc);
+}
+
+TEST(bpf, open_engine)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4 * 4096, BPF_PROBE_PATH);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open bpf engine: " << error_buffer << std::endl;
+	scap_close(h);
+}
+
+TEST(bpf, wrong_bpf_path)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4 * 4096, ".");
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the BPF path is wrong, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(bpf, empty_bpf_path)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4 * 4096, "");
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the BPF path is wrong, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(bpf, wrong_buffer_dim)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4, BPF_PROBE_PATH);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is not a system page multiple, so we should fail: " << error_buffer << std::endl;
+}
+
+/* This check is not so reliable, better than nothing but to be sure we need to obtain the producer and consumer positions from the drivers */
+TEST(bpf, events_not_overwritten)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4 * 4096, BPF_PROBE_PATH);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open bpf engine: " << error_buffer << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+/* we miss here the `event_in_order` test, but we first need to complete our driver tests, otherwise some events will be discarded kernel side */

--- a/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
+++ b/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
@@ -1,0 +1,339 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <scap.h>
+#include <gtest/gtest.h>
+#include <google/protobuf/any.pb.h>
+
+#include <pkg/sentry/seccheck/points/syscall.pb.h>
+#include <pkg/sentry/seccheck/points/sentry.pb.h>
+#include <pkg/sentry/seccheck/points/container.pb.h>
+#include <engine/gvisor/gvisor.h>
+
+template<class T>
+uint32_t prepare_message(char *message, uint32_t message_size, uint16_t message_type, T &gvisor_evt)
+{
+    uint32_t proto_size = static_cast<uint32_t>(gvisor_evt.ByteSizeLong());
+    uint16_t header_size = sizeof(scap_gvisor::header);
+    uint32_t total_size = header_size + proto_size;
+    uint32_t dropped_count = 0;
+
+    // Fill the message header
+    memcpy(message, &header_size, sizeof(uint16_t));
+    memcpy(&message[sizeof(uint16_t)], &message_type, sizeof(uint16_t));
+    memcpy(&message[sizeof(uint16_t) + sizeof(uint16_t)], &dropped_count, sizeof(uint32_t));
+
+    // Serialize proto
+    gvisor_evt.SerializeToArray(&message[header_size], message_size - header_size);
+
+    return total_size;
+}
+
+TEST(gvisor_parsers, parse_execve_e)
+{
+    char message[1024];
+    char buffer[1024];
+
+    gvisor::syscall::Execve gvisor_evt;
+    uint16_t message_type = gvisor::common::MessageType::MESSAGE_SYSCALL_EXECVE;
+    gvisor_evt.set_pathname("/usr/bin/ls");
+    auto *context_data = gvisor_evt.mutable_context_data();
+    context_data->set_container_id("1234");
+
+    uint32_t total_size = prepare_message(message, 1024, message_type, gvisor_evt);
+
+    scap_const_sized_buffer gvisor_msg = {.buf = message, .size = total_size};
+    scap_sized_buffer scap_buf = {.buf = buffer, .size = 1024};
+
+    scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+    EXPECT_EQ("", res.error);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+
+    EXPECT_EQ(res.scap_events.size(), 1);
+
+    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
+    EXPECT_EQ(n, 1);
+    EXPECT_STREQ(static_cast<const char*>(decoded_params[0].buf), "/usr/bin/ls");
+}
+
+TEST(gvisor_parsers, parse_execve_x)
+{
+    char message[1024];
+    char buffer[1024];
+
+    gvisor::syscall::Execve gvisor_evt;
+    uint16_t message_type = gvisor::common::MessageType::MESSAGE_SYSCALL_EXECVE;
+    gvisor_evt.set_pathname("/usr/bin/ls");
+    gvisor_evt.mutable_argv()->Add("ls");
+    gvisor_evt.mutable_argv()->Add("a");
+    gvisor_evt.mutable_argv()->Add("b");
+    auto *context_data = gvisor_evt.mutable_context_data();
+    context_data->set_container_id("1234");
+    context_data->set_cwd("/root");
+    gvisor::syscall::Exit *exit = gvisor_evt.mutable_exit();
+    exit->set_result(0);
+
+    uint32_t total_size = prepare_message(message, 1024, message_type, gvisor_evt);
+
+    scap_const_sized_buffer gvisor_msg = {.buf = message, .size = total_size};
+    scap_sized_buffer scap_buf = {.buf = buffer, .size = 1024};
+
+    scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+    EXPECT_EQ("", res.error);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+
+    EXPECT_EQ(res.scap_events.size(), 1);
+
+    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
+    EXPECT_EQ(n, 20);
+    EXPECT_STREQ(static_cast<const char*>(decoded_params[1].buf), "/usr/bin/ls"); // exe
+    EXPECT_STREQ(static_cast<const char*>(decoded_params[6].buf), "/root"); // cwd
+    EXPECT_STREQ(static_cast<const char*>(decoded_params[13].buf), "ls"); // comm
+}
+
+TEST(gvisor_parsers, parse_container_start)
+{
+    char message[1024];
+    char buffer[1024];
+
+    gvisor::container::Start gvisor_evt;
+    uint16_t message_type = gvisor::common::MessageType::MESSAGE_CONTAINER_START;
+    gvisor_evt.set_id("deadbeef");
+    gvisor_evt.mutable_args()->Add("ls");
+    auto *context_data = gvisor_evt.mutable_context_data();
+    context_data->set_cwd("/root");
+
+    uint32_t total_size = prepare_message(message, 1024, message_type, gvisor_evt);
+
+    scap_const_sized_buffer gvisor_msg = {.buf = message, .size = total_size};
+    scap_sized_buffer scap_buf = {.buf = buffer, .size = 1024};
+
+    scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+
+    EXPECT_EQ(res.scap_events.size(), 4);
+    EXPECT_EQ(res.scap_events[0]->type, PPME_SYSCALL_CLONE_20_E);
+    EXPECT_EQ(res.scap_events[1]->type, PPME_SYSCALL_CLONE_20_X);
+    EXPECT_EQ(res.scap_events[2]->type, PPME_SYSCALL_EXECVE_19_E);
+    EXPECT_EQ(res.scap_events[3]->type, PPME_SYSCALL_EXECVE_19_X);
+}
+
+TEST(gvisor_parsers, unhandled_syscall)
+{
+    char message[1024];
+    char buffer[1024];
+
+    gvisor::syscall::Syscall gvisor_evt;
+    uint16_t message_type = gvisor::common::MessageType::MESSAGE_SYSCALL_RAW;
+    gvisor_evt.set_sysno(999);
+    auto *context_data = gvisor_evt.mutable_context_data();
+    context_data->set_container_id("1234");
+
+    uint32_t total_size = prepare_message(message, 1024, message_type, gvisor_evt);
+
+    scap_const_sized_buffer gvisor_msg = {.buf = message, .size = total_size};
+    scap_sized_buffer scap_buf = {.buf = buffer, .size = 1024};
+
+    scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+    EXPECT_NE(res.error.find("Unhandled syscall"), std::string::npos);
+    EXPECT_EQ(res.status, SCAP_NOT_SUPPORTED);
+}
+
+TEST(gvisor_parsers, small_buffer)
+{
+    char message[1024];
+    char buffer[1024];
+
+    gvisor::syscall::Execve gvisor_evt;
+    uint16_t message_type = gvisor::common::MessageType::MESSAGE_SYSCALL_EXECVE;
+    gvisor_evt.set_pathname("/usr/bin/ls");
+    gvisor_evt.mutable_argv()->Add("ls");
+    auto *context_data = gvisor_evt.mutable_context_data();
+    context_data->set_container_id("1234");
+    context_data->set_cwd("/root");
+    gvisor::syscall::Exit *exit = gvisor_evt.mutable_exit();
+    exit->set_result(0);
+
+    uint32_t total_size = prepare_message(message, 1024, message_type, gvisor_evt);
+
+    scap_const_sized_buffer gvisor_msg = {.buf = message, .size = total_size};
+    scap_sized_buffer scap_buf = {.buf = buffer, .size = 1};
+
+    scap_gvisor::parsers::parse_result res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+    EXPECT_EQ(res.status, SCAP_INPUT_TOO_SMALL);
+    scap_buf.size = res.size;
+    res = scap_gvisor::parsers::parse_gvisor_proto(gvisor_msg, scap_buf);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+}
+
+TEST(gvisor_parsers, procfs_entry)
+{
+    scap_gvisor::parsers::procfs_result res = {0};
+    std::string not_json = "not a json string";
+    std::string sandbox_id = "deadbeef";
+
+    res = scap_gvisor::parsers::parse_procfs_json(not_json, sandbox_id);
+    EXPECT_EQ(res.status, SCAP_FAILURE);
+
+    std::string json = R"(
+{
+  "args": [ "bash" ],
+  "clone_ts": 1655473752715788585,
+  "cwd": "/",
+  "env": [
+    "HOSTNAME=91e91fdd849d",
+    "TERM=xterm",
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "HOME=/root"
+  ],
+  "exe": "/usr/bin/bash",
+  "fdlist": [
+    {
+      "number": 0,
+      "mode": 0,
+      "path": "host:[1]"
+    },
+    {
+      "number": 1,
+      "mode": 0,
+      "path": "host:[1]"
+    },
+    {
+      "number": 2,
+      "mode": 0,
+      "path": "host:[1]"
+    },
+    {
+      "number": 255,
+      "mode": 0,
+      "path": "host:[1]"
+    }
+  ],
+  "limits": {
+    "RLIMIT_NOFILE": {
+      "cur": 1048576,
+      "max": 1048576
+    }
+  },
+  "root": "/",
+  "stat": {
+    "pgid": 1,
+    "sid": 1
+  },
+  "status": {
+    "comm": "bash",
+    "gid": {"effective": 0, "real": 0, "saved": 0},
+    "pid": 1,
+    "uid": {"effective": 0, "real": 0, "saved": 0},
+    "vm_rss": 4664,
+    "vm_size": 12164
+  }
+}
+    )";
+
+    res = scap_gvisor::parsers::parse_procfs_json(json, sandbox_id);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+    EXPECT_EQ(res.tinfo.vtid, 1);
+    EXPECT_STREQ(res.tinfo.comm, "bash");
+    EXPECT_STREQ(res.tinfo.exepath, "/usr/bin/bash");
+    std::string args = std::string(res.tinfo.args, res.tinfo.args_len);
+    EXPECT_TRUE(args.find("bash") != std::string::npos);
+    std::string env = std::string(res.tinfo.env, res.tinfo.env_len);
+    EXPECT_TRUE(env.find("HOSTNAME=91e91fdd849d") != std::string::npos);
+    EXPECT_TRUE(env.find("TERM=xterm") != std::string::npos);
+    EXPECT_TRUE(env.find("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin") != std::string::npos);
+    EXPECT_TRUE(env.find("HOME=/root") != std::string::npos);
+
+    std::string json_missing_fields = "{\"exe\":\"/usr/bin/bash\"}\n";
+    res = scap_gvisor::parsers::parse_procfs_json(json_missing_fields, sandbox_id);
+    EXPECT_EQ(res.status, SCAP_FAILURE);
+    EXPECT_STREQ(res.error.c_str(), "Missing json field or wrong type: cannot parse procfs entry");
+
+    std::string args_arr = "[ \"bash\" ]";
+    std::string args_no_arr = "\"bash\"";
+    auto pos = json.find(args_arr);
+    json.replace(pos, args_arr.size(), args_no_arr);
+    res = scap_gvisor::parsers::parse_procfs_json(json, sandbox_id);
+    EXPECT_EQ(res.status, SCAP_FAILURE);
+    EXPECT_STREQ(res.error.c_str(), "Missing json field or wrong type: cannot parse procfs entry");
+
+}
+
+TEST(gvisor_parsers, config_socket)
+{
+    std::string config = R"(
+{
+    "trace_session": {
+        "name": "Default",
+        "points": [
+        {
+            "name": "container/start", 
+            "context_fields": [
+                "cwd",
+                "time"
+            ]
+        },
+        {
+            "name": "syscall/openat/enter",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        },
+        {
+            "name": "syscall/openat/exit",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        },
+        {
+            "name": "sentry/task_exit",
+            "context_fields": [
+                "credentials",
+                "container_id",
+                "thread_id",
+                "task_start_time",
+                "time"
+            ]
+        }
+        ],
+        "sinks": [
+        {
+            "name": "remote",
+            "config": {
+                "endpoint": "/tmp/gvisor.sock"
+            }
+        }
+        ]
+    }
+}
+    )";
+
+    scap_gvisor::parsers::config_result res;
+
+    res = scap_gvisor::parsers::parse_config(config);
+    EXPECT_EQ(res.status, SCAP_SUCCESS);
+    EXPECT_STREQ(res.socket_path.c_str(), "/tmp/gvisor.sock");
+}

--- a/test/libscap/test_suites/engines/kmod/kmod.cpp
+++ b/test/libscap/test_suites/engines/kmod/kmod.cpp
@@ -1,0 +1,158 @@
+#include <scap.h>
+#include <gtest/gtest.h>
+#include <unordered_set>
+#include <helpers/engines.h>
+
+#include <syscall.h>
+#include <fcntl.h>
+
+#define KMOD_DEFAULT_PATH "./driver/scap.ko"
+#define KMOD_NAME "scap"
+
+int remove_kmod(char* error_buf)
+{
+	if(syscall(__NR_delete_module, KMOD_NAME, O_NONBLOCK))
+	{
+		switch(errno)
+		{
+		case ENOENT:
+			return EXIT_SUCCESS;
+
+		/* If a module has a nonzero reference count with `O_NONBLOCK` flag
+		 * the call returns immediately, with `EWOULDBLOCK` code. So in that
+		 * case we wait until the module is detached.
+		 */
+		case EWOULDBLOCK:
+			for(int i = 0; i < 4; i++)
+			{
+				int ret = syscall(__NR_delete_module, KMOD_NAME, O_NONBLOCK);
+				if(ret == 0 || errno == ENOENT)
+				{
+					return EXIT_SUCCESS;
+				}
+				sleep(1);
+			}
+			snprintf(error_buf, SCAP_LASTERR_SIZE, "could not remove the kernel module");
+			return EXIT_FAILURE;
+
+		case EBUSY:
+		case EFAULT:
+		case EPERM:
+			snprintf(error_buf, SCAP_LASTERR_SIZE, "Unable to remove kernel module. Errno message: %s, errno: %d\n", strerror(errno), errno);
+			return EXIT_FAILURE;
+
+		default:
+			snprintf(error_buf, SCAP_LASTERR_SIZE, "Unexpected error code. Errno message: %s, errno: %d\n", strerror(errno), errno);
+			return EXIT_FAILURE;
+		}
+	}
+	return EXIT_SUCCESS;
+}
+
+int insert_kmod(const char* kmod_path, char* error_buf)
+{
+	/* Here we want to insert the module if we fail we need to abort the program. */
+	int fd = open(kmod_path, O_RDONLY);
+	if(fd < 0)
+	{
+		snprintf(error_buf, SCAP_LASTERR_SIZE, "Unable to open the kmod file. Errno message: %s, errno: %d\n", strerror(errno), errno);
+		return EXIT_FAILURE;
+	}
+
+	if(syscall(__NR_finit_module, fd, "", 0))
+	{
+		snprintf(error_buf, SCAP_LASTERR_SIZE, "Unable to inject the kmod. Errno message: %s, errno: %d\n", strerror(errno), errno);
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}
+
+scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* kmod_path, std::unordered_set<uint32_t> tp_set = {}, std::unordered_set<uint32_t> ppm_sc_set = {})
+{
+	struct scap_open_args oargs = {
+		.engine_name = KMOD_ENGINE,
+		.mode = SCAP_MODE_LIVE,
+	};
+
+	/* Remove previously inserted kernel module */
+	if(remove_kmod(error_buf) != EXIT_SUCCESS)
+	{
+		return NULL;
+	}
+
+	/* Insert again the kernel module */
+	if(insert_kmod(kmod_path, error_buf) != EXIT_SUCCESS)
+	{
+		return NULL;
+	}
+
+	/* If empty we fill with all tracepoints */
+	if(tp_set.empty())
+	{
+		for(int i = 0; i < TP_VAL_MAX; i++)
+		{
+			oargs.tp_of_interest.tp[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto tp : tp_set)
+		{
+			oargs.tp_of_interest.tp[tp] = 1;
+		}
+	}
+
+	/* If empty we fill with all syscalls */
+	if(ppm_sc_set.empty())
+	{
+		for(int i = 0; i < PPM_SC_MAX; i++)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto ppm_sc : ppm_sc_set)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[ppm_sc] = 1;
+		}
+	}
+
+	struct scap_kmod_engine_params kmod_params = {
+		.buffer_bytes_dim = buffer_dim,
+	};
+	oargs.engine_params = &kmod_params;
+
+	return scap_open(&oargs, error_buf, rc);
+}
+
+TEST(kmod, open_engine)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_kmod_engine(error_buffer, &ret, 4 * 4096, KMOD_DEFAULT_PATH);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open kmod engine: " << error_buffer << std::endl;
+	scap_close(h);
+}
+
+TEST(kmod, wrong_buffer_dim)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_kmod_engine(error_buffer, &ret, 4, KMOD_DEFAULT_PATH);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is not a system page multiple, so we should fail: " << error_buffer << std::endl;
+}
+
+/* This check is not so reliable, better than nothing but to be sure we need to obtain the producer and consumer positions from the drivers */
+TEST(kmod, events_not_overwritten)
+{
+	char error_buffer[SCAP_LASTERR_SIZE] = {0};
+	int ret = 0;
+	scap_t* h = open_kmod_engine(error_buffer, &ret, 4 * 4096, KMOD_DEFAULT_PATH);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open kmod engine: " << error_buffer << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+/* we miss here the `event_in_order` test, but we first need to complete our driver tests, otherwise some events will be discarded kernel side */

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -1,0 +1,209 @@
+#include "scap.h"
+#include <gtest/gtest.h>
+#include <unordered_set>
+#include <syscall.h>
+#include <helpers/engines.h>
+
+scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, uint16_t cpus_for_each_buffer, bool online_only, std::unordered_set<uint32_t> tp_set = {}, std::unordered_set<uint32_t> ppm_sc_set = {})
+{
+	struct scap_open_args oargs = {
+		.engine_name = MODERN_BPF_ENGINE,
+		.mode = SCAP_MODE_LIVE,
+	};
+
+	/* If empty we fill with all tracepoints */
+	if(tp_set.empty())
+	{
+		for(int i = 0; i < TP_VAL_MAX; i++)
+		{
+			oargs.tp_of_interest.tp[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto tp : tp_set)
+		{
+			oargs.tp_of_interest.tp[tp] = 1;
+		}
+	}
+
+	/* If empty we fill with all syscalls */
+	if(ppm_sc_set.empty())
+	{
+		for(int i = 0; i < PPM_SC_MAX; i++)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[i] = 1;
+		}
+	}
+	else
+	{
+		for(auto ppm_sc : ppm_sc_set)
+		{
+			oargs.ppm_sc_of_interest.ppm_sc[ppm_sc] = 1;
+		}
+	}
+
+	struct scap_modern_bpf_engine_params modern_bpf_params = {
+		.cpus_for_each_buffer = cpus_for_each_buffer,
+		.allocate_online_only = online_only,
+		.buffer_bytes_dim = buffer_dim,
+	};
+	oargs.engine_params = &modern_bpf_params;
+
+	return scap_open(&oargs, error_buf, rc);
+}
+
+TEST(modern_bpf, open_engine)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* we want 1 ring buffer for each CPU */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine: " << error_buffer << std::endl;
+	scap_close(h);
+}
+
+TEST(modern_bpf, empty_buffer_dim)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 0, 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is 0, we should fail: " << error_buffer << std::endl;
+	/* In case of failure the `scap_close(h)` is already called in the vtable `init` method */
+}
+
+TEST(modern_bpf, wrong_buffer_dim)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* ring buffer dim is not a multiple of PAGE_SIZE */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 + 4 * 4096, 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the buffer dimension is not a multiple of the page size, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, not_enough_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_possible_CPUs + 1, false);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater than the system possible CPUs, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, not_enough_online_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_online_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_online_CPUs + 1, true);
+	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater than the system online CPUs, we should fail: " << error_buffer << std::endl;
+}
+
+TEST(modern_bpf, one_buffer_per_possible_CPU)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer << std::endl;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+	uint32_t num_expected_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_expected_rings, num_possible_CPUs) << "we should have a ring buffer for every possible CPU!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, one_buffer_every_two_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 2, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer every 2 CPUs: " << error_buffer << std::endl;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_CONF);
+	uint32_t num_expected_rings = num_possible_CPUs / 2;
+	if(num_possible_CPUs % 2 != 0)
+	{
+		num_expected_rings++;
+	}
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, num_expected_rings) << "we should have one ring buffer every 2 CPUs!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, one_buffer_shared_between_all_possible_CPUs_with_special_value)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* `0` is a special value that means one single shared ring buffer */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0, false);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, 1) << "we should have only one ring buffer shared between all CPUs!" << std::endl;
+
+	check_event_is_not_overwritten(h);
+	scap_close(h);
+}
+
+/* In this test we don't need to check for buffer corruption with `check_event_is_not_overwritten`
+ * we have already done it in the previous test `one_buffer_shared_between_all_CPUs_with_special_value`.
+ */
+TEST(modern_bpf, one_buffer_shared_between_all_online_CPUs_with_explicit_CPUs_number)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+
+	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
+
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, num_possible_CPUs, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	uint32_t num_rings = scap_get_ndevs(h);
+	ASSERT_EQ(num_rings, 1) << "we should have only one ring buffer shared between all CPUs!" << std::endl;
+
+	scap_close(h);
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_per_online_CPU)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 1, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_every_two_online_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 2, true);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open modern bpf engine with one ring buffer every 2 CPUs: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}
+
+TEST(modern_bpf, read_in_order_one_buffer_shared_between_all_possible_CPUs)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	/* We use buffers of 1 MB to be sure that we don't have drops */
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false) << "unable to open modern bpf engine with one single shared ring buffer: " << error_buffer << std::endl;
+
+	check_event_order(h);
+	scap_close(h);
+}

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -1,4 +1,4 @@
-#include "scap.h"
+#include <scap.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include <syscall.h>

--- a/test/libscap/test_suites/generic/scap_event.cpp
+++ b/test/libscap/test_suites/generic/scap_event.cpp
@@ -1,0 +1,152 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <scap.h>
+#include <gtest/gtest.h>
+
+// fills the buffer with ASCII data to catch bugs 
+static void fill_buffer(scap_sized_buffer buf)
+{
+    char *cbuf = static_cast<char*>(buf.buf);
+    size_t i = 0;
+    for (char upper = 'A'; upper < 'Z'; upper++) {
+        for (char lower = 'a'; lower < 'z'; lower++) {
+            for (char digit = '0'; digit < '9'; digit++) {
+                if (i == buf.size) return;
+                cbuf[i] = upper;
+                i++;
+                if (i == buf.size) return;
+                cbuf[i] = lower;
+                i++;
+                if (i == buf.size) return;
+                cbuf[i] = digit;
+                i++;
+            }
+        }
+    }
+}
+
+// This function behaves exactly like scap_event_encode_params but it will allocate the event and return it by setting the event pointer.
+static int32_t scap_event_generate(scap_evt **event, char *error, enum ppm_event_type event_type, uint32_t n, ...)
+{
+    struct scap_sized_buffer event_buf = {NULL, 0};
+    size_t event_size;
+    va_list args;
+    va_start(args, n);
+    int32_t ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+    va_end(args);
+
+    if(ret != SCAP_INPUT_TOO_SMALL) {
+        if (ret == SCAP_SUCCESS) {
+            snprintf(error, SCAP_LASTERR_SIZE, "Could not generate event. Expected SCAP_INPUT_TOO_SMALL, got SCAP_SUCCESS for event type %d with %d args", event_type, n);
+        }
+        return SCAP_FAILURE;
+    }
+
+    event_buf.buf = malloc(event_size);
+    event_buf.size = event_size;
+
+    fill_buffer(event_buf);
+
+    if(event_buf.buf == NULL) {
+        snprintf(error, SCAP_LASTERR_SIZE, "Could not generate event. Allocation failed for %zu bytes", event_size);
+        return SCAP_FAILURE;
+    }
+
+    va_start(args, n);
+    ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);
+    va_end(args);
+
+    if(ret != SCAP_SUCCESS) {
+        free(event_buf.buf);
+        event_buf.size = 0;
+    }
+
+    *event = (scap_evt*)event_buf.buf;
+
+    return ret;
+}
+
+TEST(scap_event, empty_clone)
+{
+    char scap_error[SCAP_LASTERR_SIZE];
+    scap_evt *maybe_evt;
+    uint32_t status = scap_event_generate(&maybe_evt, scap_error, PPME_SYSCALL_CLONE_20_E, 0);
+    ASSERT_EQ(status, SCAP_SUCCESS) << "scap_event_generate failed with error " << scap_error;
+    ASSERT_NE(maybe_evt, nullptr);
+    std::unique_ptr<scap_evt, decltype(free)*> evt {maybe_evt, free};
+
+    EXPECT_EQ(evt->nparams, 0);
+
+    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
+    EXPECT_EQ(n, 0);
+}
+
+TEST(scap_event, int_args)
+{
+    char scap_error[SCAP_LASTERR_SIZE];
+    scap_evt *maybe_evt;
+    uint32_t status = scap_event_generate(&maybe_evt, scap_error, PPME_SYSCALL_KILL_E, 2, 1234, 9);
+    ASSERT_EQ(status, SCAP_SUCCESS) << "scap_event_generate failed with error " << scap_error;
+    ASSERT_NE(maybe_evt, nullptr);
+    std::unique_ptr<scap_evt, decltype(free)*> evt {maybe_evt, free};
+
+    EXPECT_EQ(evt->nparams, 2);
+
+    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
+    EXPECT_EQ(n, 2);
+    EXPECT_EQ(decoded_params[0].size, sizeof(uint64_t));
+    uint64_t val64;
+    memcpy(&val64, decoded_params[0].buf, sizeof(uint64_t));
+    EXPECT_EQ(val64, 1234);
+
+    uint8_t val8;
+    memcpy(&val8, decoded_params[1].buf, sizeof(uint8_t));
+    EXPECT_EQ(val8, 9);
+}
+
+TEST(scap_event, empty_buffers)
+{
+    char scap_error[SCAP_LASTERR_SIZE];
+
+    // empty string should be of size 1
+    scap_evt *maybe_evt;
+    uint32_t status = scap_event_generate(&maybe_evt, scap_error, PPME_SYSCALL_GETCWD_X, 2, 0, "");
+    ASSERT_EQ(status, SCAP_SUCCESS) << "scap_event_generate failed with error " << scap_error;
+    ASSERT_NE(maybe_evt, nullptr);
+    std::unique_ptr<scap_evt, decltype(free)*> evt {maybe_evt, free};
+
+    EXPECT_EQ(evt->nparams, 2);
+
+    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
+    EXPECT_EQ(n, 2);
+    EXPECT_EQ(decoded_params[0].size, sizeof(uint64_t));
+    EXPECT_EQ(decoded_params[1].size, 1);
+
+    status = scap_event_generate(&maybe_evt, scap_error, PPME_SYSCALL_READ_X, 2, 0, scap_const_sized_buffer{nullptr, 0});
+    ASSERT_EQ(status, SCAP_SUCCESS) << "scap_event_generate failed with error " << scap_error;
+    ASSERT_NE(maybe_evt, nullptr);
+    evt.reset(maybe_evt);
+
+    n = scap_event_decode_params(evt.get(), decoded_params);
+    EXPECT_EQ(n, 2);
+    EXPECT_EQ(decoded_params[0].size, sizeof(uint64_t));
+    EXPECT_EQ(decoded_params[1].size, 0);
+}

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -425,6 +425,13 @@ return SCAP_SUCCESS;
 //
 int32_t scap_kmod_stop_capture(struct scap_engine_handle engine)
 {
+	/* This could happen if we fail to instantiate `m_devs` in the init method */
+	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
+	if(devset->m_devs == NULL)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	/* Disable all tracepoints */
 	int ret = SCAP_SUCCESS;
 	for (int i = 0; i < TP_VAL_MAX && ret == SCAP_SUCCESS; i++)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -807,6 +807,10 @@ void scap_close(scap_t* handle)
 	{
 		/* The capture should be stopped before
 		 * closing the engine, here we only enforce it.
+	     * Please note that there are some corner cases in which 
+		 * we call `scap_close` before the engine is validated
+		 * so we need to pay attention to NULL pointers in the 
+		 * following v-table methods.
 		 */
 		handle->m_vtable->stop_capture(handle->m_engine);
 		handle->m_vtable->close(handle->m_engine);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area CI

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR moves all libscap tests into the `test` folder and adds some tests for engines `modern_bpf`, `bpf`, `kmod`. The PR is just a proposal, if you have other ideas or suggestions on how to do that I'm all ears.

RIght now this PR moves only the existing tests to the new directory and add some new ones, the old libscap tests are still there because we need to change a little bit our CI job before doing the switch

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
