### PR TITLE
fix(readme): minimum kver to build kmod on arm64 is 3.16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ If you build this project from a git working directory, the main [CMakeLists.txt
 
 Right now our drivers officially support the following architectures:
 
-|             | Kernel module | eBPF probe | Modern eBPF probe |
-| ----------- | ------------- | ---------- | ---------------- |
-| **x86_64**  | >= 2.6        | >= 4.14    | WIP 👷           |
-| **aarch64** | >= 3.4        | >= 4.17    | WIP 👷           |
-| **s390x**   | >= 2.6        | ❌         | WIP 👷            |
+|             | Kernel module                                                                                | eBPF probe | Modern eBPF probe |
+| ----------- |----------------------------------------------------------------------------------------------| ---------- | ---------------- |
+| **x86_64**  | >= 2.6                                                                                       | >= 4.14    | WIP 👷           |
+| **aarch64** | >= [3.16](https://github.com/torvalds/linux/commit/055b1212d141f1f398fca548f8147787c0b6253f) | >= 4.17    | WIP 👷           |
+| **s390x**   | >= 2.6                                                                                       | ❌         | WIP 👷            |
 
 >**Please note**: BPF has some issues with architectures like `s390x`! Some helpers like `bpf_probe_read()` and `bpf_probe_read_str()` are broken on archs with overlapping address ranges.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**


**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

`HAVE_SYSCALL_TRACEPOINTS` was added to arm64 in linux 3.16: https://github.com/torvalds/linux/commit/055b1212d141f1f398fca548f8147787c0b6253f

Properly bump minimum kver to build kmod on arm64.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
