### PR TITLE
fix(userspace/libsinsp): properly compute set size

### DIFF
--- a/userspace/libsinsp/events/sinsp_events_set.h
+++ b/userspace/libsinsp/events/sinsp_events_set.h
@@ -156,13 +156,16 @@ public:
 	}
 
 	iterator begin() const { return iterator(m_types.data(), 0, m_max); }
-        iterator end() const { return iterator(m_types.data(), m_max, m_max); }
+	iterator end() const { return iterator(m_types.data(), m_max, m_max); }
 
 	inline void insert(T e)
 	{
 		check_range(e);
+		if (m_types[e] == 0)
+		{
+			m_size++;
+		}
 		m_types[e] = 1;
-		m_size++;
 	}
 
 	template<typename InputIterator>
@@ -177,8 +180,11 @@ public:
 	inline void remove(T e)
 	{
 		check_range(e);
+		if (m_types[e] == 1)
+		{
+			m_size--;
+		}
 		m_types[e] = 0;
-		m_size--;
 	}
 
 	inline bool contains(T e) const
@@ -325,13 +331,13 @@ inline bool operator!=(const libsinsp::events::set<T>& lhs, const libsinsp::even
 template<typename T>
 std::ostream& operator<<(std::ostream& os, const libsinsp::events::set<T>& s)
 {
-    os << "(";
+	os << "(";
 	auto first = true;
 	for (const auto& v : s)
 	{
 		os << (first ? "" : ", ") << v;
-        first = false;
+		first = false;
 	}
-    os << ")";
-    return os;
+	os << ")";
+	return os;
 }

--- a/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/events_set.cpp
@@ -27,6 +27,12 @@ TEST(events_set, check_size)
 	sc_set.insert(PPM_SC_ACCEPT);
 	ASSERT_EQ(sc_set.size(), 1);
 
+	sc_set.insert(PPM_SC_ACCEPT);
+	ASSERT_EQ(sc_set.size(), 1);
+
+	sc_set.remove(PPM_SC_ACCEPT4);
+	ASSERT_EQ(sc_set.size(), 1);
+
 	sc_set.insert(PPM_SC_ACCEPT4);
 	ASSERT_EQ(sc_set.size(), 2);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The `libsinsp::events::set` class computed a wrong size when inserting elements already present in the set, or when removing non-existing elements. Tests have been updated to assert this.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
