### PR TITLE
new(libpman): Improve error logging

### DIFF
--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -156,7 +156,18 @@ bool pman_check_support()
 	bool res;
 
 	res = libbpf_probe_bpf_map_type(BPF_MAP_TYPE_RINGBUF, NULL) > 0;
-	res = res ?: libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_TRACING, NULL) > 0;
+	if (!res)
+	{
+		pman_print_error("ring buffer map type is not supported");
+		return res;
+	}
+
+	res = libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_TRACING, NULL) > 0;
+	if (!res)
+	{
+		pman_print_error("tracing program type is not supported");
+		return res;
+	}
 
 	/* Probe result depends on the success of map creation, no additional
 	 * check required for unprivileged users

--- a/userspace/libpman/src/state.c
+++ b/userspace/libpman/src/state.c
@@ -33,7 +33,23 @@ void pman_print_error(const char* error_message)
 
 	if(errno != 0)
 	{
-		fprintf(stderr, "libpman: %s (errno: %d | message: %s)\n", error_message, errno, strerror(errno));
+		/*
+		 * libbpf uses -ESRCH to indicate that something could not be found,
+		 * e.g. vmlinux or btf id. This will be interpreted via strerror as "No
+		 * such process" (which was the original meaning of the error code),
+		 * and it is extremely confusing. Avoid that by having a special case
+		 * for this error code.
+		 */
+		if (errno == ESRCH)
+		{
+			fprintf(stderr, "libpman: %s (errno: %d | message: %s)\n",
+					error_message, errno, "Object not found");
+		}
+		else
+		{
+			fprintf(stderr, "libpman: %s (errno: %d | message: %s)\n",
+					error_message, errno, strerror(errno));
+		}
 	}
 	else
 	{

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -29,10 +29,6 @@ limitations under the License.
 #include <sys/utsname.h>
 #include "ringbuffer/ringbuffer.h"
 
-#define REQUIRED_MAJOR 5
-#define REQUIRED_MINOR 8
-#define REQUIRED_PATCH 0
-
 /*=============================== UTILS ===============================*/
 
 static void update_single_64bit_syscall_of_interest(int ppm_sc, bool interesting)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

/area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

When logging an error via libpman, it uses strerror to represent the error. libbpf in turn uses -ESRCH for certain scenarios when some objects were not found, e.g. vmlinux or btf id. This makes libpman report "No such process" together with the error message, which is confusing.

Add a special case to handle -ESRCH in error reporting logic.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
