### PR TITLE
update(driver): remove UF_ALWAYS_DROP from mmap

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -254,10 +254,10 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 	[__NR__llseek - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_LLSEEK_E, PPME_SYSCALL_LLSEEK_X, PPM_SC__LLSEEK},
 #endif
 #ifdef __NR_mmap
-	[__NR_mmap - SYSCALL_TABLE_ID0] =                       {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MMAP_E, PPME_SYSCALL_MMAP_X, PPM_SC_MMAP},
+	[__NR_mmap - SYSCALL_TABLE_ID0] =                       {UF_USED, PPME_SYSCALL_MMAP_E, PPME_SYSCALL_MMAP_X, PPM_SC_MMAP},
 #endif
 #ifdef __NR_mmap2
-	[__NR_mmap2 - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MMAP2_E, PPME_SYSCALL_MMAP2_X, PPM_SC_MMAP2},
+	[__NR_mmap2 - SYSCALL_TABLE_ID0] =                      {UF_USED, PPME_SYSCALL_MMAP2_E, PPME_SYSCALL_MMAP2_X, PPM_SC_MMAP2},
 #endif
 	[__NR_munmap - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MUNMAP_E, PPME_SYSCALL_MUNMAP_X, PPM_SC_MUNMAP},
 	[__NR_splice - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_SPLICE_E, PPME_SYSCALL_SPLICE_X, PPM_SC_SPLICE},
@@ -1082,10 +1082,10 @@ const struct syscall_evt_pair g_syscall_ia32_table[SYSCALL_TABLE_SIZE] = {
 	[__NR_ia32__llseek - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_LLSEEK_E, PPME_SYSCALL_LLSEEK_X, PPM_SC__LLSEEK},
 #endif
 #ifdef __NR_ia32_mmap
-	[__NR_ia32_mmap - SYSCALL_TABLE_ID0] =                       {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MMAP_E, PPME_SYSCALL_MMAP_X, PPM_SC_MMAP},
+	[__NR_ia32_mmap - SYSCALL_TABLE_ID0] =                       {UF_USED, PPME_SYSCALL_MMAP_E, PPME_SYSCALL_MMAP_X, PPM_SC_MMAP},
 #endif
 #ifdef __NR_ia32_mmap2
-	[__NR_ia32_mmap2 - SYSCALL_TABLE_ID0] =                      {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MMAP2_E, PPME_SYSCALL_MMAP2_X, PPM_SC_MMAP2},
+	[__NR_ia32_mmap2 - SYSCALL_TABLE_ID0] =                      {UF_USED, PPME_SYSCALL_MMAP2_E, PPME_SYSCALL_MMAP2_X, PPM_SC_MMAP2},
 #endif
 	[__NR_ia32_munmap - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_MUNMAP_E, PPME_SYSCALL_MUNMAP_X, PPM_SC_MUNMAP},
 	[__NR_ia32_splice - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_SPLICE_E, PPME_SYSCALL_SPLICE_X, PPM_SC_SPLICE},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

**What this PR does / why we need it**:
Remove UF_ALWAYS_DROP from mmap to be able to use it in dropping mode

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(driver): remove UF_ALWAYS_DROP from mmap
```
