### PR TITLE
cleanup(driver): uniform feature gates between drivers

### DIFF
--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -117,6 +117,11 @@ BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 		drop_flags = UF_ALWAYS_DROP;
 	}
 
+#if defined(CAPTURE_SCHED_PROC_FORK) || defined(CAPTURE_SCHED_PROC_EXEC)
+	if(bpf_drop_syscall_exit_events(ctx, evt_type))
+		return 0;
+#endif
+
 	call_filler(ctx, ctx, evt_type, drop_flags);
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -43,6 +43,19 @@ int BPF_PROG(vfork_x,
 	     struct pt_regs *regs,
 	     long ret)
 {
+
+/* We already catch the vfork child event with our `sched_process_fork` tracepoint,
+ * for this reason we don't need also this instrumentation. Please note that we use
+ * the aforementioned tracepoint only for the child event but we need to catch also
+ * the father event or the failure case, for this reason we check the `ret==0`
+ */
+#ifdef CAPTURE_SCHED_PROC_FORK
+	if(ret == 0)
+	{
+		return 0;
+	}
+#endif
+
 	struct auxiliary_map *auxmap = auxmap__get();
 	if(!auxmap)
 	{
@@ -163,19 +176,6 @@ int BPF_PROG(t1_vfork_x,
 	     struct pt_regs *regs,
 	     long ret)
 {
-
-/* We already catch the vfork child event with our `sched_process_fork` tracepoint,
- * for this reason we don't need also this instrumentation. Please note that we use
- * the aforementioned tracepoint only for the child event but we need to catch also
- * the father event or the failure case, for this reason we check the `ret==0`
- */
-#ifdef CAPTURE_SCHED_PROC_FORK
-	if(ret == 0)
-	{
-		return 0;
-	}
-#endif
-
 	struct auxiliary_map *auxmap = auxmap__get();
 	if(!auxmap)
 	{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

* When `CAPTURE_SCHED_PROC_FORK` is enabled we generate `clone/fork-family` child exit events from a dedicated tracepoint, so we don't need to catch them from `sys_exit` tracepoint otherwise we will have duplicated events.
* When `CAPTURE_SCHED_PROC_EXEC` is enabled we generate `execve-family` successful events from a dedicated tracepoint, so we don't need to catch them from `sys_exit` tracepoint otherwise we will have duplicated events.

This PR should enforce the behavior between the 3 drivers 

See this conversation: https://github.com/falcosecurity/libs/pull/809/files#r1097245003 (@hbrueckner)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
