### PR TITLE
cleanup(scap): minor header cleanups

### DIFF
--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -20,6 +20,10 @@ limitations under the License.
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "uthash.h"
 
 typedef struct scap_tid
@@ -64,3 +68,7 @@ int32_t scap_update_suppressed(struct scap_suppress *suppress,
 			       bool *suppressed);
 
 void scap_suppress_close(struct scap_suppress* suppress);
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/strerror.h
+++ b/userspace/libscap/strerror.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __GNUC__
 int32_t scap_errprintf_unchecked(char *buf, int errnum, const char* fmt, ...) __attribute__ ((format (printf, 3, 4)));
 #define scap_errprintf scap_errprintf_unchecked


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Just a few minor header tweaks:
* include stdint.h in strerror.h (we refer to int32_t in there)
* __cplusplus in scap_suppress.h (since it's included in scap-int.h, it's effectively a public header)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
