### PR TITLE
new(driver): support additional tracepoints into the modern BPF probe

### DIFF
--- a/driver/feature_gates.h
+++ b/driver/feature_gates.h
@@ -159,6 +159,15 @@ or GPL2.txt for full copies of the license.
 	#define CAPTURE_SCHED_PROC_FORK 
 #endif
 
+///////////////////////////////
+// CAPTURE_PAGE_FAULTS
+///////////////////////////////
+
+#if defined(__TARGET_ARCH_x86)
+	#define CAPTURE_PAGE_FAULTS 
+#endif
+
+
 #else /* Userspace */
 
 /* Please note: the userspace loads the filler table for the bpf probe

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -168,6 +168,7 @@
 /* Generic tracepoints events. */
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4
 #define SCHED_SWITCH_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + sizeof(uint32_t) * 3 + PARAM_LEN * 6
+#define PAGE_FAULT_SIZE HEADER_LEN + sizeof(uint64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
 
 /* Special internal events */
 #define DROP_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -169,6 +169,7 @@
 #define PROC_EXIT_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) * 2 + PARAM_LEN * 4
 #define SCHED_SWITCH_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint64_t) * 2 + sizeof(uint32_t) * 3 + PARAM_LEN * 6
 #define PAGE_FAULT_SIZE HEADER_LEN + sizeof(uint64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
+#define SIGNAL_DELIVER_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint8_t) + PARAM_LEN * 3
 
 /* Special internal events */
 #define DROP_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -36,6 +36,54 @@
 
 /*=============================== ARCH SPECIFIC ===========================*/
 
+/*=============================== SIGNALS ===========================*/
+
+#define SI_QUEUE -1
+#define SI_USER 0
+#define SIGHUP 1
+#define SIGINT 2
+#define SIGQUIT 3
+#define SIGILL 4
+#define SIGTRAP 5
+#define SIGABRT 6
+#define SIGIOT 6
+#define SIGBUS 7
+#define SIGFPE 8
+#define SIGKILL 9
+#define SIGUSR1 10
+#define SIGSEGV 11
+#define SIGUSR2 12
+#define SIGPIPE 13
+#define SIGALRM 14
+#define SIGTERM 15
+#define SIGSTKFLT 16
+#define SIGCHLD 17
+#define SIGCONT 18
+#define SIGSTOP 19
+#define SIGTSTP 20
+#define SIGTTIN 21
+#define SIGTTOU 22
+#define SIGURG 23
+#define SIGXCPU 24
+#define SIGXFSZ 25
+#define SIGVTALRM 26
+#define SIGPROF 27
+#define SIGWINCH 28
+#define SIGIO 29
+#define SIGPOLL SIGIO
+/*
+#define SIGLOST		29
+*/
+#define SIGPWR 30
+#define SIGSYS 31
+#define SIGUNUSED 31
+#define SIGRTMIN 32
+#define __SIGRTMAX 64
+#define _NSIG (__SIGRTMAX + 1)
+#define SIGRTMAX _NSIG
+
+/*=============================== SIGNALS ===========================*/
+
 /*=============================== FLAGS ===========================*/
 
 //////////////////////////

--- a/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/* From linux tree: `/arch/x86/include/asm/trace/exceptions.h`
+ *	 TP_PROTO(unsigned long address, struct pt_regs *regs,
+ *		unsigned long error_code)
+ */
+#ifdef CAPTURE_PAGE_FAULTS
+SEC("tp_btf/page_fault_kernel")
+int BPF_PROG(pf_kernel,
+	     unsigned long address, struct pt_regs *regs,
+	     unsigned long error_code)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_PAGE_FAULT_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	ringbuf__store_u64(&ringbuf, address);
+
+	/* Parameter 2: ip (type: PT_UINT64) */
+	long unsigned int ip = 0;
+	bpf_probe_read_kernel(&ip, sizeof(ip), (void *)regs->ip);
+	ringbuf__store_u64(&ringbuf, ip);
+
+	/* Parameter 3: error (type: PT_FLAGS32) */
+	ringbuf__store_u32(&ringbuf, pf_flags_to_scap(error_code));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+#endif

--- a/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: `/arch/x86/include/asm/trace/exceptions.h`
  *	 TP_PROTO(unsigned long address, struct pt_regs *regs,
@@ -17,6 +18,11 @@ int BPF_PROG(pf_kernel,
 	     unsigned long address, struct pt_regs *regs,
 	     unsigned long error_code)
 {
+	if(sampling_logic(PPME_PAGE_FAULT_E, TRACEPOINT))
+	{
+		return 0;
+	}
+
 	struct ringbuf_struct ringbuf;
 	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
 	{

--- a/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: `/arch/x86/include/asm/trace/exceptions.h`
  *	 TP_PROTO(unsigned long address, struct pt_regs *regs,
@@ -17,6 +18,11 @@ int BPF_PROG(pf_user,
 	     unsigned long address, struct pt_regs *regs,
 	     unsigned long error_code)
 {
+	if(sampling_logic(PPME_PAGE_FAULT_E, TRACEPOINT))
+	{
+		return 0;
+	}
+
 	struct ringbuf_struct ringbuf;
 	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
 	{

--- a/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/* From linux tree: `/arch/x86/include/asm/trace/exceptions.h`
+ *	 TP_PROTO(unsigned long address, struct pt_regs *regs,
+ *		unsigned long error_code)
+ */
+#ifdef CAPTURE_PAGE_FAULTS
+SEC("tp_btf/page_fault_user")
+int BPF_PROG(pf_user,
+	     unsigned long address, struct pt_regs *regs,
+	     unsigned long error_code)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_PAGE_FAULT_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	ringbuf__store_u64(&ringbuf, address);
+
+	/* Parameter 2: ip (type: PT_UINT64) */
+	long unsigned int ip = 0;
+	bpf_probe_read_kernel(&ip, sizeof(ip), (void *)regs->ip);
+	ringbuf__store_u64(&ringbuf, ip);
+
+	/* Parameter 3: error (type: PT_FLAGS32) */
+	ringbuf__store_u32(&ringbuf, pf_flags_to_scap(error_code));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+#endif

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -10,7 +10,7 @@ int BPF_PROG(sched_switch,
 	     bool preempt, struct task_struct *prev,
 	     struct task_struct *next)
 {
-	if(sampling_logic(PPME_SCHEDSWITCH_1_E, TRACEPOINT))
+	if(sampling_logic(PPME_SCHEDSWITCH_6_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -6,6 +6,7 @@
  */
 
 #include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/attached_programs.h>
 
 /* From linux tree: `/include/trace/events/signal.h`
  *	 TP_PROTO(int sig, struct kernel_siginfo *info, struct k_sigaction *ka)
@@ -14,6 +15,11 @@ SEC("tp_btf/signal_deliver")
 int BPF_PROG(signal_deliver,
 	     int sig, struct kernel_siginfo *info, struct k_sigaction *ka)
 {
+	if(sampling_logic(PPME_SIGNALDELIVER_E, TRACEPOINT))
+	{
+		return 0;
+	}
+
 	struct ringbuf_struct ringbuf;
 	if(!ringbuf__reserve_space(&ringbuf, SIGNAL_DELIVER_SIZE))
 	{

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/* From linux tree: `/include/trace/events/signal.h`
+ *	 TP_PROTO(int sig, struct kernel_siginfo *info, struct k_sigaction *ka)
+ */
+SEC("tp_btf/signal_deliver")
+int BPF_PROG(signal_deliver,
+	     int sig, struct kernel_siginfo *info, struct k_sigaction *ka)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, SIGNAL_DELIVER_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SIGNALDELIVER_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Try to find the source pid */
+	pid_t spid = 0;
+
+	switch(sig)
+	{
+	case SIGKILL:
+		spid = info->_sifields._kill._pid;
+		break;
+
+	case SIGTERM:
+	case SIGHUP:
+	case SIGINT:
+	case SIGTSTP:
+	case SIGQUIT:
+	{
+		int si_code = info->si_code;
+		if(si_code == SI_USER ||
+		   si_code == SI_QUEUE ||
+		   si_code <= 0)
+		{
+			/* This is equivalent to `info->si_pid` where
+			 * `si_pid` is a macro `_sifields._kill._pid`
+			 */
+			spid = info->_sifields._kill._pid;
+		}
+		break;
+	}
+
+	case SIGCHLD:
+		spid = info->_sifields._sigchld._pid;
+		break;
+
+	default:
+		spid = 0;
+		break;
+	}
+
+	if(sig >= SIGRTMIN && sig <= SIGRTMAX)
+	{
+		spid = info->_sifields._rt._pid;
+	}
+
+	/* Parameter 1: spid (type: PT_PID) */
+	ringbuf__store_u64(&ringbuf, (s64)spid);
+
+	/* Parameter 2: dpid (type: PT_PID) */
+	ringbuf__store_u64(&ringbuf, (s64)bpf_get_current_pid_tgid() & 0xffffffff);
+
+	/* Parameter 3: sig (type: PT_SIGTYPE) */
+	ringbuf__store_u8(&ringbuf, (u8)sig);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -145,6 +145,11 @@ event_test::event_test(tp_values tp_code):
 		break;
 #endif
 
+	case SIGNAL_DELIVER:
+		m_tp_set[SIGNAL_DELIVER] = 1;
+		m_event_type = PPME_SIGNALDELIVER_E;
+		break;
+
 	default:
 		std::cout << " Unable to find the correct BPF program to attach" << std::endl;
 		break;

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -127,6 +127,13 @@ event_test::event_test(ppm_event_type event_type):
 #endif
 		break;
 
+	case PPME_PAGE_FAULT_E:
+#ifdef CAPTURE_PAGE_FAULTS
+		m_tp_set[PAGE_FAULT_USER] = 1;
+		m_tp_set[PAGE_FAULT_KERN] = 1;
+#endif
+		break;
+
 	default:
 		std::cout << " Unable to find the correct BPF program to attach" << std::endl;
 		break;

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -110,43 +110,36 @@ event_test::event_test(tp_values tp_code):
 	switch(tp_code)
 	{
 	case SCHED_PROC_EXIT:
-		m_tp_set[SCHED_PROC_EXIT] = 1;
 		m_event_type = PPME_PROCEXIT_1_E;
 		break;
 
 	case SCHED_SWITCH:
-		m_tp_set[SCHED_SWITCH] = 1;
 		m_event_type = PPME_SCHEDSWITCH_6_E;
 		break;
 
 #ifdef CAPTURE_SCHED_PROC_EXEC
 	case SCHED_PROC_EXEC:
-		m_tp_set[SCHED_PROC_EXEC] = 1;
 		m_event_type = PPME_SYSCALL_EXECVE_19_X;
 		break;
 #endif
 
 #ifdef CAPTURE_SCHED_PROC_FORK
 	case SCHED_PROC_FORK:
-		m_tp_set[SCHED_PROC_FORK] = 1;
 		m_event_type = PPME_SYSCALL_CLONE_20_X;
 		break;
 #endif
 
 #ifdef CAPTURE_PAGE_FAULTS
 	case PAGE_FAULT_USER:
-		m_tp_set[PAGE_FAULT_USER] = 1;
 		m_event_type = PPME_PAGE_FAULT_E;
 		break;
 
 	case PAGE_FAULT_KERN:
-		m_tp_set[PAGE_FAULT_KERN] = 1;
 		m_event_type = PPME_PAGE_FAULT_E;
 		break;
 #endif
 
 	case SIGNAL_DELIVER:
-		m_tp_set[SIGNAL_DELIVER] = 1;
 		m_event_type = PPME_SIGNALDELIVER_E;
 		break;
 
@@ -154,6 +147,8 @@ event_test::event_test(tp_values tp_code):
 		std::cout << " Unable to find the correct BPF program to attach" << std::endl;
 		break;
 	}
+
+	m_tp_set[tp_code] = 1;
 }
 
 /* This constructor must be used with syscalls events */

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -127,7 +127,7 @@ public:
 	 *
 	 * @param event_type event that we want to assert.
 	 */
-	explicit event_test(ppm_event_type event_type);
+	explicit event_test(tp_values tp_code);
 
 	/**
 	 * @brief Construct a new event_test object for syscall events:
@@ -690,7 +690,7 @@ private:
  *
  * @param event_type event that we want to assert.
  */
-std::unique_ptr<event_test> get_generic_event_test(ppm_event_type event_type);
+std::unique_ptr<event_test> get_generic_event_test(tp_values tp_code);
 
 /**
  * @brief Get a new event_test object for syscall events:

--- a/test/drivers/test_suites/generic_tracepoints_suite/page_fault_kernel.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/page_fault_kernel.cpp
@@ -1,0 +1,57 @@
+#include "../../event_class/event_class.h"
+
+#if defined(CAPTURE_PAGE_FAULTS) && defined(__NR_fork) && defined(__NR_wait4)
+TEST(GenericTracepoints, page_fault_kernel)
+{
+	auto evt_test = get_generic_event_test(PPME_PAGE_FAULT_E);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		exit(EXIT_SUCCESS);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	evt_test->assert_only_param_len(1, sizeof(uint64_t));
+
+	/* Parameter 2: ip (type: PT_UINT64) */
+	evt_test->assert_only_param_len(2, sizeof(uint64_t));
+
+	/* Parameter 3: error (type: PT_FLAGS32) */
+	evt_test->assert_only_param_len(3, sizeof(uint32_t));
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/drivers/test_suites/generic_tracepoints_suite/page_fault_kernel.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/page_fault_kernel.cpp
@@ -3,7 +3,7 @@
 #if defined(CAPTURE_PAGE_FAULTS) && defined(__NR_fork) && defined(__NR_wait4)
 TEST(GenericTracepoints, page_fault_kernel)
 {
-	auto evt_test = get_generic_event_test(PPME_PAGE_FAULT_E);
+	auto evt_test = get_generic_event_test(PAGE_FAULT_KERN);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/page_fault_user.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/page_fault_user.cpp
@@ -3,7 +3,7 @@
 #if defined(CAPTURE_PAGE_FAULTS) && defined(__NR_fork) && defined(__NR_wait4)
 TEST(GenericTracepoints, page_fault_user)
 {
-	auto evt_test = get_generic_event_test(PPME_PAGE_FAULT_E);
+	auto evt_test = get_generic_event_test(PAGE_FAULT_USER);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/page_fault_user.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/page_fault_user.cpp
@@ -1,0 +1,57 @@
+#include "../../event_class/event_class.h"
+
+#if defined(CAPTURE_PAGE_FAULTS) && defined(__NR_fork) && defined(__NR_wait4)
+TEST(GenericTracepoints, page_fault_user)
+{
+	auto evt_test = get_generic_event_test(PPME_PAGE_FAULT_E);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		exit(EXIT_SUCCESS);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: addr (type: PT_UINT64) */
+	evt_test->assert_only_param_len(1, sizeof(uint64_t));
+
+	/* Parameter 2: ip (type: PT_UINT64) */
+	evt_test->assert_only_param_len(2, sizeof(uint64_t));
+
+	/* Parameter 3: error (type: PT_FLAGS32) */
+	evt_test->assert_only_param_len(3, sizeof(uint32_t));
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
@@ -7,7 +7,7 @@
 
 TEST(GenericTracepoints, sched_proc_exec)
 {
-	auto evt_test = get_generic_event_test(PPME_SYSCALL_EXECVE_19_X);
+	auto evt_test = get_generic_event_test(SCHED_PROC_EXEC);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
@@ -9,7 +9,7 @@
 
 TEST(GenericTracepoints, sched_proc_exit)
 {
-	auto evt_test = get_generic_event_test(PPME_PROCEXIT_1_E);
+	auto evt_test = get_generic_event_test(SCHED_PROC_EXIT);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
@@ -8,7 +8,7 @@
 #ifdef __NR_clone3
 TEST(GenericTracepoints, sched_proc_fork_case_clone3)
 {
-	auto evt_test = get_generic_event_test(PPME_SYSCALL_CLONE_20_X);
+	auto evt_test = get_generic_event_test(SCHED_PROC_FORK);
 
 	evt_test->enable_capture();
 
@@ -109,7 +109,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3)
 #ifdef __NR_clone
 TEST(GenericTracepoints, sched_proc_fork_case_clone)
 {
-	auto evt_test = get_generic_event_test(PPME_SYSCALL_CLONE_20_X);
+	auto evt_test = get_generic_event_test(SCHED_PROC_FORK);
 
 	evt_test->enable_capture();
 
@@ -219,7 +219,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone)
 #ifdef __NR_fork
 TEST(GenericTracepoints, sched_proc_fork_case_fork)
 {
-	auto evt_test = get_generic_event_test(PPME_SYSCALL_CLONE_20_X);
+	auto evt_test = get_generic_event_test(SCHED_PROC_FORK);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
@@ -7,7 +7,7 @@
 
 TEST(GenericTracepoints, sched_switch)
 {
-	auto evt_test = get_generic_event_test(PPME_SCHEDSWITCH_6_E);
+	auto evt_test = get_generic_event_test(SCHED_SWITCH);
 
 	evt_test->enable_capture();
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/signal_deliver.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/signal_deliver.cpp
@@ -1,0 +1,72 @@
+#include "../../event_class/event_class.h"
+
+#if defined(__NR_clone3) && defined(__NR_kill)
+
+#include <signal.h>
+#include <linux/sched.h>
+
+TEST(GenericTracepoints, signal_deliver)
+{
+	auto evt_test = get_generic_event_test(SIGNAL_DELIVER);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	struct clone_args cl_args = {0};
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		sleep(10);
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	/* Kill the child */
+	assert_syscall_state(SYSCALL_SUCCESS, "kill", syscall(__NR_kill, ret_pid, SIGKILL), NOT_EQUAL, -1);
+	
+	/* Wait for the child to be killed */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WTERMSIG(status) != SIGKILL)
+	{
+		FAIL() << "The child is not killed by the signal." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: spid (type: PT_PID) */
+	/* In this case we are not able to extract the sender pid */
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: dpid (type: PT_PID) */
+	evt_test->assert_numeric_param(2, (int64_t)ret_pid);
+
+	/* Parameter 3: sig (type: PT_SIGTYPE) */
+	evt_test->assert_numeric_param(3, (uint8_t)SIGKILL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(3);
+}
+#endif

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -174,6 +174,7 @@ extern "C"
 	 */
 	int pman_detach_sched_switch(void);
 
+#ifdef CAPTURE_SCHED_PROC_EXEC
 	/**
 	 * @brief Attach only the sched_proc_exec tracepoint
 	 *
@@ -187,7 +188,9 @@ extern "C"
 	 * @return `0` on success, `errno` in case of error.
 	 */
 	int pman_detach_sched_proc_exec(void);
+#endif
 
+#ifdef CAPTURE_SCHED_PROC_FORK
 	/**
 	 * @brief Attach only the sched_proc_fork tracepoint
 	 *
@@ -201,6 +204,37 @@ extern "C"
 	 * @return `0` on success, `errno` in case of error.
 	 */
 	int pman_detach_sched_proc_fork(void);
+#endif
+
+#ifdef CAPTURE_PAGE_FAULTS
+	/**
+	 * @brief Attach only the page_fault_user tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_attach_page_fault_user(void);
+
+	/**
+	 * @brief Detach only the page_fault_user tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_detach_page_fault_user(void);
+
+	/**
+	 * @brief Attach only the page_fault_kernel tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_attach_page_fault_kernel(void);
+
+	/**
+	 * @brief Detach only the page_fault_kernel tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_detach_page_fault_kernel(void);
+#endif
 
 	/////////////////////////////
 	// MANAGE RINGBUFFERS

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -236,6 +236,20 @@ extern "C"
 	int pman_detach_page_fault_kernel(void);
 #endif
 
+	/**
+	 * @brief Attach only the signal_deliver tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_attach_signal_deliver(void);
+
+	/**
+	 * @brief Detach only the signal_deliver tracepoint
+	 *
+	 * @return `0` on success, `errno` in case of error.
+	 */
+	int pman_detach_signal_deliver(void);
+
 	/////////////////////////////
 	// MANAGE RINGBUFFERS
 	/////////////////////////////

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -133,6 +133,8 @@ void pman_fill_syscall_tracepoint_table()
 	/* Right now these are the only 2 tracepoints involved in the dropping logic. We need to add them here */
 	g_state.skel->bss->g_64bit_sampling_tracepoint_table[PPME_PROCEXIT_1_E] = UF_NEVER_DROP;
 	g_state.skel->bss->g_64bit_sampling_tracepoint_table[PPME_SCHEDSWITCH_6_E] = 0;
+	g_state.skel->bss->g_64bit_sampling_tracepoint_table[PPME_PAGE_FAULT_E] = UF_ALWAYS_DROP;
+	g_state.skel->bss->g_64bit_sampling_tracepoint_table[PPME_SIGNALDELIVER_E] = UF_ALWAYS_DROP;
 }
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR introduces 3 new tracepoints:
*  `page_fault_user`
*  `page_fault_kernel`
*  `signal_deliver`

With these new tracepoints, we should have implemented all the tracepoints supported in other drivers :) 
Since we merged the sampling logic, I've added it also to these new tracepoints
Part of our porting issue: https://github.com/falcosecurity/libs/issues/723

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
