### PR TITLE
new(driver): unify support for some new syscalls between drivers 2/n

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3713,43 +3713,26 @@ FILLER(sys_epoll_create1_x, true)
 
 FILLER(sys_sendfile_e, true)
 {
-	unsigned long val;
-	off_t *offp;
-	off_t off;
-	int res;
+	/* Parameter 1: out_fd (type: PT_FD) */
+	s32 out_fd = (s32)bpf_syscall_get_argument(data, 0);
+	int res = bpf_val_to_ring(data, (s64)out_fd);
+	CHECK_RES(res);
 
-	/*
-	 * out_fd
-	 */
-	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	/* Parameter 2: in_fd (type: PT_FD) */
+	s32 in_fd = (s32)bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, (s64)in_fd);
+	CHECK_RES(res);
 
-	/*
-	 * in_fd
-	 */
-	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	/* Parameter 3: offset (type: PT_UINT64) */
+	unsigned long offset = 0;
+	unsigned long offset_pointer = bpf_syscall_get_argument(data, 2);
+	bpf_probe_read((void *)&offset, sizeof(offset), (void *)offset_pointer);
+	res = bpf_val_to_ring(data, offset);
+	CHECK_RES(res);
 
-	/*
-	 * offset
-	 */
-	offp = (off_t *)bpf_syscall_get_argument(data, 2);
-	off = _READ(*offp);
-	res = bpf_val_to_ring(data, off);
-	if (res != PPM_SUCCESS)
-		return res;
-
-	/*
-	 * size
-	 */
-	val = bpf_syscall_get_argument(data, 3);
-	res = bpf_val_to_ring(data, val);
-
-	return res;
+	/* Parameter 4: size (type: PT_UINT64) */
+	u64 size = bpf_syscall_get_argument(data, 3);
+	return bpf_val_to_ring(data, size);
 }
 
 FILLER(sys_sendfile_x, true)

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3726,7 +3726,7 @@ FILLER(sys_sendfile_e, true)
 	/* Parameter 3: offset (type: PT_UINT64) */
 	unsigned long offset = 0;
 	unsigned long offset_pointer = bpf_syscall_get_argument(data, 2);
-	bpf_probe_read((void *)&offset, sizeof(offset), (void *)offset_pointer);
+	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
 	res = bpf_val_to_ring(data, offset);
 	CHECK_RES(res);
 
@@ -3737,27 +3737,16 @@ FILLER(sys_sendfile_e, true)
 
 FILLER(sys_sendfile_x, true)
 {
-	long retval;
-	off_t *offp;
-	off_t off;
-	int res;
+	/* Parameter 1: res (type: PT_ERRNO) */
+	long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_val_to_ring(data, retval);
+	CHECK_RES(res);
 
-	/*
-	 * res
-	 */
-	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
-
-	/*
-	 * offset
-	 */
-	offp = (off_t *)bpf_syscall_get_argument(data, 2);
-	off = _READ(*offp);
-	res = bpf_val_to_ring(data, off);
-
-	return res;
+	/* Parameter 2: offset (type: PT_UINT64) */
+	unsigned long offset = 0;
+	unsigned long offset_pointer = bpf_syscall_get_argument(data, 2);
+	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
+	return bpf_val_to_ring(data, offset);
 }
 
 FILLER(sys_prlimit_e, true)

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -170,6 +170,8 @@
 #define SENDMMSG_X_SIZE HEADER_LEN
 #define SEMOP_E_SIZE HEADER_LEN + sizeof(int32_t) + PARAM_LEN
 #define SEMOP_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + sizeof(uint16_t) * 4 + sizeof(int16_t) * 2 + PARAM_LEN * 8
+#define SENDFILE_E_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint64_t) * 2 + PARAM_LEN * 4
+#define SENDFILE_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) + PARAM_LEN * 2
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -168,6 +168,8 @@
 #define RECVMMSG_X_SIZE HEADER_LEN
 #define SENDMMSG_E_SIZE HEADER_LEN
 #define SENDMMSG_X_SIZE HEADER_LEN
+#define SEMOP_E_SIZE HEADER_LEN + sizeof(int32_t) + PARAM_LEN
+#define SEMOP_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + sizeof(uint16_t) * 4 + sizeof(int16_t) * 2 + PARAM_LEN * 8
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -164,6 +164,8 @@
 #define SEMGET_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN 
 #define SEMCTL_E_SIZE HEADER_LEN + sizeof(int32_t) * 3 + sizeof(uint16_t) + PARAM_LEN * 4
 #define SEMCTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
+#define RECVMMSG_E_SIZE HEADER_LEN
+#define RECVMMSG_X_SIZE HEADER_LEN
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -166,6 +166,8 @@
 #define SEMCTL_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define RECVMMSG_E_SIZE HEADER_LEN
 #define RECVMMSG_X_SIZE HEADER_LEN
+#define SENDMMSG_E_SIZE HEADER_LEN
+#define SENDMMSG_X_SIZE HEADER_LEN
 
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -174,6 +174,19 @@ static __always_inline void ringbuf__submit_event(struct ringbuf_struct *ringbuf
  */
 
 /**
+ * @brief This helper should be used to store signed 16 bit params.
+ * The following types are compatible with this helper:
+ * - PT_INT16
+ *
+ * @param ringbuf pointer to the `ringbuf_struct`.
+ * @param param param to store.
+ */
+static __always_inline void ringbuf__store_s16(struct ringbuf_struct *ringbuf, s16 param)
+{
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(s16));
+}
+
+/**
  * @brief This helper should be used to store signed 32 bit params.
  * The following types are compatible with this helper:
  * - PT_INT32
@@ -183,8 +196,7 @@ static __always_inline void ringbuf__submit_event(struct ringbuf_struct *ringbuf
  */
 static __always_inline void ringbuf__store_s32(struct ringbuf_struct *ringbuf, s32 param)
 {
-	push__s32(ringbuf->data, &ringbuf->payload_pos, param);
-	push__param_len(ringbuf->data, &ringbuf->lengths_pos, sizeof(s32));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(s32));
 }
 
 /**

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(recvmmsg_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, RECVMMSG_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVMMSG_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(recvmmsg_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, RECVMMSG_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_RECVMMSG_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(semop_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SEMOP_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SEMOP_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: semid (type: PT_INT32)*/
+	s32 semid = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s32(&ringbuf, semid);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(semop_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SEMOP_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SEMOP_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: nsops (type: PT_UINT32) */
+	u32 nsops = (u32)extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, nsops);
+
+	/* Extract pointer to the `sembuf` struct */
+	struct sembuf sops[2] = {0};
+	unsigned long sops_pointer = extract__syscall_argument(regs, 1);
+
+	if(ret != 0 || sops_pointer == 0 || nsops == 0)
+	{
+		/* We send all 0 when one of these is true:
+		 * - the syscall fails (ret != 0)
+		 * - `sops_pointer` is NULL
+		 * - `nsops` is 0
+		 */
+	}
+	else if(nsops == 1)
+	{
+		/* If we have just one entry the second will be empty, we don't fill it */
+		bpf_probe_read_user((void *)sops, bpf_core_type_size(struct sembuf), (void *)sops_pointer);
+	}
+	else
+	{
+		/* If `nsops>1` we read just the first 2 entries. */
+		bpf_probe_read_user((void *)sops, bpf_core_type_size(struct sembuf) * 2, (void *)sops_pointer);
+	}
+
+	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
+	ringbuf__store_u16(&ringbuf, sops[0].sem_num);
+
+	/* Parameter 4: sem_op_0 (type: PT_INT16) */
+	ringbuf__store_s16(&ringbuf, sops[0].sem_op);
+
+	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
+	ringbuf__store_u16(&ringbuf, semop_flags_to_scap(sops[0].sem_flg));
+
+	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
+	ringbuf__store_u16(&ringbuf, sops[1].sem_num);
+
+	/* Parameter 7: sem_op_1 (type: PT_INT16) */
+	ringbuf__store_s16(&ringbuf, sops[1].sem_op);
+
+	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
+	ringbuf__store_u16(&ringbuf, semop_flags_to_scap(sops[1].sem_flg));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(sendfile_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SENDFILE_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SENDFILE_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: out_fd (type: PT_FD) */
+	s32 out_fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)out_fd);
+
+	/* Parameter 2: in_fd (type: PT_FD) */
+	s32 in_fd = (s32)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, (s64)in_fd);
+
+	/* Parameter 3: offset (type: PT_UINT64) */
+	unsigned long offset = 0;
+	unsigned long offset_pointer = extract__syscall_argument(regs, 2);
+	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
+	ringbuf__store_u64(&ringbuf, offset);
+
+	/* Parameter 4: size (type: PT_UINT64) */
+	u64 size = extract__syscall_argument(regs, 3);
+	ringbuf__store_u64(&ringbuf, size);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(sendfile_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SENDFILE_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_SENDFILE_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: offset (type: PT_UINT64) */
+	unsigned long offset = 0;
+	unsigned long offset_pointer = extract__syscall_argument(regs, 2);
+	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
+	ringbuf__store_u64(&ringbuf, offset);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(sendmmsg_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SENDMMSG_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SENDMMSG_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(sendmmsg_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SENDMMSG_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SOCKET_SENDMMSG_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -5785,29 +5785,26 @@ int f_sys_procexit_e(struct event_filler_arguments *args)
 
 int f_sys_sendfile_e(struct event_filler_arguments *args)
 {
-	unsigned long val;
-	int res;
-	off_t offset;
+	unsigned long val = 0;
+	int res = 0;
+	off_t offset = 0;
+	s32 out_fd = 0;
+	s32 in_fd = 0;
 
-	/*
-	 * out_fd
-	 */
+	/* Parameter 1: out_fd (type: PT_FD) */
 	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
-	res = val_to_ring(args, val, 0, true, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	out_fd = (s32)val;
+	res = val_to_ring(args, (s64)out_fd, 0, true, 0);
+	CHECK_RES(res);
 
-	/*
-	 * in_fd
-	 */
+	/* Parameter 2: in_fd (type: PT_FD) */
 	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
-	res = val_to_ring(args, val, 0, true, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	in_fd = (s32)val;
+	res = val_to_ring(args, (s64)in_fd, 0, true, 0);
+	CHECK_RES(res);
 
-	/*
-	 * offset
-	 */
+
+	/* Parameter 3: offset (type: PT_UINT64) */
 	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
 
 	if (val != 0) {
@@ -5827,16 +5824,12 @@ int f_sys_sendfile_e(struct event_filler_arguments *args)
 	}
 
 	res = val_to_ring(args, val, 0, true, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	CHECK_RES(res);
 
-	/*
-	 * size
-	 */
+	/* Parameter 4: size (type: PT_UINT64) */
 	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
-	if (unlikely(res != PPM_SUCCESS))
-		return res;
+	CHECK_RES(res);
 
 	return add_sentinel(args);
 }

--- a/test/drivers/test_suites/syscall_enter_suite/recvmmsg_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/recvmmsg_e.cpp
@@ -1,0 +1,42 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvmmsg
+TEST(SyscallEnter, recvmmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	struct timespec *timeout = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmmsg", syscall(__NR_recvmmsg, mock_fd, msg, vlen, flags, timeout));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/semop_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/semop_e.cpp
@@ -1,0 +1,44 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_semop
+
+#include <sys/sem.h>
+
+TEST(SyscallEnter, semopE)
+{
+	auto evt_test = get_syscall_event_test(__NR_semop, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int semid = -1;
+	struct sembuf *sops = NULL;
+	size_t nsops = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "semop", syscall(__NR_semop, semid, sops, nsops));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: semid (type: PT_INT32)*/
+	evt_test->assert_numeric_param(1, (int32_t)semid);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/sendfile_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendfile_e.cpp
@@ -1,0 +1,101 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendfile
+
+TEST(SyscallEnter, sendfileE_null_pointer)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendfile, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int out_fd = -1;
+	int in_fd = -2;
+	void* offsite = NULL;
+	unsigned long size = 37;
+	assert_syscall_state(SYSCALL_FAILURE, "sendfile", syscall(__NR_sendfile, out_fd, in_fd, offsite, size));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: out_fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)out_fd);
+
+	/* Parameter 2: in_fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)in_fd);
+
+	/* Parameter 3: offset (type: PT_UINT64) */
+	/* The pointer is NULL so the offset should be 0 */
+	evt_test->assert_numeric_param(3, (uint64_t)0);
+
+	/* Parameter 4: size (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)size);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+
+TEST(SyscallEnter, sendfileE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendfile, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int out_fd = -1;
+	int in_fd = -2;
+	unsigned long offsite = 24;
+	unsigned long size = 37;
+	assert_syscall_state(SYSCALL_FAILURE, "sendfile", syscall(__NR_sendfile, out_fd, in_fd, &offsite, size));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: out_fd (type: PT_FD) */
+	evt_test->assert_numeric_param(1, (int64_t)out_fd);
+
+	/* Parameter 2: in_fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)in_fd);
+
+	/* Parameter 3: offset (type: PT_UINT64) */
+	evt_test->assert_numeric_param(3, (uint64_t)offsite);
+
+	/* Parameter 4: size (type: PT_UINT64) */
+	evt_test->assert_numeric_param(4, (uint64_t)size);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/sendmmsg_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendmmsg_e.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendmmsg
+TEST(SyscallEnter, sendmmsgE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "sendmmsg", syscall(__NR_sendmmsg, mock_fd, msg, vlen, flags));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/recvmmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvmmsg_x.cpp
@@ -1,0 +1,42 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_recvmmsg
+TEST(SyscallExit, recvmmsgX)
+{
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	struct timespec *timeout = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "recvmmsg", syscall(__NR_recvmmsg, mock_fd, msg, vlen, flags, timeout));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
@@ -1,0 +1,290 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_semop
+
+#include <sys/sem.h>
+
+TEST(SyscallExit, semopX_null_pointer)
+{
+	auto evt_test = get_syscall_event_test(__NR_semop, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int semid = -1;
+	struct sembuf *sops = NULL;
+	size_t nsops = 12;
+	assert_syscall_state(SYSCALL_FAILURE, "semop", syscall(__NR_semop, semid, sops, nsops));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: nsops (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)nsops);
+
+	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(3, (uint16_t)0);
+
+	/* Parameter 4: sem_op_0 (type: PT_INT16) */
+	evt_test->assert_numeric_param(4, (int16_t)0);
+
+	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(5, (uint16_t)0);
+
+	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(6, (uint16_t)0);
+
+	/* Parameter 7: sem_op_1 (type: PT_INT16) */
+	evt_test->assert_numeric_param(7, (int16_t)0);
+
+	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(8, (uint16_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(8);
+}
+
+#if defined(__NR_semget) && defined(__NR_semctl)
+
+/* This case was not managed correctly by old drivers, if we don't check for the syscall return value
+ * there is the risk to send junk data to userspace when `nops` is wrong.
+ */
+TEST(SyscallExit, semopX_wrong_nops)
+{
+	auto evt_test = get_syscall_event_test(__NR_semop, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create a semaphore set with 1 semaphore */
+	key_t key = 29; /* Random number */
+	int semid = syscall(__NR_semget, key, 1, 0666 | IPC_CREAT);
+	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
+
+	struct sembuf sops = {0};
+	sops.sem_num = 0;
+	sops.sem_op = 3;
+	sops.sem_flg = SEM_UNDO;
+	/* Here we have just one `ops` but we are trying to read 2 of them, if we don't check
+	 * the syscall failure in the kernel there is the risk to read junk data.
+	 */
+	size_t nsops = 2;
+	assert_syscall_state(SYSCALL_FAILURE, "semop", syscall(__NR_semop, semid, &sops, nsops));
+	int64_t errno_value = -errno;
+
+	/* Close a semaphore */
+	syscall(__NR_semctl, semid, 0, IPC_RMID);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: nsops (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)nsops);
+
+	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(3, (uint16_t)0);
+
+	/* Parameter 4: sem_op_0 (type: PT_INT16) */
+	evt_test->assert_numeric_param(4, (int16_t)0);
+
+	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(5, (uint16_t)0);
+
+	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(6, (uint16_t)0);
+
+	/* Parameter 7: sem_op_1 (type: PT_INT16) */
+	evt_test->assert_numeric_param(7, (int16_t)0);
+
+	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(8, (uint16_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(8);
+}
+
+TEST(SyscallExit, semopX_1_operation)
+{
+	auto evt_test = get_syscall_event_test(__NR_semop, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create a semaphore set with 1 semaphore: */
+	key_t key = 28; /* Random number */
+	int semid = syscall(__NR_semget, key, 1, 0666 | IPC_CREAT);
+	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
+
+	struct sembuf sops = {0};
+	sops.sem_num = 0;
+	sops.sem_op = 3;
+	sops.sem_flg = SEM_UNDO;
+	size_t nsops = 1;
+	assert_syscall_state(SYSCALL_SUCCESS, "semop", syscall(__NR_semop, semid, &sops, nsops), NOT_EQUAL, -1);
+
+	/* Close a semaphore */
+	syscall(__NR_semctl, semid, 0, IPC_RMID);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: nsops (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)nsops);
+
+	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(3, (uint16_t)sops.sem_num);
+
+	/* Parameter 4: sem_op_0 (type: PT_INT16) */
+	evt_test->assert_numeric_param(4, (int16_t)sops.sem_op);
+
+	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(5, (uint16_t)PPM_SEM_UNDO);
+
+	/* We use just one option so the second one will be empty */
+
+	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(6, (uint16_t)0);
+
+	/* Parameter 7: sem_op_1 (type: PT_INT16) */
+	evt_test->assert_numeric_param(7, (int16_t)0);
+
+	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(8, (uint16_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(8);
+}
+
+TEST(SyscallExit, semopX_2_operation)
+{
+	auto evt_test = get_syscall_event_test(__NR_semop, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Create a semaphore set with 1 semaphore */
+	key_t key = 29; /* Random number */
+	int semid = syscall(__NR_semget, key, 2, 0666 | IPC_CREAT);
+	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
+
+	struct sembuf sops[2] = {0};
+	sops[0].sem_num = 0;
+	sops[0].sem_op = 3;
+	sops[0].sem_flg = SEM_UNDO;
+	sops[1].sem_num = 1;
+	sops[1].sem_op = 7;
+	sops[1].sem_flg = IPC_NOWAIT;
+	size_t nsops = 2;
+	assert_syscall_state(SYSCALL_SUCCESS, "semop", syscall(__NR_semop, semid, sops, nsops), NOT_EQUAL, -1);
+
+	/* Close a semaphore */
+	syscall(__NR_semctl, semid, 0, IPC_RMID);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: nsops (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)nsops);
+
+	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(3, (uint16_t)sops[0].sem_num);
+
+	/* Parameter 4: sem_op_0 (type: PT_INT16) */
+	evt_test->assert_numeric_param(4, (int16_t)sops[0].sem_op);
+
+	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(5, (uint16_t)PPM_SEM_UNDO);
+
+	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
+	evt_test->assert_numeric_param(6, (uint16_t)sops[1].sem_num);
+
+	/* Parameter 7: sem_op_1 (type: PT_INT16) */
+	evt_test->assert_numeric_param(7, (int16_t)sops[1].sem_op);
+
+	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
+	evt_test->assert_numeric_param(8, (uint16_t)PPM_IPC_NOWAIT);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(8);
+}
+
+#endif
+
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
@@ -86,10 +86,10 @@ TEST(SyscallExit, semopX_wrong_nops)
 	sops.sem_num = 0;
 	sops.sem_op = 3;
 	sops.sem_flg = SEM_UNDO;
-	/* Here we have just one `ops` but we are trying to read 2 of them, if we don't check
+	/* Here we have just one `ops` but we are trying to read a huge number, if we don't check
 	 * the syscall failure in the kernel there is the risk to read junk data.
 	 */
-	size_t nsops = 2;
+	size_t nsops = (size_t)-1;
 	assert_syscall_state(SYSCALL_FAILURE, "semop", syscall(__NR_semop, semid, &sops, nsops));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendfile_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendfile_x.cpp
@@ -1,0 +1,92 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendfile
+
+TEST(SyscallExit, sendfileX_null_pointer)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendfile, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int out_fd = -1;
+	int in_fd = -2;
+	void* offsite = NULL;
+	unsigned long size = 37;
+	assert_syscall_state(SYSCALL_FAILURE, "sendfile", syscall(__NR_sendfile, out_fd, in_fd, offsite, size));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: offset (type: PT_UINT64) */
+	/* The pointer is NULL so the offset should be 0 */
+	evt_test->assert_numeric_param(2, (uint64_t)0);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, sendfileX)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendfile, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int out_fd = -1;
+	int in_fd = -2;
+	unsigned long offsite = 24;
+	unsigned long size = 37;
+	assert_syscall_state(SYSCALL_FAILURE, "sendfile", syscall(__NR_sendfile, out_fd, in_fd, &offsite, size));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: offset (type: PT_UINT64) */
+	/* The syscall fails so the offsite is not overwritten by the kernel */
+	evt_test->assert_numeric_param(2, (uint64_t)offsite);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/sendmmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmmsg_x.cpp
@@ -1,0 +1,41 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_sendmmsg
+TEST(SyscallExit, sendmmsgX)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr *msg = NULL;
+	uint32_t vlen = 0;
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "sendmmsg", syscall(__NR_sendmmsg, mock_fd, msg, vlen, flags));
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -223,6 +223,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_SEMGET_X] = "semget_x",
 	[PPME_SYSCALL_SEMCTL_E] = "semctl_e",
 	[PPME_SYSCALL_SEMCTL_X] = "semctl_x",
+	[PPME_SOCKET_RECVMMSG_E] = "recvmmsg_e",
+	[PPME_SOCKET_RECVMMSG_X] = "recvmmsg_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -225,6 +225,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_SEMCTL_X] = "semctl_x",
 	[PPME_SOCKET_RECVMMSG_E] = "recvmmsg_e",
 	[PPME_SOCKET_RECVMMSG_X] = "recvmmsg_x",
+	[PPME_SOCKET_SENDMMSG_E] = "sendmmsg_e",
+	[PPME_SOCKET_SENDMMSG_X] = "sendmmsg_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -227,6 +227,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_RECVMMSG_X] = "recvmmsg_x",
 	[PPME_SOCKET_SENDMMSG_E] = "sendmmsg_e",
 	[PPME_SOCKET_SENDMMSG_X] = "sendmmsg_x",
+	[PPME_SYSCALL_SEMOP_E] = "semop_e",
+	[PPME_SYSCALL_SEMOP_X] = "semop_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -229,6 +229,8 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SOCKET_SENDMMSG_X] = "sendmmsg_x",
 	[PPME_SYSCALL_SEMOP_E] = "semop_e",
 	[PPME_SYSCALL_SEMOP_X] = "semop_x",
+	[PPME_SYSCALL_SENDFILE_E] = "sendfile_e",
+	[PPME_SYSCALL_SENDFILE_X] = "sendfile_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

On one side this PR supports 4 missing syscalls in the modern bpf probe https://github.com/falcosecurity/libs/issues/723:
*  `sendmmsg`
*  `recvmmsg`
*  `semop`
*  `sendfile`

On the other side, it unifies the behavior of this syscall between our 3 drivers:
* send event even when the pointer is invalid

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(driver): unify support for some new syscalls between drivers 2/n
```
