### PR TITLE
new(driver/modern_bpf): Support syscall specific dropping logic into modern bpf probe

### DIFF
--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -1397,4 +1397,13 @@
 
 /*=============================== SOCKETCALL CODES ===========================*/
 
+/*=============================== OPENED FILE DESCRIPTORS ===========================*/
+
+/* `/include/asm-generic/bitsperlong.h` from kernel source tree. */
+
+#define BITS_PER_LONG 64
+#define BIT_WORD(nr)		((nr) / BITS_PER_LONG)
+
+/*=============================== OPENED FILE DESCRIPTORS ===========================*/
+
 #endif /* __MISSING_DEFINITIONS_H__ */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -49,6 +49,11 @@ int BPF_PROG(bind_x,
 	     struct pt_regs *regs,
 	     long ret)
 {
+	if(maps__get_dropping_mode() && ret < 0)
+	{
+		return 0;
+	}
+
 	struct auxiliary_map *auxmap = auxmap__get();
 	if(!auxmap)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -14,6 +14,40 @@ int BPF_PROG(close_e,
 	     struct pt_regs *regs,
 	     long id)
 {
+	if(maps__get_dropping_mode())
+	{
+		s32 fd = (s32)extract__syscall_argument(regs, 0);
+		/* We drop the event if we are closing a negative file descriptor */
+		if(fd < 0)
+		{
+			return 0;
+		}
+
+		struct task_struct *task = get_current_task();
+		u32 max_fds = 0;
+		READ_TASK_FIELD_INTO(&max_fds, task, files, fdt, max_fds);
+		/* We drop the event if the fd is >= than `max_fds` */
+		if(fd >= max_fds)
+		{
+			return 0;
+		}
+
+		/* We drop the event if the fd is not open */
+		long unsigned int entry = 0;
+		long unsigned int *open_fds = READ_TASK_FIELD(task, files, fdt, open_fds);
+		if(open_fds == NULL)
+		{
+			return 0;
+		}
+		if(bpf_probe_read_kernel(&entry, sizeof(entry), (const void *)&(open_fds[BIT_WORD(fd)])) == 0)
+		{
+			if(!(1UL & (entry >> (fd & (BITS_PER_LONG - 1)))))
+			{
+				return 0;
+			}
+		}
+	}
+
 	struct ringbuf_struct ringbuf;
 	if(!ringbuf__reserve_space(&ringbuf, CLOSE_E_SIZE))
 	{
@@ -44,6 +78,11 @@ int BPF_PROG(close_x,
 	     struct pt_regs *regs,
 	     long ret)
 {
+	if(maps__get_dropping_mode() && ret < 0)
+	{
+		return 0;
+	}
+
 	struct ringbuf_struct ringbuf;
 	if(!ringbuf__reserve_space(&ringbuf, CLOSE_X_SIZE))
 	{

--- a/test/drivers/test_suites/actions_suite/sampling_ratio.cpp
+++ b/test/drivers/test_suites/actions_suite/sampling_ratio.cpp
@@ -36,7 +36,7 @@ TEST(Actions, sampling_ratio_UF_NEVER_DROP)
 {
 	/* Here we set just one `UF_NEVER_DROP` syscall as interesting... this process will send
 	 * only this specific syscall and we have to check that the corresponding event is
-     * not dropped when the sampling logic is enabled.
+	 * not dropped when the sampling logic is enabled.
 	 */
 	auto evt_test = get_syscall_event_test(__NR_eventfd, ENTER_EVENT);
 
@@ -49,7 +49,7 @@ TEST(Actions, sampling_ratio_UF_NEVER_DROP)
 	int32_t fd = syscall(__NR_eventfd, 3);
 	syscall(__NR_close, fd);
 
-    /* We should find the event */
+	/* We should find the event */
 	evt_test->assert_event_presence();
 
 	evt_test->disable_sampling_logic();
@@ -62,9 +62,9 @@ TEST(Actions, sampling_ratio_UF_NEVER_DROP)
 TEST(Actions, sampling_ratio_NO_FLAGS)
 {
 	/* Here we set just one syscall with no flags (UF_ALWAYS_DROP/UF_NEVER_DROP)
-     * as interesting... this process will send only this specific syscall and 
-     * we have to check that the corresponding event is not dropped when the
-     * sampling logic is enabled with ratio==1.
+	 * as interesting... this process will send only this specific syscall and
+	 * we have to check that the corresponding event is not dropped when the
+	 * sampling logic is enabled with ratio==1.
 	 */
 	auto evt_test = get_syscall_event_test(__NR_capset, ENTER_EVENT);
 
@@ -76,10 +76,204 @@ TEST(Actions, sampling_ratio_NO_FLAGS)
 	/* Call the syscall */
 	syscall(__NR_capset, NULL, NULL);
 
-    /* We should find the event */
+	/* We should find the event */
 	evt_test->assert_event_presence();
 
 	evt_test->disable_sampling_logic();
+
+	evt_test->disable_capture();
+}
+#endif
+
+#ifdef __NR_fcntl
+#include <fcntl.h>
+TEST(Actions, sampling_ratio_dropping_FCNTL_E)
+{
+	auto evt_test = get_syscall_event_test(__NR_fcntl, ENTER_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* If called with `F_DUPFD_CLOEXEC` flag the fcntl event shouldn't be dropped by the dropping logic */
+	int32_t invalid_fd = -1;
+	int cmd = F_DUPFD_CLOEXEC;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_presence();
+
+	/* This fcntl event should be dropped now since the flag is `F_NOTIFY` */
+	cmd = F_NOTIFY;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_absence();
+
+	evt_test->disable_sampling_logic();
+
+	/* Now that the sampling logic is disabled we should catch the event */
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+
+TEST(Actions, sampling_ratio_dropping_FCNTL_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_fcntl, EXIT_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* If called with `F_DUPFD_CLOEXEC` flag the fcntl event shouldn't be dropped by the dropping logic */
+	int32_t invalid_fd = -1;
+	int cmd = F_DUPFD_CLOEXEC;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_presence();
+
+	/* This fcntl event should be dropped now since the flag is `F_NOTIFY` */
+	cmd = F_NOTIFY;
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_absence();
+
+	evt_test->disable_sampling_logic();
+
+	/* Now that the sampling logic is disabled we should catch the event */
+	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+#endif
+
+#if defined(__NR_close) && defined(__NR_socket)
+TEST(Actions, sampling_ratio_dropping_CLOSE_E_invalid_fd)
+{
+	auto evt_test = get_syscall_event_test(__NR_close, ENTER_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* If called an invalid `fd` the close enter event should be dropped */
+	int32_t invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->assert_event_absence();
+
+	/* Now that the sampling logic is disabled we should catch the event */
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+
+TEST(Actions, sampling_ratio_dropping_CLOSE_E_max_fds)
+{
+	auto evt_test = get_syscall_event_test(__NR_close, ENTER_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, 8192));
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->assert_event_absence();
+
+	// /* Now that the sampling logic is disabled we should be able to collect this event */
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, 8192));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+
+TEST(Actions, sampling_ratio_dropping_CLOSE_E_already_closed_fd)
+{
+	auto evt_test = get_syscall_event_test(__NR_close, ENTER_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	int socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+	assert_syscall_state(SYSCALL_SUCCESS, "socket", socket_fd, NOT_EQUAL, -1);
+
+	/* This close event should be catched since it is called on an existing socket */
+	assert_syscall_state(SYSCALL_SUCCESS, "close", syscall(__NR_close, socket_fd), NOT_EQUAL, -1);
+
+	evt_test->assert_event_presence();
+
+	/* Now we call again the close on the already close fd and we shouldn't be able to catch the close enter event */
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, socket_fd));
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->assert_event_absence();
+
+	/* Now that the sampling logic is disabled we should be able to collect this event */
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, socket_fd));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+
+TEST(Actions, sampling_ratio_dropping_CLOSE_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_close, EXIT_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* If the syscall fails the close exit event should be dropped */
+	int32_t invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->assert_event_absence();
+
+	/* Now that the sampling logic is disabled we should catch the event */
+	assert_syscall_state(SYSCALL_FAILURE, "close", syscall(__NR_close, invalid_fd));
+
+	evt_test->assert_event_presence();
+
+	evt_test->disable_capture();
+}
+#endif
+
+#ifdef __NR_bind
+TEST(Actions, sampling_ratio_dropping_BIND_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_bind, EXIT_EVENT);
+
+	evt_test->enable_sampling_logic(1);
+
+	evt_test->enable_capture();
+
+	/* If the syscall fails the bind exit event should be dropped */
+	int32_t invalid_fd = -1;
+	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, invalid_fd, NULL, 0));
+
+	evt_test->disable_sampling_logic();
+
+	evt_test->assert_event_absence();
+
+	/* Now that the sampling logic is disabled we should catch the event */
+	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, invalid_fd, NULL, 0));
+
+	evt_test->assert_event_presence();
 
 	evt_test->disable_capture();
 }

--- a/test/drivers/test_suites/syscall_enter_suite/fcntl_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/fcntl_e.cpp
@@ -12,8 +12,9 @@ TEST(SyscallEnter, fcntlE)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
+	/* If the dropping logic is not enabled we should be always able to collect this event */
 	int32_t invalid_fd = -1;
-	int cmd = F_DUPFD_CLOEXEC;
+	int cmd = F_NOTIFY;
 	assert_syscall_state(SYSCALL_FAILURE, "fcntl", syscall(__NR_fcntl, invalid_fd, cmd));
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
@@ -37,7 +38,7 @@ TEST(SyscallEnter, fcntlE)
 	evt_test->assert_numeric_param(1, (int64_t)invalid_fd);
 
 	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
-	evt_test->assert_numeric_param(2, (uint8_t)PPM_FCNTL_F_DUPFD_CLOEXEC);
+	evt_test->assert_numeric_param(2, (uint8_t)PPM_FCNTL_F_NOTIFY);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR supports the syscall-specific dropping logic we have in the other 2 drivers. This logic is disabled by default but it can be enabled by using `dropping_mode=true`

The code section that I'm implementing here is this one (in the old probe)

```c
switch (evt_type) {
case PPME_SYSCALL_CLOSE_X:
case PPME_SOCKET_BIND_X: {
	long ret = bpf_syscall_get_retval(ctx);

	if (ret < 0)
		return true;

	break;
}
case PPME_SYSCALL_CLOSE_E: {
	struct sys_enter_args *args;
	struct files_struct *files;
	struct task_struct *task;
	unsigned long *open_fds;
	struct fdtable *fdt;
	int close_fd;
	int max_fds;

	close_fd = bpf_syscall_get_argument_from_ctx(ctx, 0);
	if (close_fd < 0)
		return true;

	task = (struct task_struct *)bpf_get_current_task();
	if (!task)
		break;

	files = _READ(task->files);
	if (!files)
		break;

	fdt = _READ(files->fdt);
	if (!fdt)
		break;

	max_fds = _READ(fdt->max_fds);
	if (close_fd >= max_fds)
		return true;

	open_fds = _READ(fdt->open_fds);
	if (!open_fds)
		break;

	if (!bpf_test_bit(close_fd, open_fds))
		return true;

	break;
}
case PPME_SYSCALL_FCNTL_E:
case PPME_SYSCALL_FCNTL_X: {
	long cmd = bpf_syscall_get_argument_from_ctx(ctx, 1);

	if (cmd != F_DUPFD && cmd != F_DUPFD_CLOEXEC)
		return true;

	break;
}
default:
	break;
}

```


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
