### PR TITLE
fix(userspace/libscap): fix build with bundled zlib and `-jX` parallel build

### DIFF
--- a/userspace/libscap/engine/noop/CMakeLists.txt
+++ b/userspace/libscap/engine/noop/CMakeLists.txt
@@ -1,2 +1,5 @@
 include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_noop noop.c)
+if(USE_BUNDLED_ZLIB AND NOT MINIMAL_BUILD)
+    add_dependencies(scap_engine_noop zlib)
+endif()

--- a/userspace/libscap/linux/CMakeLists.txt
+++ b/userspace/libscap/linux/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_library(scap_platform scap_procs.c scap_fds.c scap_userlist.c scap_iflist.c)
 target_link_libraries(scap_platform scap_error)
+if(USE_BUNDLED_ZLIB AND NOT MINIMAL_BUILD)
+    add_dependencies(scap_platform zlib)
+endif()

--- a/userspace/libscap/macos/CMakeLists.txt
+++ b/userspace/libscap/macos/CMakeLists.txt
@@ -1,3 +1,6 @@
 # note: since macOS is effectively non-existent, this library will go away
 # as soon as we clean up the interface enough
 add_library(scap_platform scap_procs.c)
+if(USE_BUNDLED_ZLIB AND NOT MINIMAL_BUILD)
+    add_dependencies(scap_platform zlib)
+endif()

--- a/userspace/libscap/win32/CMakeLists.txt
+++ b/userspace/libscap/win32/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_library(scap_platform scap_procs.c)
+if(USE_BUNDLED_ZLIB AND NOT MINIMAL_BUILD)
+    add_dependencies(scap_platform zlib)
+endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build
/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When building with a bundled zlib, in a system without system zlib headers installed (ie: an ubuntu:22.04 docker image), parallel build of scap fails with:
```
In file included from /libs/userspace/libscap/scap_savefile_api.h:24,
from /libs/userspace/libscap/scap.h:21,
from /libs/userspace/libscap/engine/noop/noop.c:29:
/libs/userspace/libscap/scap_zlib.h:23:10: fatal error: zlib.h: No such file or directory
23 | #include <zlib.h>
```
Or, with just the scap_noop engine patch applied, with:
```
In file included from /libs/userspace/libscap/scap_savefile_api.h:24,
from /libs/userspace/libscap/scap.h:21,
from /libs/userspace/libscap/linux/scap_iflist.c:20:
/libs/userspace/libscap/scap_zlib.h:23:10: fatal error: zlib.h: No such file or directory
23 | #include <zlib.h>
|          ^~~~~~~~
compilation terminated.
make[3]: *** [libscap/linux/CMakeFiles/scap_platform.dir/build.make:118: libscap/linux/CMakeFiles/scap_platform.dir/scap_iflist.c.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from /libs/userspace/libscap/scap_savefile_api.h:24,
from /libs/userspace/libscap/scap.h:21,
from /libs/userspace/libscap/linux/scap_userlist.c:19:
/libs/userspace/libscap/scap_zlib.h:23:10: fatal error: zlib.h: No such file or directory
23 | #include <zlib.h>
|          ^~~~~~~~
compilation terminated.
make[3]: *** [libscap/linux/CMakeFiles/scap_platform.dir/build.make:104: libscap/linux/CMakeFiles/scap_platform.dir/scap_userlist.c.o] Error 1
In file included from /libs/userspace/libscap/scap_savefile_api.h:24,
from /libs/userspace/libscap/scap.h:21,
from /libs/userspace/libscap/linux/scap_fds.c:20:
/libs/userspace/libscap/scap_zlib.h:23:10: fatal error: zlib.h: No such file or directory
23 | #include <zlib.h>
|          ^~~~~~~~
compilation terminated.
make[3]: *** [libscap/linux/CMakeFiles/scap_platform.dir/build.make:90: libscap/linux/CMakeFiles/scap_platform.dir/scap_fds.c.o] Error 1
In file included from /libs/userspace/libscap/scap_savefile_api.h:24,
from /libs/userspace/libscap/scap.h:21,
from /libs/userspace/libscap/linux/scap_procs.c:33:
/libs/userspace/libscap/scap_zlib.h:23:10: fatal error: zlib.h: No such file or directory
23 | #include <zlib.h>
|          ^~~~~~~~
compilation terminated.
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
