### PR TITLE
cleanup(libsinsp): add `ppm_sc_modifies_state` and `ppm_sc_repair_state` flags to sinsp-example

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -45,7 +45,7 @@ void json_dump(sinsp& inspector);
 void json_dump_init(sinsp& inspector);
 void json_dump_reinit_evt_formatter(sinsp& inspector);
 
-std::unordered_set<std::string> extract_filter_events(sinsp& inspector);
+libsinsp::events::set<ppm_sc_code> extract_filter_sc_codes(sinsp& inspector);
 std::function<void(sinsp& inspector)> dump;
 static bool g_interrupted = false;
 static const uint8_t g_backoff_timeout_secs = 2;
@@ -170,13 +170,12 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv)
 }
 #endif // _WIN32
 
-std::unordered_set<std::string> extract_filter_events(sinsp& inspector)
+libsinsp::events::set<ppm_sc_code> extract_filter_sc_codes(sinsp& inspector)
 {
 	auto ast = inspector.get_filter_ast();
 	if(ast != nullptr)
 	{
-		auto codes = libsinsp::filter::ast::ppm_event_codes(ast.get());
-		return libsinsp::events::event_set_to_names(codes);
+		return libsinsp::filter::ast::ppm_sc_codes(ast.get());
 	}
 
 	return {};
@@ -318,10 +317,11 @@ int main(int argc, char** argv)
 		}
 	}
 
-	auto event_names = extract_filter_events(inspector);
-	if(!event_names.empty())
+	auto events_sc_codes = extract_filter_sc_codes(inspector);
+	if(!events_sc_codes.empty())
 	{
-		printf("-- Filter event types names: %s\n", concat_set_in_order(event_names).c_str());
+		auto events_sc_names = libsinsp::events::sc_set_to_sc_names(events_sc_codes);
+		printf("-- Filter event types sc codes names: %s\n", concat_set_in_order(events_sc_names).c_str());
 	}
 
 	std::cout << "-- Start capture" << std::endl;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

As the major `ppm sc` API refactor has completed extend `sinsp-example` for demonstration and e2e testing purposes. 

Select sc codes for active tracing in the kernel:
- Include each ppm sc code from filter expression AST.
- Demonstrate ppm sc API usage for both  `sinsp_state_sc_set` and `sinsp_repair_state_sc_set` options.

CC @FedeDP @Andreagit97 @jasondellaluce 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(libsinsp): add `ppm_sc_modifies_state` and `ppm_sc_repair_state` flags to sinsp-example
```
