### PR TITLE
cleanup(sinsp): minor sinsp_dumper cleanups

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -392,18 +392,14 @@ bool sinsp_container_manager::async_allowed() const
 	return m_inspector->m_inited;
 }
 
-void sinsp_container_manager::dump_containers(scap_dumper_t* dumper)
+void sinsp_container_manager::dump_containers(sinsp_dumper& dumper)
 {
 	for(const auto& it : (*m_containers.lock()))
 	{
 		sinsp_evt evt;
 		if(container_to_sinsp_event(container_to_json(*it.second), &evt, it.second->get_tinfo(m_inspector)))
 		{
-			int32_t res = scap_dump(dumper, evt.m_pevt, evt.m_cpuid, SCAP_DF_LARGE);
-			if(res != SCAP_SUCCESS)
-			{
-				throw sinsp_exception(scap_dump_getlasterr(dumper));
-			}
+			dumper.dump(&evt);
 		}
 	}
 }

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -37,6 +37,8 @@ limitations under the License.
 #include "container_engine/sinsp_container_type.h"
 #include "mutex.h"
 
+class sinsp_dumper;
+
 class sinsp_container_manager :
 	public libsinsp::container_engine::container_cache_interface
 {
@@ -118,7 +120,7 @@ public:
 	 * it may still be happening in the background asynchronously
 	 */
 	bool resolve_container(sinsp_threadinfo* tinfo, bool query_os_for_missing_info);
-	void dump_containers(scap_dumper_t* dumper);
+	void dump_containers(sinsp_dumper& dumper);
 	std::string get_container_name(sinsp_threadinfo* tinfo) const;
 
 	// Set tinfo's m_category based on the container context.  It

--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -29,7 +29,6 @@ cycle_writer::cycle_writer(bool is_live) :
 	m_file_index(0),
 	m_first_consider(false),
 	m_event_count(0L),
-	m_dumper(NULL),
 	m_past_names(NULL)
 {
 	//
@@ -43,7 +42,7 @@ cycle_writer::cycle_writer(bool is_live) :
 	this->live = is_live;
 }
 
-bool cycle_writer::setup(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, scap_dumper_t** dumper)
+bool cycle_writer::setup(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit)
 {
 	if(m_first_consider) 
 	{
@@ -54,7 +53,6 @@ bool cycle_writer::setup(std::string base_file_name, int rollover_mb, int durati
 	m_duration_seconds = duration_seconds;
 	m_file_limit = file_limit;
 	m_event_limit = event_limit;
-	m_dumper = dumper;
 
 	if(duration_seconds > 0 && file_limit > 0)
 	{
@@ -70,7 +68,7 @@ bool cycle_writer::setup(std::string base_file_name, int rollover_mb, int durati
 	// Seed the filename with an initial
 	// value.
 	//
-	consider(NULL);
+	consider(NULL, 0);
 	return true;
 }
 
@@ -83,7 +81,7 @@ bool cycle_writer::setup(std::string base_file_name, int rollover_mb, int durati
 //  * NEWFILE - use a new file (inquiry with get_current_file_name())
 //  * DOQUIT - end the capture.
 //
-cycle_writer::conclusion cycle_writer::consider(sinsp_evt* evt) 
+cycle_writer::conclusion cycle_writer::consider(sinsp_evt* evt, uint64_t written_bytes)
 {
 	if(m_first_consider == false) 
 	{
@@ -123,7 +121,7 @@ cycle_writer::conclusion cycle_writer::consider(sinsp_evt* evt)
 		}
 	}
 
-	if(m_rollover_mb > 0 && scap_dump_get_offset(*m_dumper) > m_rollover_mb)
+	if(m_rollover_mb > 0 && written_bytes > m_rollover_mb)
 	{
 		m_last_reason = "Maximum File Size Reached";
 		return next_file();

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -63,7 +63,7 @@ public:
 	// (via a call to consider()), then this will
 	// be locked down and return false.
 	//
-	bool setup(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, scap_dumper_t** dumper);
+	bool setup(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit);
 	
 	//
 	// Consider file size at the current time
@@ -79,7 +79,7 @@ public:
 	// get_current_file_name() will tell us the new
 	// capture file name to use.
 	// 
-	cycle_writer::conclusion consider(sinsp_evt* evt);
+	cycle_writer::conclusion consider(sinsp_evt* evt, uint64_t written_bytes);
 
 	//
 	// The yields the current file name 
@@ -157,8 +157,6 @@ private:
 
 	// number of events
 	unsigned long m_event_count; // = 0L
-
-	scap_dumper_t** m_dumper;
 
 	bool live;
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -76,9 +76,9 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 		inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	}
 
-	inspector->m_container_manager.dump_containers(m_dumper);
+	inspector->m_container_manager.dump_containers(*this);
 
-	inspector->m_usergroup_manager.dump_users_groups(m_dumper);
+	inspector->m_usergroup_manager.dump_users_groups(*this);
 
 	m_nevts = 0;
 }
@@ -109,9 +109,9 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_
 		inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	}
 
-	inspector->m_container_manager.dump_containers(m_dumper);
+	inspector->m_container_manager.dump_containers(*this);
 
-	inspector->m_usergroup_manager.dump_users_groups(m_dumper);
+	inspector->m_usergroup_manager.dump_users_groups(*this);
 
 	m_nevts = 0;
 }
@@ -143,8 +143,16 @@ void sinsp_dumper::dump(sinsp_evt* evt)
 	}
 
 	scap_evt* pdevt = (evt->m_poriginal_evt)? evt->m_poriginal_evt : evt->m_pevt;
+	bool do_drop = false;
+	scap_dump_flags dflags;
 
-	int32_t res = scap_dump(m_dumper, pdevt, evt->m_cpuid, 0);
+	dflags = evt->get_dump_flags(&do_drop);
+	if(do_drop)
+	{
+		return;
+	}
+
+	int32_t res = scap_dump(m_dumper, pdevt, evt->m_cpuid, dflags);
 
 	if(res != SCAP_SUCCESS)
 	{

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -125,12 +125,12 @@ void sinsp_dumper::close()
 	}
 }
 
-bool sinsp_dumper::is_open()
+bool sinsp_dumper::is_open() const
 {
 	return (m_dumper != NULL);
 }
 
-bool sinsp_dumper::written_events()
+bool sinsp_dumper::written_events() const
 {
 	return m_nevts;
 }
@@ -154,7 +154,7 @@ void sinsp_dumper::dump(sinsp_evt* evt)
 	m_nevts++;
 }
 
-uint64_t sinsp_dumper::written_bytes()
+uint64_t sinsp_dumper::written_bytes() const
 {
 	if(m_dumper == NULL)
 	{
@@ -170,7 +170,7 @@ uint64_t sinsp_dumper::written_bytes()
 	return written_bytes;
 }
 
-uint64_t sinsp_dumper::next_write_position()
+uint64_t sinsp_dumper::next_write_position() const
 {
 	if(m_dumper == NULL)
 	{

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -86,19 +86,19 @@ public:
 	  \brief Return whether or not the underling scap file has been
 	         opened.
 	*/
-	bool is_open();
+	bool is_open() const;
 
 	/*!
 	  \brief Return the number of events dumped so far.
 	*/
-	bool written_events();
+	bool written_events() const;
 
 	/*!
 	  \brief Return the current size of a trace file.
 
 	  \return The current size of the dump file.
 	*/
-	uint64_t written_bytes();
+	uint64_t written_bytes() const;
 
 	/*!
 	  \brief Return the starting position for the next write into
@@ -107,7 +107,7 @@ public:
 
 	  \return The starting position for the next write.
 	*/
-	uint64_t next_write_position();
+	uint64_t next_write_position() const;
 
 	/*!
 	  \brief Flush all pending output into the file.

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1460,7 +1460,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 
 		if(m_write_cycling)
 		{
-			switch(m_cycle_writer->consider(evt))
+			switch(m_cycle_writer->consider(evt, scap_dump_get_offset(m_dumper)))
 			{
 				case cycle_writer::NEWFILE:
 					autodump_next_file();
@@ -2030,7 +2030,7 @@ bool sinsp::setup_cycle_writer(std::string base_file_name, int rollover_mb, int 
 		m_write_cycling = true;
 	}
 
-	return m_cycle_writer->setup(base_file_name, rollover_mb, duration_seconds, file_limit, event_limit, &m_dumper);
+	return m_cycle_writer->setup(base_file_name, rollover_mb, duration_seconds, file_limit, event_limit);
 }
 
 double sinsp::get_read_progress_file()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1067,7 +1067,7 @@ private:
 	// the parsing engine
 	sinsp_parser* m_parser;
 	// the statistics analysis engine
-	scap_dumper_t* m_dumper;
+	std::unique_ptr<sinsp_dumper> m_dumper;
 	bool m_is_dumping;
 	const scap_machine_info* m_machine_info;
 	const scap_agent_info* m_agent_info;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -154,17 +154,14 @@ void sinsp_usergroup_manager::subscribe_container_mgr()
 	}
 }
 
-void sinsp_usergroup_manager::dump_users_groups(scap_dumper_t* dumper) {
+void sinsp_usergroup_manager::dump_users_groups(sinsp_dumper& dumper) {
 	for (const auto &it: m_userlist) {
 		std::string container_id = it.first;
 		auto usrlist = m_userlist[container_id];
 		for (const auto &user: usrlist) {
 			sinsp_evt evt;
 			if (user_to_sinsp_event(&user.second, &evt, container_id, PPME_USER_ADDED_E)) {
-				int32_t res = scap_dump(dumper, evt.m_pevt, evt.m_cpuid, 0);
-				if (res != SCAP_SUCCESS) {
-					throw sinsp_exception(scap_dump_getlasterr(dumper));
-				}
+				dumper.dump(&evt);
 			}
 		}
 	}
@@ -175,10 +172,7 @@ void sinsp_usergroup_manager::dump_users_groups(scap_dumper_t* dumper) {
 		for (const auto &group: grplist) {
 			sinsp_evt evt;
 			if (group_to_sinsp_event(&group.second, &evt, container_id, PPME_GROUP_ADDED_E)) {
-				int32_t res = scap_dump(dumper, evt.m_pevt, evt.m_cpuid, 0);
-				if (res != SCAP_SUCCESS) {
-					throw sinsp_exception(scap_dump_getlasterr(dumper));
-				}
+				dumper.dump(&evt);
 			}
 		}
 	}

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -24,9 +24,8 @@ limitations under the License.
 #include "procfs_utils.h"
 #include "scap.h"
 
-typedef struct scap_dumper scap_dumper_t;
-
 class sinsp;
+class sinsp_dumper;
 class sinsp_evt;
 namespace libsinsp { namespace procfs_utils { class ns_helper; }}
 
@@ -70,7 +69,7 @@ public:
 	// events shall not be sent as they will be loaded from capture file.
 	void subscribe_container_mgr();
 
-	void dump_users_groups(scap_dumper_t* dumper);
+	void dump_users_groups(sinsp_dumper& dumper);
 
 	/*!
   	  \brief Return the table with all the machine users.


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This is nothing groundbreaking, just a series of small cleanups around sinsp_dumper:
* make a few methods in sinsp_dumper const
* don't hold the (address of) the dumper in cyclewriter

    The only thing we need from the scap_dumper is the number of written
    bytes so we can simply pass it in

* use sinsp_dumper instead of scap_dumper

    Since we have the abstraction, we might as well use it.
    Note: we still use scap_dumper to dump the thread list
    as it uses APIs not exposed by sinsp_dumper (and it can be
    considered a part of the sinsp_dumper implementation)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
