### PR TITLE
Run e2e tests with modern probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,31 +305,25 @@ jobs:
   run-e2e-tests-amd64:
     name: run-e2e-tests-amd64
     strategy:
+      fail-fast: false
       matrix:
         name: [system_deps, bundled_deps, system_deps_w_chisels]
         include:
           - name: system_deps
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False
+            cmake_opts: -DUSE_BUNDLED_DEPS=False
           - name: bundled_deps
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=True
+            cmake_opts: -DUSE_BUNDLED_DEPS=True
           - name: system_deps_w_chisels
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False -DWITH_CHISEL=True
-    runs-on: ubuntu-20.04
-    container:
-      image: debian:buster
-      volumes:
-        - /tmp/report/:/tmp/report/
-        - /usr/src:/usr/src
-        - /lib/modules:/lib/modules
-        - /usr/include/bpf:/usr/include/bpf
-        - /dev:/dev
+            cmake_opts: -DUSE_BUNDLED_DEPS=False -DWITH_CHISEL=True
+    runs-on: ubuntu-22.04
     steps:
       - name: Install deps ⛓️
         run: |
-          apt update && apt install -y --no-install-recommends \
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
             ca-certificates \
             cmake \
             build-essential \
+            clang-14 llvm-14 \
             git \
             clang \
             llvm \
@@ -341,6 +335,8 @@ jobs:
             wget \
             libb64-dev \
             libc-ares-dev \
+            libbpf-dev \
+            libcap-dev \
             libcurl4-openssl-dev \
             libssl-dev \
             libtbb-dev \
@@ -351,18 +347,10 @@ jobs:
             libgtest-dev \
             libprotobuf-dev \
             liblua5.1-dev \
-            curl \
-            gnupg \
-            lsb-release
-
-          # install docker-ce-cli, required for e2e tests
-          mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-            $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-          apt-get update
-          apt-get install -y docker-ce-cli
+            "linux-headers-$(uname -r)"
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
+          sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
+          sudo update-alternatives --install /usr/bin/llc llc /usr/bin/llc-14 90
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
@@ -371,7 +359,7 @@ jobs:
 
       - name: Install deps ⛓️
         run: |
-          .github/install-deps.sh
+          sudo .github/install-deps.sh
 
       - name: Git safe directory
         run: |
@@ -379,10 +367,16 @@ jobs:
 
       - name: Build and test 🏗️🧪
         run: |
-          mkdir -p build
-          cd build && cmake ${{ matrix.cmake_opts }} ../
-          KERNELDIR=/lib/modules/$(uname -r)/build make -j4
-          make  e2e-tests-container
+          mkdir -p build && cd build
+          cmake -DBUILD_BPF=ON \
+                -DBUILD_LIBSCAP_MODERN_BPF=ON \
+                -DBUILD_LIBSCAP_GVISOR=OFF \
+                ${{ matrix.cmake_opts }} \
+                -DUSE_BUNDLED_LIBBPF=ON \
+                ..
+          make -j$(nproc) sinsp-example driver bpf
+          sudo make e2e-install-deps
+          sudo ../test/e2e/scripts/run_tests.sh
 
       - name: Archive test reports
         uses: actions/upload-artifact@v3
@@ -390,4 +384,4 @@ jobs:
         with:
           name: ${{ matrix.name }}_report
           path: |
-            /tmp/report/
+            ${{ github.workspace }}/build/report/

--- a/test/e2e/tests/commons/sinspqa/__init__.py
+++ b/test/e2e/tests/commons/sinspqa/__init__.py
@@ -14,3 +14,11 @@ else:
     LOGS_PATH = tempfile.mkdtemp()
 
 SINSP_LOG_PATH = os.path.join(LOGS_PATH, 'sinsp.log')
+
+
+kernel = os.uname().release.split('.')
+kernel_major = int(kernel[0])
+kernel_minor = int(kernel[1])
+
+BTF_IS_AVAILABLE = kernel_major > 5 or (
+    kernel_major == 5 and kernel_minor >= 8)

--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -11,7 +11,7 @@ from queue import Queue, Empty
 from threading import Thread
 from typing import IO, AnyStr
 
-from sinspqa import is_containerized, LOGS_PATH
+from sinspqa import is_containerized, LOGS_PATH, BTF_IS_AVAILABLE
 
 SINSP_TAG = os.environ.get('SINSP_TAG', 'latest')
 
@@ -320,14 +320,6 @@ def process_spec(path: str, args: list, env: dict) -> dict:
     }
 
 
-def btf_is_available() -> bool:
-    kernel = os.uname().release.split('.')
-    kernel_major = int(kernel[0])
-    kernel_minor = int(kernel[1])
-
-    return kernel_major > 5 or (kernel_major == 5 and kernel_minor >= 8)
-
-
 def generate_specs(image: str = 'sinsp-example:latest',
                    path: str = os.environ.get('SINSP_EXAMPLE_PATH', ''),
                    args: list = []) -> list:
@@ -355,7 +347,7 @@ def generate_specs(image: str = 'sinsp-example:latest',
     if is_containerized():
         specs.append(container_spec(image, args, kernel_module_env))
         specs.append(container_spec(image, bpf_args, bpf_env))
-        if btf_is_available():
+        if BTF_IS_AVAILABLE:
             specs.append(container_spec(image, modern_bpf_args, {}))
     else:
         args.extend(['-j', '-a'])
@@ -364,7 +356,7 @@ def generate_specs(image: str = 'sinsp-example:latest',
 
         specs.append(process_spec(path, args, kernel_module_env))
         specs.append(process_spec(path, bpf_args, bpf_env))
-        if btf_is_available():
+        if BTF_IS_AVAILABLE:
             specs.append(process_spec(path, modern_bpf_args, {}))
 
     return specs

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -1,5 +1,5 @@
 import pytest
-from sinspqa import sinsp, event_generator
+from sinspqa import sinsp, event_generator, BTF_IS_AVAILABLE
 from sinspqa.sinsp import assert_events, SinspField
 from sinspqa.docker import get_container_id
 
@@ -19,7 +19,9 @@ ids = [
 ]
 
 # modern probe doesn't support EXE_WRITABLE flag yet
-sinsp_examples[2] = pytest.param(sinsp_examples[2], marks=pytest.mark.xfail)
+if BTF_IS_AVAILABLE:
+    sinsp_examples[2] = pytest.param(
+        sinsp_examples[2], marks=pytest.mark.xfail)
 
 
 @pytest.mark.parametrize('sinsp', sinsp_examples, indirect=True, ids=ids)

--- a/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
+++ b/test/e2e/tests/test_event_generator/test_db_program_spawned_process.py
@@ -18,6 +18,9 @@ ids = [
     sinsp.generate_id(sinsp_example) for sinsp_example in sinsp_examples
 ]
 
+# modern probe doesn't support EXE_WRITABLE flag yet
+sinsp_examples[2] = pytest.param(sinsp_examples[2], marks=pytest.mark.xfail)
+
 
 @pytest.mark.parametrize('sinsp', sinsp_examples, indirect=True, ids=ids)
 @pytest.mark.parametrize("run_containers", containers, indirect=True)

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -16,6 +16,9 @@ ids = [
     sinsp.generate_id(sinsp_example) for sinsp_example in sinsp_examples
 ]
 
+# modern probe doesn't support EXE_WRITABLE flag yet
+sinsp_examples[2] = pytest.param(sinsp_examples[2], marks=pytest.mark.xfail)
+
 
 @pytest.mark.parametrize('sinsp', sinsp_examples, indirect=True, ids=ids)
 @pytest.mark.parametrize("run_containers", containers, indirect=True)

--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -21,6 +21,10 @@ sinsp_examples = [
 ]
 ids = [sinsp.generate_id(sinsp_example) for sinsp_example in sinsp_examples]
 
+# For some reason, the modern probe gives a longer proc.exe than the legacy
+# drivers, needs further investigation.
+sinsp_examples[2] = pytest.param(sinsp_examples[2], marks=pytest.mark.xfail)
+
 
 def expected_events(origin: dict, destination: dict) -> list:
     return [

--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -1,5 +1,5 @@
 import pytest
-from sinspqa import sinsp
+from sinspqa import sinsp, BTF_IS_AVAILABLE
 from sinspqa.sinsp import assert_events
 from sinspqa.docker import get_container_id, get_network_data
 
@@ -23,7 +23,9 @@ ids = [sinsp.generate_id(sinsp_example) for sinsp_example in sinsp_examples]
 
 # For some reason, the modern probe gives a longer proc.exe than the legacy
 # drivers, needs further investigation.
-sinsp_examples[2] = pytest.param(sinsp_examples[2], marks=pytest.mark.xfail)
+if BTF_IS_AVAILABLE:
+    sinsp_examples[2] = pytest.param(
+        sinsp_examples[2], marks=pytest.mark.xfail)
 
 
 def expected_events(origin: dict, destination: dict) -> list:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area CI

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

With the modern BPF probe quickly reaching a production ready state, I think it's time we start running e2e tests with it. This PR achieves this by adding a new set of `sinsp-example` binaries to be run using this new driver to the tests. A small check was added to prevent the tests from being run on systems that are not supported by the driver.

There are currently 3 tests that are failing:
- 2 of them are due to the `exe_writable` flag not being supported yet on the modern probe.
- 1 test is failing because the test expects `proc.exe` to be `nginx: master proces`, but the modern probe sets it to `nginx: master process nginx -g daemon off;`. This is not a major problem IMO, but some extra investigation is needed to understand why this happens before changing the test to pass.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I couldn't get `sinsp-example` to compile with the system libbpf in CI, so I set `-DUSE_BUNDLED_LIBBPF=ON` when compiling the tests.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
