### PR TITLE
Add a const base_expr_visitor

### DIFF
--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -66,6 +66,52 @@ void base_expr_visitor::visit(list_expr* e) { }
 
 void base_expr_visitor::visit(unary_check_expr* e) { }
 
+void const_base_expr_visitor::visit(const and_expr* e)
+{
+    for(auto &c: e->children)
+    {
+        if (m_should_stop_visit)
+        {
+            return;
+        }
+        c->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const or_expr* e)
+{
+    for(auto &c: e->children)
+    {
+        if (m_should_stop_visit)
+        {
+            return;
+        }
+        c->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const not_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
+        e->child->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const binary_check_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
+        e->value->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const value_expr* e) { }
+
+void const_base_expr_visitor::visit(const list_expr* e) { }
+
+void const_base_expr_visitor::visit(const unary_check_expr* e) { }
+
 void string_visitor::visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children)
 {
 	bool first = true;

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -145,6 +145,35 @@ private:
 };
 
 /*!
+    \brief An analog of base_expr_visitor, but const.
+*/
+struct SINSP_PUBLIC const_base_expr_visitor: public const_expr_visitor
+{
+public:
+    /*!
+        \brief Can be set to true by subclasses to instruct the
+        visitor that the exploration can be stopped, so
+        that the recursion gets rewinded and no more nodes
+        are explored.
+    */
+    inline void stop(bool v)
+    {
+        m_should_stop_visit = v;
+    }
+
+    virtual void visit(const and_expr*) override;
+    virtual void visit(const or_expr*) override;
+    virtual void visit(const not_expr*) override;
+    virtual void visit(const value_expr*) override;
+    virtual void visit(const list_expr*) override;
+    virtual void visit(const unary_check_expr*) override;
+    virtual void visit(const binary_check_expr*) override;
+
+private:
+    bool m_should_stop_visit = false;
+};
+
+/*!
     \brief A visitor that builds a string as it traverses the
     ast. Used to convert to strings.
 */


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Following on the changes in
https://github.com/falcosecurity/libs/pull/837, add a const variant of base_expr_visitor. This allows definining subclasses that want to traverse an ast read-only without implementng all the methods.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
