### PR TITLE
fix(driver): fix build on linux-6.2

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2662,11 +2662,15 @@ static int get_tracepoint_handles(void)
 #endif
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+static char *ppm_devnode(const struct device *dev, umode_t *mode)
+#else
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0)
 static char *ppm_devnode(struct device *dev, umode_t *mode)
 #else
 static char *ppm_devnode(struct device *dev, mode_t *mode)
-#endif
+#endif /* LINUX_VERSION_CODE > KERNEL_VERSION(3, 3, 0) */
+#endif /* LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0) */
 {
 	if (mode) {
 		*mode = 0400;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**What this PR does / why we need it**:

Attributes in "struct device*" are const since kernel-6.2, so add a matching prototype for ppm_devnode().

**Which issue(s) this PR fixes**:

Fixes #918 

**Special notes for your reviewer**:

Not sure about the driver version/ABI compatibility. Shouldn't impact ABI but then I don't really know whether a driver built for 6.1 is expected to work on 6.2. :shrug: 


```release-note
fix(driver): fixed kmod build on kernel >= 6.2
```