### PR TITLE
fix: handle unshare_setns_x missing thread_info, chore: thread_info check cleanups

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5812,7 +5812,7 @@ void sinsp_parser::parse_unshare_setns_exit(sinsp_evt *evt)
 	//
 	// Update capabilities
 	//
-	if(flags & PPM_CL_CLONE_NEWUSER)
+	if(flags & PPM_CL_CLONE_NEWUSER && evt->m_tinfo != nullptr)
 	{
 		tinfo = evt->m_tinfo;
 		uint64_t max_caps = sinsp_utils::get_max_caps();

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -846,7 +846,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 
 void sinsp_parser::store_event(sinsp_evt *evt)
 {
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		//
 		// No thread in the table. We won't store this event, which mean that
@@ -1103,7 +1103,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		// it was created recently. Otherwise, assume it's an old thread for which
 		// we lost the exit event and remove it from the table.
 		//
-		if(evt->m_tinfo && evt->m_tinfo->m_clone_ts != 0)
+		if(evt->m_tinfo != nullptr && evt->m_tinfo->m_clone_ts != 0)
 		{
 			if(evt->get_ts() - evt->m_tinfo->m_clone_ts > CLONE_STALE_TIME_NS)
 			{
@@ -1136,7 +1136,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 
 		// Validate that the child thread info has actually been created.
 		//
-		if(!evt->m_tinfo)
+		if(evt->m_tinfo == nullptr)
 		{
 			//
 			// No thread yet.
@@ -1710,7 +1710,7 @@ void sinsp_parser::parse_execve_enter(sinsp_evt *evt)
 {
 	store_event(evt);
 
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		// Should be impossible
 		ASSERT(false);
@@ -1763,7 +1763,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// We get here when `execve` or `execveat` return. The thread has already been added by a previous fork or clone,
 	// and we just update the entry with the new information.
 	//
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		//
 		// No thread to update?
@@ -3308,7 +3308,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt *evt)
 	//
 	// Lookup the thread
 	//
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		ASSERT(false);
 		return;
@@ -3421,7 +3421,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_close_enter(sinsp_evt *evt)
 {
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		return;
 	}
@@ -3660,7 +3660,7 @@ void sinsp_parser::parse_thread_exit(sinsp_evt *evt)
 	//
 	// Schedule the process for removal
 	//
-	if(evt->m_tinfo)
+	if(evt->m_tinfo != nullptr)
 	{
 		evt->m_tinfo->m_flags |= PPM_CL_CLOSED;
 		m_inspector->m_tid_to_remove = evt->get_tid();
@@ -4453,7 +4453,7 @@ void sinsp_parser::parse_chdir_exit(sinsp_evt *evt)
 	sinsp_evt_param *parinfo;
 	int64_t retval;
 
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		return;
 	}
@@ -4526,7 +4526,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 	//
 	if(retval >= 0)
 	{
-		if(!evt->m_tinfo)
+		if(evt->m_tinfo == nullptr)
 		{
 			//
 			// No thread in the table. We won't store this event, which mean that
@@ -4892,7 +4892,7 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_select_poll_epollwait_enter(sinsp_evt *evt)
 {
-	if(evt->m_tinfo == NULL)
+	if(evt->m_tinfo == nullptr)
 	{
 		ASSERT(false);
 		return;
@@ -4906,7 +4906,7 @@ void sinsp_parser::parse_select_poll_epollwait_enter(sinsp_evt *evt)
 }
 void sinsp_parser::parse_fcntl_enter(sinsp_evt *evt)
 {
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		return;
 	}
@@ -4963,7 +4963,7 @@ void sinsp_parser::parse_fcntl_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_context_switch(sinsp_evt* evt)
 {
-	if(evt->m_tinfo)
+	if(evt->m_tinfo != nullptr)
 	{
 		sinsp_evt_param *parinfo;
 		parinfo = evt->get_param(1);
@@ -4995,7 +4995,7 @@ void sinsp_parser::parse_context_switch(sinsp_evt* evt)
 void sinsp_parser::parse_brk_munmap_mmap_exit(sinsp_evt* evt)
 {
 	ASSERT(evt->m_tinfo);
-	if(evt->m_tinfo)
+	if(evt->m_tinfo != nullptr)
 	{
 		sinsp_evt_param *parinfo;
 
@@ -5666,7 +5666,7 @@ void sinsp_parser::parse_getsockopt_exit(sinsp_evt *evt)
 	int64_t fd;
 	int8_t level, optname;
 
-	if(!evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
 	{
 		return;
 	}


### PR DESCRIPTION
Signed-off-by: Adnan Ali [adduali1310@hotmail.com]

**What type of PR is this?**

/kind bug
/kind cleanup



<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area libsinsp
<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
no

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR is made of 2 commits:

Commit1: (fix)
Adds a safety check to validate if thread information is available before trying to dereference it when parsing the unshare_setns_exit event. Follows https://github.com/falcosecurity/libs/pull/818 to avoid further segfaults I encountered in specific parsers.

Commit2: (chore)
Performs a cleanup and follows a consistent method of thread information validation rather than having multiple different ways to check the same condition within a file making it very confusing and inconsistent.
For More Details , please refer to https://github.com/falcosecurity/libs/issues/817#issuecomment-1372257283 where I have provided code examples of the issue.



**Which issue(s) this PR fixes**:
Continuation from  https://github.com/falcosecurity/libs/issues/817
See https://github.com/falcosecurity/libs/issues/817#issuecomment-1372382513 as well.


**Special notes for your reviewer**:

I have gone through the whole parsers.cpp file and specifically taken a look at the different parsers to see where we need to perform fixes and cleanups. Most parsers already have both - the thread information check as well as the comparison to nullptr as a consistent means of comparison.

I would also like to point out the below parsers where m_tinfo is dereferenced directly without a check, but I personally have not faced any segfaults due to the same. I have only seen segfaults due to the parsers I have mentioned(the same ones for which I have created PRs), which makes me believe that either the below parsers are fine or my rules do not make use of the parsers which is why segfaults have not yet been observed. I will leave it to the maintainers to decide on the best course of action for these parsers and will be happy to create follow up PR's if needed for the same.

As an example:

parse_rw_exit: https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/parsers.cpp#L4336
fcntl_exit: https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/parsers.cpp#L4960
eventfd_exit: https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/parsers.cpp#L4448


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
