### PR TITLE
chore(ci): properly use `pull_request_target` trigger type for driver api and schema version ci checks

### DIFF
--- a/.github/workflows/driver-api-version.yml
+++ b/.github/workflows/driver-api-version.yml
@@ -1,3 +1,7 @@
+# NOTE: it is UNSAFE to run ANY kind of script when using the pull_request_target trigger!
+# DO NOT TOUCH THIS FILE UNLESS THE TRIGGER IS CHANGED.
+# See warning in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+
 name: Driver API_VERSION checks
 on:
   pull_request_target:

--- a/.github/workflows/driver-api-version.yml
+++ b/.github/workflows/driver-api-version.yml
@@ -1,6 +1,6 @@
 name: Driver API_VERSION checks
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'driver/ppm_fillers.c'
       - 'driver/bpf/fillers.h'

--- a/.github/workflows/driver-schema-version.yml
+++ b/.github/workflows/driver-schema-version.yml
@@ -1,3 +1,7 @@
+# NOTE: it is UNSAFE to run ANY kind of script when using the pull_request_target trigger!
+# DO NOT TOUCH THIS FILE UNLESS THE TRIGGER IS CHANGED.
+# See warning in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+
 name: Driver SCHEMA_VERSION checks
 on:
   pull_request_target:

--- a/.github/workflows/driver-schema-version.yml
+++ b/.github/workflows/driver-schema-version.yml
@@ -1,6 +1,6 @@
 name: Driver SCHEMA_VERSION checks
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'driver/event_table.c'
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The PR switches the newly added driver API and SCHEMA version CI checks to use the `pull_request_target` trigger: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
This trigger is capable of commenting on PRs coming from forks:
> Warning: For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch. To help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)" on the GitHub Security Lab website.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
