### PR TITLE
new(ci): add semgrep checks for insecure API usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,3 +367,24 @@ jobs:
           name: ${{ matrix.name }}_report
           path: |
             /tmp/report/
+
+  insecure-api:
+    name: check-insecure-api
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+
+    steps:
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Scan PR for insecure API usage 🕵️
+        run: |
+          semgrep scan \
+            --error \
+            --metrics=off \
+            --baseline-commit ${{ github.event.pull_request.base.sha }} \
+            --config=./semgrep

--- a/semgrep/insecure-api-gets.yaml
+++ b/semgrep/insecure-api-gets.yaml
@@ -1,0 +1,44 @@
+# MIT License
+#
+# Copyright (c) 2022 raptor
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+rules:
+  - id: raptor-insecure-api-gets
+    metadata:
+      author: Marco Ivaldi <raptor@0xdeadbeef.info>
+      references:
+        - https://cwe.mitre.org/data/definitions/242
+        - https://cwe.mitre.org/data/definitions/120
+      confidence: HIGH
+    message: >-
+      The program calls a function that can never be guaranteed to work
+      safely.
+      Certain functions behave in dangerous ways regardless of how they are
+      used. Functions in this category were often implemented without
+      taking security concerns into account. The gets() function is unsafe
+      because it does not perform bounds checking on the size of its input.
+      An attacker can easily send arbitrarily-sized input to gets() and
+      overflow the destination buffer.
+    severity: ERROR
+    languages:
+      - c
+      - cpp
+    pattern: gets(...)

--- a/semgrep/insecure-api-sprintf-vsprintf.yaml
+++ b/semgrep/insecure-api-sprintf-vsprintf.yaml
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2022 raptor
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+rules:
+  - id: raptor-insecure-api-sprintf-vsprintf
+    metadata:
+      author: Marco Ivaldi <raptor@0xdeadbeef.info>
+      references:
+        - https://cwe.mitre.org/data/definitions/676
+        - https://cwe.mitre.org/data/definitions/120
+        - https://cwe.mitre.org/data/definitions/787
+        - https://g.co/kgs/PCHQjJ
+      confidence: HIGH
+    message: >-
+      The program invokes a potentially dangerous function that could
+      introduce a vulnerability if it is used incorrectly, but the function
+      can also be used safely.
+      A buffer overflow condition exists when a program attempts to put
+      more data in a buffer than it can hold, or when a program attempts to
+      put data in a memory area outside of the boundaries of a buffer. The
+      simplest type of error, and the most common cause of buffer
+      overflows, is the classic case in which the program copies the buffer
+      without restricting how much is copied. Other variants exist, but the
+      existence of a classic overflow strongly suggests that the programmer
+      is not considering even the most basic of security protections.
+    severity: ERROR
+    languages:
+      - c
+      - cpp
+    patterns:
+      - pattern-either:
+        - pattern: sprintf($BUF, $FMT, ...)
+        - pattern: vsprintf($BUF, $FMT, ...)
+        # swprintf() and vswprintf() should have a size parameter
+      - metavariable-regex:
+          metavariable: $FMT
+          # NOTE: some format string modifiers are not handled
+          regex: '(".*%l?s.*"|".*%S.*"|[a-zA-Z_][a-zA-Z0-9_]*)'

--- a/semgrep/insecure-api-strcpy-stpcpy-strcat.yaml
+++ b/semgrep/insecure-api-strcpy-stpcpy-strcat.yaml
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2022 raptor
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+rules:
+  - id: raptor-insecure-api-strcpy-stpcpy-strcat
+    metadata:
+      author: Marco Ivaldi <raptor@0xdeadbeef.info>
+      references:
+        - https://cwe.mitre.org/data/definitions/676
+        - https://cwe.mitre.org/data/definitions/120
+        - https://cwe.mitre.org/data/definitions/787
+        - https://g.co/kgs/PCHQjJ
+      confidence: HIGH
+    message: >-
+      The program invokes a potentially dangerous function that could
+      introduce a vulnerability if it is used incorrectly, but the function
+      can also be used safely.
+      A buffer overflow condition exists when a program attempts to put
+      more data in a buffer than it can hold, or when a program attempts to
+      put data in a memory area outside of the boundaries of a buffer. The
+      simplest type of error, and the most common cause of buffer
+      overflows, is the classic case in which the program copies the buffer
+      without restricting how much is copied. Other variants exist, but the
+      existence of a classic overflow strongly suggests that the programmer
+      is not considering even the most basic of security protections.
+
+      In the Falco codebase you can use the safer alternative strlcpy().
+    severity: ERROR
+    languages:
+      - c
+      - cpp
+    patterns:
+      - pattern-either:
+        - pattern: strcpy(...)
+        - pattern: stpcpy(...)
+        - pattern: strcat(...)
+        - pattern: wcscpy(...)
+        - pattern: wcpcpy(...)
+        - pattern: wcscat(...)
+      - pattern-not: $FUN($BUF, "...", ...)

--- a/semgrep/insecure-api-strncpy.yaml
+++ b/semgrep/insecure-api-strncpy.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: falco-insecure-api-strncpy
+    metadata:
+      references:
+        - https://cwe.mitre.org/data/definitions/120
+      confidence: HIGH
+    message: >-
+      The libc function strncpy is not used in the Falco codebase as it is error prone.
+      Read more: https://www.cisa.gov/uscert/bsi/articles/knowledge/coding-practices/strncpy-and-strncat .
+      In the Falco codebase you can use the safer alternative strlcpy().
+    severity: ERROR
+    languages:
+      - c
+      - cpp
+    pattern: strncpy(...)


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

There are some functions that we prefer not to use in the Falco codebase, namely `strcpy()` (most of it), `sprintf()`... because it's way too easy to misuse them and introduce security issues in the process.

While it's possible to use these functions safely we prefer not to have them entirely. We devoted some efforts to remove all of their instances in the libs codebase but there's nothing preventing anyone from adding them again. To make contributors' and maintainers' life easier, I propose to add a CI check that stops if any such function is introduced.

Note that the Falco repository does something similar but uses a `banned.h` header. The upside of doing it with a header file is that any contributor will see the error way before making the PR since the compilation would stop, but on the other hand there is a cost to maintain that option, since everyone needs to make sure to add the `banned.h` header to every new `.c`/`.cpp` file, making it less practical.

PS: the implementation uses rules from the excellent https://github.com/0xdea/semgrep-rules repository :)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
