### PR TITLE
new(driver/modern_bpf): support CPU hot-plug event

### DIFF
--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -245,5 +245,6 @@
 /* Special internal events */
 #define DROP_E_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
 #define DROP_X_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN
+#define HOTPLUG_E_SIZE HEADER_LEN + sizeof(uint32_t) * 2 + PARAM_LEN * 2
 
 #endif /* __EVENT_DIMENSIONS_H__ */

--- a/driver/modern_bpf/helpers/interfaces/attached_programs.h
+++ b/driver/modern_bpf/helpers/interfaces/attached_programs.h
@@ -21,40 +21,40 @@ enum intrumentation_type
 
 static __always_inline void send_drop_e_event()
 {
-	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DROP_E_SIZE))
-	{
-		return;
-	}
+	// struct ringbuf_struct ringbuf;
+	// if(!ringbuf__reserve_space(&ringbuf, ctx, DROP_E_SIZE))
+	// {
+	// 	return;
+	// }
 
-	ringbuf__store_event_header(&ringbuf, PPME_DROP_E);
+	// ringbuf__store_event_header(&ringbuf, PPME_DROP_E);
 
-	/*=============================== COLLECT PARAMETERS ===========================*/
+	// /*=============================== COLLECT PARAMETERS ===========================*/
 
-	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+	// ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
 
-	/*=============================== COLLECT PARAMETERS ===========================*/
+	// /*=============================== COLLECT PARAMETERS ===========================*/
 
-	ringbuf__submit_event(&ringbuf);
+	// ringbuf__submit_event(&ringbuf);
 }
 
 static __always_inline void send_drop_x_event()
 {
-	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DROP_X_SIZE))
-	{
-		return;
-	}
+	// struct ringbuf_struct ringbuf;
+	// if(!ringbuf__reserve_space(&ringbuf, ctx, DROP_X_SIZE))
+	// {
+	// 	return;
+	// }
 
-	ringbuf__store_event_header(&ringbuf, PPME_DROP_X);
+	// ringbuf__store_event_header(&ringbuf, PPME_DROP_X);
 
-	/*=============================== COLLECT PARAMETERS ===========================*/
+	// /*=============================== COLLECT PARAMETERS ===========================*/
 
-	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+	// ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
 
-	/*=============================== COLLECT PARAMETERS ===========================*/
+	// /*=============================== COLLECT PARAMETERS ===========================*/
 
-	ringbuf__submit_event(&ringbuf);
+	// ringbuf__submit_event(&ringbuf);
 }
 
 

--- a/driver/modern_bpf/helpers/interfaces/attached_programs.h
+++ b/driver/modern_bpf/helpers/interfaces/attached_programs.h
@@ -62,7 +62,7 @@ static __always_inline void send_drop_x_event()
  * We treat the syscalls tracepoints in a dedicated way because they could generate
  * more than one event (1 for each syscall) for this reason we need a dedicated table.
  */
-static __always_inline bool sampling_logic(u32 id, enum intrumentation_type type)
+static __always_inline bool sampling_logic(void* ctx, u32 id, enum intrumentation_type type)
 {
 	/* If dropping mode is not enabled we don't perform any sampling
 	 * false: means don't drop the syscall

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -115,8 +115,9 @@ static __always_inline void auxmap__finalize_event_header(struct auxiliary_map *
  * of events sent to userspace, otherwise we increment the dropped events.
  *
  * @param auxmap pointer to the auxmap in which we have already written the entire event.
+ * @param ctx BPF prog context
  */
-static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap)
+static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap, void* ctx)
 {
 
 	struct ringbuf_map *rb = maps__get_ringbuf_map();

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -119,10 +119,11 @@ static __always_inline void auxmap__finalize_event_header(struct auxiliary_map *
  */
 static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap, void* ctx)
 {
-
 	struct ringbuf_map *rb = maps__get_ringbuf_map();
 	if(!rb)
 	{
+		bpf_tail_call(ctx, &extra_event_prog_tail_table, T1_HOTPLUG_E);
+		bpf_printk("failed to tail call into the 'hotplug' prog");
 		return;
 	}
 

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -82,10 +82,11 @@ struct ringbuf_struct
  * to know the event dimension at compile time.
  *
  * @param ringbuf pointer to the `ringbuf_struct`
+ * @param ctx BPF prog context
  * @param event_size exact size of the fixed-size event
  * @return `1` in case of success, `0` in case of failure.
  */
-static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf, u32 event_size)
+static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf, void* ctx, u32 event_size)
 {
 
 	struct ringbuf_map *rb = maps__get_ringbuf_map();

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -88,10 +88,11 @@ struct ringbuf_struct
  */
 static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf, void* ctx, u32 event_size)
 {
-
 	struct ringbuf_map *rb = maps__get_ringbuf_map();
 	if(!rb)
 	{
+		bpf_tail_call(ctx, &extra_event_prog_tail_table, T1_HOTPLUG_E);
+		bpf_printk("failed to tail call into the 'hotplug' prog");
 		return 0;
 	}
 

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
@@ -36,7 +36,7 @@ int BPF_PROG(sys_enter,
 		return 0;
 	}
 
-	if(sampling_logic(syscall_id, SYSCALL))
+	if(sampling_logic(ctx, syscall_id, SYSCALL))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -37,7 +37,7 @@ int BPF_PROG(sys_exit,
 		return 0;
 	}
 
-	if(sampling_logic(syscall_id, SYSCALL))
+	if(sampling_logic(ctx, syscall_id, SYSCALL))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
@@ -18,7 +18,7 @@ int BPF_PROG(pf_kernel,
 	     unsigned long address, struct pt_regs *regs,
 	     unsigned long error_code)
 {
-	if(sampling_logic(PPME_PAGE_FAULT_E, TRACEPOINT))
+	if(sampling_logic(ctx, PPME_PAGE_FAULT_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_kernel.bpf.c
@@ -24,7 +24,7 @@ int BPF_PROG(pf_kernel,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PAGE_FAULT_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
@@ -24,7 +24,7 @@ int BPF_PROG(pf_user,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PAGE_FAULT_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PAGE_FAULT_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/page_fault_user.bpf.c
@@ -18,7 +18,7 @@ int BPF_PROG(pf_user,
 	     unsigned long address, struct pt_regs *regs,
 	     unsigned long error_code)
 {
-	if(sampling_logic(PPME_PAGE_FAULT_E, TRACEPOINT))
+	if(sampling_logic(ctx, PPME_PAGE_FAULT_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -222,7 +222,7 @@ int BPF_PROG(t1_sched_p_exec,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 #endif /* CAPTURE_SCHED_PROC_EXEC */

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -9,7 +9,7 @@ SEC("tp_btf/sched_process_exit")
 int BPF_PROG(sched_proc_exit,
 	     struct task_struct *task)
 {
-	if(sampling_logic(PPME_PROCEXIT_1_E, TRACEPOINT))
+	if(sampling_logic(ctx, PPME_PROCEXIT_1_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -24,7 +24,7 @@ int BPF_PROG(sched_proc_exit,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PROC_EXIT_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PROC_EXIT_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -239,7 +239,7 @@ int BPF_PROG(t2_sched_p_fork,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 #endif /* CAPTURE_SCHED_PROC_EXEC */

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -10,7 +10,7 @@ int BPF_PROG(sched_switch,
 	     bool preempt, struct task_struct *prev,
 	     struct task_struct *next)
 {
-	if(sampling_logic(PPME_SCHEDSWITCH_6_E, TRACEPOINT))
+	if(sampling_logic(ctx, PPME_SCHEDSWITCH_6_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -18,7 +18,7 @@ int BPF_PROG(sched_switch,
 	/// TODO: we could avoid switches from kernel threads to kernel threads (?).
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SCHED_SWITCH_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SCHED_SWITCH_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -21,7 +21,7 @@ int BPF_PROG(signal_deliver,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SIGNAL_DELIVER_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SIGNAL_DELIVER_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -15,7 +15,7 @@ SEC("tp_btf/signal_deliver")
 int BPF_PROG(signal_deliver,
 	     int sig, struct kernel_siginfo *info, struct k_sigaction *ka)
 {
-	if(sampling_logic(PPME_SIGNALDELIVER_E, TRACEPOINT))
+	if(sampling_logic(ctx, PPME_SIGNALDELIVER_E, TRACEPOINT))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/custom_logic/drop.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/custom_logic/drop.bpf.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+/*=============================== ENTER EVENT ===========================*/
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(t1_drop_e)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DROP_E_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_DROP_E);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+	return 0;
+}
+
+/*=============================== ENTER EVENT ===========================*/
+
+/*=============================== EXIT EVENT ===========================*/
+
+SEC("tp_btf/sys_exit")
+int BPF_PROG(t1_drop_x)
+{
+	struct ringbuf_struct ringbuf;
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DROP_X_SIZE))
+	{
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_DROP_X);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__store_u32(&ringbuf, maps__get_sampling_ratio());
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+	return 0;
+}
+
+/*=============================== EXIT EVENT ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/custom_logic/hotplug.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/custom_logic/hotplug.bpf.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 The Falco Authors.
+ *
+ * This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+ * or GPL2.txt for full copies of the license.
+ */
+
+#include <helpers/interfaces/fixed_size_event.h>
+
+SEC("tp_btf/sys_enter")
+int BPF_PROG(t1_hotplug_e)
+{
+	/* We assume that the ring buffer for CPU 0 is always there so we send the
+	 * HOT-PLUG event through this buffer.
+	 */
+	u32 cpu_0 = 0;
+	struct ringbuf_map *rb = bpf_map_lookup_elem(&ringbuf_maps, &cpu_0);
+	if(!rb)
+	{
+		bpf_printk("unable to obtain the ring buffer for CPU 0");
+		return 0;
+	}
+
+	struct counter_map *counter = bpf_map_lookup_elem(&counter_maps, &cpu_0);
+	if(!counter)
+	{
+		bpf_printk("unable to obtain the counter map for CPU 0");
+		return 0;
+	}
+
+	/* This counts the event seen by the drivers even if they are dropped because the buffer is full. */
+	counter->n_evts++;
+
+	/* If we are not able to reserve space we stop here
+	 * the event collection.
+	 */
+	struct ringbuf_struct ringbuf;
+	ringbuf.reserved_event_size = HOTPLUG_E_SIZE;
+	ringbuf.data = bpf_ringbuf_reserve(rb, HOTPLUG_E_SIZE, 0);
+	if(!ringbuf.data)
+	{
+		counter->n_drops_buffer++;
+		return 0;
+	}
+
+	ringbuf__store_event_header(&ringbuf, PPME_CPU_HOTPLUG_E);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	/* Parameter 1: cpu (type: PT_UINT32) */
+	u32 current_cpu_id = (u32)bpf_get_smp_processor_id();
+	ringbuf__store_u32(&ringbuf, current_cpu_id);
+
+	/* Parameter 2: action (type: PT_UINT32) */
+	/* Right now we don't have actions we always send 0 */
+	ringbuf__store_u32(&ringbuf, 0);
+
+	/*=============================== COLLECT PARAMETERS ===========================*/
+
+	ringbuf__submit_event(&ringbuf);
+	return 0;
+}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -114,7 +114,7 @@ int BPF_PROG(accept_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(accept_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, ACCEPT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, ACCEPT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -118,7 +118,7 @@ int BPF_PROG(accept4_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(accept4_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, ACCEPT4_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, ACCEPT4_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -66,7 +66,7 @@ int BPF_PROG(access_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(access_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, ACCESS_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, ACCESS_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -79,7 +79,7 @@ int BPF_PROG(bind_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(bind_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, BIND_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, BIND_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(bpf_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, BPF_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, BPF_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(bpf_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, BPF_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, BPF_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/brk.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/brk.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(brk_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, BRK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, BRK_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(brk_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, BRK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, BRK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(capset_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CAPSET_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CAPSET_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(capset_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CAPSET_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CAPSET_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(chdir_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CHDIR_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CHDIR_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chdir.bpf.c
@@ -64,7 +64,7 @@ int BPF_PROG(chdir_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
@@ -68,7 +68,7 @@ int BPF_PROG(chmod_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chmod.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(chmod_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CHMOD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CHMOD_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
@@ -72,7 +72,7 @@ int BPF_PROG(chown_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chown.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(chown_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CHOWN_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CHOWN_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
@@ -64,7 +64,7 @@ int BPF_PROG(chroot_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/chroot.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(chroot_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CHROOT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CHROOT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(clone_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CLONE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CLONE_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -253,7 +253,7 @@ int BPF_PROG(t2_clone_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(clone3_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CLONE3_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CLONE3_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -246,7 +246,7 @@ int BPF_PROG(t2_clone3_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -49,7 +49,7 @@ int BPF_PROG(close_e,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CLOSE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CLOSE_E_SIZE))
 	{
 		return 0;
 	}
@@ -84,7 +84,7 @@ int BPF_PROG(close_x,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, CLOSE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, CLOSE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -39,7 +39,7 @@ int BPF_PROG(connect_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -86,7 +86,7 @@ int BPF_PROG(connect_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(copy_file_range_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, COPY_FILE_RANGE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, COPY_FILE_RANGE_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(copy_file_range_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, COPY_FILE_RANGE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, COPY_FILE_RANGE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
@@ -36,7 +36,7 @@ int BPF_PROG(creat_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -89,7 +89,7 @@ int BPF_PROG(creat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(dup_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(dup_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(dup2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP2_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(dup2_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP2_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP2_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(dup3_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP3_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP3_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(dup3_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, DUP3_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, DUP3_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(epoll_create_e,
 	    long id)
 {
        struct ringbuf_struct ringbuf;
-       if(!ringbuf__reserve_space(&ringbuf, EPOLL_CREATE_E_SIZE))
+       if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_CREATE_E_SIZE))
        {
 	       return 0;
        }
@@ -45,7 +45,7 @@ int BPF_PROG(epoll_create_x,
 	    long ret)
 {
        struct ringbuf_struct ringbuf;
-       if(!ringbuf__reserve_space(&ringbuf, EPOLL_CREATE_X_SIZE))
+       if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_CREATE_X_SIZE))
        {
 	       return 0;
        }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(epoll_create1_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EPOLL_CREATE1_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_CREATE1_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(epoll_create1_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EPOLL_CREATE1_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_CREATE1_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_wait.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_wait.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(epoll_wait_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EPOLL_WAIT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_WAIT_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(epoll_wait_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EPOLL_WAIT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EPOLL_WAIT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(eventfd_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EVENTFD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EVENTFD_E_SIZE))
 	{
 		return 0;
 	}
@@ -51,7 +51,7 @@ int BPF_PROG(eventfd_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EVENTFD_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EVENTFD_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(eventfd2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EVENTFD2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EVENTFD2_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(eventfd2_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, EVENTFD2_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, EVENTFD2_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(execve_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 
@@ -286,7 +286,7 @@ int BPF_PROG(t1_execve_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -43,7 +43,7 @@ int BPF_PROG(execveat_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 
@@ -303,7 +303,7 @@ int BPF_PROG(t1_execveat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(fchdir_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHDIR_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHDIR_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(fchdir_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHDIR_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHDIR_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(fchmod_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHMOD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHMOD_E_SIZE))
 	{
 		return 0;
 	}
@@ -44,7 +44,7 @@ int BPF_PROG(fchmod_x,
 {
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHMOD_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHMOD_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(fchmodat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHMODAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHMODAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -76,7 +76,7 @@ int BPF_PROG(fchmodat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(fchown_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHOWN_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHOWN_E_SIZE))
 	{
 		return 0;
 	}
@@ -44,7 +44,7 @@ int BPF_PROG(fchown_x,
 {
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHOWN_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHOWN_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
@@ -84,7 +84,7 @@ int BPF_PROG(fchownat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(fchownat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCHOWNAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCHOWNAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(fcntl_e,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCNTL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCNTL_E_SIZE))
 	{
 		return 0;
 	}
@@ -69,7 +69,7 @@ int BPF_PROG(fcntl_x,
 	}
 
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FCNTL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FCNTL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(flock_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FLOCK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FLOCK_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(flock_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FLOCK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FLOCK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -245,7 +245,7 @@ int BPF_PROG(t2_fork_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(fork_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FORK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FORK_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(fsconfig_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FSCONFIG_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FSCONFIG_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
@@ -146,7 +146,7 @@ int BPF_PROG(fsconfig_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(fstat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FSTAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FSTAT_E_SIZE))
 	{
 		return 0;
 	}
@@ -46,7 +46,7 @@ int BPF_PROG(fstat_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FSTAT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FSTAT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(futex_e,
         long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FUTEX_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FUTEX_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(futex_x,
         long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, FUTEX_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, FUTEX_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/generic.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(generic_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GENERIC_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GENERIC_E_SIZE))
 	{
 		return 0;
 	}
@@ -48,7 +48,7 @@ int BPF_PROG(generic_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GENERIC_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GENERIC_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getcwd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getcwd.bpf.c
@@ -73,7 +73,7 @@ int BPF_PROG(getcwd_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getcwd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getcwd.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(getcwd_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETCWD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETCWD_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getdents_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETDENTS_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETDENTS_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(getdents_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETDENTS_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETDENTS_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getdents64_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETDENTS64_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETDENTS64_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(getdents64_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETDENTS64_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETDENTS64_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getegid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getegid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getegid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETEGID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETEGID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(getegid_x,
 	     long ret)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETEGID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETEGID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/geteuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/geteuid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(geteuid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETEUID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETEUID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(geteuid_x,
 	     long ret)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETEUID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETEUID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getgid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getgid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETGID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETGID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(getgid_x,
 	     long ret)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETGID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETGID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getpeername.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getpeername.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getpeername_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETPEERNAME_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETPEERNAME_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(getpeername_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETPEERNAME_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETPEERNAME_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresgid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getresgid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETRESGID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETRESGID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(getresgid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETRESGID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETRESGID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresuid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getresuid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETRESUID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETRESUID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(getresuid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETRESUID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETRESUID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getrlimit.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getrlimit.bpf.c
@@ -17,7 +17,7 @@ int BPF_PROG(getrlimit_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETRLIMIT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETRLIMIT_E_SIZE))
 	{
 		return 0;
 	}
@@ -47,7 +47,7 @@ int BPF_PROG(getrlimit_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETRLIMIT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETRLIMIT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockname.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockname.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getsockname_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETSOCKNAME_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETSOCKNAME_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(getsockname_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETSOCKNAME_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETSOCKNAME_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(getsockopt_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, GETSOCKOPT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, GETSOCKOPT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
@@ -90,7 +90,7 @@ int BPF_PROG(getsockopt_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getuid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(getuid_e,
 	     long id)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETUID_E_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETUID_E_SIZE))
         {
                 return 0;
         }
@@ -41,7 +41,7 @@ int BPF_PROG(getuid_x,
 	     long ret)
 {
         struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, GETUID_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, GETUID_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(inotify_init_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, INOTIFY_INIT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, INOTIFY_INIT_E_SIZE))
 	{
 		return 0;
 	}
@@ -48,7 +48,7 @@ int BPF_PROG(inotify_init_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, INOTIFY_INIT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, INOTIFY_INIT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init1.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init1.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(inotify_init1_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, INOTIFY_INIT1_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, INOTIFY_INIT1_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(inotify_init1_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, INOTIFY_INIT1_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, INOTIFY_INIT1_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(io_uring_enter_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_ENTER_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_ENTER_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(io_uring_enter_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_ENTER_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_ENTER_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(io_uring_register_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_REGISTER_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_REGISTER_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(io_uring_register_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_REGISTER_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_REGISTER_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_setup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_setup.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(io_uring_setup_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_SETUP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_SETUP_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(io_uring_setup_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IO_URING_SETUP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IO_URING_SETUP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(ioctl_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IOCTL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IOCTL_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(ioctl_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, IOCTL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, IOCTL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(kill_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, KILL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, KILL_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(kill_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, KILL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, KILL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
@@ -72,7 +72,7 @@ int BPF_PROG(lchown_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lchown.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(lchown_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LCHOWN_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LCHOWN_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(link_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LINK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LINK_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/link.bpf.c
@@ -68,7 +68,7 @@ int BPF_PROG(link_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -88,7 +88,7 @@ int BPF_PROG(linkat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(linkat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LINKAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LINKAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(listen_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LISTEN_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LISTEN_E_SIZE))
 	{
 		return 0;
 	}
@@ -54,7 +54,7 @@ int BPF_PROG(listen_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LISTEN_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LISTEN_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(llseek_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LLSEEK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LLSEEK_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(llseek_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LLSEEK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LLSEEK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(lseek_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LSEEK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LSEEK_E_SIZE))
 	{
 		return 0;
 	}
@@ -51,7 +51,7 @@ int BPF_PROG(lseek_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LSEEK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LSEEK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lstat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lstat.bpf.c
@@ -17,7 +17,7 @@ int BPF_PROG(lstat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, LSTAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, LSTAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lstat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lstat.bpf.c
@@ -65,7 +65,7 @@ int BPF_PROG(lstat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -66,7 +66,7 @@ int BPF_PROG(mkdir_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(mkdir_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MKDIR_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MKDIR_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -76,7 +76,7 @@ int BPF_PROG(mkdirat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(mkdirat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MKDIRAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MKDIRAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlock.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mlock_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCK_E_SIZE))
 	{
 		return 0;
 	}
@@ -41,7 +41,7 @@ int BPF_PROG(mlock_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlock2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlock2.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mlock2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCK2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCK2_E_SIZE))
 	{
 		return 0;
 	}
@@ -41,7 +41,7 @@ int BPF_PROG(mlock2_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCK2_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCK2_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlockall.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mlockall.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mlockall_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCKALL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCKALL_E_SIZE))
 	{
 		return 0;
 	}
@@ -41,7 +41,7 @@ int BPF_PROG(mlockall_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MLOCKALL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MLOCKALL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mmap_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MMAP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MMAP_E_SIZE))
 	{
 		return 0;
 	}
@@ -65,7 +65,7 @@ int BPF_PROG(mmap_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MMAP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MMAP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mmap2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MMAP2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MMAP2_E_SIZE))
 	{
 		return 0;
 	}
@@ -65,7 +65,7 @@ int BPF_PROG(mmap2_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MMAP2_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MMAP2_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(mount_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MOUNT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MOUNT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
@@ -87,7 +87,7 @@ int BPF_PROG(mount_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(mprotect_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MPROTECT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MPROTECT_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(mprotect_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-        if(!ringbuf__reserve_space(&ringbuf, MPROTECT_X_SIZE))
+        if(!ringbuf__reserve_space(&ringbuf, ctx, MPROTECT_X_SIZE))
         {
                 return 0;
         }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munlock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munlock.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(munlock_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNLOCK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNLOCK_E_SIZE))
 	{
 		return 0;
 	}
@@ -41,7 +41,7 @@ int BPF_PROG(munlock_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNLOCK_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNLOCK_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munlockall.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munlockall.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(munlockall_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNLOCKALL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNLOCKALL_E_SIZE))
 	{
 		return 0;
 	}
@@ -41,7 +41,7 @@ int BPF_PROG(munlockall_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNLOCKALL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNLOCKALL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munmap.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munmap.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(munmap_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNMAP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNMAP_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(munmap_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, MUNMAP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, MUNMAP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(nanosleep_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, NANOSLEEP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, NANOSLEEP_E_SIZE))
 	{
 		return 0;
 	}
@@ -47,7 +47,7 @@ int BPF_PROG(nanosleep_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, NANOSLEEP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, NANOSLEEP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
@@ -40,7 +40,7 @@ int BPF_PROG(open_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -97,7 +97,7 @@ int BPF_PROG(open_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -83,7 +83,7 @@ int BPF_PROG(open_by_handle_at_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(open_by_handle_at_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, OPEN_BY_HANDLE_AT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, OPEN_BY_HANDLE_AT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
@@ -48,7 +48,7 @@ int BPF_PROG(openat_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -113,7 +113,7 @@ int BPF_PROG(openat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
@@ -54,7 +54,7 @@ int BPF_PROG(openat2_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -111,7 +111,7 @@ int BPF_PROG(openat2_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(pipe_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PIPE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PIPE_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(pipe_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PIPE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PIPE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(pipe2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PIPE2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PIPE2_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(pipe2_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PIPE2_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PIPE2_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
@@ -43,7 +43,7 @@ int BPF_PROG(poll_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -81,7 +81,7 @@ int BPF_PROG(poll_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
@@ -57,7 +57,7 @@ int BPF_PROG(ppoll_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -95,7 +95,7 @@ int BPF_PROG(ppoll_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -92,7 +92,7 @@ int BPF_PROG(pread64_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(pread64_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PREAD64_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PREAD64_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(preadv_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PREADV_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PREADV_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -96,7 +96,7 @@ int BPF_PROG(preadv_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(prlimit64_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PRLIMIT64_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PRLIMIT64_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(prlimit64_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PRLIMIT64_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PRLIMIT64_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -78,7 +78,7 @@ int BPF_PROG(ptrace_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(ptrace_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PTRACE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PTRACE_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -84,7 +84,7 @@ int BPF_PROG(pwrite64_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(pwrite64_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PWRITE64_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PWRITE64_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(pwritev_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, PWRITEV_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, PWRITEV_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -89,7 +89,7 @@ int BPF_PROG(pwritev_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(quotactl_e,
 	     long syscall_id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, QUOTACTL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, QUOTACTL_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -245,7 +245,7 @@ int BPF_PROG(quotactl_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(read_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, READ_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, READ_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -88,7 +88,7 @@ int BPF_PROG(read_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(readv_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, READV_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, READV_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -92,7 +92,7 @@ int BPF_PROG(readv_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -92,7 +92,7 @@ int BPF_PROG(recv_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(recv_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RECV_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RECV_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -107,7 +107,7 @@ int BPF_PROG(recvfrom_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(recvfrom_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RECVFROM_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RECVFROM_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(recvmmsg_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RECVMMSG_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RECVMMSG_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(recvmmsg_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RECVMMSG_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RECVMMSG_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(recvmsg_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RECVMSG_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RECVMSG_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -110,7 +110,7 @@ int BPF_PROG(recvmsg_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(rename_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RENAME_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RENAME_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rename.bpf.c
@@ -68,7 +68,7 @@ int BPF_PROG(rename_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
@@ -84,7 +84,7 @@ int BPF_PROG(renameat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(renameat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RENAMEAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RENAMEAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(renameat2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RENAMEAT2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RENAMEAT2_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
@@ -89,7 +89,7 @@ int BPF_PROG(renameat2_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
@@ -64,7 +64,7 @@ int BPF_PROG(rmdir_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/rmdir.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(rmdir_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, RMDIR_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, RMDIR_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(seccomp_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SECCOMP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SECCOMP_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(seccomp_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SECCOMP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SECCOMP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/select.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/select.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(select_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SELECT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SELECT_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(select_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SELECT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SELECT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(semctl_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMCTL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMCTL_E_SIZE))
 	{
 		return 0;
 	}
@@ -57,7 +57,7 @@ int BPF_PROG(semctl_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMCTL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMCTL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(semget_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMGET_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMGET_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(semget_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMGET_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMGET_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(semop_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMOP_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMOP_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(semop_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEMOP_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEMOP_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(send_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SEND_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SEND_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -85,7 +85,7 @@ int BPF_PROG(send_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(sendfile_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SENDFILE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SENDFILE_E_SIZE))
 	{
 		return 0;
 	}
@@ -59,7 +59,7 @@ int BPF_PROG(sendfile_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SENDFILE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SENDFILE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(sendmmsg_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SENDMMSG_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SENDMMSG_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(sendmmsg_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SENDMMSG_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SENDMMSG_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -55,7 +55,7 @@ int BPF_PROG(sendmsg_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -105,7 +105,7 @@ int BPF_PROG(sendmsg_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -55,7 +55,7 @@ int BPF_PROG(sendto_e,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }
@@ -104,7 +104,7 @@ int BPF_PROG(sendto_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setgid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETGID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETGID_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(setgid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETGID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETGID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setns_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETNS_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETNS_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(setns_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETNS_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETNS_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setpgid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETPGID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETPGID_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(setpgid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETPGID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETPGID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setresgid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRESGID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRESGID_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(setresgid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRESGID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRESGID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setresuid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRESUID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRESUID_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(setresuid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRESUID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRESUID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setrlimit.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setrlimit.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setrlimit_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRLIMIT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRLIMIT_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(setrlimit_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETRLIMIT_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETRLIMIT_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setsid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETSID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETSID_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(setsid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETSID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETSID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -84,7 +84,7 @@ int BPF_PROG(setsockopt_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(setsockopt_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETSOCKOPT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETSOCKOPT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(setuid_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETUID_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETUID_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(setuid_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SETUID_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SETUID_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(shutdown_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SHUTDOWN_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SHUTDOWN_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(shutdown_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SHUTDOWN_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SHUTDOWN_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(signalfd_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SIGNALFD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SIGNALFD_E_SIZE))
 	{
 		return 0;
 	}
@@ -55,7 +55,7 @@ int BPF_PROG(signalfd_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SIGNALFD_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SIGNALFD_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(signalfd4_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SIGNALFD4_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SIGNALFD4_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(signalfd4_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SIGNALFD4_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SIGNALFD4_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(socket_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SOCKET_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SOCKET_E_SIZE))
 	{
 		return 0;
 	}
@@ -60,7 +60,7 @@ int BPF_PROG(socket_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SOCKET_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SOCKET_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(socketpair_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SOCKETPAIR_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SOCKETPAIR_E_SIZE))
 	{
 		return 0;
 	}
@@ -60,7 +60,7 @@ int BPF_PROG(socketpair_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SOCKETPAIR_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SOCKETPAIR_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(splice_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SPLICE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SPLICE_E_SIZE))
 	{
 		return 0;
 	}
@@ -57,7 +57,7 @@ int BPF_PROG(splice_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SPLICE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SPLICE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/stat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/stat.bpf.c
@@ -17,7 +17,7 @@ int BPF_PROG(stat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, STAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, STAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/stat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/stat.bpf.c
@@ -65,7 +65,7 @@ int BPF_PROG(stat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(symlink_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SYMLINK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SYMLINK_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlink.bpf.c
@@ -68,7 +68,7 @@ int BPF_PROG(symlink_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
@@ -76,7 +76,7 @@ int BPF_PROG(symlinkat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(symlinkat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, SYMLINKAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, SYMLINKAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(tgkill_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TGKILL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TGKILL_E_SIZE))
 	{
 		return 0;
 	}
@@ -53,7 +53,7 @@ int BPF_PROG(tgkill_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TGKILL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TGKILL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/timerfd_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/timerfd_create.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(timerfd_create_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TIMERFD_CREATE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TIMERFD_CREATE_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(timerfd_create_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TIMERFD_CREATE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TIMERFD_CREATE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(tkill_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TKILL_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TKILL_E_SIZE))
 	{
 		return 0;
 	}
@@ -49,7 +49,7 @@ int BPF_PROG(tkill_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, TKILL_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, TKILL_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount.bpf.c
@@ -64,7 +64,7 @@ int BPF_PROG(umount_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(umount_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UMOUNT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UMOUNT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
@@ -66,7 +66,7 @@ int BPF_PROG(umount2_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(umount2_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UMOUNT2_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UMOUNT2_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
@@ -64,7 +64,7 @@ int BPF_PROG(unlink_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlink.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(unlink_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UNLINK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UNLINK_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -76,7 +76,7 @@ int BPF_PROG(unlinkat_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(unlinkat_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UNLINKAT_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UNLINKAT_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(unshare_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UNSHARE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UNSHARE_E_SIZE))
 	{
 		return 0;
 	}
@@ -45,7 +45,7 @@ int BPF_PROG(unshare_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, UNSHARE_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, UNSHARE_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
@@ -15,7 +15,7 @@ int BPF_PROG(userfaultfd_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, USERFAULTFD_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, USERFAULTFD_E_SIZE))
 	{
 		return 0;
 	}
@@ -43,7 +43,7 @@ int BPF_PROG(userfaultfd_x,
 	     long ret)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, USERFAULTFD_X_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, USERFAULTFD_X_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(vfork_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, VFORK_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, VFORK_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -243,7 +243,7 @@ int BPF_PROG(t2_vfork_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(write_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, WRITE_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, WRITE_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -80,7 +80,7 @@ int BPF_PROG(write_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -85,7 +85,7 @@ int BPF_PROG(writev_x,
 
 	auxmap__finalize_event_header(auxmap);
 
-	auxmap__submit_event(auxmap);
+	auxmap__submit_event(auxmap, ctx);
 
 	return 0;
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -16,7 +16,7 @@ int BPF_PROG(writev_e,
 	     long id)
 {
 	struct ringbuf_struct ringbuf;
-	if(!ringbuf__reserve_space(&ringbuf, WRITEV_E_SIZE))
+	if(!ringbuf__reserve_space(&ringbuf, ctx, WRITEV_E_SIZE))
 	{
 		return 0;
 	}

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1232,7 +1232,8 @@ enum extra_event_prog_code
 	T2_VFORK_X = 12,
 	T1_DROP_E = 13,
 	T1_DROP_X = 14,
-	TAIL_EXTRA_EVENT_PROG_MAX = 15
+	T1_HOTPLUG_E = 15,
+	TAIL_EXTRA_EVENT_PROG_MAX = 16
 };
 
 /*

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1230,7 +1230,9 @@ enum extra_event_prog_code
 	T2_CLONE3_X = 10,
 	T2_FORK_X = 11,
 	T2_VFORK_X = 12,
-	TAIL_EXTRA_EVENT_PROG_MAX = 13
+	T1_DROP_E = 13,
+	T1_DROP_X = 14,
+	TAIL_EXTRA_EVENT_PROG_MAX = 15
 };
 
 /*

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -221,27 +221,27 @@ void event_test::clear_ring_buffers()
 	}
 }
 
-void event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
+struct ppm_evt_hdr* event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
 {
-	/* Clear acutal event */
-	m_event_header = NULL;
+	struct ppm_evt_hdr* hdr = NULL;
 	uint16_t attempts = 0;
 	int32_t res = 0;
 
 	/* Try 2 times just to be sure that all the buffers are empty. */
 	while(attempts <= 1)
 	{
-		res = scap_next(s_scap_handle, (scap_evt**)&m_event_header, cpu_id);
-		if(res == SCAP_SUCCESS && m_event_header != NULL)
+		res = scap_next(s_scap_handle, (scap_evt**)&hdr, cpu_id);
+		if(res == SCAP_SUCCESS && hdr != NULL)
 		{
-			return;
+			break;
 		}
 		else if(res != SCAP_TIMEOUT && res != SCAP_SUCCESS)
 		{
-			FAIL() << "Unexpected error value from scap-next: " << res << std::endl;
+			return NULL;
 		}
 		attempts++;
 	}
+	return hdr;
 }
 
 void event_test::parse_event()
@@ -899,7 +899,7 @@ void event_test::assert_event_in_buffers(pid_t pid_to_search, int event_to_searc
 	 */
 	while(true)
 	{
-		get_event_from_ringbuffer(&cpu_id);
+		m_event_header = get_event_from_ringbuffer(&cpu_id);
 		if(m_event_header == NULL)
 		{
 			if(presence)

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -187,7 +187,7 @@ public:
 	 *
 	 * @param cpu_id CPU from which we extracted the event.
 	 */
-	void get_event_from_ringbuffer(uint16_t* cpu_id);
+	struct ppm_evt_hdr* get_event_from_ringbuffer(uint16_t* cpu_id);
 
 	/**
 	 * @brief Parse information from the event that we have extracted from the buffer:

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -331,4 +331,6 @@ static const char* extra_event_prog_names[TAIL_EXTRA_EVENT_PROG_MAX] = {
 	[T2_CLONE3_X] = "t2_clone3_x",
 	[T2_FORK_X] = "t2_fork_x",
 	[T2_VFORK_X] = "t2_vfork_x",
+	[T1_DROP_E] = "t1_drop_e",
+	[T1_DROP_X] = "t1_drop_x",
 };

--- a/userspace/libpman/src/events_prog_names.h
+++ b/userspace/libpman/src/events_prog_names.h
@@ -333,4 +333,5 @@ static const char* extra_event_prog_names[TAIL_EXTRA_EVENT_PROG_MAX] = {
 	[T2_VFORK_X] = "t2_vfork_x",
 	[T1_DROP_E] = "t1_drop_e",
 	[T1_DROP_X] = "t1_drop_x",
+	[T1_HOTPLUG_E] = "t1_hotplug_e",
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR allows the modern bpf probe to manage the CPU hot-plug. Note that this PR introduces just the management driver side, we will another PR to manage the hot-plug userspace side. The idea here is quite simple if on our CPU we don't have a ring buffer allocated it means that our CPU was not online and so we need to throw a `PPME_CPU_HOTPLUG_E` event to ask userspace a new ring buffer for us. The logic used to send this is event is the `tail-call` mechanism. We don't have a ring buffer for our CPU so we jump into another bpf prog and we try to send a `PPME_CPU_HOTPLUG_E` event on the ring buffer associated with `CPU 0`. This is very similar to what we do in the old drivers, we use `CPU 0` because it should be always online...

Since we introduced the tail call mechanism for custom logic, I have extended the same pattern also to the `DROP_E` event. This should be the cleanest way to do that, it could cause some issues if we will use other types of bpf prog, but I've already in mind some strategies to handle these cases if necessary :) 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
