### PR TITLE
new(modern_bpf): Relax required kernel version for modern bpf

### DIFF
--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -146,3 +146,21 @@ int pman_get_required_buffers()
 {
 	return g_state.n_required_buffers;
 }
+
+/*
+ * Probe the kernel for required dependencies, ring buffer maps and tracing
+ * progs needs to be supported.
+ */
+bool pman_check_support()
+{
+	bool res;
+
+	res = libbpf_probe_bpf_map_type(BPF_MAP_TYPE_RINGBUF, NULL) > 0;
+	res = res ?: libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_TRACING, NULL) > 0;
+
+	/* Probe result depends on the success of map creation, no additional
+	 * check required for unprivileged users
+	 */
+
+	return res;
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

/area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently, modern bpf engine supports only kernels newer than 5.8, assuming all the dependencies (BTF and ring buffer maps) are supported on those kernels. This prevents it from supporting older versions, where BTF and ring buffers were back patched.

Make modern bpf engine to check required dependencies explicitly:

* Examine the kernel config to find out if CONFIG_DEBUG_INFO_BTF is present. The implementation is based on similar functionality in bpftool.

* Use libbpf helpers to verify if ring buffer map type is supported.

* Introduce a new parameter for modern probe engine to pass the custom kernel config path if needed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
