### PR TITLE
fix(userspace/libsinsp): fixed PT_ENUMFLAGS `get_param_as_{str,json}` impl

### DIFF
--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -32,7 +32,7 @@ def expected_events(origin: dict, destination: dict) -> list:
     return [
         {
             "container.id": origin['id'],
-            "evt.args": "domain=2 type=1 proto=0 ",
+            "evt.args": "domain=2(AF_INET) type=1 proto=0 ",
             "evt.category": "net",
             "evt.type": "socket",
             "fd.name": None,

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1188,7 +1188,24 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 	case PT_ENUMFLAGS16:
 	case PT_ENUMFLAGS32:
 		{
-			uint32_t val = *(uint32_t *)payload & (((uint64_t)1 << payload_len * 8) - 1);
+			uint32_t val = 0;
+			switch(param_info->type)
+			{
+			case PT_FLAGS8:
+			case PT_ENUMFLAGS8:
+				val = *(uint8_t *)payload;
+				break;
+			case PT_FLAGS16:
+			case PT_ENUMFLAGS16:
+				val = *(uint16_t *)payload;
+				break;
+			case PT_FLAGS32:
+			case PT_ENUMFLAGS32:
+				val = *(uint32_t *)payload;
+				break;
+			default:
+				ASSERT(false);
+			}
 			ret["val"] = val;
 			ret["flags"] = Json::arrayValue;
 
@@ -2088,7 +2105,24 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	case PT_ENUMFLAGS16:
 	case PT_ENUMFLAGS32:
 		{
-			uint32_t val = *(uint32_t *)payload & (((uint64_t)1 << payload_len * 8) - 1);
+			uint32_t val = 0;
+			switch(param_info->type)
+			{
+			case PT_FLAGS8:
+			case PT_ENUMFLAGS8:
+				val = *(uint8_t *)payload;
+				break;
+			case PT_FLAGS16:
+			case PT_ENUMFLAGS16:
+				val = *(uint16_t *)payload;
+				break;
+			case PT_FLAGS32:
+			case PT_ENUMFLAGS32:
+				val = *(uint32_t *)payload;
+				break;
+			default:
+				ASSERT(false);
+			}
 			snprintf(&m_paramstr_storage[0],
 				     m_paramstr_storage.size(),
 				     "%" PRIu32, val);

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2129,15 +2129,9 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 						      "%s%s",
 						      separator,
 						      flags->name);
-					if (exact_match)
+					separator = "|";
+					if (!exact_match)
 					{
-						// Multiple flags name match same enum value
-						separator = " ";
-					}
-					else
-					{
-						// It is a bitmask, ok to use bitwise OR
-						separator = "|";
 						if (flags->value == initial_val)
 						{
 							// if we reached initial val, we have finished.

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -355,6 +355,26 @@ TEST_F(sinsp_with_test_input, enumparams)
 	ASSERT_STREQ(val_str, "AF_LOCAL|AF_UNIX");
 }
 
+TEST_F(sinsp_with_test_input, enumparams_fcntl_dupfd)
+{
+	add_default_init_thread();
+
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	sinsp_evt_param* param = NULL;
+
+	/* `PPME_SYSCALL_FCNTL_E` is a simple event that uses a PT_ENUMFLAGS32 (param 2) */
+	uint8_t flag = PPM_FCNTL_F_DUPFD;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_FCNTL_E, 2, 0, flag);
+
+	param = evt->get_param(1);
+	ASSERT_EQ(*(uint8_t *)param->m_val, PPM_FCNTL_F_DUPFD);
+
+	const char *val_str = NULL;
+	evt->get_param_as_str(1, &val_str);
+	ASSERT_STREQ(val_str, "F_DUPFD");
+}
+
 /* Check that bitmask flags are correctly handled
  */
 TEST_F(sinsp_with_test_input, bitmaskparams)

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -365,8 +365,9 @@ TEST_F(sinsp_with_test_input, bitmaskparams)
 	sinsp_evt* evt = NULL;
 	sinsp_evt_param* param = NULL;
 
+	int64_t dirfd = 0;
 	/* `PPME_SYSCALL_OPENAT_E` is a simple event that uses a PT_FLAGS32 (param 3) */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_E, 4, 0, "/tmp/foo", PPM_O_RDONLY|PPM_O_CLOEXEC, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_E, 4, dirfd, "/tmp/foo", PPM_O_RDONLY|PPM_O_CLOEXEC, 0);
 
 	param = evt->get_param(2);
 	ASSERT_EQ(*(uint32_t *)param->m_val, PPM_O_RDONLY|PPM_O_CLOEXEC);

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -352,7 +352,7 @@ TEST_F(sinsp_with_test_input, enumparams)
 	evt->get_param_as_str(0, &val_str);
 	// Since the enum value "1" matches multiple flags values,
 	// we expect a space-separated list of them
-	ASSERT_STREQ(val_str, "AF_LOCAL AF_UNIX");
+	ASSERT_STREQ(val_str, "AF_LOCAL|AF_UNIX");
 }
 
 /* Check that bitmask flags are correctly handled


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

NOPE

**What this PR does / why we need it**:

Since the introduction of PT_ENUMFLAGS types for enum-like flags (#289), `get_param_as_str` impl had a bug.
Indeed we had 2 bugs:
* given that the loop was `while(flags != NULL && flags->name != NULL && flags->value != initial_val)`, we never matched enum flags values (note the `flags->value != initial_val` loop condition)
* some enum flags (namely `socket_families` ones) can have multiple flags that have different names but same value (eg: `PPM_AF_UNIX` and `PPM_AF_LOCAL`)

This PR fixes both issues.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): fixed management of PT_ENUMFLAGS types in `get_param_as_str`.
```
