### PR TITLE
update!: change libsisnp default verbosity and add some helper methods

### DIFF
--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -117,7 +117,14 @@ public:
 	 *
 	 * Note that this is intentionally inline.
 	 */
-	bool is_enabled(const severity sev) const { return (sev <= m_sev); }
+	bool is_logging(const severity sev) const { return (sev <= m_sev); }
+
+	/**
+	 * Returns true if the logger has at least one output configured.
+	 *
+	 * Note that this is intentionally inline.
+	 */
+	bool has_output() const { return (!(m_flags == OT_NONE)); }
 
 	/**
 	 * Emit the given msg to the configured log sink if the given sev
@@ -172,7 +179,7 @@ extern sinsp_logger g_logger;
 #define SINSP_LOG_(severity, fmt, ...)                                         \
 	do                                                                     \
 	{                                                                      \
-		if(g_logger.is_enabled(severity))                              \
+		if(g_logger.is_logging(severity))                              \
 		{                                                              \
 			g_logger.format((severity), ("" fmt), ##__VA_ARGS__);  \
 		}                                                              \
@@ -182,7 +189,7 @@ extern sinsp_logger g_logger;
 #define SINSP_LOG_STR_(severity, msg)                                          \
 	do                                                                     \
 	{                                                                      \
-		if(g_logger.is_enabled(severity))                              \
+		if(g_logger.is_logging(severity))                              \
 		{                                                              \
 			g_logger.log((msg), (severity));                       \
 		}                                                              \

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -117,14 +117,14 @@ public:
 	 *
 	 * Note that this is intentionally inline.
 	 */
-	bool is_logging(const severity sev) const { return (sev <= m_sev); }
+	bool is_enabled(const severity sev) const { return (sev <= m_sev); }
 
 	/**
 	 * Returns true if the logger has at least one output configured.
 	 *
 	 * Note that this is intentionally inline.
 	 */
-	bool has_output() const { return (!(m_flags == OT_NONE)); }
+	bool has_output() const { return m_flags != OT_NONE; }
 
 	/**
 	 * Emit the given msg to the configured log sink if the given sev
@@ -179,7 +179,7 @@ extern sinsp_logger g_logger;
 #define SINSP_LOG_(severity, fmt, ...)                                         \
 	do                                                                     \
 	{                                                                      \
-		if(g_logger.is_logging(severity))                              \
+		if(g_logger.is_enabled(severity))                              \
 		{                                                              \
 			g_logger.format((severity), ("" fmt), ##__VA_ARGS__);  \
 		}                                                              \
@@ -189,7 +189,7 @@ extern sinsp_logger g_logger;
 #define SINSP_LOG_STR_(severity, msg)                                          \
 	do                                                                     \
 	{                                                                      \
-		if(g_logger.is_logging(severity))                              \
+		if(g_logger.is_enabled(severity))                              \
 		{                                                              \
 			g_logger.log((msg), (severity));                       \
 		}                                                              \

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -656,7 +656,7 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.cpus_for_each_buffer = cpus_for_each_buffer;
 	params.allocate_online_only = online_only;
-	params.verbose = g_logger.has_output() && g_logger.is_logging(sinsp_logger::severity::SEV_DEBUG);
+	params.verbose = g_logger.has_output() && g_logger.is_enabled(sinsp_logger::severity::SEV_DEBUG);
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -656,7 +656,7 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.cpus_for_each_buffer = cpus_for_each_buffer;
 	params.allocate_online_only = online_only;
-	params.verbose = g_logger.get_severity() >= sinsp_logger::severity::SEV_DEBUG;
+	params.verbose = g_logger.has_output() && g_logger.is_logging(sinsp_logger::severity::SEV_DEBUG);
 	oargs.engine_params = &params;
 	open_common(&oargs);
 }

--- a/userspace/libsinsp/test/public_sinsp_API/sinsp_logger.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/sinsp_logger.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include <sinsp.h>
+#include <logger.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+static void log_callback_fn(std::string&& str, const sinsp_logger::severity sev)
+{
+	return;
+}
+
+TEST(sinsp_logger, constructor)
+{
+	auto logger = sinsp_logger();
+	ASSERT_FALSE(logger.has_output());
+	ASSERT_EQ(logger.get_severity(), sinsp_logger::SEV_INFO);
+	ASSERT_EQ(logger.get_log_output_type(), sinsp_logger::OT_NONE);
+}
+
+TEST(sinsp_logger, output_type)
+{
+	auto logger = sinsp_logger();
+	ASSERT_FALSE(logger.has_output());
+	logger.add_stdout_log();
+	logger.add_stderr_log();
+	logger.disable_timestamps();
+	logger.add_encoded_severity();
+	logger.add_callback_log(log_callback_fn);
+
+	// int fd = open(".", O_WRONLY | O_TMPFILE, 0);
+
+	int fd = open("./xyazd", O_RDWR | O_CREAT, S_IWUSR);
+	logger.add_file_log("./xyazd");
+	close(fd);
+
+	ASSERT_EQ(logger.get_log_output_type(), (sinsp_logger::OT_STDOUT | sinsp_logger::OT_STDERR | sinsp_logger::OT_FILE | sinsp_logger::OT_CALLBACK | sinsp_logger::OT_NOTS | sinsp_logger::OT_ENCODE_SEV));
+
+	logger.remove_callback_log();
+	ASSERT_EQ(logger.get_log_output_type(), (sinsp_logger::OT_STDOUT | sinsp_logger::OT_STDERR | sinsp_logger::OT_FILE | sinsp_logger::OT_NOTS | sinsp_logger::OT_ENCODE_SEV));
+	ASSERT_TRUE(logger.has_output());
+}
+
+TEST(sinsp_logger, get_set_severity)
+{
+	auto logger = sinsp_logger();
+	logger.set_severity(sinsp_logger::SEV_FATAL);
+	ASSERT_EQ(logger.get_severity(), sinsp_logger::SEV_FATAL);
+	ASSERT_TRUE(logger.is_logging(sinsp_logger::SEV_FATAL));
+	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_TRACE));
+	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_CRITICAL));
+	logger.set_severity(sinsp_logger::SEV_NOTICE);
+	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_INFO));
+	ASSERT_TRUE(logger.is_logging(sinsp_logger::SEV_ERROR));
+}

--- a/userspace/libsinsp/test/public_sinsp_API/sinsp_logger.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/sinsp_logger.cpp
@@ -62,10 +62,10 @@ TEST(sinsp_logger, get_set_severity)
 	auto logger = sinsp_logger();
 	logger.set_severity(sinsp_logger::SEV_FATAL);
 	ASSERT_EQ(logger.get_severity(), sinsp_logger::SEV_FATAL);
-	ASSERT_TRUE(logger.is_logging(sinsp_logger::SEV_FATAL));
-	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_TRACE));
-	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_CRITICAL));
+	ASSERT_TRUE(logger.is_enabled(sinsp_logger::SEV_FATAL));
+	ASSERT_FALSE(logger.is_enabled(sinsp_logger::SEV_TRACE));
+	ASSERT_FALSE(logger.is_enabled(sinsp_logger::SEV_CRITICAL));
 	logger.set_severity(sinsp_logger::SEV_NOTICE);
-	ASSERT_FALSE(logger.is_logging(sinsp_logger::SEV_INFO));
-	ASSERT_TRUE(logger.is_logging(sinsp_logger::SEV_ERROR));
+	ASSERT_FALSE(logger.is_enabled(sinsp_logger::SEV_INFO));
+	ASSERT_TRUE(logger.is_enabled(sinsp_logger::SEV_ERROR));
 }

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -86,7 +86,7 @@ sinsp_initializer::sinsp_initializer()
 	//
 	// Init the logger
 	//
-	g_logger.set_severity(sinsp_logger::SEV_TRACE);
+	g_logger.set_severity(sinsp_logger::SEV_INFO);
 
 	//
 	// Sockets initialization on windows


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR changes the default libsinsp verbosity from `SEV_TRACE` to `SEV_INFO`, this seems a more reasonable default value. 
Moreover, this PR adds a new helper method to check if there is at least an output configured for the logger.
I've added some minimal tests for this class but for sure we can improve the coverage in the next future

/hold 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update!: change libsisnp default verbosity and add some helper methods
```
