### PR TITLE
[moved to #921] fix(libsinsp): fix sinsp_state_sc_set ppm sc APIs

### DIFF
--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -19,16 +19,63 @@ limitations under the License.
 
 libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_state_sc_set()
 {
-	static libsinsp::events::set<ppm_sc_code> ppm_sc_set;
-	if (ppm_sc_set.empty())
-	{
-		/* Should never happen but just to be sure. */
-		if(scap_get_modifies_state_ppm_sc(ppm_sc_set.data()) != SCAP_SUCCESS)
-		{
-			throw sinsp_exception("'ppm_sc_set' is an unexpected NULL vector!");
-		}
-	}
-	return ppm_sc_set;
+	/* syscalls tagged with EF_MODIFIES_STATE in event_table.c */
+	static libsinsp::events::set<ppm_sc_code> static_state_set = {
+		PPM_SC_OPEN,
+		PPM_SC_CLOSE,
+		PPM_SC_EXECVE,
+		PPM_SC_CLONE,
+		PPM_SC_SOCKET,
+		PPM_SC_BIND,
+		PPM_SC_CONNECT,
+		PPM_SC_ACCEPT,
+		PPM_SC_SENDTO,
+		PPM_SC_RECVFROM,
+		PPM_SC_SHUTDOWN,
+		PPM_SC_SOCKETPAIR,
+		PPM_SC_GETSOCKOPT,
+		PPM_SC_SENDMSG,
+		PPM_SC_RECVMSG,
+		PPM_SC_ACCEPT4,
+		PPM_SC_CREAT,
+		PPM_SC_PIPE,
+		PPM_SC_EVENTFD,
+		PPM_SC_CHDIR,
+		PPM_SC_FCHDIR,
+		PPM_SC_OPENAT,
+		PPM_SC_DUP,
+		PPM_SC_SIGNALFD,
+		PPM_SC_TIMERFD_CREATE,
+		PPM_SC_INOTIFY_INIT,
+		PPM_SC_FCNTL,
+		PPM_SC_FORK,
+		PPM_SC_VFORK,
+		PPM_SC_SETRESUID,
+		PPM_SC_SETRESUID32,
+		PPM_SC_SETRESGID,
+		PPM_SC_SETRESGID32,
+		PPM_SC_SETUID,
+		PPM_SC_SETUID32,
+		PPM_SC_SETGID,
+		PPM_SC_SETGID32,
+		PPM_SC_MOUNT,
+		PPM_SC_UMOUNT,
+		PPM_SC_CHROOT,
+		PPM_SC_SETSID,
+		PPM_SC_SETPGID,
+		PPM_SC_USERFAULTFD,
+		PPM_SC_OPENAT2,
+		PPM_SC_EXECVEAT,
+		PPM_SC_CLONE3,
+		PPM_SC_OPEN_BY_HANDLE_AT,
+		PPM_SC_IO_URING_SETUP,
+		PPM_SC_CAPSET,
+		PPM_SC_DUP2,
+		PPM_SC_DUP3,
+		PPM_SC_EPOLL_CREATE,
+		PPM_SC_EPOLL_CREATE1,
+	};
+	return static_state_set;
 }
 
 libsinsp::events::set<ppm_sc_code> libsinsp::events::enforce_simple_sc_set(libsinsp::events::set<ppm_sc_code> ppm_sc_set)

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -28,283 +28,45 @@ limitations under the License.
 #include "syscall_compat_s390x.h"
 #endif /* __x86_64__ */
 
-/* Please note this set must be kept in sync if we update the sinsp internal state set
- * otherwise some of the following checks will fail.
+/* This test asserts that `sinsp_state_sc_set` is of expected length.
+ * Please note this set must be kept in sync if we update the sinsp internal
+ * state set, otherwise some of the following checks will fail.
  */
-libsinsp::events::set<ppm_sc_code> expected_sinsp_state_ppm_sc_set = {
-#ifdef __NR_accept
-	PPM_SC_ACCEPT,
-#endif
-
-#ifdef __NR_accept4
-	PPM_SC_ACCEPT4,
-#endif
-
-#ifdef __NR_bind
-	PPM_SC_BIND,
-#endif
-
-#ifdef __NR_capset
-	PPM_SC_CAPSET,
-#endif
-
-#ifdef __NR_chdir
-	PPM_SC_CHDIR,
-#endif
-
-#ifdef __NR_chroot
-	PPM_SC_CHROOT,
-#endif
-
-#ifdef __NR_clone
-	PPM_SC_CLONE,
-#endif
-
-#ifdef __NR_clone3
-	PPM_SC_CLONE3,
-#endif
-
-#ifdef __NR_close
-	PPM_SC_CLOSE,
-#endif
-
-#ifdef __NR_connect
-	PPM_SC_CONNECT,
-#endif
-
-#ifdef __NR_creat
-	PPM_SC_CREAT,
-#endif
-
-#ifdef __NR_dup
-	PPM_SC_DUP,
-#endif
-
-#ifdef __NR_dup2
-	PPM_SC_DUP2,
-#endif
-
-#ifdef __NR_dup3
-	PPM_SC_DUP3,
-#endif
-
-#ifdef __NR_eventfd
-	PPM_SC_EVENTFD,
-#endif
-
-#ifdef __NR_eventfd2
-	PPM_SC_EVENTFD2,
-#endif
-
-#ifdef __NR_execve
-	PPM_SC_EXECVE,
-#endif
-
-#ifdef __NR_execveat
-	PPM_SC_EXECVEAT,
-#endif
-
-#ifdef __NR_fchdir
-	PPM_SC_FCHDIR,
-#endif
-
-#ifdef __NR_fcntl
-	PPM_SC_FCNTL,
-#endif
-
-#ifdef __NR_fcntl64
-	PPM_SC_FCNTL64,
-#endif
-
-#ifdef __NR_fork
-	PPM_SC_FORK,
-#endif
-
-#ifdef __NR_inotify_init
-	PPM_SC_INOTIFY_INIT,
-#endif
-
-#ifdef __NR_inotify_init1
-	PPM_SC_INOTIFY_INIT1,
-#endif
-
-#ifdef __NR_io_uring_setup
-	PPM_SC_IO_URING_SETUP,
-#endif
-
-#ifdef __NR_mount
-	PPM_SC_MOUNT,
-#endif
-
-#ifdef __NR_open
-	PPM_SC_OPEN,
-#endif
-
-#ifdef __NR_open_by_handle_at
-	PPM_SC_OPEN_BY_HANDLE_AT,
-#endif
-
-#ifdef __NR_openat
-	PPM_SC_OPENAT,
-#endif
-
-#ifdef __NR_openat2
-	PPM_SC_OPENAT2,
-#endif
-
-#ifdef __NR_pipe
-	PPM_SC_PIPE,
-#endif
-
-#ifdef __NR_pipe2
-	PPM_SC_PIPE2,
-#endif
-
-#ifdef __NR_prlimit64
-	PPM_SC_PRLIMIT64,
-#endif
-
-#ifdef __NR_recvfrom
-	PPM_SC_RECVFROM,
-#endif
-
-#ifdef __NR_recvmsg
-	PPM_SC_RECVMSG,
-#endif
-
-#ifdef __NR_getsockopt
-	PPM_SC_GETSOCKOPT, /// TODO: In the next future probably we could remove this from the state
-#endif
-
-#ifdef __NR_sendmsg
-	PPM_SC_SENDMSG,
-#endif
-
-#ifdef __NR_sendto
-	PPM_SC_SENDTO,
-#endif
-
-#ifdef __NR_setgid
-	PPM_SC_SETGID,
-#endif
-
-#ifdef __NR_setgid32
-	PPM_SC_SETGID32,
-#endif
-
-#ifdef __NR_setpgid
-	PPM_SC_SETPGID,
-#endif
-
-#ifdef __NR_setresgid
-	PPM_SC_SETRESGID,
-#endif
-
-#ifdef __NR_setresgid32
-	PPM_SC_SETRESGID32,
-#endif
-
-#ifdef __NR_setresuid
-	PPM_SC_SETRESUID,
-#endif
-
-#ifdef __NR_setresuid32
-	PPM_SC_SETRESUID32,
-#endif
-
-#ifdef __NR_setrlimit
-	PPM_SC_SETRLIMIT,
-#endif
-
-#ifdef __NR_setsid
-	PPM_SC_SETSID,
-#endif
-
-#ifdef __NR_setuid
-	PPM_SC_SETUID,
-#endif
-
-#ifdef __NR_setuid32
-	PPM_SC_SETUID32,
-#endif
-
-#ifdef __NR_shutdown
-	PPM_SC_SHUTDOWN,
-#endif
-
-#ifdef __NR_signalfd
-	PPM_SC_SIGNALFD,
-#endif
-
-#ifdef __NR_signalfd4
-	PPM_SC_SIGNALFD4,
-#endif
-
-#ifdef __NR_socket
-	PPM_SC_SOCKET,
-#endif
-
-#ifdef __NR_socketpair
-	PPM_SC_SOCKETPAIR,
-#endif
-
-#ifdef __NR_timerfd_create
-	PPM_SC_TIMERFD_CREATE,
-#endif
-
-#ifdef __NR_umount2
-	PPM_SC_UMOUNT2,
-#endif
-
-#ifdef __NR_userfaultfd
-	PPM_SC_USERFAULTFD,
-#endif
-
-#ifdef __NR_vfork
-	PPM_SC_VFORK,
-#endif
-
-#ifdef __NR_epoll_create
-	PPM_SC_EPOLL_CREATE,
-#endif
-
-#ifdef __NR_epoll_create1
-	PPM_SC_EPOLL_CREATE1,
-#endif
-};
-
-/* This test asserts that `enforce_sinsp_state_ppm_sc` correctly retrieves
- * the `libsinsp` state ppm_sc set.
- */
-TEST(interesting_syscalls, enforce_sinsp_state_basic)
+TEST(interesting_syscalls, sinsp_state_sc_set)
 {
-	auto state_ppm_sc_set = libsinsp::events::sinsp_state_sc_set();
-
-	ASSERT_TRUE(expected_sinsp_state_ppm_sc_set.equals(state_ppm_sc_set));
+	auto sinsp_state_sc_set = libsinsp::events::sinsp_state_sc_set();
+	ASSERT_EQ(sinsp_state_sc_set.size(), 53);
 }
 
-/* This test asserts that `enforce_sinsp_state_ppm_sc` correctly merges
+/* This test asserts that `enforce_simple_sc_set` correctly merges
  * the provided set with the `libsinsp` state set.
  */
-TEST(interesting_syscalls, enforce_sinsp_state_with_additions)
+TEST(interesting_syscalls, enforce_simple_sc_set_with_additions)
 {
 	libsinsp::events::set<ppm_sc_code> additional_syscalls;
-	auto ppm_sc_matching_set = expected_sinsp_state_ppm_sc_set;
 
 #ifdef __NR_kill
 	additional_syscalls.insert(PPM_SC_KILL);
-	ppm_sc_matching_set.insert(PPM_SC_KILL);
 #endif
 
 #ifdef __NR_read
 	additional_syscalls.insert(PPM_SC_READ);
-	ppm_sc_matching_set.insert(PPM_SC_READ);
 #endif
 
 	auto sinsp_state_set = libsinsp::events::sinsp_state_sc_set();
 	auto ppm_sc_final_set = additional_syscalls.merge(sinsp_state_set);
+	auto intersection = ppm_sc_final_set.intersect(additional_syscalls);
+	ASSERT_EQ(sinsp_state_set.size(), ppm_sc_final_set.size() - 2);
+	ASSERT_EQ(intersection.size(), 2);
+}
 
-	ASSERT_TRUE(ppm_sc_matching_set.equals(ppm_sc_final_set));
+/* This test asserts that `io_sc_set` correctly retrieves the expected
+ * number of corresponding sycalls.
+ */
+TEST(interesting_syscalls, io_sc_set)
+{
+	auto io_sc_set = libsinsp::events::io_sc_set();
+	ASSERT_EQ(io_sc_set.size(), 15);
 }
 
 /// TODO: we can add also some tests for `enforce_io_ppm_sc_set`, `enforce_net_ppm_sc_set`, ... here.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`libsinsp::events::sinsp_state_sc_set` returned no results, instead of fixing the bug cut over to a new approach.

We have many more refactors and feature additions planned not just around the ppm sc API, but also the event and syscalls lookup tables ...

Therefore, suggesting to hard-code the sinsp state set based on `EF_MODIFIES_STATE` flag only in order to reduce the number of moving parts in the interim and introduce stability.

Lastly, we had multiple discussions around getting this fully out of `scap` anyways, so this is a great interim step towards this step, which will fall in place alongside the already in progress additional refactors.

Updated and added more unit tests.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
