### PR TITLE
fix(userspace): release unused resources on error and cleanup buffer reads

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -507,6 +507,7 @@ static int32_t load_tracepoint(struct bpf_engine* handle, const char *event, str
 
 	if(*event == 0)
 	{
+		free(error);
 		return scap_errprintf(handle->m_lasterr, 0, "event name cannot be empty");
 	}
 

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -65,6 +65,7 @@ static uint32_t get_max_consumers()
 		int w = fscanf(pfile, "%"PRIu32, &max);
 		if(w == 0)
 		{
+			fclose(pfile);
 			return 0;
 		}
 

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -75,7 +75,7 @@ int32_t scap_fd_handle_pipe(struct scap_proclist* proclist, char *fname, scap_th
 	uint64_t ino;
 	struct stat sb;
 
-	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE - 1);
 	if (r <= 0)
 	{
 		return scap_errprintf(error, errno, "Could not read link %s", fname);
@@ -274,7 +274,7 @@ int32_t scap_fd_handle_regular_file(struct scap_proclist *proclist, char *fname,
 	char link_name[SCAP_MAX_PATH_SIZE];
 	ssize_t r;
 
-	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE - 1);
 	if (r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -382,7 +382,7 @@ int32_t scap_fd_handle_socket(struct scap_proclist *proclist, char *fname, scap_
 		}
 	}
 
-	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE);
+	r = readlink(fname, link_name, SCAP_MAX_PATH_SIZE - 1);
 	if(r <= 0)
 	{
 		return SCAP_SUCCESS;
@@ -1232,7 +1232,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 	// Get the network namespace of the process
 	//
 	snprintf(f_name, sizeof(f_name), "%sns/net", procdir);
-	r = readlink(f_name, link_name, sizeof(link_name));
+	r = readlink(f_name, link_name, sizeof(link_name) - 1);
 	if(r <= 0)
 	{
 		//

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -558,8 +558,10 @@ int32_t scap_proc_fill_root(char* error, struct scap_threadinfo* tinfo, const ch
 {
 	char root_path[SCAP_MAX_PATH_SIZE];
 	snprintf(root_path, sizeof(root_path), "%sroot", procdirname);
-	if ( readlink(root_path, tinfo->root, sizeof(tinfo->root)) > 0)
+	ssize_t r = readlink(root_path, tinfo->root, sizeof(tinfo->root) - 1);
+	if (r > 0)
 	{
+		tinfo->root[r] = '\0';
 		return SCAP_SUCCESS;
 	}
 	else

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4561,6 +4561,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 
 				if(target_res > 0)
 				{
+					target_name[target_res] = '\0';
 					if(target_name != evt->m_tinfo->get_cwd())
 					{
 						printf("%s != %s", target_name, evt->m_tinfo->get_cwd().c_str());

--- a/userspace/libsinsp/sinsp_auth.cpp
+++ b/userspace/libsinsp/sinsp_auth.cpp
@@ -68,7 +68,7 @@ std::string sinsp_ssl::memorize_file(const std::string& disk_file)
 		char buf[FILENAME_MAX] = { 0 };
 		std::ifstream ifs(disk_file);
 		std::string fd_path = "/proc/self/fd/" + std::to_string(fd);
-		ssize_t sz = readlink(fd_path.c_str(), buf, sizeof(buf));
+		ssize_t sz = readlink(fd_path.c_str(), buf, sizeof(buf) - 1);
 		if(sz != -1 && sz <= static_cast<ssize_t>(sizeof(buf)))
 		{
 			mem_file.assign(buf, sz);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/area libscap

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This brings a couple of minor cleanups on buffer reads and releasing allocated mem before returning with an error.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
