### PR TITLE
fix(userspace/libsinsp): removed wrong assertions

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3076,12 +3076,12 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
     parinfo = evt->get_param(1);
     if(parinfo->m_len == 0)
     {
-        //
-        // No address, there's nothing we can really do with this.
-        // This happens for socket types that we don't support, so we have the assertion
-        // to make sure that this is not a type of socket that we support.
-        //
-        ASSERT(!(evt->m_fdinfo->is_unix_socket() || evt->m_fdinfo->is_ipv4_socket()));
+		//
+		// Address can be NULL:
+		// sk is a TCP fastopen active socket and
+		// TCP_FASTOPEN_CONNECT sockopt is set and
+		// we already have a valid cookie for this socket.
+		//
         return;
     }
 
@@ -3273,11 +3273,11 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 	if(parinfo->m_len == 0)
 	{
 		//
-		// No address, there's nothing we can really do with this.
-		// This happens for socket types that we don't support, so we have the assertion
-		// to make sure that this is not a type of socket that we support.
+		// Address can be NULL:
+		// sk is a TCP fastopen active socket and
+		// TCP_FASTOPEN_CONNECT sockopt is set and
+		// we already have a valid cookie for this socket.
 		//
-		ASSERT(!(evt->m_fdinfo->is_unix_socket() || evt->m_fdinfo->is_ipv4_socket()));
 		return;
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This removes old assertions that handled not supported socket types: this assumed that the `addr` values was NULL only in that case. In reality in the `connect` syscall `addr` can be NULL [https://elixir.bootlin.com/linux/latest/source/net/ipv4/af_inet.c#L622](https://elixir.bootlin.com/linux/latest/source/net/ipv4/af_inet.c#L622):
"uaddr can be NULL and addr_len can be 0 if: sk is a TCP fastopen active socket and TCP_FASTOPEN_CONNECT sockopt is set and we already have a valid cookie for this socket."

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
