### PR TITLE
Remove scap_t parameter from proc_callback

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -635,8 +635,7 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		else
 		{
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context,
-				proclist->m_main_handle, tinfo.tid, &tinfo, NULL);
+				proclist->m_proc_callback_context, tinfo.tid, &tinfo, NULL);
 		}
 
 		if(sub_len && subreadsize != sub_len)
@@ -1595,8 +1594,7 @@ static int32_t scap_read_fdlist(scap_reader_t* r, uint32_t block_length, uint32_
 			ASSERT(tinfo == NULL);
 
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context,
-				proclist->m_main_handle, tid, NULL, &fdi);
+				proclist->m_proc_callback_context, tid, NULL, &fdi);
 		}
 	}
 

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1031,8 +1031,7 @@ static int32_t scap_proc_add_from_proc(scap_t* handle, uint32_t tid, char* procd
 		else
 		{
 			handle->m_proclist.m_proc_callback(
-				handle->m_proclist.m_proc_callback_context,
-				handle->m_proclist.m_main_handle, tinfo->tid, tinfo, NULL);
+				handle->m_proclist.m_proc_callback_context, tinfo->tid, tinfo, NULL);
 			free_tinfo = true;
 		}
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -71,7 +71,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 		return SCAP_FAILURE;
 	}
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -189,7 +188,6 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs)
 		return rc;
 	}
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -295,7 +293,6 @@ int32_t scap_init_test_input_int(scap_t* handle, scap_open_args* oargs)
 	//
 	handle->m_mode = SCAP_MODE_LIVE;
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -343,7 +340,6 @@ int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs)
 
 	// XXX - interface list initialization and user list initalization goes here if necessary
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -390,7 +386,6 @@ int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_driver_procinfo = NULL;
 	handle->m_fd_lookup_limit = 0;
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -438,7 +433,6 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs)
 		return SCAP_FAILURE;
 	}
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
 	handle->m_proclist.m_proclist = NULL;
@@ -518,7 +512,6 @@ int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs)
 		return SCAP_FAILURE;
 	}
 
-	handle->m_proclist.m_main_handle = handle;
 	handle->m_proclist.m_proc_callback = NULL;
 	handle->m_proclist.m_proc_callback_context = NULL;
 	handle->m_proclist.m_proclist = NULL;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -507,7 +507,36 @@ typedef struct scap_const_sized_buffer scap_const_sized_buffer;
  */
 
 /*!
-  \brief Advanced function to start a capture.
+  \brief Allocate a handle
+
+  \return The capture instance handle in case of success. NULL in case of failure.
+  Before the handle can be used, \ref scap_init must be called on it.
+*/
+scap_t* scap_alloc(void);
+
+/*!
+  \brief Initialize a handle
+
+  \param oargs a \ref scap_open_args structure containing the open parameters.
+
+  \return the scap return code describing whether the function succeeded or failed.
+  The error string in case the function fails is accessible via \ref scap_getlasterr
+
+  If this function fails, the only thing you can safely do with the handle is to call
+  \ref scap_deinit on it.
+*/
+int32_t scap_init(scap_t* handle, scap_open_args* oargs);
+
+/*!
+  \brief Allocate and initialize a handle
+
+  This function combines scap_alloc and scap_init in a single call.
+  It's more convenient to use if you do not rely on having access to the handle
+  address while it's being initialized.
+
+  One notable example where you do need the address is the process callback:
+  without calling scap_alloc/scap_init it can't know where the handle is
+  (it's first called from scap_init)
 
   \param oargs a \ref scap_open_args structure containing the open parameters.
   \param error Pointer to a buffer that will contain the error string in case the
@@ -518,6 +547,23 @@ typedef struct scap_const_sized_buffer scap_const_sized_buffer;
   \return The capture instance handle in case of success. NULL in case of failure.
 */
 scap_t* scap_open(scap_open_args* oargs, char *error, int32_t *rc);
+
+/*!
+  \brief Deinitialize a capture handle.
+
+  \param handle Handle to the capture instance.
+*/
+void scap_deinit(scap_t* handle);
+
+/*!
+  \brief Free a capture handle.
+
+  \param handle Handle to the capture instance.
+
+  You need to call \ref scap_deinit before calling this function
+  or you risk leaking memory. Or just call \ref scap_close.
+*/
+void scap_free(scap_t* handle);
 
 /*!
   \brief Close a capture handle.

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -90,8 +90,7 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinf
 	else
 	{
 		proclist->m_proc_callback(
-			proclist->m_proc_callback_context,
-			proclist->m_main_handle, tinfo->tid, tinfo, fdi);
+			proclist->m_proc_callback_context, tinfo->tid, tinfo, fdi);
 	}
 
 	return SCAP_SUCCESS;

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -303,8 +303,7 @@ int32_t scap_proc_scan_vtable(char *error, scap_t *handle)
 		else
 		{
 			handle->m_proclist.m_proc_callback(
-				handle->m_proclist.m_proc_callback_context,
-				handle->m_proclist.m_main_handle, tinfo->tid, tinfo, NULL);
+				handle->m_proclist.m_proc_callback_context, tinfo->tid, tinfo, NULL);
 			free_tinfo = true;
 		}
 

--- a/userspace/libscap/scap_procs.h
+++ b/userspace/libscap/scap_procs.h
@@ -26,14 +26,12 @@ typedef struct scap_threadinfo scap_threadinfo;
 typedef struct scap_fdinfo scap_fdinfo;
 
 typedef void (*proc_entry_callback)(void* context,
-				    scap_t* handle,
 				    int64_t tid,
 				    scap_threadinfo* tinfo,
 				    scap_fdinfo* fdinfo);
 
 struct scap_proclist
 {
-	scap_t *m_main_handle;
 	proc_entry_callback m_proc_callback;
 	void* m_proc_callback_context;
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -60,7 +60,7 @@ limitations under the License.
 #include "tracer_emitter.h"
 #endif
 
-void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_threadinfo* tinfo,
+void on_new_entry_from_proc(void* context, int64_t tid, scap_threadinfo* tinfo,
 							scap_fdinfo* fdinfo);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -893,20 +893,17 @@ void sinsp::autodump_stop()
 }
 
 void sinsp::on_new_entry_from_proc(void* context,
-								   scap_t* handle,
 								   int64_t tid,
 								   scap_threadinfo* tinfo,
 								   scap_fdinfo* fdinfo)
 {
 	ASSERT(tinfo != NULL);
 
-	m_h = handle;
-
 	//
 	// Retrieve machine information if we don't have it yet
 	//
 	{
-		m_machine_info = scap_get_machine_info(handle);
+		m_machine_info = scap_get_machine_info(m_h);
 		if(m_machine_info != NULL)
 		{
 			m_num_cpus = m_machine_info->num_cpus;
@@ -970,13 +967,12 @@ void sinsp::on_new_entry_from_proc(void* context,
 }
 
 void on_new_entry_from_proc(void* context,
-							scap_t* handle,
 							int64_t tid,
 							scap_threadinfo* tinfo,
 							scap_fdinfo* fdinfo)
 {
 	sinsp* _this = (sinsp*)context;
-	_this->on_new_entry_from_proc(context, handle, tid, tinfo, fdinfo);
+	_this->on_new_entry_from_proc(context, tid, tinfo, fdinfo);
 }
 
 void sinsp::import_thread_table()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -828,8 +828,7 @@ public:
 	//
 	void stop_dropping_mode();
 	void start_dropping_mode(uint32_t sampling_ratio);
-	void on_new_entry_from_proc(void* context, scap_t* handle, int64_t tid, scap_threadinfo* tinfo,
-		scap_fdinfo* fdinfo);
+	void on_new_entry_from_proc(void* context, int64_t tid, scap_threadinfo* tinfo, scap_fdinfo* fdinfo);
 	void set_get_procs_cpu_from_driver(bool get_procs_cpu_from_driver)
 	{
 		m_get_procs_cpu_from_driver = get_procs_cpu_from_driver;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The scap handle is passed explicitly as an extra parameter to the proc_callback that gets called on every new process. This introduces tight coupling between the /proc scan and the main handle, which can otherwise be fairly easily removed from the /proc scan code (actually doing this is left for a future PR).

Removing the parameter is somewhat tricky because the callback gets called from inside `scap_open`, i.e. while `m_h` is still unset inside the inspector. To solve this, we split allocation from initialization:

* `scap_open` becomes `scap_alloc` + `scap_init`
* `scap_close` becomes `scap_deinit` + `scap_free`

Both original functions are still available in the API when you prefer to keep things simple (note how e.g. test binaries remain unchanged, only libsinsp uses the new API).

 **Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The bulk of the patch is moving the allocation (and deallocation in the error paths) in `scap_open_*_int` (which got renamed to `scap_init_*_int`) and the resulting signature changes.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(scap): `scap_alloc`/`scap_free` + `scap_init`/`scap_deinit` APIs to separate allocation from initialization
cleanup(scap): `proc_entry_callback` no longer takes a `scap_t`
```
