### PR TITLE
fix(userspace/libsinsp): correct init of m_flags

### DIFF
--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -620,6 +620,7 @@ void chisel_table::print_raw(vector<chisel_sample_row>* sample_data, uint64_t ti
 			}
 
 			m_printer->set_val(m_types->at(j + 1), 
+				EPF_NONE,
 				it->m_values[j].m_val,
 				it->m_values[j].m_len,
 				it->m_values[j].m_cnt,
@@ -679,6 +680,7 @@ void chisel_table::print_json(vector<chisel_sample_row>* sample_data, uint64_t t
 			}
 
 			m_printer->set_val(m_types->at(j + 1), 
+				EPF_NONE,
 				row.m_values[j].m_val,
 				row.m_values[j].m_len,
 				row.m_values[j].m_cnt,
@@ -742,6 +744,7 @@ void chisel_table::filter_sample()
 				type == PT_UID || type == PT_GID)
 			{
 				m_printer->set_val(type, 
+					EPF_NONE,
 					it.m_values[j].m_val, 
 					it.m_values[j].m_len,
 					it.m_values[j].m_cnt,
@@ -789,6 +792,7 @@ chisel_table_field* chisel_table::search_in_sample(string text)
 				type == PT_UID || type == PT_GID)
 			{
 				m_printer->set_val(type,
+					EPF_NONE,
 					it->m_values[j].m_val,
 					it->m_values[j].m_len,
 					it->m_values[j].m_cnt,
@@ -1549,6 +1553,7 @@ pair<filtercheck_field_info*, string> chisel_table::get_row_key_name_and_val(uin
 		ASSERT(res.first != NULL);
 
 		m_printer->set_val(types->at(0),
+			EPF_NONE,
 			m_sample_data->at(rownum).m_key.m_val, 
 			m_sample_data->at(rownum).m_key.m_len,
 			m_sample_data->at(rownum).m_key.m_cnt,

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4040,6 +4040,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				}
 
 				m_converter->set_val(PT_RELTIME,
+					EPF_NONE,
 					(uint8_t*)&evt->m_tinfo->m_latency,
 					8,
 					0,
@@ -5779,6 +5780,7 @@ uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			else
 			{
 				m_converter->set_val(PT_RELTIME,
+					EPF_NONE,
 					(uint8_t*)&m_s64val,
 					8,
 					0,

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -846,12 +846,12 @@ public:
 
 	sinsp_filter_check_reference();
 	sinsp_filter_check* allocate_new();
-	inline void set_val(ppm_param_type type, uint8_t* val,
-		int32_t len, uint32_t cnt,
-		ppm_print_format print_format)
+	inline void set_val(ppm_param_type type, filtercheck_field_flags flags,
+		uint8_t* val, int32_t len,
+		uint32_t cnt, ppm_print_format print_format)
 	{
 		m_finfo.m_type = type;
-		m_finfo.m_flags = EPF_NONE;
+		m_finfo.m_flags = flags;
 		m_val = val;
 		m_len = len;
 		m_cnt = cnt;

--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -851,6 +851,7 @@ public:
 		ppm_print_format print_format)
 	{
 		m_finfo.m_type = type;
+		m_finfo.m_flags = EPF_NONE;
 		m_val = val;
 		m_len = len;
 		m_cnt = cnt;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Previously the `m_flags` variable was uninitialized resulting in unpredictable behaviour in various functions (e.g. `tostring`).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
