### PR TITLE
fix(libsinsp): add nullpointer check to struct passwd parsing

### DIFF
--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -256,9 +256,11 @@ scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(
 	auto &usr = map[uid];
 	usr.uid = uid;
 	usr.gid = gid;
-	strlcpy(usr.name, name, MAX_CREDENTIALS_STR_LEN);
-	strlcpy(usr.homedir, home, SCAP_MAX_PATH_SIZE);
-	strlcpy(usr.shell, shell, SCAP_MAX_PATH_SIZE);
+	// In case the node is configured to use NIS,
+	// some struct passwd* fields may be set to NULL.
+	strlcpy(usr.name, (name != nullptr) ? name : "<NA>", MAX_CREDENTIALS_STR_LEN);
+	strlcpy(usr.homedir, (home != nullptr) ? home : "<NA>", SCAP_MAX_PATH_SIZE);
+	strlcpy(usr.shell, (shell != nullptr) ? shell : "<NA>", SCAP_MAX_PATH_SIZE);
 
 	return &usr;
 }
@@ -272,7 +274,7 @@ scap_groupinfo *sinsp_usergroup_manager::groupinfo_map_insert(
 
 	auto &grp = map[gid];
 	grp.gid = gid;
-	strlcpy(grp.name, name, MAX_CREDENTIALS_STR_LEN);
+	strlcpy(grp.name, (name != nullptr) ? name : "<NA>", MAX_CREDENTIALS_STR_LEN);
 
 	return &grp;
 }


### PR DESCRIPTION
When node is using NIS / nss_compat for user management, /etc/passwd entries can refer to NIS groups or users, which causes parser to return null pointers instead of c-strings.

This change includes checks agains those.
In addition, a check is added to /etc/group parsing.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch


**What this PR does / why we need it**:
This ensures that char* members of struct passwd and struct group are not null pointers when being copied.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #926

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
