### PR TITLE
fix(driver): avoid `ppm_consumer_t` being defined twice.

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -115,6 +115,7 @@ set(DRIVER_SOURCES
 	systype_compat.h
 	ppm_tp.h
 	ppm_tp.c
+	ppm_consumer.h
 )
 
 foreach(FILENAME IN LISTS DRIVER_SOURCES)

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -1,6 +1,6 @@
 /*
 
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2023 The Falco Authors.
 
 This file is dual licensed under either the MIT or GPL 2. See MIT.txt
 or GPL2.txt for full copies of the license.
@@ -10,13 +10,13 @@ or GPL2.txt for full copies of the license.
 #ifndef PPM_H_
 #define PPM_H_
 
-
 /*
  * Our Own ASSERT implementation, so we can easily switch among BUG_ON, WARN_ON and nothing
  */
 #ifndef UDIG
 
 #include <linux/time.h>
+#include "ppm_consumer.h"
 
 #ifdef _DEBUG
 #define ASSERT(expr) WARN_ON(!(expr))
@@ -60,35 +60,6 @@ struct ppm_ring_buffer_context {
 #endif	
 	char *str_storage;	/* String storage. Size is one page. */
 };
-
-#ifndef UDIG
-struct ppm_consumer_t {
-	unsigned int id; // numeric id for the consumer (ie: registration index)
-	struct task_struct *consumer_id;
-#ifdef __percpu
-	struct ppm_ring_buffer_context __percpu *ring_buffers;
-#else
-	struct ppm_ring_buffer_context *ring_buffers;
-#endif
-	u32 snaplen;
-	u32 sampling_ratio;
-	bool do_dynamic_snaplen;
-	u32 sampling_interval;
-	int is_dropping;
-	int dropping_mode;
-	volatile int need_to_insert_drop_e;
-	volatile int need_to_insert_drop_x;
-	struct list_head node;
-	uint16_t fullcapture_port_range_start;
-	uint16_t fullcapture_port_range_end;
-	uint16_t statsd_port;
-	unsigned long buffer_bytes_dim; /* Every consumer will have its per-CPU buffer dim in bytes. */
-	DECLARE_BITMAP(syscalls_mask, SYSCALL_TABLE_SIZE);
-	u32 tracepoints_attached;
-};
-
-typedef struct ppm_consumer_t ppm_consumer_t;
-#endif // UDIG
 
 #define STR_STORAGE_SIZE PAGE_SIZE
 

--- a/driver/ppm_consumer.h
+++ b/driver/ppm_consumer.h
@@ -1,0 +1,42 @@
+/*
+
+Copyright (C) 2023 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+#ifndef CONSUMER_H_
+#define CONSUMER_H_
+
+#include <linux/types.h>
+
+struct ppm_consumer_t {
+	unsigned int id; // numeric id for the consumer (ie: registration index)
+	struct task_struct *consumer_id;
+#ifdef __percpu
+	struct ppm_ring_buffer_context __percpu *ring_buffers;
+#else
+	struct ppm_ring_buffer_context *ring_buffers;
+#endif
+	u32 snaplen;
+	u32 sampling_ratio;
+	bool do_dynamic_snaplen;
+	u32 sampling_interval;
+	int is_dropping;
+	int dropping_mode;
+	volatile int need_to_insert_drop_e;
+	volatile int need_to_insert_drop_x;
+	struct list_head node;
+	uint16_t fullcapture_port_range_start;
+	uint16_t fullcapture_port_range_end;
+	uint16_t statsd_port;
+	unsigned long buffer_bytes_dim; /* Every consumer will have its per-CPU buffer dim in bytes. */
+	DECLARE_BITMAP(syscalls_mask, SYSCALL_TABLE_SIZE);
+	u32 tracepoints_attached;
+};
+
+typedef struct ppm_consumer_t ppm_consumer_t;
+
+#endif // CONSUMER_H_

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -1,6 +1,6 @@
 /*
 
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2023 The Falco Authors.
 
 This file is dual licensed under either the MIT or GPL 2. See MIT.txt
 or GPL2.txt for full copies of the license.
@@ -13,6 +13,7 @@ or GPL2.txt for full copies of the license.
 /* To know about __NR_socketcall */
 #ifndef UDIG
 #include <asm/unistd.h>
+#include "ppm_consumer.h"
 #endif
 #ifdef CONFIG_COMPAT
 #include <linux/compat.h>
@@ -26,8 +27,6 @@ or GPL2.txt for full copies of the license.
 #endif
 
 #include "ppm_events_public.h"
-
-typedef struct ppm_consumer_t ppm_consumer_t;
 
 /*
  * Various crap that a callback might need


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

It fixes the kmod build on ancient centos6.
`ppm_consumer_t` was `typedef`ed both in ppm.h and in ppm_events.h, both included in kmod main.c.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): avoid typedefing ppm_consumer_t twice
```
