### PR TITLE
new(sinsp): rework sinsp-example output

### DIFF
--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -197,6 +197,10 @@ def parse_log(log: str) -> dict:
     Returns:
         A dictionary holding all the captured values for the event.
     """
+    if log.startswith('--'):
+        # sinsp-example diagnostic messages
+        print(log)
+        return None
     try:
         return json.loads(log)
     except json.JSONDecodeError as e:

--- a/test/e2e/tests/test_process/test_container.py
+++ b/test/e2e/tests/test_process/test_container.py
@@ -4,6 +4,7 @@ from sinspqa.sinsp import assert_events
 from sinspqa.docker import get_container_id
 
 sinsp_args = [
+    "-j",
     "-f", "evt.category=process and not container.id=host",
     "-o", "%container.id %evt.args %evt.category %evt.type %proc.cmdline %proc.exe %user.uid %user.name %user.homedir %group.gid %group.name"
 ]

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <csignal>
 #include <sinsp.h>
 #include <functional>
+#include <memory>
 #include "util.h"
 #include "filter/ppm_codes.h"
 #include <unordered_set>

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -43,7 +43,6 @@ using namespace std;
 // Functions used for dumping to stdout
 void plaintext_dump(sinsp_evt* ev);
 void formatted_dump(sinsp_evt* ev);
-void json_dump_init(sinsp& inspector);
 
 libsinsp::events::set<ppm_sc_code> extract_filter_sc_codes(sinsp& inspector);
 std::function<void(sinsp_evt*)> dump;
@@ -143,7 +142,8 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 			filter_string = optarg;
 			break;
 		case 'j':
-			json_dump_init(inspector);
+			dump = formatted_dump;
+			inspector.set_buffer_format(sinsp_evt::PF_JSON);
 			break;
 		case 'a':
 			g_all_threads = true;
@@ -508,11 +508,6 @@ void plaintext_dump(sinsp_evt* ev)
 	formatted_dump(ev);
 }
 
-void json_dump_init(sinsp& inspector)
-{
-	dump = formatted_dump;
-	inspector.set_buffer_format(sinsp_evt::PF_JSON);
-}
 
 void formatted_dump(sinsp_evt* ev)
 {

--- a/userspace/libsinsp/examples/util.cpp
+++ b/userspace/libsinsp/examples/util.cpp
@@ -50,7 +50,7 @@ std::string get_event_category_name(ppm_event_category category)
 //
 // Get the string representation of a ppm_event_type
 //
-std::string get_event_type_name(sinsp& inspector, sinsp_evt* ev)
+std::string get_event_type_name(sinsp_evt *ev)
 {
 	uint16_t type = ev->get_type();
 	if (type >= PPM_EVENT_MAX)

--- a/userspace/libsinsp/examples/util.h
+++ b/userspace/libsinsp/examples/util.h
@@ -25,4 +25,4 @@ std::string get_event_category_name(ppm_event_category category);
 //
 // Get the string representation of a ppm_event_type
 //
-std::string get_event_type_name(sinsp& inspector, sinsp_evt* ev);
+std::string get_event_type_name(sinsp_evt *ev);

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -5287,6 +5287,21 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		case EC_SCHEDULER:
 			m_strstorage = "scheduler";
 			break;
+		case EC_INTERNAL:
+			m_strstorage = "internal";
+			break;
+		case EC_SYSCALL:
+			m_strstorage = "syscall";
+			break;
+		case EC_TRACEPOINT:
+			m_strstorage = "tracepoint";
+			break;
+		case EC_PLUGIN:
+			m_strstorage = "plugin";
+			break;
+		case EC_METAEVENT:
+			m_strstorage = "meta";
+			break;
 		default:
 			m_strstorage = "unknown";
 			break;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -6658,7 +6658,7 @@ void sinsp_parser::parse_pidfd_open_exit(sinsp_evt *evt)
 	/* pid (fd) */
 	parinfo = evt->get_param(1);
 	ASSERT(parinfo->m_len == sizeof(int64_t));
-	ASSERT(evt->get_param_info(0)->type == PT_PID);
+	ASSERT(evt->get_param_info(1)->type == PT_PID);
 	pid = *(int64_t *)parinfo->m_val;
 	
 	/* flags */


### PR DESCRIPTION
This PR all but drops the custom output code we have in sinsp-example and switches to using the same formatters as JSON output. This makes sinsp-example output actually useful to look at events (making it a usable replacement for `sysdig` in some scenarios)

It turns out our category->name mapping was incomplete (which we didn't really notice if we used our own in sinsp-example) so I updated that too.

I also added a raw output mode to almost literally dump the raw events in hex.

Sample default output:
```
 16:14:39.647872382 cat=memory container=host proc=curl(13267.13267) > mmap addr=0 length=8392704 prot=3(PROT_READ|PROT_WRITE) flags=10(MAP_PRIVATE|MAP_ANONYMOUS) fd=-1(EPERM) offset=0
 16:14:39.647881810 cat=memory container=host proc=curl(13267.13267) < mmap res=7F16D533D000 vm_size=0 vm_rss=0 vm_swap=0
 16:14:39.647895264 cat=memory container=host proc=curl(13267.13267) > mprotect addr=7F16D533D000 length=4096 prot=0(PROT_NONE)
 16:14:39.647904283 cat=memory container=host proc=curl(13267.13267) < mprotect res=0
 16:14:39.647915148 cat=process container=host proc=curl(13267.13267) ppid=13266 exe=curl args=[curl example.com] > clone
 16:14:39.647936980 cat=process container=host proc=curl(13267.13267) ppid=13266 exe=curl args=[curl example.com] < clone res=13268(curl) exe=curl args=example.com. tid=13267(curl) pid=13267(curl) ptid=13266(pdig) cwd=/tmp fdlimit=1024 pgft_maj=0 pgft_min=776 vm_size=94832 vm_rss=5436 vm_swap=0 comm=curl cgroups=freezer=.memory=/user.slice/user-0.slice/session-6605.scop.rdma=.pids=/user.slice/user-0.slice/session-6605.scop.devices=/user.slice/user-0.slice/session-6605.scop.perf_event=.cpu=/user.slice/user-0.slice/session-6605.scop.cpuacct=/user.slice/user-0.slice/session-6605.scop.hugetlb=.cpuset=.net_cls=.net_prio=.blkio=/user.slice/user-0.slice/session-6605.scop.name=systemd=/user.slice/user-0.slice/session-6605.scop. flags=41990659(CLONE_FILES|CLONE_FS|CLONE_PARENT_SETTID|CLONE_SIGHAND|CLONE_SYSVSEM|CLONE_THREAD|CLONE_VM|CLONE_CHILD_CLEARTID|CLONE_SETTLS) uid=0 gid=0 vtid=13267(curl) vpid=13267(curl)
```

Sample raw output:
```
ts=2023-01-20T15:14:02.937887462+0000 tid=13259 type=>mmap category=MEMORY nparams=6 0:addr=[00 00 00 00 00 00 00 00] 1:length=[00 10 80 00 00 00 00 00] 2:prot=[03 00 00 00] 3:flags=[0a 00 00 00] 4:fd=[ff ff ff ff ff ff ff ff] 5:offset=[00 00 00 00 00 00 00 00]
ts=2023-01-20T15:14:02.937897024+0000 tid=13259 type=<mmap category=MEMORY nparams=4 0:res=[00 00 93 03 ea 7f 00 00] 1:vm_size=[00 00 00 00] 2:vm_rss=[00 00 00 00] 3:vm_swap=[00 00 00 00]
ts=2023-01-20T15:14:02.937911755+0000 tid=13259 type=>mprotect category=MEMORY nparams=3 0:addr=[00 00 93 03 ea 7f 00 00] 1:length=[00 10 00 00 00 00 00 00] 2:prot=[00 00 00 00]
ts=2023-01-20T15:14:02.937920949+0000 tid=13259 type=<mprotect category=MEMORY nparams=1 0:res=[00 00 00 00 00 00 00 00]
ts=2023-01-20T15:14:02.937930917+0000 tid=13259 type=>clone category=PROCESS nparams=0
ts=2023-01-20T15:14:02.937952362+0000 tid=13259 type=<clone category=PROCESS nparams=20 0:res=[cc "3" 00 00 00 00 00 00] 1:exe=["curl" 00] 2:args=["example.com" 00] 3:tid=[cb "3" 00 00 00 00 00 00] 4:pid=[cb "3" 00 00 00 00 00 00] 5:ptid=[ca "3" 00 00 00 00 00 00] 6:cwd=["/tmp" 00] 7:fdlimit=[00 04 00 00 00 00 00 00] 8:pgft_maj=[00 00 00 00 00 00 00 00] 9:pgft_min=[0c 03 00 00 00 00 00 00] 10:vm_size=["pr" 01 00] 11:vm_rss=[e8 14 00 00] 12:vm_swap=[00 00 00 00] 13:comm=["curl" 00] 14:cgroups=["freezer=" 00 "memory=/user.slice/user-0.slice/session-6605.scop" 00 "rdma=" 00 "pids=/user.slice/user-0.slice/session-6605.scop" 00 "devices=/user.slice/user-0.slice/session-6605.scop" 00 "perf_event=" 00 "cpu=/user.slice/user-0.slice/session-6605.scop" 00 "cpuacct=/user.slice/user-0.slice/session-6605.scop" 00 "hugetlb=" 00 "cpuset=" 00 "net_cls=" 00 "net_prio=" 00 "blkio=/user.slice/user-0.slice/session-6605.scop" 00 "name=systemd=/user.slice/user-0.slice/session-6605.scop" 00] 15:flags=[03 ba 80 02] 16:uid=[00 00 00 00] 17:gid=[00 00 00 00] 18:vtid=[cb "3" 00 00 00 00 00 00] 19:vpid=[cb "3" 00 00 00 00 00 00]
```

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(sinsp)!: sinsp-example output is now different
```
