### PR TITLE
chore: improve modern bpf probe build phase

### DIFF
--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -243,7 +243,6 @@ endforeach()
 # Generate a unique `bpf.o` file
 ########################
 
-set(UNIQUE_BPF_O_FILE_NAME bpf_probe)
 set(UNIQUE_BPF_O_FILE ${CMAKE_CURRENT_BINARY_DIR}/${UNIQUE_BPF_O_FILE_NAME}.o)
 add_custom_command(
   OUTPUT ${UNIQUE_BPF_O_FILE}

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -1,10 +1,15 @@
 option(MODERN_BPF_DEBUG_MODE "Enable BPF debug prints" OFF)
 
+########################
+# Debug mode
+########################
+
 if(MODERN_BPF_DEBUG_MODE)
   set(DEBUG "MODERN_BPF_DEBUG")
 else()
   set(DEBUG "")
 endif()
+message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_DEBUG_MODE: ${MODERN_BPF_DEBUG_MODE}")
 
 ########################
 # Check kernel version.
@@ -13,17 +18,21 @@ endif()
 # We check it here because the skeleton could be provided with the `MODERN_BPF_SKEL_DIR` env variable
 # so the compilation is still possible on older kernels.
 execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(-- " Kernel version: " ${UNAME_RESULT})
+message(STATUS  "${MODERN_BPF_LOG_PREFIX} Kernel version: ${UNAME_RESULT}")
 string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
 
 if (LINUX_KERNEL_VERSION VERSION_LESS 5.8)
-    message(FATAL_ERROR "Linux kernel version should be >= 5.8 but actual kernel version is: ${UNAME_RESULT}")
+    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= 5.8 but actual kernel version is: ${UNAME_RESULT}")
 endif()
+
+########################
+# Get driver version.
+########################
 
 # This is needed to obtain the modern bpf driver version
 include(compute_versions RESULT_VARIABLE RESULT)
 if(RESULT STREQUAL NOTFOUND)
-  message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 compute_versions(../API_VERSION ../SCHEMA_VERSION)
 configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
@@ -36,9 +45,13 @@ configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_confi
 if(NOT MODERN_CLANG_EXE)
   find_program(MODERN_CLANG_EXE NAMES clang DOC "Path to clang executable")
   if(NOT MODERN_CLANG_EXE)
-    message(FATAL_ERROR "unable to find clang")
+    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} unable to find clang")
   endif()
 endif()
+
+# If it is a relative path we convert it to an absolute one relative to the root source directory.
+get_filename_component(MODERN_CLANG_EXE "${MODERN_CLANG_EXE}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+message(STATUS "${MODERN_BPF_LOG_PREFIX} clang used by the modern bpf probe: '${MODERN_CLANG_EXE}'")
 
 # Check the right clang version (>=12)
 execute_process(COMMAND ${MODERN_CLANG_EXE} --version
@@ -54,39 +67,80 @@ if(${CLANG_version_result} EQUAL 0)
     string(REPLACE "." ";" CLANG_VERSION_LIST ${CLANG_VERSION})
     list(GET CLANG_VERSION_LIST 0 CLANG_VERSION_MAJOR)
 
-    # Anything older than clang 12 doesn't really work
     string(COMPARE LESS ${CLANG_VERSION_MAJOR} 12 CLANG_VERSION_MAJOR_LT12)
 
     if(${CLANG_VERSION_MAJOR_LT12})
-      message(FATAL_ERROR "clang ${CLANG_VERSION} is too old for compiling the modern BPF probe")
+      message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} clang '${CLANG_VERSION}' is too old for compiling the modern BPF probe, you need at least '12.0.0' version")
     endif()
 
-    message(STATUS "Found clang version: ${CLANG_VERSION}")
+    message(STATUS "${MODERN_BPF_LOG_PREFIX} Found clang version: ${CLANG_VERSION}")
   else()
-    message(FATAL_ERROR "Failed to parse clang version string: ${CLANG_version_output}")
+    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Failed to parse clang version string: ${CLANG_version_output}")
   endif()
 else()
-  message(FATAL_ERROR "Command \"${MODERN_CLANG_EXE} --version\" failed with output:\n ${CLANG_version_error}")
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Command \"${MODERN_CLANG_EXE} --version\" failed with output:\n ${CLANG_version_error}")
 endif()
-
-message(STATUS "clang used by the modern bpf probe: '${MODERN_CLANG_EXE}'")
 
 ########################
 # Check bpftool version.
 ########################
 
 # If the user doesn't provide the path to `bpftool` try to find it locally
-# set(MODERN_BPFTOOL_EXE "" CACHE STRING "Path to bpftool executable")
 if(NOT MODERN_BPFTOOL_EXE)
   find_program(MODERN_BPFTOOL_EXE NAMES bpftool DOC "Path to bpftool executable")
   if(NOT MODERN_BPFTOOL_EXE)
-    message(FATAL_ERROR "unable to find bpftool on the system")
+    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} unable to find bpftool on the system")
   endif()
 endif()
 
-message(STATUS "bpftool used by the modern bpf probe: '${MODERN_BPFTOOL_EXE}'")
+# If it is a relative path we convert it to an absolute one relative to the root source directory.
+get_filename_component(MODERN_BPFTOOL_EXE "${MODERN_BPFTOOL_EXE}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+message(STATUS "${MODERN_BPF_LOG_PREFIX} bpftool used by the modern bpf probe: '${MODERN_BPFTOOL_EXE}'")
 
-## Get clang bpf system includes
+# Check the right bpftool version (>=5.13)
+# Note that the output of `bpftool --version` is in this form `vM.m.p`, we have a `v` before the semver
+execute_process(COMMAND ${MODERN_BPFTOOL_EXE} --version
+  OUTPUT_VARIABLE BPFTOOL_version_output
+  ERROR_VARIABLE BPFTOOL_version_error
+  RESULT_VARIABLE BPFTOOL_version_result
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(${BPFTOOL_version_result} EQUAL 0)
+  if("${BPFTOOL_version_output}" MATCHES "bpftool v([^\n]+)\n")
+    # Transform X.Y.Z into X;Y;Z which can then be interpreted as a list
+    set(BPFTOOL_VERSION "${CMAKE_MATCH_1}")
+    string(REPLACE "." ";" BPFTOOL_VERSION_LIST ${BPFTOOL_VERSION})
+    list(GET BPFTOOL_VERSION_LIST 0 BPFTOOL_VERSION_MAJOR)
+
+    string(COMPARE LESS ${BPFTOOL_VERSION_MAJOR} 5 BPFTOOL_VERSION_MAJOR_LT5)
+
+    if(${BPFTOOL_VERSION_MAJOR_LT5})
+      message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} bpftool '${BPFTOOL_VERSION}' is too old for compiling the modern BPF probe, you need at least '5.13.0' version")
+    endif()
+
+    string(COMPARE EQUAL ${BPFTOOL_VERSION_MAJOR} 5 BPFTOOL_VERSION_MAJOR_EQ5)
+
+    if(${BPFTOOL_VERSION_MAJOR_EQ5})
+      list(GET BPFTOOL_VERSION_LIST 1 BPFTOOL_VERSION_MINOR)
+      string(COMPARE LESS ${BPFTOOL_VERSION_MINOR} 13 BPFTOOL_VERSION_MINOR_LT13)
+      if(${BPFTOOL_VERSION_MINOR_LT13})
+        message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} bpftool '${BPFTOOL_VERSION}' is too old for compiling the modern BPF probe, you need at least '5.13.0' version")
+      endif()  
+    endif()
+
+    message(STATUS "${MODERN_BPF_LOG_PREFIX} Found bpftool version: ${BPFTOOL_VERSION}")
+  else()
+    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Failed to parse bpftool version string: ${BPFTOOL_version_output}")
+  endif()
+else()
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Command \"${MODERN_BPFTOOL_EXE} --version\" failed with output:\n ${BPFTOOL_version_error}")
+endif()
+
+
+########################
+# Get clang bpf system includes
+########################
+
 execute_process(
   COMMAND bash -c "${MODERN_CLANG_EXE} -v -E - < /dev/null 2>&1 |
           sed -n '/<...> search starts here:/,/End of search list./{ s| \\(/.*\\)|-idirafter \\1|p }'"
@@ -96,10 +150,14 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(${CLANG_SYSTEM_INCLUDES_result} EQUAL 0)
   string(REPLACE "\n" " " CLANG_SYSTEM_INCLUDES ${CLANG_SYSTEM_INCLUDES_output})
-  message(STATUS "BPF system include flags: ${CLANG_SYSTEM_INCLUDES}")
+  message(STATUS "${MODERN_BPF_LOG_PREFIX} BPF system include flags: ${CLANG_SYSTEM_INCLUDES}")
 else()
-  message(FATAL_ERROR "Failed to determine BPF system includes: ${CLANG_SYSTEM_INCLUDES_error}")
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Failed to determine BPF system includes: ${CLANG_SYSTEM_INCLUDES_error}")
 endif()
+
+########################
+# Get target arch
+########################
 
 execute_process(COMMAND uname -m
   COMMAND sed "s/x86_64/x86/"
@@ -113,10 +171,14 @@ execute_process(COMMAND uname -m
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(${ARCH_result} EQUAL 0)
   set(ARCH ${ARCH_output})
-  message(STATUS "Target arch: ${ARCH}")
+  message(STATUS "${MODERN_BPF_LOG_PREFIX} Target arch: ${ARCH}")
 else()
-  message(FATAL_ERROR "Failed to determine target architecture: ${ARCH_error}")
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Failed to determine target architecture: ${ARCH_error}")
 endif()
+
+########################
+# Set includes and compilation flags
+########################
 
 # Get modern probe include.
 set(MODERN_PROBE_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -145,7 +207,10 @@ file(GLOB_RECURSE BPF_H_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 ## Search all bpf.c files
 file(GLOB_RECURSE BPF_C_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.bpf.c)
 
-## Generate an bpf.o file for every bpf.c
+########################
+# Generate an `bpf.o` file for every `bpf.c`
+########################
+
 foreach(BPF_C_FILE ${BPF_C_FILES})
     get_filename_component(file_stem ${BPF_C_FILE} NAME_WE)
     set(BPF_O_FILE ${CMAKE_CURRENT_BINARY_DIR}/${file_stem}.bpf.o)
@@ -159,7 +224,7 @@ if(USE_BUNDLED_LIBBPF)
         VERBATIM
         DEPENDS libbpf
         DEPENDS ${BPF_C_FILE} ${BPF_H_FILES}
-        COMMENT "[clang] Building BPF object: ${BPF_O_FILE}"
+        COMMENT "${MODERN_BPF_LOG_PREFIX} Building BPF object: ${BPF_O_FILE}"
     )
 else()
     add_custom_command(
@@ -167,14 +232,17 @@ else()
       COMMAND ${MODERN_CLANG_EXE} ${CLANG_FLAGS} ${CLANG_SYSTEM_INCLUDES} -c ${BPF_C_FILE} -o ${BPF_O_FILE}
       VERBATIM
       DEPENDS ${BPF_C_FILE} ${BPF_H_FILES}
-      COMMENT "[clang] Building BPF object: ${BPF_O_FILE}"
+      COMMENT "${MODERN_BPF_LOG_PREFIX} Building BPF object: ${BPF_O_FILE}"
     )
 endif()
 
     list(APPEND BPF_OBJECT_FILES ${BPF_O_FILE})
 endforeach()
 
-## Generate a unique bpf.o file
+########################
+# Generate a unique `bpf.o` file
+########################
+
 set(UNIQUE_BPF_O_FILE_NAME bpf_probe)
 set(UNIQUE_BPF_O_FILE ${CMAKE_CURRENT_BINARY_DIR}/${UNIQUE_BPF_O_FILE_NAME}.o)
 add_custom_command(
@@ -182,19 +250,25 @@ add_custom_command(
   COMMAND ${MODERN_BPFTOOL_EXE} gen object ${UNIQUE_BPF_O_FILE} ${BPF_OBJECT_FILES}
   VERBATIM
   DEPENDS ${BPF_OBJECT_FILES}
-  COMMENT "[bpftool]  Building BPF unique object file: ${UNIQUE_BPF_O_FILE}"
+  COMMENT "${MODERN_BPF_LOG_PREFIX} Building BPF unique object file: ${UNIQUE_BPF_O_FILE}"
 )
 
-## Generate the skeleton file
+########################
+# Generate the skeleton file
+########################
+
 set(BPF_SKEL_FILE ${MODERN_BPF_SKEL_DIR}/${UNIQUE_BPF_O_FILE_NAME}.skel.h)
 add_custom_command(
     OUTPUT ${BPF_SKEL_FILE}
     COMMAND bash -c "${MODERN_BPFTOOL_EXE} gen skeleton ${UNIQUE_BPF_O_FILE} > ${BPF_SKEL_FILE}"
     VERBATIM
     DEPENDS ${UNIQUE_BPF_O_FILE}
-    COMMENT "[bpftool]  Building BPF skeleton: ${BPF_SKEL_FILE}"
+    COMMENT "${MODERN_BPF_LOG_PREFIX} Building BPF skeleton: ${BPF_SKEL_FILE}"
 )
 
-## Add the skeleton as a custom target
+########################
+# Add the skeleton as a custom target
+########################
+
 set(BPF_SKEL_TARGET ProbeSkeleton)
 add_custom_target(${BPF_SKEL_TARGET} ALL DEPENDS ${BPF_SKEL_FILE})

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -6,6 +6,21 @@ else()
   set(DEBUG "")
 endif()
 
+########################
+# Check kernel version.
+########################
+
+# We check it here because the skeleton could be provided with the `MODERN_BPF_SKEL_DIR` env variable
+# so the compilation is still possible on older kernels.
+execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(-- " Kernel version: " ${UNAME_RESULT})
+string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
+
+if (LINUX_KERNEL_VERSION VERSION_LESS 5.8)
+    message(FATAL_ERROR "Linux kernel version should be >= 5.8 but actual kernel version is: ${UNAME_RESULT}")
+endif()
+
+# This is needed to obtain the modern bpf driver version
 include(compute_versions RESULT_VARIABLE RESULT)
 if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
@@ -13,15 +28,67 @@ endif()
 compute_versions(../API_VERSION ../SCHEMA_VERSION)
 configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
 
-#### TODO: we could add checks on the minimum required clang version.
-find_program(CLANG_EXE NAMES clang DOC "Path to clang executable")
+########################
+# Check clang version.
+########################
 
-## Get bpftool executable
-find_program(BPFTOOL_EXE NAMES bpftool DOC "Path to bpftool executable")
+# If the user doesn't provide the path to `clang` try to find it locally
+if(NOT MODERN_CLANG_EXE)
+  find_program(MODERN_CLANG_EXE NAMES clang DOC "Path to clang executable")
+  if(NOT MODERN_CLANG_EXE)
+    message(FATAL_ERROR "unable to find clang")
+  endif()
+endif()
+
+# Check the right clang version (>=12)
+execute_process(COMMAND ${MODERN_CLANG_EXE} --version
+  OUTPUT_VARIABLE CLANG_version_output
+  ERROR_VARIABLE CLANG_version_error
+  RESULT_VARIABLE CLANG_version_result
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(${CLANG_version_result} EQUAL 0)
+  if("${CLANG_version_output}" MATCHES "clang version ([^\n]+)\n")
+    # Transform X.Y.Z into X;Y;Z which can then be interpreted as a list
+    set(CLANG_VERSION "${CMAKE_MATCH_1}")
+    string(REPLACE "." ";" CLANG_VERSION_LIST ${CLANG_VERSION})
+    list(GET CLANG_VERSION_LIST 0 CLANG_VERSION_MAJOR)
+
+    # Anything older than clang 12 doesn't really work
+    string(COMPARE LESS ${CLANG_VERSION_MAJOR} 12 CLANG_VERSION_MAJOR_LT12)
+
+    if(${CLANG_VERSION_MAJOR_LT12})
+      message(FATAL_ERROR "clang ${CLANG_VERSION} is too old for compiling the modern BPF probe")
+    endif()
+
+    message(STATUS "Found clang version: ${CLANG_VERSION}")
+  else()
+    message(FATAL_ERROR "Failed to parse clang version string: ${CLANG_version_output}")
+  endif()
+else()
+  message(FATAL_ERROR "Command \"${MODERN_CLANG_EXE} --version\" failed with output:\n ${CLANG_version_error}")
+endif()
+
+message(STATUS "clang used by the modern bpf probe: '${MODERN_CLANG_EXE}'")
+
+########################
+# Check bpftool version.
+########################
+
+# If the user doesn't provide the path to `bpftool` try to find it locally
+# set(MODERN_BPFTOOL_EXE "" CACHE STRING "Path to bpftool executable")
+if(NOT MODERN_BPFTOOL_EXE)
+  find_program(MODERN_BPFTOOL_EXE NAMES bpftool DOC "Path to bpftool executable")
+  if(NOT MODERN_BPFTOOL_EXE)
+    message(FATAL_ERROR "unable to find bpftool on the system")
+  endif()
+endif()
+
+message(STATUS "bpftool used by the modern bpf probe: '${MODERN_BPFTOOL_EXE}'")
 
 ## Get clang bpf system includes
 execute_process(
-  COMMAND bash -c "${CLANG_EXE} -v -E - < /dev/null 2>&1 |
+  COMMAND bash -c "${MODERN_CLANG_EXE} -v -E - < /dev/null 2>&1 |
           sed -n '/<...> search starts here:/,/End of search list./{ s| \\(/.*\\)|-idirafter \\1|p }'"
   OUTPUT_VARIABLE CLANG_SYSTEM_INCLUDES_output
   ERROR_VARIABLE CLANG_SYSTEM_INCLUDES_error
@@ -34,7 +101,6 @@ else()
   message(FATAL_ERROR "Failed to determine BPF system includes: ${CLANG_SYSTEM_INCLUDES_error}")
 endif()
 
-## Get target arch (right now we explicitly support only `x86` and `arm64`)
 execute_process(COMMAND uname -m
   COMMAND sed "s/x86_64/x86/"
   COMMAND sed "s/aarch64/arm64/"
@@ -89,7 +155,7 @@ foreach(BPF_C_FILE ${BPF_C_FILES})
 if(USE_BUNDLED_LIBBPF)
     add_custom_command(
         OUTPUT ${BPF_O_FILE}
-        COMMAND ${CLANG_EXE} ${CLANG_FLAGS} ${CLANG_SYSTEM_INCLUDES} -c ${BPF_C_FILE} -o ${BPF_O_FILE}
+        COMMAND ${MODERN_CLANG_EXE} ${CLANG_FLAGS} ${CLANG_SYSTEM_INCLUDES} -c ${BPF_C_FILE} -o ${BPF_O_FILE}
         VERBATIM
         DEPENDS libbpf
         DEPENDS ${BPF_C_FILE} ${BPF_H_FILES}
@@ -98,7 +164,7 @@ if(USE_BUNDLED_LIBBPF)
 else()
     add_custom_command(
       OUTPUT ${BPF_O_FILE}
-      COMMAND ${CLANG_EXE} ${CLANG_FLAGS} ${CLANG_SYSTEM_INCLUDES} -c ${BPF_C_FILE} -o ${BPF_O_FILE}
+      COMMAND ${MODERN_CLANG_EXE} ${CLANG_FLAGS} ${CLANG_SYSTEM_INCLUDES} -c ${BPF_C_FILE} -o ${BPF_O_FILE}
       VERBATIM
       DEPENDS ${BPF_C_FILE} ${BPF_H_FILES}
       COMMENT "[clang] Building BPF object: ${BPF_O_FILE}"
@@ -113,7 +179,7 @@ set(UNIQUE_BPF_O_FILE_NAME bpf_probe)
 set(UNIQUE_BPF_O_FILE ${CMAKE_CURRENT_BINARY_DIR}/${UNIQUE_BPF_O_FILE_NAME}.o)
 add_custom_command(
   OUTPUT ${UNIQUE_BPF_O_FILE}
-  COMMAND ${BPFTOOL_EXE} gen object ${UNIQUE_BPF_O_FILE} ${BPF_OBJECT_FILES}
+  COMMAND ${MODERN_BPFTOOL_EXE} gen object ${UNIQUE_BPF_O_FILE} ${BPF_OBJECT_FILES}
   VERBATIM
   DEPENDS ${BPF_OBJECT_FILES}
   COMMENT "[bpftool]  Building BPF unique object file: ${UNIQUE_BPF_O_FILE}"
@@ -123,7 +189,7 @@ add_custom_command(
 set(BPF_SKEL_FILE ${MODERN_BPF_SKEL_DIR}/${UNIQUE_BPF_O_FILE_NAME}.skel.h)
 add_custom_command(
     OUTPUT ${BPF_SKEL_FILE}
-    COMMAND bash -c "${BPFTOOL_EXE} gen skeleton ${UNIQUE_BPF_O_FILE} > ${BPF_SKEL_FILE}"
+    COMMAND bash -c "${MODERN_BPFTOOL_EXE} gen skeleton ${UNIQUE_BPF_O_FILE} > ${BPF_SKEL_FILE}"
     VERBATIM
     DEPENDS ${UNIQUE_BPF_O_FILE}
     COMMENT "[bpftool]  Building BPF skeleton: ${BPF_SKEL_FILE}"

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <errno.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <shared_definitions/struct_definitions.h>
 #include <bpf_probe.skel.h>
 #include <unistd.h>
+#include <errno.h>
 
 #define MAX_ERROR_MESSAGE_LEN 100
 

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
 
+message(STATUS "Build modern BPF engine")
 option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)
 
 # Include `libbpf` library.
@@ -8,6 +9,7 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "problem with libbpf.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 
+# This must be a dir because we use it as an include path
 if(NOT MODERN_BPF_SKEL_DIR)
   # Directory in which the BPF skeleton will be built
   set(MODERN_BPF_SKEL_DIR "${CMAKE_BINARY_DIR}/skel_dir")
@@ -16,6 +18,8 @@ if(NOT MODERN_BPF_SKEL_DIR)
   add_subdirectory(${LIBSCAP_DIR}/driver/modern_bpf ${CMAKE_BINARY_DIR}/driver/modern_bpf)
 else()
   set(USE_BUNDLED_MODERN_BPF OFF)
+  # If it is a relative path we convert it to an absolute one relative to the root source directory.
+  get_filename_component(MODERN_BPF_SKEL_DIR "${MODERN_BPF_SKEL_DIR}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
 endif()
 message(STATUS "USE_BUNDLED_MODERN_BPF: ${USE_BUNDLED_MODERN_BPF}, using skeleton dir: ${MODERN_BPF_SKEL_DIR}")
 

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -10,6 +10,10 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "problem with libbpf.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 
+# This will be the name of the final `bpf.o` file. We put it here this way
+# we can log it even if `USE_BUNDLED_MODERN_BPF` is `OFF` 
+set(UNIQUE_BPF_O_FILE_NAME bpf_probe)
+
 # This must be a dir because we use it as an include path
 if(NOT MODERN_BPF_SKEL_DIR)
   # Directory in which the BPF skeleton will be built
@@ -23,6 +27,7 @@ else()
   get_filename_component(MODERN_BPF_SKEL_DIR "${MODERN_BPF_SKEL_DIR}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
 endif()
 message(STATUS "${MODERN_BPF_LOG_PREFIX} USE_BUNDLED_MODERN_BPF: ${USE_BUNDLED_MODERN_BPF}, using skeleton dir: ${MODERN_BPF_SKEL_DIR}")
+message(STATUS "${MODERN_BPF_LOG_PREFIX} full skeleton path: ${MODERN_BPF_SKEL_DIR}/${UNIQUE_BPF_O_FILE_NAME}.skel.h")
 
 # Build `libpman` library.
 add_subdirectory(${LIBSCAP_DIR}/userspace/libpman ${CMAKE_BINARY_DIR}/libpman)

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
 
 message(STATUS "Build modern BPF engine")
 option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)
+set(MODERN_BPF_LOG_PREFIX "[MODERN BPF]")
 
 # Include `libbpf` library.
 include(libbpf RESULT_VARIABLE RESULT)
@@ -21,7 +22,7 @@ else()
   # If it is a relative path we convert it to an absolute one relative to the root source directory.
   get_filename_component(MODERN_BPF_SKEL_DIR "${MODERN_BPF_SKEL_DIR}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
 endif()
-message(STATUS "USE_BUNDLED_MODERN_BPF: ${USE_BUNDLED_MODERN_BPF}, using skeleton dir: ${MODERN_BPF_SKEL_DIR}")
+message(STATUS "${MODERN_BPF_LOG_PREFIX} USE_BUNDLED_MODERN_BPF: ${USE_BUNDLED_MODERN_BPF}, using skeleton dir: ${MODERN_BPF_SKEL_DIR}")
 
 # Build `libpman` library.
 add_subdirectory(${LIBSCAP_DIR}/userspace/libpman ${CMAKE_BINARY_DIR}/libpman)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR brings to the table some improvements in the modern  bpf build:
* check on minimum kernel version at build time (>=5.8), only if `MODERN_BPF_SKEL_DIR` is not specified
* check on clang version (>=12)
* `MODERN_CLANG_EXE` to specify a custom clang exe
* `MODERN_BPFTOOL_EXE` to specify a custom bpftool exe

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
