### PR TITLE
Add <cstdint> for uintXX_t types

### DIFF
--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include "ast.h"
+#include <cstdint>
 
 namespace re2 { class RE2; };
 

--- a/userspace/libsinsp/filter_value.h
+++ b/userspace/libsinsp/filter_value.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include <string.h>
+#include <cstdint>
 #include <utility>
 
 // Used for CO_IN/CO_PMATCH filterchecks using PT_CHARBUFs to allow


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Fixes a build error found by upcoming new GCC compiler ( 13.x release )
gcc 13 moved some [includes](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes) around and as a result <cstdint> is no longer transitively included. Explicitly include it for uintXX_t.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
