### PR TITLE
chore(driver): check minimum kernel versions for each driver.

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -25,7 +25,7 @@ set(kmod_min_kver_map_x86_64 2.6)
 set(kmod_min_kver_map_aarch64 3.16)
 set(kmod_min_kver_map_s390x 2.6)
 if (LINUX_KERNEL_VERSION VERSION_LESS ${kmod_min_kver_map_${TARGET_ARCH}})
-	message(FATAL_ERROR "[KMOD] Linux kernel version should be >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+	message(WARNING "[KMOD] Linux kernel version should be >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
 endif()
 
 option(BUILD_DRIVER "Build the driver on Linux" ON)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -25,7 +25,7 @@ set(kmod_min_kver_map_x86_64 2.6)
 set(kmod_min_kver_map_aarch64 3.16)
 set(kmod_min_kver_map_s390x 2.6)
 if (LINUX_KERNEL_VERSION VERSION_LESS ${kmod_min_kver_map_${TARGET_ARCH}})
-	message(WARNING "[KMOD] Linux kernel version should be >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+	message(WARNING "[KMOD] To run this driver you need a Linux kernel version >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
 endif()
 
 option(BUILD_DRIVER "Build the driver on Linux" ON)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -15,6 +15,19 @@ if((NOT TARGET_ARCH STREQUAL "x86_64") AND
 	message(WARNING "Target architecture not officially supported by our drivers!")
 endif()
 
+# Load current kernel version
+execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
+message(STATUS  "Kernel version: ${UNAME_RESULT}")
+
+# Check minimum kernel version
+set(kmod_min_kver_map_x86_64 2.6)
+set(kmod_min_kver_map_aarch64 3.16)
+set(kmod_min_kver_map_s390x 2.6)
+if (LINUX_KERNEL_VERSION VERSION_LESS ${kmod_min_kver_map_${TARGET_ARCH}})
+	message(FATAL_ERROR "[KMOD] Linux kernel version should be >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+endif()
+
 option(BUILD_DRIVER "Build the driver on Linux" ON)
 option(ENABLE_DKMS "Enable DKMS on Linux" ON)
 

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -10,6 +10,14 @@ configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_confi
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
 if(BUILD_BPF)
+	# Check minimum kernel version
+	set(bpf_min_kver_map_x86_64 4.14)
+	set(bpf_min_kver_map_aarch64 4.17)
+	set(bpf_min_kver_map_s390x 5.5)
+	if (LINUX_KERNEL_VERSION VERSION_LESS ${bpf_min_kver_map_${TARGET_ARCH}})
+		message(FATAL_ERROR "[BPF] Linux kernel version should be >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+	endif()
+
 	add_custom_target(bpf ALL
 		COMMAND make
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different probe.o "${CMAKE_CURRENT_BINARY_DIR}"

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -15,7 +15,7 @@ if(BUILD_BPF)
 	set(bpf_min_kver_map_aarch64 4.17)
 	set(bpf_min_kver_map_s390x 5.5)
 	if (LINUX_KERNEL_VERSION VERSION_LESS ${bpf_min_kver_map_${TARGET_ARCH}})
-		message(FATAL_ERROR "[BPF] Linux kernel version should be >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+		message(WARNING "[BPF] Linux kernel version should be >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
 	endif()
 
 	add_custom_target(bpf ALL

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -15,7 +15,7 @@ if(BUILD_BPF)
 	set(bpf_min_kver_map_aarch64 4.17)
 	set(bpf_min_kver_map_s390x 5.5)
 	if (LINUX_KERNEL_VERSION VERSION_LESS ${bpf_min_kver_map_${TARGET_ARCH}})
-		message(WARNING "[BPF] Linux kernel version should be >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+		message(WARNING "[BPF] To run this driver you need a Linux kernel version >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
 	endif()
 
 	add_custom_target(bpf ALL

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -23,7 +23,7 @@ set(modern_bpf_min_kver_map_x86_64 5.8)
 set(modern_bpf_min_kver_map_aarch64 5.8)
 set(modern_bpf_min_kver_map_s390x 5.8)
 if (LINUX_KERNEL_VERSION VERSION_LESS ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}})
-  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}} but actual kernel version is: ${UNAME_RESULT}")
+  message(WARNING "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}} but actual kernel version is: ${UNAME_RESULT}")
 endif()
 
 ########################

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -23,7 +23,7 @@ set(modern_bpf_min_kver_map_x86_64 5.8)
 set(modern_bpf_min_kver_map_aarch64 5.8)
 set(modern_bpf_min_kver_map_s390x 5.8)
 if (LINUX_KERNEL_VERSION VERSION_LESS ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}})
-  message(WARNING "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}} but actual kernel version is: ${UNAME_RESULT}")
+  message(WARNING "${MODERN_BPF_LOG_PREFIX} To run this driver you need a Linux kernel version >= ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}} but actual kernel version is: ${UNAME_RESULT}")
 endif()
 
 ########################

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -18,11 +18,12 @@ message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_DEBUG_MODE: ${MODERN_BPF_DEB
 # We check it here because the skeleton could be provided with the `MODERN_BPF_SKEL_DIR` env variable
 # so the compilation is still possible on older kernels.
 execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-message(STATUS  "${MODERN_BPF_LOG_PREFIX} Kernel version: ${UNAME_RESULT}")
 string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
-
-if (LINUX_KERNEL_VERSION VERSION_LESS 5.8)
-    message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= 5.8 but actual kernel version is: ${UNAME_RESULT}")
+set(modern_bpf_min_kver_map_x86_64 5.8)
+set(modern_bpf_min_kver_map_aarch64 5.8)
+set(modern_bpf_min_kver_map_s390x 5.8)
+if (LINUX_KERNEL_VERSION VERSION_LESS ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}})
+  message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} Linux kernel version should be >= ${modern_bpf_min_kver_map_${CMAKE_HOST_SYSTEM_PROCESSOR}} but actual kernel version is: ${UNAME_RESULT}")
 endif()
 
 ########################


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds a configure time check for:
* kmod
* ebpf

Much similar to the modern bpf one (added in #863).

Example output:
```
CMake Error at driver/bpf/CMakeLists.txt:18 (message):
[BPF] Linux kernel version should be >= 6.14 but actual kernel version is:
6.1.9-arch1-2
```

```
CMake Error at driver/CMakeLists.txt:27 (message):
[KMOD] Linux kernel version should be >= 6.6 but actual kernel version is:
6.1.9-arch1-2
```

(Notice i had to bump minimum kernel version to a version > than mine, to check ;) )

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

See https://github.com/falcosecurity/libs#drivers-officially-supported-architectures

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
