### PR TITLE
update(driver): add support for chown syscall family

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -119,6 +119,10 @@ FILLER_RAW(terminate_filler)
 			case PPME_SYSCALL_CHMOD_E:
 			case PPME_SYSCALL_FCHMOD_E:
 			case PPME_SYSCALL_FCHMODAT_E:
+			case PPME_SYSCALL_CHOWN_E:
+			case PPME_SYSCALL_LCHOWN_E:
+			case PPME_SYSCALL_FCHOWN_E:
+			case PPME_SYSCALL_FCHOWNAT_E:
 			case PPME_SYSCALL_LINK_E:
 			case PPME_SYSCALL_LINK_2_E:
 			case PPME_SYSCALL_LINKAT_E:
@@ -197,6 +201,10 @@ FILLER_RAW(terminate_filler)
 			case PPME_SYSCALL_CHMOD_X:
 			case PPME_SYSCALL_FCHMOD_X:
 			case PPME_SYSCALL_FCHMODAT_X:
+			case PPME_SYSCALL_CHOWN_X:
+			case PPME_SYSCALL_LCHOWN_X:
+			case PPME_SYSCALL_FCHOWN_X:
+			case PPME_SYSCALL_FCHOWNAT_X:
 			case PPME_SYSCALL_LINK_X:
 			case PPME_SYSCALL_LINK_2_X:
 			case PPME_SYSCALL_LINKAT_X:
@@ -5774,6 +5782,108 @@ FILLER(sys_fchmod_x, true)
 	/* Parameter 3: mode (type: PT_MODE) */
 	unsigned long mode = bpf_syscall_get_argument(data, 1);
 	return bpf_val_to_ring(data, chmod_mode_to_scap(mode));
+}
+
+FILLER(sys_chown_x, true)
+{
+	/* Parameter 1: res (type: PT_ERRNO) */
+	long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_val_to_ring(data, retval);
+	CHECK_RES(res);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	unsigned long path_pointer = bpf_syscall_get_argument(data, 0);
+	res = bpf_val_to_ring(data, path_pointer);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, uid);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
+	return bpf_val_to_ring(data, gid);
+}
+
+FILLER(sys_lchown_x, true)
+{
+	/* Parameter 1: res (type: PT_ERRNO) */
+	long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_val_to_ring(data, retval);
+	CHECK_RES(res);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	unsigned long path_pointer = bpf_syscall_get_argument(data, 0);
+	res = bpf_val_to_ring(data, path_pointer);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, uid);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
+	return bpf_val_to_ring(data, gid);
+}
+
+FILLER(sys_fchown_x, true)
+{
+	/* Parameter 1: res (type: PT_ERRNO) */
+	long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_val_to_ring(data, retval);
+	CHECK_RES(res);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
+	res = bpf_val_to_ring(data, (s64)fd);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, uid);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
+	return bpf_val_to_ring(data, gid);
+}
+
+FILLER(sys_fchownat_x, true)
+{
+	/* Parameter 1: res (type: PT_ERRNO) */
+	long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_val_to_ring(data, retval);
+	CHECK_RES(res);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)bpf_syscall_get_argument(data, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	res = bpf_val_to_ring(data, (s64)dirfd);
+	CHECK_RES(res);
+
+	/* Parameter 3: pathname (type: PT_FSRELPATH) */
+	unsigned long path_pointer = bpf_syscall_get_argument(data, 1);
+	res = bpf_val_to_ring(data, path_pointer);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	u32 uid = (u32)bpf_syscall_get_argument(data, 2);
+	res = bpf_val_to_ring(data, uid);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	u32 gid = (u32)bpf_syscall_get_argument(data, 3);
+	res = bpf_val_to_ring(data, gid);
+	CHECK_RES(res);
+
+	/* Parameter 5: flags (type: PT_FLAGS32) */
+	unsigned long flags = bpf_syscall_get_argument(data, 4);
+	return bpf_val_to_ring(data, fchownat_flags_to_scap(flags));
 }
 
 FILLER(sys_copy_file_range_e, true)

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -390,6 +390,15 @@ const struct ppm_event_info g_event_info[PPM_EVENT_MAX] = {
 	/* PPME_SYSCALL_EPOLL_CREATE_X */{"epoll_create", EC_WAIT | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 1, { {"res", PT_ERRNO, PF_DEC} } },
 	/* PPME_SYSCALL_EPOLL_CREATE1_E */{"epoll_create1", EC_WAIT | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 1, {{"flags", PT_FLAGS32, PF_HEX, epoll_create1_flags} } },
 	/* PPME_SYSCALL_EPOLL_CREATE1_X */{"epoll_create1", EC_WAIT | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 1, {{"res", PT_ERRNO, PF_DEC} } },
+	/* PPME_SYSCALL_CHOWN_E */{"chown", EC_FILE | EC_SYSCALL, EF_NONE, 0},
+	/* PPME_SYSCALL_CHOWN_X */{"chown", EC_FILE | EC_SYSCALL, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA}, {"uid", PT_UINT32, PF_DEC}, {"gid", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_LCHOWN_E */{"lchown", EC_FILE | EC_SYSCALL, EF_NONE, 0},
+	/* PPME_SYSCALL_LCHOWN_X */{"lchown", EC_FILE | EC_SYSCALL, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"path", PT_FSPATH, PF_NA}, {"uid", PT_UINT32, PF_DEC}, {"gid", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_FCHOWN_E */{"fchown", EC_FILE | EC_SYSCALL, EF_NONE, 0},
+	/* PPME_SYSCALL_FCHOWN_X */{"fchown", EC_FILE | EC_SYSCALL, EF_NONE, 4, {{"res", PT_ERRNO, PF_DEC}, {"fd", PT_FD, PF_DEC}, {"uid", PT_UINT32, PF_DEC}, {"gid", PT_UINT32, PF_DEC} } },
+	/* PPME_SYSCALL_FCHOWNAT_E */{"fchownat", EC_FILE | EC_SYSCALL, EF_NONE, 0},
+	/* PPME_SYSCALL_FCHOWNAT_X */{"fchownat", EC_FILE | EC_SYSCALL, EF_NONE, 6, {{"res", PT_ERRNO, PF_DEC}, {"dirfd", PT_FD, PF_DEC}, {"pathname", PT_FSRELPATH, PF_NA, DIRFD_PARAM(1)}, {"uid", PT_UINT32, PF_DEC}, {"gid", PT_UINT32, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX, fchownat_flags}} },
+
 
 	/* NB: Starting from scap version 1.2, event types will no longer be changed when an event is modified, and the only kind of change permitted for pre-existent events is adding parameters.
 	 *     New event types are allowed only for new syscalls or new internal events.

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -332,4 +332,12 @@ const struct ppm_event_entry g_ppm_events[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_EPOLL_CREATE_X] = {FILLER_REF(sys_epoll_create_x)},
 	[PPME_SYSCALL_EPOLL_CREATE1_E] = {FILLER_REF(sys_epoll_create1_e)},
 	[PPME_SYSCALL_EPOLL_CREATE1_X] = {FILLER_REF(sys_epoll_create1_x)},
+	[PPME_SYSCALL_CHOWN_E] = {FILLER_REF(sys_empty)},
+	[PPME_SYSCALL_CHOWN_X] = {FILLER_REF(sys_chown_x)},
+	[PPME_SYSCALL_LCHOWN_E] = {FILLER_REF(sys_empty)},
+	[PPME_SYSCALL_LCHOWN_X] = {FILLER_REF(sys_lchown_x)},
+	[PPME_SYSCALL_FCHOWN_E] = {FILLER_REF(sys_empty)},
+	[PPME_SYSCALL_FCHOWN_X] = {FILLER_REF(sys_fchown_x)},
+	[PPME_SYSCALL_FCHOWNAT_E] = {FILLER_REF(sys_empty)},
+	[PPME_SYSCALL_FCHOWNAT_X] = {FILLER_REF(sys_fchownat_x)},
 };

--- a/driver/flags_table.c
+++ b/driver/flags_table.c
@@ -519,6 +519,12 @@ const struct ppm_name_value chmod_mode[] = {
     {0, 0},
 };
 
+const struct ppm_name_value fchownat_flags[] = {
+	{"AT_SYMLINK_NOFOLLOW", PPM_AT_SYMLINK_FOLLOW},
+	{"AT_EMPTY_PATH", PPM_AT_EMPTY_PATH},
+	{0, 0},
+};
+
 const struct ppm_name_value renameat2_flags[] = {
 	{"RENAME_NOREPLACE", PPM_RENAME_NOREPLACE},
 	{"RENAME_EXCHANGE", PPM_RENAME_EXCHANGE},

--- a/driver/main.c
+++ b/driver/main.c
@@ -1462,6 +1462,10 @@ static inline void drops_buffer_syscall_categories_counters(ppm_event_code event
 	case PPME_SYSCALL_CHMOD_E:
 	case PPME_SYSCALL_FCHMOD_E:
 	case PPME_SYSCALL_FCHMODAT_E:
+	case PPME_SYSCALL_CHOWN_E:
+	case PPME_SYSCALL_LCHOWN_E:
+	case PPME_SYSCALL_FCHOWN_E:
+	case PPME_SYSCALL_FCHOWNAT_E:
 	case PPME_SYSCALL_LINK_E:
 	case PPME_SYSCALL_LINK_2_E:
 	case PPME_SYSCALL_LINKAT_E:
@@ -1528,6 +1532,10 @@ static inline void drops_buffer_syscall_categories_counters(ppm_event_code event
 	case PPME_SYSCALL_CHMOD_X:
 	case PPME_SYSCALL_FCHMOD_X:
 	case PPME_SYSCALL_FCHMODAT_X:
+	case PPME_SYSCALL_CHOWN_X:
+	case PPME_SYSCALL_LCHOWN_X:
+	case PPME_SYSCALL_FCHOWN_X:
+	case PPME_SYSCALL_FCHOWNAT_X:
 	case PPME_SYSCALL_LINK_X:
 	case PPME_SYSCALL_LINK_2_X:
 	case PPME_SYSCALL_LINKAT_X:

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -36,12 +36,17 @@
 #define DUP3_X_SIZE HEADER_LEN + sizeof(int64_t) * 3 + sizeof(uint32_t) + PARAM_LEN * 4
 #define CHDIR_E_SIZE HEADER_LEN
 #define CHMOD_E_SIZE HEADER_LEN
+#define CHOWN_E_SIZE HEADER_LEN
+#define LCHOWN_E_SIZE HEADER_LEN
 #define CHROOT_E_SIZE HEADER_LEN
 #define FCHDIR_E_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define FCHDIR_X_SIZE HEADER_LEN + sizeof(int64_t) + PARAM_LEN
 #define FCHMOD_E_SIZE HEADER_LEN
 #define FCHMOD_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) + PARAM_LEN * 3
 #define FCHMODAT_E_SIZE HEADER_LEN
+#define FCHOWN_E_SIZE HEADER_LEN
+#define FCHOWN_X_SIZE HEADER_LEN + sizeof(int64_t) * 2 + sizeof(uint32_t) * 2 + PARAM_LEN * 4
+#define FCHOWNAT_E_SIZE HEADER_LEN
 #define MKDIRAT_E_SIZE HEADER_LEN
 #define RMDIR_E_SIZE HEADER_LEN
 #define EVENTFD_E_SIZE HEADER_LEN + sizeof(uint64_t) + sizeof(uint32_t) + PARAM_LEN * 2

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(chown_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, CHOWN_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_CHOWN_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(chown_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CHOWN_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	unsigned long uid = extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	unsigned long gid = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, gid);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fchown_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHOWN_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHOWN_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fchown_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHOWN_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHOWN_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	ringbuf__store_s64(&ringbuf, ret);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, (s64)fd);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	unsigned long uid = extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	unsigned long gid = extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, gid);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(fchownat_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, FCHOWNAT_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_FCHOWNAT_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(fchownat_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_FCHOWNAT_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	if(dirfd == AT_FDCWD)
+	{
+		dirfd = PPM_AT_FDCWD;
+	}
+	auxmap__store_s64_param(auxmap, (s64)dirfd);
+
+	/* Parameter 3: filename (type: PT_FSRELPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 1);
+	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
+
+	/* Parameter 4: uid (type: PT_UINT32) */
+	unsigned long uid = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, uid);
+
+	/* Parameter 5: gid (type: PT_UINT32) */
+	unsigned long gid = extract__syscall_argument(regs, 3);
+	auxmap__store_u32_param(auxmap, gid);
+
+	/* Parameter 6: flags (type: PT_FLAGS32) */
+	unsigned long flags = extract__syscall_argument(regs, 4);
+	auxmap__store_u32_param(auxmap, fchownat_flags_to_scap(flags));
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+#include <helpers/interfaces/variable_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(lchown_e,
+	     struct pt_regs *regs,
+	     long id)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, LCHOWN_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_SYSCALL_LCHOWN_E);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to collect.
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(lchown_x,
+	     struct pt_regs *regs,
+	     long ret)
+{
+	struct auxiliary_map *auxmap = auxmap__get();
+	if(!auxmap)
+	{
+		return 0;
+	}
+
+	auxmap__preload_event_header(auxmap, PPME_SYSCALL_LCHOWN_X);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	auxmap__store_s64_param(auxmap, ret);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	unsigned long path_pointer = extract__syscall_argument(regs, 0);
+	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	unsigned long uid = extract__syscall_argument(regs, 1);
+	auxmap__store_u32_param(auxmap, uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	unsigned long gid = extract__syscall_argument(regs, 2);
+	auxmap__store_u32_param(auxmap, gid);
+
+	/*=============================== COLLECT PARAMETERS  ===========================*/
+
+	auxmap__finalize_event_header(auxmap);
+
+	auxmap__submit_event(auxmap);
+
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1180,7 +1180,15 @@ typedef enum {
 	PPME_SYSCALL_EPOLL_CREATE_X = 375,
 	PPME_SYSCALL_EPOLL_CREATE1_E = 376,
 	PPME_SYSCALL_EPOLL_CREATE1_X = 377,
-	PPM_EVENT_MAX = 378
+	PPME_SYSCALL_CHOWN_E = 378,
+	PPME_SYSCALL_CHOWN_X = 379,
+	PPME_SYSCALL_LCHOWN_E = 380,
+	PPME_SYSCALL_LCHOWN_X = 381,
+	PPME_SYSCALL_FCHOWN_E = 382,
+	PPME_SYSCALL_FCHOWN_X = 383,
+	PPME_SYSCALL_FCHOWNAT_E = 384,
+	PPME_SYSCALL_FCHOWNAT_X = 385,
+	PPM_EVENT_MAX = 386
 } ppm_event_code;
 /*@}*/
 
@@ -1870,6 +1878,7 @@ extern const struct ppm_name_value mlockall_flags[];
 extern const struct ppm_name_value mlock2_flags[];
 extern const struct ppm_name_value fsconfig_cmds[];
 extern const struct ppm_name_value epoll_create1_flags[];
+extern const struct ppm_name_value fchownat_flags[];
 
 extern const struct ppm_param_info sockopt_dynamic_param[];
 extern const struct ppm_param_info ptrace_dynamic_param[];

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6749,6 +6749,151 @@ int f_sys_fchmod_x(struct event_filler_arguments *args)
 	return add_sentinel(args);
 }
 
+int f_sys_chown_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+
+	res = val_to_ring(args, val, 0, true, 0);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	return add_sentinel(args);
+}
+
+int f_sys_lchown_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 2: path (type: PT_FSPATH) */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+
+	res = val_to_ring(args, val, 0, true, 0);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	return add_sentinel(args);
+}
+
+int f_sys_fchown_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+	s32 fd;
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	fd = (s32)val;
+	res = val_to_ring(args, (s64)fd, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	return add_sentinel(args);
+}
+
+int f_sys_fchownat_x(struct event_filler_arguments *args)
+{
+	unsigned long val;
+	int res;
+	int64_t retval;
+	s32 fd;
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	retval = (int64_t)syscall_get_return_value(current, args->regs);
+	res = val_to_ring(args, retval, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &val);
+	fd = (s32)val;
+
+	if ((int)fd == AT_FDCWD)
+		fd = PPM_AT_FDCWD;
+
+	res = val_to_ring(args, (s64)fd, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 3: pathname (type: PT_FSRELPATH) */
+	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+
+	res = val_to_ring(args, val, 0, true, 0);
+	CHECK_RES(res);
+
+	/* Parameter 4: uid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 5: gid (type: PT_UINT32) */
+	syscall_get_arguments_deprecated(current, args->regs, 3, 1, &val);
+
+	res = val_to_ring(args, val, 0, false, 0);
+	CHECK_RES(res);
+
+	/* Parameter 6: flags (type: PT_FLAGS32) */
+	syscall_get_arguments_deprecated(current, args->regs, 4, 1, &val);
+	res = val_to_ring(args, fchownat_flags_to_scap(val), 0, false, 0);
+	CHECK_RES(res);
+
+	return add_sentinel(args);
+}
+
 int f_sys_capset_x(struct event_filler_arguments *args)
 {
 	unsigned long val;

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -97,6 +97,10 @@ or GPL2.txt for full copies of the license.
 	FN(sys_fchmodat_x)			\
 	FN(sys_chmod_x)				\
 	FN(sys_fchmod_x)			\
+        FN(sys_chown_x)				\
+	FN(sys_lchown_x)			\
+	FN(sys_fchown_x)			\
+	FN(sys_fchownat_x)			\
 	FN(sys_mkdirat_x)			\
 	FN(sys_openat_e)			\
 	FN(sys_openat_x)			\

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1711,6 +1711,21 @@ static __always_inline u32 chmod_mode_to_scap(unsigned long modes)
 	return res;
 }
 
+static __always_inline u32 fchownat_flags_to_scap(unsigned long flags)
+{
+	u32 res = 0;
+
+	if (flags & AT_SYMLINK_FOLLOW)
+		res |= PPM_AT_SYMLINK_FOLLOW;
+
+#ifdef AT_EMPTY_PATH
+	if (flags & AT_EMPTY_PATH)
+		res |= PPM_AT_EMPTY_PATH;
+#endif
+
+	return res;
+}
+
 static __always_inline u64 capabilities_to_scap(unsigned long caps)
 {
 	u64 res = 0;

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1715,8 +1715,10 @@ static __always_inline u32 fchownat_flags_to_scap(unsigned long flags)
 {
 	u32 res = 0;
 
+#ifdef AT_SYMLINK_FOLLOW
 	if (flags & AT_SYMLINK_FOLLOW)
 		res |= PPM_AT_SYMLINK_FOLLOW;
+#endif
 
 #ifdef AT_EMPTY_PATH
 	if (flags & AT_EMPTY_PATH)

--- a/driver/report.md
+++ b/driver/report.md
@@ -23,7 +23,7 @@ This table represents the syscalls supported by our drivers.
 | capset                  | 🟢        |
 | chdir                   | 🟢        |
 | chmod                   | 🟢        |
-| chown                   | 🟡        |
+| chown                   | 🟢        |
 | chroot                  | 🟢        |
 | clock_adjtime           | 🟡        |
 | clock_getres            | 🟡        |
@@ -65,8 +65,8 @@ This table represents the syscalls supported by our drivers.
 | fchdir                  | 🟢        |
 | fchmod                  | 🟢        |
 | fchmodat                | 🟢        |
-| fchown                  | 🟡        |
-| fchownat                | 🟡        |
+| fchown                  | 🟢        |
+| fchownat                | 🟢        |
 | fcntl                   | 🟢        |
 | fdatasync               | 🟡        |
 | fgetxattr               | 🟡        |
@@ -146,7 +146,7 @@ This table represents the syscalls supported by our drivers.
 | landlock_add_rule       | 🟡        |
 | landlock_create_ruleset | 🟡        |
 | landlock_restrict_self  | 🟡        |
-| lchown                  | 🟡        |
+| lchown                  | 🟢        |
 | lgetxattr               | 🟡        |
 | link                    | 🟢        |
 | linkat                  | 🟢        |

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -499,9 +499,11 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_setregid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETREGID},
 	[__NR_getgroups - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_GETGROUPS},
 	[__NR_setgroups - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETGROUPS},
-	[__NR_fchown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FCHOWN},
+#ifdef __NR_fchown
+	[__NR_fchown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_FCHOWN_E, PPME_SYSCALL_FCHOWN_X, PPM_SC_FCHOWN},
+#endif
 #ifdef __NR_chown
-	[__NR_chown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_CHOWN},
+	[__NR_chown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_CHOWN_E, PPME_SYSCALL_CHOWN_X, PPM_SC_CHOWN},
 #endif
 	[__NR_setfsuid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETFSUID},
 	[__NR_setfsgid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETFSGID},
@@ -565,7 +567,9 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_inotify_add_watch - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_INOTIFY_ADD_WATCH},
 	[__NR_inotify_rm_watch - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_INOTIFY_RM_WATCH},
 	[__NR_mknodat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_MKNODAT},
-	[__NR_fchownat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FCHOWNAT},
+#ifdef __NR_fchownat
+	[__NR_fchownat - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_FCHOWNAT_E, PPME_SYSCALL_FCHOWNAT_X, PPM_SC_FCHOWNAT},
+#endif
 #ifdef __NR_futimesat
 	[__NR_futimesat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FUTIMESAT},
 #endif
@@ -894,7 +898,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_uselib - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_USELIB},
 #endif
 #ifdef __NR_lchown
-	[__NR_lchown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LCHOWN},
+	[__NR_lchown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LCHOWN_E, PPME_SYSCALL_LCHOWN_X, PPM_SC_LCHOWN},
 #endif
 #ifdef __NR_alarm
 	[__NR_alarm - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_ALARM},
@@ -1302,9 +1306,11 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32_setregid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETREGID},
 	[__NR_ia32_getgroups - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_GETGROUPS},
 	[__NR_ia32_setgroups - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETGROUPS},
-	[__NR_ia32_fchown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FCHOWN},
+#ifdef __NR_ia32_fchown
+	[__NR_ia32_fchown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_FCHOWN_E, PPME_SYSCALL_FCHOWN_X, PPM_SC_FCHOWN},
+#endif
 #ifdef __NR_ia32_chown
-	[__NR_ia32_chown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_CHOWN},
+	[__NR_ia32_chown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_CHOWN_E, PPME_SYSCALL_CHOWN_X, PPM_SC_CHOWN},
 #endif
 	[__NR_ia32_setfsuid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETFSUID},
 	[__NR_ia32_setfsgid - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_SETFSGID},
@@ -1368,7 +1374,9 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32_inotify_add_watch - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_INOTIFY_ADD_WATCH},
 	[__NR_ia32_inotify_rm_watch - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_INOTIFY_RM_WATCH},
 	[__NR_ia32_mknodat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_MKNODAT},
-	[__NR_ia32_fchownat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FCHOWNAT},
+#ifdef __NR_ia32_fchownat
+	[__NR_ia32_fchownat - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_FCHOWNAT_E, PPME_SYSCALL_FCHOWNAT_X, PPM_SC_FCHOWNAT},
+#endif
 #ifdef __NR_ia32_futimesat
 	[__NR_ia32_futimesat - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_FUTIMESAT},
 #endif
@@ -1685,7 +1693,7 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32_pselect6 - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_PSELECT6},
 #endif
 #ifdef __NR_ia32_lchown
-	[__NR_ia32_lchown - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LCHOWN},
+	[__NR_ia32_lchown - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LCHOWN_E, PPME_SYSCALL_LCHOWN_X, PPM_SC_LCHOWN},
 #endif
 #ifdef __NR_ia32_alarm
 	[__NR_ia32_alarm - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_ALARM},

--- a/test/drivers/test_suites/syscall_enter_suite/chown_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/chown_e.cpp
@@ -1,0 +1,37 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chown
+TEST(SyscallEnter, chownE)
+{
+	auto evt_test = get_syscall_event_test(__NR_chown, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "chown", syscall(__NR_chown, NULL, 0, 0));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/fchown_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/fchown_e.cpp
@@ -1,0 +1,40 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchown
+TEST(SyscallEnter, fchownE)
+{
+	auto evt_test = get_syscall_event_test(__NR_fchown, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchown", syscall(__NR_fchown, mock_fd, uid, gid));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/fchownat_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/fchownat_e.cpp
@@ -1,0 +1,42 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchownat
+TEST(SyscallEnter, fchownatE)
+{
+	auto evt_test = get_syscall_event_test(__NR_fchownat, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = 0;
+	const char* pathname = NULL;
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	uint32_t flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchownat", syscall(__NR_fchownat, mock_dirfd, pathname, uid, gid, flags));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_enter_suite/lchown_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/lchown_e.cpp
@@ -1,0 +1,37 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_lchown
+TEST(SyscallEnter, lchownE)
+{
+	auto evt_test = get_syscall_event_test(__NR_lchown, ENTER_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	assert_syscall_state(SYSCALL_FAILURE, "lchown", syscall(__NR_lchown, NULL, 0, 0));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	// Here we have no parameters to assert.
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(0);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/chown_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/chown_x.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_chown
+TEST(SyscallExit, chownX)
+{
+	auto evt_test = get_syscall_event_test(__NR_chown, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* filename = "*//null";
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "chown", syscall(__NR_chown, filename, uid, gid));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, filename);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)gid);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/fchown_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fchown_x.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchown
+TEST(SyscallExit, fchownX)
+{
+	auto evt_test = get_syscall_event_test(__NR_fchown, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_fd = -1;
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "fchown", syscall(__NR_fchown, mock_fd, uid, gid));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_fd);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)gid);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/fchownat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fchownat_x.cpp
@@ -1,0 +1,59 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_fchownat
+TEST(SyscallExit, fchownatX)
+{
+	auto evt_test = get_syscall_event_test(__NR_fchownat, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t mock_dirfd = -1;
+	const char* pathname = "*//null";
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	uint32_t flags = AT_SYMLINK_FOLLOW | AT_EMPTY_PATH;
+	assert_syscall_state(SYSCALL_FAILURE, "fchownat", syscall(__NR_fchownat, mock_dirfd, pathname, uid, gid, flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)mock_dirfd);
+
+	/* Parameter 3: pathname (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, pathname);
+
+	/* Parameter 4: uid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)uid);
+
+	/* Parameter 5: gid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)gid);
+
+	/* Parameter 6: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(6, (uint32_t)(PPM_AT_SYMLINK_FOLLOW | PPM_AT_EMPTY_PATH));
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/lchown_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/lchown_x.cpp
@@ -1,0 +1,51 @@
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_lchown
+TEST(SyscallExit, lchownX)
+{
+	auto evt_test = get_syscall_event_test(__NR_lchown, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char* filename = "*//null";
+	uint32_t uid = 0;
+	uint32_t gid = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "lchown", syscall(__NR_lchown, filename, uid, gid));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, errno_value);
+
+	/* Parameter 2: filename (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, filename);
+
+	/* Parameter 3: uid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)uid);
+
+	/* Parameter 4: gid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)gid);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -239,6 +239,14 @@ static const char* event_prog_names[PPM_EVENT_MAX] = {
 	[PPME_SYSCALL_LLSEEK_X] = "llseek_x",
 	[PPME_SYSCALL_GETRESGID_E] = "getresgid_e",
 	[PPME_SYSCALL_GETRESGID_X] = "getresgid_x",
+	[PPME_SYSCALL_CHOWN_E] = "chown_e",
+	[PPME_SYSCALL_CHOWN_X] = "chown_x",
+	[PPME_SYSCALL_LCHOWN_E] = "lchown_e",
+	[PPME_SYSCALL_LCHOWN_X] = "lchown_x",
+	[PPME_SYSCALL_FCHOWN_E] = "fchown_e",
+	[PPME_SYSCALL_FCHOWN_X] = "fchown_x",
+	[PPME_SYSCALL_FCHOWNAT_E] = "fchownat_e",
+	[PPME_SYSCALL_FCHOWNAT_X] = "fchownat_x",
 };
 
 /* Some events can require more than one bpf program to collect all the data. */

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3570,6 +3570,11 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 		dirfdarg = "dirfd";
 		patharg = "filename";
 	}
+	else if(etype == PPME_SYSCALL_FCHOWNAT_X)
+	{
+		dirfdarg = "dirfd";
+		patharg = "pathname";
+	}
 
 	if(!dirfdarg || !patharg)
 	{

--- a/userspace/libsinsp/test/table/event_table.cpp
+++ b/userspace/libsinsp/test/table/event_table.cpp
@@ -2,7 +2,7 @@
 #include <sinsp.h>
 
 /* These numbers must be updated when we add new events */
-#define SYSCALL_EVENTS_NUM 332
+#define SYSCALL_EVENTS_NUM 340
 #define TRACEPOINT_EVENTS_NUM 6
 #define METAEVENTS_NUM 19
 #define PLUGIN_EVENTS_NUM 1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod
/area driver-bpf
/area driver-modern-bpf
/area libpman
/area libsinsp

**Does this PR require a change in the driver versions?**

/version driver-API-version-minor
/version driver-SCHEMA-version-minor

**What this PR does / why we need it**:

Adds full processing for `chown`, `lchown`, `fchown`, `fchownat` syscalls extracting their parameters: filename, new user id and group id.

**Which issue(s) this PR fixes**:

Fixes #892

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new: add support for chown, lchown, fchown, fchownat syscalls
```
