### PR TITLE
fix(build): don't write to source directory during build

### DIFF
--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
+configure_file(../driver_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/driver_config.h)
 
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
@@ -28,6 +28,7 @@ endif()
 install(FILES
 	bpf_helpers.h
 	builtins.h
+	driver_config.h
 	filler_helpers.h
 	fillers.h
 	Makefile

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -15,7 +15,7 @@ or GPL2.txt for full copies of the license.
 #endif
 #include <linux/sched.h>
 
-#include "../driver_config.h"
+#include "driver_config.h"
 #include "../ppm_events_public.h"
 #include "bpf_helpers.h"
 #include "types.h"

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -47,7 +47,7 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 compute_versions(../API_VERSION ../SCHEMA_VERSION)
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
+configure_file(../driver_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/driver/driver_config.h)
 
 ########################
 # Check clang version.
@@ -211,6 +211,7 @@ list(APPEND CLANG_FLAGS
     -I${LIBBPF_INCLUDE}
     ${MODERN_PROBE_INCLUDE}
     -I${PPM_INCLUDE}
+    -I${CMAKE_CURRENT_BINARY_DIR}
     -isystem
 )
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

/area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

/area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This patch makes it possible to build the libs from a read-only directory (like in a container).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
