### PR TITLE
new: kmod socketcall refactor

### DIFF
--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -760,7 +760,8 @@ static __always_inline long convert_network_syscalls(void *ctx)
 		break;
 	}
 
-	return 0;
+	// Reset NR_socketcall to send a generic even with correct id
+	return __NR_socketcall;
 }
 #endif
 

--- a/driver/kernel_hacks.h
+++ b/driver/kernel_hacks.h
@@ -65,6 +65,9 @@ static inline struct inode *file_inode(struct file *f)
 }
 #endif
 
+/* We keep this macro because we want to preserve udig compatibility otherwise
+ * we could simply use _args->args[...] in our fillers, avoiding a useless memcpy
+ */
 #define syscall_get_arguments_deprecated(_task, _args, _start, _len, _out) \
 	do { \
 	    memcpy(_out, &_args->args[_start], _len * sizeof(unsigned long)); \

--- a/driver/kernel_hacks.h
+++ b/driver/kernel_hacks.h
@@ -65,19 +65,7 @@ static inline struct inode *file_inode(struct file *f)
 }
 #endif
 
-/*
- * Linux 5.1 kernels modify the syscall_get_arguments function to always
- * return all arguments rather than allowing the caller to select which
- * arguments are desired. This wrapper replicates the original
- * functionality.
- */
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0))
-#define syscall_get_arguments_deprecated syscall_get_arguments
-#else
-#define syscall_get_arguments_deprecated(_task, _reg, _start, _len, _args) \
+#define syscall_get_arguments_deprecated(_task, _args, _start, _len, _out) \
 	do { \
-	    unsigned long _sga_args[6] = {}; \
-	    syscall_get_arguments(_task, _reg, _sga_args); \
-	    memcpy(_args, &_sga_args[_start], _len * sizeof(unsigned long)); \
+	    memcpy(_out, &_args->args[_start], _len * sizeof(unsigned long)); \
 	} while(0)
-#endif

--- a/driver/kernel_hacks.h
+++ b/driver/kernel_hacks.h
@@ -65,10 +65,7 @@ static inline struct inode *file_inode(struct file *f)
 }
 #endif
 
-/* We keep this macro because we want to preserve udig compatibility otherwise
- * we could simply use _args->args[...] in our fillers, avoiding a useless memcpy
- */
-#define syscall_get_arguments_deprecated(_task, _args, _start, _len, _out) \
+#define syscall_get_arguments_deprecated(_args, _start, _len, _out) \
 	do { \
 	    memcpy(_out, &_args->args[_start], _len * sizeof(unsigned long)); \
 	} while(0)

--- a/driver/main.c
+++ b/driver/main.c
@@ -2216,7 +2216,6 @@ TRACEPOINT_PROBE(syscall_enter_probe, struct pt_regs *regs, long id)
 
 	event_data.category = PPMC_SYSCALL;
 	event_data.event_info.syscall_data.regs = regs;
-	event_data.event_info.syscall_data.id = id;
 
 	/* This is used when we preload params */
 	event_data.is_socketcall = false;
@@ -2255,6 +2254,8 @@ TRACEPOINT_PROBE(syscall_enter_probe, struct pt_regs *regs, long id)
 	}
 #endif
 
+	/* We need to set here the `syscall_id` because it could change in case of socketcalls */
+	event_data.event_info.syscall_data.id = id;
 	table_index = id - SYSCALL_TABLE_ID0;
 	if (unlikely(table_index < 0 || table_index >= SYSCALL_TABLE_SIZE))
 	{
@@ -2313,7 +2314,6 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret)
 
 	event_data.category = PPMC_SYSCALL;
 	event_data.event_info.syscall_data.regs = regs;
-	event_data.event_info.syscall_data.id = id;
 
 	/* This is used when we preload params */
 	event_data.is_socketcall = false;
@@ -2354,6 +2354,8 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret)
 	}
 #endif
 
+	/* We need to set here the `syscall_id` because it could change in case of socketcalls */
+	event_data.event_info.syscall_data.id = id;
 	table_index = id - SYSCALL_TABLE_ID0;
 	if (unlikely(table_index < 0 || table_index >= SYSCALL_TABLE_SIZE))
 	{

--- a/driver/main.c
+++ b/driver/main.c
@@ -2231,20 +2231,20 @@ TRACEPOINT_PROBE(syscall_enter_probe, struct pt_regs *regs, long id)
 
 	g_n_tracepoint_hit_inc();
 
+#ifdef _HAS_SOCKETCALL
+	if (id == socketcall_syscall)
+	{
+		id = convert_network_syscalls(regs);
+		is_socketcall = true;
+	}
+#endif
+
 	table_index = id - SYSCALL_TABLE_ID0;
 	if (unlikely(table_index < 0 || table_index >= SYSCALL_TABLE_SIZE))
 	{
 		return;
 	}
 
-#ifdef _HAS_SOCKETCALL
-	if (id == socketcall_syscall)
-	{
-		id = convert_network_syscalls(regs);
-		table_index = id - SYSCALL_TABLE_ID0;
-		is_socketcall = true;
-	}
-#endif
 	struct event_data_t event_data;
 	int used = cur_g_syscall_table[table_index].flags & UF_USED;
 	enum syscall_flags drop_flags = cur_g_syscall_table[table_index].flags;
@@ -2333,20 +2333,20 @@ TRACEPOINT_PROBE(syscall_exit_probe, struct pt_regs *regs, long ret)
 
 	g_n_tracepoint_hit_inc();
 
+#ifdef _HAS_SOCKETCALL
+	if (id == socketcall_syscall)
+	{
+		id = convert_network_syscalls(regs);
+		is_socketcall = true;
+	}
+#endif
+
 	table_index = id - SYSCALL_TABLE_ID0;
 	if (unlikely(table_index < 0 || table_index >= SYSCALL_TABLE_SIZE))
 	{
 		return;
 	}
 
-#ifdef _HAS_SOCKETCALL
-	if (id == socketcall_syscall)
-	{
-		id = convert_network_syscalls(regs);
-		table_index = id - SYSCALL_TABLE_ID0;
-		is_socketcall = true;
-	}
-#endif
 	struct event_data_t event_data;
 	int used = cur_g_syscall_table[table_index].flags & UF_USED;
 	enum syscall_flags drop_flags = cur_g_syscall_table[table_index].flags;

--- a/driver/main.c
+++ b/driver/main.c
@@ -1377,7 +1377,7 @@ static long convert_network_syscalls(struct pt_regs *regs)
 #endif
 
 	case SYS_ACCEPT:
-#if defined(__TARGET_ARCH_s390) && defined(__NR_accept4)
+#if defined(CONFIG_S390) && defined(__NR_accept4)
 		return __NR_accept4;
 #elif defined(__NR_accept)
 		return __NR_accept;

--- a/driver/main.c
+++ b/driver/main.c
@@ -1357,7 +1357,7 @@ static const unsigned char compat_nas[21] = {
 
 
 #ifdef _HAS_SOCKETCALL
-static ppm_event_code parse_socketcall(struct event_filler_arguments *filler_args, struct pt_regs *regs)
+static long parse_socketcall(struct event_filler_arguments *filler_args, struct pt_regs *regs)
 {
 	unsigned long __user args[6] = {};
 	unsigned long __user *scargs;
@@ -1374,7 +1374,7 @@ static ppm_event_code parse_socketcall(struct event_filler_arguments *filler_arg
 #else
 		socketcall_id > SYS_ACCEPT4))
 #endif
-		return PPME_GENERIC_E;
+		return 0;
 
 #ifdef CONFIG_COMPAT
 	if (unlikely(filler_args->compat)) {
@@ -1382,66 +1382,126 @@ static ppm_event_code parse_socketcall(struct event_filler_arguments *filler_arg
 		int j;
 
 		if (unlikely(ppm_copy_from_user(socketcall_args32, compat_ptr(args[1]), compat_nas[socketcall_id])))
-			return PPME_GENERIC_E;
+			return 0;
 		for (j = 0; j < 6; ++j)
 			filler_args->socketcall_args[j] = (unsigned long)socketcall_args32[j];
 	} else {
 #endif
 		if (unlikely(ppm_copy_from_user(filler_args->socketcall_args, scargs, nas[socketcall_id])))
-			return PPME_GENERIC_E;
+			return 0;
 #ifdef CONFIG_COMPAT
 	}
 #endif
 
-	switch (socketcall_id) {
+	switch(socketcall_id)
+	{
+#ifdef __NR_socket
 	case SYS_SOCKET:
-		return PPME_SOCKET_SOCKET_E;
-	case SYS_BIND:
-		return PPME_SOCKET_BIND_E;
-	case SYS_CONNECT:
-		return PPME_SOCKET_CONNECT_E;
-	case SYS_LISTEN:
-		return PPME_SOCKET_LISTEN_E;
-	case SYS_ACCEPT:
-		return PPME_SOCKET_ACCEPT_5_E;
-	case SYS_GETSOCKNAME:
-		return PPME_SOCKET_GETSOCKNAME_E;
-	case SYS_GETPEERNAME:
-		return PPME_SOCKET_GETPEERNAME_E;
+		return __NR_socket;
+#endif
+
+#ifdef __NR_socketpair
 	case SYS_SOCKETPAIR:
-		return PPME_SOCKET_SOCKETPAIR_E;
-	case SYS_SEND:
-		return PPME_SOCKET_SEND_E;
-	case SYS_SENDTO:
-		return PPME_SOCKET_SENDTO_E;
-	case SYS_RECV:
-		return PPME_SOCKET_RECV_E;
-	case SYS_RECVFROM:
-		return PPME_SOCKET_RECVFROM_E;
-	case SYS_SHUTDOWN:
-		return PPME_SOCKET_SHUTDOWN_E;
-	case SYS_SETSOCKOPT:
-		return PPME_SOCKET_SETSOCKOPT_E;
-	case SYS_GETSOCKOPT:
-		return PPME_SOCKET_GETSOCKOPT_E;
-	case SYS_SENDMSG:
-		return PPME_SOCKET_SENDMSG_E;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0)
-	case SYS_SENDMMSG:
-		return PPME_SOCKET_SENDMMSG_E;
+		return __NR_socketpair;
 #endif
-	case SYS_RECVMSG:
-		return PPME_SOCKET_RECVMSG_E;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 33)
-	case SYS_RECVMMSG:
-		return PPME_SOCKET_RECVMMSG_E;
+
+	case SYS_ACCEPT:
+#if defined(__TARGET_ARCH_s390) && defined(__NR_accept4)
+		return __NR_accept4;
+#elif defined(__NR_accept)
+		return __NR_accept;
 #endif
+		break;
+
+#ifdef __NR_accept4
 	case SYS_ACCEPT4:
-		return PPME_SOCKET_ACCEPT4_6_E;
+		return __NR_accept4;
+#endif
+
+#ifdef __NR_bind
+	case SYS_BIND:
+		return __NR_bind;
+#endif
+
+#ifdef __NR_listen
+	case SYS_LISTEN:
+		return __NR_listen;
+#endif
+
+#ifdef __NR_connect
+	case SYS_CONNECT:
+		return __NR_connect;
+#endif
+
+#ifdef __NR_getsockname
+	case SYS_GETSOCKNAME:
+		return __NR_getsockname;
+#endif
+
+#ifdef __NR_getpeername
+	case SYS_GETPEERNAME:
+		return __NR_getpeername;
+#endif
+
+#ifdef __NR_getsockopt
+	case SYS_GETSOCKOPT:
+		return __NR_getsockopt;
+#endif
+
+#ifdef __NR_setsockopt
+	case SYS_SETSOCKOPT:
+		return __NR_setsockopt;
+#endif
+
+#ifdef __NR_recv
+	case SYS_RECV:
+		return __NR_recv;
+#endif
+
+#ifdef __NR_recvfrom
+	case SYS_RECVFROM:
+		return __NR_recvfrom;
+#endif
+
+#ifdef __NR_recvmsg
+	case SYS_RECVMSG:
+		return __NR_recvmsg;
+#endif
+
+#ifdef __NR_recvmmsg
+	case SYS_RECVMMSG:
+		return __NR_recvmmsg;
+#endif
+
+#ifdef __NR_send
+	case SYS_SEND:
+		return __NR_send;
+#endif
+
+#ifdef __NR_sendto
+	case SYS_SENDTO:
+		return __NR_sendto;
+#endif
+
+#ifdef __NR_sendmsg
+	case SYS_SENDMSG:
+		return __NR_sendmsg;
+#endif
+
+#ifdef __NR_sendmmsg
+	case SYS_SENDMMSG:
+		return __NR_sendmmsg;
+#endif
+
+#ifdef __NR_shutdown
+	case SYS_SHUTDOWN:
+		return __NR_shutdown;
+#endif
 	default:
-		ASSERT(false);
-		return PPME_GENERIC_E;
+		break;
 	}
+
+	return 0;
 }
 #endif /* _HAS_SOCKETCALL */
 
@@ -1894,12 +1954,24 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	 * call. I guess this was done to reduce the number of syscalls...
 	 */
 	if (event_datap->category == PPMC_SYSCALL && event_datap->event_info.syscall_data.regs && event_datap->event_info.syscall_data.id == event_datap->socketcall_syscall) {
+		long syscall_id;
 		ppm_event_code tet;
 
 		args.is_socketcall = true;
 		args.compat = event_datap->compat;
-		tet = parse_socketcall(&args, event_datap->event_info.syscall_data.regs);
+		syscall_id = parse_socketcall(&args, event_datap->event_info.syscall_data.regs);
+		// Filter interesting syscalls even for socketcall resolved ones
+		table_index = syscall_id - SYSCALL_TABLE_ID0;
+		if (!test_bit(table_index, consumer->syscalls_mask))
+		{
+			return res;
+		}
 
+
+		tet = event_datap->event_info.syscall_data.cur_g_syscall_table[syscall_id].enter_event_type;
+		// We do not directly use exit_event_type since
+		// when `syscall_id` is 0 (ie: parse_socketcall could not match anything),
+		// we still need to map PPME_GENERIC_{E,X}
 		if (event_type == PPME_GENERIC_E)
 			event_type = tet;
 		else

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -36,6 +36,7 @@ static __always_inline bool syscalls_dispatcher__64bit_interesting_syscall(u32 s
 	return maps__64bit_interesting_syscall(syscall_id);
 }
 
+#ifdef CAPTURE_SOCKETCALL
 static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 {
 	int socketcall_id = (int)extract__syscall_argument(regs, 0);
@@ -148,5 +149,7 @@ static __always_inline long convert_network_syscalls(struct pt_regs *regs)
 		break;
 	}
 
-	return 0;
+	// Reset NR_socketcall to send a generic even with correct id
+	return __NR_socketcall;
 }
+#endif

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -1510,7 +1510,15 @@ int32_t parse_readv_writev_bufs(struct event_filler_arguments *args, const struc
 			/*
 			 * Retrieve the FD. It will be used for dynamic snaplen calculation.
 			 */
+#ifdef UDIG
+		{
+			unsigned long syscall_args[6] = {};
+			ppm_syscall_get_arguments(current, args->regs, syscall_args);
+			val = syscall_args[0];
+		}
+#else
 			val = args->args[0];
+#endif			
 			args->fd = (int)val;
 
 			/*
@@ -1736,7 +1744,15 @@ int f_sys_autofill(struct event_filler_arguments *args)
 
 	for (j = 0; j < evinfo->n_autofill_args; j++) {
 		if (evinfo->autofill_args[j].id >= 0) {
+#ifdef UDIG
+		{
+			syscall_arg_t syscall_args[6] = {0};
+			ppm_syscall_get_arguments(current, args->regs, syscall_args);
+			val = syscall_args[evinfo->autofill_args[j].id];
+		}
+#else
 			val = args->args[evinfo->autofill_args[j].id];
+#endif
 			res = val_to_ring(args, val, 0, true, 0);
 			if (unlikely(res != PPM_SUCCESS))
 				return res;

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -19,10 +19,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/compat.h>
 #endif
 
-#ifdef __NR_socketcall
-	#define _HAS_SOCKETCALL
-#endif
-#if defined(CONFIG_X86_64) && defined(CONFIG_IA32_EMULATION)
+#if defined(__NR_socketcall) || (defined(CONFIG_X86_64) && defined(CONFIG_IA32_EMULATION))
 	#define _HAS_SOCKETCALL
 #endif
 

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -70,11 +70,10 @@ struct event_filler_arguments {
 
 	char *str_storage; /* String storage. Size is one page. */
 #ifndef UDIG
-	unsigned long socketcall_args[6];
+	unsigned long args[6];
 #endif
 	bool is_socketcall;
 #ifndef UDIG
-	int socketcall_syscall;
 	bool compat;
 #endif
 	int fd; /* Passed by some of the fillers to val_to_ring to compute the snaplen dynamically */

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -71,9 +71,6 @@ struct event_filler_arguments {
 	char *str_storage; /* String storage. Size is one page. */
 #ifndef UDIG
 	unsigned long args[6];
-#endif
-	bool is_socketcall;
-#ifndef UDIG
 	bool compat;
 #endif
 	int fd; /* Passed by some of the fillers to val_to_ring to compute the snaplen dynamically */

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -7815,7 +7815,7 @@ int f_sys_prctl_x(struct event_filler_arguments *args)
 	/*
 	 * option
 	 */
-	syscall_get_arguments_deprecated(current, args->regs, 0, 1, &option);
+	syscall_get_arguments_deprecated(current, args, 0, 1, &option);
 	option = prctl_options_to_scap(option);
 	res = val_to_ring(args, option, 0, false, 0);
 	CHECK_RES(res);
@@ -7823,7 +7823,7 @@ int f_sys_prctl_x(struct event_filler_arguments *args)
 	/*
 	 * arg2
 	 */
-	syscall_get_arguments_deprecated(current, args->regs, 1, 1, &arg2);
+	syscall_get_arguments_deprecated(current, args, 1, 1, &arg2);
 
 	switch(option){
 		case PPM_PR_GET_NAME:

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -154,7 +154,7 @@ int f_sys_single(struct event_filler_arguments *args)
 	int res;
 	syscall_arg_t val;
 
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -182,7 +182,7 @@ int f_sys_fstat_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -246,7 +246,7 @@ int f_sys_open_e(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	if(likely(ppm_strncpy_from_user(args->str_storage, (const void __user *)val, PPM_MAX_PATH_SIZE) >= 0))
 	{
 		name = args->str_storage;
@@ -260,7 +260,7 @@ int f_sys_open_e(struct event_filler_arguments *args)
 	 * Flags
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &flags);
+	syscall_get_arguments_deprecated(args, 1, 1, &flags);
 	res = val_to_ring(args, open_flags_to_scap(flags), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -268,7 +268,7 @@ int f_sys_open_e(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &modes);
+	syscall_get_arguments_deprecated(args, 2, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(flags, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -298,7 +298,7 @@ int f_sys_open_x(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -307,7 +307,7 @@ int f_sys_open_x(struct event_filler_arguments *args)
 	 * Flags
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &flags);
+	syscall_get_arguments_deprecated(args, 1, 1, &flags);
 	res = val_to_ring(args, open_flags_to_scap(flags), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -315,7 +315,7 @@ int f_sys_open_x(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &modes);
+	syscall_get_arguments_deprecated(args, 2, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(flags, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -346,13 +346,13 @@ int f_sys_read_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -369,7 +369,7 @@ int f_sys_read_x(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the FD. It will be used for dynamic snaplen calculation.
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	args->fd = (int)val;
 
 	/*
@@ -390,7 +390,7 @@ int f_sys_read_x(struct event_filler_arguments *args)
 		val = 0;
 		bufsize = 0;
 	} else {
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 		/*
 		 * The return value can be lower than the value provided by the user,
@@ -417,13 +417,13 @@ int f_sys_write_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -440,7 +440,7 @@ int f_sys_write_x(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the FD. It will be used for dynamic snaplen calculation.
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	args->fd = (int)val;
 
 	/* Parameter 1: res (type: PT_ERRNO) */
@@ -450,10 +450,10 @@ int f_sys_write_x(struct event_filler_arguments *args)
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 	/* Get the size from userspace paramater */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	bufsize = retval > 0 ? retval : val;
 
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	args->enforce_snaplen = true;
 	res = val_to_ring(args, val, bufsize, true, 0);
 	CHECK_RES(res);
@@ -919,11 +919,11 @@ int f_proc_startupdate(struct event_filler_arguments *args)
 			switch (args->event_type)
 			{
 			case PPME_SYSCALL_EXECVE_19_X:
-				syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+				syscall_get_arguments_deprecated(args, 1, 1, &val);
 				break;
 			
 			case PPME_SYSCALL_EXECVEAT_X:
-				syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+				syscall_get_arguments_deprecated(args, 2, 1, &val);
 				break;
 
 			default:
@@ -1109,15 +1109,15 @@ cgroups_error:
 		{
 		case PPME_SYSCALL_CLONE_20_X:
 #ifdef CONFIG_S390
-			syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+			syscall_get_arguments_deprecated(args, 1, 1, &val);
 #else
-			syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+			syscall_get_arguments_deprecated(args, 0, 1, &val);
 #endif
 			break;
 
 		case PPME_SYSCALL_CLONE3_X:
 #ifdef __NR_clone3
-			syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+			syscall_get_arguments_deprecated(args, 0, 1, &val);
 			res = ppm_copy_from_user(&cl_args, (void *)val, sizeof(struct clone_args));
 			if (unlikely(res != 0))
 			{
@@ -1240,11 +1240,11 @@ cgroups_error:
 			switch (args->event_type)
 			{
 			case PPME_SYSCALL_EXECVE_19_X:
-				syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+				syscall_get_arguments_deprecated(args, 2, 1, &val);
 				break;
 			
 			case PPME_SYSCALL_EXECVEAT_X:
-				syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+				syscall_get_arguments_deprecated(args, 3, 1, &val);
 				break;
 
 			default:
@@ -1460,7 +1460,7 @@ int f_sys_execve_e(struct event_filler_arguments *args)
 	/*
 	 * filename
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if(unlikely(res != PPM_SUCCESS))
 	{
@@ -1479,7 +1479,7 @@ int f_sys_execveat_e(struct event_filler_arguments *args)
 	/*
 	 * dirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 	{
@@ -1495,7 +1495,7 @@ int f_sys_execveat_e(struct event_filler_arguments *args)
 	/*
 	 * pathname
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 	{
@@ -1505,7 +1505,7 @@ int f_sys_execveat_e(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	flags = execveat_flags_to_scap(val);
 
 	res = val_to_ring(args, flags, 0, false, 0);
@@ -1523,7 +1523,7 @@ int f_sys_socket_bind_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 	unsigned long val = 0;
 	
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	
 	/* Parameter 1: fd (type: PT_FD) */
 	fd = (int32_t)val;
@@ -1553,14 +1553,14 @@ int f_sys_socket_bind_x(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	usrsockaddr = (struct sockaddr __user *)val;
 
 	/*
 	 * Get the address len
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if (usrsockaddr != NULL && val != 0) {
 		/*
@@ -1603,7 +1603,7 @@ int f_sys_connect_e(struct event_filler_arguments *args)
 	struct sockaddr_storage address;
 	syscall_arg_t val;
 
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int)val;
 
 	res = val_to_ring(args, fd, 0, true, 0);
@@ -1614,14 +1614,14 @@ int f_sys_connect_e(struct event_filler_arguments *args)
 		/*
 		 * Get the address
 		 */
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 		usrsockaddr = (struct sockaddr __user *)val;
 
 		/*
 		 * Get the address len
 		 */
-		syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+		syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 		if (usrsockaddr != NULL && val != 0) {
 			/*
@@ -1677,21 +1677,21 @@ int f_sys_connect_x(struct event_filler_arguments *args)
 	 * Note that, even if we are in the exit callback, the arguments are still
 	 * in the stack, and therefore we can consume them.
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int)val;
 
 	if (fd >= 0) {
 		/*
 		 * Get the address
 		 */
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 		usrsockaddr = (struct sockaddr __user *)val;
 
 		/*
 		 * Get the address len
 		 */
-		syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+		syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 		if (usrsockaddr != NULL && val != 0) {
 			/*
@@ -1759,7 +1759,7 @@ int f_sys_socketpair_x(struct event_filler_arguments *args)
 		/*
 		 * fds
 		 */
-		syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+		syscall_get_arguments_deprecated(args, 3, 1, &val);
 #ifdef CONFIG_COMPAT
 		if (!args->compat) {
 #endif
@@ -2031,7 +2031,7 @@ int f_sys_setsockopt_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Get all the five arguments */
-	syscall_get_arguments_deprecated(current, args, 0, 5, val);
+	syscall_get_arguments_deprecated(args, 0, 5, val);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	fd = (s32)val[0];
@@ -2066,7 +2066,7 @@ int f_sys_getsockopt_x(struct event_filler_arguments *args)
 	syscall_arg_t val[5] = {0};
 
 	/* Get all the five arguments */
-	syscall_get_arguments_deprecated(current, args, 0, 5, val);
+	syscall_get_arguments_deprecated(args, 0, 5, val);
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = (int64_t)(long)syscall_get_return_value(current, args->regs);
@@ -2159,7 +2159,7 @@ int f_sys_accept_x(struct event_filler_arguments *args)
 		/*
 		 * queuepct
 		 */
-		syscall_get_arguments_deprecated(current, args, 0, 1, &srvskfd);
+		syscall_get_arguments_deprecated(args, 0, 1, &srvskfd);
 
 #ifndef UDIG
 		sock = sockfd_lookup(srvskfd, &err);
@@ -2220,7 +2220,7 @@ int f_sys_send_e_common(struct event_filler_arguments *args, int *fd)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -2231,7 +2231,7 @@ int f_sys_send_e_common(struct event_filler_arguments *args, int *fd)
 	/*
 	 * size
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &size);
+	syscall_get_arguments_deprecated(args, 2, 1, &size);
 
 	res = val_to_ring(args, size, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -2275,14 +2275,14 @@ int f_sys_sendto_e(struct event_filler_arguments *args)
 	/*
 	 * Get the address
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 
 	usrsockaddr = (struct sockaddr __user *)val;
 
 	/*
 	 * Get the address len
 	 */
-	syscall_get_arguments_deprecated(current, args, 5, 1, &val);
+	syscall_get_arguments_deprecated(args, 5, 1, &val);
 
 	if (usrsockaddr != NULL && val != 0) {
 		/*
@@ -2327,7 +2327,7 @@ int f_sys_send_x(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the FD. It will be used for dynamic snaplen calculation.
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	args->fd = (int)val;
 
@@ -2339,10 +2339,10 @@ int f_sys_send_x(struct event_filler_arguments *args)
 	/* If the syscall doesn't fail we use the return value as `size`
 	 * otherwise we need to rely on the syscall parameter provided by the user.
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	bufsize = retval > 0 ? retval : val;
 
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	args->enforce_snaplen = true;
 	res = val_to_ring(args, val, bufsize, true, 0);
@@ -2360,7 +2360,7 @@ int f_sys_recv_x_common(struct event_filler_arguments *args, int64_t *retval)
 	/*
 	 * Retrieve the FD. It will be used for dynamic snaplen calculation.
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	args->fd = (int)val;
 
@@ -2382,7 +2382,7 @@ int f_sys_recv_x_common(struct event_filler_arguments *args, int64_t *retval)
 		val = 0;
 		bufsize = 0;
 	} else {
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 		/*
 		 * The return value can be lower than the value provided by the user,
@@ -2416,13 +2416,13 @@ int f_sys_recvfrom_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -2453,19 +2453,19 @@ int f_sys_recvfrom_x(struct event_filler_arguments *args)
 		/*
 		 * Get the fd
 		 */
-		syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+		syscall_get_arguments_deprecated(args, 0, 1, &val);
 		fd = (int)val;
 
 		/*
 		 * Get the address
 		 */
-		syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+		syscall_get_arguments_deprecated(args, 4, 1, &val);
 		usrsockaddr = (struct sockaddr __user *)val;
 
 		/*
 		 * Get the address len
 		 */
-		syscall_get_arguments_deprecated(current, args, 5, 1, &val);
+		syscall_get_arguments_deprecated(args, 5, 1, &val);
 		if (usrsockaddr != NULL && val != 0) {
 #ifdef CONFIG_COMPAT
 			if (!args->compat) {
@@ -2542,7 +2542,7 @@ int f_sys_sendmsg_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	fd = val;
 	res = val_to_ring(args, val, 0, false, 0);
@@ -2552,7 +2552,7 @@ int f_sys_sendmsg_e(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the message header
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
@@ -2663,7 +2663,7 @@ int f_sys_sendmsg_x(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the message header
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
 #ifdef CONFIG_COMPAT
@@ -2711,7 +2711,7 @@ int f_sys_recvmsg_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -2775,7 +2775,7 @@ int f_sys_recvmsg_x(struct event_filler_arguments *args)
 	/*
 	 * Retrieve the message header
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
@@ -2815,7 +2815,7 @@ int f_sys_recvmsg_x(struct event_filler_arguments *args)
 		/*
 		 * Get the fd
 		 */
-		syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+		syscall_get_arguments_deprecated(args, 0, 1, &val);
 		fd = (int)val;
 
 		/*
@@ -2866,7 +2866,7 @@ int f_sys_creat_e(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	if(likely(ppm_strncpy_from_user(args->str_storage, (const void __user *)val, PPM_MAX_PATH_SIZE) >= 0))
 	{
 		name = args->str_storage;
@@ -2879,7 +2879,7 @@ int f_sys_creat_e(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &modes);
+	syscall_get_arguments_deprecated(args, 1, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(O_CREAT, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -2907,7 +2907,7 @@ int f_sys_creat_x(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -2915,7 +2915,7 @@ int f_sys_creat_x(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &modes);
+	syscall_get_arguments_deprecated(args, 1, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(O_CREAT, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -2954,7 +2954,7 @@ int f_sys_pipe_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Here `val` is a pointer to the vector with the 2 file descriptors. */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
@@ -3010,7 +3010,7 @@ int f_sys_pipe2_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Here `val` is a pointer to the vector with the 2 file descriptors. */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
@@ -3049,7 +3049,7 @@ int f_sys_pipe2_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, pipe2_flags_to_scap((s32)val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -3062,7 +3062,7 @@ int f_sys_eventfd_e(struct event_filler_arguments *args)
 	unsigned long val = 0;
 
 	/* Parameter 1: initval (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -3082,7 +3082,7 @@ int f_sys_eventfd2_e(struct event_filler_arguments *args)
 	unsigned long val = 0;
 
 	/* Parameter 1: initval (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -3101,7 +3101,7 @@ int f_sys_eventfd2_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, eventfd2_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -3115,14 +3115,14 @@ int f_sys_shutdown_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	res = val_to_ring(args, (unsigned long)shutdown_how_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
@@ -3138,7 +3138,7 @@ int f_sys_futex_e(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3146,7 +3146,7 @@ int f_sys_futex_e(struct event_filler_arguments *args)
 	/*
 	 * op
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, (unsigned long)futex_op_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3154,7 +3154,7 @@ int f_sys_futex_e(struct event_filler_arguments *args)
 	/*
 	 * val
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3171,7 +3171,7 @@ int f_sys_lseek_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -3180,7 +3180,7 @@ int f_sys_lseek_e(struct event_filler_arguments *args)
 	/*
 	 * offset
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3188,7 +3188,7 @@ int f_sys_lseek_e(struct event_filler_arguments *args)
 	/*
 	 * whence
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, lseek_whence_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3208,7 +3208,7 @@ int f_sys_llseek_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -3218,8 +3218,8 @@ int f_sys_llseek_e(struct event_filler_arguments *args)
 	 * offset
 	 * We build it by combining the offset_high and offset_low system call arguments
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &oh);
-	syscall_get_arguments_deprecated(current, args, 2, 1, &ol);
+	syscall_get_arguments_deprecated(args, 1, 1, &oh);
+	syscall_get_arguments_deprecated(args, 2, 1, &ol);
 	offset = (((uint64_t)oh) << 32) + ((uint64_t)ol);
 	res = val_to_ring(args, offset, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -3228,7 +3228,7 @@ int f_sys_llseek_e(struct event_filler_arguments *args)
 	/*
 	 * whence
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	res = val_to_ring(args, lseek_whence_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3252,7 +3252,7 @@ static int poll_parse_fds(struct event_filler_arguments *args, bool enter_event)
 	 *
 	 * Get the number of fds
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &nfds);
+	syscall_get_arguments_deprecated(args, 1, 1, &nfds);
 
 	/*
 	 * Check if we have enough space to store both the fd list
@@ -3262,7 +3262,7 @@ static int poll_parse_fds(struct event_filler_arguments *args, bool enter_event)
 		return PPM_FAILURE_BUFFER_FULL;
 
 	/* Get the fds pointer */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	fds = (struct pollfd *)args->str_storage;
 
@@ -3324,7 +3324,7 @@ int f_sys_poll_e(struct event_filler_arguments *args)
 	/*
 	 * timeout
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3383,12 +3383,12 @@ int f_sys_ppoll_e(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: timeout (type: PT_RELTIME) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = timespec_parse(args, val);
 	CHECK_RES(res);
 
 	/* Parameter 3: sigmask (type: PT_SIGSET) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	if (val == (unsigned long)NULL || ppm_copy_from_user(&val, (void __user *)val, sizeof(val)))
 	{
 		val = 0;
@@ -3429,7 +3429,7 @@ int f_sys_mount_e(struct event_filler_arguments *args)
 	 * Fix mount flags in arg 3.
 	 * See http://lxr.free-electrons.com/source/fs/namespace.c?v=4.2#L2650
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	if ((val & PPM_MS_MGC_MSK) == PPM_MS_MGC_VAL)
 		val &= ~PPM_MS_MGC_MSK;
 	res = val_to_ring(args, val, 0, false, 0);
@@ -3450,7 +3450,7 @@ int f_sys_openat_e(struct event_filler_arguments *args)
 	/*
 	 * dirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -3462,7 +3462,7 @@ int f_sys_openat_e(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	if(likely(ppm_strncpy_from_user(args->str_storage, (const void __user *)val, PPM_MAX_PATH_SIZE) >= 0))
 	{
 		name = args->str_storage;
@@ -3476,7 +3476,7 @@ int f_sys_openat_e(struct event_filler_arguments *args)
 	 * Flags
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &flags);
+	syscall_get_arguments_deprecated(args, 2, 1, &flags);
 	res = val_to_ring(args, open_flags_to_scap(flags), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3484,7 +3484,7 @@ int f_sys_openat_e(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &modes);
+	syscall_get_arguments_deprecated(args, 3, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(flags, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3510,7 +3510,7 @@ int f_sys_openat_x(struct event_filler_arguments *args)
 	/*
 	 * dirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -3522,7 +3522,7 @@ int f_sys_openat_x(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3531,7 +3531,7 @@ int f_sys_openat_x(struct event_filler_arguments *args)
 	 * Flags
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &flags);
+	syscall_get_arguments_deprecated(args, 2, 1, &flags);
 	res = val_to_ring(args, open_flags_to_scap(flags), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3539,7 +3539,7 @@ int f_sys_openat_x(struct event_filler_arguments *args)
 	/*
 	 *  mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &modes);
+	syscall_get_arguments_deprecated(args, 3, 1, &modes);
 	res = val_to_ring(args, open_modes_to_scap(flags, modes), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3576,7 +3576,7 @@ int f_sys_unlinkat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	dirfd = (s32)val;
 	if(dirfd == AT_FDCWD)
 	{
@@ -3586,12 +3586,12 @@ int f_sys_unlinkat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, unlinkat_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -3613,7 +3613,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	/*
 	 * olddir
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -3625,7 +3625,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	/*
 	 * oldpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3633,7 +3633,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	/*
 	 * newdir
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -3645,7 +3645,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	/*
 	 * newpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3654,7 +3654,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	 * Flags
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &flags);
+	syscall_get_arguments_deprecated(args, 4, 1, &flags);
 	res = val_to_ring(args, linkat_flags_to_scap(flags), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3673,7 +3673,7 @@ int f_sys_pread64_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -3682,7 +3682,7 @@ int f_sys_pread64_e(struct event_filler_arguments *args)
 	/*
 	 * size
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &size);
+	syscall_get_arguments_deprecated(args, 2, 1, &size);
 	res = val_to_ring(args, size, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -3695,11 +3695,11 @@ int f_sys_pread64_e(struct event_filler_arguments *args)
 	unsigned long pos0;
 	unsigned long pos1;
 #if defined CONFIG_X86
-	syscall_get_arguments_deprecated(current, args, 3, 1, &pos0);
-	syscall_get_arguments_deprecated(current, args, 4, 1, &pos1);
+	syscall_get_arguments_deprecated(args, 3, 1, &pos0);
+	syscall_get_arguments_deprecated(args, 4, 1, &pos1);
 #elif defined CONFIG_ARM && CONFIG_AEABI
-	syscall_get_arguments_deprecated(current, args, 4, 1, &pos0);
-	syscall_get_arguments_deprecated(current, args, 5, 1, &pos1);
+	syscall_get_arguments_deprecated(args, 4, 1, &pos0);
+	syscall_get_arguments_deprecated(args, 5, 1, &pos1);
 #else
  #error This architecture/abi not yet supported
 #endif
@@ -3707,7 +3707,7 @@ int f_sys_pread64_e(struct event_filler_arguments *args)
 	pos64 = merge_64(pos1, pos0);
 }
 #else 
-	syscall_get_arguments_deprecated(current, args, 3, 1, &pos64);
+	syscall_get_arguments_deprecated(args, 3, 1, &pos64);
 #endif
 
 	res = val_to_ring(args, pos64, 0, false, 0);
@@ -3728,7 +3728,7 @@ int f_sys_pwrite64_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -3736,7 +3736,7 @@ int f_sys_pwrite64_e(struct event_filler_arguments *args)
 	/*
 	 * size
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &size);
+	syscall_get_arguments_deprecated(args, 2, 1, &size);
 	res = val_to_ring(args, size, 0, false, 0);
 	CHECK_RES(res);
 
@@ -3746,18 +3746,18 @@ int f_sys_pwrite64_e(struct event_filler_arguments *args)
 		unsigned long pos0 = 0;
 		unsigned long pos1 = 0;
 #if defined CONFIG_X86
-		syscall_get_arguments_deprecated(current, args, 3, 1, &pos0);
-		syscall_get_arguments_deprecated(current, args, 4, 1, &pos1);
+		syscall_get_arguments_deprecated(args, 3, 1, &pos0);
+		syscall_get_arguments_deprecated(args, 4, 1, &pos1);
 #elif defined CONFIG_ARM && CONFIG_AEABI
-		syscall_get_arguments_deprecated(current, args, 4, 1, &pos0);
-		syscall_get_arguments_deprecated(current, args, 5, 1, &pos1);
+		syscall_get_arguments_deprecated(args, 4, 1, &pos0);
+		syscall_get_arguments_deprecated(args, 5, 1, &pos1);
 #else
   		#error This architecture/abi not yet supported
 #endif
 		pos64 = merge_64(pos1, pos0);
 	}
 #else
-	syscall_get_arguments_deprecated(current, args, 3, 1, &pos64);
+	syscall_get_arguments_deprecated(args, 3, 1, &pos64);
 #endif /* CAPTURE_64BIT_ARGS_SINGLE_REGISTER*/
 
 	res = val_to_ring(args, pos64, 0, false, 0);
@@ -3776,7 +3776,7 @@ int f_sys_preadv_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -3794,13 +3794,13 @@ int f_sys_preadv_e(struct event_filler_arguments *args)
 		* requirements apply here. For an overly-detailed discussion about
 		* this, see https://lwn.net/Articles/311630/
 		*/
-		syscall_get_arguments_deprecated(current, args, 3, 1, &pos0);
-		syscall_get_arguments_deprecated(current, args, 4, 1, &pos1);
+		syscall_get_arguments_deprecated(args, 3, 1, &pos0);
+		syscall_get_arguments_deprecated(args, 4, 1, &pos1);
 
 		pos64 = merge_64(pos1, pos0);
 	}
 #else
-	syscall_get_arguments_deprecated(current, args, 3, 1, &pos64);
+	syscall_get_arguments_deprecated(args, 3, 1, &pos64);
 #endif
 
 	res = val_to_ring(args, pos64, 0, false, 0);
@@ -3818,7 +3818,7 @@ int f_sys_readv_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -3843,8 +3843,8 @@ int f_sys_readv_preadv_x(struct event_filler_arguments *args)
 
 	if(retval > 0)
 	{
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
-		syscall_get_arguments_deprecated(current, args, 2, 1, &iovcnt);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 2, 1, &iovcnt);
 
 	#ifdef CONFIG_COMPAT
 		if (unlikely(args->compat)) {
@@ -3881,18 +3881,18 @@ int f_sys_writev_e(struct event_filler_arguments *args)
 	unsigned long iovcnt;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &iovcnt);
+	syscall_get_arguments_deprecated(args, 2, 1, &iovcnt);
 
 	/*
 	 * Copy the buffer
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 #ifdef CONFIG_COMPAT
 	if (unlikely(args->compat)) {
 		const struct compat_iovec __user *compat_iov = (const struct compat_iovec __user *)compat_ptr(val);
@@ -3938,13 +3938,13 @@ int f_sys_writev_pwritev_x(struct event_filler_arguments *args)
 	/*
 	 * data and size
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &iovcnt);
+	syscall_get_arguments_deprecated(args, 2, 1, &iovcnt);
 
 
 	/*
 	 * Copy the buffer
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 #ifdef CONFIG_COMPAT
 	if (unlikely(args->compat)) {
 		const struct compat_iovec __user *compat_iov = (const struct compat_iovec __user *)compat_ptr(val);
@@ -3980,7 +3980,7 @@ int f_sys_pwritev_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -3988,12 +3988,12 @@ int f_sys_pwritev_e(struct event_filler_arguments *args)
 	/*
 	 * size
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &iovcnt);
+	syscall_get_arguments_deprecated(args, 2, 1, &iovcnt);
 
 	/*
 	 * Copy the buffer
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 #ifdef CONFIG_COMPAT
 	if (unlikely(args->compat))
 	{
@@ -4030,13 +4030,13 @@ int f_sys_pwritev_e(struct event_filler_arguments *args)
 		* requirements apply here. For an overly-detailed discussion about
 		* this, see https://lwn.net/Articles/311630/
 		*/
-		syscall_get_arguments_deprecated(current, args, 3, 1, &pos0);
-		syscall_get_arguments_deprecated(current, args, 4, 1, &pos1);
+		syscall_get_arguments_deprecated(args, 3, 1, &pos0);
+		syscall_get_arguments_deprecated(args, 4, 1, &pos1);
 
 		pos64 = merge_64(pos1, pos0);
 	}
 #else
-	syscall_get_arguments_deprecated(current, args, 3, 1, &pos64);
+	syscall_get_arguments_deprecated(args, 3, 1, &pos64);
 #endif /* CAPTURE_64BIT_ARGS_SINGLE_REGISTER */
 
 	res = val_to_ring(args, pos64, 0, false, 0);
@@ -4050,7 +4050,7 @@ int f_sys_nanosleep_e(struct event_filler_arguments *args)
 	unsigned long val;
 	int res;
 
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = timespec_parse(args, val);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4067,7 +4067,7 @@ int f_sys_getrlimit_setrlimit_e(struct event_filler_arguments *args)
 	/*
 	 * resource
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	ppm_resource = rlimit_resource_to_scap(val);
 
@@ -4102,7 +4102,7 @@ int f_sys_getrlimit_setrlrimit_x(struct event_filler_arguments *args)
 	 * Copy the user structure and extract cur and max
 	 */
 	if (retval >= 0 || args->event_type == PPME_SYSCALL_SETRLIMIT_X) {
-		syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+		syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 #ifdef CONFIG_COMPAT
 		if (!args->compat) {
@@ -4148,13 +4148,13 @@ int f_sys_prlimit_e(struct event_filler_arguments *args)
 	pid_t pid = 0;
 
 	/* Parameter 1: pid (type: PT_PID) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	pid = (s32)val;
 	res = val_to_ring(args, (s64)pid, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, rlimit_resource_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -4187,7 +4187,7 @@ int f_sys_prlimit_x(struct event_filler_arguments *args)
 	 * Copy the user structure and extract cur and max
 	 */
 	if (retval >= 0) {
-		syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+		syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 #ifdef CONFIG_COMPAT
 		if (!args->compat) {
@@ -4215,7 +4215,7 @@ int f_sys_prlimit_x(struct event_filler_arguments *args)
 		newmax = -1;
 	}
 
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
@@ -4369,13 +4369,13 @@ int f_sys_fcntl_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, fcntl_cmd_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -4388,7 +4388,7 @@ static inline int parse_ptrace_addr(struct event_filler_arguments *args, u16 req
 	uint64_t dst;
 	u8 idx;
 
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	switch (request) {
 	default:
 		idx = PPM_PTRACE_IDX_UINT64;
@@ -4405,7 +4405,7 @@ static inline int parse_ptrace_data(struct event_filler_arguments *args, u16 req
 	uint64_t dst;
 	u8 idx;
 
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	switch (request) {
 	case PPM_PTRACE_PEEKTEXT:
 	case PPM_PTRACE_PEEKDATA:
@@ -4452,12 +4452,12 @@ int f_sys_ptrace_e(struct event_filler_arguments *args)
 	pid_t pid = 0;
 
 	/* Parameter 1: request (type: PT_FLAGS16) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, ptrace_requests_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: pid (type: PT_PID) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	pid = (s32)val;
 	res = val_to_ring(args, (s64)pid, 0, false, 0);
 	CHECK_RES(res);
@@ -4495,7 +4495,7 @@ int f_sys_ptrace_x(struct event_filler_arguments *args)
 	/*
 	 * request
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	request = ptrace_requests_to_scap(val);
 
 	res = parse_ptrace_addr(args, request);
@@ -4566,7 +4566,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4574,7 +4574,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * length
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4582,7 +4582,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * prot
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, prot_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4590,7 +4590,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, mmap_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4598,7 +4598,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * fd
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -4607,7 +4607,7 @@ int f_sys_mmap_e(struct event_filler_arguments *args)
 	/*
 	 * offset/pgoffset
 	 */
-	syscall_get_arguments_deprecated(current, args, 5, 1, &val);
+	syscall_get_arguments_deprecated(args, 5, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4623,7 +4623,7 @@ int f_sys_mprotect_e(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4631,7 +4631,7 @@ int f_sys_mprotect_e(struct event_filler_arguments *args)
 	/*
 	 * length
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4639,7 +4639,7 @@ int f_sys_mprotect_e(struct event_filler_arguments *args)
 	/*
 	 * prot
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, prot_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4674,7 +4674,7 @@ int f_sys_renameat_x(struct event_filler_arguments *args)
 	/*
 	 * olddirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4686,7 +4686,7 @@ int f_sys_renameat_x(struct event_filler_arguments *args)
 	/*
 	 * oldpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4694,7 +4694,7 @@ int f_sys_renameat_x(struct event_filler_arguments *args)
 	/*
 	 * newdirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4706,7 +4706,7 @@ int f_sys_renameat_x(struct event_filler_arguments *args)
 	/*
 	 * newpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4728,7 +4728,7 @@ int f_sys_renameat2_x(struct event_filler_arguments *args)
 	/*
 	 * olddirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4740,7 +4740,7 @@ int f_sys_renameat2_x(struct event_filler_arguments *args)
 	/*
 	 * oldpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4748,7 +4748,7 @@ int f_sys_renameat2_x(struct event_filler_arguments *args)
 	/*
 	 * newdirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4760,7 +4760,7 @@ int f_sys_renameat2_x(struct event_filler_arguments *args)
 	/*
 	 * newpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4769,7 +4769,7 @@ int f_sys_renameat2_x(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4791,7 +4791,7 @@ int f_sys_symlinkat_x(struct event_filler_arguments *args)
 	/*
 	 * oldpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4799,7 +4799,7 @@ int f_sys_symlinkat_x(struct event_filler_arguments *args)
 	/*
 	 * newdirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4811,7 +4811,7 @@ int f_sys_symlinkat_x(struct event_filler_arguments *args)
 	/*
 	 * newpath
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4834,7 +4834,7 @@ int f_sys_openat2_e(struct event_filler_arguments *args)
 	/*
 	 * dirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4846,7 +4846,7 @@ int f_sys_openat2_e(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	if(likely(ppm_strncpy_from_user(args->str_storage, (const void __user *)val, PPM_MAX_PATH_SIZE) >= 0))
 	{
 		name = args->str_storage;
@@ -4861,7 +4861,7 @@ int f_sys_openat2_e(struct event_filler_arguments *args)
 	/*
 	 * how: we get the data structure, and put its fields in the buffer one by one
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = ppm_copy_from_user(&how, (void *)val, sizeof(struct open_how));
 	if (unlikely(res != 0))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
@@ -4921,7 +4921,7 @@ int f_sys_openat2_x(struct event_filler_arguments *args)
 	/*
 	 * dirfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
@@ -4933,7 +4933,7 @@ int f_sys_openat2_x(struct event_filler_arguments *args)
 	/*
 	 * name
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -4943,7 +4943,7 @@ int f_sys_openat2_x(struct event_filler_arguments *args)
 	/*
 	 * how: we get the data structure, and put its fields in the buffer one by one
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = ppm_copy_from_user(&how, (void *)val, sizeof(struct open_how));
 	if (unlikely(res != 0))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
@@ -4992,7 +4992,7 @@ int f_sys_copy_file_range_e(struct event_filler_arguments *args)
 	int res = 0;
 
 	/* Parameter 1: fdin (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fdin = (s32)val;
 	res = val_to_ring(args, (s64)fdin, 0, false, 0);
 	CHECK_RES(res);
@@ -5000,14 +5000,14 @@ int f_sys_copy_file_range_e(struct event_filler_arguments *args)
 	/*
 	* offin
 	*/
-	syscall_get_arguments_deprecated(current, args, 1, 1, &offin);
+	syscall_get_arguments_deprecated(args, 1, 1, &offin);
 	res = val_to_ring(args, offin, 0, false, 0);
 	CHECK_RES(res);
 
 	/*
 	* len
 	*/
-	syscall_get_arguments_deprecated(current, args, 4, 1, &len);
+	syscall_get_arguments_deprecated(args, 4, 1, &len);
 	res = val_to_ring(args, len, 0, false, 0);
 	CHECK_RES(res);
 	
@@ -5028,13 +5028,13 @@ int f_sys_copy_file_range_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: fdout (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	fdout = (s32)val;
 	res = val_to_ring(args, (s64)fdout, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: offout (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &offout);
+	syscall_get_arguments_deprecated(args, 3, 1, &offout);
 	res = val_to_ring(args, offout, 0, false, 0);
 	CHECK_RES(res);
 
@@ -5055,7 +5055,7 @@ int f_sys_open_by_handle_at_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: mountfd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	mountfd = (s32)val;
 	if(mountfd == AT_FDCWD)
 	{
@@ -5065,7 +5065,7 @@ int f_sys_open_by_handle_at_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, open_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -5113,7 +5113,7 @@ int f_sys_io_uring_setup_x(struct event_filler_arguments *args)
 
 #ifdef __NR_io_uring_setup
 	struct io_uring_params params = {0};
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = ppm_copy_from_user(&params, (void *)val, sizeof(struct io_uring_params));
 	if(unlikely(res != 0))
 	{
@@ -5141,7 +5141,7 @@ int f_sys_io_uring_setup_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 	
 	/* Parameter 2: entries (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -5184,28 +5184,28 @@ int f_sys_io_uring_enter_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: to_submit (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: min_complete (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, io_uring_enter_flags_to_scap(val), 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 6: sig (type: PT_SIGSET) */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -5227,23 +5227,23 @@ int f_sys_io_uring_register_x (struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: opcode (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, io_uring_register_opcodes_to_scap(val) , 0 , true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: arg (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 5: nr_args (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -5273,7 +5273,7 @@ int f_sys_inotify_init1_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, inotify_init1_flags_to_scap((s32)val), 0, true, 0);
 	CHECK_RES(res);
 
@@ -5291,14 +5291,14 @@ int f_sys_mlock_x(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	/*
 	 * len
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5317,21 +5317,21 @@ int f_sys_mlock2_x(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	/*
 	 * len
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, mlock2_flags_to_scap(val), 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5350,14 +5350,14 @@ int f_sys_munlock_x(struct event_filler_arguments *args)
 	/*
 	 * addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	/*
 	 * len
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5376,7 +5376,7 @@ int f_sys_mlockall_x(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, mlockall_flags_to_scap(val), 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5413,22 +5413,22 @@ int f_sys_fsconfig_x(struct event_filler_arguments *args)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	/* This is the file-system fd */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &fd);
+	syscall_get_arguments_deprecated(args, 0, 1, &fd);
 	res = val_to_ring(args, fd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &cmd);
+	syscall_get_arguments_deprecated(args, 1, 1, &cmd);
 	scap_cmd = fsconfig_cmds_to_scap(cmd);
 	res = val_to_ring(args, scap_cmd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: key (type: PT_CHARBUF) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &key_pointer);
+	syscall_get_arguments_deprecated(args, 2, 1, &key_pointer);
 	res = val_to_ring(args, key_pointer, 0, true, 0);
 	CHECK_RES(res);
 
-	syscall_get_arguments_deprecated(current, args, 4, 1, &aux);
+	syscall_get_arguments_deprecated(args, 4, 1, &aux);
 
 	if(ret < 0)
 	{
@@ -5444,7 +5444,7 @@ int f_sys_fsconfig_x(struct event_filler_arguments *args)
 	}
 	else
 	{
-		syscall_get_arguments_deprecated(current, args, 3, 1, &value_pointer);
+		syscall_get_arguments_deprecated(args, 3, 1, &value_pointer);
 
 		/* According to the command we need to understand what value we have to push to userspace. */
 		/* see https://elixir.bootlin.com/linux/latest/source/fs/fsopen.c#L271 */
@@ -5522,7 +5522,7 @@ int f_sys_signalfd_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -5549,7 +5549,7 @@ int f_sys_signalfd4_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -5574,7 +5574,7 @@ int f_sys_signalfd4_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, signalfd4_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -5589,7 +5589,7 @@ int f_sys_epoll_create_e(struct event_filler_arguments *args)
 	/*
 	 * size
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &size);
+	syscall_get_arguments_deprecated(args, 0, 1, &size);
 	res = val_to_ring(args, size, 0, false, 0);
 	CHECK_RES(res);
 
@@ -5616,7 +5616,7 @@ int f_sys_epoll_create1_e(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &flags);
+	syscall_get_arguments_deprecated(args, 0, 1, &flags);
 	res = val_to_ring(args, epoll_create1_flags_to_scap(flags), 0, false, 0);
 	CHECK_RES(res);
 
@@ -5643,7 +5643,7 @@ int f_sys_dup_e(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5665,7 +5665,7 @@ int f_sys_dup_x(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5681,7 +5681,7 @@ int f_sys_dup2_e(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5703,7 +5703,7 @@ int f_sys_dup2_x(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5711,7 +5711,7 @@ int f_sys_dup2_x(struct event_filler_arguments *args)
 	/*
 	 * newfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5727,7 +5727,7 @@ int f_sys_dup3_e(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5749,7 +5749,7 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 	/*
 	 * oldfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5757,7 +5757,7 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 	/*
 	 * newfd
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5765,7 +5765,7 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, dup3_flags_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -5838,20 +5838,20 @@ int f_sys_sendfile_e(struct event_filler_arguments *args)
 	s32 in_fd = 0;
 
 	/* Parameter 1: out_fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	out_fd = (s32)val;
 	res = val_to_ring(args, (s64)out_fd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: in_fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	in_fd = (s32)val;
 	res = val_to_ring(args, (s64)in_fd, 0, true, 0);
 	CHECK_RES(res);
 
 
 	/* Parameter 3: offset (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if (val != 0) {
 #ifdef CONFIG_COMPAT
@@ -5873,7 +5873,7 @@ int f_sys_sendfile_e(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 4: size (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -5898,7 +5898,7 @@ int f_sys_sendfile_x(struct event_filler_arguments *args)
 	/*
 	 * offset
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	if (val != 0) {
 #ifdef CONFIG_COMPAT
@@ -5933,7 +5933,7 @@ int f_sys_quotactl_e(struct event_filler_arguments *args)
 	uint16_t scap_cmd = 0;
 
 	/* Parameter 1: cmd (type: PT_FLAGS16) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	cmd = (uint32_t)val;
 	scap_cmd = quotactl_cmd_to_scap(cmd);
 	res = val_to_ring(args, scap_cmd, 0, false, 0);
@@ -5944,7 +5944,7 @@ int f_sys_quotactl_e(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: id (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	id = (u32)val;
 	if ((scap_cmd != PPM_Q_GETQUOTA) &&
 		 (scap_cmd != PPM_Q_SETQUOTA) &&
@@ -5985,7 +5985,7 @@ int f_sys_quotactl_x(struct event_filler_arguments *args)
 	/*
 	 * extract cmd
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	cmd = quotactl_cmd_to_scap(val);
 
 	/*
@@ -5999,7 +5999,7 @@ int f_sys_quotactl_x(struct event_filler_arguments *args)
 	/*
 	 * Add special
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6007,7 +6007,7 @@ int f_sys_quotactl_x(struct event_filler_arguments *args)
 	/*
 	 * get addr
 	 */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 
 	/*
 	 * get quotafilepath only for QUOTAON
@@ -6185,7 +6185,7 @@ int f_sys_getresuid_and_gid_x(struct event_filler_arguments *args)
 	/*
 	 * ruid
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 #ifdef CONFIG_COMPAT
 	if (!args->compat) {
 #endif
@@ -6205,7 +6205,7 @@ int f_sys_getresuid_and_gid_x(struct event_filler_arguments *args)
 	/*
 	 * euid
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	len = ppm_copy_from_user(&uid, (void *)val, sizeof(uint32_t));
 	if (unlikely(len != 0))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
@@ -6217,7 +6217,7 @@ int f_sys_getresuid_and_gid_x(struct event_filler_arguments *args)
 	/*
 	 * suid
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	len = ppm_copy_from_user(&uid, (void *)val, sizeof(uint32_t));
 	if (unlikely(len != 0))
 		return PPM_FAILURE_INVALID_USER_MEMORY;
@@ -6237,13 +6237,13 @@ int f_sys_flock_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	flags = flock_flags_to_scap(val);
 	res = val_to_ring(args, flags, 0, false, 0);
 	CHECK_RES(res);
@@ -6258,18 +6258,18 @@ int f_sys_ioctl_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: request (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: argument (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -6282,7 +6282,7 @@ int f_sys_mkdir_e(struct event_filler_arguments *args)
 	int res = 0;
 
 	/* Parameter 1: mode (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -6296,13 +6296,13 @@ int f_sys_setns_e(struct event_filler_arguments *args)
 	s32 fd = 0;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, clone_flags_to_scap(val), 0, true, 0);
 	CHECK_RES(res);
 
@@ -6317,13 +6317,13 @@ int f_sys_setpgid_e(struct event_filler_arguments *args)
 	pid_t pgid = 0;
 
 	/* Parameter 1: pid (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	pid = (s32)val;
 	res = val_to_ring(args, (s64)pid, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: pgid (type: PT_PID) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	pgid = (s32)val;
 	res = val_to_ring(args, (s64)pgid, 0, true, 0);
 	CHECK_RES(res);
@@ -6340,7 +6340,7 @@ int f_sys_unshare_e(struct event_filler_arguments *args)
 	/*
 	 * get type, parse as clone flags as it's a subset of it
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	flags = clone_flags_to_scap(val);
 	res = val_to_ring(args, flags, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
@@ -6435,12 +6435,12 @@ int f_sys_semop_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: nsops (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &nsops);
+	syscall_get_arguments_deprecated(args, 2, 1, &nsops);
 	res = val_to_ring(args, nsops, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Extract pointer to the `sembuf` struct */
-	syscall_get_arguments_deprecated(current, args, 1, 1, (unsigned long *) &sops_pointer);
+	syscall_get_arguments_deprecated(args, 1, 1, (unsigned long *) &sops_pointer);
 
 	if(retval != 0 || sops_pointer == 0 || nsops == 0)
 	{
@@ -6502,7 +6502,7 @@ int f_sys_semget_e(struct event_filler_arguments *args)
 	/*
 	 * key
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6510,7 +6510,7 @@ int f_sys_semget_e(struct event_filler_arguments *args)
 	/*
 	 * nsems
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6518,7 +6518,7 @@ int f_sys_semget_e(struct event_filler_arguments *args)
 	/*
 	 * semflg
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, semget_flags_to_scap(val), 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6534,7 +6534,7 @@ int f_sys_semctl_e(struct event_filler_arguments *args)
 	/*
 	 * semid
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6542,7 +6542,7 @@ int f_sys_semctl_e(struct event_filler_arguments *args)
 	/*
 	 * semnum
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6550,7 +6550,7 @@ int f_sys_semctl_e(struct event_filler_arguments *args)
 	/*
 	 * cmd
 	 */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, semctl_cmd_to_scap(val), 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6559,7 +6559,7 @@ int f_sys_semctl_e(struct event_filler_arguments *args)
 	 * optional argument semun/val
 	 */
 	if (val == SETVAL)
-		syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+		syscall_get_arguments_deprecated(args, 3, 1, &val);
 	else
 		val = 0;
 	res = val_to_ring(args, val, 0, true, 0);
@@ -6577,7 +6577,7 @@ int f_sys_access_e(struct event_filler_arguments *args)
 	/*
 	 * mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, access_flags_to_scap(val), 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6592,7 +6592,7 @@ int f_sys_fchdir_e(struct event_filler_arguments *args)
 	unsigned long val = 0;
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -6617,7 +6617,7 @@ int f_sys_close_e(struct event_filler_arguments *args)
 	unsigned long val = 0;
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -6640,7 +6640,7 @@ int f_sys_bpf_e(struct event_filler_arguments *args)
 	int res = 0;
 	s32 cmd = 0;
 	unsigned long val = 0;
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	/* Parameter 1: cmd (type: PT_INT64) */
 	cmd = (int32_t)val;
@@ -6678,7 +6678,7 @@ int f_sys_mkdirat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	dirfd = (s32)val;
 	if(dirfd == AT_FDCWD)
 	{
@@ -6688,12 +6688,12 @@ int f_sys_mkdirat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: mode (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
@@ -6713,7 +6713,7 @@ int f_sys_fchmodat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	dirfd = (s32)val;
 	if(dirfd == AT_FDCWD)
 	{
@@ -6723,12 +6723,12 @@ int f_sys_fchmodat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: filename (type: PT_FSRELPATH) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: mode (type: PT_MODE) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, chmod_mode_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -6749,7 +6749,7 @@ int f_sys_chmod_x(struct event_filler_arguments *args)
 	/*
 	 * filename
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6757,7 +6757,7 @@ int f_sys_chmod_x(struct event_filler_arguments *args)
 	/*
 	 * mode
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, chmod_mode_to_scap(val), 0, false, 0);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
@@ -6778,13 +6778,13 @@ int f_sys_fchmod_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: mode (type: PT_MODE) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, chmod_mode_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -6803,19 +6803,19 @@ int f_sys_chown_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: path (type: PT_FSPATH) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
@@ -6835,19 +6835,19 @@ int f_sys_lchown_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: path (type: PT_FSPATH) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
@@ -6868,19 +6868,19 @@ int f_sys_fchown_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
@@ -6901,7 +6901,7 @@ int f_sys_fchownat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (s32)val;
 
 	if ((int)fd == AT_FDCWD)
@@ -6911,25 +6911,25 @@ int f_sys_fchownat_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 3: pathname (type: PT_FSRELPATH) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: uid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 5: gid (type: PT_UINT32) */
-	syscall_get_arguments_deprecated(current, args, 3, 1, &val);
+	syscall_get_arguments_deprecated(args, 3, 1, &val);
 
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 6: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	res = val_to_ring(args, fchownat_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -6992,24 +6992,24 @@ int f_sys_splice_e(struct event_filler_arguments *args)
 	int res;
 
 	/* Parameter 1: fd_in (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd_in = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd_in, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 2, 1, &val);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	fd_out = (int32_t)val;
 	res = val_to_ring(args, (int64_t)fd_out, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: size (type: PT_UINT64) */
-	syscall_get_arguments_deprecated(current, args, 4, 1, &val);
+	syscall_get_arguments_deprecated(args, 4, 1, &val);
 	res = val_to_ring(args, val, 0, false, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 5, 1, &val);
+	syscall_get_arguments_deprecated(args, 5, 1, &val);
 	res = val_to_ring(args, splice_flags_to_scap(val), 0, false, 0);
 	CHECK_RES(res);
 
@@ -7028,7 +7028,7 @@ int f_sys_umount_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: name (type: PT_FSPATH) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -7041,7 +7041,7 @@ int f_sys_umount2_e(struct event_filler_arguments *args)
 	int res;
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &val);
+	syscall_get_arguments_deprecated(args, 1, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -7060,7 +7060,7 @@ int f_sys_umount2_x(struct event_filler_arguments *args)
 	CHECK_RES(res);
 
 	/* Parameter 2: name (type: PT_FSPATH) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
 	CHECK_RES(res);
 
@@ -7080,7 +7080,7 @@ int f_sys_getcwd_x(struct event_filler_arguments *args)
 	if(retval >= 0)
 	{
 		/* Parameter 2: path (type: PT_CHARBUF) */
-		syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+		syscall_get_arguments_deprecated(args, 0, 1, &val);
 		res = val_to_ring(args, val, 0, true, 0);
 	}
 	else
@@ -7101,7 +7101,7 @@ int f_sys_getdents_e(struct event_filler_arguments *args)
 	int res;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -7116,7 +7116,7 @@ int f_sys_getdents64_e(struct event_filler_arguments *args)
 	int res;
 
 	/* Parameter 1: fd (type: PT_FD) */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &val);
+	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int32_t)val;
 	res = val_to_ring(args, (s64)fd, 0, false, 0);
 	CHECK_RES(res);
@@ -7815,7 +7815,7 @@ int f_sys_prctl_x(struct event_filler_arguments *args)
 	/*
 	 * option
 	 */
-	syscall_get_arguments_deprecated(current, args, 0, 1, &option);
+	syscall_get_arguments_deprecated(args, 0, 1, &option);
 	option = prctl_options_to_scap(option);
 	res = val_to_ring(args, option, 0, false, 0);
 	CHECK_RES(res);
@@ -7823,7 +7823,7 @@ int f_sys_prctl_x(struct event_filler_arguments *args)
 	/*
 	 * arg2
 	 */
-	syscall_get_arguments_deprecated(current, args, 1, 1, &arg2);
+	syscall_get_arguments_deprecated(args, 1, 1, &arg2);
 
 	switch(option){
 		case PPM_PR_GET_NAME:

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -3273,4 +3273,47 @@ TEST(SyscallExit, socketcall_getsocknameX)
 }
 #endif
 
+TEST(SyscallExit, socketcall_wrong_code)
+{
+	auto evt_test = get_syscall_event_test(__NR_socketcall, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	unsigned long args[3] = {0};
+	args[0] = 47;
+	args[1] = 0;
+	args[2] = 0;
+	int wrong_code = 1230;
+
+	assert_syscall_state(SYSCALL_FAILURE, "socketcall", syscall(__NR_socketcall, wrong_code, args));
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	/* if we send a socketcall with a wrong code we should immediately drop the event */
+	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* this is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_SOCKETCALL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+
 #endif /* __NR_socketcall */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

NONE

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR contains multiple improvements:
* fixed a bug in `socketcall` handling: socketcall resolved syscalls were not being checked against interesting set
* ported kmod socketcall code to follow similar structure to eBPF and modern eBPF
* given that since linux 5.1 `syscall_get_arguments` copies all the arguments of a syscall, try to give a boost to perf by preloading syscalls arguments and reusing them, instead of fetching them every time we want to access a single argument (see: https://elixir.bootlin.com/linux/latest/source/arch/arm64/include/asm/syscall.h#L66 or https://elixir.bootlin.com/linux/latest/source/arch/x86/include/asm/syscall.h#L83 for example)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
