### PR TITLE
cleanup(userspace): remove unused `drop_event_flags` logic

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -67,7 +67,6 @@ sinsp_parser::sinsp_parser(sinsp *inspector) :
 
 	init_metaevt(m_k8s_metaevents_state, PPME_K8S_E, SP_EVT_BUF_SIZE);
 	init_metaevt(m_mesos_metaevents_state, PPME_MESOS_E, SP_EVT_BUF_SIZE);
-	m_drop_event_flags = EF_NONE;
 }
 
 sinsp_parser::~sinsp_parser()
@@ -152,26 +151,6 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 		}
 	}
 #endif
-
-	if(m_drop_event_flags)
-	{
-		enum ppm_event_flags flags;
-		uint16_t etype = evt->m_pevt->type;
-		if(etype == PPME_GENERIC_E || etype == PPME_GENERIC_X)
-		{
-			flags = EF_NONE;
-		}
-		else
-		{
-			flags = evt->get_info_flags();
-		}
-
-		if (flags & m_drop_event_flags)
-		{
-			evt->m_filtered_out = true;
-			return;
-		}
-	}
 
 	//
 	// Filtering

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -72,8 +72,6 @@ public:
 	std::vector<sinsp_protodecoder*> m_open_callbacks;
 	std::vector<sinsp_protodecoder*> m_connect_callbacks;
 
-	ppm_event_flags m_drop_event_flags;
-
 	//
 	// Initializers
 	//

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1980,11 +1980,6 @@ void sinsp::set_buffer_format(sinsp_evt::param_fmt format)
 	m_buffer_format = format;
 }
 
-void sinsp::set_drop_event_flags(ppm_event_flags flags)
-{
-	m_parser->m_drop_event_flags = flags;
-}
-
 sinsp_evt::param_fmt sinsp::get_buffer_format()
 {
 	return m_buffer_format;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1471,7 +1471,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	{
 		scap_dump_flags dflags;
 
-		bool do_drop;
+		bool do_drop = false;
 		dflags = evt->get_dump_flags(&do_drop);
 		if(do_drop)
 		{

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -566,11 +566,6 @@ public:
 	sinsp_evt::param_fmt get_buffer_format();
 
 	/*!
-	  \brief Set event flags for which matching events should be dropped pre-filtering
-	*/
-	void set_drop_event_flags(ppm_event_flags flags);
-
-	/*!
 	  \brief Returns true if the current capture is offline
 	*/
 	inline bool is_capture()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR proposes to remove an old dropping logic that seems no more useful, we already have the simple consumer and the sampling ratio logic in our drivers so probably we don't need also this dropping logic in userspace

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
