### PR TITLE
new(driver/modern_bpf): Allow excluding tail-called programs

### DIFF
--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(MODERN_BPF_DEBUG_MODE "Enable BPF debug prints" OFF)
+option(MODERN_BPF_EXCLUDE_PROGS "Regex to exclude tail-called programs" "")
 
 ########################
 # Debug mode
@@ -214,6 +215,14 @@ file(GLOB_RECURSE BPF_C_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.bpf.c)
 
 foreach(BPF_C_FILE ${BPF_C_FILES})
     get_filename_component(file_stem ${BPF_C_FILE} NAME_WE)
+
+    if(MODERN_BPF_EXCLUDE_PROGS)
+        if(${file_stem} MATCHES "${MODERN_BPF_EXCLUDE_PROGS}")
+            message(STATUS "Exclude file: ${file_stem}")
+            continue()
+        endif()
+    endif()
+
     set(BPF_O_FILE ${CMAKE_CURRENT_BINARY_DIR}/${file_stem}.bpf.o)
 
 ## TODO: we need to clean this!

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -146,7 +146,13 @@ static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog
 	{
 		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to find BPF program '%s'", bpf_prog_name);
 		pman_print_error((const char*)error_message);
-		goto clean_add_program_to_tail_table;
+
+		/*
+		 * It's not a hard failure, as programs could be excluded from the
+		 * build. There is no need to close the file descriptor yet, so return
+		 * success.
+		 */
+		return 0;
 	}
 
 	bpf_prog_fd = bpf_program__fd(bpf_prog);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Since modern bpf drivers contains a bunch of various tail-called progs, it makes sense to customize their build and linking process, making it more flexible. It could be helpful in a few scenarios:

* Consider a situation when one of those programs found to be faulty. In this case one have no other options except to wait for bugfix, where in theory the problematic bpf prog could be excluded from the driver.

* Another example is when the set of useful syscalls to capture is limited via `g_64bit_interesting_syscalls_table`. In such case the caller is not interested in anything else besides specified syscalls, and excluding not needed progs will reduce the overall bpf probe size.

Introduce possibility to exclude tail-called programs from the build if the name is matching specified regex, e.g.:

    -DMODERN_BPF_EXCLUDE_PROGS='^(clone3|io_uring_setup)$'

In this way affected tail-called programs will not get build and linked into the main bpf probe. Subsequent attempts to load them and put into the tail-call map will not find those progs by name, but not it's not considered a hard failure. In case if the corresponding syscalls behind excluded bpf progs are still captured, a generic "stub" program will be used instead.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
