### PR TITLE
update(userspace/libsinsp)!: support sc codes and event names bidirectional conversions

### DIFF
--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -85,7 +85,7 @@ std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsi
 			{
 				/* note: using existing ppm sc APIs and generic set operations to minimize new logic that requires maintenance beyond what we already have. */
 				auto sc_set = libsinsp::events::event_set_to_sc_set(libsinsp::events::set<ppm_event_code>{PPME_GENERIC_E, PPME_GENERIC_X});
-				events_names_set = unordered_set_union(libsinsp::events::sc_set_to_names(sc_set), events_names_set);
+				events_names_set = unordered_set_union(libsinsp::events::sc_set_to_sc_names(sc_set), events_names_set);
 				events_names_set.erase("unknown"); // not needed
 				resolved_generic = true;
 			}

--- a/userspace/libsinsp/events/sinsp_events.h
+++ b/userspace/libsinsp/events/sinsp_events.h
@@ -170,14 +170,24 @@ set<ppm_sc_code> sys_sc_set();
 set<ppm_sc_code> all_sc_set();
 
 /*!
-  \brief Get the name of all the ppm_sc provided in the set.
+  \brief Get the sc name of all the ppm_sc provided in the set.
 */
-std::unordered_set<std::string> sc_set_to_names(const set<ppm_sc_code>& ppm_sc_set);
+std::unordered_set<std::string> sc_set_to_sc_names(const set<ppm_sc_code>& ppm_sc_set);
+
+/*!
+  \brief Get the event name of all the ppm_sc provided in the set.
+*/
+std::unordered_set<std::string> sc_set_to_event_names(const set<ppm_sc_code>& ppm_sc_set);
+
+/*!
+  \brief Get the ppm_sc of all the event names provided in the set.
+*/
+set<ppm_sc_code> event_names_to_sc_set(const std::unordered_set<std::string>& events);
 
 /*!
   \brief Get the ppm_sc of all the syscalls names provided in the set.
 */
-set<ppm_sc_code> names_to_sc_set(const std::unordered_set<std::string>& syscalls);
+set<ppm_sc_code> sc_names_to_sc_set(const std::unordered_set<std::string>& syscalls);
 
 /**
 	 * @brief When you want to retrieve the events associated with a particular `ppm_sc` you have to

--- a/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
+++ b/userspace/libsinsp/events/sinsp_events_ppm_sc.cpp
@@ -236,7 +236,7 @@ libsinsp::events::set<ppm_sc_code> libsinsp::events::event_names_to_sc_set(const
 	/* Convert event names into an event set, and then convert that into a
 	 * syscall set. We exclude generics due to the potential information loss
 	 * (e.g. one generic event will include all generic syscalls in the
-	 * conversion). Generics are handled below using their actuall syacall name.
+	 * conversion). Generics are handled below using their actuall syscall name.
 	 * Note: this is the same logic with which the "evt.type" filter field
 	 * is extracted. */
 	auto gen_event_set = libsinsp::events::set<ppm_event_code>(

--- a/userspace/libsinsp/filter/ppm_codes.cpp
+++ b/userspace/libsinsp/filter/ppm_codes.cpp
@@ -234,7 +234,7 @@ libsinsp::filter::ast::ppm_sc_codes(const libsinsp::filter::ast::expr* e)
     ppm_code_visitor<
         libsinsp::events::set<ppm_sc_code>,
         libsinsp::events::all_sc_set,
-        libsinsp::events::names_to_sc_set> v;
+        libsinsp::events::event_names_to_sc_set> v;
     e->accept(&v);
     return v.m_last_node_codes;
 }

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -58,16 +58,16 @@ TEST(interesting_syscalls, all_sc_set)
 	ASSERT_TRUE(sc_set.size() <= PPM_SC_MAX);
 }
 
-TEST(interesting_syscalls, sc_set_to_names)
+TEST(interesting_syscalls, sc_set_to_event_names)
 {
 	// "syncfs" is a generic event / syscall
-	static std::set<std::string> names_truth = {"kill", "read", "syncfs"};
-	static libsinsp::events::set<ppm_sc_code> sc_set = {PPM_SC_KILL, PPM_SC_READ, PPM_SC_SYNCFS};
-	auto names = test_utils::unordered_set_to_ordered(libsinsp::events::sc_set_to_names(sc_set));
+	static std::set<std::string> names_truth = {"kill", "read", "syncfs", "procexit", "switch"};
+	static libsinsp::events::set<ppm_sc_code> sc_set = {PPM_SC_KILL, PPM_SC_READ, PPM_SC_SYNCFS, PPM_SC_SCHED_PROCESS_EXIT, PPM_SC_SCHED_SWITCH};
+	auto names = test_utils::unordered_set_to_ordered(libsinsp::events::sc_set_to_event_names(sc_set));
 	ASSERT_NAMES_EQ(names_truth, names);
 }
 
-TEST(interesting_syscalls, names_to_sc_set)
+TEST(interesting_syscalls, event_names_to_sc_set)
 {
 	static libsinsp::events::set<ppm_sc_code> sc_set_truth = {
 	PPM_SC_KILL,
@@ -88,7 +88,7 @@ TEST(interesting_syscalls, names_to_sc_set)
 	PPM_SC_SIGNALFD4
 	};
 
-	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{
+	auto sc_set = libsinsp::events::event_names_to_sc_set(std::unordered_set<std::string>{
 	"kill",
 	"read",
 	"syncfs",
@@ -108,19 +108,18 @@ TEST(interesting_syscalls, names_to_sc_set)
 	ASSERT_PPM_SC_CODES_EQ(sc_set_truth, sc_set);
 }
 
-/* This test asserts the behavior of `names_to_sc_set` API when corner cases like `accept/accept4` are involved */
-/// todo: @Andreagit97 revisit this test after new APIs to convert from event_names -> sc_set and sc_set -> event_names.
+/* This test asserts the behavior of `event_names_to_sc_set` API when corner cases like `accept/accept4` are involved */
 TEST(interesting_syscalls, names_sc_set_names_corner_cases)
 {
-	/* INCONSISTENCY: `names_to_sc_set` is converting event names to ppm_sc, but this was not its original scope, the original scope was to convert sc_names -> to sc_set  */
-	std::unordered_set<std::string> event_names{"accept", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2"};
-	auto sc_set = libsinsp::events::names_to_sc_set(event_names);
-	libsinsp::events::set<ppm_sc_code> expected_sc_set{PPM_SC_ACCEPT, PPM_SC_ACCEPT4, PPM_SC_EXECVE, PPM_SC_SYNCFS, PPM_SC_EVENTFD, PPM_SC_UMOUNT, PPM_SC_PIPE, PPM_SC_SIGNALFD, PPM_SC_UMOUNT2};
+	/* INCONSISTENCY: `event_names_to_sc_set` is converting event names to ppm_sc, but this was not its original scope, the original scope was to convert sc_names -> to sc_set  */
+	std::unordered_set<std::string> event_names{"accept", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2", "procexit"};
+	auto sc_set = libsinsp::events::event_names_to_sc_set(event_names);
+	libsinsp::events::set<ppm_sc_code> expected_sc_set{PPM_SC_ACCEPT, PPM_SC_EXECVE, PPM_SC_SYNCFS, PPM_SC_EVENTFD, PPM_SC_UMOUNT, PPM_SC_PIPE, PPM_SC_SIGNALFD, PPM_SC_UMOUNT2, PPM_SC_SCHED_PROCESS_EXIT};
 	ASSERT_PPM_SC_CODES_EQ(sc_set, expected_sc_set);
 
 	/* Please note that here we are converting sc_set to sc_names not event_names! */
-	auto sc_names = libsinsp::events::sc_set_to_names(sc_set);	
-	static std::unordered_set<std::string> expected_sc_names = {"accept", "accept4", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2"};
+	auto sc_names = libsinsp::events::sc_set_to_event_names(sc_set);	
+	static std::unordered_set<std::string> expected_sc_names = {"accept", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2", "procexit"};
 	ASSERT_NAMES_EQ(expected_sc_names, sc_names);
 }
 
@@ -172,58 +171,51 @@ TEST(filter_ppm_codes, check_sinsp_repair_state_sc_set)
     libsinsp::events::set<ppm_sc_code> input_sc_set;
     libsinsp::events::set<ppm_sc_code> sc_set;
 
-    /* todo: @incertum update / revisit once names_to_sc_set is refactored featuring new tp names as well. */
-    truth = libsinsp::events::names_to_sc_set({
-        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
+    truth = libsinsp::events::event_names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork", "procexit",
         "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
-        "setuid", "setuid32", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
+        "setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"execve", "execveat"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
-    truth = libsinsp::events::names_to_sc_set({
+    truth = libsinsp::events::event_names_to_sc_set({
         "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "connect",
-        "execve", "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect", "accept", "accept4"});
+        "execve", "execveat", "fchdir", "fork", "getsockopt",  "procexit", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"execve", "execveat", "connect", "accept", "accept4"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
-    truth = libsinsp::events::names_to_sc_set({
+    truth = libsinsp::events::event_names_to_sc_set({
         "capset", "chdir", "chroot", "clone", "clone3", "close", "connect", "execve", "execveat",
-        "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat", "connect"});
+        "fchdir", "fork", "getsockopt",  "procexit", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"execve", "execveat", "connect"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
-    truth = libsinsp::events::names_to_sc_set({
+    truth = libsinsp::events::event_names_to_sc_set({
         "accept", "accept4", "bind", "capset", "chdir", "chroot", "clone", "clone3", "close", "execve",
-        "execveat", "fchdir", "fork", "getsockopt", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "accept", "accept4"});
+        "execveat", "fchdir", "fork", "getsockopt", "procexit", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "socket", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"execve", "accept", "accept4"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
-    truth = libsinsp::events::names_to_sc_set({
-        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork",
+    truth = libsinsp::events::event_names_to_sc_set({
+        "capset", "chdir", "chroot", "clone", "clone3", "execve", "execveat", "fchdir", "fork", "procexit",
         "setgid", "setgid32", "setpgid", "setresgid", "setresgid32", "setresuid", "setresuid32", "setsid",
-        "setuid", "setuid32", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"execve", "execveat"});
+        "setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"execve", "execveat"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 
-    truth = libsinsp::events::names_to_sc_set({
+    truth = libsinsp::events::event_names_to_sc_set({
         "capset", "chdir", "chroot", "clone", "clone3", "close", "execve", "execveat", "fchdir", "fork",
-        "open", "openat", "openat2", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
-        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"})\
-        .merge({PPM_SC_SCHED_PROCESS_EXIT});
-    input_sc_set = libsinsp::events::names_to_sc_set({"open", "openat", "openat2"});
+        "open", "openat", "openat2", "procexit", "setgid", "setgid32", "setpgid", "setresgid", "setresgid32",
+        "setresuid", "setresuid32", "setsid", "setuid", "setuid32", "vfork"});
+    input_sc_set = libsinsp::events::event_names_to_sc_set({"open", "openat", "openat2"});
     sc_set = sinsp_repair_state_sc_set(input_sc_set);
     ASSERT_PPM_SC_CODES_EQ(truth, sc_set);
 

--- a/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/interesting_syscalls.cpp
@@ -114,12 +114,12 @@ TEST(interesting_syscalls, names_sc_set_names_corner_cases)
 	/* INCONSISTENCY: `event_names_to_sc_set` is converting event names to ppm_sc, but this was not its original scope, the original scope was to convert sc_names -> to sc_set  */
 	std::unordered_set<std::string> event_names{"accept", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2", "procexit"};
 	auto sc_set = libsinsp::events::event_names_to_sc_set(event_names);
-	libsinsp::events::set<ppm_sc_code> expected_sc_set{PPM_SC_ACCEPT, PPM_SC_EXECVE, PPM_SC_SYNCFS, PPM_SC_EVENTFD, PPM_SC_UMOUNT, PPM_SC_PIPE, PPM_SC_SIGNALFD, PPM_SC_UMOUNT2, PPM_SC_SCHED_PROCESS_EXIT};
+	libsinsp::events::set<ppm_sc_code> expected_sc_set{PPM_SC_ACCEPT, PPM_SC_ACCEPT4, PPM_SC_EXECVE, PPM_SC_SYNCFS, PPM_SC_EVENTFD, PPM_SC_UMOUNT, PPM_SC_PIPE, PPM_SC_SIGNALFD, PPM_SC_UMOUNT2, PPM_SC_SCHED_PROCESS_EXIT};
 	ASSERT_PPM_SC_CODES_EQ(sc_set, expected_sc_set);
 
 	/* Please note that here we are converting sc_set to sc_names not event_names! */
 	auto sc_names = libsinsp::events::sc_set_to_event_names(sc_set);	
-	static std::unordered_set<std::string> expected_sc_names = {"accept", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2", "procexit"};
+	static std::unordered_set<std::string> expected_sc_names = {"accept", "accept4", "execve", "syncfs", "eventfd", "umount", "pipe", "signalfd", "umount2", "procexit"};
 	ASSERT_NAMES_EQ(expected_sc_names, sc_names);
 }
 

--- a/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
@@ -796,7 +796,7 @@ TEST(ppm_sc_API, all_sc_set)
 
 TEST(ppm_sc_API, all_sc_names)
 {
-	auto sc_names = test_utils::unordered_set_to_ordered(libsinsp::events::sc_set_to_names(libsinsp::events::all_sc_set()));
+	auto sc_names = test_utils::unordered_set_to_ordered(libsinsp::events::sc_set_to_sc_names(libsinsp::events::all_sc_set()));
 	std::set<std::string> expected_sc_names;
 	/* In all_sc we don't have `PPM_SC_UNKNOWN` so we don't have to retrieve the "unknown" name, we start the for loop from 1 */
 	for(int ppm_sc = 1; ppm_sc < PPM_SC_MAX; ppm_sc++)
@@ -830,9 +830,9 @@ TEST(ppm_sc_API, enforce_sinsp_state_sc_set)
 TEST(ppm_sc_API, sc_empty_sets)
 {
 	std::unordered_set<std::string> empty_string_set;
-	const auto empty_sc_set = libsinsp::events::names_to_sc_set(empty_string_set);
+	const auto empty_sc_set = libsinsp::events::sc_names_to_sc_set(empty_string_set);
 	const auto empty_event_set = libsinsp::events::sc_set_to_event_set(empty_sc_set);
-	const auto empty_sc_names = libsinsp::events::sc_set_to_names(empty_sc_set);
+	const auto empty_sc_names = libsinsp::events::sc_set_to_sc_names(empty_sc_set);
 	ASSERT_TRUE(empty_sc_set.empty());
 	ASSERT_TRUE(empty_event_set.empty());
 	ASSERT_TRUE(empty_sc_names.empty());
@@ -842,14 +842,22 @@ TEST(ppm_sc_API, sc_unknown)
 {
 	libsinsp::events::set<ppm_sc_code> unknown_sc{PPM_SC_UNKNOWN};
 	ASSERT_TRUE(libsinsp::events::sc_set_to_event_set(unknown_sc).empty());
-	ASSERT_NAMES_EQ(libsinsp::events::sc_set_to_names(unknown_sc), std::unordered_set<std::string>{"unknown"});
+	ASSERT_NAMES_EQ(libsinsp::events::sc_set_to_sc_names(unknown_sc), std::unordered_set<std::string>{"unknown"});
 }
 
-TEST(ppm_sc_API, ASS_names_ASS)
+TEST(ppm_sc_API, ASS_sc_names_ASS)
 {
 	const auto all_sc = libsinsp::events::all_sc_set();
-	const auto all_sc_names = libsinsp::events::sc_set_to_names(all_sc);
-	const auto all_sc_again = libsinsp::events::names_to_sc_set(all_sc_names);
+	const auto all_sc_names = libsinsp::events::sc_set_to_sc_names(all_sc);
+	const auto all_sc_again = libsinsp::events::sc_names_to_sc_set(all_sc_names);
+	ASSERT_PPM_SC_CODES_EQ(all_sc, all_sc_again);
+}
+
+TEST(ppm_sc_API, ASS_event_names_ASS)
+{
+	const auto all_sc = libsinsp::events::all_sc_set();
+	const auto all_event_names = libsinsp::events::sc_set_to_event_names(all_sc);
+	const auto all_sc_again = libsinsp::events::event_names_to_sc_set(all_event_names);
 	ASSERT_PPM_SC_CODES_EQ(all_sc, all_sc_again);
 }
 
@@ -931,7 +939,7 @@ TEST(ppm_sc_API, NGSS_event_set_NGSS)
 
 TEST(ppm_sc_API, SSN_sc_set_SSN)
 {
-	auto sc_set = libsinsp::events::names_to_sc_set(std::unordered_set<std::string>{"open", "openat", "alarm", "****!!!!!", "NOT-SC", "", "unknown", "sched_process_exit"});
+	auto sc_set = libsinsp::events::sc_names_to_sc_set(std::unordered_set<std::string>{"open", "openat", "alarm", "****!!!!!", "NOT-SC", "", "unknown", "sched_process_exit"});
 	ASSERT_TRUE(sc_set.contains(PPM_SC_OPEN));
 	ASSERT_TRUE(sc_set.contains(PPM_SC_OPENAT));
 	ASSERT_TRUE(sc_set.contains(PPM_SC_ALARM));
@@ -940,7 +948,7 @@ TEST(ppm_sc_API, SSN_sc_set_SSN)
 	ASSERT_EQ(sc_set.size(), 5);
 
 	std::unordered_set<std::string> expected_sc_names{"open", "openat", "alarm", "unknown", "sched_process_exit"};
-	auto sc_names_again = libsinsp::events::sc_set_to_names(sc_set);
+	auto sc_names_again = libsinsp::events::sc_set_to_sc_names(sc_set);
 	ASSERT_NAMES_EQ(expected_sc_names, sc_names_again);
 }
 

--- a/userspace/libsinsp/test/test_utils.h
+++ b/userspace/libsinsp/test/test_utils.h
@@ -24,36 +24,36 @@ limitations under the License.
 #include <netinet/in.h>
 #include <event_stats.h>
 
-#define ASSERT_NAMES_EQ(a, b)                                                                                        \
-	{                                                                                                            \
+#define ASSERT_NAMES_EQ(a, b)                                                                                \
+	{                                                                                                        \
 		auto a1 = a;                                                                                         \
 		auto b1 = b;                                                                                         \
+		EXPECT_EQ(a1.size(), b1.size());                                                                     \
 		ASSERT_EQ(std::set<std::string>(a1.begin(), a1.end()), std::set<std::string>(b1.begin(), b1.end())); \
-		ASSERT_EQ(a1.size(), b1.size());                                                                     \
 	}
 
 // `merge` requires cpp17...
-#define ASSERT_CONTAINS(a, b)                    \
-	{                                        \
+#define ASSERT_CONTAINS(a, b)            \
+	{                                    \
 		auto a1 = a;                     \
 		auto b1 = b;                     \
 		uint32_t prev_size = a1.size();  \
 		for(const auto& val : b1)        \
 		{                                \
-			a1.insert(val);          \
+			a1.insert(val);              \
 		}                                \
 		ASSERT_EQ(prev_size, a1.size()); \
 	}
 
 // `merge` requires cpp17...
-#define ASSERT_NOT_CONTAINS(a, b)                            \
-	{                                                    \
+#define ASSERT_NOT_CONTAINS(a, b)                    \
+	{                                                \
 		auto a1 = a;                                 \
 		auto b1 = b;                                 \
 		uint32_t prev_size = a1.size();              \
 		for(const auto& val : b1)                    \
 		{                                            \
-			a1.insert(val);                      \
+			a1.insert(val);                          \
 		}                                            \
 		ASSERT_EQ(prev_size + b1.size(), a1.size()); \
 	}
@@ -62,18 +62,18 @@ limitations under the License.
 	{                                                                                                                                            \
 		auto a1 = a;                                                                                                                         \
 		auto b1 = b;                                                                                                                         \
+		EXPECT_EQ(a1.size(), b1.size());                                                                                               \
 		ASSERT_EQ(libsinsp::events::set<ppm_event_code>(a1.begin(), a1.end()), libsinsp::events::set<ppm_event_code>(b1.begin(), b1.end())); \
 		ASSERT_TRUE(a1.equals(b1));                                                                                                          \
-		ASSERT_EQ(a1.size(), b1.size());                                                                                                     \
 	}
 
 #define ASSERT_PPM_SC_CODES_EQ(a, b)                                                                                                           \
 	{                                                                                                                                      \
 		auto a1 = a;                                                                                                                   \
 		auto b1 = b;                                                                                                                   \
+		EXPECT_EQ(a1.size(), b1.size());                                                                                               \
 		ASSERT_EQ(libsinsp::events::set<ppm_sc_code>(a1.begin(), a1.end()), libsinsp::events::set<ppm_sc_code>(b1.begin(), b1.end())); \
 		ASSERT_TRUE(a1.equals(b1));                                                                                                    \
-		ASSERT_EQ(a1.size(), b1.size());                                                                                               \
 	}
 
 namespace test_utils {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This is (hopefully) the last code change required for the effort of https://github.com/falcosecurity/falco/issues/2443. This basically extends the sinsp API for handling event names <-> syscall sets conversions, while still supporting the old APIs as well. The API change is as follows:
- `names_to_sc_set` -> `event_names_to_sc_set` and `sc_names_to_sc_set`
- `sc_set_to_names` -> `sc_set_to_event_names` and `sc_set_to_sc_names`

With this step, we're able to finally solve the last few TODO's in the ppm_sc/interesting syscalls test suite.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This PR is already tested in Falco with the adaptations in the branch https://github.com/falcosecurity/falco/compare/update/sc-names-fixups. I'll open a PR on Falco from that branch once this one gets merged.

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp)!: support sc codes and event names bidirectional conversions
```
