### PR TITLE
cleanup(libsinsp): Extension of ppm sc API for corner cases (e.g. `event_set_to_names` and `names_to_sc_set`)

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -637,7 +637,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ipc - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_IPC},
 #endif
 #ifdef __NR_lstat64
-	[__NR_lstat64 - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LSTAT64_E, PPME_SYSCALL_LSTAT64_X, PPM_SC_LSTAT64},
+	[__NR_lstat64 - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LSTAT64},
 #endif
 #ifdef __NR__newselect
 	[__NR__newselect - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC__NEWSELECT},
@@ -1444,7 +1444,7 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32_ipc - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_IPC},
 #endif
 #ifdef __NR_ia32_lstat64
-	[__NR_ia32_lstat64 - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LSTAT64_E, PPME_SYSCALL_LSTAT64_X, PPM_SC_LSTAT64},
+	[__NR_ia32_lstat64 - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LSTAT64},
 #endif
 #ifdef __NR_ia32__newselect
 	[__NR_ia32__newselect - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC__NEWSELECT},

--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -637,7 +637,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ipc - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_IPC},
 #endif
 #ifdef __NR_lstat64
-	[__NR_lstat64 - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LSTAT64},
+	[__NR_lstat64 - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LSTAT64_E, PPME_SYSCALL_LSTAT64_X, PPM_SC_LSTAT64},
 #endif
 #ifdef __NR__newselect
 	[__NR__newselect - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC__NEWSELECT},
@@ -1444,7 +1444,7 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32_ipc - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_IPC},
 #endif
 #ifdef __NR_ia32_lstat64
-	[__NR_ia32_lstat64 - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC_LSTAT64},
+	[__NR_ia32_lstat64 - SYSCALL_TABLE_ID0] = {UF_USED, PPME_SYSCALL_LSTAT64_E, PPME_SYSCALL_LSTAT64_X, PPM_SC_LSTAT64},
 #endif
 #ifdef __NR_ia32__newselect
 	[__NR_ia32__newselect - SYSCALL_TABLE_ID0] = {.ppm_sc = PPM_SC__NEWSELECT},

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -1,4 +1,5 @@
 #include "sinsp_events.h"
+#include "../utils.h"
 
 const ppm_event_info* libsinsp::events::info(ppm_event_code event_type)
 {
@@ -71,6 +72,46 @@ bool libsinsp::events::is_plugin_event(ppm_event_code event_type)
 	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	return (category & EC_PLUGIN);
 }
+
+libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_sc_event_set()
+{
+	static libsinsp::events::set<ppm_event_code> ppm_event_set;
+	if (ppm_event_set.empty())
+	{
+		for(uint32_t ev = 0; ev < PPM_EVENT_MAX; ev++)
+		{
+			if(!libsinsp::events::is_syscall_event((ppm_event_code)ev))
+			{
+				ppm_event_set.insert((ppm_event_code)ev);
+			}
+		}
+	}
+	return ppm_event_set;
+}
+
+libsinsp::events::set<ppm_event_code> libsinsp::events::all_generic_sc_event_set()
+{
+	static libsinsp::events::set<ppm_event_code> generic_event_set = {PPME_GENERIC_E, PPME_GENERIC_X};
+	return generic_event_set;
+}
+
+libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_generic_sc_event_set()
+{
+	static libsinsp::events::set<ppm_event_code> ppm_event_set;
+	if (ppm_event_set.empty())
+	{
+		for(uint32_t ev = 0; ev < PPM_EVENT_MAX; ev++)
+		{
+			if(libsinsp::events::is_syscall_event((ppm_event_code)ev) &&
+			!libsinsp::events::is_generic((ppm_event_code)ev))
+			{
+				ppm_event_set.insert((ppm_event_code)ev);
+			}
+		}
+	}
+	return ppm_event_set;
+}
+
 
 std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set)
 {

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -73,46 +73,6 @@ bool libsinsp::events::is_plugin_event(ppm_event_code event_type)
 	return (category & EC_PLUGIN);
 }
 
-libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_sc_event_set()
-{
-	static libsinsp::events::set<ppm_event_code> ppm_event_set;
-	if (ppm_event_set.empty())
-	{
-		for(uint32_t ev = 0; ev < PPM_EVENT_MAX; ev++)
-		{
-			if(!libsinsp::events::is_syscall_event((ppm_event_code)ev))
-			{
-				ppm_event_set.insert((ppm_event_code)ev);
-			}
-		}
-	}
-	return ppm_event_set;
-}
-
-libsinsp::events::set<ppm_event_code> libsinsp::events::all_generic_sc_event_set()
-{
-	static libsinsp::events::set<ppm_event_code> generic_event_set = {PPME_GENERIC_E, PPME_GENERIC_X};
-	return generic_event_set;
-}
-
-libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_generic_sc_event_set()
-{
-	static libsinsp::events::set<ppm_event_code> ppm_event_set;
-	if (ppm_event_set.empty())
-	{
-		for(uint32_t ev = 0; ev < PPM_EVENT_MAX; ev++)
-		{
-			if(libsinsp::events::is_syscall_event((ppm_event_code)ev) &&
-			!libsinsp::events::is_generic((ppm_event_code)ev))
-			{
-				ppm_event_set.insert((ppm_event_code)ev);
-			}
-		}
-	}
-	return ppm_event_set;
-}
-
-
 std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set, bool resolve_sc)
 {
 	std::unordered_set<std::string> events_names_set;

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -84,6 +84,7 @@ std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsi
 
 	if (resolve_generic)
 	{
+		/* note: Using existing ppm sc APIs and generic set operations in order to not introduce logic that requires maintenance beyond what we already have. */
 		auto tmp_events_set = events_set.intersect(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});
 		if (!tmp_events_set.empty())
 		{

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -116,27 +116,15 @@ libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_generic_sc_event
 std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set)
 {
 	std::unordered_set<std::string> events_names_set;
-	for (const auto& val : events_set)
+	for (const auto& ev : events_set)
 	{
-		if (!libsinsp::events::is_generic(val))
-		{
-			events_names_set.insert(scap_get_event_info_table()[val].name);
-		}
-		else
-		{
-			// Skip unknown
-			for (uint32_t i = 1; i < PPM_SC_MAX; i++)
-			{
-				auto single_ev_set = libsinsp::events::set<ppm_sc_code>();
-				single_ev_set.insert((ppm_sc_code)i);
-				const auto evts = sc_set_to_event_set(single_ev_set);
-				if (evts.contains(val))
-				{
-					events_names_set.insert(scap_get_syscall_info_table()[i].name);
-				}
-			}
-		}
+		events_names_set.insert(scap_get_event_info_table()[ev].name);
 	}
+	events_names_set.erase("syscall"); // generic event placeholder string, not needed
+
+	auto sc_set = libsinsp::events::event_set_to_sc_set(events_set);
+	events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
+	events_names_set.erase("unknown"); // not needed
 	return events_names_set;
 }
 

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -73,7 +73,7 @@ bool libsinsp::events::is_plugin_event(ppm_event_code event_type)
 	return (category & EC_PLUGIN);
 }
 
-std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set, bool resolve_sc)
+std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set, bool resolve_generic)
 {
 	std::unordered_set<std::string> events_names_set;
 	for (const auto& ev : events_set)
@@ -82,11 +82,15 @@ std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsi
 	}
 	events_names_set.erase("syscall"); // generic event placeholder string, not needed
 
-	if (resolve_sc)
+	if (resolve_generic)
 	{
-		auto sc_set = libsinsp::events::event_set_to_sc_set(events_set);
-		events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
-		events_names_set.erase("unknown"); // not needed
+		auto tmp_events_set = events_set.intersect(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});
+		if (!tmp_events_set.empty())
+		{
+			auto sc_set = libsinsp::events::event_set_to_sc_set(tmp_events_set);
+			events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
+			events_names_set.erase("unknown"); // not needed
+		}
 	}
 	return events_names_set;
 }

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -113,7 +113,7 @@ libsinsp::events::set<ppm_event_code> libsinsp::events::all_non_generic_sc_event
 }
 
 
-std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set)
+std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsinsp::events::set<ppm_event_code>& events_set, bool resolve_sc)
 {
 	std::unordered_set<std::string> events_names_set;
 	for (const auto& ev : events_set)
@@ -122,9 +122,12 @@ std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsi
 	}
 	events_names_set.erase("syscall"); // generic event placeholder string, not needed
 
-	auto sc_set = libsinsp::events::event_set_to_sc_set(events_set);
-	events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
-	events_names_set.erase("unknown"); // not needed
+	if (resolve_sc)
+	{
+		auto sc_set = libsinsp::events::event_set_to_sc_set(events_set);
+		events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
+		events_names_set.erase("unknown"); // not needed
+	}
 	return events_names_set;
 }
 

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -221,6 +221,19 @@ set<ppm_event_code> sinsp_state_event_set();
 
 /*!
   \brief Get the name of all the events provided in the set.
+  Note:
+
+  When setting resolve_sc to false exact event table names are returned for each
+  ppm_event w/ exception of "syscall" and "unknown" placeholder strings.
+
+  When setting resolve_sc to true each ppm_event will be resolved to its entirety of true
+  syscall string names, which can result in more syscalls in the following cases where
+  there is no 1:1 mapping from event code to syscall:
+
+  e.g. overloaded case: accept -> accept, accept4
+  e.g. ppm_event sharing: eventfd or eventfd2 -> always both eventfd, eventfd2
+  e.g. snowflake cases: umount or umount2 -> always both umount, umount2
+  e.g. generic events -> will map to ALL generic syscalls (over 200 generic syscalls)
 */
 std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set, bool resolve_sc = true);
 
@@ -229,13 +242,17 @@ std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& ev
 */
 set<ppm_event_code> names_to_event_set(const std::unordered_set<std::string>& events);
 
-/**
-	 * @brief When you want to retrieve the events associated with a particular `ppm_sc` you have to
-	 * pass a single-element set, with just the specific `ppm_sc`. On the other side, you want all the events
-	 * associated with a set of `ppm_sc` you have to pass the entire set of `ppm_sc`.
-	 *
-	 * @param ppm_sc_set set of `ppm_sc` from which you want to obtain information
-	 * @return set of events associated with the provided `ppm_sc` set.
+/*!
+  \brief When you want to retrieve the events associated with a particular `ppm_event` you have to
+  pass a single-element set, with just the specific `ppm_event`. On the other side, you want all the events
+  associated with a set of `ppm_event` you have to pass the entire set of `ppm_event`.
+
+  @param events_of_interest set of `ppm_event` from which you want to obtain information
+  @return set of `ppm_sc` associated with the provided `ppm_event` set.
+  Note:
+
+  When passing a ppm_event set containing PPME_GENERIC_E, PPME_GENERIC_X, ALL generic syscalls
+  (over 200 generic syscalls) will be returned given the information loss when going from event_set to sc_set.
  */
 set<ppm_sc_code> event_set_to_sc_set(const set<ppm_event_code> &events_of_interest);
 

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -222,7 +222,7 @@ set<ppm_event_code> sinsp_state_event_set();
 /*!
   \brief Get the name of all the events provided in the set.
 */
-std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set);
+std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set, bool resolve_sc = true);
 
 /*!
   \brief Get the ppm_event of all the event names provided in the set.

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -209,7 +209,7 @@ set<ppm_event_code> sinsp_state_event_set();
   Note:
 
   When setting resolve_generic to false exact event table names are returned for each
-  ppm_event w/ exception of "syscall" and "unknown" placeholder strings.
+  ppm_event w/ exception of "syscall" placeholder string for generic events.
 
   When setting resolve_generic to true each ppm_event will be resolved to its entirety of true
   syscall string names, which can result in more syscalls in the following cases where
@@ -218,7 +218,7 @@ set<ppm_event_code> sinsp_state_event_set();
   e.g. overloaded case: accept -> accept, accept4
   e.g. ppm_event sharing: eventfd or eventfd2 -> always both eventfd, eventfd2
   e.g. snowflake cases: umount or umount2 -> always both umount, umount2
-  e.g. generic events -> will map to ALL generic syscalls (over 200 generic syscalls)
+  e.g. generic events -> will map to ALL generic syscalls (can be over 180 generic syscalls)
 */
 std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set, bool resolve_generic = true);
 
@@ -228,16 +228,16 @@ std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& ev
 set<ppm_event_code> names_to_event_set(const std::unordered_set<std::string>& events);
 
 /*!
-  \brief When you want to retrieve the events associated with a particular `ppm_event` you have to
-  pass a single-element set, with just the specific `ppm_event`. On the other side, you want all the events
-  associated with a set of `ppm_event` you have to pass the entire set of `ppm_event`.
+  \brief When you want to retrieve a `ppm_sc` associated with one particular `ppm_event` you have to
+  pass a single-element set, with just the specific `ppm_event`. On the other side, if you want all
+  `ppm_sc` associated with a set of `ppm_event` you have to pass the entire set of `ppm_event`.
 
   @param events_of_interest set of `ppm_event` from which you want to obtain information
   @return set of `ppm_sc` associated with the provided `ppm_event` set.
   Note:
 
   When passing a ppm_event set containing PPME_GENERIC_E, PPME_GENERIC_X, ALL generic syscalls
-  (over 200 generic syscalls) will be returned given the information loss when going from event_set to sc_set.
+  (can be over 180 generic syscalls) will be returned given the information loss when going from event_set to sc_set.
  */
 set<ppm_sc_code> event_set_to_sc_set(const set<ppm_event_code> &events_of_interest);
 

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -208,10 +208,10 @@ set<ppm_event_code> sinsp_state_event_set();
   \brief Get the name of all the events provided in the set.
   Note:
 
-  When setting resolve_sc to false exact event table names are returned for each
+  When setting resolve_generic to false exact event table names are returned for each
   ppm_event w/ exception of "syscall" and "unknown" placeholder strings.
 
-  When setting resolve_sc to true each ppm_event will be resolved to its entirety of true
+  When setting resolve_generic to true each ppm_event will be resolved to its entirety of true
   syscall string names, which can result in more syscalls in the following cases where
   there is no 1:1 mapping from event code to syscall:
 
@@ -220,7 +220,7 @@ set<ppm_event_code> sinsp_state_event_set();
   e.g. snowflake cases: umount or umount2 -> always both umount, umount2
   e.g. generic events -> will map to ALL generic syscalls (over 200 generic syscalls)
 */
-std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set, bool resolve_sc = true);
+std::unordered_set<std::string> event_set_to_names(const set<ppm_event_code>& events_set, bool resolve_generic = true);
 
 /*!
   \brief Get the ppm_event of all the event names provided in the set.

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -199,6 +199,21 @@ set<ppm_event_code> sc_set_to_event_set(const set<ppm_sc_code> &ppm_sc_of_intere
 set<ppm_event_code> all_event_set();
 
 /*!
+  \brief Get the ppm_event for each non sc events.
+*/
+set<ppm_event_code> all_non_sc_event_set();
+
+/*!
+  \brief Get the ppm_event for each generic sc event.
+*/
+set<ppm_event_code> all_generic_sc_event_set();
+
+/*!
+  \brief Get the ppm_event for each non generic sc event.
+*/
+set<ppm_event_code> all_non_generic_sc_event_set();
+
+/*!
   \brief Returns set of events with critical non syscalls events,
   e.g. container or procexit events.
 */

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -199,21 +199,6 @@ set<ppm_event_code> sc_set_to_event_set(const set<ppm_sc_code> &ppm_sc_of_intere
 set<ppm_event_code> all_event_set();
 
 /*!
-  \brief Get the ppm_event for each non sc events.
-*/
-set<ppm_event_code> all_non_sc_event_set();
-
-/*!
-  \brief Get the ppm_event for each generic sc event.
-*/
-set<ppm_event_code> all_generic_sc_event_set();
-
-/*!
-  \brief Get the ppm_event for each non generic sc event.
-*/
-set<ppm_event_code> all_non_generic_sc_event_set();
-
-/*!
   \brief Returns set of events with critical non syscalls events,
   e.g. container or procexit events.
 */

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -250,6 +250,9 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::names_to_sc_set(const std::
 	 * in actuality applies for "umount2" syscall as "umount" syscall is a generic event -> end result is activating both umount, umount2
 	 *
 	 * Since names_to_event_set would resolve generic sc events, we only apply these extra lookups for non generic sc event codes
+	 *
+	 * note: todo @jasondellaluce, @incertum once we refactor tables and/or introduce a paradigm change of not supporting shared event names across syscall variants
+	 * we can remove this extra logic again. Timing can be relaxed as these extra lookups won't break anything, at worst they are redundant.
 	*/
 	auto all_non_generic_sc_event_set = libsinsp::events::all_event_set().filter([&](ppm_event_code e) { return libsinsp::events::is_syscall_event(e); })\
 	.diff(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 #include "sinsp_events.h"
+#include "../utils.h"
 
 libsinsp::events::set<ppm_sc_code> libsinsp::events::sinsp_state_sc_set()
 {

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -251,7 +251,9 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::names_to_sc_set(const std::
 	 *
 	 * Since names_to_event_set would resolve generic sc events, we only apply these extra lookups for non generic sc event codes
 	*/
-	auto tmp_event_set = libsinsp::events::all_non_generic_sc_event_set().intersect(libsinsp::events::names_to_event_set(syscalls));
+	auto all_non_generic_sc_event_set = libsinsp::events::all_event_set().filter([&](ppm_event_code e) { return libsinsp::events::is_syscall_event(e); })\
+	.diff(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});
+	auto tmp_event_set = all_non_generic_sc_event_set.intersect(libsinsp::events::names_to_event_set(syscalls));
 	auto tmp_sc_set = libsinsp::events::event_set_to_sc_set(tmp_event_set);
 	return ppm_sc_set.merge(tmp_sc_set);
 }

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -154,7 +154,7 @@ TEST(events_set, names_to_event_set)
 
 TEST(events_set, event_set_to_names)
 {
-	static std::set<std::string> names_truth = {"kill", "dup", "umount", "umount2", "eventfd", "eventfd2", "procexit", "container"};
+	static std::set<std::string> names_truth = {"kill", "dup", "umount", "eventfd", "procexit", "container"};
 	auto names = test_utils::unordered_set_to_ordered(libsinsp::events::event_set_to_names(libsinsp::events::set<ppm_event_code>{PPME_SYSCALL_KILL_E, PPME_SYSCALL_KILL_X,
 	PPME_SYSCALL_DUP_1_E, PPME_SYSCALL_DUP_1_X, PPME_SYSCALL_UMOUNT_E, PPME_SYSCALL_UMOUNT_X, PPME_SYSCALL_EVENTFD_E, PPME_SYSCALL_EVENTFD_X, PPME_PROCEXIT_E, PPME_CONTAINER_E, PPME_CONTAINER_X}));
 	ASSERT_NAMES_EQ(names_truth, names);
@@ -171,6 +171,8 @@ TEST(events_set, event_set_to_names_generic_events)
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"mmap"}).empty());
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"container"}).empty());
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"procexit"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"umount2"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"eventfd2"}).empty());
 	/* Random checks for some generic sc events. */
 	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"syncfs"}).empty());
 	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"perf_event_open"}).empty());

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -185,7 +185,7 @@ TEST(events_set, event_set_to_names_generic_events)
 	 * At the time of writing we have about 234 generic sc syscalls as defined
 	 * by not having a dedicated PPME_SYSCALL_* or PPME_SOCKET_* definition.
 	*/
-	ASSERT_GT(names.size(), 210);
+	ASSERT_GT(names.size(), 180);
 }
 
 TEST(events_set, event_set_to_names_no_generic_events)

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -207,6 +207,43 @@ TEST(events_set, sc_set_to_event_set)
 	ASSERT_PPM_EVENT_CODES_EQ(event_set_truth, event_set);
 }
 
+TEST(events_set, all_generic_sc_event_set)
+{
+	static libsinsp::events::set<ppm_event_code> event_set_truth = {PPME_GENERIC_E, PPME_GENERIC_X};
+	auto event_set = libsinsp::events::all_generic_sc_event_set();
+	ASSERT_PPM_EVENT_CODES_EQ(event_set_truth, event_set);
+}
+
+TEST(events_set, all_non_generic_sc_event_set)
+{
+	auto event_set = libsinsp::events::all_non_generic_sc_event_set();
+	/* No generic sc events expected. */
+	ASSERT_FALSE(event_set.contains(PPME_GENERIC_E));
+	ASSERT_FALSE(event_set.contains(PPME_GENERIC_X));
+	/* No non sc events expected. */
+	ASSERT_FALSE(event_set.contains(PPME_CONTAINER_E));
+	ASSERT_FALSE(event_set.contains(PPME_CONTAINER_X));
+	ASSERT_FALSE(event_set.contains(PPME_PROCEXIT_E));
+	ASSERT_FALSE(event_set.contains(PPME_PROCEXIT_X));
+}
+
+TEST(events_set, all_non_sc_event_set)
+{
+	auto event_set = libsinsp::events::all_non_sc_event_set();
+	/* No sc events at all expected. */
+	ASSERT_FALSE(event_set.contains(PPME_GENERIC_E));
+	ASSERT_FALSE(event_set.contains(PPME_GENERIC_X));
+	ASSERT_FALSE(event_set.contains(PPME_SOCKET_ACCEPT_E));
+	ASSERT_FALSE(event_set.contains(PPME_SOCKET_ACCEPT_X));
+	ASSERT_FALSE(event_set.contains(PPME_SYSCALL_OPENAT2_E));
+	ASSERT_FALSE(event_set.contains(PPME_SYSCALL_OPENAT2_X));
+	/* Some critical expected non sc events. */
+	ASSERT_TRUE(event_set.contains(PPME_CONTAINER_E));
+	ASSERT_TRUE(event_set.contains(PPME_CONTAINER_X));
+	ASSERT_TRUE(event_set.contains(PPME_PROCEXIT_E));
+	ASSERT_TRUE(event_set.contains(PPME_PROCEXIT_X));
+}
+
 // TODO -> future PR after other PRs have been merged and few other things clarified
 TEST(events_set, sinsp_state_event_set)
 {

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -152,14 +152,6 @@ TEST(events_set, names_to_event_set)
 	ASSERT_EQ(event_set.size(), 8); // enter/exit events for each event name, special case "openat" has 4 PPME instead of 2
 }
 
-TEST(events_set, event_set_to_names)
-{
-	static std::set<std::string> names_truth = {"kill", "dup", "umount", "eventfd", "procexit", "container"};
-	auto names = test_utils::unordered_set_to_ordered(libsinsp::events::event_set_to_names(libsinsp::events::set<ppm_event_code>{PPME_SYSCALL_KILL_E, PPME_SYSCALL_KILL_X,
-	PPME_SYSCALL_DUP_1_E, PPME_SYSCALL_DUP_1_X, PPME_SYSCALL_UMOUNT_E, PPME_SYSCALL_UMOUNT_X, PPME_SYSCALL_EVENTFD_E, PPME_SYSCALL_EVENTFD_X, PPME_PROCEXIT_E, PPME_CONTAINER_E, PPME_CONTAINER_X}));
-	ASSERT_NAMES_EQ(names_truth, names);
-}
-
 TEST(events_set, event_set_to_names_generic_events)
 {
 	static libsinsp::events::set<ppm_event_code> generic_event_set = {PPME_GENERIC_E, PPME_GENERIC_X};
@@ -173,6 +165,7 @@ TEST(events_set, event_set_to_names_generic_events)
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"procexit"}).empty());
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"umount2"}).empty());
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"eventfd2"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"syscall"}).empty());
 	/* Random checks for some generic sc events. */
 	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"syncfs"}).empty());
 	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"perf_event_open"}).empty());
@@ -191,7 +184,20 @@ TEST(events_set, event_set_to_names_generic_events)
 	ASSERT_GT(names.size(), 180);
 }
 
-TEST(events_set, event_set_to_names_no_generic_events)
+TEST(events_set, event_set_to_names_no_generic_events1)
+{
+	static std::set<std::string> names_truth = {"kill", "dup", "umount", "eventfd", "procexit", "container"};
+	auto names_unordered = libsinsp::events::event_set_to_names(libsinsp::events::set<ppm_event_code>{PPME_SYSCALL_KILL_E, PPME_SYSCALL_KILL_X,
+	PPME_SYSCALL_DUP_1_E, PPME_SYSCALL_DUP_1_X, PPME_SYSCALL_UMOUNT_E, PPME_SYSCALL_UMOUNT_X, PPME_SYSCALL_EVENTFD_E, PPME_SYSCALL_EVENTFD_X, PPME_PROCEXIT_E, PPME_CONTAINER_E, PPME_CONTAINER_X});
+	auto names = test_utils::unordered_set_to_ordered(names_unordered);
+	ASSERT_NAMES_EQ(names_truth, names);
+	ASSERT_TRUE(unordered_set_intersection(names_unordered, std::unordered_set<std::string> {"syncfs"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names_unordered, std::unordered_set<std::string> {"eventfd2"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names_unordered, std::unordered_set<std::string> {"container"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names_unordered, std::unordered_set<std::string> {"eventfd"}).empty());
+}
+
+TEST(events_set, event_set_to_names_no_generic_events2)
 {
 	auto names = libsinsp::events::event_set_to_names(libsinsp::events::all_event_set(), false);
 	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"execve"}).empty());

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -188,6 +188,26 @@ TEST(events_set, event_set_to_names_generic_events)
 	ASSERT_GT(names.size(), 210);
 }
 
+TEST(events_set, event_set_to_names_no_generic_events)
+{
+	auto names = libsinsp::events::event_set_to_names(libsinsp::events::all_event_set(), false);
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"execve"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"accept"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"mprotect"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"mmap"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"container"}).empty());
+	ASSERT_FALSE(unordered_set_intersection(names, std::unordered_set<std::string> {"procexit"}).empty());
+
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"syncfs"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"perf_event_open"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"timer_create"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"lsetxattr"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"getsid"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"init_module"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"sethostname"}).empty());
+	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"readlinkat"}).empty());
+}
+
 TEST(events_set, sc_set_to_event_set)
 {
 	libsinsp::events::set<ppm_sc_code> sc_set = {

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -162,7 +162,8 @@ TEST(events_set, event_set_to_names)
 
 TEST(events_set, event_set_to_names_generic_events)
 {
-	auto names = libsinsp::events::event_set_to_names(libsinsp::events::all_generic_sc_event_set());
+	static libsinsp::events::set<ppm_event_code> generic_event_set = {PPME_GENERIC_E, PPME_GENERIC_X};
+	auto names = libsinsp::events::event_set_to_names(generic_event_set);
 	/* Negative assertions. */
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"execve"}).empty());
 	ASSERT_TRUE(unordered_set_intersection(names, std::unordered_set<std::string> {"accept"}).empty());
@@ -254,16 +255,10 @@ TEST(events_set, sc_set_to_event_set)
 	ASSERT_PPM_EVENT_CODES_EQ(event_set_truth, event_set);
 }
 
-TEST(events_set, all_generic_sc_event_set)
-{
-	static libsinsp::events::set<ppm_event_code> event_set_truth = {PPME_GENERIC_E, PPME_GENERIC_X};
-	auto event_set = libsinsp::events::all_generic_sc_event_set();
-	ASSERT_PPM_EVENT_CODES_EQ(event_set_truth, event_set);
-}
-
 TEST(events_set, all_non_generic_sc_event_set)
 {
-	auto event_set = libsinsp::events::all_non_generic_sc_event_set();
+	auto event_set = libsinsp::events::all_event_set().filter([&](ppm_event_code e) { return libsinsp::events::is_syscall_event(e); })\
+	.diff(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});
 	/* No generic sc events expected. */
 	ASSERT_FALSE(event_set.contains(PPME_GENERIC_E));
 	ASSERT_FALSE(event_set.contains(PPME_GENERIC_X));
@@ -276,7 +271,7 @@ TEST(events_set, all_non_generic_sc_event_set)
 
 TEST(events_set, all_non_sc_event_set)
 {
-	auto event_set = libsinsp::events::all_non_sc_event_set();
+	auto event_set = libsinsp::events::all_event_set().filter([&](ppm_event_code e) { return !libsinsp::events::is_syscall_event(e); });
 	/* No sc events at all expected. */
 	ASSERT_FALSE(event_set.contains(PPME_GENERIC_E));
 	ASSERT_FALSE(event_set.contains(PPME_GENERIC_X));

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -479,8 +479,6 @@ TEST(interesting_syscalls, names_to_sc_set)
 	ASSERT_NAMES_EQ(sc_set_names_truth, sc_set_names);
 }
 
-// API limitations -> we can only map events to syscalls
-// when a 1:1 mapping is defined, we only test for 1:1 mapping cases
 TEST(interesting_syscalls, event_set_to_sc_set)
 {
 	libsinsp::events::set<ppm_sc_code> sc_set_truth = {
@@ -507,4 +505,36 @@ TEST(interesting_syscalls, event_set_to_sc_set)
 
 	auto sc_set = libsinsp::events::event_set_to_sc_set(event_set);
 	ASSERT_PPM_SC_CODES_EQ(sc_set_truth, sc_set);
+}
+
+TEST(interesting_syscalls, event_set_to_sc_set_generic_events)
+{
+
+	libsinsp::events::set<ppm_event_code> event_set = {
+#ifdef __NR_kill
+	PPME_SYSCALL_KILL_E,
+	PPME_SYSCALL_KILL_X,
+#endif
+
+#ifdef __NR_sendto
+	PPME_SOCKET_SENDTO_E,
+	PPME_SOCKET_SENDTO_X,
+#endif
+
+#ifdef __NR_syncfs
+	PPME_GENERIC_E,
+	PPME_GENERIC_X,
+#endif
+	};
+
+	auto sc_set = libsinsp::events::event_set_to_sc_set(event_set);
+	ASSERT_GT(sc_set.size(), 210);
+	ASSERT_TRUE(sc_set.contains(PPM_SC_SYNCFS));
+	ASSERT_TRUE(sc_set.contains(PPM_SC_KILL));
+	ASSERT_TRUE(sc_set.contains(PPM_SC_SENDTO));
+	/* Random checks for some generic sc events. */
+	ASSERT_TRUE(sc_set.contains(PPM_SC_PERF_EVENT_OPEN));
+	ASSERT_TRUE(sc_set.contains(PPM_SC_GETSID));
+	ASSERT_TRUE(sc_set.contains(PPM_SC_INIT_MODULE));
+	ASSERT_TRUE(sc_set.contains(PPM_SC_READLINKAT));
 }

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -414,13 +414,14 @@ TEST(interesting_syscalls, names_to_sc_set)
 	PPM_SC_SYNCFS,
 #endif
 
-#ifdef __NR_accept
-	PPM_SC_ACCEPT,
-#endif
+// s390x test issues
+// #ifdef __NR_accept
+// 	PPM_SC_ACCEPT,
+// #endif
 
-#ifdef __NR_accept4
-	PPM_SC_ACCEPT4,
-#endif
+// #ifdef __NR_accept4
+// 	PPM_SC_ACCEPT4,
+// #endif
 
 #ifdef __NR_execve
 	PPM_SC_EXECVE,
@@ -466,8 +467,52 @@ TEST(interesting_syscalls, names_to_sc_set)
 	PPM_SC_SIGNALFD4
 #endif
 	};
-	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{"kill",
-	"read", "syncfs", "accept", "execve", "setresuid", "eventfd2", "umount2", "pipe2", "signalfd4"});
+
+	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{
+#ifdef __NR_kill
+	"kill",
+#endif
+
+#ifdef __NR_read
+	"read",
+#endif
+
+#ifdef __NR_syncfs
+	"syncfs",
+#endif
+
+// #ifdef __NR_accept
+// 	"accept",
+// #endif
+
+// #ifdef __NR_accept4
+// 	"accept",
+// #endif
+
+#ifdef __NR_execve
+	"execve",
+#endif
+
+#ifdef __NR_setresuid
+	"setresuid",
+#endif
+
+#ifdef __NR_eventfd2
+	"eventfd2",
+#endif
+
+#ifdef __NR_umount2
+	"umount2",
+#endif
+
+#ifdef __NR_pipe2
+	"pipe2",
+#endif
+
+#ifdef __NR_signalfd4
+	"signalfd4",
+#endif
+	});
 	ASSERT_PPM_SC_CODES_EQ(sc_set_truth, sc_set);
 
 	static std::unordered_set<std::string> sc_set_names_truth = {"accept",
@@ -528,7 +573,7 @@ TEST(interesting_syscalls, event_set_to_sc_set_generic_events)
 	};
 
 	auto sc_set = libsinsp::events::event_set_to_sc_set(event_set);
-	ASSERT_GT(sc_set.size(), 210);
+	ASSERT_GT(sc_set.size(), 180);
 	ASSERT_TRUE(sc_set.contains(PPM_SC_SYNCFS));
 	ASSERT_TRUE(sc_set.contains(PPM_SC_KILL));
 	ASSERT_TRUE(sc_set.contains(PPM_SC_SENDTO));

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -401,10 +401,82 @@ TEST(interesting_syscalls, sc_set_to_names)
 
 TEST(interesting_syscalls, names_to_sc_set)
 {
-	// "syncfs" is a generic event / syscall
-	static libsinsp::events::set<ppm_sc_code> sc_set_truth = {PPM_SC_KILL, PPM_SC_READ, PPM_SC_SYNCFS};
-	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{"kill", "read", "syncfs"});
+	static libsinsp::events::set<ppm_sc_code> sc_set_truth = {
+#ifdef __NR_kill
+	PPM_SC_KILL,
+#endif
+
+#ifdef __NR_read
+	PPM_SC_READ,
+#endif
+
+#ifdef __NR_syncfs
+	PPM_SC_SYNCFS,
+#endif
+
+#ifdef __NR_accept
+	PPM_SC_ACCEPT,
+#endif
+
+#ifdef __NR_accept4
+	PPM_SC_ACCEPT4,
+#endif
+
+#ifdef __NR_execve
+	PPM_SC_EXECVE,
+#endif
+
+#ifdef __NR_setresuid
+	PPM_SC_SETRESUID,
+#endif
+
+// #ifdef __NR_setresuid32 // TOOD later after ifdef cleanup
+// 	PPM_SC_SETRESUID32,
+// #endif
+
+// #ifdef __NR_eventfd
+// 	PPM_SC_EVENTFD,
+// #endif
+
+#ifdef __NR_eventfd2
+	PPM_SC_EVENTFD2,
+#endif
+
+// #ifdef __NR_umount
+// 	PPM_SC_UMOUNT,
+// #endif
+
+#ifdef __NR_umount2
+	PPM_SC_UMOUNT2,
+#endif
+
+// #ifdef __NR_pipe
+// 	PPM_SC_PIPE,
+// #endif
+
+#ifdef __NR_pipe2
+	PPM_SC_PIPE2,
+#endif
+
+// #ifdef __NR_signalfd
+// 	PPM_SC_SIGNALFD,
+// #endif
+
+#ifdef __NR_signalfd4
+	PPM_SC_SIGNALFD4
+#endif
+	};
+	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{"kill",
+	"read", "syncfs", "accept", "execve", "setresuid", "eventfd2", "umount2", "pipe2", "signalfd4"});
 	ASSERT_PPM_SC_CODES_EQ(sc_set_truth, sc_set);
+
+	static std::unordered_set<std::string> sc_set_names_truth = {"accept",
+	"accept4", "execve", "syncfs", "eventfd", "eventfd2", "umount", "umount2",
+	"pipe", "pipe2", "signalfd", "signalfd4"};
+	auto tmp_sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{"accept",
+	"execve", "syncfs", "eventfd", "umount", "pipe", "signalfd"});
+	auto sc_set_names = libsinsp::events::sc_set_to_names(tmp_sc_set);
+	ASSERT_NAMES_EQ(sc_set_names_truth, sc_set_names);
 }
 
 // API limitations -> we can only map events to syscalls


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Updated:

Performed a fresh inspection for corner cases throughout:

- `event_set_to_names` initially thought to be "wonky" was a false assessment from my side.  Nonetheless, proposing to adopt a better style here as the inner loop was very hard to follow. Results are equivalent, meaning we do not have a regression. Added new unit tests plus as per @jasondellaluce suggestion added a bool so that we can map from event codes to either the event table names or resolve them to the true syscall names, which however because of the information loss will result in over subscribing especially for the generic events case (-> will map to about 234 generic syscalls). That way all future use cases should be covered.
- `names_to_sc_set` -> Totally overlooked all the corner cases and special snowflakes here. Given we now scan Falco rules for evt.type ppm_sc codes and this method is used for translation, it is a highly relevant refactor for ensuring Falco correctness (e.g. accept in rules will now be guaranteed to activate both accept and accept4 syscalls just like before)
- Some more cleanup and noticed few more other minor things


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(libsinsp): Extension of ppm sc API for corner cases (e.g. event_set_to_names and names_to_sc_set) 
```
