### PR TITLE
fix(scap): Use precise boot time for BPF engines

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1352,7 +1352,7 @@ static int32_t set_default_settings(struct bpf_engine *handle)
 	struct scap_bpf_settings settings;
 
 	uint64_t boot_time = 0;
-	if(scap_get_boot_time(handle->m_lasterr, &boot_time) != SCAP_SUCCESS)
+	if(scap_get_precise_boot_time(handle->m_lasterr, &boot_time) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -213,7 +213,7 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 
 	/* Set the boot time */
 	uint64_t boot_time = 0;
-	if(scap_get_boot_time(handle->m_lasterr, &boot_time) != SCAP_SUCCESS)
+	if(scap_get_precise_boot_time(handle->m_lasterr, &boot_time) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/scap_engine_util.c
+++ b/userspace/libscap/scap_engine_util.c
@@ -15,13 +15,19 @@ limitations under the License.
 
 */
 
+#include <errno.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "scap.h"
 #include "scap-int.h"
 #include "scap_engine_util.h"
 #include "scap_vtable.h"
 #include "strerror.h"
+
+#ifdef __linux__
+#include "compat/misc.h"
+#endif
 
 bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
 							uint32_t required_major, uint32_t required_minor, uint32_t required_patch)
@@ -95,4 +101,31 @@ static int32_t check_api_compatibility_impl(uint64_t current_version, uint64_t m
 	}
 
 	return SCAP_SUCCESS;
+}
+
+static inline uint64_t timespec_to_nsec(const struct timespec* ts)
+{
+	return ts->tv_sec * 1000000000 + ts->tv_nsec;
+}
+
+int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time)
+{
+#ifdef __linux__
+	struct timespec wall_ts, boot_ts;
+
+	if(clock_gettime(CLOCK_BOOTTIME, &boot_ts) < 0)
+	{
+		return scap_errprintf(last_err, errno, "Failed to get CLOCK_BOOTTIME");
+	}
+
+	if(clock_gettime(CLOCK_REALTIME, &wall_ts) < 0)
+	{
+		return scap_errprintf(last_err, errno, "Failed to get CLOCK_REALTIME");
+	}
+
+	*boot_time = timespec_to_nsec(&wall_ts) - timespec_to_nsec(&boot_ts);
+	return SCAP_SUCCESS;
+#else
+	return scap_errprintf(last_err, 0, "scap_get_precise_boot_time not implemented on this platform");
+#endif
 }

--- a/userspace/libscap/scap_engine_util.h
+++ b/userspace/libscap/scap_engine_util.h
@@ -40,3 +40,17 @@ bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uin
 							uint32_t required_major, uint32_t required_minor, uint32_t required_patch);
 
 int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error);
+
+/**
+ * \brief Get the timestamp of boot with subsecond accuracy
+ *
+ * @param last_err a buffer of SCAP_LASTERR_SIZE for the error message, if any
+ * @param boot_time pointer to the result (boot time in nanoseconds since the epoch)
+ * @return SCAP_SUCCESS or an error code
+ *
+ * As opposed to scap_get_boot_time, this function:
+ * - is an internal helper, intended only for the engines' use (BPF-based in particular)
+ * - doesn't need wide compatibility (only needs to work on systems supporting eBPF)
+ * - needs as much accuracy as we can get (otherwise eBPF event timestamps will be wrong)
+ */
+int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

/area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

/area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In dba2e32d3dba70e52394701fea27439ddd890416 we switched the way we determine the boot time from CLOCK_BOOTTIME based to /proc/stat based.

The new way is more compatible (including compatibility with ancient kernels) but it only has a full second accuracy (the fractional part is lost).

Unfortunately, we need the extra precision in BPF engines since we only get timestamps since boot from the kernel. Without the subsecond part, all events get their timestamps shifted by up to a second to the past (the exact value depends on the fractional part of the second the machine booted).

Since BPF engines do not need compatibility with prehistoric kernels (they don't support eBPF anyway), switch them to use CLOCK_BOOTTIME to get the boot time.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
