### PR TITLE
fix(tests): `vm_...` extracted from proc are not reliable

### DIFF
--- a/test/drivers/helpers/proc_parsing.cpp
+++ b/test/drivers/helpers/proc_parsing.cpp
@@ -82,24 +82,6 @@ bool get_proc_info(pid_t pid, proc_info* info)
 	while(fgets(line, MAX_PATH, status) != NULL)
 	{
 		sscanf(line, "%s %d %*s\n", prefix, &temp);
-		if(strncmp(prefix, "VmSize:", 8) == 0)
-		{
-			info->vm_size = temp;
-			found++;
-		}
-
-		if(strncmp(prefix, "VmRSS:", 7) == 0)
-		{
-			info->vm_rss = temp;
-			found++;
-		}
-
-		if(strncmp(prefix, "VmSwap:", 8) == 0)
-		{
-			info->vm_swap = temp;
-			found++;
-		}
-
 		if(strncmp(prefix, "Uid:", 5) == 0)
 		{
 			info->uid = temp;
@@ -124,7 +106,7 @@ bool get_proc_info(pid_t pid, proc_info* info)
 			found++;
 		}
 
-		if(found == 7)
+		if(found == 4)
 		{
 			break;
 		}

--- a/test/drivers/helpers/proc_parsing.h
+++ b/test/drivers/helpers/proc_parsing.h
@@ -18,9 +18,6 @@ struct proc_info
 	pid_t pgid; /* The process group ID of the process. */
 	char raw_args[MAX_NUM_ARGS][MAX_PATH];
 	const char* args[MAX_NUM_ARGS];
-	uint32_t vm_size;
-	uint32_t vm_rss;
-	uint32_t vm_swap;
 	uint32_t uid;
 	uint32_t gid;
 	uint32_t vpid;

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
@@ -13,18 +13,6 @@ TEST(GenericTracepoints, sched_switch)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	/* We scan proc before the BPF event is caught so we have
-	 * to use `GREATER_EQUAL` in the assertions. We will search
-	 * for a sched_switch of the father so now we are collecting
-	 * data regarding the father.
-	 */
-	struct proc_info info = {0};
-	pid_t pid = ::getpid();
-	if(!get_proc_info(pid, &info))
-	{
-		FAIL() << "Unable to get all the info from proc" << std::endl;
-	}
-
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
@@ -79,17 +67,16 @@ TEST(GenericTracepoints, sched_switch)
 	evt_test->assert_numeric_param(3, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 4: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(4, (uint32_t)info.vm_size, GREATER_EQUAL);
+	evt_test->assert_numeric_param(4, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 5: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(5, (uint32_t)info.vm_rss, GREATER_EQUAL);
+	evt_test->assert_numeric_param(5, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 6: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(6, (uint32_t)info.vm_swap, GREATER_EQUAL);
+	evt_test->assert_numeric_param(6, (uint32_t)0, GREATER_EQUAL);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	evt_test->assert_num_params_pushed(6);
-
 }
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -96,13 +96,13 @@ TEST(SyscallExit, clone3X_father)
 	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(11, (uint32_t)info.vm_size, GREATER_EQUAL);
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(12, (uint32_t)info.vm_rss, GREATER_EQUAL);
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(13, (uint32_t)info.vm_swap, GREATER_EQUAL);
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);

--- a/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
@@ -132,13 +132,13 @@ TEST(SyscallExit, cloneX_father)
 	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(11, (uint32_t)info.vm_size, GREATER_EQUAL);
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(12, (uint32_t)info.vm_rss, GREATER_EQUAL);
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(13, (uint32_t)info.vm_swap, GREATER_EQUAL);
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -98,13 +98,13 @@ TEST(SyscallExit, execveX_failure)
 	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(11, (uint32_t)info.vm_size, GREATER_EQUAL);
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(12, (uint32_t)info.vm_rss, GREATER_EQUAL);
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(13, (uint32_t)info.vm_swap, GREATER_EQUAL);
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -101,13 +101,13 @@ TEST(SyscallExit, execveatX_failure)
 	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(11, (uint32_t)info.vm_size);
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(12, (uint32_t)info.vm_rss);
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(13, (uint32_t)info.vm_swap);
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);

--- a/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
@@ -93,13 +93,13 @@ TEST(SyscallExit, forkX_father)
 	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	evt_test->assert_numeric_param(11, (uint32_t)info.vm_size, GREATER_EQUAL);
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	evt_test->assert_numeric_param(12, (uint32_t)info.vm_rss, GREATER_EQUAL);
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	evt_test->assert_numeric_param(13, (uint32_t)info.vm_swap, GREATER_EQUAL);
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Some data extracted from proc are not so reliable like `vm_rss` `vm_size` `vm_swap`, the CI is failing for this reason. This is an example: https://github.com/falcosecurity/libs/actions/runs/4043114894/jobs/6951658048#step:6:537

```
/home/runner/work/libs/libs/test/drivers/event_class/event_class.cpp:506: Failure
Expected: (*(T*)(m_event_params[m_current_param].valptr)) >= (param), actual: 14116 vs 14120
```
When we extract the `vm_rss` from proc its value is `14120` but when we assert the value is lower, this is obviously possible, quite unfortunate but possible

Instead of using the expected values we can use `GREATER_EQUAL` than `0`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
