### PR TITLE
fix(cmake): make scap_engine_savefile depend on zlib only if not in minimal build

### DIFF
--- a/userspace/libscap/engine/savefile/CMakeLists.txt
+++ b/userspace/libscap/engine/savefile/CMakeLists.txt
@@ -4,5 +4,7 @@ add_library(scap_engine_savefile
     scap_reader_gzfile.c
     scap_reader_buffered.c)
 
-add_dependencies(scap_engine_savefile zlib)
+if(NOT MINIMAL_BUILD)
+    add_dependencies(scap_engine_savefile zlib)
+endif()
 target_link_libraries(scap_engine_savefile scap_engine_noop ${ZLIB_LIB})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This fixes a regression in the cmake setup introduced in https://github.com/falcosecurity/libs/pull/851 that caused the failure of a CI job in Falco (https://github.com/falcosecurity/falco/actions/runs/4206450519/jobs/7299948726).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
