### PR TITLE
fix(userspace): remove 2 event check types not used

### DIFF
--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -518,8 +518,6 @@ public:
 		TYPE_INFRA_DOCKER_CONTAINER_NAME = 54,
 		TYPE_INFRA_DOCKER_CONTAINER_IMAGE = 55,
 		TYPE_ISOPEN_EXEC = 56,
-		TYPE_PLUGIN_NAME = 57,
-		TYPE_PLUGIN_INFO = 58,
 	};
 
 	sinsp_filter_check_event();
@@ -1010,4 +1008,3 @@ private:
 };
 
 #endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
-


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

These 2 check types shouldn't be there, they were moved some time ago [here](https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/filterchecks.h#L442-L443) with a different name. We need to remove these 2 old definitions otherwise the [`sinsp_filter_check_event_fields`](https://github.com/falcosecurity/libs/blob/ca51f17c5f7ad3ae6d85f10598976eab16bdc223/userspace/libsinsp/filterchecks.cpp#L2789) table will be desynchronized if we append new `TYPE_...` after these ones

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
