### PR TITLE
cleanup(driver): allow some "write-like" syscall to send data also when they fail

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4371,34 +4371,22 @@ FILLER(sys_sendmsg_e, true)
 
 FILLER(sys_sendmsg_x, true)
 {
-	const struct iovec *iov;
-	struct user_msghdr mh;
-	unsigned long iovcnt;
-	unsigned long val;
-
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
 	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
 	CHECK_RES(res);
 
-	/* If the syscall fails we are not able to collect reliable params
-	 * so we return empty ones.
-	 */
-	if(retval < 0)
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	struct user_msghdr mh = {0};
+	unsigned long msghdr_pointer = bpf_syscall_get_argument(data, 1);
+	if (bpf_probe_read_user(&mh, sizeof(mh), (void *)msghdr_pointer))
 	{
-		/* Parameter 2: data (type: PT_BYTEBUF) */
+		/* in case of NULL msghdr we return an empty param */
 		return bpf_push_empty_param(data);
 	}
 
-	/*
-	 * data
-	 */
-	val = bpf_syscall_get_argument(data, 1);
-	if (bpf_probe_read_user(&mh, sizeof(mh), (void *)val))
-		return PPM_FAILURE_INVALID_USER_MEMORY;
-
-	iov = (const struct iovec *)mh.msg_iov;
-	iovcnt = mh.msg_iovlen;
+	const struct iovec *iov = (const struct iovec *)mh.msg_iov;
+	unsigned long  iovcnt = mh.msg_iovlen;
 
 	res = bpf_parse_readv_writev_bufs(data, iov, iovcnt, retval,
 					  PRB_FLAG_PUSH_DATA | PRB_FLAG_IS_WRITE);

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -1096,6 +1096,7 @@ static __always_inline void auxmap__store_iovec_data_param(struct auxiliary_map 
 			       SAFE_ACCESS(total_iovec_size),
 			       (void *)iov_pointer))
 	{
+		/* in case of NULL iovec vector we return an empty param */
 		push__param_len(auxmap->data, &auxmap->lengths_pos, 0);
 		return;
 	}
@@ -1107,6 +1108,9 @@ static __always_inline void auxmap__store_iovec_data_param(struct auxiliary_map 
 	{
 		if(total_size_to_read > len_to_read)
 		{
+			/* If we break here it could be that `payload_pos` overcame the max `len_to_read` for this reason
+			 * we have an enforcement after the for loop.
+			 */
 			total_size_to_read = len_to_read;
 			break;
 		}
@@ -1124,6 +1128,7 @@ static __always_inline void auxmap__store_iovec_data_param(struct auxiliary_map 
 		}
 		total_size_to_read += bytes_read;
 	}
+	/* We need this enforcement to be sure that we don't overcome the max `len_to_read` */
 	auxmap->payload_pos = initial_payload_pos + total_size_to_read;
 	push__param_len(auxmap->data, &auxmap->lengths_pos, total_size_to_read);
 }
@@ -1143,6 +1148,7 @@ static __always_inline void auxmap__store_msghdr_iovec_data_param(struct auxilia
 	struct user_msghdr msghdr = {0};
 	if(bpf_probe_read_user((void *)&msghdr, bpf_core_type_size(struct user_msghdr), (void *)msghdr_pointer))
 	{
+		/* in case of NULL msghdr we return an empty param */
 		push__param_len(auxmap->data, &auxmap->lengths_pos, 0);
 		return;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 The Falco Authors.
+ * Copyright (C) 2023 The Falco Authors.
  *
  * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
  * or GPL2.txt for full copies of the license.
@@ -82,33 +82,24 @@ int BPF_PROG(sendmsg_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	/* Parameter 2: data (type: PT_BYTEBUF) */
-	/* Here we want to read some data sent by the `sendmsg()` syscall.
-	 * If the syscall fails we send an empty parameter.
+	/* Collect parameters at the beginning to manage socketcalls */
+	unsigned long args[2];
+	extract__network_args(args, 2, regs);
+
+	/* In case of failure `bytes_to_read` could be also lower than `snaplen`
+	 * but we will discover it directly into `auxmap__store_iovec_data_param`
+	 * otherwise we need to extract it now and it has a cost. Here we check just
+	 * the return value if the syscall is successful.
 	 */
-	if(ret >= 0)
+	unsigned long bytes_to_read = maps__get_snaplen();
+	if(ret > 0 && bytes_to_read > ret)
 	{
-		/* We read the minimum between `snaplen` and what we really
-		 * have in the buffer.
-		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
-		{
-			bytes_to_read = ret;
-		}
-
-		/* Collect parameters at the beginning to manage socketcalls */
-		unsigned long args[2];
-		extract__network_args(args, 2, regs);
-
-		unsigned long msghdr_pointer = args[1];
-		auxmap__store_msghdr_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
+		bytes_to_read = ret;
 	}
-	else
-	{
-		auxmap__store_empty_param(auxmap);
-	}
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	unsigned long msghdr_pointer = args[1];
+	auxmap__store_msghdr_iovec_data_param(auxmap, msghdr_pointer, bytes_to_read);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -2417,14 +2417,6 @@ int f_sys_send_x(struct event_filler_arguments *args)
 	 * otherwise we need to rely on the syscall parameter provided by the user.
 	 */
 	if (!args->is_socketcall)
-		syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
-#ifndef UDIG
-	else
-		val = args->socketcall_args[1];
-#endif
-	sent_data_pointer = val;
-	
-	if (!args->is_socketcall)
 		syscall_get_arguments_deprecated(current, args->regs, 2, 1, &val);
 #ifndef UDIG
 	else
@@ -2432,8 +2424,15 @@ int f_sys_send_x(struct event_filler_arguments *args)
 #endif
 	bufsize = retval > 0 ? retval : val;
 
+	if (!args->is_socketcall)
+		syscall_get_arguments_deprecated(current, args->regs, 1, 1, &val);
+#ifndef UDIG
+	else
+		val = args->socketcall_args[1];
+#endif
+
 	args->enforce_snaplen = true;
-	res = val_to_ring(args, sent_data_pointer, bufsize, true, 0);
+	res = val_to_ring(args, val, bufsize, true, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);

--- a/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -157,6 +157,127 @@ TEST(SyscallExit, sendmsgX_fail)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
+	struct msghdr send_msg = {0};
+	struct iovec iov[1] = {0};
+	memset(&send_msg, 0, sizeof(send_msg));
+	memset(iov, 0, sizeof(iov));
+	char sent_data_1[DEFAULT_SNAPLEN / 2] = "some-data";
+	iov[0].iov_base = sent_data_1;
+	iov[0].iov_len = sizeof(sent_data_1);
+	send_msg.msg_iov = iov;
+	/* here we pass a wrong `iovlen` to check the behavior */
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	assert_syscall_state(SYSCALL_FAILURE, "sendmsg", syscall(__NR_sendmsg, mock_fd, &send_msg, sendmsg_flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	if(evt_test->is_modern_bpf_engine())
+	{
+		evt_test->assert_event_presence();
+	}
+	else
+	{
+		/* we need to rewrite the logic in old drivers to support this partial collection
+		 * right now we drop the entire event.
+		 */
+		evt_test->assert_event_absence();
+		GTEST_SKIP() << "[SENDMSG_X]: what we receive is correct but we need to reimplement it, see the code" << std::endl;
+	}
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, sent_data_1, DEFAULT_SNAPLEN / 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, sendmsgX_null_iovec)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
+	struct msghdr send_msg = {0};
+	memset(&send_msg, 0, sizeof(send_msg));
+	send_msg.msg_iov = NULL;
+	/* here we pass a wrong `iovlen` to check the behavior */
+	send_msg.msg_iovlen = 3;
+	uint32_t sendmsg_flags = 0;
+
+	assert_syscall_state(SYSCALL_FAILURE, "sendmsg", syscall(__NR_sendmsg, mock_fd, &send_msg, sendmsg_flags));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	if(evt_test->is_modern_bpf_engine())
+	{
+		evt_test->assert_event_presence();
+	}
+	else
+	{
+		/* we need to rewrite the logic in old drivers to support this partial collection
+		 * right now we drop the entire event.
+		 */
+		evt_test->assert_event_absence();
+		GTEST_SKIP() << "[SENDMSG_X]: what we receive is correct but we need to reimplement it, see the code" << std::endl;
+	}
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_empty_param(2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, sendmsgX_null_msghdr)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendmsg, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
 	struct msghdr* send_msg = NULL;
 	uint32_t sendmsg_flags = 0;
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -126,11 +126,58 @@ TEST(SyscallExit, sendtoX_fail)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
+	char sent_data[DEFAULT_SNAPLEN / 2] = "some-data";
+	size_t len = DEFAULT_SNAPLEN / 2;
+	uint32_t sendto_flags = 0;
+	struct sockaddr* dest_addr = NULL;
+	socklen_t addrlen = 0;
+
+	assert_syscall_state(SYSCALL_FAILURE, "sendto", syscall(__NR_sendto, mock_fd, sent_data, len, sendto_flags, dest_addr, addrlen));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, sent_data, DEFAULT_SNAPLEN / 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, sendtoX_empty)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
 	char* sent_data = NULL;
 	size_t len = 0;
 	uint32_t sendto_flags = 0;
 	struct sockaddr* dest_addr = NULL;
 	socklen_t addrlen = 0;
+
 	assert_syscall_state(SYSCALL_FAILURE, "sendto", syscall(__NR_sendto, mock_fd, sent_data, len, sendto_flags, dest_addr, addrlen));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -1464,6 +1464,59 @@ TEST(SyscallExit, socketcall_sendtoX_fail)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
+	char sent_data[DEFAULT_SNAPLEN / 2] = "some-data";
+	size_t len = DEFAULT_SNAPLEN / 2;
+	uint32_t sendto_flags = 0;
+	struct sockaddr *dest_addr = NULL;
+	socklen_t addrlen = 0;
+
+	unsigned long args[6] = {0};
+	args[0] = mock_fd;
+	args[1] = (unsigned long)sent_data;
+	args[2] = len;
+	args[3] = sendto_flags;
+	args[4] = (unsigned long)dest_addr;
+	args[5] = addrlen;
+	assert_syscall_state(SYSCALL_FAILURE, "sendto", syscall(__NR_socketcall, SYS_SENDTO, args));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, sent_data, DEFAULT_SNAPLEN / 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, socketcall_sendtoX_empty)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	int32_t mock_fd = -1;
 	char *sent_data = NULL;
 	size_t len = 0;
 	uint32_t sendto_flags = 0;

--- a/test/drivers/test_suites/syscall_exit_suite/write_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/write_x.cpp
@@ -102,7 +102,7 @@ TEST(SyscallExit, writeX_snaplen)
 	evt_test->assert_num_params_pushed(2);
 }
 
-TEST(SyscallExit, writeXfail)
+TEST(SyscallExit, writeX_fail)
 {
 	auto evt_test = get_syscall_event_test(__NR_write, EXIT_EVENT);
 
@@ -111,11 +111,51 @@ TEST(SyscallExit, writeXfail)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Write data to an invalid fd */
-	const unsigned data_len = 64;
-	char buf[data_len];
-	ssize_t write_bytes = syscall(__NR_write, -1, (void *)buf, data_len);
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "some-data";
+	assert_syscall_state(SYSCALL_FAILURE, "write", syscall(__NR_write, -1, (void *)buf, data_len));
 	int errno_value = -errno;
-	assert_syscall_state(SYSCALL_FAILURE, "write", write_bytes);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(SyscallExit, writeX_empty)
+{
+	auto evt_test = get_syscall_event_test(__NR_write, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const unsigned data_len = 6;
+	char *buf = NULL;
+	assert_syscall_state(SYSCALL_FAILURE, "write", syscall(__NR_write, -1, (void *)buf, data_len));
+	int errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR addresses some of the inconsistencies reported here https://github.com/falcosecurity/libs/issues/942#issuecomment-1463712325. More in detail, now we collect data also when the following syscalls fail:
- [ ] `sendmsg`
- [ ] `wrte`
- [ ] `sendto`

This refactor will end I will close #942 when I will implement the last "write" syscalls `pwrite64`, `writev` ,`pwritev`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
