### PR TITLE
update(userspace/libsinsp): improve event codes api 

### DIFF
--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -240,7 +240,7 @@ void print_EF_MODIFIES_STATE_syscalls()
 
 void print_sinsp_modifies_state_syscalls()
 {
-	uint32_t ppm_scs[PPM_SC_MAX];
+	uint8_t ppm_scs[PPM_SC_MAX];
 	char str[SYSCALL_TABLE_SIZE][SYSCALL_NAME_MAX_LEN];
 	int interesting_syscall = 0;
 

--- a/userspace/libsinsp/events/sinsp_events_set.h
+++ b/userspace/libsinsp/events/sinsp_events_set.h
@@ -1,0 +1,343 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "event.h"
+#include "sinsp_exception.h"
+#include "sinsp_public.h"
+
+#include <vector>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <cstddef>
+
+// The following are needed on MacOS to be able to
+// initialize a std::(unordered)map/set<ppm_X_code>{}
+namespace std
+{
+template<>
+struct hash<ppm_sc_code> {
+	size_t operator()(const ppm_sc_code &pt) const {
+		return std::hash<uint32_t>()((uint32_t)pt);
+	}
+};
+
+template<>
+struct hash<ppm_tp_code> {
+	size_t operator()(const ppm_tp_code &pt) const {
+		return std::hash<uint32_t>()((uint32_t)pt);
+	}
+};
+
+template<>
+struct hash<ppm_event_code> {
+	size_t operator()(const ppm_event_code &pt) const {
+		return std::hash<uint32_t>()((uint32_t)pt);
+	}
+};
+}
+
+namespace libsinsp {
+namespace events {
+
+template<typename T>
+class set
+{
+private:
+	using vec_t = std::vector<uint8_t>;
+	vec_t m_types{};
+	T m_max;
+	size_t m_size;
+
+	inline void check_range(T e) const
+	{
+		if(e > m_max)
+		{
+			throw sinsp_exception("invalid event type");
+		}
+	}
+
+public:
+	struct iterator 
+	{
+		using iterator_category = std::forward_iterator_tag;
+		using difference_type   = std::ptrdiff_t;
+		using value_type        = T;
+		using pointer           = T*;
+		using reference         = T&;
+
+		iterator(const uint8_t* data, size_t index, size_t max)
+			: m_data(data), m_index(index), m_max(max)
+		{
+			set_val();
+		}
+		reference operator*() { return m_val; }
+		pointer operator->() { return &m_val; }
+		iterator& operator++() { m_index++; set_val(); return *this; }  
+		iterator operator++(int) { iterator i = *this; ++(*this); return i; }
+		friend bool operator== (const iterator& a, const iterator& b)
+		{
+			return a.m_data == b.m_data && a.m_index == b.m_index;
+		};
+		friend bool operator!= (const iterator& a, const iterator& b) { return !(a == b); };
+	private:
+		inline void set_val()
+		{
+			while (m_index < m_max && m_data[m_index] == 0)
+			{
+				m_index++;
+			}
+			m_val = (value_type) m_index;
+		}
+
+		const uint8_t* m_data;
+		size_t m_index;
+		size_t m_max;
+		value_type m_val;
+	};
+
+	set(set&&) noexcept = default;
+	set(const set&) = default;
+	set& operator=(set&&) noexcept = default;
+	set& operator=(const set&) = default;
+	set<T>() = delete;
+
+	template<typename InputIterator>
+	static set<T> from(InputIterator first, InputIterator last)
+	{
+		set<T> ret;
+		for (auto i = first; i != last; i++)
+		{
+			ret.insert(*i);
+		}
+		return ret;
+	}
+
+	template<typename Iterable>
+	static set<T> from(const Iterable& v)
+	{
+		return from(v.begin(), v.end());
+	}
+	
+	template<typename Iterable>
+	set(const Iterable& v): set(from(v)) { }
+
+	template<typename InputIterator>
+	set(InputIterator first, InputIterator last): set(from(first, last)) { }
+
+	set(std::initializer_list<T> v): set(v.begin(), v.end()) { }
+
+	inline explicit set(T maxLen):
+		m_types(maxLen + 1, 0),
+		m_max(maxLen),
+		m_size(0)
+	{
+	}
+
+	const uint8_t* data() const noexcept
+	{
+		return m_types.data();
+	}
+
+	uint8_t* data() noexcept
+	{
+		return m_types.data();
+	}
+
+	iterator begin() const { return iterator(m_types.data(), 0, m_max); }
+
+    iterator end() const { return iterator(m_types.data(), m_max, m_max); } 
+
+	inline void insert(T e)
+	{
+		check_range(e);
+		m_types[e] = 1;
+		m_size++;
+	}
+
+	template<typename InputIterator>
+	inline void insert(InputIterator first, InputIterator last)
+	{
+		for (auto i = first; i != last; i++)
+		{
+			insert(*i);
+		}
+	}
+
+	inline void remove(T e)
+	{
+		check_range(e);
+		m_types[e] = 0;
+		m_size--;
+	}
+
+	inline bool contains(T e) const
+	{
+		check_range(e);
+		return m_types[e] != 0;
+	}
+
+	void clear()
+	{
+		for(auto& v : m_types)
+		{
+			v = 0;
+		}
+		m_size = 0;
+	}
+
+	inline bool empty() const
+	{
+		return m_size == 0;
+	}
+
+	inline size_t size() const
+	{
+		return m_size;
+	}
+
+	bool equals(const set& other) const
+	{
+		return m_types == other.m_types;
+	}
+
+	set merge(const set& other) const
+	{
+		if (other.m_max != m_max)
+		{
+			throw sinsp_exception("cannot merge sets with different max size.");
+		}
+		set<T> ret(m_max);
+		for(size_t i = 0; i <= m_max; ++i)
+		{
+			if (m_types[i] | other.m_types[i])
+			{
+				ret.insert((T)i);
+			}
+		}
+		return ret;
+	}
+
+	set diff(const set& other) const
+	{
+		if (other.m_max != m_max)
+		{
+			throw sinsp_exception("cannot diff sets with different max size.");
+		}
+		set<T> ret(m_max);
+		for(size_t i = 0; i <= m_max; ++i)
+		{
+			if (m_types[i] == 1 && other.m_types[i] == 0)
+			{
+				ret.insert((T)i);
+			}
+		}
+		return ret;
+	}
+
+	set intersect(const set& other) const
+	{
+		if (other.m_max != m_max)
+		{
+			throw sinsp_exception("cannot intersect sets with different max size.");
+		}
+		set<T> ret(m_max);
+		for(size_t i = 0; i <= m_max; ++i)
+		{
+			if (m_types[i] & other.m_types[i])
+			{
+				ret.insert((T)i);
+			}
+		}
+		return ret;
+	}
+
+	void for_each(const std::function<bool(T)>& consumer) const
+	{
+		for(size_t i = 0; i < m_max; ++i)
+		{
+			if(m_types[i] != 0)
+			{
+				if(!consumer((T) i))
+				{
+					return;
+				}
+			}
+		}
+	}
+
+	set filter(const std::function<bool(T)>& predicate) const
+	{
+		set<T> ret;
+		for_each([&ret, &predicate](T v){
+			if(predicate(v))
+			{
+				ret.insert(v);
+			}
+			return true;
+		});
+		return ret;
+	}
+};
+
+// Some template specialization for useful constructors
+
+template <>
+inline set<ppm_sc_code>::set(): set(PPM_SC_MAX)
+{
+}
+
+template<>
+inline set<ppm_event_code>::set(): set(PPM_EVENT_MAX)
+{
+}
+
+template<>
+inline set<ppm_tp_code>::set(): set(TP_VAL_MAX)
+{
+}
+
+} // events
+} // libsinsp
+
+template<typename T>
+inline bool operator==(const libsinsp::events::set<T>& lhs, const libsinsp::events::set<T>& rhs)
+{
+	return lhs.equals(rhs);
+}
+
+template<typename T>
+inline bool operator!=(const libsinsp::events::set<T>& lhs, const libsinsp::events::set<T>& rhs)
+{
+	return !(lhs == rhs);
+}
+
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const libsinsp::events::set<T>& s)
+{
+    os << "(";
+	auto first = true;
+	for (const auto& v : s)
+	{
+		os << (first ? "" : ", ") << v;
+        first = false;
+	}
+    os << ")";
+    return os;
+}

--- a/userspace/libsinsp/events/sinsp_events_tp.cpp
+++ b/userspace/libsinsp/events/sinsp_events_tp.cpp
@@ -53,11 +53,10 @@ libsinsp::events::set<ppm_tp_code> libsinsp::events::all_tp_set()
 std::unordered_set<std::string> libsinsp::events::tp_set_to_names(const libsinsp::events::set<ppm_tp_code>& tp_set)
 {
 	std::unordered_set<std::string> tp_names_set;
-	tp_set.for_each([&tp_names_set](ppm_tp_code val)
+	for (const auto& val : tp_set)
 	{
 		std::string tp_name = tp_names[val];
 		tp_names_set.insert(tp_name);
-		return true;
-	});
+	}
 	return tp_names_set;
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -53,6 +53,10 @@ limitations under the License.
 #include "sinsp_public.h"
 #include "sinsp_exception.h"
 #include "events/sinsp_events.h"
+#include "filter/ast.h"
+#include "filter/escaping.h"
+#include "filter/ppm_codes.h"
+#include "filter/parser.h"
 
 #include <string>
 #include <map>

--- a/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
+++ b/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
@@ -28,9 +28,9 @@ static libsinsp::events::set<ppm_event_code> get_filter_set(const std::string &f
 
 TEST(filter_ppm_codes, check_openat)
 {
-    auto openat_only = libsinsp::events::set<ppm_event_code>::from_unordered_set({
+    libsinsp::events::set<ppm_event_code> openat_only = {
         PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
-        PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X});
+        PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X };
 
     auto not_openat = libsinsp::events::all_event_set().diff(openat_only);
 
@@ -56,10 +56,10 @@ TEST(filter_ppm_codes, check_openat)
 
 TEST(filter_ppm_codes, check_openat_or_close)
 {
-    auto openat_close_only = libsinsp::events::set<ppm_event_code>::from_unordered_set({
+    libsinsp::events::set<ppm_event_code> openat_close_only = {
         PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
         PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X,
-        PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X});
+        PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X };
 
     auto not_openat_close = libsinsp::events::all_event_set().diff(openat_close_only);
 

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -31,7 +31,7 @@ limitations under the License.
 /* Please note this set must be kept in sync if we update the sinsp internal state set
  * otherwise some of the following checks will fail.
  */
-auto expected_sinsp_state_ppm_sc_set = libsinsp::events::set<ppm_sc_code>::from_unordered_set(std::unordered_set<ppm_sc_code>{
+libsinsp::events::set<ppm_sc_code> expected_sinsp_state_ppm_sc_set = {
 #ifdef __NR_accept
 	PPM_SC_ACCEPT,
 #endif
@@ -271,7 +271,7 @@ auto expected_sinsp_state_ppm_sc_set = libsinsp::events::set<ppm_sc_code>::from_
 #ifdef __NR_epoll_create1
 	PPM_SC_EPOLL_CREATE1,
 #endif
-});
+};
 
 /* This test asserts that `enforce_sinsp_state_ppm_sc` correctly retrieves
  * the `libsinsp` state ppm_sc set.
@@ -314,7 +314,7 @@ TEST(interesting_syscalls, enforce_sinsp_state_with_additions)
  */
 TEST(interesting_syscalls, get_event_set_from_ppm_sc_set)
 {
-	auto ppm_sc_set = libsinsp::events::set<ppm_sc_code>::from_unordered_set(std::unordered_set<ppm_sc_code>{
+	libsinsp::events::set<ppm_sc_code> ppm_sc_set = {
 #ifdef __NR_kill
 	PPM_SC_KILL,
 #endif
@@ -326,9 +326,9 @@ TEST(interesting_syscalls, get_event_set_from_ppm_sc_set)
 #ifdef __NR_alarm
 	PPM_SC_ALARM,
 #endif
-	});
+	};
 
-	auto event_set = libsinsp::events::set<ppm_event_code>::from_unordered_set(std::unordered_set<ppm_event_code>{
+	libsinsp::events::set<ppm_event_code> event_set = {
 #ifdef __NR_kill
 	PPME_SYSCALL_KILL_E,
 	PPME_SYSCALL_KILL_X,
@@ -343,7 +343,7 @@ TEST(interesting_syscalls, get_event_set_from_ppm_sc_set)
 	PPME_GENERIC_E,
 	PPME_GENERIC_X,
 #endif
-	});
+	};
 
 	auto final_evt_set = libsinsp::events::sc_set_to_event_set(ppm_sc_set);
 

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_tracepoints.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_tracepoints.cpp
@@ -22,14 +22,14 @@ limitations under the License.
 /* Please note this set must be kept in sync if we update the sinsp internal state set
  * otherwise some of the following checks will fail.
  */
-auto expected_sinsp_state_tp_set = libsinsp::events::set<ppm_tp_code>::from_unordered_set(std::unordered_set<ppm_tp_code>{
+libsinsp::events::set<ppm_tp_code> expected_sinsp_state_tp_set = {
 	SYS_ENTER,
 	SYS_EXIT,
 	SCHED_PROC_EXIT,
 	SCHED_SWITCH,
 	SCHED_PROC_FORK,
 	SCHED_PROC_EXEC
-});
+};
 
 /* This test asserts that `sinsp_state_tp_set` correctly retrieves
  * the `libsinsp` state tracepoint set.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This solves a couple of issues following-up the changes of #877. Moreover, this adds two new functions `libsinsp::events::is_generic` and `libsinsp::events::info`. The latter helps reducing and avoiding the use of the `g_infotables` tables. Moreover, the `libsinsp::events::set` implementation has been improved to have an interface compatible with the standard library, hence making it much easier to use.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
