### PR TITLE
[3/n] new(libscap): platform abstraction support: clean up scap_init_*_int

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 list(APPEND targetfiles
 	scap.c
+	scap_api_version.c
 	scap_fds.c
 	scap_savefile.c
 	scap_platform.c

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -276,9 +276,8 @@ bool acquire_and_init_ring_status_buffer(struct scap_device *dev)
 	return res;
 }
 
-int32_t udig_begin_capture(struct scap_engine_handle engine, char *error)
+int32_t udig_begin_capture(struct scap_device *dev, char *error)
 {
-	struct scap_device *dev = &engine.m_handle->m_dev_set.m_devs[0];
 	struct udig_ring_buffer_status* rbs = dev->m_bufstatus;
 
 	if(rbs->m_capturing_pid != 0)
@@ -311,7 +310,6 @@ int32_t udig_begin_capture(struct scap_engine_handle engine, char *error)
 
 	if(acquire_and_init_ring_status_buffer(dev))
 	{
-		engine.m_handle->m_udig_capturing = true;
 		return SCAP_SUCCESS;
 	}
 	else
@@ -547,7 +545,20 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 		return rc;
 	}
 
-	return scap_udig_alloc_dev(&handle->m_dev_set.m_devs[0], handle->m_lasterr);
+	rc = scap_udig_alloc_dev(&handle->m_dev_set.m_devs[0], handle->m_lasterr);
+	if(rc != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
+	struct scap_device *dev = &handle->m_dev_set.m_devs[0];
+	rc = udig_begin_capture(dev, handle->m_lasterr);
+	if(rc == SCAP_SUCCESS)
+	{
+		handle->m_udig_capturing = true;
+	}
+
+	return rc;
 }
 
 static uint32_t get_n_devs(struct scap_engine_handle engine)

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -123,11 +123,6 @@ extern const struct syscall_evt_pair g_syscall_table[];
 extern const struct ppm_event_info g_event_info[];
 extern const struct ppm_event_entry g_ppm_events[];
 
-//
-// udig stuff
-//
-int32_t udig_begin_capture(struct scap_engine_handle engine, char *error);
-
 #ifdef __cplusplus
 }
 #endif

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -69,10 +69,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 
 	handle->m_debug_log_fn = oargs->debug_log_fn;
 
-	//
-	// Open and initialize all the devices
-	//
-	if((rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
+	if(handle->m_vtable->init && (rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR)
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR) || defined(HAS_ENGINE_SAVEFILE)
 int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
@@ -90,43 +90,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
-
-#ifdef HAS_ENGINE_SAVEFILE
-int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
-{
-	int32_t rc;
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = SCAP_MODE_CAPTURE;
-	handle->m_vtable = &scap_savefile_engine;
-	handle->m_platform = platform;
-
-	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
-	if(!handle->m_engine.m_handle)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
-		return SCAP_FAILURE;
-	}
-
-	handle->m_evtcnt = 0;
-
-	handle->m_debug_log_fn = oargs->debug_log_fn;
-
-	if((rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	return SCAP_SUCCESS;
-}
-#endif
 
 #ifdef HAS_ENGINE_NODRIVER
 int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
@@ -218,7 +181,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
 		}
 
-		return scap_init_offline_int(handle, oargs, platform);
+		return scap_init_live_int(handle, oargs, &scap_savefile_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_UDIG

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -16,32 +16,20 @@ limitations under the License.
 */
 
 #include <stdio.h>
-#include <stdlib.h>
-#ifdef _WIN32
-#include <Winsock2.h>
-#else
-#include <unistd.h>
-#include <inttypes.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#endif // _WIN32
 
 #include "scap.h"
 #include "strerror.h"
 #include "strl.h"
-#include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
 #include "scap_api_version.h"
 #include "scap_platform.h"
 
+#define SCAP_HANDLE_T void
 #include "scap_engines.h"
 
 #ifdef __linux__
 #include "scap_linux_platform.h"
 #endif
-
-//#define NDEBUG
-#include <assert.h>
 
 const char* scap_getlasterr(scap_t* handle)
 {

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR) || defined(HAS_ENGINE_SAVEFILE)
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR) || defined(HAS_ENGINE_SAVEFILE) || defined(HAS_ENGINE_NODRIVER)
 int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
@@ -90,36 +90,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
-
-#ifdef HAS_ENGINE_NODRIVER
-int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
-{
-	int32_t rc;
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = SCAP_MODE_NODRIVER;
-	handle->m_vtable = &scap_nodriver_engine;
-	handle->m_platform = platform;
-
-	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
-	if(!handle->m_engine.m_handle)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
-		return SCAP_FAILURE;
-	}
-
-	handle->m_debug_log_fn = oargs->debug_log_fn;
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	return SCAP_SUCCESS;
-}
-#endif // HAS_ENGINE_NODRIVER
 
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
 int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
@@ -281,7 +251,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 			((struct scap_linux_platform*)platform)->m_minimal_scan = true;
 		}
 
-		return scap_init_nodriver_int(handle, oargs, platform);
+		return scap_init_live_int(handle, oargs, &scap_nodriver_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_SOURCE_PLUGIN

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR) || defined(HAS_ENGINE_SAVEFILE) || defined(HAS_ENGINE_NODRIVER)
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR) || defined(HAS_ENGINE_SAVEFILE) || defined(HAS_ENGINE_NODRIVER) || defined(HAS_ENGINE_SOURCE_PLUGIN)
 int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
@@ -90,41 +90,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
-
-#ifdef HAS_ENGINE_SOURCE_PLUGIN
-int32_t scap_init_plugin_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
-{
-	int32_t rc;
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = SCAP_MODE_PLUGIN;
-	handle->m_vtable = &scap_source_plugin_engine;
-	handle->m_platform = platform;
-
-	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
-	if(!handle->m_engine.m_handle)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
-		return SCAP_FAILURE;
-	}
-
-	handle->m_debug_log_fn = oargs->debug_log_fn;
-
-	if((rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	return SCAP_SUCCESS;
-}
-#endif
 
 scap_t* scap_alloc(void)
 {
@@ -263,7 +228,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
 		}
 
-		return scap_init_plugin_int(handle, oargs, platform);
+		return scap_init_live_int(handle, oargs, &scap_source_plugin_engine, platform);
 	}
 #endif
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -31,7 +31,7 @@ limitations under the License.
 #include "strl.h"
 #include "../../driver/ppm_ringbuffer.h"
 #include "scap-int.h"
-#include "scap_engine_util.h"
+#include "scap_api_version.h"
 #include "scap_platform.h"
 
 #include "scap_engines.h"

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -129,11 +129,6 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs, struct scap_pl
 	//
 	// Now that /proc parsing has been done, start the capture
 	//
-	if((rc = udig_begin_capture(handle->m_engine, handle->m_lasterr)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
 	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -56,7 +56,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	//
 	// Preliminary initializations
 	//
-	handle->m_mode = SCAP_MODE_LIVE;
+	handle->m_mode = vtable->mode;
 	handle->m_vtable = vtable;
 	handle->m_platform = platform;
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG)
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT)
 int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
@@ -90,42 +90,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
-
-#ifdef HAS_ENGINE_TEST_INPUT
-int32_t scap_init_test_input_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
-{
-	int32_t rc;
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = oargs->mode;
-	handle->m_vtable = &scap_test_input_engine;
-	handle->m_platform = platform;
-
-	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
-	if(!handle->m_engine.m_handle)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
-		return SCAP_FAILURE;
-	}
-
-	rc = handle->m_vtable->init(handle, oargs);
-	if(rc != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	handle->m_debug_log_fn = oargs->debug_log_fn;
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	return SCAP_SUCCESS;
-}
-#endif
 
 #ifdef HAS_ENGINE_GVISOR
 int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
@@ -333,7 +297,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
 		}
 
-		return scap_init_test_input_int(handle, oargs, platform);
+		return scap_init_live_int(handle, oargs, &scap_test_input_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_KMOD

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT)
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_BPF) || defined(HAS_ENGINE_MODERN_BPF) || defined(HAS_ENGINE_UDIG) || defined(HAS_ENGINE_TEST_INPUT) || defined(HAS_ENGINE_GVISOR)
 int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform)
 {
 	int32_t rc;
@@ -90,42 +90,6 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
-
-#ifdef HAS_ENGINE_GVISOR
-int32_t scap_init_gvisor_int(scap_t* handle, scap_open_args* oargs, struct scap_platform *platform)
-{
-	int32_t rc;
-
-	//
-	// Preliminary initializations
-	//
-	handle->m_mode = SCAP_MODE_LIVE;
-	handle->m_vtable = &scap_gvisor_engine;
-	handle->m_platform = platform;
-
-	handle->m_engine.m_handle = handle->m_vtable->alloc_handle(handle, handle->m_lasterr);
-	if(!handle->m_engine.m_handle)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "error allocating the engine structure");
-		return SCAP_FAILURE;
-	}
-
-	rc = handle->m_vtable->init(handle, oargs);
-	if(rc != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	handle->m_debug_log_fn = oargs->debug_log_fn;
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
-
-	return SCAP_SUCCESS;
-}
-#endif // HAS_ENGINE_GVISOR
 
 #ifdef HAS_ENGINE_SAVEFILE
 int32_t scap_init_offline_int(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform)
@@ -278,7 +242,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 			return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform struct");
 		}
 
-		return scap_init_gvisor_int(handle, oargs, platform);
+		return scap_init_live_int(handle, oargs, &scap_gvisor_engine, platform);
 	}
 #endif
 #ifdef HAS_ENGINE_TEST_INPUT

--- a/userspace/libscap/scap_api_version.c
+++ b/userspace/libscap/scap_api_version.c
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "scap_api_version.h"
+#include "scap.h"
+#include "scap_engine_util.h"
+#include "scap_vtable.h"
+#include "strerror.h"
+
+
+bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
+			     uint32_t required_major, uint32_t required_minor, uint32_t required_patch)
+{
+	if(current_major != required_major)
+	{
+		return false;
+	}
+
+	if(current_minor < required_minor)
+	{
+		return false;
+	}
+	if(current_minor == required_minor && current_patch < required_patch)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version)
+{
+	unsigned long driver_major = PPM_API_VERSION_MAJOR(driver_api_version);
+	unsigned long driver_minor = PPM_API_VERSION_MINOR(driver_api_version);
+	unsigned long driver_patch = PPM_API_VERSION_PATCH(driver_api_version);
+	unsigned long required_major = PPM_API_VERSION_MAJOR(required_api_version);
+	unsigned long required_minor = PPM_API_VERSION_MINOR(required_api_version);
+	unsigned long required_patch = PPM_API_VERSION_PATCH(required_api_version);
+
+	return scap_apply_semver_check(driver_major, driver_minor, driver_patch, required_major, required_minor, required_patch);
+}
+
+static int32_t check_api_compatibility_impl(uint64_t current_version, uint64_t minimum_version, const char* label, char *error)
+{
+	if(!scap_is_api_compatible(current_version, minimum_version))
+	{
+		return scap_errprintf(error, 0, "Driver supports %s version %llu.%llu.%llu, but running version needs %llu.%llu.%llu",
+				      label,
+				      PPM_API_VERSION_MAJOR(current_version),
+				      PPM_API_VERSION_MINOR(current_version),
+				      PPM_API_VERSION_PATCH(current_version),
+				      PPM_API_VERSION_MAJOR(minimum_version),
+				      PPM_API_VERSION_MINOR(minimum_version),
+				      PPM_API_VERSION_PATCH(minimum_version));
+	}
+	return SCAP_SUCCESS;
+}
+
+int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error)
+{
+	int rc;
+	if(vtable && vtable->get_api_version)
+	{
+		uint64_t version = vtable->get_api_version(engine);
+		rc = check_api_compatibility_impl(version, SCAP_MINIMUM_DRIVER_API_VERSION, "API", error);
+		if(rc != SCAP_SUCCESS)
+		{
+			return rc;
+		}
+	}
+
+	if(vtable && vtable->get_schema_version)
+	{
+		uint64_t version = vtable->get_schema_version(engine);
+		rc = check_api_compatibility_impl(version, SCAP_MINIMUM_DRIVER_SCHEMA_VERSION, "schema", error);
+		if(rc != SCAP_SUCCESS)
+		{
+			return rc;
+		}
+	}
+
+	return SCAP_SUCCESS;
+}
+

--- a/userspace/libscap/scap_api_version.h
+++ b/userspace/libscap/scap_api_version.h
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef SCAP_HANDLE_T
+#define SCAP_HANDLE_T void
+#endif
+
+#include "engine_handle.h"
+
+struct scap_vtable;
+
+/**
+ * Is `driver_api_version` compatible with `required_api_version`?
+ */
+bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version);
+
+/**
+ * Apply the `semver` checks on current and required versions.
+ */
+bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
+			     uint32_t required_major, uint32_t required_minor, uint32_t required_patch);
+
+int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error);
+

--- a/userspace/libscap/scap_engine_util.c
+++ b/userspace/libscap/scap_engine_util.c
@@ -19,89 +19,11 @@ limitations under the License.
 #include <stdio.h>
 #include <time.h>
 
-#include "scap.h"
-#include "scap-int.h"
 #include "scap_engine_util.h"
-#include "scap_vtable.h"
+#include "scap_const.h"
 #include "strerror.h"
 
-#ifdef __linux__
 #include "compat/misc.h"
-#endif
-
-bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
-							uint32_t required_major, uint32_t required_minor, uint32_t required_patch)
-{
-	if(current_major != required_major)
-	{
-		return false;
-	}
-
-	if(current_minor < required_minor)
-	{
-		return false;
-	}
-	if(current_minor == required_minor && current_patch < required_patch)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version)
-{
-	unsigned long driver_major = PPM_API_VERSION_MAJOR(driver_api_version);
-	unsigned long driver_minor = PPM_API_VERSION_MINOR(driver_api_version);
-	unsigned long driver_patch = PPM_API_VERSION_PATCH(driver_api_version);
-	unsigned long required_major = PPM_API_VERSION_MAJOR(required_api_version);
-	unsigned long required_minor = PPM_API_VERSION_MINOR(required_api_version);
-	unsigned long required_patch = PPM_API_VERSION_PATCH(required_api_version);
-
-	return scap_apply_semver_check(driver_major, driver_minor, driver_patch, required_major, required_minor, required_patch);
-}
-
-static int32_t check_api_compatibility_impl(uint64_t current_version, uint64_t minimum_version, const char* label, char *error)
-{
-	if(!scap_is_api_compatible(current_version, minimum_version))
-	{
-		return scap_errprintf(error, 0, "Driver supports %s version %llu.%llu.%llu, but running version needs %llu.%llu.%llu",
-			label,
-			PPM_API_VERSION_MAJOR(current_version),
-			PPM_API_VERSION_MINOR(current_version),
-			PPM_API_VERSION_PATCH(current_version),
-			PPM_API_VERSION_MAJOR(minimum_version),
-			PPM_API_VERSION_MINOR(minimum_version),
-			PPM_API_VERSION_PATCH(minimum_version));
-	}
-	return SCAP_SUCCESS;
-}
-
-	int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error)
-{
-	int rc;
-	if(vtable && vtable->get_api_version)
-	{
-		uint64_t version = vtable->get_api_version(engine);
-		rc = check_api_compatibility_impl(version, SCAP_MINIMUM_DRIVER_API_VERSION, "API", error);
-		if(rc != SCAP_SUCCESS)
-		{
-			return rc;
-		}
-	}
-
-	if(vtable && vtable->get_schema_version)
-	{
-		uint64_t version = vtable->get_schema_version(engine);
-		rc = check_api_compatibility_impl(version, SCAP_MINIMUM_DRIVER_SCHEMA_VERSION, "schema", error);
-		if(rc != SCAP_SUCCESS)
-		{
-			return rc;
-		}
-	}
-
-	return SCAP_SUCCESS;
-}
 
 static inline uint64_t timespec_to_nsec(const struct timespec* ts)
 {
@@ -110,7 +32,6 @@ static inline uint64_t timespec_to_nsec(const struct timespec* ts)
 
 int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time)
 {
-#ifdef __linux__
 	struct timespec wall_ts, boot_ts;
 
 	if(clock_gettime(CLOCK_BOOTTIME, &boot_ts) < 0)
@@ -125,7 +46,4 @@ int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time)
 
 	*boot_time = timespec_to_nsec(&wall_ts) - timespec_to_nsec(&boot_ts);
 	return SCAP_SUCCESS;
-#else
-	return scap_errprintf(last_err, 0, "scap_get_precise_boot_time not implemented on this platform");
-#endif
 }

--- a/userspace/libscap/scap_engine_util.h
+++ b/userspace/libscap/scap_engine_util.h
@@ -20,27 +20,6 @@ limitations under the License.
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
-#include "engine_handle.h"
-
-struct scap_vtable;
-
-/**
- * Is `driver_api_version` compatible with `required_api_version`?
- */
-bool scap_is_api_compatible(unsigned long driver_api_version, unsigned long required_api_version);
-
-/**
- * Apply the `semver` checks on current and required versions.
- */  
-bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uint32_t current_patch,
-							uint32_t required_major, uint32_t required_minor, uint32_t required_patch);
-
-int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error);
-
 /**
  * \brief Get the timestamp of boot with subsecond accuracy
  *


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

After the giant buildup of #1040 and #1041, this puts the cherry on top and unifies all the scap_init_*_int into one.

**Special notes for your reviewer**:

This PR is huge since it contains #1040 and #1041 inside. It will get manageable after they're done.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
