### PR TITLE
new(driver): support sampling ratio in the modern bpf probe 

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -165,4 +165,8 @@
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4
 #define SCHED_SWITCH_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + sizeof(uint32_t) * 3 + PARAM_LEN * 6
 
+/* Special internal events */
+#define DROP_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define DROP_X_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/helpers/base/common.h
+++ b/driver/modern_bpf/helpers/base/common.h
@@ -13,6 +13,9 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 
+/* Convert seconds to nanoseconds */
+#define SECOND_TO_NS 1000000000
+
 /*=============================== LIBBPF MISSING TRACING DEFINITION ===========================*/
 
 /* Look at bpf/bpf_tracing.h, this definition is similar

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -26,7 +26,45 @@ static __always_inline uint32_t maps__get_snaplen()
 	return g_settings.snaplen;
 }
 
+static __always_inline bool maps__get_dropping_mode()
+{
+	return g_settings.dropping_mode;
+}
+
+static __always_inline uint32_t maps__get_sampling_ratio()
+{
+	return g_settings.sampling_ratio;
+}
+
 /*=============================== SETTINGS ===========================*/
+
+/*=============================== KERNEL CONFIGS ===========================*/
+
+static __always_inline bool maps__get_is_dropping()
+{
+	return is_dropping;
+}
+
+static __always_inline void maps__set_is_dropping(bool value)
+{
+	is_dropping = value;
+}
+
+/*=============================== KERNEL CONFIGS ===========================*/
+
+/*=============================== SAMPLING TABLES ===========================*/
+
+static __always_inline uint8_t maps__64bit_sampling_syscall_table(u32 syscall_id)
+{
+	return g_64bit_sampling_syscall_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
+}
+
+static __always_inline uint8_t maps__64bit_sampling_tracepoint_table(u32 event_id)
+{
+	return g_64bit_sampling_tracepoint_table[event_id < PPM_EVENT_MAX ? event_id : PPM_EVENT_MAX-1];
+}
+
+/*=============================== SAMPLING TABLES ===========================*/
 
 /*=============================== SYSCALL-64 INTERESTING TABLE ===========================*/
 

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -11,8 +11,6 @@
 #include <helpers/base/read_from_task.h>
 #include <driver/ppm_flag_helpers.h>
 
-#define SECOND_TO_NS 1000000000
-
 /* Used to convert from page number to KB. */
 #define DO_PAGE_SHIFT(x) (x) << (IOC_PAGE_SHIFT - 10)
 

--- a/driver/modern_bpf/helpers/interfaces/attached_programs.h
+++ b/driver/modern_bpf/helpers/interfaces/attached_programs.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#pragma once
+
+#include <helpers/base/maps_getters.h>
+#include <definitions/events_dimensions.h>
+#include <helpers/store/ringbuf_store_params.h>
+
+/* This enum is used to tell if we are considering a syscall or a tracepoint */
+enum intrumentation_type
+{
+	SYSCALL = 0,
+	TRACEPOINT = 1,
+};
+
+
+static __always_inline void send_drop_e_event()
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DROP_E_SIZE))
+	{
+		return;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_DROP_E);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+}
+
+static __always_inline void send_drop_x_event()
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, DROP_X_SIZE))
+	{
+		return;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_DROP_X);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+}
+
+
+/* The sampling logic is used by all BPF programs attached to the kernel.
+ * We treat the syscalls tracepoints in a dedicated way because they could generate
+ * more than one event (1 for each syscall) for this reason we need a dedicated table.
+ */
+static __always_inline bool sampling_logic(u32 id, enum intrumentation_type type)
+{
+	/* If dropping mode is not enabled we don't perform any sampling
+	 * false: means don't drop the syscall
+	 * true: means drop the syscall
+	 */
+	if(!maps__get_dropping_mode())
+	{
+		return false;
+	}
+
+	uint8_t sampling_flag = 0;
+
+	/* If we have a syscall we use the sampling_syscall_table otherwise
+	 * with tracepoints we use the sampling_tracepoint_table.
+	 */
+	if(type == SYSCALL)
+	{
+		sampling_flag = maps__64bit_sampling_syscall_table(id);
+	}
+	else
+	{
+		sampling_flag = maps__64bit_sampling_tracepoint_table(id);
+	}
+
+	if(sampling_flag == UF_NEVER_DROP)
+	{
+		return false;
+	}
+
+	if(sampling_flag == UF_ALWAYS_DROP)
+	{
+		return true;
+	}
+
+	if((bpf_ktime_get_boot_ns() % SECOND_TO_NS) >= (SECOND_TO_NS / maps__get_sampling_ratio()))
+	{
+		/* If we are starting the dropping phase we need to notify the userspace, otherwise, we
+		 * simply drop our event.
+		 * PLEASE NOTE: this logic is not per-CPU so it is best effort!
+		 */
+		if(!maps__get_is_dropping())
+		{
+			/* Here we are not sure we can send the drop_e event to userspace
+			 * if the buffer is full, but this is not essential even if we lose
+			 * an iteration we will synchronize again the next time the logic is enabled.
+			 */
+			maps__set_is_dropping(true);
+			send_drop_e_event();
+			return true;
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+	if(maps__get_is_dropping())
+	{
+		maps__set_is_dropping(false);
+		send_drop_x_event();
+		return true;
+	}
+
+	return false;
+}

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -57,10 +57,33 @@ __weak const volatile uint64_t probe_schema_var = PPM_SCHEMA_CURRENT_VERSION;
 __weak bool g_64bit_interesting_syscalls_table[SYSCALL_TABLE_SIZE];
 
 /**
+ * @brief Given the syscall id on 64-bit-architectures returns:
+ * - `UF_NEVER_DROP` if the syscall must not be dropped in the sampling logic.
+ * - `UF_ALWAYS_DROP` if the syscall must always be dropped in the sampling logic.
+ * - `UF_NONE` if we drop the syscall depends on the sampling ratio. 
+ */
+__weak uint8_t g_64bit_sampling_syscall_table[SYSCALL_TABLE_SIZE];
+
+/**
+ * @brief Given the tracepoint enum returns:
+ * - `UF_NEVER_DROP` if the syscall must not be dropped in the sampling logic.
+ * - `UF_ALWAYS_DROP` if the syscall must always be dropped in the sampling logic.
+ * - `UF_NONE` if we drop the syscall depends on the sampling ratio. 
+ */
+/// TOOD: we need to change the dimension! we need to create a dedicated enum for tracepoints!
+__weak uint8_t g_64bit_sampling_tracepoint_table[PPM_EVENT_MAX];
+
+/**
  * @brief Global capture settings shared between userspace and
  * bpf programs.
  */
 __weak struct capture_settings g_settings;
+
+/**
+ * @brief Variable used only kernel side to understand when we need to send
+ * `DROP_E` and `DROP_X` events
+ */
+__weak bool is_dropping;
 
 /*=============================== BPF GLOBAL VARIABLES ===============================*/
 

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/syscalls_dispatcher.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: /include/trace/events/syscall.h
  * TP_PROTO(struct pt_regs *regs, long id),
@@ -22,6 +23,11 @@ int BPF_PROG(sys_enter,
 	 * If the syscall is not interesting we drop it.
 	 */
 	if(!syscalls_dispatcher__64bit_interesting_syscall(syscall_id))
+	{
+		return 0;
+	}
+
+	if(sampling_logic(syscall_id, SYSCALL))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/syscalls_dispatcher.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: /include/trace/events/syscall.h
  * TP_PROTO(struct pt_regs *regs, long ret),
@@ -24,6 +25,11 @@ int BPF_PROG(sys_exit,
 	 * If the syscall is not interesting we drop it.
 	 */
 	if(!syscalls_dispatcher__64bit_interesting_syscall(syscall_id))
+	{
+		return 0;
+	}
+
+	if(sampling_logic(syscall_id, SYSCALL))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -1,5 +1,6 @@
 #include <helpers/interfaces/fixed_size_event.h>
 #include <driver/systype_compat.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: /include/trace/events/sched.h
  * TP_PROTO(struct task_struct *p)
@@ -8,6 +9,11 @@ SEC("tp_btf/sched_process_exit")
 int BPF_PROG(sched_proc_exit,
 	     struct task_struct *task)
 {
+	if(sampling_logic(PPME_PROCEXIT_1_E, TRACEPOINT))
+	{
+		return 0;
+	}
+
 	uint32_t flags = 0;
 	READ_TASK_FIELD_INTO(&flags, task, flags);
 

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -1,4 +1,5 @@
 #include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: /include/linux/events/sched.h
  * TP_PROTO(bool preempt, struct task_struct *prev,
@@ -9,6 +10,11 @@ int BPF_PROG(sched_switch,
 	     bool preempt, struct task_struct *prev,
 	     struct task_struct *next)
 {
+	if(sampling_logic(PPME_SCHEDSWITCH_1_E, TRACEPOINT))
+	{
+		return 0;
+	}
+	
 	/// TODO: we could avoid switches from kernel threads to kernel threads (?).
 
 	struct ringbuf_struct ringbuf;

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -23,8 +23,10 @@
  */
 struct capture_settings
 {
-	uint64_t boot_time;   /* boot time. */
-	uint32_t snaplen;     /* we use it when we want to read a maximum size from a event and no more. */
+	uint64_t boot_time;	 /* boot time. */
+	uint32_t snaplen;	 /* we use it when we want to read a maximum size from a event and no more. */
+	bool dropping_mode;	 /* this flag actives the sampling logic */
+	uint32_t sampling_ratio; /* this config tells tracepoints when they have to drop events  */
 };
 
 /**

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -220,6 +220,16 @@ void event_test::enable_capture()
 	clear_ring_buffers();
 }
 
+void event_test::enable_sampling_logic(uint32_t sampling_ratio)
+{
+	scap_start_dropping_mode(s_scap_handle, sampling_ratio);
+}
+
+void event_test::disable_sampling_logic()
+{
+	scap_stop_dropping_mode(s_scap_handle);
+}
+
 void event_test::disable_capture()
 {
 	scap_stop_capture(s_scap_handle);

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -155,6 +155,18 @@ public:
 	void disable_capture();
 
 	/**
+	 * @brief Enable driver sampling logic
+	 *
+	 */
+	void enable_sampling_logic(uint32_t sampling_ratio);
+
+	/**
+	 * @brief Disable driver sampling logic
+	 *
+	 */
+	void disable_sampling_logic();
+
+	/**
 	 * @brief Clear the ring buffers from all previous events until they
 	 * are all empty.
 	 *

--- a/test/drivers/test_suites/actions_suite/sampling_ratio.cpp
+++ b/test/drivers/test_suites/actions_suite/sampling_ratio.cpp
@@ -1,0 +1,86 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_unshare)
+TEST(Actions, sampling_ratio_UF_ALWAYS_DROP)
+{
+	/* Here we set just one `UF_ALWAYS_DROP` syscall as interesting... this process will send
+	 * only this specific syscall and we have to check that the corresponding event is dropped when
+	 * the sampling logic is enabled and not dropped when the logic is disabled.
+	 */
+	auto evt_test = get_syscall_event_test(__NR_unshare, ENTER_EVENT);
+
+	/* We are not sampling, we are just removing the `UF_ALWAYS_DROP` events */
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* Call the `UF_ALWAYS_DROP` syscall */
+	syscall(__NR_unshare, 0);
+
+	evt_test->assert_event_absence();
+
+	evt_test->disable_sampling_logic();
+
+	/* Call again the `UF_ALWAYS_DROP` syscall */
+	syscall(__NR_unshare, 0);
+
+	/* This time we should be able to find the event */
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+#endif
+
+#if defined(__NR_eventfd) && defined(__NR_close)
+TEST(Actions, sampling_ratio_UF_NEVER_DROP)
+{
+	/* Here we set just one `UF_NEVER_DROP` syscall as interesting... this process will send
+	 * only this specific syscall and we have to check that the corresponding event is
+     * not dropped when the sampling logic is enabled.
+	 */
+	auto evt_test = get_syscall_event_test(__NR_eventfd, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/* Even sampling with the maximum frequency we shouldn't drop `UF_NEVER_DROP` events */
+	evt_test->enable_sampling_logic(128);
+
+	/* Call the `UF_NEVER_DROP` syscall */
+	int32_t fd = syscall(__NR_eventfd, 3);
+	syscall(__NR_close, fd);
+
+    /* We should find the event */
+	evt_test->assert_event_presence();
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->disable_capture();
+}
+#endif
+
+#if defined(__NR_capset)
+TEST(Actions, sampling_ratio_NO_FLAGS)
+{
+	/* Here we set just one syscall with no flags (UF_ALWAYS_DROP/UF_NEVER_DROP)
+     * as interesting... this process will send only this specific syscall and 
+     * we have to check that the corresponding event is not dropped when the
+     * sampling logic is enabled with ratio==1.
+	 */
+	auto evt_test = get_syscall_event_test(__NR_capset, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/* With sampling==1 we shouldn't drop events without flags */
+	evt_test->enable_sampling_logic(1);
+
+	/* Call the syscall */
+	syscall(__NR_capset, NULL, NULL);
+
+    /* We should find the event */
+	evt_test->assert_event_presence();
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->disable_capture();
+}
+#endif

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -293,6 +293,10 @@ extern "C"
 	 */
 	void pman_set_boot_time(uint64_t boot_time);
 
+	void pman_set_dropping_mode(bool value);
+
+	void pman_set_sampling_ratio(uint32_t value);
+
 	/**
 	 * @brief Get API version to check it a runtime.
 	 *

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1136,21 +1136,6 @@ int32_t scap_bpf_disable_dynamic_snaplen(struct scap_engine_handle engine)
 int32_t scap_bpf_start_dropping_mode(struct scap_engine_handle engine, uint32_t sampling_ratio)
 {
 	struct bpf_engine *handle = engine.m_handle;
-	switch(sampling_ratio)
-	{
-		case 1:
-		case 2:
-		case 4:
-		case 8:
-		case 16:
-		case 32:
-		case 64:
-		case 128:
-			break;
-		default:
-			return scap_errprintf(handle->m_lasterr, 0, "invalid sampling ratio size");
-	}
-
 	struct scap_bpf_settings settings;
 	int k = 0;
 	int ret;

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -143,13 +143,50 @@ static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_
 	return SCAP_SUCCESS;
 }
 
+static int32_t scap_modern_bpf_start_dropping_mode(struct scap_engine_handle engine, uint32_t sampling_ratio)
+{
+	struct modern_bpf_engine *handle = engine.m_handle;
+	switch(sampling_ratio)
+	{
+		case 1:
+		case 2:
+		case 4:
+		case 8:
+		case 16:
+		case 32:
+		case 64:
+		case 128:
+			break;
+		default:
+			return SCAP_FAILURE;
+	}
+
+	pman_set_sampling_ratio(sampling_ratio);
+	pman_set_dropping_mode(true);
+	return SCAP_SUCCESS;
+}
+
+int32_t scap_modern_bpf_stop_dropping_mode()
+{
+	pman_set_sampling_ratio(1);
+	pman_set_dropping_mode(false);
+	return SCAP_SUCCESS;
+}
+
+
 static int32_t scap_modern_bpf__configure(struct scap_engine_handle engine, enum scap_setting setting, unsigned long arg1, unsigned long arg2)
 {
 	switch(setting)
 	{
 	case SCAP_SAMPLING_RATIO:
-		/* Not supported */
-		return SCAP_SUCCESS;
+		if(arg2 == 0)
+		{
+			return scap_modern_bpf_stop_dropping_mode();
+		}
+		else
+		{
+			return scap_modern_bpf_start_dropping_mode(engine, arg1);
+		}
 	case SCAP_TRACERS_CAPTURE:
 		/* Not supported */
 		return SCAP_SUCCESS;

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -145,22 +145,6 @@ static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_
 
 static int32_t scap_modern_bpf_start_dropping_mode(struct scap_engine_handle engine, uint32_t sampling_ratio)
 {
-	struct modern_bpf_engine *handle = engine.m_handle;
-	switch(sampling_ratio)
-	{
-		case 1:
-		case 2:
-		case 4:
-		case 8:
-		case 16:
-		case 32:
-		case 64:
-		case 128:
-			break;
-		default:
-			return SCAP_FAILURE;
-	}
-
 	pman_set_sampling_ratio(sampling_ratio);
 	pman_set_dropping_mode(true);
 	return SCAP_SUCCESS;

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -367,20 +367,6 @@ int32_t udig_start_dropping_mode(struct scap_engine_handle engine, uint32_t samp
 	struct udig_consumer_t* consumer = &(engine.m_handle->m_dev_set.m_devs[0].m_bufstatus->m_consumer);
 
 	consumer->dropping_mode = 1;
-
-	if(sampling_ratio != 1 &&
-		sampling_ratio != 2 &&
-		sampling_ratio != 4 &&
-		sampling_ratio != 8 &&
-		sampling_ratio != 16 &&
-		sampling_ratio != 32 &&
-		sampling_ratio != 64 &&
-		sampling_ratio != 128) 
-	{
-		snprintf(engine.m_handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid sampling ratio %u\n", sampling_ratio);
-		return SCAP_FAILURE;
-	}
-
 	consumer->sampling_interval = 1000000000 / sampling_ratio;
 	consumer->sampling_ratio = sampling_ratio;
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -1129,6 +1129,21 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 {
+	switch(sampling_ratio)
+	{
+		case 1:
+		case 2:
+		case 4:
+		case 8:
+		case 16:
+		case 32:
+		case 64:
+		case 128:
+			break;
+		default:
+			return snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "invalid sampling ratio size");
+	}
+
 	if(handle->m_vtable)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR implements the sampling ratio logic already present in the other 2 drivers (kmod,  bpf). Note that this logic is disabled by default like in the other 2 drivers, and you can enable it with the same `scap` APIs

This PR is part of the modern bpf feature parity issue: https://github.com/falcosecurity/libs/issues/723

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
