### PR TITLE
fix(libsinsp,test): remove undefined behavior in test event generation

### DIFF
--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -32,7 +32,7 @@ TEST_F(sinsp_with_test_input, file_open)
 	// since adding and reading events happens on a single thread they can be interleaved.
 	// tests may need to change if that will not be the case anymore
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", PPM_O_RDWR, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/the_file", PPM_O_RDWR, 0, 5, 123);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t) 3, "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t) 123);
 
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
@@ -47,26 +47,33 @@ TEST_F(sinsp_with_test_input, dup_dup2_dup3)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 
+	int64_t fd = 3, res = 1, oldfd = 3, newfd = 123;
+
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/test", PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY, 0666);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, "/tmp/test", PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY, 0666, 0xCA02, 123);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, fd, "/tmp/test", PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY, 0666, 0xCA02, (uint64_t) 123);
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_E, 1, 3);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_X, 1, 1);
-	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
-	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "1");
-
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP2_E, 1, 3);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP2_X, 3, 123, 1, 123);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_E, 1, fd);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_X, 1, newfd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "123");
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP3_E, 1, 3);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP3_X, 4, 123, 1, 123, 0);
+	res = 123;
+	oldfd = 1;
+	newfd = 123;
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP2_E, 1, fd);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP2_X, 3, res, oldfd, newfd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "123");
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_1_E, 1, 3);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_1_X, 2, 1, 3);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP3_E, 1, fd);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP3_X, 4, res, oldfd, newfd, 0);
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
+	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "123");
+
+	res = 1;
+	oldfd = 3;
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_1_E, 1, fd);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_DUP_1_X, 2, res, oldfd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "1");
 }
@@ -78,14 +85,18 @@ TEST_F(sinsp_with_test_input, open_by_handle_at)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 
+	int64_t fd = 4, mountfd = 5;
+
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, "/tmp/the_file.txt");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, fd, mountfd, PPM_O_RDWR, "/tmp/the_file.txt");
 
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file.txt");
 	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/tmp/the_file.txt");
 
+	fd = 6;
+	mountfd = 7;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 6, 7, PPM_O_RDWR, "<NA>");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, fd, mountfd, PPM_O_RDWR, "<NA>");
 
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "<NA>");
 }
@@ -108,13 +119,15 @@ TEST_F(sinsp_with_test_input, path_too_long)
 	long_path_ss << std::string(1000, 'C');
 
 	std::string long_path = long_path_ss.str();
+	int64_t fd = 3, mountfd = 5;
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, long_path.c_str(), PPM_O_RDWR, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, 3, long_path.c_str(), PPM_O_RDWR, 0, 5, 123);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, fd, long_path.c_str(), PPM_O_RDWR, 0, 5, (uint64_t) 123);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/PATH_TOO_LONG");
 
+	fd = 4;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, long_path.c_str());
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, fd, mountfd, PPM_O_RDWR, long_path.c_str());
 
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/PATH_TOO_LONG");
 	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/PATH_TOO_LONG");
@@ -127,57 +140,66 @@ TEST_F(sinsp_with_test_input, creates_fd_generic)
 
 	open_inspector();
 	sinsp_evt* evt = NULL;
+	int64_t fd = 5;
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_E, 3, -1, NULL, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_X, 1, 5);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_E, 3, (uint64_t) -1, NULL, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "signalfd");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "s");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "5");
 
+	fd = 6;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_E, 2, 0, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_X, 1, 6);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "timerfd");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "t");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "6");
 
+	fd = 7;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_E, 1, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, 7);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "inotify");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "i");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "7");
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_E, 1, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_X, 1, 8);
+	fd = 8;
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_E, 1, (int64_t) 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "bpf");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "b");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "8");
 
+	fd = 9;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_USERFAULTFD_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_USERFAULTFD_X, 2, 9, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_USERFAULTFD_X, 2, fd, 0);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "userfaultfd");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "u");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "9");
 
+	fd = 10;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_IO_URING_SETUP_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_IO_URING_SETUP_X, 8, 10, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_IO_URING_SETUP_X, 8, fd, 0, 0, 0, 0, 0, 0, 0);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "io_uring");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "r");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "10");
 
+	fd = 11;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE_E, 1, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE_X, 1, 11);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "eventpoll");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "l");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "11");
 
+	fd = 12;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE1_E, 1, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE1_X, 1, 12);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE1_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "eventpoll");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "l");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "12");
 
+	int64_t fd1 = 3, fd2 = 4;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIPE_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIPE_X, 4, 0, 3, 4, 81976492);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIPE_X, 4, 0, fd1, fd2, (uint64_t) 81976492);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "pipe");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "p");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "4");
@@ -190,8 +212,9 @@ TEST_F(sinsp_with_test_input, umount)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 
+	int64_t res = 0;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_UMOUNT_1_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_UMOUNT_1_X, 2, 0, "/target_name");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_UMOUNT_1_X, 2, res, "/target_name");
 	ASSERT_EQ(get_field_as_string(evt, "evt.type"), "umount");
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "file");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.res"), "0");

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -32,12 +32,13 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
+	int64_t test_errno = 0;
 
 	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF`.
 	 * A `NULL` `PT_CHARBUF` param is always converted to `<NA>`.
 	 */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, NULL);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, NULL);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "<NA>");
 
 	// this, and the following similar checks, verify that the internal state is set as we need right now.
@@ -56,10 +57,12 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	ASSERT_EQ(param->m_len, 5);
 	ASSERT_STREQ(param->m_val, "<NA>");
 
+	int64_t dirfd = 0;
+
 	/* `PPME_SYSCALL_EXECVEAT_E` is a simple event that uses a `PT_FSRELPATH`
 	 * A `NULL` `PT_FSRELPATH` param is always converted to `<NA>`.
 	 */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, 0, NULL, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, NULL, 0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.pathname"), "<NA>");
 
 	param = evt->get_param(1);
@@ -76,11 +79,13 @@ TEST_F(sinsp_with_test_input, param_charbuf_len_1)
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
 
+	int64_t test_errno = 0;
+
 	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF`.
 	 * An empty `PT_CHARBUF` param ("") is not converted to `<NA>` since the length is 1.
 	 */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, "");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "");
 
 	param = evt->get_param(1);
@@ -100,8 +105,10 @@ TEST_F(sinsp_with_test_input, charbuf_NULL_param)
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
 
+	int64_t test_errno = 0;
+
 	/* `PPME_SYSCALL_CHDIR_X` is a simple event that uses a `PT_CHARBUF` */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, 0, "(NULL)");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "(NULL)");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "<NA>");
 
 	param = evt->get_param(1);
@@ -118,11 +125,13 @@ TEST_F(sinsp_with_test_input, bytebuf_empty_param)
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
 
+	int64_t test_errno = 0;
+
 	/* `PPME_SYSCALL_PWRITE_X` is a simple event that uses a `PT_BYTEBUF` */
 	struct scap_const_sized_buffer bytebuf_param;
 	bytebuf_param.buf = NULL;
 	bytebuf_param.size = 0;
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PWRITE_X, 2, 0, bytebuf_param);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PWRITE_X, 2, test_errno, bytebuf_param);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.data"), "NULL"); // "NULL" is the string representation output of the empty buffer
 
 	param = evt->get_param(1);
@@ -138,11 +147,13 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
 
+	int64_t fd = 0;
+
 	/* `PPME_SOCKET_CONNECT_E` is a simple event that uses a `PT_SOCKADDR` */
 	struct scap_const_sized_buffer sockaddr_param;
 	sockaddr_param.buf = NULL;
 	sockaddr_param.size = 0;
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, 0, sockaddr_param);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, fd, sockaddr_param);
 	param = evt->get_param(1);
 	ASSERT_EQ(param->m_len, 0);
 
@@ -150,7 +161,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	struct scap_const_sized_buffer socktuple_param;
 	socktuple_param.buf = NULL;
 	socktuple_param.size = 0;
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 2, 0, socktuple_param);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 2, fd, socktuple_param);
 	param = evt->get_param(1);
 	ASSERT_EQ(param->m_len, 0);
 
@@ -158,7 +169,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	struct scap_const_sized_buffer fdlist_param;
 	fdlist_param.buf = NULL;
 	fdlist_param.size = 0;
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_POLL_X, 2, 0, fdlist_param);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_POLL_X, 2, fd, fdlist_param);
 	param = evt->get_param(1);
 	ASSERT_EQ(param->m_len, 0);
 }
@@ -172,16 +183,20 @@ TEST_F(sinsp_with_test_input, filename_toctou)
 	sinsp_evt *evt;
 	open_inspector();
 
+	int64_t fd = 1, dirfd = 3;
+
 	add_event(increasing_ts(), 3, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", 0, 0);
-	evt = add_event_advance_ts(increasing_ts(), 3, PPME_SYSCALL_OPEN_X, 6, 1, "/tmp/some_other_file", 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 3, PPME_SYSCALL_OPEN_X, 6, fd, "/tmp/some_other_file", 0, 0, 0, (uint64_t) 0);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
 
-	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, 3, "/tmp/the_file", 0, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, 2, 2, "/tmp/some_other_file", 0, 0, 0, 0);
+	fd = 2;
+	add_event(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, dirfd, "/tmp/the_file", 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, fd, dirfd, "/tmp/some_other_file", 0, 0, 0, (uint64_t) 0);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
 
+	fd = 4;
 	add_event(increasing_ts(), 2, PPME_SYSCALL_CREAT_E, 2, "/tmp/the_file", 0);
-	evt = add_event_advance_ts(increasing_ts(), 2, PPME_SYSCALL_CREAT_X, 5, 4, "/tmp/some_other_file", 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 2, PPME_SYSCALL_CREAT_X, 5, fd, "/tmp/some_other_file", 0, 0, (uint64_t) 0);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
 }
 
@@ -206,7 +221,7 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 		std::string test_context = std::string("openat with filename ") + test_utils::describe_string(enter_filename);
 
 		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_E, 4, dirfd, enter_filename, 0, 0);
-		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, new_fd, dirfd, expected_string, 0, 0, 0, 0);
+		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_2_X, 7, new_fd, dirfd, expected_string, 0, 0, 0, (uint64_t) 0);
 
 		ASSERT_NE(evt->get_thread_info(), nullptr) << test_context;
 		ASSERT_NE(evt->get_thread_info()->get_fd(new_fd), nullptr) << test_context;
@@ -242,7 +257,7 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 		std::string test_context = std::string("open with filename ") + test_utils::describe_string(enter_filename);
 
 		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, NULL, 0, 0);
-		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, new_fd, expected_string, 0, 0, 0, 0);
+		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, new_fd, expected_string, 0, 0, 0, (uint64_t) 0);
 
 		ASSERT_NE(evt->get_thread_info(), nullptr) << test_context;
 		ASSERT_NE(evt->get_thread_info()->get_fd(new_fd), nullptr) << test_context;
@@ -259,7 +274,7 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 		std::string test_context = std::string("creat with filename ") + test_utils::describe_string(enter_filename);
 
 		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 3, NULL, 0);
-		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, 0);
+		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, (uint64_t) 0);
 
 		ASSERT_NE(evt->get_thread_info(), nullptr) << test_context;
 		ASSERT_NE(evt->get_thread_info()->get_fd(new_fd), nullptr) << test_context;
@@ -284,7 +299,7 @@ TEST_F(sinsp_with_test_input, execve_invalid_path_entry)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_E, 1, "<NA>");
 
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, 0, "/bin/test-exe", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "test-exe", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "/bin/test-exe", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "test-exe", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.name"), "test-exe");
 }
@@ -297,19 +312,21 @@ TEST_F(sinsp_with_test_input, event_category)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 
+	int64_t fd = 4, mountfd = 5, test_errno = 0;
+
 	/* Check that `EC_SYSCALL` category is not considered */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, "/tmp/the_file.txt");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, fd, mountfd, PPM_O_RDWR, "/tmp/the_file.txt");
 	ASSERT_EQ(evt->get_category(), EC_FILE);
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "file");
 
 	/* Check that `EC_TRACEPOINT` category is not considered */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PROCEXIT_1_E, 4, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PROCEXIT_1_E, 4, test_errno, test_errno, 0, 0);
 	ASSERT_EQ(evt->get_category(), EC_PROCESS);
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "process");
 
 	/* Check that `EC_METAEVENT` category is not considered */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_NOTIFICATION_E, 2, 0, "data");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_NOTIFICATION_E, 2, NULL, "data");
 	ASSERT_EQ(evt->get_category(), EC_OTHER);
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "other");
 }

--- a/userspace/libsinsp/test/events_proc.ut.cpp
+++ b/userspace/libsinsp/test/events_proc.ut.cpp
@@ -39,7 +39,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag)
 	int64_t dirfd = 3;
 	const char *file_to_run = "/tmp/file_to_run";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, file_to_run, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, file_to_run, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -48,7 +48,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag)
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the file pointed by the `dirfd` since `execveat` is called with
 	 * `AT_EMPTY_PATH` flag.
@@ -79,7 +79,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path)
 	int64_t dirfd = 3;
 	const char *directory = "/tmp/dir";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -88,7 +88,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path)
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the directory pointed by the `dirfd` + the pathname
 	 * specified in the `execveat` enter event.
@@ -121,7 +121,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path)
 	int64_t dirfd = 3;
 	const char *directory = "/tmp/dir";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -130,7 +130,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path)
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be `<NA>`, sinsp should recognize that the `pathname`
 	 * is invalid and should set `<NA>`.
@@ -162,7 +162,7 @@ TEST_F(sinsp_with_test_input, execveat_absolute_path)
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the absolute file path that we passed in the
 	 * `execveat` enter event.
@@ -190,7 +190,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag_s390)
 	int64_t dirfd = 3;
 	const char *file_to_run = "/tmp/s390x/file_to_run";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, file_to_run, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, file_to_run, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -198,7 +198,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag_s390)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", PPM_EXVAT_AT_EMPTY_PATH);
 
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the file pointed by the `dirfd` since `execveat` is called with
 	 * `AT_EMPTY_PATH` flag.
@@ -226,7 +226,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path_s390)
 	int64_t dirfd = 3;
 	const char *directory = "/tmp/s390x/dir";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -234,7 +234,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path_s390)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "file", 0);
 
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the directory pointed by the `dirfd` + the pathname
 	 * specified in the `execveat` enter event.
@@ -264,7 +264,7 @@ TEST_F(sinsp_with_test_input, execveat_absolute_path_s390)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, invalid_dirfd, "/tmp/s390/file", 0);
 
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the absolute file path that we passed in the
 	 * `execveat` enter event.
@@ -292,7 +292,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path_s390)
 	int64_t dirfd = 3;
 	const char *directory = "/tmp/s390/dir";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, directory, 0, 0, 0, (uint64_t) 0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
 	 * event in the thread storage, in this way the exit event can use it.
@@ -300,7 +300,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path_s390)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", 0);
 
 	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, 0, "<NA>", empty_bytebuf, 1, 1, 1, "<NA>", 0, 0, 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, 0, 0, 0, 0, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be `<NA>`, sinsp should recognize that the `pathname`
 	 * is invalid and should set `<NA>`.
@@ -318,7 +318,8 @@ TEST_F(sinsp_with_test_input, spawn_process)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 
-	uint64_t parent_pid = 1, parent_tid = 1, child_pid = 20, child_tid = 20;
+	uint64_t parent_pid = 1, parent_tid = 1, child_pid = 20, child_tid = 20, null_pid = 0;
+	uint64_t fdlimit = 1024, pgft_maj = 0, pgft_min = 1;
 	scap_const_sized_buffer empty_bytebuf = {.buf = nullptr, .size = 0};
 
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
@@ -328,10 +329,10 @@ TEST_F(sinsp_with_test_input, spawn_process)
 	std::string envv = test_utils::to_null_delimited(env);
 	std::vector<std::string> args = {"--help"};
 	std::string argsv = test_utils::to_null_delimited(args);
-	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", 1024, 0, 68633, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
-	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", 1024, 0, 1, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_pid, child_tid);
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, null_pid, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_pid, child_tid);
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
-	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
+	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
 
 	// check that the cwd is inherited from the parent (default process has /root/)
 	ASSERT_EQ(get_field_as_string(evt, "proc.cwd"), "/root/");
@@ -366,6 +367,7 @@ TEST_F(sinsp_with_test_input, spawn_process)
 	ASSERT_EQ(get_field_as_string(evt, "proc.ppid"), "1");
 	ASSERT_EQ(get_field_as_string(evt, "proc.apid[1]"), "1");
 	ASSERT_FALSE(field_exists(evt, "proc.apid[2]"));
+	ASSERT_EQ(get_field_as_string(evt, "proc.fdlimit"), "1024");
 }
 
 // check parsing of container events (possibly from capture files)
@@ -378,6 +380,7 @@ TEST_F(sinsp_with_test_input, spawn_process_container)
 	sinsp_evt* evt = NULL;
 
 	uint64_t parent_pid = 1, parent_tid = 1, child_pid = 20, child_tid = 20;
+	uint64_t fdlimit = 1024, pgft_maj = 0, pgft_min = 1;
 	scap_const_sized_buffer empty_bytebuf = {.buf = nullptr, .size = 0};
 
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
@@ -389,11 +392,11 @@ TEST_F(sinsp_with_test_input, spawn_process_container)
 	std::string argsv = test_utils::to_null_delimited(args);
 
 	std::string container = R"({"container":{"Mounts":[],"cpu_period":100000,"cpu_quota":0,"cpu_shares":1024,"cpuset_cpu_count":0,"created_time":1663770709,"env":[],"full_id":"f9c7a020960a15738167a77594bff1f7ac5f5bfdb6646ecbc9b17c7ed7ec5066","id":"f9c7a020960a","image":"ubuntu","imagedigest":"sha256:a0d9e826ab87bd665cfc640598a871b748b4b70a01a4f3d174d4fb02adad07a9","imageid":"597ce1600cf4ac5f449b66e75e840657bb53864434d6bd82f00b172544c32ee2","imagerepo":"ubuntu","imagetag":"latest","ip":"172.17.0.2","is_pod_sandbox":false,"labels":null,"lookup_state":1,"memory_limit":0,"metadata_deadline":0,"name":"eloquent_mirzakhani","port_mappings":[],"privileged":false,"swap_limit":0,"type":0}})";
-	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", 1024, 0, 68633, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
-	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", 1024, 0, 1, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, 1, 1);
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, 1, 1);
 	add_event_advance_ts(increasing_ts(), -1, PPME_CONTAINER_JSON_2_E, 1, container.c_str());
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
-	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
+	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
 
 	// check that the container has been correctly detected and the short ID is correct
 	ASSERT_EQ(get_field_as_string(evt, "container.id"), "f9c7a020960a");
@@ -417,12 +420,12 @@ TEST_F(sinsp_with_test_input, chdir_fchdir)
 	ASSERT_EQ(get_field_as_string(evt, "proc.cwd"), "/tmp/target-directory/");
 
 	// generate a fd associated with the directory we wish to change to
-	int64_t dirfd = 3;
+	int64_t dirfd = 3, test_errno = 0;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/target-directory-fd", 0, 0);
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, "/tmp/target-directory-fd", 0, 0, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, dirfd, "/tmp/target-directory-fd", 0, 0, 0, (uint64_t) 0);
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_FCHDIR_E, 1, dirfd);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_FCHDIR_X, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_FCHDIR_X, 1, test_errno);
 	ASSERT_EQ(get_field_as_string(evt, "proc.cwd"), "/tmp/target-directory-fd/");
 }
 
@@ -441,6 +444,7 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 	uint64_t child_vpid = 2, child_vtid = 2;
 	uint64_t child2_pid = 0x0000000100000100, child2_tid = 0x0000000100000100;
 	uint64_t child2_vpid = 3, child2_vtid = 3;
+	uint64_t fdlimit = 1024, pgft_maj = 0, pgft_min = 1;
 	scap_const_sized_buffer empty_bytebuf = {.buf = nullptr, .size = 0};
 
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
@@ -450,8 +454,8 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 	std::string envv = test_utils::to_null_delimited(env);
 	std::vector<std::string> args = {"--help"};
 	std::string argsv = test_utils::to_null_delimited(args);
-	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", 1024, 0, 68633, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
-	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", 1024, 0, 1, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 3764, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
 	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, parent_pid, 1000, 1);
 
@@ -462,10 +466,10 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 
 	// spawn a child process to verify ppid/apid
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_E, 0);
-	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, child2_tid, "/bin/test-exe", empty_bytebuf, child_pid, child_tid, child_tid, "", 1024, 0, 68633, 12088, 7208, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
-	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "/bin/test-exe", empty_bytebuf, child2_pid, child2_tid, child_tid, "", 1024, 0, 1, 12088, 3764, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child2_vpid, child2_vtid);
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, child2_tid, "/bin/test-exe", empty_bytebuf, child_pid, child_tid, child_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_vpid, child_vtid);
+	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "/bin/test-exe", empty_bytebuf, child2_pid, child2_tid, child_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 3764, 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child2_vpid, child2_vtid);
 	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe2");
-	evt = add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe2", scap_const_sized_buffer{argsv.data(), argsv.size()}, child2_tid, child2_pid, child_tid, "", 1024, 0, 28, 29612, 4, 0, "test-exe2", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, child_pid, 1000, 1);
+	evt = add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_X, 20, 0, "/bin/test-exe2", scap_const_sized_buffer{argsv.data(), argsv.size()}, child2_tid, child2_pid, child_tid, "", fdlimit, pgft_maj, pgft_min, 29612, 4, 0, "test-exe2", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, 34818, child_pid, 1000, 1);
 
 	ASSERT_FALSE(field_exists(evt, "proc.pid"));
 	ASSERT_FALSE(field_exists(evt, "thread.tid"));

--- a/userspace/libsinsp/test/events_user.ut.cpp
+++ b/userspace/libsinsp/test/events_user.ut.cpp
@@ -28,13 +28,15 @@ TEST_F(sinsp_with_test_input, setuid_setgid)
 	open_inspector();
 	sinsp_evt* evt;
 
+	int64_t errno_success = 0, errno_failure = -1;
+
 	// set a new user ID
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_E, 1, 500);
 	// check that upon entry we have the default user ID
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
 
 	// check that the user ID is updated if the call is successful
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_X, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_X, 1, errno_success);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "500");
 
 	// set a new group ID
@@ -43,7 +45,7 @@ TEST_F(sinsp_with_test_input, setuid_setgid)
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "0");
 
 	// check that the group ID is updated if the call is successful
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_X, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_X, 1, errno_success);
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "600");
 
 	// check that the new user ID and group ID are retained
@@ -52,12 +54,12 @@ TEST_F(sinsp_with_test_input, setuid_setgid)
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "600");
 
 	// check that the user ID is not updated after an unsuccessful setuid call
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_X, 1, (int64_t) -1);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_X, 1, errno_failure);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "500");
 
 	// same for group ID
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_E, 1, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_X, 1, (int64_t) -1);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETGID_X, 1, errno_failure);
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "600");
 }
 
@@ -69,6 +71,8 @@ TEST_F(sinsp_with_test_input, setresuid_setresgid)
 	open_inspector();
 	sinsp_evt* evt;
 
+	int64_t errno_success = 0, errno_failure = -1;
+
 	// set a new user ID
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESUID_E, 3, 600, 600, 600);
 	// check that upon entry we have the default user ID
@@ -76,7 +80,7 @@ TEST_F(sinsp_with_test_input, setresuid_setresgid)
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "0");
 
 	// check that the user ID is updated if the call is successful. The expected user is the EUID
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESUID_X, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESUID_X, 1, errno_success);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "600");
 
 	// check that the new user ID is retained
@@ -84,7 +88,7 @@ TEST_F(sinsp_with_test_input, setresuid_setresgid)
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "600");
 
 	// check that the user ID is not updated after an unsuccessful setuid call
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESUID_X, 1, (int64_t) -1);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESUID_X, 1, errno_failure);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "600");
 
 	// set a new group ID
@@ -93,6 +97,6 @@ TEST_F(sinsp_with_test_input, setresuid_setresgid)
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "0");
 
 	// check that the group ID is updated if the call is successful. The expected user is the EGID
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESGID_X, 1, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETRESGID_X, 1, errno_success);
 	ASSERT_EQ(get_field_as_string(evt, "group.gid"), "600");
 }

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -96,7 +96,7 @@ protected:
 	scap_evt* add_event_v(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, va_list args)
 	{
 		struct scap_sized_buffer event_buf = {NULL, 0};
-		size_t event_size;
+		size_t event_size = 0;
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		va_list args2;
 		va_copy(args2, args);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes a fun bug in the libsinsp test suite that is simply an instance of this: https://stackoverflow.com/questions/727663/why-does-this-variadic-function-fail-on-4th-parameter-on-windows-x64 .

Essentially, passing an integer literal to a variadic function and expecting a 64 bit value is undefined behavior, as the integer literal is type `int` and not the correct 64 bit size. We caught this on ARM64 after the 8th parameter due to that specific implementation and parameter passing via registers/stack but could happen anywhere.

The fix is simply to either cast the integer or pass a variable, which is what happens in this PR. When I felt it right I added some descriptive variable names so tests can still be easy to read.

We will need another similar PR everywhere we call the event encoding function (I believe in the gVisor implementation).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Merging this PR unblocks this: https://github.com/falcosecurity/libs/pull/962 .

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
