### PR TITLE
fix(ci): split insecure-api check from ci; it will be triggered only on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,24 +367,3 @@ jobs:
           name: ${{ matrix.name }}_report
           path: |
             /tmp/report/
-
-  insecure-api:
-    name: check-insecure-api
-    runs-on: ubuntu-latest
-    container:
-      image: returntocorp/semgrep
-
-    steps:
-
-      - name: Checkout Libs ⤵️
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Scan PR for insecure API usage 🕵️
-        run: |
-          semgrep scan \
-            --error \
-            --metrics=off \
-            --baseline-commit ${{ github.event.pull_request.base.sha }} \
-            --config=./semgrep

--- a/.github/workflows/insecure-api.yml
+++ b/.github/workflows/insecure-api.yml
@@ -1,0 +1,26 @@
+name: Insecure API check
+on:
+  pull_request:
+    branches:
+      - master
+      - 'release/**'
+      - 'maintainers/**'
+
+jobs:
+  insecure-api:
+    name: check-insecure-api
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Scan PR for insecure API usage 🕵️
+        run: |
+          semgrep scan \
+            --error \
+            --metrics=off \
+            --baseline-commit ${{ github.event.pull_request.base.sha }} \
+            --config=./semgrep


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fixes master CI. Insecure api job should only run on PRs.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
