### PR TITLE
new(driver/modern_bpf): support dynamic snaplen into modern bpf probe

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -116,6 +116,7 @@ set(DRIVER_SOURCES
 	ppm_tp.h
 	ppm_tp.c
 	ppm_consumer.h
+	capture_macro.h
 )
 
 foreach(FILENAME IN LISTS DRIVER_SOURCES)

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -441,7 +441,7 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 				return SNAPLEN_EXTENDED;
 			}
 		}
-	} else if ((lookahead_size >= 4 && get_buf(1) == 0 && get_buf(2) == 0) || /* matches command */
+	} else if ((sport == PPM_PORT_MONGODB || dport == PPM_PORT_MONGODB) ||
 			(lookahead_size >= 16 && (*(s32 *)&get_buf(12) == 1 || /* matches header */
 						  *(s32 *)&get_buf(12) == 2001 ||
 						  *(s32 *)&get_buf(12) == 2002 ||

--- a/driver/capture_macro.h
+++ b/driver/capture_macro.h
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+*/
+
+#pragma once
+
+/* Possible snaplen */
+#define SNAPLEN 80
+#define SNAPLEN_EXTENDED 2000
+#define SNAPLEN_TRACERS_ENABLED 4096
+#define SNAPLEN_FULLCAPTURE_PORT 16000
+#define SNAPLEN_MAX 65000
+
+/* Deep packet inspection logic */
+#define DPI_LOOKAHEAD_SIZE 16
+#define PPM_PORT_MYSQL 3306
+#define PPM_PORT_POSTGRES 5432
+#define PPM_PORT_STATSD 8125
+#define PPM_PORT_MONGODB 27017
+
+/* HTTP */
+#define BPF_HTTP_GET 0x20544547
+#define BPF_HTTP_POST 0x54534F50
+#define BPF_HTTP_PUT 0x20545550
+#define BPF_HTTP_DELETE 0x454C4544
+#define BPF_HTTP_TRACE 0x43415254
+#define BPF_HTTP_CONNECT 0x4E4E4F43
+#define BPF_HTTP_OPTIONS 0x4954504F
+#define BPF_HTTP_PREFIX 0x50545448
+
+/* Convert seconds to nanoseconds */
+#define SECOND_TO_NS 1000000000

--- a/driver/main.c
+++ b/driver/main.c
@@ -519,7 +519,7 @@ static int ppm_open(struct inode *inode, struct file *filp)
 	 * ring->preempt_count which will become < 0, leading to the complete loss of all the events for that CPU.
 	 */
 	consumer->dropping_mode = 0;
-	consumer->snaplen = RW_SNAPLEN;
+	consumer->snaplen = SNAPLEN;
 	consumer->sampling_ratio = 1;
 	consumer->sampling_interval = 0;
 	consumer->is_dropping = 0;
@@ -989,7 +989,7 @@ cleanup_ioctl_procinfo:
 		vpr_info("PPM_IOCTL_SET_SNAPLEN, consumer %p\n", consumer_id);
 		new_snaplen = (u32)arg;
 
-		if (new_snaplen > RW_MAX_SNAPLEN) {
+		if (new_snaplen > SNAPLEN_MAX) {
 			pr_err("invalid snaplen %u\n", new_snaplen);
 			ret = -EINVAL;
 			goto cleanup_ioctl;

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -1269,6 +1269,7 @@
 #define MAJOR(dev) ((unsigned int)((dev) >> MINORBITS))
 #define MINOR(dev) ((unsigned int)((dev)&MINORMASK))
 #define MKDEV(ma, mi) (((ma) << MINORBITS) | (mi))
+#define PPM_NULL_RDEV MKDEV(1, 3)
 
 /*=============================== DEVICE_VERSIONS ===========================*/
 

--- a/driver/modern_bpf/helpers/base/common.h
+++ b/driver/modern_bpf/helpers/base/common.h
@@ -10,12 +10,10 @@
 #include <definitions/vmlinux.h>
 #include <definitions/struct_flavors.h>
 #include <definitions/missing_definitions.h>
+#include <driver/capture_macro.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
-
-/* Convert seconds to nanoseconds */
-#define SECOND_TO_NS 1000000000
 
 /*=============================== LIBBPF MISSING TRACING DEFINITION ===========================*/
 

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -41,6 +41,26 @@ static __always_inline bool maps__get_drop_failed()
 	return g_settings.drop_failed;
 }
 
+static __always_inline bool maps__get_do_dynamic_snaplen()
+{
+	return g_settings.do_dynamic_snaplen;
+}
+
+static __always_inline uint16_t maps__get_fullcapture_port_range_start()
+{
+	return g_settings.fullcapture_port_range_start;
+}
+
+static __always_inline uint16_t maps__get_fullcapture_port_range_end()
+{
+	return g_settings.fullcapture_port_range_end;
+}
+
+static __always_inline uint16_t maps__get_statsd_port()
+{
+	return g_settings.statsd_port;
+}
+
 /*=============================== SETTINGS ===========================*/
 
 /*=============================== KERNEL CONFIGS ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -71,16 +71,16 @@ int BPF_PROG(pread64_x,
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, false);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		/* Parameter 2: data (type: PT_BYTEBUF) */
 		unsigned long data_ptr = extract__syscall_argument(regs, 1);
-		auxmap__store_bytebuf_param(auxmap, data_ptr, bytes_to_read, USER);
+		auxmap__store_bytebuf_param(auxmap, data_ptr, snaplen, USER);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -65,23 +65,23 @@ int BPF_PROG(preadv_x,
 	if(ret > 0)
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-        auxmap__store_u32_param(auxmap, (u32)ret);
+		auxmap__store_u32_param(auxmap, (u32)ret);
 
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, true);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 		unsigned long iov_cnt = extract__syscall_argument(regs, 2);
 
 		//* Parameter 3: data (type: PT_BYTEBUF) */
-		auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, bytes_to_read);
+		auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, snaplen);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -69,16 +69,17 @@ int BPF_PROG(pwrite64_x,
 	/* If the syscall doesn't fail we use the return value as `size`
 	 * otherwise we need to rely on the syscall parameter provided by the user.
 	 */
-	unsigned long bytes_to_read = ret > 0 ? ret : extract__syscall_argument(regs, 2);
-	unsigned long snaplen = maps__get_snaplen();
-	if(bytes_to_read > snaplen)
+	u16 bytes_to_read = ret > 0 ? ret : extract__syscall_argument(regs, 2);
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, false);
+	if(snaplen > bytes_to_read)
 	{
-		bytes_to_read = snaplen;
+		snaplen = bytes_to_read;
 	}
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	unsigned long data_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_bytebuf_param(auxmap, data_pointer, bytes_to_read, USER);
+	auxmap__store_bytebuf_param(auxmap, data_pointer, snaplen, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -73,17 +73,18 @@ int BPF_PROG(pwritev_x,
 	 * otherwise we need to extract it now and it has a cost. Here we check just
 	 * the return value if the syscall is successful.
 	 */
-	unsigned long bytes_to_read = maps__get_snaplen();
-	if(ret > 0 && bytes_to_read > ret)
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, true);
+	if(ret > 0 && snaplen > ret)
 	{
-		bytes_to_read = ret;
+		snaplen = ret;
 	}
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 	unsigned long iov_cnt = extract__syscall_argument(regs, 2);
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
-	auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, bytes_to_read);
+	auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, snaplen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -67,16 +67,16 @@ int BPF_PROG(read_x,
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, false);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		/* Parameter 2: data (type: PT_BYTEBUF) */
 		unsigned long data_pointer = extract__syscall_argument(regs, 1);
-		auxmap__store_bytebuf_param(auxmap, data_pointer, bytes_to_read, USER);
+		auxmap__store_bytebuf_param(auxmap, data_pointer, snaplen, USER);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -61,23 +61,23 @@ int BPF_PROG(readv_x,
 	if(ret > 0)
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-        auxmap__store_u32_param(auxmap, (u32)ret);
+		auxmap__store_u32_param(auxmap, (u32)ret);
 
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, true);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 		unsigned long iov_cnt = extract__syscall_argument(regs, 2);
 
 		//* Parameter 3: data (type: PT_BYTEBUF) */
-		auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, bytes_to_read);
+		auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, snaplen);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -72,15 +72,16 @@ int BPF_PROG(recv_x,
 		unsigned long args[2];
 		extract__network_args(args, 2, regs);
 
-		unsigned long bytes_to_read = maps__get_snaplen();
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, false);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		/* Parameter 2: data (type: PT_BYTEBUF) */
 		unsigned long data_pointer = args[1];
-		auxmap__store_bytebuf_param(auxmap, data_pointer, bytes_to_read, USER);
+		auxmap__store_bytebuf_param(auxmap, data_pointer, snaplen, USER);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -75,11 +75,11 @@ int BPF_PROG(recvfrom_x,
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, false);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		/* Collect parameters at the beginning to manage socketcalls */
@@ -88,7 +88,7 @@ int BPF_PROG(recvfrom_x,
 
 		/* Parameter 2: data (type: PT_BYTEBUF) */
 		unsigned long received_data_pointer = args[1];
-		auxmap__store_bytebuf_param(auxmap, received_data_pointer, bytes_to_read, USER);
+		auxmap__store_bytebuf_param(auxmap, received_data_pointer, snaplen, USER);
 
 		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
 		u32 socket_fd = (u32)args[0];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -75,11 +75,11 @@ int BPF_PROG(recvmsg_x,
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
 		 */
-		unsigned long bytes_to_read = maps__get_snaplen();
-
-		if(bytes_to_read > ret)
+		u16 snaplen = maps__get_snaplen();
+		apply_dynamic_snaplen(regs, &snaplen, true);
+		if(snaplen > ret)
 		{
-			bytes_to_read = ret;
+			snaplen = ret;
 		}
 
 		/* Collect parameters at the beginning to manage socketcalls */
@@ -88,8 +88,8 @@ int BPF_PROG(recvmsg_x,
 
 		/* Parameter 3: data (type: PT_BYTEBUF) */
 		unsigned long msghdr_pointer = args[1];
-		auxmap__store_msghdr_data_param(auxmap, msghdr_pointer, bytes_to_read);
-		
+		auxmap__store_msghdr_data_param(auxmap, msghdr_pointer, snaplen);
+
 		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
 		u32 socket_fd = (u32)args[0];
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -70,16 +70,17 @@ int BPF_PROG(send_x,
 	unsigned long args[3];
 	extract__network_args(args, 3, regs);
 
-	unsigned long bytes_to_read = ret > 0 ? ret : args[2];
-	unsigned long snaplen = maps__get_snaplen();
-	if(bytes_to_read > snaplen)
+	u16 bytes_to_read = ret > 0 ? ret : args[2];
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, false);
+	if(snaplen > bytes_to_read)
 	{
-		bytes_to_read = snaplen;
+		snaplen = bytes_to_read;
 	}
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	unsigned long sent_data_pointer = args[1];
-	auxmap__store_bytebuf_param(auxmap, sent_data_pointer, bytes_to_read, USER);
+	auxmap__store_bytebuf_param(auxmap, sent_data_pointer, snaplen, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -91,15 +91,16 @@ int BPF_PROG(sendmsg_x,
 	 * otherwise we need to extract it now and it has a cost. Here we check just
 	 * the return value if the syscall is successful.
 	 */
-	unsigned long bytes_to_read = maps__get_snaplen();
-	if(ret > 0 && bytes_to_read > ret)
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, true);
+	if(ret > 0 && snaplen > ret)
 	{
-		bytes_to_read = ret;
+		snaplen = ret;
 	}
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	unsigned long msghdr_pointer = args[1];
-	auxmap__store_msghdr_data_param(auxmap, msghdr_pointer, bytes_to_read);
+	auxmap__store_msghdr_data_param(auxmap, msghdr_pointer, snaplen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -89,16 +89,17 @@ int BPF_PROG(sendto_x,
 	/* If the syscall doesn't fail we use the return value as `size`
 	 * otherwise we need to rely on the syscall parameter provided by the user.
 	 */
-	unsigned long bytes_to_read = ret > 0 ? ret : args[2];
-	unsigned long snaplen = maps__get_snaplen();
-	if(bytes_to_read > snaplen)
+	u16 bytes_to_read = ret > 0 ? ret : args[2];
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, false);
+	if(snaplen > bytes_to_read)
 	{
-		bytes_to_read = snaplen;
+		snaplen = bytes_to_read;
 	}
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	unsigned long sent_data_pointer = args[1];
-	auxmap__store_bytebuf_param(auxmap, sent_data_pointer, bytes_to_read, USER);
+	auxmap__store_bytebuf_param(auxmap, sent_data_pointer, snaplen, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -65,16 +65,17 @@ int BPF_PROG(write_x,
 	/* If the syscall doesn't fail we use the return value as `size`
 	 * otherwise we need to rely on the syscall parameter provided by the user.
 	 */
-	unsigned long bytes_to_read = ret > 0 ? ret : extract__syscall_argument(regs, 2);
-	unsigned long snaplen = maps__get_snaplen();
-	if(bytes_to_read > snaplen)
+	u16 bytes_to_read = ret > 0 ? ret : extract__syscall_argument(regs, 2);
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, false);
+	if(snaplen > bytes_to_read)
 	{
-		bytes_to_read = snaplen;
+		snaplen = bytes_to_read;
 	}
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	unsigned long data_pointer = extract__syscall_argument(regs, 1);
-	auxmap__store_bytebuf_param(auxmap, data_pointer, bytes_to_read, USER);
+	auxmap__store_bytebuf_param(auxmap, data_pointer, snaplen, USER);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -69,17 +69,18 @@ int BPF_PROG(writev_x,
 	 * otherwise we need to extract it now and it has a cost. Here we check just
 	 * the return value if the syscall is successful.
 	 */
-	unsigned long bytes_to_read = maps__get_snaplen();
-	if(ret > 0 && bytes_to_read > ret)
+	u16 snaplen = maps__get_snaplen();
+	apply_dynamic_snaplen(regs, &snaplen, true);
+	if(ret > 0 && snaplen > ret)
 	{
-		bytes_to_read = ret;
+		snaplen = ret;
 	}
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 	unsigned long iov_cnt = extract__syscall_argument(regs, 2);
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
-	auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, bytes_to_read);
+	auxmap__store_iovec_data_param(auxmap, iov_pointer, iov_cnt, snaplen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -23,11 +23,15 @@
  */
 struct capture_settings
 {
-	uint64_t boot_time;	 /* boot time. */
-	uint32_t snaplen;	 /* we use it when we want to read a maximum size from a event and no more. */
-	bool dropping_mode;	 /* this flag actives the sampling logic */
-	uint32_t sampling_ratio; /* this config tells tracepoints when they have to drop events  */
-	bool drop_failed;     /* whether to drop failed syscalls (exit events) */
+	uint64_t boot_time;		       /* boot time. */
+	uint32_t snaplen;		       /* we use it when we want to read a maximum size from an event and no more. */
+	bool dropping_mode;		       /* this flag actives the sampling logic */
+	uint32_t sampling_ratio;	       /* this config tells tracepoints when they have to drop events  */
+	bool drop_failed;		       /* whether to drop failed syscalls (exit events) */
+	bool do_dynamic_snaplen;	       /* enforce snaplen according to the event content */
+	uint16_t fullcapture_port_range_start; /* first interesting port */
+	uint16_t fullcapture_port_range_end;   /* last interesting port */
+	uint16_t statsd_port;		       /* port for statsd metrics */
 };
 
 /**

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -26,13 +26,8 @@ or GPL2.txt for full copies of the license.
 
 #endif /* UDIG */
 
-#define RW_SNAPLEN_EVENT 4096
-#define DPI_LOOKAHEAD_SIZE 16
+#include "capture_macro.h"
 #define PPM_NULL_RDEV MKDEV(1, 3)
-#define PPM_PORT_MYSQL 3306
-#define PPM_PORT_POSTGRES 5432
-#define PPM_PORT_STATSD 8125
-#define PPM_PORT_MONGODB 27017
 
 typedef u64 nanoseconds;
 

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -372,7 +372,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 	struct sockaddr_storage peer_address;
 	u16 sport, dport;
 	u16 min_port = 0, max_port = 0;
-	u32 dynamic_snaplen = 2000;
+	u32 dynamic_snaplen = SNAPLEN_EXTENDED;
 
 	if (args->consumer->snaplen > dynamic_snaplen) {
 		/*
@@ -389,7 +389,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 
 		if (f.file && f.file->f_inode) {
 			if (f.file->f_inode->i_rdev == PPM_NULL_RDEV) {
-				res = RW_SNAPLEN_EVENT;
+				res = SNAPLEN_TRACERS_ENABLED;
 				fdput(f);
 				return res;
 			}
@@ -412,7 +412,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 		if (file && file->f_path.dentry && file->f_path.dentry->d_inode) {
 			if (file->f_path.dentry->d_inode->i_rdev == PPM_NULL_RDEV) {
 #endif
-				res = RW_SNAPLEN_EVENT;
+				res = SNAPLEN_TRACERS_ENABLED;
 				fput(file);
 				return res;
 			}
@@ -575,7 +575,7 @@ inline u32 compute_snaplen(struct event_filler_arguments *args, char *buf, u32 l
 		 * an increased snaplen for the port in question.
 		 */
 		sockfd_put(sock);
-		return RW_MAX_FULLCAPTURE_PORT_SNAPLEN;
+		return SNAPLEN_FULLCAPTURE_PORT;
 	} else if (sport == PPM_PORT_MYSQL || dport == PPM_PORT_MYSQL) {
 		if (lookahead_size >= 5) {
 			if (buf[0] == 3 || buf[1] == 3 || buf[2] == 3 || buf[3] == 3 || buf[4] == 3) {

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -2001,10 +2001,6 @@ struct ppm_event_entry {
 #define PPM_SKIP_EVENT -4
 #define PPM_FAILURE_FRAME_SCRATCH_MAP_FULL -5	/* this is used only inside bpf, kernel module does not have a frame scratch map*/
 
-#define RW_SNAPLEN 80
-#define RW_MAX_SNAPLEN PPM_MAX_ARG_SIZE
-#define RW_MAX_FULLCAPTURE_PORT_SNAPLEN 16000
-
 /*
  * machine_info flags.
  */

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -205,6 +205,28 @@ void event_test::disable_drop_failed()
 	scap_set_dropfailed(s_scap_handle, false);
 }
 
+void event_test::set_do_dynamic_snaplen(bool enable)
+{
+	if(enable)
+	{
+		scap_enable_dynamic_snaplen(s_scap_handle);
+	}
+	else
+	{
+		scap_disable_dynamic_snaplen(s_scap_handle);
+	}
+}
+
+void event_test::set_statsd_port(uint16_t port)
+{
+	scap_set_statsd_port(s_scap_handle, port);
+}
+
+void event_test::set_fullcapture_port_range(uint16_t start, uint16_t end)
+{
+	scap_set_fullcapture_port_range(s_scap_handle, start, end);
+}
+
 void event_test::disable_capture()
 {
 	scap_stop_capture(s_scap_handle);
@@ -340,7 +362,7 @@ void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	strlcpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH);
 }
 
-void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr)
+void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr, int32_t port_client, int32_t port_server)
 {
 	/* Create the server socket. */
 	*server_socket = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -348,7 +370,7 @@ void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct so
 	server_reuse_address_port(*server_socket);
 
 	memset(server_sockaddr, 0, sizeof(*server_sockaddr));
-	server_fill_sockaddr_in(server_sockaddr);
+	server_fill_sockaddr_in(server_sockaddr, port_server);
 
 	/* Now we bind the server socket with the server address. */
 	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
@@ -361,7 +383,7 @@ void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct so
 	client_reuse_address_port(*client_socket);
 
 	memset(client_sockaddr, 0, sizeof(*client_sockaddr));
-	client_fill_sockaddr_in(client_sockaddr);
+	client_fill_sockaddr_in(client_sockaddr, port_client);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
 	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -174,6 +174,27 @@ public:
 	void disable_drop_failed();
 
 	/**
+	 * @brief Enable/Disable dynamic snaplen logic
+	 *
+	 */
+	void set_do_dynamic_snaplen(bool enable);
+
+	/**
+	 * @brief Set stasd port
+	 * 
+	 * @param port new statsd port
+	 */
+	void set_statsd_port(uint16_t port);
+
+	/**
+	 * @brief Set a range of network ports as interesting
+	 * 
+	 * @param start first port of the range
+	 * @param end last port of the range
+	 */
+	void set_fullcapture_port_range(uint16_t start, uint16_t end);
+
+	/**
 	 * @brief Clear the ring buffers from all previous events until they
 	 * are all empty.
 	 *
@@ -281,7 +302,7 @@ public:
 	 * @param server_socket server socket file descriptor.
 	 * @param server_sockaddr server `sockaddr` struct to fill.
 	 */
-	void connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr);
+	void connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr, int32_t client_port = IPV4_PORT_CLIENT, int32_t server_port = IPV4_PORT_SERVER);
 	void connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr);
 	void connect_unix_client_to_server(int32_t* client_socket, struct sockaddr_un* client_sockaddr, int32_t* server_socket, struct sockaddr_un* server_sockaddr);
 
@@ -590,7 +611,7 @@ public:
 	void assert_fd_list(int param_num, struct fd_poll* expected_fds, int32_t nfds);
 
 private:
-	ppm_event_code m_event_type;	  /* type of the event we want to assert in this test. */
+	ppm_event_code m_event_type;		  /* type of the event we want to assert in this test. */
 	std::vector<struct param> m_event_params; /* all the params of the event (len+value). */
 	struct ppm_evt_hdr* m_event_header;	  /* header of the event. */
 	uint32_t m_event_len;			  /* total event length. */

--- a/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
+++ b/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
@@ -1,0 +1,849 @@
+#include "../../event_class/event_class.h"
+#include <capture_macro.h>
+
+#ifdef __NR_write
+TEST(Actions, dynamic_snaplen_negative_fd)
+{
+	auto evt_test = get_syscall_event_test(__NR_write, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we have a len greater than the default snaplen, thanks to the dynamic snaplen
+	 * we could be able to retrieve all `DEFAULT_SNAPLEN * 2` bytes but since the fd is negative
+	 * we cannot enable this logic.
+	 */
+	int fd = -1;
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "HTTP/\0";
+	ssize_t write_bytes = syscall(__NR_write, fd, (void *)buf, data_len);
+	assert_syscall_state(SYSCALL_FAILURE, "write", write_bytes);
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	/* We expect the default snaplen since we cannot enable the dynamic snaplen logic */
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_no_socket)
+{
+	auto evt_test = get_syscall_event_test(__NR_write, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we have a len greater than the default snaplen, thanks to the dynamic snaplen
+	 * we could be able to retrieve all `DEFAULT_SNAPLEN * 2` bytes but since the fd is not
+	 * a socket we cannot enable this logic.
+	 */
+	int fd = (2 ^ 16) - 1;
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "HTTP/\0";
+	ssize_t write_bytes = syscall(__NR_write, fd, (void *)buf, data_len);
+	assert_syscall_state(SYSCALL_FAILURE, "write", write_bytes);
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	/* We expect the default snaplen since we cannot enable the dynamic snaplen logic */
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+#if defined(__NR_sendto) && defined(__NR_socket) && defined(__NR_shutdown) && defined(__NR_close) && defined(__NR_bind) && defined(__NR_listen) && defined(__NR_connect)
+TEST(Actions, dynamic_snaplen_HTTP)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "HTTP/\0";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_partial_HTTP_OPT)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	/* This is not recognized in the dynamic snaplen logic */
+	char buf[data_len] = "OP\0";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_HTTP_TRACE)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "TRACE\0";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_MYSQL)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "simple message";
+	/* This should trigger our SQL detection logic, `3` is used as ASCII code */
+	buf[3] = 3;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_not_MYSQL)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "1111\0";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_POSTGRES)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	/* This should trigger our Postgres detection logic, `0` is used as ASCII code */
+	char buf[data_len] = "P2434242\0";
+	buf[1] = 0;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_not_POSTGRES)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "00\0";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_MONGO)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = {0};
+	*(int32_t *)(&buf[12]) = 0x01; // this 1 and it's ok
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_not_MONGO)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = {0};
+	*(int32_t *)(&buf[12]) = 0x07;
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_fullcapture_port_range)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	/* The server's port is in the range so the dynamic snaplen should be enabled */
+	evt_test->set_fullcapture_port_range(IPV4_PORT_SERVER, IPV4_PORT_SERVER);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "simple message";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_statsd_port)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	/* The server's port is the statsd port so the dynamic snaplen should be enabled */
+	evt_test->set_statsd_port(IPV4_PORT_SERVER);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "simple message";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_statsd_port(0);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN * 2);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+
+TEST(Actions, dynamic_snaplen_no_statsd_port)
+{
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	/* The server's port is not the statsd port so the dynamic snaplen shouldn't be enabled */
+	evt_test->set_statsd_port(IPV4_PORT_SERVER + 1);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	struct sockaddr_in client_addr = {0};
+	struct sockaddr_in server_addr = {0};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
+
+	/* Send a message to the server */
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char buf[data_len] = "simple message";
+	uint32_t sendto_flags = 0;
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto", sent_bytes, NOT_EQUAL, -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_statsd_port(0);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)sent_bytes);
+
+	/* Parameter 2: data (type: PT_BYTEBUF)*/
+	evt_test->assert_bytebuf_param(2, buf, DEFAULT_SNAPLEN);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(2);
+}
+#endif

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -334,6 +334,28 @@ extern "C"
 	void pman_set_drop_failed(bool drop_failed);
 
 	/**
+	 * @brief Ask driver to enable/disable dynamic_snaplen.
+	 *
+	 * @param do_dynamic_snaplen whether to enable the dynamic_snaplen.
+	 */
+	void pman_set_do_dynamic_snaplen(bool do_dynamic_snaplen);
+
+	/**
+	 * @brief Ask driver to set a range of interesting ports.
+	 *
+	 * @param range_start first interesting port.
+	 * @param range_end last interesting port.
+	 */
+	void pman_set_fullcapture_port_range(uint16_t range_start, uint16_t range_end);
+
+	/**
+	 * @brief Ask driver to set a specific statsd_port.
+	 *
+	 * @param statsd_port port number.
+	 */
+	void pman_set_statsd_port(uint16_t statsd_port);
+
+	/**
 	 * @brief Get API version to check it a runtime.
 	 *
 	 * @return API version

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -347,7 +347,12 @@ int pman_finalize_maps_after_loading()
 
 	/* set bpf global variables. */
 	pman_set_snaplen(80);
+	pman_set_dropping_mode(false);
+	pman_set_sampling_ratio(1);
 	pman_set_drop_failed(false);
+	pman_set_do_dynamic_snaplen(false);
+	pman_set_fullcapture_port_range(0, 0);
+	pman_set_statsd_port(PPM_PORT_STATSD);
 
 	/* We have to fill all ours tail tables. */
 	pman_fill_syscall_sampling_table();

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -87,6 +87,22 @@ void pman_set_drop_failed(bool drop_failed)
 	g_state.skel->bss->g_settings.drop_failed = drop_failed;
 }
 
+void pman_set_do_dynamic_snaplen(bool do_dynamic_snaplen)
+{
+	g_state.skel->bss->g_settings.do_dynamic_snaplen = do_dynamic_snaplen;
+}
+
+void pman_set_fullcapture_port_range(uint16_t range_start, uint16_t range_end)
+{
+	g_state.skel->bss->g_settings.fullcapture_port_range_start = range_start;
+	g_state.skel->bss->g_settings.fullcapture_port_range_end = range_end;
+}
+
+void pman_set_statsd_port(uint16_t statsd_port)
+{
+	g_state.skel->bss->g_settings.statsd_port = statsd_port;
+}
+
 void pman_mark_single_64bit_syscall(int intersting_syscall_id, bool interesting)
 {
 	g_state.skel->bss->g_64bit_interesting_syscalls_table[intersting_syscall_id] = interesting;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1074,9 +1074,9 @@ int32_t scap_bpf_set_snaplen(struct scap_engine_handle engine, uint32_t snaplen)
 	int k = 0;
 	int ret;
 
-	if(snaplen > RW_MAX_SNAPLEN)
+	if(snaplen > SNAPLEN_MAX)
 	{
-		return scap_errprintf(handle->m_lasterr, 0, "snaplen can't exceed %d\n", RW_MAX_SNAPLEN);
+		return scap_errprintf(handle->m_lasterr, 0, "snaplen can't exceed %d\n", SNAPLEN_MAX);
 	}
 
 	if((ret = bpf_map_lookup_elem(handle->m_bpf_map_fds[SCAP_SETTINGS_MAP], &k, &settings)) != 0)
@@ -1359,7 +1359,7 @@ static int32_t set_default_settings(struct bpf_engine *handle)
 
 	settings.boot_time = boot_time;
 	settings.socket_file_ops = NULL;
-	settings.snaplen = RW_SNAPLEN;
+	settings.snaplen = SNAPLEN;
 	settings.sampling_ratio = 1;
 	settings.do_dynamic_snaplen = false;
 	settings.dropping_mode = false;
@@ -1368,7 +1368,7 @@ static int32_t set_default_settings(struct bpf_engine *handle)
 	settings.tracers_enabled = false;
 	settings.fullcapture_port_range_start = 0;
 	settings.fullcapture_port_range_end = 0;
-	settings.statsd_port = 8125;
+	settings.statsd_port = PPM_PORT_STATSD;
 
 	int k = 0;
 	int ret;

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -114,16 +114,16 @@ static int32_t scap_modern_bpf__configure(struct scap_engine_handle engine, enum
 		return scap_modern_bpf_handle_sc(engine, arg1, arg2);
 	case SCAP_DROP_FAILED:
 		pman_set_drop_failed(arg1);
-		return SCAP_SUCCESS;
+		break;
 	case SCAP_DYNAMIC_SNAPLEN:
-		/* Not supported */
-		return SCAP_SUCCESS;
+		pman_set_do_dynamic_snaplen(arg1);
+		break;
 	case SCAP_FULLCAPTURE_PORT_RANGE:
-		/* Not supported */
-		return SCAP_SUCCESS;
+		pman_set_fullcapture_port_range(arg1, arg2);
+		break;
 	case SCAP_STATSD_PORT:
-		/* Not supported */
-		return SCAP_SUCCESS;
+		pman_set_statsd_port(arg1);
+		break;
 	default:
 	{
 		char msg[SCAP_LASTERR_SIZE];

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -20,8 +20,6 @@
 #include "strerror.h"
 #include "strlcpy.h"
 
-#define PPM_PORT_STATSD 8125
-
 #ifndef UDIG_INSTRUMENTER
 #define ud_shm_open shm_open
 #else
@@ -263,7 +261,7 @@ bool acquire_and_init_ring_status_buffer(struct scap_device *dev)
 
 		memset(consumer, 0, sizeof(struct udig_consumer_t));
 		consumer->dropping_mode = 0;
-		consumer->snaplen = RW_SNAPLEN;
+		consumer->snaplen = SNAPLEN;
 		consumer->sampling_ratio = 1;
 		consumer->sampling_interval = 0;
 		consumer->is_dropping = 0;

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -37,8 +37,6 @@ limitations under the License.
 #include "clock_helpers.h"
 #include "debug_log_helpers.h"
 
-#define SECOND_TO_NS 1000000000
-
 int32_t scap_proc_fill_cwd(char* error, char* procdirname, struct scap_threadinfo* tinfo)
 {
 	int target_res;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -34,8 +34,6 @@ limitations under the License.
 
 #include "scap_engines.h"
 
-#define SECOND_TO_NS 1000000000
-
 //#define NDEBUG
 #include <assert.h>
 

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -62,6 +62,7 @@ typedef struct ppm_evt_hdr scap_evt;
 #include "../common/types.h"
 #include "../../driver/ppm_api_version.h"
 #include "../../driver/ppm_events_public.h"
+#include "../../driver/capture_macro.h"
 #ifdef _WIN32
 #include <time.h>
 #endif

--- a/userspace/libscap/scap_machine_agent.c
+++ b/userspace/libscap/scap_machine_agent.c
@@ -29,8 +29,6 @@ limitations under the License.
 #include "scap.h"
 #include "scap-int.h"
 
-#define SECOND_TO_NS 1000000000
-
 void scap_gethostname(scap_t* handle)
 {
 	char *env_hostname = getenv(SCAP_HOSTNAME_ENV_VAR);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR introduces the dynamic snaplen logic into the modern bpf probe. As I wrote in some comments, the logic is slightly different with respect to the old drivers:

```c
	/* The syscalls involved in this logic are:
	 *  - read
	 *  - pread64
	 *  - readv
	 *  - preadv
	 *  - write
	 *  - pwrite64
	 *  - writev
	 *  - pwritev
	 *  - recvmsg
	 *  - sendmsg
	 *  - send
	 *  - recv
	 *  - recvfrom
	 *  - sendto
	 *
	 * Almost all syscalls involved have:
	 *  - `fd` as the first argument.
	 *  - `buf` as the second argument.
	 *  - `len` as the third argument.
	 * So extracting data is quite simple in this case.
	 *
	 * Some syscalls use `iovec` structs so their extraction would be quite complex,
	 * for this reason we apply only the port_range logic. The following syscalls fall
	 * in this category:
	 *  - readv
	 *  - preadv
	 *  - writev
	 *  - pwritev
	 *  - recvmsg
	 *  - sendmsg
	 */
```
So syscalls that use `iovec` structs are involved only in the port_range logic avoiding the extra complexity to extract an iovec and its length in this helper function. Maybe we could add it in a second step but right now i would keep this logic as simple as possible

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
