### PR TITLE
[WIP] Collect correct arguments when `setproctitle` is called

### DIFF
--- a/driver/bpf/ring_helpers.h
+++ b/driver/bpf/ring_helpers.h
@@ -30,6 +30,12 @@ static __always_inline void fixup_evt_len(char *p, unsigned long len)
 	evt_hdr->len = len;
 }
 
+/* Should be used only on a param already pushed */
+static __always_inline u16 get_param_len(char *p, const unsigned int argnum)
+{
+	return *((u16 *)&p[sizeof(struct ppm_evt_hdr)] + (argnum & (PPM_MAX_EVENT_PARAMS - 1)));
+}
+
 static __always_inline void fixup_evt_arg_len(char *p,
 					      unsigned int argnum,
 					      unsigned int arglen)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Some days ago we faced this strange thing in the PR regarding e2e tests (https://github.com/falcosecurity/libs/pull/967#discussion_r1133483599).
The question was, why the modern probe is taking something different respect than the other 2 drivers? the answer is pretty funny.

`nginx` under the hood calls the [`setproctitle`](https://www.commandlinux.com/man-page/man3/setproctitle.3.html) method, what this method does is quite strange it moves the actual args of the process from `mm->arg_start` to `mm->arg_env`, so into the environment variables space, and overwrite the content of `mm->arg_start` with the "process title". In our case the modern probe prints:

```
nginx: master process nginx -g daemon off;
```

this is because it tries to read a string until the first `\0` is faced, in this case since `args` memory and `env` memory are contiguous we are reading both the process title (`nginx: master process`) and the exe+args (`nginx -g daemon off`). The other 2 drivers try to read only the `args` memory and for this reason, we read just the process title `nginx: master process` instead of real `exe` and `args`.

This patch tries to solve this issue in all three drivers but we have some concerns:

* in the old probe this part of the code is probably the most fragile, so I had to rewrite it :( it is still too complex for some kernels like 4.14 but I can simplify it a little bit! Btw this is always the same topic we have here https://github.com/falcosecurity/libs/issues/940, changes like these that touch fillers like `proc_startupdate` are very dangerous from the stability point of view. This is why we were evaluating a partial refactor...
* The actual patch takes inspiration from there https://elixir.bootlin.com/linux/latest/source/mm/util.c#L965 (this is a kernel helper that tries to address the issue of `setproctitle` function). What this function does is check if there is a null terminator at the end of the `args` memory, if no, it considers this area modified by `setproctitle` and checks for the real `args` into the `env` memory. BTW it could happen that for some reason `args` memory misses the final terminator, this would mean that we read the `env` memory even if  `setproctitle` was not called and so we read junk...take a look at the `forkX_father_setproctitle` test in `drivers_tests`

Before proceeding in fixing the verifier losing some days (:laughing:) we would be sure that this is what we want :) WDYT @LucaGuerra @Molter73 @incertum ?


**Which issue(s) this PR fixes**:

Fixes #988 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
