### PR TITLE
[1/n] new(scap): platform abstraction support

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND targetfiles
 	scap_fds.c
 	scap_iflist.c
 	scap_savefile.c
+	scap_platform.c
 	scap_procs.c
 	scap_userlist.c
 	scap_machine_agent.c

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -23,6 +23,7 @@ namespace scap_gvisor {
 
 #include "scap.h"
 #include "gvisor.h"
+#include "gvisor_platform.h"
 #include "scap-int.h"
 
 #include <stdio.h>
@@ -41,6 +42,36 @@ namespace scap_gvisor {
 #ifdef __cplusplus
 extern "C"{
 #endif
+
+static int32_t scap_gvisor_init_platform(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs)
+{
+	return SCAP_SUCCESS;
+}
+
+static int32_t scap_gvisor_close_platform(struct scap_platform* platform)
+{
+	return SCAP_SUCCESS;
+}
+
+static void scap_gvisor_free_platform(struct scap_platform* platform)
+{
+	auto gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(platform);
+	delete gvisor_platform;
+}
+
+static const struct scap_platform_vtable scap_gvisor_platform_vtable = {
+	.init_platform = scap_gvisor_init_platform,
+	.close_platform = scap_gvisor_close_platform,
+	.free_platform = scap_gvisor_free_platform,
+};
+
+struct scap_platform* scap_gvisor_alloc_platform()
+{
+	auto platform = new scap_gvisor_platform;
+	platform->m_generic.m_vtable = &scap_gvisor_platform_vtable;
+
+	return &platform->m_generic;
+}
 
 static SCAP_HANDLE_T *gvisor_alloc_handle(scap_t* main_handle, char *lasterr_ptr)
 {

--- a/userspace/libscap/engine/gvisor/gvisor_platform.h
+++ b/userspace/libscap/engine/gvisor/gvisor_platform.h
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "scap_platform_impl.h"
+
+struct scap_gvisor_platform
+{
+	struct scap_platform m_generic;
+};

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -28,6 +28,9 @@ extern "C"
 		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 	};
 
+	struct scap_platform;
+	struct scap_platform* scap_gvisor_alloc_platform();
+
 #ifdef __cplusplus
 };
 #endif

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -38,6 +38,11 @@ static struct nodriver_engine* alloc_handle(scap_t* main_handle, char* lasterr_p
 	return engine;
 }
 
+static int32_t init(scap_t* handle, scap_open_args *oargs)
+{
+	return SCAP_SUCCESS;
+}
+
 static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid)
 {
 	static scap_evt evt;
@@ -59,7 +64,7 @@ const struct scap_vtable scap_nodriver_engine = {
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,
-	.init = NULL,
+	.init = init,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,
 	.next = next,

--- a/userspace/libscap/engine/savefile/savefile_platform.h
+++ b/userspace/libscap/engine/savefile/savefile_platform.h
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "scap_platform_impl.h"
+
+struct scap_savefile_platform
+{
+	struct scap_platform m_generic;
+};

--- a/userspace/libscap/engine/savefile/savefile_public.h
+++ b/userspace/libscap/engine/savefile/savefile_public.h
@@ -30,6 +30,9 @@ extern "C"
 		uint32_t fbuffer_size; ///< If non-zero, offline captures will read from file using a buffer of this size.
 	};
 
+	struct scap_platform;
+	struct scap_platform* scap_savefile_alloc_platform();
+
 #ifdef __cplusplus
 };
 #endif

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -33,6 +33,7 @@ struct iovec {
 #include "savefile.h"
 #include "scap.h"
 #include "scap-int.h"
+#include "scap_platform.h"
 #include "scap_savefile.h"
 #include "scap_reader.h"
 #include "../noop/noop.h"
@@ -2263,6 +2264,8 @@ static int32_t scap_savefile_restart_capture(scap_t* handle)
 {
 	struct savefile_engine *engine = handle->m_engine.m_handle;
 	int32_t res;
+
+	scap_platform_close(handle->m_platform);
 
 	if((res = scap_read_init(
 		engine,

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -35,6 +35,7 @@ struct iovec {
 #include "scap-int.h"
 #include "scap_platform.h"
 #include "scap_savefile.h"
+#include "savefile_platform.h"
 #include "scap_reader.h"
 #include "../noop/noop.h"
 
@@ -2126,6 +2127,42 @@ void scap_savefile_fseek(struct scap_engine_handle engine, uint64_t off)
 {
 	scap_reader_t* reader = engine.m_handle->m_reader;
 	reader->seek(reader, off, SEEK_SET);
+}
+
+static int32_t
+scap_savefile_init_platform(struct scap_platform *platform, char *lasterr, struct scap_engine_handle engine,
+			    struct scap_open_args *oargs)
+{
+	return SCAP_SUCCESS;
+}
+
+static int32_t scap_savefile_close_platform(struct scap_platform* platform)
+{
+	return SCAP_SUCCESS;
+}
+
+static void scap_savefile_free_platform(struct scap_platform* platform)
+{
+	free(platform);
+}
+
+static const struct scap_platform_vtable scap_savefile_platform_vtable = {
+	.init_platform = scap_savefile_init_platform,
+	.close_platform = scap_savefile_close_platform,
+	.free_platform = scap_savefile_free_platform,
+};
+
+struct scap_platform* scap_savefile_alloc_platform()
+{
+    struct scap_savefile_platform* platform = calloc(sizeof(*platform), 1);
+
+	if(platform == NULL)
+	{
+		return NULL;
+	}
+
+	platform->m_generic.m_vtable = &scap_savefile_platform_vtable;
+	return &platform->m_generic;
 }
 
 static struct savefile_engine* alloc_handle(struct scap* main_handle, char* lasterr_ptr)

--- a/userspace/libscap/linux/CMakeLists.txt
+++ b/userspace/libscap/linux/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(scap_platform scap_procs.c scap_fds.c scap_userlist.c scap_iflist.c scap_ppm_sc.c)
+add_library(scap_platform scap_linux_platform.c scap_procs.c scap_fds.c scap_userlist.c scap_iflist.c scap_ppm_sc.c)
 target_link_libraries(scap_platform scap_error)
 set_scap_target_properties(scap_platform)

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "scap_linux_platform.h"
+
+#include "scap.h"
+#include "scap-int.h"
+
+#include <stdlib.h>
+
+static int32_t scap_linux_close_platform(struct scap_platform* platform)
+{
+	return SCAP_SUCCESS;
+}
+
+static void scap_linux_free_platform(struct scap_platform* platform)
+{
+	free(platform);
+}
+
+int32_t scap_linux_init_platform(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs)
+{
+	return SCAP_SUCCESS;
+}
+
+static const struct scap_platform_vtable scap_linux_platform = {
+	.init_platform = scap_linux_init_platform,
+	.close_platform = scap_linux_close_platform,
+	.free_platform = scap_linux_free_platform,
+};
+
+struct scap_platform* scap_linux_alloc_platform()
+{
+	struct scap_linux_platform* platform = calloc(sizeof(*platform), 1);
+
+	if(platform == NULL)
+	{
+		return NULL;
+	}
+
+	struct scap_platform* generic = &platform->m_generic;
+	generic->m_vtable = &scap_linux_platform;
+
+	return generic;
+}

--- a/userspace/libscap/linux/scap_linux_platform.h
+++ b/userspace/libscap/linux/scap_linux_platform.h
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "scap_platform_impl.h"
+
+struct scap_linux_platform
+{
+	struct scap_platform m_generic;
+};
+
+struct scap_platform* scap_linux_alloc_platform();
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -44,6 +44,7 @@ struct scap
 	const struct scap_vtable *m_vtable;
 	struct scap_engine_handle m_engine;
 	struct scap_suppress m_suppress;
+	struct scap_platform *m_platform;
 
 	scap_mode_t m_mode;
 	char m_lasterr[SCAP_LASTERR_SIZE];

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -323,11 +323,17 @@ int32_t scap_init_test_input_int(scap_t* handle, scap_open_args* oargs)
 #endif
 
 #ifdef HAS_ENGINE_GVISOR
-int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs)
+int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
 {
 	int32_t rc;
 
+	//
+	// Preliminary initializations
+	//
+	handle->m_mode = SCAP_MODE_LIVE;
 	handle->m_vtable = &scap_gvisor_engine;
+	handle->m_platform = platform;
+
 	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
 	if(!handle->m_engine.m_handle)
 	{
@@ -340,13 +346,6 @@ int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs)
 	{
 		return rc;
 	}
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = SCAP_MODE_LIVE;
-
-	// XXX - interface list initialization and user list initalization goes here if necessary
 
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
@@ -361,6 +360,11 @@ int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs)
 	}
 
 	if ((rc = scap_proc_scan_vtable(handle->m_lasterr, handle)) != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}
@@ -582,7 +586,13 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_GVISOR
 	if(strcmp(engine_name, GVISOR_ENGINE) == 0)
 	{
-		return scap_init_gvisor_int(handle, oargs);
+		platform = scap_gvisor_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_gvisor_int(handle, oargs, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_TEST_INPUT

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -27,6 +27,7 @@ limitations under the License.
 #endif // _WIN32
 
 #include "scap.h"
+#include "strerror.h"
 #include "strlcpy.h"
 #include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
@@ -34,6 +35,10 @@ limitations under the License.
 #include "scap_platform.h"
 
 #include "scap_engines.h"
+
+#ifdef __linux__
+#include "scap_linux_platform.h"
+#endif
 
 //#define NDEBUG
 #include <assert.h>
@@ -44,7 +49,7 @@ const char* scap_getlasterr(scap_t* handle)
 }
 
 #if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF)
-int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable)
+int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
 
@@ -62,6 +67,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	//
 	handle->m_mode = SCAP_MODE_LIVE;
 	handle->m_vtable = vtable;
+	handle->m_platform = platform;
 
 	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
 	if(!handle->m_engine.m_handle)
@@ -69,6 +75,8 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
 		return SCAP_FAILURE;
 	}
+
+	handle->m_platform = platform;
 
 	handle->m_proclist.m_proc_callback = oargs->proc_callback;
 	handle->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
@@ -145,6 +153,11 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	if((rc = scap_proc_scan_proc_dir(handle, proc_scan_err)) != SCAP_SUCCESS)
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_init_live_int() error creating the process list: %s. Make sure you have root credentials.", proc_scan_err);
+		return rc;
+	}
+
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
+	{
 		return rc;
 	}
 
@@ -546,6 +559,7 @@ scap_t* scap_alloc(void)
 int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 {
 	const char* engine_name = oargs->engine_name;
+	struct scap_platform* platform = NULL;
 
 	memset(handle, 0, sizeof(*handle));
 
@@ -580,19 +594,25 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_KMOD
 	if(strcmp(engine_name, KMOD_ENGINE) == 0)
 	{
-		return scap_init_live_int(handle, oargs, &scap_kmod_engine);
+		return scap_init_live_int(handle, oargs, &scap_kmod_engine, NULL);
 	}
 #endif
 #ifdef HAS_ENGINE_BPF
-	if( strcmp(engine_name, BPF_ENGINE) == 0)
+	if(strcmp(engine_name, BPF_ENGINE) == 0)
 	{
-		return scap_init_live_int(handle, oargs, &scap_bpf_engine);
+		platform = scap_linux_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_live_int(handle, oargs, &scap_bpf_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_MODERN_BPF
 	if(strcmp(engine_name, MODERN_BPF_ENGINE) == 0)
 	{
-		return scap_init_live_int(handle, oargs, &scap_modern_bpf_engine);
+		return scap_init_live_int(handle, oargs, &scap_modern_bpf_engine, NULL);
 	}
 #endif
 #ifdef HAS_ENGINE_NODRIVER

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -628,7 +628,13 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_MODERN_BPF
 	if(strcmp(engine_name, MODERN_BPF_ENGINE) == 0)
 	{
-		return scap_init_live_int(handle, oargs, &scap_modern_bpf_engine, NULL);
+		platform = scap_linux_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_live_int(handle, oargs, &scap_modern_bpf_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_NODRIVER

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -604,7 +604,13 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_KMOD
 	if(strcmp(engine_name, KMOD_ENGINE) == 0)
 	{
-		return scap_init_live_int(handle, oargs, &scap_kmod_engine, NULL);
+		platform = scap_linux_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_live_int(handle, oargs, &scap_kmod_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_BPF

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -526,7 +526,7 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct sca
 #endif // HAS_ENGINE_NODRIVER
 
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
-int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs)
+int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
 {
 	int32_t rc;
 
@@ -535,6 +535,8 @@ int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs)
 	//
 	handle->m_mode = SCAP_MODE_PLUGIN;
 	handle->m_vtable = &scap_source_plugin_engine;
+	handle->m_platform = platform;
+
 	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
 	if(!handle->m_engine.m_handle)
 	{
@@ -561,6 +563,11 @@ int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs)
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
 	if((rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}
@@ -672,7 +679,13 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
 	if(strcmp(engine_name, SOURCE_PLUGIN_ENGINE) == 0)
 	{
-		return scap_init_plugin_int(handle, oargs);
+		platform = scap_generic_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_plugin_int(handle, oargs, platform);
 	}
 #endif
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -31,6 +31,7 @@ limitations under the License.
 #include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
 #include "scap_engine_util.h"
+#include "scap_platform.h"
 
 #include "scap_engines.h"
 
@@ -686,6 +687,12 @@ void scap_deinit(scap_t* handle)
 {
 	scap_deinit_state(handle);
 	scap_suppress_close(&handle->m_suppress);
+
+	if(handle->m_platform)
+	{
+		scap_platform_close(handle->m_platform);
+		scap_platform_free(handle->m_platform);
+	}
 
 	if(handle->m_vtable)
 	{

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -374,7 +374,7 @@ int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs, struct scap_
 #endif // HAS_ENGINE_GVISOR
 
 #ifdef HAS_ENGINE_SAVEFILE
-int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
+int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
 {
 	int32_t rc;
 
@@ -383,6 +383,8 @@ int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
 	//
 	handle->m_mode = SCAP_MODE_CAPTURE;
 	handle->m_vtable = &scap_savefile_engine;
+	handle->m_platform = platform;
+
 	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
 	if(!handle->m_engine.m_handle)
 	{
@@ -412,6 +414,11 @@ int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs)
 	if ((rc = scap_suppress_init(&handle->m_suppress, oargs->suppressed_comms)) != SCAP_SUCCESS)
 	{
 		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error copying suppressed comms");
+		return rc;
+	}
+
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
+	{
 		return rc;
 	}
 
@@ -581,7 +588,13 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 #ifdef HAS_ENGINE_SAVEFILE
 	if(strcmp(engine_name, SAVEFILE_ENGINE) == 0)
 	{
-		return scap_init_offline_int(handle, oargs);
+		platform = scap_savefile_alloc_platform();
+		if(!platform)
+		{
+			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
+		}
+
+		return scap_init_offline_int(handle, oargs, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_UDIG

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -1,0 +1,123 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "scap_platform_impl.h"
+#include "scap_platform.h"
+
+#include "scap.h"
+#include "scap-int.h"
+
+static int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs)
+{
+	return SCAP_SUCCESS;
+}
+
+static int32_t scap_generic_close_platform(struct scap_platform* platform)
+{
+	return SCAP_SUCCESS;
+}
+
+static void scap_generic_free_platform(struct scap_platform* platform)
+{
+	free(platform);
+}
+
+struct scap_platform_vtable scap_generic_platform_vtable = {
+	.init_platform = NULL,
+	.close_platform = NULL,
+	.free_platform = scap_generic_free_platform,
+};
+
+struct scap_platform* scap_generic_alloc_platform()
+{
+	struct scap_platform* platform = calloc(sizeof(*platform), 1);
+
+	if(platform == NULL)
+	{
+		return NULL;
+	}
+
+	platform->m_vtable = &scap_generic_platform_vtable;
+	return platform;
+}
+
+int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct scap_engine_handle engine,
+			   struct scap_open_args *oargs)
+{
+	int32_t rc;
+
+	if(!platform)
+	{
+		return SCAP_SUCCESS;
+	}
+
+	rc = scap_generic_init_platform(platform, lasterr, oargs);
+	if(rc != SCAP_SUCCESS)
+	{
+		scap_platform_close(platform);
+		return rc;
+	}
+
+	if(platform->m_vtable && platform->m_vtable->init_platform)
+	{
+		rc = platform->m_vtable->init_platform(platform, lasterr, engine, oargs);
+		if(rc != SCAP_SUCCESS)
+		{
+			scap_platform_close(platform);
+		}
+		return rc;
+	}
+	else
+	{
+		return SCAP_SUCCESS;
+	}
+}
+
+int32_t scap_platform_close(struct scap_platform* platform)
+{
+	int32_t rc;
+
+	if(!platform)
+	{
+		return SCAP_SUCCESS;
+	}
+
+	rc = scap_generic_close_platform(platform);
+	if(rc != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
+	if(platform->m_vtable && platform->m_vtable->close_platform)
+	{
+		return platform->m_vtable->close_platform(platform);
+	}
+	else
+	{
+		return SCAP_SUCCESS;
+	}
+}
+
+void scap_platform_free(struct scap_platform* platform)
+{
+	if(!platform)
+	{
+		return;
+	}
+
+	platform->m_vtable->free_platform(platform);
+}

--- a/userspace/libscap/scap_platform.h
+++ b/userspace/libscap/scap_platform.h
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdint.h>
+
+#ifndef SCAP_HANDLE_T
+#define SCAP_HANDLE_T void
+#endif
+#include "engine_handle.h"
+
+// this header is designed to be useful to platform *users*
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct scap;
+struct scap_open_args;
+struct scap_platform;
+
+// allocate a generic platform handle with no behavior (no platform data is returned)
+struct scap_platform* scap_generic_alloc_platform();
+
+// initialize a platform handle
+// this calls `init_platform` from the vtable and also
+// does any common initialization
+int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct scap_engine_handle engine,
+			   struct scap_open_args *oargs);
+
+// close a platform
+// this calls `close_platform` from the vtable and also
+// does any common cleanup
+int32_t scap_platform_close(struct scap_platform* platform);
+
+// free a platform structure
+// in reality, this will be a pointer to a platform-specific struct
+void scap_platform_free(struct scap_platform* platform);
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -1,0 +1,66 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// this header is designed to be useful to platform *implementors*
+// i.e. different platforms
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SCAP_HANDLE_T
+#define SCAP_HANDLE_T void
+#endif
+
+#include "engine_handle.h"
+
+struct scap_open_args;
+struct scap_platform;
+
+// a method table for platform-specific operations
+struct scap_platform_vtable
+{
+	// initialize the platform-specific structure
+	// at this point the engine is fully initialized and operational
+	int32_t (*init_platform)(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs);
+
+	// close the platform structure
+	// clean up all data, make it ready for another call to `init_platform`
+	int32_t (*close_platform)(struct scap_platform* platform);
+
+	// free the structure
+	// it must have been previously closed (using `close_platform`)
+	// to ensure there are no memory leaks
+	void (*free_platform)(struct scap_platform* platform);
+};
+
+// the parts of the platform struct shared across all implementations
+// this *must* be the first member of all implementations
+// (the pointers are cast back&forth between the two)
+struct scap_platform
+{
+	const struct scap_platform_vtable* m_vtable;
+};
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/strerror.h
+++ b/userspace/libscap/strerror.h
@@ -20,6 +20,10 @@ limitations under the License.
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef __GNUC__
 int32_t scap_errprintf_unchecked(char *buf, int errnum, const char* fmt, ...) __attribute__ ((format (printf, 3, 4)));
 #define scap_errprintf scap_errprintf_unchecked
@@ -29,4 +33,8 @@ int32_t scap_errprintf_unchecked(char *buf, int errnum, const char* fmt, ...) __
 
 #define scap_errprintf(BUF, ERRNUM, ...) ((void)sizeof(printf(__VA_ARGS__)), scap_errprintf_unchecked(BUF, ERRNUM, __VA_ARGS__))
 int32_t scap_errprintf_unchecked(char *buf, int errnum, const char* fmt, ...);
+#endif
+
+#ifdef __cplusplus
+};
 #endif

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1314,7 +1314,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	}
 
 	/* Here we shouldn't receive unknown events */
-	ASSERT(!libsinsp::events::is_unknown_event((ppm_event_code)evt->get_type()))
+	ASSERT(!libsinsp::events::is_unknown_event((ppm_event_code)evt->get_type()));
 
 	uint64_t ts = evt->get_ts();
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces a bunch of code that literally does nothing but prepare the stage for future PRs.

Similar to the engine vtable work, a "platform"  is an abstraction over all the work that libscap does that's *not* related to delivering events, i.e. building the process/user/interface etc. lists.

This lets us (eventually) greatly simplify all the scap_init_foo_int functions (reduce them to just one) and (after more work of untangling savefiles) completely decouple libscap from e.g. scanning /proc and e.g. have the code written in a less hostile language.

**Special notes for your reviewer**:

This PR series involves all platforms containing the same types of data as current libscap (e.g. `scap_threadinfo`s in a uthash table). IMO this is undesirable in the long run since we're forced to stuff any platform data into C compatible structs. Abstracting this away (so that we can e.g. load the proc table directly into a C++ map of `sinsp_threadinfo`s) will still need some work.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
