### PR TITLE
fix(libsinsp,libscap): remove legacy references to is_windows, fix uninitialized var

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1725,8 +1725,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					(char*)cwd.c_str(),
 					(uint32_t)cwd.length(),
 					payload,
-					payload_len,
-					m_inspector->m_is_windows))
+					payload_len))
 				{
 					m_resolved_paramstr_storage[0] = 0;
 				}

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -265,8 +265,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 				sdir.c_str(),
 				(uint32_t)sdir.length(),
 				name,
-				namelen,
-				m_inspector->m_is_windows);
+				namelen);
 
 			if(fd_nameraw)
 			{
@@ -3797,7 +3796,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 			parinfo = evt->get_param(3);
 
 			sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, "", 0,
-				parinfo->m_val, parinfo->m_len, m_inspector->m_is_windows);
+				parinfo->m_val, parinfo->m_len);
 
 			m_strstorage = fullname;
 			RETURN_EXTRACT_STRING(m_strstorage);
@@ -3910,7 +3909,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 
 	char fullname[SCAP_MAX_PATH_SIZE];
 	sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, sdir.c_str(),
-		(uint32_t)sdir.length(), path, pathlen, m_inspector->m_is_windows);
+		(uint32_t)sdir.length(), path, pathlen);
 
 	m_strstorage = fullname;
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1404,11 +1404,6 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 
 	if(!(tinfo->m_flags & PPM_CL_CLONE_THREAD))
 	{
-		if(m_inspector->m_is_windows)
-		{
-			tinfo->m_flags |= PPM_CL_IS_MAIN_THREAD;
-		}
-
 		//
 		// Copy the fd list
 		// XXX this is a gross oversimplification that will need to be fixed.
@@ -1443,22 +1438,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		//
 		// Not a thread, copy cwd
 		//
-		if(m_inspector->m_is_windows)
-		{
-			if(ptinfo->m_tid == 0 && ptinfo->m_pid == 0)
-			{
-				parinfo = evt->get_param(6);
-				tinfo->m_cwd = parinfo->m_val;
-			}
-			else
-			{
-				tinfo->m_cwd = ptinfo->get_cwd();
-			}
-		}
-		else
-		{
-			tinfo->m_cwd = ptinfo->get_cwd();
-		}
+		tinfo->m_cwd = ptinfo->get_cwd();
 	}
 	//if((tinfo->m_flags & (PPM_CL_CLONE_FILES)))
 	//{
@@ -1981,8 +1961,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 												evt->m_tinfo->m_cwd.c_str(),
 												(uint32_t)evt->m_tinfo->m_cwd.size(),
 												parinfo->m_val,
-												(uint32_t)parinfo->m_len,
-												m_inspector->m_is_windows);
+												(uint32_t)parinfo->m_len);
 			}
 		}
 		else if(enter_evt->get_type() == PPME_SYSCALL_EXECVEAT_E)
@@ -2050,8 +2029,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 								"\0", 
 								0,
 								sdir.c_str(), 
-								(uint32_t)sdir.length(), 
-								m_inspector->m_is_windows);
+								(uint32_t)sdir.length());
 
 			}
 			/* (2)/(1) If it is relative or absolute we craft the `fullpath` as usual:
@@ -2063,8 +2041,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 											sdir.c_str(), 
 											(uint32_t)sdir.length(),
 											pathname, 
-											namelen, 
-											m_inspector->m_is_windows);
+											namelen);
 			}
 		}
 		evt->m_tinfo->m_exepath = fullpath;
@@ -2646,7 +2623,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	char fullpath[SCAP_MAX_PATH_SIZE];
 
 	sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE, sdir.c_str(), (uint32_t)sdir.length(),
-		name, namelen, m_inspector->m_is_windows);
+		name, namelen);
 
 	if(fd >= 0)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -320,13 +320,6 @@ void sinsp::init()
 	}
 
 	//
-	// XXX
-	// This will need to be integrated in the machine info
-	//
-	scap_os_platform platform = scap_get_os_platform(m_h);
-	m_is_windows = (platform == SCAP_PFORM_WINDOWS_I386 || platform == SCAP_PFORM_WINDOWS_X64);
-
-	//
 	// Attach the protocol decoders
 	//
 #ifndef HAS_ANALYZER

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1051,7 +1051,6 @@ private:
 	// <m_input_fd>". Otherwise, reading from m_input_filename.
 	int m_input_fd;
 	std::string m_input_filename;
-	bool m_is_windows;
 	bool m_isdebug_enabled;
 	bool m_isfatfile_enabled;
 	bool m_isinternal_events_enabled;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -910,8 +910,7 @@ void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 			(char*)tinfo->m_cwd.c_str(),
 			(uint32_t)tinfo->m_cwd.size(),
 			cwd,
-			cwdlen,
-			m_inspector->m_is_windows);
+			cwdlen);
 
 		tinfo->m_cwd = tpath;
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -754,8 +754,7 @@ bool sinsp_utils::concatenate_paths(char* target,
 									const char* path1,
 									uint32_t len1,
 									const char* path2,
-									uint32_t len2,
-									bool windows_paths)
+									uint32_t len2)
 {
 	if(targetlen < (len1 + len2 + 1))
 	{
@@ -763,35 +762,17 @@ bool sinsp_utils::concatenate_paths(char* target,
 		return false;
 	}
 
-	if(windows_paths)
+	if(len2 != 0 && path2[0] != '/')
 	{
-		if(len2 != 0 && path2[0] != '\\' && path2[1] != ':')
-		{
-			memcpy(target, path1, len1);
-			copy_and_sanitize_path(target + len1, target, path2, '\\');
-			return true;
-		}
-		else
-		{
-			target[0] = 0;
-			copy_and_sanitize_path(target, target, path2, '\\');
-			return false;
-		}
+		memcpy(target, path1, len1);
+		copy_and_sanitize_path(target + len1, target, path2, '/');
+		return true;
 	}
 	else
 	{
-		if(len2 != 0 && path2[0] != '/')
-		{
-			memcpy(target, path1, len1);
-			copy_and_sanitize_path(target + len1, target, path2, '/');
-			return true;
-		}
-		else
-		{
-			target[0] = 0;
-			copy_and_sanitize_path(target, target, path2, '/');
-			return false;
-		}
+		target[0] = 0;
+		copy_and_sanitize_path(target, target, path2, '/');
+		return false;
 	}
 }
 

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -94,9 +94,8 @@ public:
 	// If path2 is relative, the concatenation happens and the result is true.
 	// If path2 is absolute, the concatenation does not happen, target contains path2 and the result is false.
 	// Assumes that path1 is well formed.
-	// Supports both unix and windows paths. Use the windows_paths argument to specify which one you want.
 	//
-	static bool concatenate_paths(char* target, uint32_t targetlen, const char* path1, uint32_t len1, const char* path2, uint32_t len2, bool windows_paths);
+	static bool concatenate_paths(char* target, uint32_t targetlen, const char* path1, uint32_t len1, const char* path2, uint32_t len2);
 
 	//
 	// Determines if an IPv6 address is IPv4-mapped


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp
/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

This PR removes legacy references to `is_windows`, including the `m_is_windows` flag in sinsp. This does not affect ability to read scap files / use plugins / compile libs and clients on Windows.

The reason why this fixes a bug is that `m_is_windows` is initialized here: https://github.com/falcosecurity/libs/blob/96a913f4761a9187ab6ab1a9e897afd062d1345a/userspace/libsinsp/sinsp.cpp#L327

However, the variable is accessed in the callbacks that are called from sinsp while the chosen scap engine performs the proc scan, in the function `sinsp_threadinfo::set_cwd()`, called by `sinsp_threadinfo::init()` during the callback `sinsp::on_new_entry_from_proc()`:

https://github.com/falcosecurity/libs/blob/96a913f4761a9187ab6ab1a9e897afd062d1345a/userspace/libsinsp/threadinfo.cpp#L914

At that point, `sinsp::init()` has not yet been called, leading to reads from uninitialized memory. One option would be to move the initialization of this field above in the `sinsp::open_common` call, the other to remove it entirely. I chose the latter since it is not actually used meaningfully anymore.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp,libscap): remove legacy references to is_windows, fix uninitialized m_is_windows
```
