### PR TITLE
Stop hard failing configuration on unsupported archs

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -13,19 +13,19 @@ if((NOT TARGET_ARCH STREQUAL "x86_64") AND
    (NOT TARGET_ARCH STREQUAL "aarch64") AND
    (NOT TARGET_ARCH STREQUAL "s390x"))
 	message(WARNING "Target architecture not officially supported by our drivers!")
-endif()
+else()
+	# Load current kernel version
+	execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+	string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
+	message(STATUS  "Kernel version: ${UNAME_RESULT}")
 
-# Load current kernel version
-execute_process(COMMAND uname -r OUTPUT_VARIABLE UNAME_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REGEX MATCH "[0-9]+.[0-9]+" LINUX_KERNEL_VERSION ${UNAME_RESULT})
-message(STATUS  "Kernel version: ${UNAME_RESULT}")
-
-# Check minimum kernel version
-set(kmod_min_kver_map_x86_64 2.6)
-set(kmod_min_kver_map_aarch64 3.16)
-set(kmod_min_kver_map_s390x 2.6)
-if (LINUX_KERNEL_VERSION VERSION_LESS ${kmod_min_kver_map_${TARGET_ARCH}})
-	message(WARNING "[KMOD] To run this driver you need a Linux kernel version >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+	# Check minimum kernel version
+	set(kmod_min_kver_map_x86_64 2.6)
+	set(kmod_min_kver_map_aarch64 3.16)
+	set(kmod_min_kver_map_s390x 2.6)
+	if (LINUX_KERNEL_VERSION VERSION_LESS ${kmod_min_kver_map_${TARGET_ARCH}})
+		message(WARNING "[KMOD] To run this driver you need a Linux kernel version >= ${kmod_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
+	endif()
 endif()
 
 option(BUILD_DRIVER "Build the driver on Linux" ON)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
When trying to compile the drivers for unsupported architectures, cmake is hard failing due to it trying to access a non-existent variable. As an example, when trying to compile for `ppc64le`, cmake complains with the following message:
```
CMake Warning at driver/CMakeLists.txt:15 (message):
  Target architecture not officially supported by our drivers!


-- Kernel version: 4.18.0-425.13.1.el8_7.ppc64le
CMake Error at driver/CMakeLists.txt:27 (if):
  if given arguments:

    "LINUX_KERNEL_VERSION" "VERSION_LESS"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!
```

Since we are already printing a warning message I see no reason why we should prevent people from building the drivers on unsupported archs at their own risk.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
