### PR TITLE
new(scap): Support no_events mode

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1756,6 +1756,11 @@ static int32_t configure(struct scap_engine_handle engine, enum scap_setting set
 
 static int32_t init(scap_t* handle, scap_open_args *oargs)
 {
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	int32_t rc = 0;
 	char bpf_probe_buf[SCAP_MAX_PATH_SIZE] = {0};
 	struct scap_engine_handle engine = handle->m_engine;

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -47,9 +47,21 @@ static SCAP_HANDLE_T *gvisor_alloc_handle(scap_t* main_handle, char *lasterr_ptr
 
 static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
+	int32_t ret;
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path);
+	ret = gv->init(params->gvisor_config_path, params->gvisor_root_path);
+	if(ret != SCAP_SUCCESS)
+	{
+		return ret;
+	}
+
+	if(!oargs->no_events)
+	{
+		return gv->open_socket();
+	}
+
+	return SCAP_SUCCESS;
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -133,6 +133,7 @@ public:
     engine(char *lasterr);
     ~engine();
     int32_t init(std::string config_path, std::string root_path);
+    int32_t open_socket();
     int32_t close();
 
     int32_t start_capture();

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -135,8 +135,6 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		return SCAP_FAILURE;
 	}
 
-	unlink(m_socket_path.c_str());
-	
 	// Check if runsc is installed in the system
 	runsc::result version = runsc::version();
 	if(version.error)
@@ -144,6 +142,13 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		strlcpy(m_lasterr, "Cannot find runsc binary", SCAP_LASTERR_SIZE);
 		return SCAP_FAILURE;
 	}
+
+	return SCAP_SUCCESS;
+}
+
+int32_t engine::open_socket()
+{
+	unlink(m_socket_path.c_str());
 
 	int sock = socket(PF_UNIX, SOCK_SEQPACKET, 0);
 	if(sock == -1)

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -169,7 +169,6 @@ static int32_t scap_kmod_handle_ppm_sc_mask(struct scap_engine_handle engine, ui
 
 int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 {
-	uint32_t j = 0;
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_kmod_engine_params* params  = oargs->engine_params;
 	char filename[SCAP_MAX_PATH_SIZE] = {0};
@@ -178,7 +177,6 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	int32_t rc = 0;
 
 	int mapped_len = 0;
-	uint32_t all_scanned_devs = 0;
 	uint64_t api_version = 0;
 	uint64_t schema_version = 0;
 
@@ -223,7 +221,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	mapped_len = single_buffer_dim * 2;
 
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
-	for(j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
+	for(uint32_t j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
 	{
 		struct scap_device *dev = &devset->m_devs[j];
 

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -169,6 +169,11 @@ static int32_t scap_kmod_handle_ppm_sc_mask(struct scap_engine_handle engine, ui
 
 int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 {
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_kmod_engine_params* params  = oargs->engine_params;
 	char filename[SCAP_MAX_PATH_SIZE] = {0};

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -178,6 +178,11 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_modern_bpf_engine_params* params = oargs->engine_params;
 
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	pman_clear_state();
 
 	/* Some checks to test if we can use the modern BPF probe

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -542,6 +542,11 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 	struct udig_engine *handle = main_handle->m_engine.m_handle;
 	int rc;
 
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	rc = devset_init(&handle->m_dev_set, 1, handle->m_lasterr);
 	if(rc != SCAP_SUCCESS)
 	{

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -64,6 +64,8 @@ struct scap
 
 	// Function which may be called to log a debug event
 	void(*m_debug_log_fn)(const char* msg);
+
+	bool m_no_events;
 };
 
 //

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -78,6 +78,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	handle->m_proc_scan_timeout_ms = oargs->proc_scan_timeout_ms;
 	handle->m_proc_scan_log_interval_ms = oargs->proc_scan_log_interval_ms;
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	//
 	// Extract machine information
@@ -195,6 +196,7 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proc_scan_timeout_ms = oargs->proc_scan_timeout_ms;
 	handle->m_proc_scan_log_interval_ms = oargs->proc_scan_log_interval_ms;
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	//
 	// Extract machine information
@@ -298,6 +300,7 @@ int32_t scap_init_test_input_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proclist.m_proclist = NULL;
 
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	if ((rc = scap_suppress_init(&handle->m_suppress, oargs->suppressed_comms)) != SCAP_SUCCESS)
 	{
@@ -345,6 +348,7 @@ int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proclist.m_proclist = NULL;
 
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	if ((rc = scap_suppress_init(&handle->m_suppress, oargs->suppressed_comms)) != SCAP_SUCCESS)
 	{
@@ -391,6 +395,7 @@ int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proclist.m_proclist = NULL;
 
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	if((rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
 	{
@@ -440,6 +445,7 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proc_scan_timeout_ms = oargs->proc_scan_timeout_ms;
 	handle->m_proc_scan_log_interval_ms = oargs->proc_scan_log_interval_ms;
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	//
 	// Extract machine information
@@ -517,6 +523,7 @@ int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_proclist.m_proclist = NULL;
 
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 
 	//
 	// Extract machine information
@@ -747,7 +754,7 @@ scap_os_platform scap_get_os_platform(scap_t* handle)
 
 uint32_t scap_get_ndevs(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_n_devs(handle->m_engine);
 	}
@@ -763,7 +770,7 @@ int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT uint32_
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_max_buf_used(handle->m_engine);
 	}
@@ -773,7 +780,7 @@ uint64_t scap_max_buf_used(scap_t* handle)
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 {
 	int32_t res = SCAP_FAILURE;
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		res = handle->m_vtable->next(handle->m_engine, pevent, pcpuid);
 	}
@@ -843,7 +850,7 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 	stats->n_suppressed = handle->m_suppress.m_num_suppressed_evts;
 	stats->n_tids_suppressed = HASH_COUNT(handle->m_suppress.m_suppressed_tids);
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_stats(handle->m_engine, stats);
 	}
@@ -856,7 +863,7 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 //
 int32_t scap_stop_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->stop_capture(handle->m_engine);
 	}
@@ -871,7 +878,7 @@ int32_t scap_stop_capture(scap_t* handle)
 //
 int32_t scap_start_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->start_capture(handle->m_engine);
 	}
@@ -883,7 +890,7 @@ int32_t scap_start_capture(scap_t* handle)
 
 int32_t scap_enable_tracers_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
 	}
@@ -895,7 +902,7 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 
 int32_t scap_stop_dropping_mode(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
 	}
@@ -922,7 +929,7 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 			return snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "invalid sampling ratio size");
 	}
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
 	}
@@ -968,7 +975,7 @@ const scap_machine_info* scap_get_machine_info(scap_t* handle)
 
 int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
 	}
@@ -1005,7 +1012,7 @@ static int32_t scap_handle_ppm_sc_mask(scap_t* handle, uint32_t op, ppm_sc_code 
 		break;
 	}
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_PPM_SC_MASK, op, ppm_sc);
 	}
@@ -1025,6 +1032,7 @@ int32_t scap_set_ppm_sc(scap_t* handle, ppm_sc_code ppm_sc, bool enabled) {
 		ASSERT(false);
 		return SCAP_FAILURE;
 	}
+
 	return(scap_handle_ppm_sc_mask(handle, enabled ? SCAP_PPM_SC_MASK_SET : SCAP_PPM_SC_MASK_UNSET, ppm_sc));
 }
 
@@ -1042,7 +1050,7 @@ uint32_t scap_event_get_dump_flags(scap_t* handle)
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
 	}
@@ -1053,7 +1061,7 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
 	}
@@ -1147,7 +1155,7 @@ void scap_fseek(scap_t *handle, uint64_t off)
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
 	}
@@ -1177,7 +1185,7 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
 	}
@@ -1188,7 +1196,7 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
 	}

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -92,6 +92,7 @@ extern "C"
 		void(*debug_log_fn)(const char* msg); //< Function which SCAP may use to log a debug message
 		uint64_t proc_scan_timeout_ms; //< Timeout in msec, after which so-far-successful scan of /proc should be cut short with success return
 		uint64_t proc_scan_log_interval_ms; //< Interval for logging progress messages from /proc scan
+		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 		void* engine_params;			   ///< engine-specific params.
 	} scap_open_args;
 

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SINSP_SOURCES
 	threadinfo.cpp
 	tuples.cpp
 	sinsp.cpp
+	sinsp_driver_params.cpp
 	stats.cpp
 	token_bucket.cpp
 	stopwatch.cpp

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -543,7 +543,7 @@ void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, sinsp_driver_params
 	open_common(driver_params);
 }
 
-void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_bytes_dim, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
+void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_bytes_dim, sinsp_driver_params* driver_params)
 {
 	/* Validate the BPF path. */
 	if(bpf_path.empty())
@@ -551,17 +551,21 @@ void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_by
 		throw sinsp_exception("When you use the 'BPF' engine you need to provide a path to the bpf object file.");
 	}
 
-	scap_open_args oargs = factory_open_args(BPF_ENGINE, SCAP_MODE_LIVE);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
 
-	/* Set interesting syscalls and tracepoints. */
-	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
+	driver_params->engine_name = BPF_ENGINE;
+	driver_params->mode = SCAP_MODE_LIVE;
 
 	/* Engine-specific args. */
 	struct scap_bpf_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.bpf_probe = bpf_path.data();
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 }
 
 void sinsp::open_udig()

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -582,10 +582,18 @@ void sinsp::open_udig(sinsp_driver_params* driver_params)
 	open_common(driver_params);
 }
 
-void sinsp::open_nodriver()
+void sinsp::open_nodriver(sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(NODRIVER_ENGINE, SCAP_MODE_NODRIVER);
-	open_common(&oargs);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = NODRIVER_ENGINE;
+	driver_params->mode = SCAP_MODE_NODRIVER;
+
+	open_common(driver_params);
 }
 
 void sinsp::open_savefile(const std::string& filename, int fd)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -482,14 +482,6 @@ void sinsp::open_common(scap_open_args* oargs)
 	init();
 }
 
-scap_open_args sinsp::factory_open_args(const char* engine_name, scap_mode_t scap_mode)
-{
-	scap_open_args oargs{};
-	oargs.engine_name = engine_name;
-	oargs.mode = scap_mode;
-	return oargs;
-}
-
 void sinsp::mark_ppm_sc_of_interest(ppm_sc_code ppm_sc, bool enable)
 {
 	/* This API must be used only after the initialization phase. */
@@ -505,23 +497,6 @@ void sinsp::mark_ppm_sc_of_interest(ppm_sc_code ppm_sc, bool enable)
 	if (ret != SCAP_SUCCESS)
 	{
 		throw sinsp_exception(scap_getlasterr(m_h));
-	}
-}
-
-
-static void fill_ppm_sc_of_interest(scap_open_args *oargs, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
-{
-	for (int i = 0; i < PPM_SC_MAX; i++)
-	{
-		/* If the set is empty, fallback to all interesting syscalls */
-		if (ppm_sc_of_interest.empty())
-		{
-			oargs->ppm_sc_of_interest.ppm_sc[i] = true;
-		}
-		else
-		{
-			oargs->ppm_sc_of_interest.ppm_sc[i] = ppm_sc_of_interest.contains((ppm_sc_code)i);
-		}
 	}
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -596,9 +596,17 @@ void sinsp::open_nodriver(sinsp_driver_params* driver_params)
 	open_common(driver_params);
 }
 
-void sinsp::open_savefile(const std::string& filename, int fd)
+void sinsp::open_savefile(const std::string& filename, int fd, sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(SAVEFILE_ENGINE, SCAP_MODE_CAPTURE);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = SAVEFILE_ENGINE;
+	driver_params->mode = SCAP_MODE_CAPTURE;
+
 	struct scap_savefile_engine_params params;
 
 	m_input_filename = filename;
@@ -631,8 +639,8 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 
 	params.start_offset = 0;
 	params.fbuffer_size = 0;
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 }
 
 void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -643,15 +643,23 @@ void sinsp::open_savefile(const std::string& filename, int fd, sinsp_driver_para
 	open_common(driver_params);
 }
 
-void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params)
+void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params, sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(SOURCE_PLUGIN_ENGINE, SCAP_MODE_PLUGIN);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = SOURCE_PLUGIN_ENGINE;
+	driver_params->mode = SCAP_MODE_PLUGIN;
+
 	struct scap_source_plugin_engine_params params;
 	set_input_plugin(plugin_name, plugin_open_params);
 	params.input_plugin = &m_input_plugin->as_scap_source();
 	params.input_plugin_params = (char*)m_input_plugin_open_params.c_str();
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 }
 
 void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -708,13 +708,20 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	open_common(driver_params);
 }
 
-void sinsp::open_test_input(scap_test_input_data* data)
+void sinsp::open_test_input(scap_test_input_data* data, sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(TEST_INPUT_ENGINE, SCAP_MODE_TEST);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = TEST_INPUT_ENGINE;
+	driver_params->mode = SCAP_MODE_TEST;
 	struct scap_test_input_engine_params params;
 	params.test_input_data = data;
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 
 	set_get_procs_cpu_from_driver(false);
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -568,10 +568,18 @@ void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_by
 	open_common(driver_params);
 }
 
-void sinsp::open_udig()
+void sinsp::open_udig(sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(UDIG_ENGINE, SCAP_MODE_LIVE);
-	open_common(&oargs);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = UDIG_ENGINE;
+	driver_params->mode = SCAP_MODE_LIVE;
+
+	open_common(driver_params);
 }
 
 void sinsp::open_nodriver()

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -662,19 +662,27 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 	open_common(driver_params);
 }
 
-void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path)
+void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path, sinsp_driver_params* driver_params)
 {
 	if(config_path.empty())
 	{
 		throw sinsp_exception("When you use the 'gvisor' engine you need to provide a path to the config file.");
 	}
 
-	scap_open_args oargs = factory_open_args(GVISOR_ENGINE, SCAP_MODE_LIVE);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
+
+	driver_params->engine_name = GVISOR_ENGINE;
+	driver_params->mode = SCAP_MODE_LIVE;
+
 	struct scap_gvisor_engine_params params;
 	params.gvisor_root_path = root_path.c_str();
 	params.gvisor_config_path = config_path.c_str();
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 
 	set_get_procs_cpu_from_driver(false);
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -525,18 +525,22 @@ static void fill_ppm_sc_of_interest(scap_open_args *oargs, const libsinsp::event
 	}
 }
 
-void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
+void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(KMOD_ENGINE, SCAP_MODE_LIVE);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
 
-	/* Set interesting syscalls and tracepoints. */
-	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
+	driver_params->engine_name = KMOD_ENGINE;
+	driver_params->mode = SCAP_MODE_LIVE;
 
 	/* Engine-specific args. */
 	struct scap_kmod_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 }
 
 void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_bytes_dim, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -687,12 +687,16 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	set_get_procs_cpu_from_driver(false);
 }
 
-void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus_for_each_buffer, bool online_only, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
+void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus_for_each_buffer, bool online_only, sinsp_driver_params* driver_params)
 {
-	scap_open_args oargs = factory_open_args(MODERN_BPF_ENGINE, SCAP_MODE_LIVE);
+	sinsp_driver_params p = {};
+	if(driver_params == nullptr)
+	{
+		driver_params = &p;
+	}
 
-	/* Set interesting syscalls and tracepoints. */
-	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
+	driver_params->engine_name = MODERN_BPF_ENGINE;
+	driver_params->mode = SCAP_MODE_LIVE;
 
 	/* Engine-specific args. */
 	struct scap_modern_bpf_engine_params params;
@@ -700,8 +704,8 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	params.cpus_for_each_buffer = cpus_for_each_buffer;
 	params.allocate_online_only = online_only;
 	params.verbose = g_logger.get_severity() >= sinsp_logger::severity::SEV_DEBUG;
-	oargs.engine_params = &params;
-	open_common(&oargs);
+	driver_params->engine_params = &params;
+	open_common(driver_params);
 }
 
 void sinsp::open_test_input(scap_test_input_data* data)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -42,6 +42,7 @@ limitations under the License.
 #pragma once
 
 #include "capture_stats_source.h"
+#include "sinsp_driver_params.h"
 
 #ifdef _WIN32
 #pragma warning(disable: 4251 4200 4221 4190)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -226,7 +226,7 @@ public:
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_udig(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_nodriver(sinsp_driver_params* driver_params = nullptr);
-	virtual void open_savefile(const std::string &filename, int fd = 0);
+	virtual void open_savefile(const std::string &filename, int fd = 0, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -224,7 +224,7 @@ public:
 	/* Wrappers to open a specific engine. */
 	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
-	virtual void open_udig();
+	virtual void open_udig(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_nodriver();
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -236,8 +236,6 @@ public:
 	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_test_input(scap_test_input_data *data, sinsp_driver_params* driver_params = nullptr);
 
-	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);
-
 	std::string generate_gvisor_config(std::string socket_path);
 
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -227,7 +227,7 @@ public:
 	virtual void open_udig(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_nodriver(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_savefile(const std::string &filename, int fd = 0, sinsp_driver_params* driver_params = nullptr);
-	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
+	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -228,7 +228,7 @@ public:
 	virtual void open_nodriver(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_savefile(const std::string &filename, int fd = 0, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params, sinsp_driver_params* driver_params = nullptr);
-	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
+	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, sinsp_driver_params* driver_params = nullptr);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -222,7 +222,7 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
+	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
 	virtual void open_udig();
 	virtual void open_nodriver();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -223,7 +223,7 @@ public:
 
 	/* Wrappers to open a specific engine. */
 	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
-	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
+	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_udig();
 	virtual void open_nodriver();
 	virtual void open_savefile(const std::string &filename, int fd = 0);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -233,7 +233,7 @@ public:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.
 	 */
-	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
+	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_test_input(scap_test_input_data *data);
 
 	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -234,7 +234,7 @@ public:
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.
 	 */
 	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, sinsp_driver_params* driver_params = nullptr);
-	virtual void open_test_input(scap_test_input_data *data);
+	virtual void open_test_input(scap_test_input_data *data, sinsp_driver_params* driver_params = nullptr);
 
 	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -225,7 +225,7 @@ public:
 	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_udig(sinsp_driver_params* driver_params = nullptr);
-	virtual void open_nodriver();
+	virtual void open_nodriver(sinsp_driver_params* driver_params = nullptr);
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);

--- a/userspace/libsinsp/sinsp_driver_params.cpp
+++ b/userspace/libsinsp/sinsp_driver_params.cpp
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sinsp_driver_params.h"
+
+sinsp_driver_params& sinsp_driver_params::set_ppm_sc_of_interest(const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest_set)
+{
+	for (int i = 0; i < PPM_SC_MAX; i++)
+	{
+		/* If the set is empty, fallback to all interesting syscalls */
+		if (ppm_sc_of_interest_set.empty())
+		{
+			ppm_sc_of_interest.ppm_sc[i] = true;
+		}
+		else
+		{
+			ppm_sc_of_interest.ppm_sc[i] = ppm_sc_of_interest_set.contains((ppm_sc_code)i);
+		}
+	}
+	return *this;
+}

--- a/userspace/libsinsp/sinsp_driver_params.h
+++ b/userspace/libsinsp/sinsp_driver_params.h
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "scap_open.h"
+#include "sinsp_public.h"
+#include "events/sinsp_events_set.h"
+
+struct SINSP_PUBLIC sinsp_driver_params : public scap_open_args
+{
+	sinsp_driver_params& set_ppm_sc_of_interest(const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest_set);
+};

--- a/userspace/libsinsp/sinsp_driver_params.h
+++ b/userspace/libsinsp/sinsp_driver_params.h
@@ -24,4 +24,9 @@ limitations under the License.
 struct SINSP_PUBLIC sinsp_driver_params : public scap_open_args
 {
 	sinsp_driver_params& set_ppm_sc_of_interest(const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest_set);
+	sinsp_driver_params& set_no_events(bool f)
+	{
+		no_events = f;
+		return *this;
+	}
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

/area libscap-engine-bpf

/area libscap-engine-gvisor

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces a no_events mode for libscap (controlled by a new scap_open_args flag). In this mode, no events are generated from the engine. Opening an inspector *not* to get any events from it sounds pointless but (due to the current scap architecture) we need an engine to access e.g. /proc scan data (which may have different implementations, see e.g. gVisor).

The engine must also be aware that it's being opened in no_events mode, since otherwise it can do things that would break the original (main) inspector used to process events (again, e.g. gVisor opens a listening socket which would redirect all new connections to the new, presumably temporary, inspector).

So the end result is that we can use scap to run a /proc scan (or equivalent) without interfering with the main event loop.

**Special notes for your reviewer**:

In order to avoid adding a new parameter to all sinsp::open_* methods, I created a (C++) wrapper over scap_open_args with one (hopefully) final API change. Nothing changes if you use the default ppm_sc_set but otherwise it's the caller's responsibility to create a `sinsp_driver_params` struct (which is equivalent to `scap_open_args`).

I really wanted to use something more modern than a raw pointer but every approach I tried around references had worse (IMHO) downsides.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(sinsp)!: all `sinsp::open_*` methods take an optional `sinsp_driver_params*` pointer which contains the ppm_sc_set that was previously explicitly passed (to some methods; now all open methods respect ppm_sc_set even if not all engines do)
```
