### PR TITLE
new(driver): unify support for some new syscalls between drivers 1/n

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4597,13 +4597,15 @@ FILLER(sys_ppoll_e, true)
 	val = bpf_syscall_get_argument(data, 2);
 
 	/* NULL timeout specified as 0xFFFFFF.... */
-	if (val == (unsigned long)NULL) {
+	if(val == (unsigned long)NULL)
+	{
 		res = bpf_val_to_ring_type(data, (u64)(-1), PT_RELTIME);
-		CHECK_RES(res);
-	} else {
-		res = timespec_parse(data, val);
-		CHECK_RES(res);
 	}
+	else
+	{
+		res = timespec_parse(data, val);
+	}
+	CHECK_RES(res);
 
 	/* Parameter 3: sigmask (type: PT_SIGSET) */
 	long unsigned int sigmask[1] = {0};

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -175,7 +175,7 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_MMAP_E */{"mmap", EC_MEMORY | EC_SYSCALL, EF_NONE, 6, {{"addr", PT_UINT64, PF_HEX}, {"length", PT_UINT64, PF_DEC}, {"prot", PT_FLAGS32, PF_HEX, prot_flags}, {"flags", PT_FLAGS32, PF_HEX, mmap_flags}, {"fd", PT_FD, PF_DEC}, {"offset", PT_UINT64, PF_DEC} } },
 	/* PPME_SYSCALL_MMAP_X */{"mmap", EC_MEMORY | EC_SYSCALL, EF_NONE, 4, {{"res", PT_UINT64, PF_HEX}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
 	/* PPME_SYSCALL_MMAP2_E */{"mmap2", EC_MEMORY | EC_SYSCALL, EF_NONE, 6, {{"addr", PT_UINT64, PF_HEX}, {"length", PT_UINT64, PF_DEC}, {"prot", PT_FLAGS32, PF_HEX, prot_flags}, {"flags", PT_FLAGS32, PF_HEX, mmap_flags}, {"fd", PT_FD, PF_DEC}, {"pgoffset", PT_UINT64, PF_DEC} } },
-	/* PPME_SYSCALL_MMAP2_X */{"mmap2", EC_MEMORY | EC_SYSCALL, EF_NONE, 4, {{"res", PT_UINT64, PF_HEX}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_MMAP2_X */{"mmap2", EC_MEMORY | EC_SYSCALL, EF_NONE, 4, {{"res", PT_ERRNO, PF_HEX}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_E */{"munmap", EC_MEMORY | EC_SYSCALL, EF_NONE, 2, {{"addr", PT_UINT64, PF_HEX}, {"length", PT_UINT64, PF_DEC} } },
 	/* PPME_SYSCALL_MUNMAP_X */{"munmap", EC_MEMORY | EC_SYSCALL, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"vm_size", PT_UINT32, PF_DEC}, {"vm_rss", PT_UINT32, PF_DEC}, {"vm_swap", PT_UINT32, PF_DEC} } },
 	/* PPME_SYSCALL_SPLICE_E */{"splice", EC_IO_OTHER | EC_SYSCALL, EF_USES_FD, 4, {{"fd_in", PT_FD, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"size", PT_UINT64, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX, splice_flags} } },

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -158,6 +158,8 @@
 #define IO_URING_REGISTER_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint16_t) + sizeof(uint64_t) + sizeof(uint32_t) + PARAM_LEN * 5
 #define IO_URING_SETUP_E_SIZE HEADER_LEN
 #define IO_URING_SETUP_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) * 7 + PARAM_LEN * 8
+#define MMAP2_E_SIZE HEADER_LEN + sizeof(uint64_t) * 3 + sizeof(int64_t) + sizeof(uint32_t) * 2 + PARAM_LEN * 6
+#define MMAP2_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) * 3 + PARAM_LEN * 4
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -158,6 +158,12 @@ static __always_inline void push__u64(u8 *data, u64 *payload_pos, u64 param)
 	*payload_pos += sizeof(u64);
 }
 
+static __always_inline void push__s16(u8 *data, u64 *payload_pos, s16 param)
+{
+	*((s16 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(s16);
+}
+
 static __always_inline void push__s32(u8 *data, u64 *payload_pos, s32 param)
 {
 	*((s32 *)&data[SAFE_ACCESS(*payload_pos)]) = param;

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -11,6 +11,8 @@
 #include <helpers/base/read_from_task.h>
 #include <driver/ppm_flag_helpers.h>
 
+#define SECOND_TO_NS 1000000000
+
 /* Used to convert from page number to KB. */
 #define DO_PAGE_SHIFT(x) (x) << (IOC_PAGE_SHIFT - 10)
 

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -33,6 +33,9 @@
 /* Maximum number of `iovec` structures that we can analyze. */
 #define MAX_IOVCNT 32
 
+/* Maximum number of `pollfd` structures that we can analyze. */
+#define MAX_POLLFD 16
+
 /* Maximum number of charbuf pointers that we assume an array can have. */
 #define MAX_CHARBUF_POINTERS 16
 
@@ -71,6 +74,15 @@ enum connection_direction
 {
 	OUTBOUND = 0,
 	INBOUND = 1,
+};
+
+/* This enum is used to tell poll helpers if we need requested or returned
+ * events.
+ */
+enum poll_events_direction
+{
+	REQUESTED_EVENTS = 0,
+	RETURNED_EVENTS = 1,
 };
 
 /*=============================== COMMON DEFINITIONS ===============================*/
@@ -285,6 +297,20 @@ static __always_inline void auxmap__store_u8_param(struct auxiliary_map *auxmap,
 {
 	push__u8(auxmap->data, &auxmap->payload_pos, param);
 	push__param_len(auxmap->data, &auxmap->lengths_pos, sizeof(u8));
+}
+
+/**
+ * @brief This helper should be used to store unsigned 16 bit params.
+ * The following types are compatible with this helper:
+ * - PT_UINT16
+ *
+ * @param auxmap pointer to the auxmap in which we are storing the param.
+ * @param param param to store
+ */
+static __always_inline void auxmap__store_u16_param(struct auxiliary_map *auxmap, u16 param)
+{
+	push__u16(auxmap->data, &auxmap->payload_pos, param);
+	push__param_len(auxmap->data, &auxmap->lengths_pos, sizeof(u16));
 }
 
 /**
@@ -1349,4 +1375,60 @@ static __always_inline void auxmap__store_cgroups_param(struct auxiliary_map *au
 		total_croups_len += store_cgroup_subsys(auxmap, task, bpf_core_enum_value(enum cgroup_subsys_id, memory_cgrp_id));
 	}
 	push__param_len(auxmap->data, &auxmap->lengths_pos, total_croups_len);
+}
+
+static __always_inline void auxmap__store_fdlist_param(struct auxiliary_map *auxmap, unsigned long fds_pointer, u32 nfds, enum poll_events_direction dir)
+{
+	/* In this helper we push data in this format:
+	 *  - number of `fd + flags` pairs  -> (u16)
+	 *  - first pair (`fd + flags`)     -> (s64 + s16)
+	 *  - second pair (`fd + flags`)    -> (s64 + s16)
+	 *  - ...
+	 *
+	 * If `fds_pointer` is NULL we push just a pair's number equal to `0`
+	 */
+
+	/* We store all the struct's array in the second part of our auxmap
+	 * like in `auxmap__store_sockaddr_param`. This is a scratch space.
+	 */
+	u32 structs_size = nfds * bpf_core_type_size(struct pollfd);
+	if(bpf_probe_read_user((void *)&auxmap->data[MAX_PARAM_SIZE],
+			       SAFE_ACCESS(structs_size),
+			       (void *)fds_pointer))
+	{
+		/* pair's number equal to `0` */
+		auxmap__store_u16_param(auxmap, 0);
+		return;
+	}
+
+	/* The pair's number is equal to `nfds` if it is `<=MAX_POLLFD` otherwise it is `MAX_POLLFD` */
+	u32 num_pairs = nfds <= MAX_POLLFD ? nfds : MAX_POLLFD;
+	push__u16(auxmap->data, &auxmap->payload_pos, num_pairs);
+
+	/* Pointer to `pollfd` structs */
+	const struct pollfd *fds = (const struct pollfd *)&auxmap->data[MAX_PARAM_SIZE];
+
+	/* For every `pollfd` struct we try to push an `fd` (s64) + `flags` (s16) */
+	for(int j = 0; j < MAX_POLLFD; j++)
+	{
+		if(j == nfds)
+		{
+			break;
+		}
+
+		/* Push `fd` on 64 bit */
+		push__s64(auxmap->data, &auxmap->payload_pos, (s64)fds[j].fd);
+
+		/* Push `flags` according to the direction */
+		if(dir == REQUESTED_EVENTS)
+		{
+			push__s16(auxmap->data, &auxmap->payload_pos, (s16)poll_events_to_scap(fds[j].events));
+		}
+		else
+		{
+			push__s16(auxmap->data, &auxmap->payload_pos, (s16)poll_events_to_scap(fds[j].revents));
+		}
+	}
+	/* The param size is: 16 bit for the number of pairs + size of the pairs */
+	push__param_len(auxmap->data, &auxmap->lengths_pos, sizeof(u16) + (num_pairs * (sizeof(s64) + sizeof(s16))));
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(mmap2_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, MMAP2_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MMAP2_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	unsigned long addr = extract__syscall_argument(regs, 0);
+	ringbuf__store_u64(&ringbuf, addr);
+
+	/* Parameter 2: length (type: PT_UINT64) */
+	unsigned long length = extract__syscall_argument(regs, 1);
+	ringbuf__store_u64(&ringbuf, length);
+
+	/* Parameter 3: prot (type: PT_FLAGS32) */
+	unsigned long prot = extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, prot_flags_to_scap(prot));
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	unsigned long flags = extract__syscall_argument(regs, 3);
+	ringbuf__store_u32(&ringbuf, mmap_flags_to_scap(flags));
+
+	/* Paremeter 5: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 4);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 6: pgoffset (type: PT_UINT64) */
+	unsigned long offset = extract__syscall_argument(regs, 5);
+	ringbuf__store_u64(&ringbuf, offset);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(mmap2_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, MMAP2_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_MMAP2_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	struct task_struct *task = get_current_task();
+	struct mm_struct *mm = NULL;
+	READ_TASK_FIELD_INTO(&mm, task, mm);
+
+	u32 vm_size = extract__vm_size(mm);
+	u32 rss_size = extract__vm_rss(mm);
+	u32 swap_size = extract__vm_swap(mm);
+
+	/* Parameter 2: vm_size (type: PT_UINT32) */
+	ringbuf__store_u32(&ringbuf, vm_size);
+
+	/* Parameter 3: vm_rss (type: PT_UINT32) */
+	ringbuf__store_u32(&ringbuf, rss_size);
+
+	/* Parameter 4: vm_swap (type: PT_UINT32) */
+	ringbuf__store_u32(&ringbuf, swap_size);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(poll_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_POLL_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
+	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
+	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* We are in the enter event so we get the requested events, the returned events are only available
+	 * in the exit event.
+	 */
+	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, REQUESTED_EVENTS);
+
+	/* Parameter 2: timeout (type: PT_INT64) */
+	/* This is an `int` in the syscall signature but we push it as an `int64` */
+	u32 timeout_msecs = (s32)extract__syscall_argument(regs, 2);
+	auxmap__store_s64_param(auxmap, (s64)timeout_msecs);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(poll_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_POLL_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
+	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
+	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+
+	/* Parameter 2: fds (type: PT_FDLIST) */
+	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, RETURNED_EVENTS);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(ppoll_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_PPOLL_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
+	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
+	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* We are in the enter event so we get the requested events, the returned events are only available
+	 * in the exit event.
+	 */
+	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, REQUESTED_EVENTS);
+
+	/* Parameter 2: timeout (type: PT_RELTIME) */
+	struct __kernel_timespec timeout_ts = {0};
+	unsigned long timeout_ts_pointer = extract__syscall_argument(regs, 2);
+	if(bpf_probe_read_user(&timeout_ts, bpf_core_type_size(struct __kernel_timespec), (void *)timeout_ts_pointer))
+	{
+		/* In case of invalid pointer, like in the other drivers */
+		auxmap__store_u64_param(auxmap, (u64)-1);
+	}
+	else
+	{
+		auxmap__store_u64_param(auxmap, ((u64)timeout_ts.tv_sec) * SECOND_TO_NS + timeout_ts.tv_nsec);
+	}
+
+	/* Parameter 3: sigmask (type: PT_SIGSET) */
+	long unsigned int sigmask[1] = {0};
+	unsigned long sigmask_pointer = extract__syscall_argument(regs, 3);
+	if(bpf_probe_read_user(&sigmask, sizeof(sigmask), (void *)sigmask_pointer))
+	{
+		/* In case of invalid pointer, return 0 */
+		auxmap__store_u32_param(auxmap, (u32)0);
+	}
+	else
+	{
+		auxmap__store_u32_param(auxmap, (u32)sigmask[0]);
+	}
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(ppoll_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_PPOLL_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
+	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
+	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+
+	/* Parameter 2: fds (type: PT_FDLIST) */
+	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, RETURNED_EVENTS);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/test/drivers/README.md
+++ b/test/drivers/README.md
@@ -16,7 +16,7 @@ In this case, only the `kmod` engine will be built and you can assert only the b
 Let's build all the 3 engines:
 
 ```bash
-cmake -DUSE_BUNDLED_DEPS=On -DENABLE_DRIVERS_TESTS=On -DBUILD_LIBSCAP_GVISOR=Off -DBUILD_BPF=True -DBUILD_LIBSCAP_MODERN_BPF=On -DCREATE_TEST_TARGETS=On ..
+cmake -DUSE_BUNDLED_DEPS=On -DENABLE_DRIVERS_TESTS=On -DBUILD_LIBSCAP_GVISOR=Off -DBUILD_BPF=On -DBUILD_LIBSCAP_MODERN_BPF=On -DCREATE_TEST_TARGETS=On -DMODERN_BPF_DEBUG_MODE=On ..
 make drivers_test
 ```
 

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -29,6 +29,13 @@ struct param
 	uint16_t len;
 };
 
+/* This is the struct we send to userspace in `poll` and `ppoll` syscalls */
+struct fd_poll
+{
+	int64_t fd;
+	int16_t flags;
+};
+
 /* Assertion operators */
 enum assertion_operators
 {
@@ -93,7 +100,7 @@ public:
 
 	static void clear_ppm_sc_mask()
 	{
-		for (int i = 0; i < PPM_SC_MAX; i++)
+		for(int i = 0; i < PPM_SC_MAX; i++)
 		{
 			scap_set_ppm_sc(s_scap_handle, i, false);
 		}
@@ -552,6 +559,16 @@ public:
 	 * @param param_num number of the parameter to assert into the event.
 	 */
 	void assert_ptrace_data(int param_num);
+
+	/**
+	 * @brief Some syscalls like `poll` and `ppoll` send
+	 * a list of file descriptors to assert.
+	 *
+	 * @param param_num number of the parameter to assert into the event.
+	 * @param expected_fds pointer to an array of `struct fd_poll`
+	 * @param nfds number of fd structs we expect in the array.
+	 */
+	void assert_fd_list(int param_num, struct fd_poll* expected_fds, int32_t nfds);
 
 private:
 	enum ppm_event_type m_event_type;	  /* type of the event we want to assert in this test. */

--- a/test/drivers/test_suites/syscall_enter_suite/mmap2_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/mmap2_e.cpp
@@ -1,0 +1,64 @@
+
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mmap2
+
+#include <sys/mman.h>
+
+TEST(SyscallEnter, mmap2E)
+{
+	auto evt_test = get_syscall_event_test(__NR_mmap2, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	void *mock_addr = (void *)87;
+	size_t mock_length = 4096;
+	int mock_prot = PROT_EXEC | PROT_READ;
+	int mock_flags = MAP_SHARED;
+	int mock_fd = -1;
+	off_t mock_offset = 1023;
+
+	assert_syscall_state(SYSCALL_FAILURE, "mmap2", syscall(__NR_mmap2, mock_addr, mock_length, mock_prot, mock_flags, mock_fd, mock_offset));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	evt_test->assert_numeric_param(1, (uint64_t)mock_addr);
+
+	/* Parameter 2: length (type: PT_UINT64) */
+	evt_test->assert_numeric_param(2, (uint64_t)mock_length);
+
+	/* Parameter 3: prot (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PPM_PROT_EXEC | PPM_PROT_READ);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_MAP_SHARED);
+
+	/* Parameter 5: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(5, (int64_t)mock_fd);
+
+	/* Parameter 6: pgoffset (type: PT_UINT64) */
+	evt_test->assert_numeric_param(6, (uint64_t)mock_offset);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/poll_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/poll_e.cpp
@@ -1,0 +1,214 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_poll
+
+#include <poll.h>
+/* Right now this is our limit in the drivers */
+#define MAX_FDS 16
+
+TEST(SyscallEnter, pollE_null_pointer)
+{
+	auto evt_test = get_syscall_event_test(__NR_poll, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	struct pollfd *fds = NULL;
+	uint32_t nfds = 5;
+	int timeout = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "poll", syscall(__NR_poll, fds, nfds, timeout));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* The pointer is NULL so we should have no `fd` collected */
+	evt_test->assert_fd_list(1, NULL, (uint16_t)0);
+
+	/* Parameter 2: timeout (type: PT_INT64) */
+	evt_test->assert_numeric_param(2, (int64_t)timeout);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, pollE_empty_nfds)
+{
+	auto evt_test = get_syscall_event_test(__NR_poll, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	struct pollfd fds[2];
+
+	fds[0].fd = -1;
+	fds[0].events = POLLIN;
+	fds[0].revents = 0;
+
+	fds[1].fd = -10;
+	fds[1].events = POLLWRBAND;
+	fds[1].revents = 0;
+
+	/* We send it empty so expect no fd in the structs to be collected */
+	uint32_t nfds = 0;
+	int timeout = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "poll", syscall(__NR_poll, fds, nfds, timeout), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* `nfds` is 0 so we should have no `fd` collected */
+	evt_test->assert_fd_list(1, NULL, (uint16_t)0);
+
+	/* Parameter 2: timeout (type: PT_INT64) */
+	evt_test->assert_numeric_param(2, (int64_t)timeout);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, pollE_not_truncated)
+{
+	auto evt_test = get_syscall_event_test(__NR_poll, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	struct pollfd fds[2];
+
+	fds[0].fd = -1;
+	fds[0].events = POLLIN | POLLPRI | POLLOUT | POLLRDHUP | POLLERR | POLLHUP | POLLNVAL | POLLRDNORM | POLLRDBAND | POLLWRNORM | POLLWRBAND;
+	fds[0].revents = 0;
+
+	fds[1].fd = -10;
+	fds[1].events = POLLWRBAND;
+	fds[1].revents = 0;
+
+	nfds_t nfds = 2;
+	int timeout = 0;
+
+	/* We will use this array for assertions */
+	struct fd_poll expected[2];
+
+	expected[0].fd = fds[0].fd;
+	expected[0].flags = PPM_POLLIN | PPM_POLLPRI | PPM_POLLOUT | PPM_POLLRDHUP | PPM_POLLERR | PPM_POLLHUP | PPM_POLLNVAL | PPM_POLLRDNORM | PPM_POLLRDBAND | PPM_POLLWRNORM | PPM_POLLWRBAND;
+
+	expected[1].fd = fds[1].fd;
+	expected[1].flags = PPM_POLLWRBAND;
+
+	assert_syscall_state(SYSCALL_SUCCESS, "poll", syscall(__NR_poll, fds, nfds, timeout), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	evt_test->assert_fd_list(1, (struct fd_poll *)&expected, 2);
+
+	/* Parameter 2: timeout (type: PT_INT64) */
+	evt_test->assert_numeric_param(2, (int64_t)timeout);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallEnter, pollE_truncated)
+{
+	auto evt_test = get_syscall_event_test(__NR_poll, ENTER_EVENT);
+
+	if(evt_test->is_kmod_engine())
+	{
+		GTEST_SKIP() << "[POLL_E]: the kmod is not subject to params truncation like BPF drivers" << std::endl;
+	}
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* We push more than MAX_FDS structs. We should obtain only `MAX_FDS` structs */
+	struct pollfd fds[MAX_FDS + 1] = {0};
+	nfds_t nfds = MAX_FDS + 1;
+	int timeout = 0;
+
+	/* We expect only `MAX_FDS` structs */
+	struct fd_poll expected[MAX_FDS] = {0};
+
+	assert_syscall_state(SYSCALL_SUCCESS, "poll", syscall(__NR_poll, fds, nfds, timeout), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	evt_test->assert_fd_list(1, (struct fd_poll *)&expected, MAX_FDS);
+
+	/* Parameter 2: timeout (type: PT_INT64) */
+	evt_test->assert_numeric_param(2, (int64_t)timeout);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/ppoll_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/ppoll_e.cpp
@@ -1,0 +1,113 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ppoll
+
+#include <poll.h>
+#include <signal.h>
+
+TEST(SyscallEnter, ppollE_null_pointers)
+{
+	auto evt_test = get_syscall_event_test(__NR_ppoll, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we are not interested in testing the `fd` collection logic we have already
+	 * tested it with `poll` syscall.
+	 */
+	struct pollfd* fds = NULL;
+	struct timespec* timestamp = NULL;
+	sigset_t* sigmask = NULL;
+	uint32_t nfds = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "ppoll", syscall(__NR_ppoll, fds, nfds, timestamp, sigmask));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* The pointer is NULL so we should have no `fd` collected */
+	evt_test->assert_fd_list(1, NULL, (uint16_t)0);
+
+	/* Parameter 2: timeout (type: PT_RELTIME) */
+	/* The pointer is NULL so we should have UINT64_MAX */
+	evt_test->assert_numeric_param(2, (uint64_t)-1);
+
+	/* Parameter 3: sigmask (type: PT_SIGSET) */
+	/* The pointer is NULL so we should have `0` */
+	evt_test->assert_numeric_param(3, (uint32_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+TEST(SyscallEnter, ppollE_valid_pointers)
+{
+	auto evt_test = get_syscall_event_test(__NR_ppoll, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we are not interested in testing the `fd` collection logic we have already
+	 * tested it with `poll` syscall.
+	 */
+	struct pollfd* fds = NULL;
+	struct timespec timestamp = {0};
+	timestamp.tv_sec = 2;
+	timestamp.tv_nsec = 0;
+	sigset_t sigmask;
+	sigmask.__val[0] = SIGIO;
+	sigmask.__val[1] = SIGTERM;
+	uint32_t nfds = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "ppoll", syscall(__NR_ppoll, fds, nfds, &timestamp, &sigmask));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: fds (type: PT_FDLIST) */
+	/* The pointer is NULL so we should have no `fd` collected */
+	evt_test->assert_fd_list(1, NULL, (uint16_t)0);
+
+	/* Parameter 2: timeout (type: PT_RELTIME) */
+	/* The pointer is NULL so we should have UINT64_MAX */
+	evt_test->assert_numeric_param(2, ((uint64_t)timestamp.tv_sec * SEC_FACTOR) + timestamp.tv_nsec);
+
+	/* Parameter 3: sigmask (type: PT_SIGSET) */
+	evt_test->assert_numeric_param(3, (uint32_t)SIGIO);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/mmap2_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/mmap2_x.cpp
@@ -1,0 +1,58 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_mmap2
+
+#include <sys/mman.h>
+
+TEST(SyscallExit, mmap2X)
+{
+	auto evt_test = get_syscall_event_test(__NR_mmap2, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	void *mock_addr = (void *)0;
+	size_t mock_length = 0;
+	int mock_prot = 0;
+	int mock_flags = MAP_SHARED;
+	int mock_fd = -1;
+	off_t mock_offset = 0;
+
+	assert_syscall_state(SYSCALL_FAILURE, "mmap", syscall(__NR_mmap2, mock_addr, mock_length, mock_prot, mock_flags, mock_fd, mock_offset));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: vm_size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)0, GREATER_EQUAL);
+
+	/* Parameter 3: vm_rss (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)0, GREATER_EQUAL);
+
+	/* Parameter 4: vm_swap (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)0, GREATER_EQUAL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/poll_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/poll_x.cpp
@@ -1,0 +1,83 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_poll
+
+#include <poll.h>
+
+TEST(SyscallExit, pollX_success)
+{
+	auto evt_test = get_syscall_event_test(__NR_poll, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	struct pollfd fds[2];
+
+	fds[0].fd = -1;
+	fds[0].events = POLLIN;
+	fds[0].revents = 0;
+
+	fds[1].fd = -10;
+	fds[1].events = POLLWRBAND;
+	fds[1].revents = 0;
+
+	nfds_t nfds = 2;
+	int timeout = 0;
+
+	/* We will use this array for assertions */
+	struct fd_poll expected[2];
+
+	expected[0].fd = fds[0].fd;
+	/* Here we will catch the returned events `revents`. Since the file descriptor is negative
+	 * according to the the `poll` man the `revents` should be `0`.
+	 */
+	expected[0].flags = 0;
+
+	expected[1].fd = fds[1].fd;
+	expected[1].flags = 0;
+
+	assert_syscall_state(SYSCALL_SUCCESS, "poll", syscall(__NR_poll, fds, nfds, timeout), NOT_EQUAL, -1);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	/* The return value should be 0 since timeout is `0` and `poll` should
+	 * return `0` when timed out before any file descriptors became read.
+	 */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: fds (type: PT_FDLIST) */
+	if(evt_test->is_kmod_engine())
+	{
+		/* The logic in the kmod is slightly different: we collect data only if `revents != 0`
+		 * https://github.com/falcosecurity/libs/blob/master/driver/ppm_fillers.c#L3322-L3326
+		 */
+		evt_test->assert_fd_list(2, NULL, 0);
+	}
+	else
+	{
+		evt_test->assert_fd_list(2, (struct fd_poll *)&expected, 2);
+	}
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/ppoll_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/ppoll_x.cpp
@@ -1,0 +1,53 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_ppoll
+
+#include <poll.h>
+
+TEST(SyscallExit, ppollX)
+{
+	auto evt_test = get_syscall_event_test(__NR_ppoll, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we are not interested in testing the `fd` collection logic we have already
+	 * tested it with `poll` syscall.
+	 */
+	struct pollfd* fds = NULL;
+	struct timespec* timestamp = NULL;
+	sigset_t* sigmask = NULL;
+	uint32_t nfds = 5;
+	assert_syscall_state(SYSCALL_FAILURE, "ppoll", syscall(__NR_ppoll, fds, nfds, timestamp, sigmask));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ret (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fds (type: PT_FDLIST) */
+	/* The pointer is NULL so we should have no `fd` collected */
+	evt_test->assert_fd_list(2, NULL, (uint16_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -217,6 +217,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_POLL_X] = "poll_x",
 	[PPME_SYSCALL_PPOLL_E] = "ppoll_e",
 	[PPME_SYSCALL_PPOLL_X] = "ppoll_x",
+	[PPME_SYSCALL_MMAP2_E] = "mmap2_e",
+	[PPME_SYSCALL_MMAP2_X] = "mmap2_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -215,6 +215,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_IO_URING_SETUP_X] = "io_uring_setup_x",
 	[PPME_SYSCALL_POLL_E] = "poll_e",
 	[PPME_SYSCALL_POLL_X] = "poll_x",
+	[PPME_SYSCALL_PPOLL_E] = "ppoll_e",
+	[PPME_SYSCALL_PPOLL_X] = "ppoll_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -213,6 +213,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_IO_URING_REGISTER_X] = "io_uring_register_x",
 	[PPME_SYSCALL_IO_URING_SETUP_E] = "io_uring_setup_e",
 	[PPME_SYSCALL_IO_URING_SETUP_X] = "io_uring_setup_x",
+	[PPME_SYSCALL_POLL_E] = "poll_e",
+	[PPME_SYSCALL_POLL_X] = "poll_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

On one side this PR supports 3 missing syscalls in the modern bpf probe https://github.com/falcosecurity/libs/issues/723:
*  `poll`
*  `ppoll`
*  `mmap2`

On the other side, it unifies the behavior of this syscall between our 3 drivers:
* send event even when the pointer is invalid

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(driver): unify support for some new syscalls between drivers
```
