### PR TITLE
new(libsinsp/libscap): introduce SCAP_MODE_TEST

### DIFF
--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -113,7 +113,7 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 
 const struct scap_vtable scap_test_input_engine = {
 	.name = TEST_INPUT_ENGINE,
-	.mode = SCAP_MODE_LIVE,
+	.mode = SCAP_MODE_TEST,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -61,6 +61,11 @@ extern "C"
 		 * Do not read system call data. Events come from the configured input plugin.
 		 */
 		SCAP_MODE_PLUGIN,
+		/*!
+		 * Read system call and event data from the test event generator.
+		 * Do not attempt to query the underlying system.
+		 */
+		SCAP_MODE_TEST,
 	} scap_mode_t;
 
 	/*!

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -322,7 +322,7 @@ void sinsp_container_manager::replace_container(const sinsp_container_info::ptr_
 
 void sinsp_container_manager::notify_new_container(const sinsp_container_info& container_info, sinsp_threadinfo *tinfo)
 {
-	if (!m_inspector->m_inited || m_inspector->is_capture())
+	if (!m_inspector->m_inited || m_inspector->is_offline())
 	{
 		// This is either:
 		// * being called from a threadinfo->resolve_container

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -443,7 +443,7 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo_t* fdi, uint64_t fd)
 {
 #ifdef HAS_CAPTURE
 #ifndef _WIN32
-	if(m_inspector->is_capture())
+	if(m_inspector->is_offline())
 	{
 		return;
 	}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -697,7 +697,7 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 
 void sinsp::open_test_input(scap_test_input_data* data)
 {
-	scap_open_args oargs = factory_open_args(TEST_INPUT_ENGINE, SCAP_MODE_LIVE);
+	scap_open_args oargs = factory_open_args(TEST_INPUT_ENGINE, SCAP_MODE_TEST);
 	struct scap_test_input_engine_params params;
 	params.test_input_data = data;
 	oargs.engine_params = &params;
@@ -1032,7 +1032,7 @@ void sinsp::import_user_list()
 void sinsp::refresh_ifaddr_list()
 {
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
-	if(!is_capture())
+	if(!is_offline())
 	{
 		ASSERT(m_network_interfaces);
 		scap_refresh_iflist(m_h);
@@ -1334,7 +1334,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			remove_thread(remove_tid, false);
 		}
 
-		if(!is_capture())
+		if(!is_offline())
 		{
 			m_thread_manager->remove_inactive_threads();
 		}
@@ -1397,7 +1397,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	//
 	// Run the periodic connection, thread and users/groups table cleanup
 	//
-	if(!is_capture())
+	if(!is_offline())
 	{
 		m_container_manager.remove_inactive_containers();
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -570,11 +570,19 @@ public:
 	sinsp_evt::param_fmt get_buffer_format();
 
 	/*!
-	  \brief Returns true if the current capture is offline
+	  \brief Returns true if the current capture is happening from a scap file
 	*/
 	inline bool is_capture()
 	{
 		return m_mode == SCAP_MODE_CAPTURE;
+	}
+
+	/*!
+	  \brief Returns true if the current capture is offline
+	*/
+	inline bool is_offline()
+	{
+		return m_mode == SCAP_MODE_CAPTURE || m_mode == SCAP_MODE_TEST;
 	}
 
 	/*!

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -447,7 +447,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	set_cgroups(pi->cgroups, pi->cgroups_len);
 	m_root = pi->root;
 	ASSERT(m_inspector);
-	m_inspector->m_container_manager.resolve_container(this, !m_inspector->is_capture());
+	m_inspector->m_container_manager.resolve_container(this, !m_inspector->is_offline());
 
 	set_group(pi->gid);
 	set_user(pi->uid);

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -145,7 +145,7 @@ void sinsp_usergroup_manager::subscribe_container_mgr()
 {
 	// Do nothing if subscribe_container_mgr() is called in capture mode, because
 	// events shall not be sent as they will be loaded from capture file.
-	if (m_import_users && !m_inspector->is_capture())
+	if (m_import_users && !m_inspector->is_offline())
 	{
 		// Emplace container manager listener to delete container users upon container deletion
 		m_inspector->m_container_manager.subscribe_on_remove_container([&](const sinsp_container_info &cinfo) -> void {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap

/area libsinsp

/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Integration tests for libsinsp have been running in "live" mode, which means that the inspector will think it's running on the system that is collecting syscalls. That is not completely accurate and one thing that has been bothering me is the fact that sinsp may decide from time to time to query the underlying system to collect users, missing proc data, containers or anything else. This is in general pretty bad for tests because it introduces variables that depend on the state of the system that is running them and may lead to flakiness.

My solution for that is to introduce a new scap mode `SCAP_MODE_TEST` which operates in a similar way to a scap file, but without requiring header blocks or other scap file specific structure.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp/libscap): introduce SCAP_MODE_TEST
```
