### PR TITLE
new(scap): Support gVisor no_events mode/full proc scan for nodriver

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -49,7 +49,7 @@ static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path);
+	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -132,7 +132,7 @@ class engine {
 public:
     engine(char *lasterr);
     ~engine();
-    int32_t init(std::string config_path, std::string root_path);
+    int32_t init(std::string config_path, std::string root_path, bool no_events);
     int32_t close();
 
     int32_t start_capture();
@@ -152,6 +152,7 @@ private:
     int m_listenfd = 0;
     int m_epollfd = 0;
     bool m_capture_started = false;
+    bool m_no_events = false;
 
     std::string m_socket_path;
     std::thread m_accept_thread;

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -24,6 +24,8 @@ extern "C"
 	{
 		const char* gvisor_root_path;	///< When using gvisor, the root path used by runsc commands
 		const char* gvisor_config_path; ///< When using gvisor, the path to the configuration file
+
+		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 	};
 
 #ifdef __cplusplus

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -97,7 +97,7 @@ engine::~engine()
 
 }
 
-int32_t engine::init(std::string config_path, std::string root_path)
+int32_t engine::init(std::string config_path, std::string root_path, bool no_events)
 {
 	if(root_path.empty())
 	{
@@ -127,6 +127,14 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		return config_result.status;
 	}
 
+	// Check if runsc is installed in the system
+	runsc::result version = runsc::version();
+	if(version.error)
+	{
+		strlcpy(m_lasterr, "Cannot find runsc binary", SCAP_LASTERR_SIZE);
+		return SCAP_FAILURE;
+	}
+
 	// Initialize the listen fd
 	m_socket_path = config_result.socket_path;
 	if (m_socket_path.empty())
@@ -135,15 +143,13 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		return SCAP_FAILURE;
 	}
 
-	unlink(m_socket_path.c_str());
-	
-	// Check if runsc is installed in the system
-	runsc::result version = runsc::version();
-	if(version.error)
+	m_no_events = no_events;
+	if(no_events)
 	{
-		strlcpy(m_lasterr, "Cannot find runsc binary", SCAP_LASTERR_SIZE);
-		return SCAP_FAILURE;
+		return SCAP_SUCCESS;
 	}
+
+	unlink(m_socket_path.c_str());
 
 	int sock = socket(PF_UNIX, SOCK_SEQPACKET, 0);
 	if(sock == -1)
@@ -189,6 +195,11 @@ int32_t engine::init(std::string config_path, std::string root_path)
 
 int32_t engine::close()
 {
+	if(m_no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	stop_capture();
 	unlink(m_socket_path.c_str());
     return SCAP_SUCCESS;
@@ -266,6 +277,10 @@ static void accept_thread(int listenfd, int epollfd)
 
 int32_t engine::start_capture()
 {
+	if(m_no_events)
+	{
+		return SCAP_FAILURE;
+	}
 	//
 	// Retrieve all running sandboxes
 	// We will need to recreate a session for each of them
@@ -505,6 +520,11 @@ int32_t engine::process_message_from_fd(int fd)
 
 int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 {
+	if(m_no_events)
+	{
+		return SCAP_FAILURE;
+	}
+
 	epoll_event evts[max_ready_sandboxes];
 	*pcpuid = 0;
 

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -169,7 +169,6 @@ static int32_t scap_kmod_handle_ppm_sc_mask(struct scap_engine_handle engine, ui
 
 int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 {
-	uint32_t j = 0;
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_kmod_engine_params* params  = oargs->engine_params;
 	char filename[SCAP_MAX_PATH_SIZE] = {0};
@@ -178,7 +177,6 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	int32_t rc = 0;
 
 	int mapped_len = 0;
-	uint32_t all_scanned_devs = 0;
 	uint64_t api_version = 0;
 	uint64_t schema_version = 0;
 
@@ -223,7 +221,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	mapped_len = single_buffer_dim * 2;
 
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
-	for(j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
+	for(uint32_t j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
 	{
 		struct scap_device *dev = &devset->m_devs[j];
 

--- a/userspace/libscap/engine/nodriver/nodriver_public.h
+++ b/userspace/libscap/engine/nodriver/nodriver_public.h
@@ -14,3 +14,17 @@ limitations under the License.
 #pragma once
 
 #define NODRIVER_ENGINE "nodriver"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	struct scap_nodriver_engine_params
+	{
+		bool full_proc_scan; //< run a full /proc scan instead of the normal reduced one (no threads, no sockets)
+	};
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -1288,7 +1288,7 @@ int32_t scap_fd_scan_fd_dir(scap_t *handle, char *procdir, scap_threadinfo *tinf
 
 		// In no driver mode to limit cpu usage we just parse sockets
 		// because we are interested only on them
-		if(handle->m_mode == SCAP_MODE_NODRIVER && !S_ISSOCK(sb.st_mode))
+		if(handle->m_minimal_scan && !S_ISSOCK(sb.st_mode))
 		{
 			continue;
 		}

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1201,7 +1201,7 @@ static int32_t _scap_proc_scan_proc_dir_impl(scap_t* handle, char* procdirname, 
 		// See if this process includes tasks that need to be added
 		// Note the use of recursion will re-enter this function for the childdir.
 		//
-		if(parenttid == -1 && handle->m_mode != SCAP_MODE_NODRIVER)
+		if(parenttid == -1 && !handle->m_minimal_scan)
 		{
 			snprintf(childdir, sizeof(childdir), "%s/%u/task", procdirname, (int)tid);
 			if(_scap_proc_scan_proc_dir_impl(handle, childdir, tid, error) == SCAP_FAILURE)

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -56,6 +56,7 @@ struct scap
 	scap_userlist* m_userlist;
 	struct ppm_proclist_info* m_driver_procinfo;
 	uint32_t m_fd_lookup_limit;
+	bool m_minimal_scan;
 	uint8_t m_cgroup_version;
 
 	// /proc scan parameters

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -411,6 +411,7 @@ int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
 int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs)
 {
 	int32_t rc;
+	struct scap_nodriver_engine_params* engine_params = oargs->engine_params;
 
 	//
 	// Get boot_time
@@ -453,8 +454,12 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_machine_info.reserved3 = 0;
 	handle->m_machine_info.reserved4 = 0;
 	handle->m_driver_procinfo = NULL;
-	handle->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP; // fd lookup is limited here because is very expensive
-	handle->m_minimal_scan = true;
+
+	if(!engine_params || !engine_params->full_proc_scan)
+	{
+		handle->m_minimal_scan = true;
+		handle->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP; // fd lookup is limited here because is very expensive
+	}
 
 	//
 	// Create the interface list

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -454,6 +454,7 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs)
 	handle->m_machine_info.reserved4 = 0;
 	handle->m_driver_procinfo = NULL;
 	handle->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP; // fd lookup is limited here because is very expensive
+	handle->m_minimal_scan = true;
 
 	//
 	// Create the interface list

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -626,7 +626,7 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 	open_common(&oargs);
 }
 
-void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path)
+void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path, bool no_events)
 {
 	if(config_path.empty())
 	{
@@ -637,6 +637,7 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	struct scap_gvisor_engine_params params;
 	params.gvisor_root_path = root_path.c_str();
 	params.gvisor_config_path = config_path.c_str();
+	params.no_events = no_events;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -566,9 +566,13 @@ void sinsp::open_udig()
 	open_common(&oargs);
 }
 
-void sinsp::open_nodriver()
+void sinsp::open_nodriver(bool full_proc_scan)
 {
 	scap_open_args oargs = factory_open_args(NODRIVER_ENGINE, SCAP_MODE_NODRIVER);
+	struct scap_nodriver_engine_params params;
+	params.full_proc_scan = full_proc_scan;
+
+	oargs.engine_params = &params;
 	open_common(&oargs);
 }
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -227,7 +227,7 @@ public:
 	virtual void open_nodriver(bool full_proc_scan = false);
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
-	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
+	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, bool no_events = false);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -224,7 +224,7 @@ public:
 	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
 	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
 	virtual void open_udig();
-	virtual void open_nodriver();
+	virtual void open_nodriver(bool full_proc_scan = false);
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

/area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR is a smaller patch to achieve the same thing as https://github.com/falcosecurity/libs/pull/986. Instead of introducing a no_events mode for all engines, it introduces one just for gVisor. kmod/bpf/modern_bpf can use the nodriver engine instead (with the new full_proc_scan=true flag) to achieve the same result.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
