### PR TITLE
fix(driver): verifier issues on clang-7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,9 +108,50 @@ jobs:
             cd /tmp/libs/build && cmake -DUSE_BUNDLED_DEPS=Off -DBUILD_BPF=Off -DBUILD_DRIVER=Off ..
             make run-unit-tests -j6
 
+  "test-clang-7":
+    machine:
+      image: ubuntu-2004:202107-02
+    steps:
+      - run:
+          name: Install deps ⛓️
+          command: |
+            sudo apt update -y
+            sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends ca-certificates git make build-essential clang-7 libelf-dev libcap-dev cmake linux-headers-$(uname -r)
+            ls /usr/bin/ | grep clang
+            ls /usr/bin/ | grep llc
+            sudo ln -s /usr/bin/clang-7 /usr/bin/clang
+
+      - checkout:
+          path: /tmp/libs
+
+      - run:
+          name: Print kernel info 🔢
+          command: |
+            uname -a
+
+      - run:
+          name: Build drivers and engines tests 🏗️
+          command: |
+            mkdir -p /tmp/libs/build
+            cd /tmp/libs/build && cmake -DUSE_BUNDLED_DEPS=On -DENABLE_DRIVERS_TESTS=On -DBUILD_LIBSCAP_GVISOR=Off -DBUILD_BPF=True -DBUILD_LIBSCAP_MODERN_BPF=Off -DCREATE_TEST_TARGETS=On ..
+            make drivers_test driver bpf -j6
+
+      - run:
+          name: Run drivers_test with kernel module 🏎️
+          command: |
+            cd /tmp/libs/build
+            sudo ./test/drivers/drivers_test -k --gtest_filter=-'GenericTracepoints.page_fault_kernel'
+
+      - run:
+          name: Run drivers_test with bpf 🏎️
+          command: |
+            cd /tmp/libs/build
+            sudo ./test/drivers/drivers_test -b --gtest_filter=-'GenericTracepoints.page_fault_kernel'
+
 workflows:
   version: 2.1
   build_and_test:
     jobs:
       - "test-drivers-engines-arm64"
       - "test-libraries-arm64"
+      - "test-clang-7"

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1121,6 +1121,57 @@ static __always_inline int bpf_val_to_ring_mem(struct filler_data *data,
 	return __bpf_val_to_ring(data, val, 0, param_info->type, -1, false, mem);
 }
 
+/// TODO: @Andreagit97 these functions should return void
+static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, s64 val)
+{
+	/// TODO: @Andreagit97 this could be removed in a second iteration.
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(s64);
+	*((s64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	/// TODO: @Andreagit97 this could be simplified
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, u64 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(u64);
+	*((u64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(u32);
+	*((u32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
 static __always_inline int bpf_val_to_ring(struct filler_data *data,
 					   unsigned long val)
 {

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -916,7 +916,7 @@ FILLER(sys_mmap_e, true)
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -924,7 +924,7 @@ FILLER(sys_mmap_e, true)
 	 * length
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -932,7 +932,7 @@ FILLER(sys_mmap_e, true)
 	 * prot
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, prot_flags_to_scap(val));
+	res = bpf_push_u32_to_ring(data, prot_flags_to_scap(val));
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -940,7 +940,7 @@ FILLER(sys_mmap_e, true)
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 3);
-	res = bpf_val_to_ring(data, mmap_flags_to_scap(val));
+	res = bpf_push_u32_to_ring(data, mmap_flags_to_scap(val));
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -948,7 +948,7 @@ FILLER(sys_mmap_e, true)
 	 * fd
 	 */
 	val = bpf_syscall_get_argument(data, 4);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	if (res != PPM_SUCCESS)
 		return res;
 
@@ -956,9 +956,7 @@ FILLER(sys_mmap_e, true)
 	 * offset/pgoffset
 	 */
 	val = bpf_syscall_get_argument(data, 5);
-	res = bpf_val_to_ring(data, val);
-
-	return res;
+	return bpf_push_u64_to_ring(data, val);
 }
 
 FILLER(sys_mprotect_e, true)
@@ -2940,12 +2938,12 @@ FILLER(sys_setns_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
 	unsigned long nstype = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, clone_flags_to_scap(nstype));
+	return bpf_push_u32_to_ring(data, clone_flags_to_scap(nstype));
 }
 
 FILLER(sys_setpgid_e, true)

--- a/test/drivers/test_suites/syscall_enter_suite/io_uring_enter_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/io_uring_enter_e.cpp
@@ -15,7 +15,7 @@ TEST(SyscallEnter, io_uring_enterE)
 	int32_t fd = -1;
 	uint32_t to_submit = 10;
 	uint32_t min_complete = 20;
-	uint32_t flags = IORING_ENTER_EXT_ARG;
+	uint32_t flags = 0;
 	const void* argp = NULL;
 	size_t argsz = 7;
 	assert_syscall_state(SYSCALL_FAILURE, "io_uring_enter", syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags, argp, argsz));

--- a/test/drivers/test_suites/syscall_enter_suite/io_uring_register_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/io_uring_register_e.cpp
@@ -13,7 +13,7 @@ TEST(SyscallEnter, io_uring_registerE)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t fd = -1;
-	uint32_t opcode = IORING_REGISTER_BUFFERS;
+	uint32_t opcode = 0;
 	const void* arg = NULL;
 	unsigned int nr_args = 7;
 	assert_syscall_state(SYSCALL_FAILURE, "io_uring_register", syscall(__NR_io_uring_register, fd, opcode, arg, nr_args));

--- a/test/drivers/test_suites/syscall_exit_suite/io_uring_enter_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/io_uring_enter_x.cpp
@@ -15,7 +15,12 @@ TEST(SyscallExit, io_uring_enterX)
 	int32_t fd = -1;
 	uint32_t to_submit = 10;
 	uint32_t min_complete = 20;
-	uint32_t flags = IORING_ENTER_EXT_ARG;
+	uint32_t flags = 0;
+	uint32_t expected_flags = 0;
+#ifdef IORING_ENTER_EXT_ARG
+	flags = IORING_ENTER_EXT_ARG;
+	expected_flags = PPM_IORING_ENTER_EXT_ARG;
+#endif
 	const void* argp = NULL;
 	size_t argsz = 7;
 	assert_syscall_state(SYSCALL_FAILURE, "io_uring_enter", syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags, argp, argsz));
@@ -51,7 +56,7 @@ TEST(SyscallExit, io_uring_enterX)
 	evt_test->assert_numeric_param(4, (uint32_t)min_complete);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	evt_test->assert_numeric_param(5, (uint32_t)PPM_IORING_ENTER_EXT_ARG);
+	evt_test->assert_numeric_param(5, (uint32_t)expected_flags);
 
 	/* Parameter 6: sig (type: PT_SIGSET) */
 	/* These are the first 32 bit of a pointer so in this case all zeros */

--- a/test/drivers/test_suites/syscall_exit_suite/io_uring_register_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/io_uring_register_x.cpp
@@ -13,7 +13,10 @@ TEST(SyscallExit, io_uring_registerX)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t fd = -1;
-	uint32_t opcode = IORING_REGISTER_RESTRICTIONS;
+	uint32_t opcode = 0;
+#ifdef IORING_REGISTER_RESTRICTIONS
+	opcode = IORING_REGISTER_RESTRICTIONS;
+#endif
 	const void* arg = (const void*)0x7fff5694dc58;
 	unsigned int nr_args = 34;
 	assert_syscall_state(SYSCALL_FAILURE, "io_uring_register", syscall(__NR_io_uring_register, fd, opcode, arg, nr_args));

--- a/test/drivers/test_suites/syscall_exit_suite/io_uring_setup_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/io_uring_setup_x.cpp
@@ -16,17 +16,22 @@ TEST(SyscallExit, io_uring_setupX)
 	 * doesn't have the filed `feature`, so define it to `0` as default.
 	 */
 	uint32_t expected_features = 0;
+	uint32_t expected_flags = (uint32_t)-1;
 	uint32_t entries = 4;
 	struct io_uring_params params = {0};
 	params.sq_entries = 5;
 	params.cq_entries = 6;
+	params.flags = (uint32_t)-1;
 	/* The call should fail since we specified only `IORING_SETUP_SQ_AFF`
 	 * but not `IORING_SETUP_SQPOLL`
 	 */
+#ifdef IORING_FEAT_SINGLE_MMAP
 	params.flags = IORING_SETUP_SQ_AFF;
+	expected_flags = PPM_IORING_SETUP_SQ_AFF;
+#endif
 	params.sq_thread_cpu = 7;
 	params.sq_thread_idle = 8;
-#ifdef IORING_FEAT_SINGLE_MMAP
+#ifdef IORING_FEAT_NODROP
 	params.features = IORING_FEAT_NODROP;
 	expected_features = PPM_IORING_FEAT_NODROP;
 #endif
@@ -63,7 +68,7 @@ TEST(SyscallExit, io_uring_setupX)
 	evt_test->assert_numeric_param(4, (uint32_t)params.cq_entries);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	evt_test->assert_numeric_param(5, (uint32_t)PPM_IORING_SETUP_SQ_AFF);
+	evt_test->assert_numeric_param(5, (uint32_t)expected_flags);
 
 	/* Parameter 6: sq_thread_cpu (type: PT_UINT32) */
 	evt_test->assert_numeric_param(6, (uint32_t)params.sq_thread_cpu);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

After recent changes in the old bpf probe, we are facing some stability issues. This is probably the moment to replace the old `bpf_val_to_ring`  helper with dedicated helpers like in the modern probe to reduce complexity and help the verifier.
This PR adds three new helpers:

* `bpf_push_u32_to_ring`
* `bpf_push_u64_to_ring`
* `bpf_push_s64_to_ring`

These helpers are still dirty because until we remove the `val_to_ring` we have to preserve some code patterns, I left some TODOs to address them in next PRs. This doesn't want to address all issues we have in one shot, it's just a little step to the final solution and it solves some verifier issues we faced with 2 fillers `sys_setns_e` and `sys_mmap_e`.

I also added a CI job to test the probe on the machine that caused these verifier issues: kernel `5.8.0-1041-aws` with `clang-7`

I fixed also some drivers' tests to run them on older kernels that miss the support of some `io_uring` flags.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This was the original failure:

```
regs=0 stack=10 before 1356: (15) if r1 == 0x2 goto pc+110
 R0_rw=map_value(id=0,off=0,ks=4,vs=262144,imm=0) R1_rw=inv(id=0) R2=inv(id=0,umax_value=131071,var_off=(0x0; 0x1ffff)) R3_w=inv(id=0) R4_w=inv(id=0,smax_value=2) R5=inv(id=0,umax_value=64,var_off=(0x0; 0x40)) R6_r=ctx(id=0,off=0,imm=0) R7_r=map_value(id=0,off=0,ks=4,vs=181,imm=0) R8=inv0 R9_rw=inv4294967293 R10=fp0 fp-8=mmmmmmmm fp-16=map_value fp-24=map_value fp-32=mmmmmmmm fp-40_r=mmmmmmmm fp-48=inv1 fp-56=mmmmmmmm
parent already had regs=0 stack=0 marks
math between map_value pointer and register with unbounded min value is not allowed
processed 1019 insns (limit 1000000) max_states_per_insn 0 total_states 25 peak_states 25 mark_read 5

-- END PROG LOAD LOG --
Fri Feb 17 18:42:25 2023: An error occurred in an event source, forcing termination...
Events detected: 0
Rule counts by severity:
Triggered rules by rule name:
Error: libscap: bpf_load_program() event=raw_tracepoint/filler/sys_mmap_e: Operation not permitted
```

Falco CI job :point_right: https://app.circleci.com/pipelines/github/falcosecurity/falco/3782/workflows/b5e04864-b926-4e04-b8e1-da5bc1f3fe85/jobs/32304/parallel-runs/0/steps/0-102

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
