### PR TITLE
fix(libsinsp): fix `copy_and_sanitize_path` function implementation

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -50,6 +50,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_ppm_codes.ut.cpp
 	user.ut.cpp
 	container_info.ut.cpp
+	sinsp_utils.ut.cpp
 	"${PUBLIC_SINSP_API_SUITE}"
 	"${TABLE_SUITE}"
 )

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -1,0 +1,123 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include "utils.h"
+
+// copy_and_sanitize_path is not exported in utils.h
+void copy_and_sanitize_path(char* target, char* targetbase, const char* path, char separator);
+
+TEST(sinsp_utils_test, copy_and_sanitize_path)
+{
+	char target[SCAP_MAX_PATH_SIZE];
+
+	std::string path = "/dir/term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ(path, std::string(target));
+
+	path = "/dir/term/";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir/../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/term", std::string(target));
+
+	path = "/dir/dir/../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir/dir/../../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/term", std::string(target));
+
+	path = "/dir/term/..";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir", std::string(target));
+
+	path = "/dir/./term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir/././term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir/term/.";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir/.../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/.../term", std::string(target));
+
+	path = "/dir/term/...";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term/...", std::string(target));
+
+	path = "/dir/term/....";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term/....", std::string(target));
+
+	path = "/dir/..../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/..../term", std::string(target));
+
+	path = "/dir/dir../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/dir../term", std::string(target));
+
+	path = "/dir/dir./term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/dir./term", std::string(target));
+
+	path = "/dir/..dir/term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/..dir/term", std::string(target));
+
+	path = "/dir/.dir/term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/.dir/term", std::string(target));
+
+	path = ".dir";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ(".dir", std::string(target));
+
+	path = "./";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+
+	path = "./.";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+
+	path = ".";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+
+	path = "../";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+
+	path = "../..";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+
+	path = "..";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("", std::string(target));
+}

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -120,4 +120,20 @@ TEST(sinsp_utils_test, copy_and_sanitize_path)
 	path = "..";
 	copy_and_sanitize_path(target, target, path.c_str(), '/');
 	EXPECT_EQ("", std::string(target));
+
+	path = "/dir//./term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/term", std::string(target));
+
+	path = "/dir//../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/term", std::string(target));
+
+	path = "/dir//.../term";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/.../term", std::string(target));
+
+	path = "/dir//...";
+	copy_and_sanitize_path(target, target, path.c_str(), '/');
+	EXPECT_EQ("/dir/...", std::string(target));
 }

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -665,56 +665,49 @@ void copy_and_sanitize_path(char* target, char* targetbase, const char* path, ch
 		}
 		else
 		{
-			if(*pc == '.' && *(pc + 1) == '.' && *(pc + 2) == separator)
+			if(*pc == '.')
 			{
 				//
 				// '../', rewind to the previous separator
 				//
-				rewind_to_parent_path(targetbase, &tc, &pc, 3);
-
-			}
-			else if(*pc == '.' && *(pc + 1) == '.')
-			{
+				if(*(pc + 1) == '.' && *(pc + 2) == separator)
+				{
+					rewind_to_parent_path(targetbase, &tc, &pc, 3);
+				}
 				//
 				// '..', with no separator.
 				// This is valid if we are at the end of the string, and in that case we rewind.
-				// Otherwise it shouldn't happen and we leave the string intact
 				//
-				if(*(pc + 2) == 0)
+				else if(*(pc + 1) == '.' && *(pc + 2) == 0)
 				{
 					rewind_to_parent_path(targetbase, &tc, &pc, 2);
 				}
-				else
-				{
-					*tc = '.';
-					*(tc + 1) = '.';
-					pc += 2;
-					tc += 2;
-				}
-			}
-			else if(*pc == '.' && *(pc + 1) == separator)
-			{
 				//
 				// './', just skip it
 				//
-				pc += 2;
-			}
-			else if(*pc == '.')
-			{
+				else if(*(pc + 1) == separator)
+				{
+					pc += 2;
+				}
 				//
 				// '.', with no separator.
 				// This is valid if we are at the end of the string, and in that case we rewind.
-				// Otherwise it shouldn't happen and we leave the string intact
 				//
-				if(*(pc + 1) == 0)
+				else if(*(pc + 1) == 0)
 				{
 					pc++;
 				}
+				//
+				// Otherwise, we leave the string intact up to the next separator or the end of string.
+				//
 				else
 				{
-					*tc = *pc;
-					tc++;
-					pc++;
+					while(*pc != separator && *pc != 0)
+					{
+						*tc = *pc;
+						pc++;
+						tc++;
+					}
 				}
 			}
 			else if(*pc == separator)

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -665,7 +665,10 @@ void copy_and_sanitize_path(char* target, char* targetbase, const char* path, ch
 		}
 		else
 		{
-			if(*pc == '.')
+			//
+			// If path begins with '.' or '.' is the first char after a '/'
+			//
+			if(*pc == '.' && (tc == targetbase || *(tc - 1) == separator))
 			{
 				//
 				// '../', rewind to the previous separator
@@ -698,16 +701,13 @@ void copy_and_sanitize_path(char* target, char* targetbase, const char* path, ch
 					pc++;
 				}
 				//
-				// Otherwise, we leave the string intact up to the next separator or the end of string.
+				// Otherwise, we leave the string intact.
 				//
 				else
 				{
-					while(*pc != separator && *pc != 0)
-					{
-						*tc = *pc;
-						pc++;
-						tc++;
-					}
+					*tc = *pc;
+					pc++;
+					tc++;
 				}
 			}
 			else if(*pc == separator)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR fixes a bug in the implementation of `copy_and_sanitize_path` in libsisnp causing system calls that copy filesystem paths to mishandle paths containing three or more consecutive dots. 

**Which issue(s) this PR fixes**:

Fixes #974

**Special notes for your reviewer**:

Parts of the original function were refactored.

**Does this PR introduce a user-facing change?**:

```release-note
fix: sanitization of paths containing three or more consecutive dots 
```