### PR TITLE
cleanup(driver/bpf): split bpf_val_to_ring into many int-pushing helpers

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1065,18 +1065,12 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 static __always_inline int bpf_push_empty_param(struct filler_data *data)
 {
-	/* This is not so necessary but just keep it for compliance with other helpers */
-	if (data->state->tail_ctx.curarg >= PPM_MAX_EVENT_PARAMS) {
-		bpf_printk("invalid curarg: %d\n", data->state->tail_ctx.curarg);
-		return PPM_FAILURE_BUG;
-	}
-
 	/* We push 0 in the length array */
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, 0);
 	data->curarg_already_on_frame = false;
 
-	 /* We increment the current argument - to make verifier happy, properly check it against u32 max */
-	data->state->tail_ctx.curarg = (data->state->tail_ctx.curarg + 1) & (PPM_MAX_EVENT_PARAMS - 1);
+	 /* We increment the current argument */
+	++data->state->tail_ctx.curarg;
 	return PPM_SUCCESS;
 }
 
@@ -1129,7 +1123,7 @@ static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, s64 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(s64);
+	const unsigned int len = sizeof(s64);
 	*((s64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	/// TODO: @Andreagit97 this could be simplified
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
@@ -1146,7 +1140,7 @@ static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, u64 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(u64);
+	const unsigned int len = sizeof(u64);
 	*((u64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1162,7 +1156,7 @@ static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(u32);
+	const unsigned int len = sizeof(u32);
 	*((u32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1178,7 +1172,7 @@ static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, s32 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(s32);
+	const unsigned int len = sizeof(s32);
 	*((s32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1194,7 +1188,7 @@ static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, u16 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(u16);
+	const unsigned int len = sizeof(u16);
 	*((u16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1210,7 +1204,7 @@ static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, s16 va
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(s16);
+	const unsigned int len = sizeof(s16);
 	*((s16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1226,7 +1220,7 @@ static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, u8 val)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(u8);
+	const unsigned int len = sizeof(u8);
 	*((u8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1242,7 +1236,7 @@ static __always_inline int bpf_push_s8_to_ring(struct filler_data *data, s16 val
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	unsigned int len = sizeof(s8);
+	const unsigned int len = sizeof(s8);
 	*((s8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -25,6 +25,9 @@ or GPL2.txt for full copies of the license.
 #define MAX_PATH_COMPONENTS 16
 #define MAX_PATH_LENGTH 4096
 
+/* Helper used to please the verifier with operations on the number of arguments */
+#define SAFE_ARG_NUMBER(x) x & (PPM_MAX_EVENT_PARAMS - 1)
+
 /* This enum is used to tell our helpers if they have to
  * read from kernel or user memory.
  */
@@ -1069,8 +1072,8 @@ static __always_inline int bpf_push_empty_param(struct filler_data *data)
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, 0);
 	data->curarg_already_on_frame = false;
 
-	 /* We increment the current argument */
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1130,7 +1133,8 @@ static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, s64 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1146,7 +1150,8 @@ static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, u64 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1162,7 +1167,8 @@ static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1178,7 +1184,8 @@ static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, s32 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1194,7 +1201,8 @@ static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, u16 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1210,7 +1218,8 @@ static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, s16 va
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1226,7 +1235,8 @@ static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, u8 val)
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 
@@ -1242,7 +1252,8 @@ static __always_inline int bpf_push_s8_to_ring(struct filler_data *data, s16 val
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
 	data->curarg_already_on_frame = false;
-	++data->state->tail_ctx.curarg;
+	/* We increment the current argument - to make verifier happy, properly check it */
+	data->state->tail_ctx.curarg = SAFE_ARG_NUMBER(data->state->tail_ctx.curarg + 1);
 	return PPM_SUCCESS;
 }
 

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1172,11 +1172,92 @@ static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 va
 	return PPM_SUCCESS;
 }
 
+static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, s32 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(s32);
+	*((s32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, u16 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(u16);
+	*((u16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, s16 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(s16);
+	*((s16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, u8 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(u8);
+	*((u8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
+static __always_inline int bpf_push_s8_to_ring(struct filler_data *data, s16 val)
+{
+	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
+	{
+		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
+	}
+	unsigned int len = sizeof(s8);
+	*((s8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
+	data->state->tail_ctx.curoff += len;
+	data->state->tail_ctx.len += len;
+	data->curarg_already_on_frame = false;
+	++data->state->tail_ctx.curarg;
+	return PPM_SUCCESS;
+}
+
 static __always_inline int bpf_val_to_ring(struct filler_data *data,
 					   unsigned long val)
 {
 	const struct ppm_param_info *param_info;
 
+	/// TODO this is something we want to enforce at test time, not runtime
 	if (data->state->tail_ctx.curarg >= PPM_MAX_EVENT_PARAMS) {
 		bpf_printk("invalid curarg: %d\n", data->state->tail_ctx.curarg);
 		return PPM_FAILURE_BUG;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3063,7 +3063,6 @@ FILLER(sys_openat_x, true)
 	return res;
 }
 
-// TODO RESUME FROM HERE
 FILLER(sys_openat2_e, true)
 {
 	unsigned long resolve;
@@ -3081,7 +3080,7 @@ FILLER(sys_openat2_e, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -3112,21 +3111,21 @@ FILLER(sys_openat2_e, true)
 	 * flags (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/*
 	 * mode (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	/*
 	 * resolve (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, resolve);
+	res = bpf_push_u32_to_ring(data, resolve);
 	return res;
 }
 
@@ -3144,7 +3143,7 @@ FILLER(sys_openat2_x, true)
 #endif
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3154,7 +3153,7 @@ FILLER(sys_openat2_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -3185,21 +3184,21 @@ FILLER(sys_openat2_x, true)
 	 * flags (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/*
 	 * mode (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	/*
 	 * resolve (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
-	res = bpf_val_to_ring(data, resolve);
+	res = bpf_push_u32_to_ring(data, resolve);
 	return res;
 }
 
@@ -3207,7 +3206,7 @@ FILLER(sys_open_by_handle_at_x, true)
 {
 	/* Parameter 1: ret (type: PT_FD) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: mountfd (type: PT_FD) */
@@ -3216,12 +3215,12 @@ FILLER(sys_open_by_handle_at_x, true)
 	{
 		mountfd = PPM_AT_FDCWD;
 	}
-	res = bpf_val_to_ring(data, (s64)mountfd);
+	res = bpf_push_s64_to_ring(data, (s64)mountfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, open_flags_to_scap(flags));
+	res = bpf_push_u32_to_ring(data, open_flags_to_scap(flags));
 	CHECK_RES(res);
 	
 	/* Parameter 4: path (type: PT_FSPATH) */
@@ -3271,68 +3270,68 @@ FILLER(sys_io_uring_setup_x, true)
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: entries (type: PT_UINT32) */
 	u32 entries = (u32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, entries);
+	res = bpf_push_u32_to_ring(data, entries);
 	CHECK_RES(res);
 
 	/* Parameter 3: sq_entries (type: PT_UINT32) */
-	res = bpf_val_to_ring(data, sq_entries);
+	res = bpf_push_u32_to_ring(data, sq_entries);
 	CHECK_RES(res);
 
 	/* Parameter 4: cq_entries (type: PT_UINT32) */
-	res = bpf_val_to_ring(data, cq_entries);
+	res = bpf_push_u32_to_ring(data, cq_entries);
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/* Parameter 6: sq_thread_cpu (type: PT_UINT32) */
-	res = bpf_val_to_ring(data, sq_thread_cpu);
+	res = bpf_push_u32_to_ring(data, sq_thread_cpu);
 	CHECK_RES(res);
 
 	/* Parameter 7: sq_thread_idle (type: PT_UINT32) */
-	res = bpf_val_to_ring(data, sq_thread_idle);
+	res = bpf_push_u32_to_ring(data, sq_thread_idle);
 	CHECK_RES(res);
 
 	/* Parameter 8: features (type: PT_FLAGS32) */
-	return bpf_val_to_ring(data, features);
+	return bpf_push_u32_to_ring(data, features);
 }
 
 FILLER(sys_io_uring_enter_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: to_submit (type: PT_UINT32) */
 	u32 to_submit = (u32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, to_submit);
+	res = bpf_push_u32_to_ring(data, to_submit);
 	CHECK_RES(res);
 
 	/* Parameter 4: min_complete (type: PT_UINT32) */
 	u32 min_complete = (u32)bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, min_complete);
+	res = bpf_push_u32_to_ring(data, min_complete);
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)bpf_syscall_get_argument(data, 3);
-	res = bpf_val_to_ring(data, io_uring_enter_flags_to_scap(flags));
+	res = bpf_push_u32_to_ring(data, io_uring_enter_flags_to_scap(flags));
 	CHECK_RES(res);
 
 	/* Parameter 6: sig (type: PT_SIGSET) */
 	u32 sig = (u32)bpf_syscall_get_argument(data, 4);
-	return bpf_val_to_ring(data, sig);
+	return bpf_push_u32_to_ring(data, sig);
 
 	/// TODO: We miss the last parameter `size_t argsz`
 	/// we need to implement it in all our drivers
@@ -3342,27 +3341,27 @@ FILLER(sys_io_uring_register_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: opcode (type: PT_ENUMFLAGS16) */
 	u32 opcode = (u32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, io_uring_register_opcodes_to_scap(opcode));
+	res = bpf_push_u16_to_ring(data, io_uring_register_opcodes_to_scap(opcode));
 	CHECK_RES(res);
 
 	/* Parameter 4: arg (type: PT_UINT64) */
 	unsigned long arg = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, arg);
+	res = bpf_push_u64_to_ring(data, arg);
 	CHECK_RES(res);
 
 	/* Parameter 5: nr_args (type: PT_UINT32) */
 	u32 nr_args = (u32)bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring(data, nr_args);
+	return bpf_push_u32_to_ring(data, nr_args);
 }
 
 FILLER(sys_inotify_init_e, true)
@@ -3371,19 +3370,19 @@ FILLER(sys_inotify_init_e, true)
 	/* We have nothing to extract from the kernel here so we send `0`.
 	 * This is done to preserve the `PPME_SYSCALL_INOTIFY_INIT_E` event with 1 param.
 	 */
-	return bpf_val_to_ring(data, 0);
+	return bpf_push_u8_to_ring(data, 0);
 }
 
 FILLER(sys_inotify_init1_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
 	s32 flags = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, inotify_init1_flags_to_scap(flags));
+	return bpf_push_u16_to_ring(data, inotify_init1_flags_to_scap(flags));
 }
 
 FILLER(sys_mlock_x, true)
@@ -3393,19 +3392,19 @@ FILLER(sys_mlock_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 	/*
 	 * len
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 
 	return res;
 }
@@ -3418,26 +3417,26 @@ FILLER(sys_mlock2_x, true)
 	unsigned long flags;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 	/*
 	 * len
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 	/*
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	flags = mlock2_flags_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 
 	return res;
 }
@@ -3449,19 +3448,19 @@ FILLER(sys_munlock_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 	/*
 	 * len
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 
 	return res;
 }
@@ -3473,13 +3472,13 @@ FILLER(sys_mlockall_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, mlockall_flags_to_scap(val));
+	res = bpf_push_u32_to_ring(data, mlockall_flags_to_scap(val));
 
 	return res;
 }
@@ -3490,7 +3489,7 @@ FILLER(sys_munlockall_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 
 	return res;
 }
@@ -3501,19 +3500,19 @@ FILLER(sys_fsconfig_x, true)
 
 	/* Parameter 1: ret (type: PT_ERRNO) */
 	int64_t ret = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, ret);
+	res = bpf_push_s64_to_ring(data, ret);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	/* This is the file-system fd */
 	unsigned long fd = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, fd);
+	res = bpf_push_s64_to_ring(data, fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS32) */
 	u32 cmd = bpf_syscall_get_argument(data, 1);
 	u32 scap_cmd = fsconfig_cmds_to_scap(cmd);
-	res = bpf_val_to_ring(data, scap_cmd);
+	res = bpf_push_u32_to_ring(data, scap_cmd);
 	CHECK_RES(res);
 
 	/* Parameter 4: key (type: PT_CHARBUF) */
@@ -3597,7 +3596,7 @@ FILLER(sys_fsconfig_x, true)
 	}
 
 	/* Parameter 7: aux (type: PT_INT32) */
-	res = bpf_val_to_ring(data, aux);
+	res = bpf_push_s32_to_ring(data, aux);
 	return res;
 }
 
@@ -3605,43 +3604,43 @@ FILLER(sys_signalfd_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
 	/* Right now we are not interested in the `sigmask`, we can populate it if we need */
-	res = bpf_val_to_ring(data, 0);
+	res = bpf_push_u32_to_ring(data, 0);
 	CHECK_RES(res);
 
 	/* Parameter 3: flags (type: PT_FLAGS8) */
 	/* The syscall `signalfd` has no flags! only `signalfd4` has the `flags` param.
 	 * For compatibility with the event definition here we send `0` as flags.
 	 */
-	return bpf_val_to_ring(data, 0);
+	return bpf_push_u32_to_ring(data, 0);
 }
 
 FILLER(sys_signalfd4_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
 	/* Right now we are not interested in the `sigmask`, we can populate it if we need */
-	return bpf_val_to_ring(data, 0);
+	return bpf_push_u32_to_ring(data, 0);
 }
 
 FILLER(sys_signalfd4_x, true)
 {
 	/* Parameter 1: res (type: PT_FD) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
 	s32 flags = (s32)bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring(data, signalfd4_flags_to_scap(flags));
+	return bpf_push_u16_to_ring(data, signalfd4_flags_to_scap(flags));
 }
 
 FILLER(sys_epoll_create_e, true)
@@ -3652,7 +3651,7 @@ FILLER(sys_epoll_create_e, true)
 	 * size
 	 */
 	size = bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, size);
+	return bpf_push_s32_to_ring(data, size);
 }
 
 FILLER(sys_epoll_create_x, true)
@@ -3660,7 +3659,7 @@ FILLER(sys_epoll_create_x, true)
 	unsigned long retval;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	return bpf_val_to_ring(data, retval);
+	return bpf_push_s64_to_ring(data, retval);
 }
 
 FILLER(sys_epoll_create1_e, true)
@@ -3671,7 +3670,7 @@ FILLER(sys_epoll_create1_e, true)
 	 * flags
 	 */
 	flags = bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, epoll_create1_flags_to_scap(flags));
+	return bpf_push_u32_to_ring(data, epoll_create1_flags_to_scap(flags));
 }
 
 FILLER(sys_epoll_create1_x, true)
@@ -3679,57 +3678,57 @@ FILLER(sys_epoll_create1_x, true)
 	unsigned long retval;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	return bpf_val_to_ring(data, retval);
+	return bpf_push_s64_to_ring(data, retval);
 }
 
 FILLER(sys_sendfile_e, true)
 {
 	/* Parameter 1: out_fd (type: PT_FD) */
 	s32 out_fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)out_fd);
+	int res = bpf_push_s64_to_ring(data, (s64)out_fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: in_fd (type: PT_FD) */
 	s32 in_fd = (s32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, (s64)in_fd);
+	res = bpf_push_s64_to_ring(data, (s64)in_fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: offset (type: PT_UINT64) */
 	unsigned long offset = 0;
 	unsigned long offset_pointer = bpf_syscall_get_argument(data, 2);
 	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
-	res = bpf_val_to_ring(data, offset);
+	res = bpf_push_u64_to_ring(data, offset);
 	CHECK_RES(res);
 
 	/* Parameter 4: size (type: PT_UINT64) */
 	u64 size = bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring(data, size);
+	return bpf_push_u64_to_ring(data, size);
 }
 
 FILLER(sys_sendfile_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: offset (type: PT_UINT64) */
 	unsigned long offset = 0;
 	unsigned long offset_pointer = bpf_syscall_get_argument(data, 2);
 	bpf_probe_read_user((void *)&offset, sizeof(offset), (void *)offset_pointer);
-	return bpf_val_to_ring(data, offset);
+	return bpf_push_u64_to_ring(data, offset);
 }
 
 FILLER(sys_prlimit_e, true)
 {
 	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)pid);
+	int res = bpf_push_s64_to_ring(data, (s64)pid);
 	CHECK_RES(res);
 
 	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
 	unsigned long resource = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, rlimit_resource_to_scap(resource));
+	return bpf_push_u8_to_ring(data, rlimit_resource_to_scap(resource));
 }
 
 FILLER(sys_prlimit_x, true)
@@ -3747,7 +3746,7 @@ FILLER(sys_prlimit_x, true)
 	 * res
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3779,25 +3778,25 @@ FILLER(sys_prlimit_x, true)
 	/*
 	 * newcur
 	 */
-	res = bpf_val_to_ring_type(data, newcur, PT_INT64);
+	res = bpf_push_s64_to_ring(data, newcur);
 	CHECK_RES(res);
 
 	/*
 	 * newmax
 	 */
-	res = bpf_val_to_ring_type(data, newmax, PT_INT64);
+	res = bpf_push_s64_to_ring(data, newmax);
 	CHECK_RES(res);
 
 	/*
 	 * oldcur
 	 */
-	res = bpf_val_to_ring_type(data, oldcur, PT_INT64);
+	res = bpf_push_s64_to_ring(data, oldcur);
 	CHECK_RES(res);
 
 	/*
 	 * oldmax
 	 */
-	res = bpf_val_to_ring_type(data, oldmax, PT_INT64);
+	res = bpf_push_s64_to_ring(data, oldmax);
 
 	return res;
 }
@@ -3806,7 +3805,7 @@ FILLER(sys_pwritev_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	unsigned long iov_pointer = bpf_syscall_get_argument(data, 1);
@@ -3824,13 +3823,13 @@ FILLER(sys_pwritev_e, true)
 	 */
 	if(res == PPM_FAILURE_INVALID_USER_MEMORY)
 	{
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_push_u32_to_ring(data, 0);
 	}
 	CHECK_RES(res);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
 	u64 pos = (u64)bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring_type(data, pos, PT_UINT64);
+	return bpf_push_u64_to_ring(data, pos);
 }
 
 FILLER(sys_getresuid_and_gid_x, true)
@@ -3844,7 +3843,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	 * return value
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3853,7 +3852,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	idp = (u32 *)bpf_syscall_get_argument(data, 0);
 	id = _READ(*idp);
 
-	res = bpf_val_to_ring(data, id);
+	res = bpf_push_u32_to_ring(data, id);
 	CHECK_RES(res);
 
 	/*
@@ -3862,7 +3861,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	idp = (u32 *)bpf_syscall_get_argument(data, 1);
 	id = _READ(*idp);
 
-	res = bpf_val_to_ring(data, id);
+	res = bpf_push_u32_to_ring(data, id);
 	CHECK_RES(res);
 
 	/*
@@ -3871,7 +3870,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	idp = (u32 *)bpf_syscall_get_argument(data, 2);
 	id = _READ(*idp);
 
-	res = bpf_val_to_ring(data, id);
+	res = bpf_push_u32_to_ring(data, id);
 
 	return res;
 }
@@ -3880,7 +3879,7 @@ FILLER(sys_socket_bind_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_socket_bind_x, true)
@@ -3896,7 +3895,7 @@ FILLER(sys_socket_bind_x, true)
 	 * res
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3939,7 +3938,7 @@ static __always_inline int f_sys_recv_x_common(struct filler_data *data, long re
 	/*
 	 * res
 	 */
-	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3982,12 +3981,12 @@ FILLER(sys_recvfrom_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, size);
+	return bpf_push_u32_to_ring(data, size);
 }
 
 FILLER(sys_recvfrom_x, true)
@@ -4059,19 +4058,19 @@ FILLER(sys_shutdown_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int	res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
 	int how = (s32)bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, (u8)shutdown_how_to_scap(how));
+	return bpf_push_u8_to_ring(data, (u8)shutdown_how_to_scap(how));
 }
 
 FILLER(sys_recvmsg_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_recvmsg_x, true)
@@ -4083,7 +4082,7 @@ FILLER(sys_recvmsg_x, true)
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* If the syscall fails we are not able to collect reliable params
@@ -4092,7 +4091,7 @@ FILLER(sys_recvmsg_x, true)
 	if(retval < 0)
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_push_u32_to_ring(data, 0);
 		CHECK_RES(res);
 
 		/* Parameter 3: data (type: PT_BYTEBUF) */
@@ -4202,7 +4201,7 @@ FILLER(sys_sendmsg_e, true)
 	 * fd
 	 */
 	fd = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring_type(data, fd, PT_FD);
+	res = bpf_push_s64_to_ring(data, fd);
 	CHECK_RES(res);
 
 	/*
@@ -4260,7 +4259,7 @@ FILLER(sys_sendmsg_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: data (type: PT_BYTEBUF) */
@@ -4299,7 +4298,7 @@ FILLER(sys_creat_e, true)
 	 */
 	mode = bpf_syscall_get_argument(data, 1);
 	mode = open_modes_to_scap(O_CREAT, mode);
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	return res;
@@ -4315,7 +4314,7 @@ FILLER(sys_creat_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -4330,7 +4329,7 @@ FILLER(sys_creat_x, true)
 	 */
 	mode = bpf_syscall_get_argument(data, 1);
 	mode = open_modes_to_scap(O_CREAT, mode);
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	bpf_get_fd_dev_ino(retval, &dev, &ino);
@@ -4338,16 +4337,18 @@ FILLER(sys_creat_x, true)
 	/*
 	 * Device
 	 */
-	res = bpf_val_to_ring(data, dev);
+	res = bpf_push_u32_to_ring(data, dev);
 	CHECK_RES(res);
 
 	/*
 	 * Ino
 	 */
-	res = bpf_val_to_ring(data, ino);
+	res = bpf_push_u64_to_ring(data, ino);
 
 	return res;
 }
+
+// TODO RESUME FROM HERE
 
 FILLER(sys_pipe_x, true)
 {

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -5111,19 +5111,19 @@ FILLER(sys_signaldeliver_e, false)
 	/*
 	 * source pid
 	 */
-	res = bpf_val_to_ring(data, spid);
+	res = bpf_push_s64_to_ring(data, spid);
 	CHECK_RES(res);
 
 	/*
 	 * destination pid
 	 */
-	res = bpf_val_to_ring(data, bpf_get_current_pid_tgid() & 0xffffffff);
+	res = bpf_push_s64_to_ring(data, bpf_get_current_pid_tgid() & 0xffffffff);
 	CHECK_RES(res);
 
 	/*
 	 * signal number
 	 */
-	res = bpf_val_to_ring(data, sig);
+	res = bpf_push_u8_to_ring(data, sig);
 
 	return res;
 }
@@ -5133,11 +5133,11 @@ FILLER(sys_quotactl_e, true)
 	/* Parameter 1: cmd (type: PT_FLAGS16) */
 	uint32_t cmd = (uint32_t)bpf_syscall_get_argument(data, 0);
 	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
-	int res = bpf_val_to_ring_type(data, scap_cmd, PT_FLAGS16);
+	int res = bpf_push_s16_to_ring(data, scap_cmd);
 	CHECK_RES(res);
 
 	/* Parameter 2: type (type: PT_FLAGS8) */
-	res = bpf_val_to_ring_type(data, quotactl_type_to_scap(cmd), PT_FLAGS8);
+	res = bpf_push_u8_to_ring(data, quotactl_type_to_scap(cmd));
 	CHECK_RES(res);
 
 	/* Parameter 3: id (type: PT_UINT32) */
@@ -5148,11 +5148,11 @@ FILLER(sys_quotactl_e, true)
 	   scap_cmd != PPM_Q_XSETQLIM)
 	{
 		/* In this case `id` don't represent a `userid` or a `groupid` */
-		res = bpf_val_to_ring_type(data, 0, PT_UINT32);
+		res = bpf_push_u32_to_ring(data, 0);
 	}
 	else
 	{
-		res = bpf_val_to_ring_type(data, id, PT_UINT32);
+		res = bpf_push_u32_to_ring(data, id);
 	}
 
 	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
@@ -5161,7 +5161,7 @@ FILLER(sys_quotactl_e, true)
 	{
 		quota_fmt = quotactl_fmt_to_scap(id);
 	}
-	return bpf_val_to_ring_type(data, quota_fmt, PT_FLAGS8);
+	return bpf_push_u8_to_ring(data, quota_fmt);
 }
 
 FILLER(sys_quotactl_x, true)
@@ -5184,7 +5184,7 @@ FILLER(sys_quotactl_x, true)
 	 * return value
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -5219,52 +5219,52 @@ FILLER(sys_quotactl_x, true)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
 	if (dqblk.dqb_valid & QIF_BLIMITS) {
-		res = bpf_val_to_ring_type(data, dqblk.dqb_bhardlimit, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_bhardlimit);
 		CHECK_RES(res);
 
-		res = bpf_val_to_ring_type(data, dqblk.dqb_bsoftlimit, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_bsoftlimit);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 
-		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_SPACE) {
-		res = bpf_val_to_ring_type(data, dqblk.dqb_curspace, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_curspace);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_ILIMITS) {
-		res = bpf_val_to_ring_type(data, dqblk.dqb_ihardlimit, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_ihardlimit);
 		CHECK_RES(res);
-		res = bpf_val_to_ring_type(data, dqblk.dqb_isoftlimit, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_isoftlimit);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
-		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_BTIME) {
-		res = bpf_val_to_ring_type(data, dqblk.dqb_btime, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_btime);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_ITIME) {
-		res = bpf_val_to_ring_type(data, dqblk.dqb_itime, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, dqblk.dqb_itime);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
@@ -5278,26 +5278,26 @@ FILLER(sys_quotactl_x, true)
 	}
 
 	if (dqinfo.dqi_valid & IIF_BGRACE) {
-		res = bpf_val_to_ring_type(data, dqinfo.dqi_bgrace, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, dqinfo.dqi_bgrace);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqinfo.dqi_valid & IIF_IGRACE) {
-		res = bpf_val_to_ring_type(data, dqinfo.dqi_igrace, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, dqinfo.dqi_igrace);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
+		res = bpf_push_u64_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
 	if (dqinfo.dqi_valid & IIF_FLAGS) {
-		res = bpf_val_to_ring_type(data, dqinfo.dqi_flags, PT_FLAGS8);
+		res = bpf_push_u8_to_ring(data, dqinfo.dqi_flags);
 		CHECK_RES(res);
 	} else {
-		res = bpf_val_to_ring_type(data, 0, PT_FLAGS8);
+		res = bpf_push_u8_to_ring(data, 0);
 		CHECK_RES(res);
 	}
 
@@ -5310,7 +5310,7 @@ FILLER(sys_quotactl_x, true)
 		quota_fmt_out = quotactl_fmt_to_scap(tmp);
 	}
 
-	res = bpf_val_to_ring_type(data, quota_fmt_out, PT_FLAGS8);
+	res = bpf_push_u8_to_ring(data, quota_fmt_out);
 
 	return res;
 }
@@ -5324,21 +5324,21 @@ FILLER(sys_semget_e, true)
 	 * key
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s32_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * nsems
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s32_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * semflg
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, semget_flags_to_scap(val));
+	res = bpf_push_u32_to_ring(data, semget_flags_to_scap(val));
 
 	return res;
 }
@@ -5352,21 +5352,21 @@ FILLER(sys_semctl_e, true)
 	 * semid
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s32_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * semnum
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s32_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * cmd
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, semctl_cmd_to_scap(val));
+	res = bpf_push_u16_to_ring(data, semctl_cmd_to_scap(val));
 	CHECK_RES(res);
 
 	/*
@@ -5377,7 +5377,7 @@ FILLER(sys_semctl_e, true)
 	else
 		val = 0;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s32_to_ring(data, val);
 
 	return res;
 }
@@ -5387,12 +5387,12 @@ FILLER(sys_ptrace_e, true)
 
 	/* Parameter 1: request (type: PT_FLAGS16) */
 	unsigned long request = bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, ptrace_requests_to_scap(request));
+	int res = bpf_push_u16_to_ring(data, ptrace_requests_to_scap(request));
 	CHECK_RES(res);
 
 	/* Parameter 2: pid (type: PT_PID) */
 	pid_t pid = (s32) bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, (s64)pid);
+	return bpf_push_s64_to_ring(data, (s64)pid);
 }
 
 static __always_inline int bpf_parse_ptrace_addr(struct filler_data *data, u16 request)
@@ -5463,7 +5463,7 @@ FILLER(sys_ptrace_x, true)
 	 * res
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	if (retval < 0) {
@@ -5490,27 +5490,23 @@ FILLER(sys_bpf_e, true)
 {
 	/* Parameter 1: cmd (type: PT_INT64) */
 	s32 cmd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)cmd);
+	return bpf_push_s64_to_ring(data, (s64)cmd);
 }
 
 FILLER(sys_bpf_x, true)
 {
-	long fd;
-	int res;
-
 	/*
 	 * fd
 	 */
-	fd = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, fd);
-	return res;
+	long fd = bpf_syscall_get_retval(data->ctx);
+	return bpf_push_s64_to_ring(data, fd);
 }
 
 FILLER(sys_unlinkat_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
@@ -5519,7 +5515,7 @@ FILLER(sys_unlinkat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_val_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (s64)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
@@ -5529,14 +5525,14 @@ FILLER(sys_unlinkat_x, true)
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	unsigned long flags = bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, unlinkat_flags_to_scap(flags));
+	return bpf_push_u32_to_ring(data, unlinkat_flags_to_scap(flags));
 }
 
 FILLER(sys_mkdirat_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
@@ -5545,7 +5541,7 @@ FILLER(sys_mkdirat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_val_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (s64)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
@@ -5555,7 +5551,7 @@ FILLER(sys_mkdirat_x, true)
 
 	/* Parameter 4: mode (type: PT_UINT32) */
 	u32 mode = (u32)bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, mode);
+	return bpf_push_u32_to_ring(data, mode);
 }
 
 FILLER(sys_linkat_x, true)
@@ -5565,7 +5561,7 @@ FILLER(sys_linkat_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -5575,7 +5571,7 @@ FILLER(sys_linkat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -5592,7 +5588,7 @@ FILLER(sys_linkat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -5606,7 +5602,7 @@ FILLER(sys_linkat_x, true)
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 4);
-	res = bpf_val_to_ring(data, linkat_flags_to_scap(val));
+	res = bpf_push_u32_to_ring(data, linkat_flags_to_scap(val));
 
 	return res;
 }
@@ -5646,6 +5642,7 @@ FILLER(sys_autofill, true)
 		else if (arg.id == AF_ID_USEDEFAULT)
 			val = arg.default_val;
 
+		// TODO HOW TO?
 		res = bpf_val_to_ring(data, val);
 		CHECK_RES(res);
 	}
@@ -5657,7 +5654,7 @@ FILLER(sys_fchmodat_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
@@ -5666,7 +5663,7 @@ FILLER(sys_fchmodat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_val_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (s64)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: filename (type: PT_FSRELPATH) */
@@ -5676,7 +5673,7 @@ FILLER(sys_fchmodat_x, true)
 
 	/* Parameter 4: mode (type: PT_MODE) */
 	unsigned long mode = bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, chmod_mode_to_scap(mode));
+	return bpf_push_u32_to_ring(data, chmod_mode_to_scap(mode));
 }
 
 FILLER(sys_chmod_x, true)
@@ -5686,7 +5683,7 @@ FILLER(sys_chmod_x, true)
 	long retval;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -5700,7 +5697,7 @@ FILLER(sys_chmod_x, true)
 	 * mode
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u32_to_ring(data, val);
 
 	return res;
 }
@@ -5709,24 +5706,24 @@ FILLER(sys_fchmod_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: mode (type: PT_MODE) */
 	unsigned long mode = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, chmod_mode_to_scap(mode));
+	return bpf_push_u32_to_ring(data, chmod_mode_to_scap(mode));
 }
 
 FILLER(sys_chown_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: path (type: PT_FSPATH) */
@@ -5736,19 +5733,19 @@ FILLER(sys_chown_x, true)
 
 	/* Parameter 3: uid (type: PT_UINT32) */
 	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, uid);
+	res = bpf_push_u32_to_ring(data, uid);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
 	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, gid);
+	return bpf_push_u32_to_ring(data, gid);
 }
 
 FILLER(sys_lchown_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: path (type: PT_FSPATH) */
@@ -5758,41 +5755,41 @@ FILLER(sys_lchown_x, true)
 
 	/* Parameter 3: uid (type: PT_UINT32) */
 	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, uid);
+	res = bpf_push_u32_to_ring(data, uid);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
 	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, gid);
+	return bpf_push_u32_to_ring(data, gid);
 }
 
 FILLER(sys_fchown_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
 	u32 uid = (u32)bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, uid);
+	res = bpf_push_u32_to_ring(data, uid);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
 	u32 gid = (u32)bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, gid);
+	return bpf_push_u32_to_ring(data, gid);
 }
 
 FILLER(sys_fchownat_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
@@ -5801,7 +5798,7 @@ FILLER(sys_fchownat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_val_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (s64)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: pathname (type: PT_FSRELPATH) */
@@ -5811,17 +5808,17 @@ FILLER(sys_fchownat_x, true)
 
 	/* Parameter 3: uid (type: PT_UINT32) */
 	u32 uid = (u32)bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, uid);
+	res = bpf_push_u32_to_ring(data, uid);
 	CHECK_RES(res);
 
 	/* Parameter 4: gid (type: PT_UINT32) */
 	u32 gid = (u32)bpf_syscall_get_argument(data, 3);
-	res = bpf_val_to_ring(data, gid);
+	res = bpf_push_u32_to_ring(data, gid);
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
 	unsigned long flags = bpf_syscall_get_argument(data, 4);
-	return bpf_val_to_ring(data, fchownat_flags_to_scap(flags));
+	return bpf_push_u32_to_ring(data, fchownat_flags_to_scap(flags));
 }
 
 FILLER(sys_copy_file_range_e, true)
@@ -5830,17 +5827,17 @@ FILLER(sys_copy_file_range_e, true)
 
 	/* Parameter 1: fdin (type: PT_FD) */
 	s32 fdin = (s32)bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, (s64)fdin);
+	res = bpf_push_s64_to_ring(data, (s64)fdin);
 	CHECK_RES(res);
 
 	/* Parameter 2: offin (type: PT_UINT64) */
 	u64 offin = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, offin);
+	res = bpf_push_u64_to_ring(data, offin);
 	CHECK_RES(res);
 
 	/* Parameter 3: len (type: PT_UINT64) */
 	u64 len = bpf_syscall_get_argument(data, 4);
-	return bpf_val_to_ring(data, len);
+	return bpf_push_u64_to_ring(data, len);
 }
 
 FILLER(sys_copy_file_range_x, true)
@@ -5851,13 +5848,13 @@ FILLER(sys_copy_file_range_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	
 	/*
 	* fdout
 	*/
 	fdout = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, fdout);
+	res = bpf_push_s64_to_ring(data, fdout);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 
@@ -5865,7 +5862,7 @@ FILLER(sys_copy_file_range_x, true)
 	* offout
 	*/
 	offout = bpf_syscall_get_argument(data, 3);
-	res = bpf_val_to_ring(data, offout);
+	res = bpf_push_u64_to_ring(data, offout);
 	if (unlikely(res != PPM_SUCCESS))
 		return res;
 	
@@ -5880,7 +5877,7 @@ FILLER(sys_capset_x, true)
 	kernel_cap_t cap;
 	
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	struct task_struct *task = (struct task_struct *) bpf_get_current_task();
@@ -5888,22 +5885,19 @@ FILLER(sys_capset_x, true)
 
 	cap = _READ(cred->cap_inheritable);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
-	res = bpf_val_to_ring(data, capabilities_to_scap(val));
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(val));
 	if(unlikely(res != PPM_SUCCESS))
 		return res;
 
 	cap = _READ(cred->cap_permitted);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
-	res = bpf_val_to_ring(data, capabilities_to_scap(val));
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(val));
 	if(unlikely(res != PPM_SUCCESS))
 		return res;
 
 	cap = _READ(cred->cap_effective);
 	val = ((unsigned long)cap.cap[1] << 32) | cap.cap[0];
-	res = bpf_val_to_ring(data, capabilities_to_scap(val));
-	if(unlikely(res != PPM_SUCCESS))
-		return res;
-
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(val));
 	return res;
 }
 
@@ -5916,23 +5910,23 @@ FILLER(sys_splice_e, true)
 	/* Parameter 1: fd_in (type: PT_FD) */
 	val = bpf_syscall_get_argument(data, 0);
 	fd_in = (int32_t)val;
-	res = bpf_val_to_ring(data, (int64_t)fd_in);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd_in);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
 	val = bpf_syscall_get_argument(data, 2);
 	fd_out = (int32_t)val;
-	res = bpf_val_to_ring(data, (int64_t)fd_out);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd_out);
 	CHECK_RES(res);
 
 	/* Parameter 3: size (type: PT_UINT64) */
 	val = bpf_syscall_get_argument(data, 4);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	val = bpf_syscall_get_argument(data, 5);
-	return bpf_val_to_ring(data, splice_flags_to_scap(val));
+	return bpf_push_s32_to_ring(data, splice_flags_to_scap(val));
 }
 
 FILLER(sys_dup_e, true)
@@ -5943,7 +5937,7 @@ FILLER(sys_dup_e, true)
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 
 	return res;
 }
@@ -5955,13 +5949,13 @@ FILLER(sys_dup_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 
 	return res;
 }
@@ -5974,7 +5968,7 @@ FILLER(sys_dup2_e, true)
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 
 	return res;
 }
@@ -5986,20 +5980,20 @@ FILLER(sys_dup2_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * newfd
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	
 	return res;
 }
@@ -6012,7 +6006,7 @@ FILLER(sys_dup3_e, true)
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 
 	return res;
 }
@@ -6025,20 +6019,20 @@ FILLER(sys_dup3_x, true)
 	unsigned long res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * newfd
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -6046,7 +6040,7 @@ FILLER(sys_dup3_x, true)
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	flags = dup3_flags_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 
 	return res;
 }
@@ -6055,7 +6049,7 @@ FILLER(sys_umount_x, true)
 {
 	/* Parameter 1: ret (type: PT_FD) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: name (type: PT_FSPATH) */
@@ -6067,14 +6061,14 @@ FILLER(sys_umount2_e, true)
 {
 	/* Parameter 1: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, flags);
+	return bpf_push_u32_to_ring(data, flags);
 }
 
 FILLER(sys_umount2_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: name (type: PT_FSPATH) */
@@ -6086,7 +6080,7 @@ FILLER(sys_getcwd_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* we get the path only in case of success, in case of failure we would read only userspace junk */
@@ -6108,14 +6102,14 @@ FILLER(sys_getdents_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_getdents64_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 #ifdef CAPTURE_SCHED_PROC_EXEC
@@ -6134,11 +6128,8 @@ FILLER(sched_prog_exec, false)
 	/* Please note: if this filler is called the execve is correctly
 	 * performed, so the return value will be always 0.
 	 */
-	res = bpf_val_to_ring_type(data, 0, PT_ERRNO);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, 0);
+	CHECK_RES(res);
 
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	struct mm_struct *mm = _READ(task->mm);
@@ -6226,63 +6217,42 @@ FILLER(sched_prog_exec, false)
 
 	/* Parameter 4: tid (type: PT_PID) */
 	pid_t pid = _READ(task->pid);
-	res = bpf_val_to_ring_type(data, pid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, pid);
+	CHECK_RES(res);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	pid_t tgid = _READ(task->tgid);
-	res = bpf_val_to_ring_type(data, tgid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, tgid);
+	CHECK_RES(res);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	struct task_struct *real_parent = _READ(task->real_parent);
 	pid_t ptid = _READ(real_parent->pid);
-	res = bpf_val_to_ring_type(data, ptid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, ptid);
+	CHECK_RES(res);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
 	res = bpf_push_empty_param(data);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	struct signal_struct *signal = _READ(task->signal);
 	unsigned long fdlimit = _READ(signal->rlim[RLIMIT_NOFILE].rlim_cur);
-	res = bpf_val_to_ring_type(data, fdlimit, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, fdlimit);
+	CHECK_RES(res);
 
 	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	unsigned long maj_flt = _READ(task->maj_flt);
-	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, maj_flt);
+	CHECK_RES(res);
 
 	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	unsigned long min_flt = _READ(task->min_flt);
-	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, min_flt);
+	CHECK_RES(res);
 
 	unsigned long total_vm = 0;
 	unsigned long total_rss = 0;
@@ -6297,32 +6267,20 @@ FILLER(sched_prog_exec, false)
 	}
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, total_vm);
+	CHECK_RES(res);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, total_rss);
+	CHECK_RES(res);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, swap, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, swap);
+	CHECK_RES(res);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = bpf_val_to_ring_type_mem(data, (unsigned long)task->comm, PT_CHARBUF, KERNEL);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_exec_2);
 	bpf_printk("Can't tail call 'sched_prog_exec_2' filler\n");
@@ -6336,17 +6294,11 @@ FILLER(sched_prog_exec_2, false)
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 
 	res = bpf_append_cgroup(task, data->tmp_scratch, &cgroups_len);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = __bpf_val_to_ring(data, (unsigned long)data->tmp_scratch, cgroups_len, PT_BYTEBUF, -1, false, KERNEL);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_exec_3);
 	bpf_printk("Can't tail call 'sched_prog_exec_3' filler\n");
@@ -6396,25 +6348,16 @@ FILLER(sched_prog_exec_3, false)
 	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
 	data->curarg_already_on_frame = true;
 	res = __bpf_val_to_ring(data, 0, env_len, PT_BYTEBUF, -1, false, KERNEL);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	/* Parameter 17: tty (type: PT_INT32) */
 	int tty = bpf_ppm_get_tty(task);
-	res = bpf_val_to_ring_type(data, tty, PT_INT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s32_to_ring(data, tty);
+	CHECK_RES(res);
 
 	/* Parameter 18: pgid (type: PT_PID) */
-	res = bpf_val_to_ring_type(data, bpf_task_pgrp_vnr(task), PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, bpf_task_pgrp_vnr(task));
+	CHECK_RES(res);
 
 	/* TODO: implement user namespace support */
 	kuid_t loginuid;
@@ -6439,11 +6382,8 @@ FILLER(sched_prog_exec_3, false)
 #endif /* CONFIG_AUDIT... */
 
 	/* Parameter 19: loginuid (type: PT_INT32) */
-	res = bpf_val_to_ring_type(data, loginuid.val, PT_INT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s32_to_ring(data, loginuid.val, PT_INT32);
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_exec_4);
 	bpf_printk("Can't tail call 'sched_prog_exec_4' filler\n");
@@ -6486,44 +6426,44 @@ FILLER(sched_prog_exec_4, false)
 	}
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	int res = bpf_val_to_ring_type(data, flags, PT_UINT32);
+	int res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
 	kernel_cap_t cap = _READ(cred->cap_inheritable);
-	res = bpf_val_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
 	CHECK_RES(res);
 
 	/* Parameter 22: cap_permitted (type: PT_UINT64) */
 	cap = _READ(cred->cap_permitted);
-	res = bpf_val_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
 	CHECK_RES(res);
 
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
 	cap = _READ(cred->cap_effective);
-	res = bpf_val_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
+	res = bpf_push_u64_to_ring(data, capabilities_to_scap(((unsigned long)cap.cap[1] << 32) | cap.cap[0]));
 	CHECK_RES(res);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
 	unsigned long ino = _READ(inode->i_ino);
-	res = bpf_val_to_ring_type(data, ino, PT_UINT64);
+	res = bpf_push_u64_to_ring(data, ino);
 	CHECK_RES(res);
 
 	struct timespec64 time = {0};
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	time = _READ(inode->i_ctime);
-	res = bpf_val_to_ring_type(data, bpf_epoch_ns_from_time(time), PT_ABSTIME);
+	res = bpf_push_u64_to_ring(data, bpf_epoch_ns_from_time(time));
 	CHECK_RES(res);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	time = _READ(inode->i_mtime);
-	res = bpf_val_to_ring_type(data, bpf_epoch_ns_from_time(time), PT_ABSTIME);
+	res = bpf_push_u64_to_ring(data, bpf_epoch_ns_from_time(time));
 	CHECK_RES(res);
 
 	/* Parameter 27: uid */
 	euid = _READ(cred->euid);
-	return bpf_val_to_ring_type(data, euid.val, PT_UINT32);
+	return bpf_push_u32_to_ring(data, euid.val, PT_UINT32);
 }
 #endif
 
@@ -6554,11 +6494,8 @@ FILLER(sched_prog_fork, false)
 	/* Please note: here we are in the clone child exit
 	 * event, so the return value will be always 0.
 	 */
-	res = bpf_val_to_ring_type(data, 0, PT_ERRNO);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, 0);
+	CHECK_RES(res);
 
 	struct mm_struct *mm = _READ(child->mm);
 	if(!mm)
@@ -6641,63 +6578,42 @@ FILLER(sched_prog_fork, false)
 
 	/* Parameter 4: tid (type: PT_PID) */
 	pid_t pid = _READ(child->pid);
-	res = bpf_val_to_ring_type(data, pid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, pid);
+	CHECK_RES(res);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	pid_t tgid = _READ(child->tgid);
-	res = bpf_val_to_ring_type(data, tgid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, tgid);
+	CHECK_RES(res);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	struct task_struct *real_parent = _READ(child->real_parent);
 	pid_t ptid = _READ(real_parent->pid);
-	res = bpf_val_to_ring_type(data, ptid, PT_PID);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_s64_to_ring(data, ptid);
+	CHECK_RES(res);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF)
 	 * cwd, pushed empty to avoid breaking compatibility
 	 * with the older event format
 	 */
 	res = bpf_push_empty_param(data);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	/* Parameter 8: fdlimit (type: PT_UINT64) */
 	struct signal_struct *signal = _READ(child->signal);
 	unsigned long fdlimit = _READ(signal->rlim[RLIMIT_NOFILE].rlim_cur);
-	res = bpf_val_to_ring_type(data, fdlimit, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, fdlimit);
+	CHECK_RES(res);
 
 	/* Parameter 9: pgft_maj (type: PT_UINT64) */
 	unsigned long maj_flt = _READ(child->maj_flt);
-	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, maj_flt);
+	CHECK_RES(res);
 
 	/* Parameter 10: pgft_min (type: PT_UINT64) */
 	unsigned long min_flt = _READ(child->min_flt);
-	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u64_to_ring(data, min_flt);
+	CHECK_RES(res);
 
 	unsigned long total_vm = 0;
 	unsigned long total_rss = 0;
@@ -6712,32 +6628,20 @@ FILLER(sched_prog_fork, false)
 	}
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, total_vm);
+	CHECK_RES(res);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, total_rss);
+	CHECK_RES(res);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, swap, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, swap);
+	CHECK_RES(res);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
 	res = bpf_val_to_ring_type_mem(data, (unsigned long)child->comm, PT_CHARBUF, KERNEL);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_fork_2);
 	bpf_printk("Can't tail call 'sched_prog_fork_2' filler\n");
@@ -6752,17 +6656,11 @@ FILLER(sched_prog_fork_2, false)
 	struct task_struct *child = (struct task_struct *)original_ctx->child;
 
 	res = bpf_append_cgroup(child, data->tmp_scratch, &cgroups_len);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
 	res = __bpf_val_to_ring(data, (unsigned long)data->tmp_scratch, cgroups_len, PT_BYTEBUF, -1, false, KERNEL);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_fork_3);
 	bpf_printk("Can't tail call 'sched_prog_fork_3' filler\n");
@@ -6815,39 +6713,30 @@ FILLER(sched_prog_fork_3, false)
 	}
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
-	res = bpf_val_to_ring_type(data, flags, PT_FLAGS32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, flags);
+	CHECK_RES(res);
 
 	struct cred *cred = (struct cred *)_READ(child->cred);
 
 	/* Parameter 17: uid (type: PT_UINT32) */
 	kuid_t euid = _READ(cred->euid);
-	res = bpf_val_to_ring_type(data, euid.val, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, euid.val);
+	CHECK_RES(res);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
 	kgid_t egid = _READ(cred->egid);
-	res = bpf_val_to_ring_type(data, egid.val, PT_UINT32);
-	if(res != PPM_SUCCESS)
-	{
-		return res;
-	}
+	res = bpf_push_u32_to_ring(data, egid.val);
+	CHECK_RES(res);
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = bpf_task_pid_vnr(child);
-	res = bpf_val_to_ring_type(data, vtid, PT_PID);
+	res = bpf_push_s64_to_ring(data, vtid);
 	if(res != PPM_SUCCESS)
 		return res;
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = bpf_task_tgid_vnr(child);
-	res = bpf_val_to_ring_type(data, vpid, PT_PID);
+	res = bpf_push_s64_to_ring(data, vpid);
 	CHECK_RES(res);
 
 	/* Parameter 21: pid_namespace init task start_time monotonic time in ns (type: PT_UINT64) */
@@ -6857,7 +6746,7 @@ FILLER(sched_prog_fork_3, false)
 		struct task_struct *child_reaper = (struct task_struct *)_READ(pidns->child_reaper);
 		pidns_init_start_time = _READ(child_reaper->start_time);
 	}
-	return bpf_val_to_ring_type(data, pidns_init_start_time, PT_UINT64);
+	return bpf_push_u64_to_ring(data, pidns_init_start_time);
 }
 #endif
 
@@ -6870,14 +6759,14 @@ FILLER(sys_prctl_x, true)
 	long retval;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
 	 * option
 	 */
 	option = prctl_options_to_scap(bpf_syscall_get_argument(data, 0));
-	res = bpf_val_to_ring(data, option);
+	res = bpf_push_u32_to_ring(data, option);
 	CHECK_RES(res);
 
 	arg2 = bpf_syscall_get_argument(data, 1);
@@ -6893,7 +6782,7 @@ FILLER(sys_prctl_x, true)
 			/*
 			 * arg2_int
 			 */
-			res = bpf_val_to_ring(data, 0);
+			res = bpf_push_s64_to_ring(data, 0);
 			CHECK_RES(res);
 			break;
 		case PPM_PR_GET_CHILD_SUBREAPER:
@@ -6906,7 +6795,7 @@ FILLER(sys_prctl_x, true)
 			 * arg2_int
 			 */
 			bpf_probe_read_user(&arg2_int,sizeof(arg2_int),(void*)arg2);
-			res = bpf_val_to_ring(data, (int)arg2_int);
+			res = bpf_push_s64_to_ring(data, (int)arg2_int);
 			CHECK_RES(res);
 			break;
 		case PPM_PR_SET_CHILD_SUBREAPER:
@@ -6919,7 +6808,7 @@ FILLER(sys_prctl_x, true)
 			/*
 			 * arg2_int
 			 */
-			res = bpf_val_to_ring(data, arg2);
+			res = bpf_push_s64_to_ring(data, arg2);
 			CHECK_RES(res);
 			break;
 	}

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -3035,14 +3035,7 @@ FILLER(sys_openat2_e, true)
 	if (bpf_probe_read_user(&how, sizeof(struct open_how), (void *)val)) {
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
-	if (how.flags <= U32_MAX)
-	{
-		flags = open_flags_to_scap(how.flags);
-	}
-	else
-	{
-		flags = 0;
-	}
+	flags = open_flags_to_scap(how.flags);
 	mode = open_modes_to_scap(how.flags, how.mode);
 	resolve = openat2_resolve_to_scap(how.resolve);
 #else
@@ -3114,14 +3107,7 @@ FILLER(sys_openat2_x, true)
 	if (bpf_probe_read_user(&how, sizeof(struct open_how), (void *)val)) {
 		return PPM_FAILURE_INVALID_USER_MEMORY;
 	}
-	if (how.flags <= U32_MAX)
-	{
-		flags = open_flags_to_scap(how.flags);
-	}
-	else
-	{
-		flags = 0;
-	}
+	flags = open_flags_to_scap(how.flags);
 	mode = open_modes_to_scap(how.flags, how.mode);
 	resolve = openat2_resolve_to_scap(how.resolve);
 #else

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -634,8 +634,7 @@ static __always_inline int bpf_parse_readv_writev_bufs(struct filler_data *data,
 
 	if (flags & PRB_FLAG_PUSH_SIZE) {
 		res = bpf_push_u32_to_ring(data, (u32)size);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (flags & PRB_FLAG_PUSH_DATA) {
@@ -950,40 +949,35 @@ FILLER(sys_mmap_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_push_u64_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * length
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_push_u64_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * prot
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	res = bpf_push_u32_to_ring(data, prot_flags_to_scap(val));
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 3);
 	res = bpf_push_u32_to_ring(data, mmap_flags_to_scap(val));
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * fd
 	 */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 4);
 	res = bpf_push_s64_to_ring(data, (s64)fd);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * offset/pgoffset
@@ -1573,8 +1567,7 @@ FILLER(sys_sendto_e, true)
 	 */
 	fd = bpf_syscall_get_argument(data, 0);
 	res = f_sys_send_e_common(data, fd);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Get the address
@@ -1919,32 +1912,27 @@ static __always_inline int bpf_append_cgroup(struct task_struct *task,
 
 #if IS_ENABLED(CONFIG_CPUSETS)
 	res = __bpf_append_cgroup(cgroups, cpuset_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 #endif
 
 #if IS_ENABLED(CONFIG_CGROUP_SCHED)
 	res = __bpf_append_cgroup(cgroups, cpu_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 #endif
 
 #if IS_ENABLED(CONFIG_CGROUP_CPUACCT)
 	res = __bpf_append_cgroup(cgroups, cpuacct_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 #endif
 
 #if IS_ENABLED(CONFIG_BLK_CGROUP)
 	res = __bpf_append_cgroup(cgroups, io_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 #endif
 
 #if IS_ENABLED(CONFIG_MEMCG)
 	res = __bpf_append_cgroup(cgroups, memory_cgrp_id, buf, len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 #endif
 
 	return PPM_SUCCESS;
@@ -2336,8 +2324,7 @@ FILLER(proc_startupdate, true)
 		 */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, exe_len, PT_CHARBUF, -1, false, KERNEL);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		args_len -= exe_len;
 		if (args_len < 0)
@@ -2348,22 +2335,19 @@ FILLER(proc_startupdate, true)
 		 */
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, args_len, PT_BYTEBUF, -1, false, KERNEL);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		/*
 		 * exe
 		 */
 		res = bpf_push_empty_param(data);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * Args
 		 */
 		res = bpf_push_empty_param(data);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	/*
@@ -2448,15 +2432,13 @@ FILLER(proc_startupdate, true)
 	 * vm_swap
 	 */
 	res = bpf_push_u32_to_ring(data, swap);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * comm
 	 */
 	res = bpf_val_to_ring_type_mem(data, (unsigned long)task->comm, PT_CHARBUF, KERNEL);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_proc_startupdate_2);
 	bpf_printk("Can't tail call f_proc_startupdate_2 filler\n");
@@ -2475,12 +2457,10 @@ FILLER(proc_startupdate_2, true)
 	 * cgroups
 	 */
 	res = bpf_append_cgroup(task, data->tmp_scratch, &cgroups_len);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	res = __bpf_val_to_ring(data, (unsigned long)data->tmp_scratch, cgroups_len, PT_BYTEBUF, -1, false, KERNEL);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_proc_startupdate_3);
 	bpf_printk("Can't tail call f_proc_startupdate_3 filler\n");
@@ -2568,8 +2548,7 @@ FILLER(proc_startupdate_3, true)
 		}
 
 		res = bpf_push_u32_to_ring(data, flags);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * This logic is wrong and doesn't account for user
@@ -2585,8 +2564,7 @@ FILLER(proc_startupdate_3, true)
 		 * uid
 		 */
 		res = bpf_push_u32_to_ring(data, euid.val);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		egid = _READ(cred->egid);
 
@@ -2594,16 +2572,14 @@ FILLER(proc_startupdate_3, true)
 		 * gid
 		 */
 		res = bpf_push_u32_to_ring(data, egid.val);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * vtid
 		 */
 		vtid = bpf_task_pid_vnr(task);
 		res = bpf_push_s64_to_ring(data, vtid);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * vpid
@@ -2690,8 +2666,7 @@ FILLER(proc_startupdate_3, true)
 
 		data->curarg_already_on_frame = true;
 		res = __bpf_val_to_ring(data, 0, env_len, PT_BYTEBUF, -1, false, KERNEL);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * tty
@@ -2699,15 +2674,13 @@ FILLER(proc_startupdate_3, true)
 		tty = bpf_ppm_get_tty(task);
 
 		res = bpf_push_s32_to_ring(data, tty);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * pgid
 		 */
 		res = bpf_push_s64_to_ring(data, bpf_task_pgrp_vnr(task));
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		/*
 		 * loginuid
@@ -2731,8 +2704,7 @@ FILLER(proc_startupdate_3, true)
 #endif /* CONFIG_AUDIT... */
 
 		res = bpf_push_s32_to_ring(data, loginuid.val);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_execve_family_flags);
 		bpf_printk("Can't tail call execve_family_flags filler\n");
@@ -2973,8 +2945,7 @@ FILLER(sys_generic, true)
 	 * id
 	 */
 	res = bpf_val_to_ring(data, scap_id);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	if (data->state->tail_ctx.evt_type == PPME_GENERIC_E) {
 		/*
@@ -3001,16 +2972,14 @@ FILLER(sys_openat_e, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * name
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Flags
@@ -3019,8 +2988,7 @@ FILLER(sys_openat_e, true)
 	val = bpf_syscall_get_argument(data, 2);
 	flags = open_flags_to_scap(val);
 	res = bpf_val_to_ring(data, flags);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode
@@ -3028,8 +2996,7 @@ FILLER(sys_openat_e, true)
 	mode = bpf_syscall_get_argument(data, 3);
 	mode = open_modes_to_scap(val, mode);
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	return res;
 }
@@ -3046,8 +3013,7 @@ FILLER(sys_openat_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * dirfd
@@ -3057,16 +3023,14 @@ FILLER(sys_openat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * name
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Flags
@@ -3075,8 +3039,7 @@ FILLER(sys_openat_x, true)
 	val = bpf_syscall_get_argument(data, 2);
 	flags = open_flags_to_scap(val);
 	res = bpf_val_to_ring(data, flags);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode
@@ -3084,8 +3047,7 @@ FILLER(sys_openat_x, true)
 	mode = bpf_syscall_get_argument(data, 3);
 	mode = open_modes_to_scap(val, mode);
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	bpf_get_fd_dev_ino(retval, &dev, &ino);
 
@@ -3093,8 +3055,7 @@ FILLER(sys_openat_x, true)
 	 * Device
 	 */
 	res = bpf_val_to_ring(data, dev);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Ino
@@ -3121,16 +3082,14 @@ FILLER(sys_openat2_e, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * name
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 #ifdef __NR_openat2
 	/*
@@ -3154,16 +3113,14 @@ FILLER(sys_openat2_e, true)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
 	res = bpf_val_to_ring(data, flags);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * resolve (extracted from open_how structure)
@@ -3188,8 +3145,7 @@ FILLER(sys_openat2_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * dirfd
@@ -3199,16 +3155,14 @@ FILLER(sys_openat2_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * name
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 #ifdef __NR_openat2
 	/*
@@ -3232,16 +3186,14 @@ FILLER(sys_openat2_x, true)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
 	res = bpf_val_to_ring(data, flags);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode (extracted from open_how structure)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * resolve (extracted from open_how structure)
@@ -3442,15 +3394,13 @@ FILLER(sys_mlock_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * len
 	 */
@@ -3469,22 +3419,19 @@ FILLER(sys_mlock2_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * len
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * flags
 	 */
@@ -3503,15 +3450,13 @@ FILLER(sys_munlock_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * addr
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * len
 	 */
@@ -3529,8 +3474,7 @@ FILLER(sys_mlockall_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * flags
 	 */
@@ -3804,8 +3748,7 @@ FILLER(sys_prlimit_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Copy the user structure and extract cur and max
@@ -3837,22 +3780,19 @@ FILLER(sys_prlimit_x, true)
 	 * newcur
 	 */
 	res = bpf_val_to_ring_type(data, newcur, PT_INT64);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newmax
 	 */
 	res = bpf_val_to_ring_type(data, newmax, PT_INT64);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldcur
 	 */
 	res = bpf_val_to_ring_type(data, oldcur, PT_INT64);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldmax
@@ -3905,8 +3845,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * ruid
@@ -3915,8 +3854,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	id = _READ(*idp);
 
 	res = bpf_val_to_ring(data, id);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * euid
@@ -3925,8 +3863,7 @@ FILLER(sys_getresuid_and_gid_x, true)
 	id = _READ(*idp);
 
 	res = bpf_val_to_ring(data, id);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * suid
@@ -3960,8 +3897,7 @@ FILLER(sys_socket_bind_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * addr
@@ -4004,8 +3940,7 @@ static __always_inline int f_sys_recv_x_common(struct filler_data *data, long re
 	 * res
 	 */
 	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * data
@@ -4071,8 +4006,7 @@ FILLER(sys_recvfrom_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = f_sys_recv_x_common(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	if (retval >= 0) {
 		/*
@@ -4183,8 +4117,7 @@ FILLER(sys_recvmsg_x, true)
 	iovcnt = mh.msg_iovlen;
 
 	res = bpf_parse_readv_writev_bufs(data, iov, iovcnt, retval, PRB_FLAG_PUSH_ALL);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sys_recvmsg_x_2);
 	bpf_printk("Can't tail call f_sys_recvmsg_x_2 filler\n");
@@ -4270,8 +4203,7 @@ FILLER(sys_sendmsg_e, true)
 	 */
 	fd = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring_type(data, fd, PT_FD);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Retrieve the message header
@@ -4288,8 +4220,7 @@ FILLER(sys_sendmsg_e, true)
 
 	res = bpf_parse_readv_writev_bufs(data, iov, iovcnt, 0,
 					  PRB_FLAG_PUSH_SIZE | PRB_FLAG_IS_WRITE);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * tuple
@@ -4361,8 +4292,7 @@ FILLER(sys_creat_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring_mem(data, val, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode
@@ -4370,8 +4300,7 @@ FILLER(sys_creat_e, true)
 	mode = bpf_syscall_get_argument(data, 1);
 	mode = open_modes_to_scap(O_CREAT, mode);
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	return res;
 }
@@ -4387,16 +4316,14 @@ FILLER(sys_creat_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * name
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring_mem(data, val, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode
@@ -4404,8 +4331,7 @@ FILLER(sys_creat_x, true)
 	mode = bpf_syscall_get_argument(data, 1);
 	mode = open_modes_to_scap(O_CREAT, mode);
 	res = bpf_val_to_ring(data, mode);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	bpf_get_fd_dev_ino(retval, &dev, &ino);
 
@@ -4413,8 +4339,7 @@ FILLER(sys_creat_x, true)
 	 * Device
 	 */
 	res = bpf_val_to_ring(data, dev);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Ino
@@ -4516,16 +4441,14 @@ FILLER(sys_lseek_e, true)
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (s32)val;
 	res = bpf_val_to_ring(data, (s64)fd);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * offset
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * whence
@@ -4553,8 +4476,7 @@ FILLER(sys_llseek_e, true)
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (s32)val;
 	res = bpf_val_to_ring(data, (s64)fd);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * offset
@@ -4565,8 +4487,7 @@ FILLER(sys_llseek_e, true)
 	ol = bpf_syscall_get_argument(data, 2);
 	offset = (((u64)oh) << 32) + ((u64)ol);
 	res = bpf_val_to_ring(data, offset);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * whence
@@ -4716,8 +4637,7 @@ FILLER(sys_socket_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	if (retval >= 0 &&
 	    !data->settings->socket_file_ops) {
@@ -4830,8 +4750,7 @@ FILLER(sys_renameat_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * olddirfd
@@ -4842,16 +4761,14 @@ FILLER(sys_renameat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldpath
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring_mem(data, val, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newdirfd
@@ -4862,8 +4779,7 @@ FILLER(sys_renameat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newpath
@@ -4882,8 +4798,7 @@ FILLER(sys_renameat2_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * olddirfd
@@ -4894,16 +4809,14 @@ FILLER(sys_renameat2_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldpath
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring_mem(data, val, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newdirfd
@@ -4914,8 +4827,7 @@ FILLER(sys_renameat2_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newpath
@@ -4940,16 +4852,14 @@ FILLER(sys_symlinkat_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldpath
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring_type_mem(data, val, PT_CHARBUF, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newdirfd
@@ -4960,8 +4870,7 @@ FILLER(sys_symlinkat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring_type(data, val, PT_FD);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newpath
@@ -4983,12 +4892,10 @@ FILLER(cpu_hotplug_e, false)
 	int res;
 
 	res = bpf_val_to_ring(data, data->state->hotplug_cpu);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	res = bpf_val_to_ring(data, 0);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	data->state->hotplug_cpu = 0;
 
@@ -5020,13 +4927,11 @@ FILLER(sys_procexit_e, false)
 
 	/* Exit status */
 	res = bpf_val_to_ring(data, exit_code);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/* Ret code */
 	res = bpf_val_to_ring(data, __WEXITSTATUS(exit_code));
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/* If signaled -> signum, else 0 */
 	if (__WIFSIGNALED(exit_code))
@@ -5035,13 +4940,11 @@ FILLER(sys_procexit_e, false)
 	} else {
 		res = bpf_val_to_ring(data, 0);
 	}
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/* Did it produce a core? */
 	res = bpf_val_to_ring(data, __WCOREDUMP(exit_code) != 0);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 #ifndef BPF_SUPPORTS_RAW_TRACEPOINTS
 	delete_args();
@@ -5075,8 +4978,7 @@ FILLER(sched_switch_e, false)
 	 * next
 	 */
 	res = bpf_val_to_ring_type(data, next_pid, PT_PID);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	task = (struct task_struct *)bpf_get_current_task();
 
@@ -5085,16 +4987,14 @@ FILLER(sched_switch_e, false)
 	 */
 	maj_flt = _READ(task->maj_flt);
 	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * pgft_min
 	 */
 	min_flt = _READ(task->min_flt);
 	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	total_vm = 0;
 	total_rss = 0;
@@ -5112,15 +5012,13 @@ FILLER(sched_switch_e, false)
 	 * vm_size
 	 */
 	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * vm_rss
 	 */
 	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * vm_swap
@@ -5154,12 +5052,10 @@ FILLER(sys_pagefault_e, false)
 #endif
 
 	res = bpf_val_to_ring(data, address);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	res = bpf_val_to_ring(data, ip);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	flags = pf_flags_to_scap(error_code);
 	res = bpf_val_to_ring(data, flags);
@@ -5215,15 +5111,13 @@ FILLER(sys_signaldeliver_e, false)
 	 * source pid
 	 */
 	res = bpf_val_to_ring(data, spid);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * destination pid
 	 */
 	res = bpf_val_to_ring(data, bpf_get_current_pid_tgid() & 0xffffffff);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * signal number
@@ -5290,16 +5184,14 @@ FILLER(sys_quotactl_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * Add special
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring_type_mem(data, val, PT_CHARBUF, USER);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * get addr
@@ -5311,12 +5203,10 @@ FILLER(sys_quotactl_x, true)
 	 */
 	if (cmd == PPM_Q_QUOTAON) {
 		res = bpf_val_to_ring_type_mem(data, val, PT_CHARBUF, USER);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_push_empty_param(data);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	/*
@@ -5329,66 +5219,52 @@ FILLER(sys_quotactl_x, true)
 	}
 	if (dqblk.dqb_valid & QIF_BLIMITS) {
 		res = bpf_val_to_ring_type(data, dqblk.dqb_bhardlimit, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		res = bpf_val_to_ring_type(data, dqblk.dqb_bsoftlimit, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_SPACE) {
 		res = bpf_val_to_ring_type(data, dqblk.dqb_curspace, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_ILIMITS) {
 		res = bpf_val_to_ring_type(data, dqblk.dqb_ihardlimit, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 		res = bpf_val_to_ring_type(data, dqblk.dqb_isoftlimit, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 		res = bpf_val_to_ring_type(data, 0, PT_UINT64);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_BTIME) {
 		res = bpf_val_to_ring_type(data, dqblk.dqb_btime, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqblk.dqb_valid & QIF_ITIME) {
 		res = bpf_val_to_ring_type(data, dqblk.dqb_itime, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	/*
@@ -5402,32 +5278,26 @@ FILLER(sys_quotactl_x, true)
 
 	if (dqinfo.dqi_valid & IIF_BGRACE) {
 		res = bpf_val_to_ring_type(data, dqinfo.dqi_bgrace, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqinfo.dqi_valid & IIF_IGRACE) {
 		res = bpf_val_to_ring_type(data, dqinfo.dqi_igrace, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_RELTIME);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	if (dqinfo.dqi_valid & IIF_FLAGS) {
 		res = bpf_val_to_ring_type(data, dqinfo.dqi_flags, PT_FLAGS8);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	} else {
 		res = bpf_val_to_ring_type(data, 0, PT_FLAGS8);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	quota_fmt_out = PPM_QFMT_NOT_USED;
@@ -5454,16 +5324,14 @@ FILLER(sys_semget_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * nsems
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * semflg
@@ -5484,24 +5352,21 @@ FILLER(sys_semctl_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * semnum
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * cmd
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	res = bpf_val_to_ring(data, semctl_cmd_to_scap(val));
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * optional argument semun/val
@@ -5598,13 +5463,11 @@ FILLER(sys_ptrace_x, true)
 	 */
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	if (retval < 0) {
 		res = bpf_val_to_ring_dyn(data, 0, PT_UINT64, 0);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 
 		res = bpf_val_to_ring_dyn(data, 0, PT_UINT64, 0);
 
@@ -5615,8 +5478,7 @@ FILLER(sys_ptrace_x, true)
 	request = ptrace_requests_to_scap(val);
 
 	res = bpf_parse_ptrace_addr(data, request);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	res = bpf_parse_ptrace_data(data, request);
 
@@ -5703,8 +5565,7 @@ FILLER(sys_linkat_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * olddir
@@ -5714,16 +5575,14 @@ FILLER(sys_linkat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * oldpath
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newdir
@@ -5733,16 +5592,14 @@ FILLER(sys_linkat_x, true)
 		val = PPM_AT_FDCWD;
 
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newpath
 	 */
 	val = bpf_syscall_get_argument(data, 3);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * flags
@@ -5789,8 +5646,7 @@ FILLER(sys_autofill, true)
 			val = arg.default_val;
 
 		res = bpf_val_to_ring(data, val);
-		if (res != PPM_SUCCESS)
-			return res;
+		CHECK_RES(res);
 	}
 
 	return res;
@@ -5830,16 +5686,14 @@ FILLER(sys_chmod_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * filename
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * mode
@@ -6026,8 +5880,7 @@ FILLER(sys_capset_x, true)
 	
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	struct task_struct *task = (struct task_struct *) bpf_get_current_task();
 	struct cred *cred = (struct cred*) _READ(task->cred);
@@ -6102,8 +5955,7 @@ FILLER(sys_dup_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
@@ -6134,15 +5986,13 @@ FILLER(sys_dup2_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newfd
@@ -6175,23 +6025,20 @@ FILLER(sys_dup3_x, true)
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_val_to_ring(data, retval);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 	/*
 	 * oldfd
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * newfd
 	 */
 	val = bpf_syscall_get_argument(data, 1);
 	res = bpf_val_to_ring(data, val);
-	if (res != PPM_SUCCESS)
-		return res;
+	CHECK_RES(res);
 
 	/*
 	 * flags

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -325,7 +325,7 @@ FILLER(sys_single, true)
 	int res;
 
 	val = bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, val);
+	return bpf_push_s64_to_ring(data, val);
 }
 
 FILLER(sys_single_x, true)
@@ -341,7 +341,7 @@ FILLER(sys_fstat_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_open_e, true)
@@ -750,7 +750,7 @@ FILLER(sys_readv_preadv_x, true)
 	else 
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_push_u32_to_ring(data, 0);
 
 		/* Parameter 3: data (type: PT_BYTEBUF) */
 		res = bpf_push_empty_param(data);
@@ -832,7 +832,7 @@ static __always_inline int timespec_parse(struct filler_data *data,
 	struct timespec ts = {};
 #endif	
 	bpf_probe_read_user(&ts, sizeof(ts), (void *)val);
-	return bpf_val_to_ring_type(data, ((u64)ts.tv_sec) * 1000000000 + ts.tv_nsec, PT_RELTIME);
+	return bpf_push_u64_to_ring(data, ((u64)ts.tv_sec) * 1000000000 + ts.tv_nsec);
 }
 
 FILLER(sys_nanosleep_e, true)
@@ -5070,8 +5070,6 @@ static __always_inline int siginfo_not_a_pointer(struct siginfo* info)
 	return info == (struct siginfo*)SEND_SIG_NOINFO || info == (struct siginfo*)SEND_SIG_PRIV;
 #endif
 }
-
-// TODO RESUME FROM HERE
 
 FILLER(sys_signaldeliver_e, false)
 {

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2805,7 +2805,6 @@ FILLER(sys_accept4_e, true)
 	return res;
 }
 
-// TODO RESUME FROM HERE
 FILLER(sys_accept_x, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
@@ -2814,7 +2813,7 @@ FILLER(sys_accept_x, true)
 	 * in the stack, and therefore we can consume them.
 	 */
 	s32 fd = (s32)bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, (s64)fd, PT_FD);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	u32 queuelen = 0;
@@ -2847,43 +2846,43 @@ FILLER(sys_accept_x, true)
 	}
 
 	/* Parameter 3: queuepct (type: PT_UINT8) */
-	res = bpf_val_to_ring_type(data, queuepct, PT_UINT8);
+	res = bpf_push_u8_to_ring(data, queuepct);
 	CHECK_RES(res);
 
 	/* Parameter 4: queuelen (type: PT_UINT32) */
-	res = bpf_val_to_ring_type(data, queuelen, PT_UINT32);
+	res = bpf_push_u32_to_ring(data, queuelen);
 	CHECK_RES(res);
 
 	/* Parameter 5: queuemax (type: PT_UINT32) */
-	return bpf_val_to_ring_type(data, queuemax, PT_UINT32);
+	return bpf_push_u32_to_ring(data, queuemax);
 }
 
 FILLER(sys_close_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_close_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO)*/
 	long retval = bpf_syscall_get_retval(data->ctx);
-	return bpf_val_to_ring(data, retval);
+	return bpf_push_s64_to_ring(data, retval);
 }
 
 FILLER(sys_fchdir_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (s64)fd);
 }
 
 FILLER(sys_fchdir_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO)*/
 	long retval = bpf_syscall_get_retval(data->ctx);
-	return bpf_val_to_ring(data, retval);
+	return bpf_push_s64_to_ring(data, retval);
 }
 
 FILLER(sys_setns_e, true)
@@ -2900,14 +2899,14 @@ FILLER(sys_setns_e, true)
 
 FILLER(sys_setpgid_e, true)
 {
-	/* Parameter 1: pid (type: PT_FD) */
+	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)pid);
+	int res = bpf_push_s64_to_ring(data, (s64)pid);
 	CHECK_RES(res);
 
 	/* Parameter 2: pgid (type: PT_PID) */
 	pid_t pgid = (s32)bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, (s64)pgid);
+	return bpf_push_s64_to_ring(data, (s64)pgid);
 }
 
 FILLER(sys_unshare_e, true)
@@ -2918,7 +2917,7 @@ FILLER(sys_unshare_e, true)
 
 	val = bpf_syscall_get_argument(data, 0);
 	flags = clone_flags_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_s32_to_ring(data, flags);
 
 	return res;
 }
@@ -2944,14 +2943,14 @@ FILLER(sys_generic, true)
 	/*
 	 * id
 	 */
-	res = bpf_val_to_ring(data, scap_id);
+	res = bpf_push_u16_to_ring(data, scap_id);
 	CHECK_RES(res);
 
 	if (data->state->tail_ctx.evt_type == PPME_GENERIC_E) {
 		/*
 		 * native id
 		 */
-		res = bpf_val_to_ring(data, native_id);
+		res = bpf_push_u16_to_ring(data, native_id);
 	}
 
 	return res;
@@ -2971,7 +2970,7 @@ FILLER(sys_openat_e, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -2987,7 +2986,7 @@ FILLER(sys_openat_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	flags = open_flags_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/*
@@ -2995,7 +2994,7 @@ FILLER(sys_openat_e, true)
 	 */
 	mode = bpf_syscall_get_argument(data, 3);
 	mode = open_modes_to_scap(val, mode);
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	return res;
@@ -3012,7 +3011,7 @@ FILLER(sys_openat_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -3022,7 +3021,7 @@ FILLER(sys_openat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -3038,7 +3037,7 @@ FILLER(sys_openat_x, true)
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	flags = open_flags_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	CHECK_RES(res);
 
 	/*
@@ -3046,7 +3045,7 @@ FILLER(sys_openat_x, true)
 	 */
 	mode = bpf_syscall_get_argument(data, 3);
 	mode = open_modes_to_scap(val, mode);
-	res = bpf_val_to_ring(data, mode);
+	res = bpf_push_u32_to_ring(data, mode);
 	CHECK_RES(res);
 
 	bpf_get_fd_dev_ino(retval, &dev, &ino);
@@ -3054,16 +3053,17 @@ FILLER(sys_openat_x, true)
 	/*
 	 * Device
 	 */
-	res = bpf_val_to_ring(data, dev);
+	res = bpf_push_u32_to_ring(data, dev);
 	CHECK_RES(res);
 
 	/*
 	 * Ino
 	 */
-	res = bpf_val_to_ring(data, ino);
+	res = bpf_push_u64_to_ring(data, ino);
 	return res;
 }
 
+// TODO RESUME FROM HERE
 FILLER(sys_openat2_e, true)
 {
 	unsigned long resolve;

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6395,7 +6395,7 @@ FILLER(sched_prog_exec_3, false)
 #endif /* CONFIG_AUDIT... */
 
 	/* Parameter 19: loginuid (type: PT_INT32) */
-	res = bpf_push_s32_to_ring(data, loginuid.val, PT_INT32);
+	res = bpf_push_s32_to_ring(data, loginuid.val);
 	CHECK_RES(res);
 
 	bpf_tail_call(data->ctx, &tail_map, PPM_FILLER_sched_prog_exec_4);
@@ -6476,7 +6476,7 @@ FILLER(sched_prog_exec_4, false)
 
 	/* Parameter 27: uid */
 	euid = _READ(cred->euid);
-	return bpf_push_u32_to_ring(data, euid.val, PT_UINT32);
+	return bpf_push_u32_to_ring(data, euid.val);
 }
 #endif
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4348,13 +4348,11 @@ FILLER(sys_creat_x, true)
 	return res;
 }
 
-// TODO RESUME FROM HERE
-
 FILLER(sys_pipe_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	s32 pipefd[2] = {-1, -1};
@@ -4367,11 +4365,11 @@ FILLER(sys_pipe_x, true)
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	res = bpf_val_to_ring(data, (s64)pipefd[0]);
+	res = bpf_push_s64_to_ring(data, (s64)pipefd[0]);
 	CHECK_RES(res);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	res = bpf_val_to_ring(data, (s64)pipefd[1]);
+	res = bpf_push_s64_to_ring(data, (s64)pipefd[1]);
 	CHECK_RES(res);
 
 	unsigned long ino = 0;
@@ -4384,14 +4382,14 @@ FILLER(sys_pipe_x, true)
 	}
 
 	/* Parameter 4: ino (type: PT_UINT64) */
-	return bpf_val_to_ring(data, ino);
+	return bpf_push_u64_to_ring(data, ino);
 }
 
 FILLER(sys_pipe2_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	s32 pipefd[2] = {-1, -1};
@@ -4404,11 +4402,11 @@ FILLER(sys_pipe2_x, true)
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	res = bpf_val_to_ring(data, (s64)pipefd[0]);
+	res = bpf_push_s64_to_ring(data, (s64)pipefd[0]);
 	CHECK_RES(res);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	res = bpf_val_to_ring(data, (s64)pipefd[1]);
+	res = bpf_push_s64_to_ring(data, (s64)pipefd[1]);
 	CHECK_RES(res);
 
 	unsigned long ino = 0;
@@ -4421,12 +4419,12 @@ FILLER(sys_pipe2_x, true)
 	}
 
 	/* Parameter 4: ino (type: PT_UINT64) */
-	res = bpf_val_to_ring(data, ino);
+	res = bpf_push_u64_to_ring(data, ino);
 	CHECK_RES(res);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
 	s32 flags = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, pipe2_flags_to_scap(flags));
+	return bpf_push_u32_to_ring(data, pipe2_flags_to_scap(flags));
 }
 
 FILLER(sys_lseek_e, true)
@@ -4441,14 +4439,14 @@ FILLER(sys_lseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (s32)val;
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/*
 	 * offset
 	 */
 	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4456,7 +4454,7 @@ FILLER(sys_lseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 2);
 	flags = lseek_whence_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u8_to_ring(data, flags);
 
 	return res;
 }
@@ -4476,7 +4474,7 @@ FILLER(sys_llseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (s32)val;
-	res = bpf_val_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4487,7 +4485,7 @@ FILLER(sys_llseek_e, true)
 	oh = bpf_syscall_get_argument(data, 1);
 	ol = bpf_syscall_get_argument(data, 2);
 	offset = (((u64)oh) << 32) + ((u64)ol);
-	res = bpf_val_to_ring(data, offset);
+	res = bpf_push_u64_to_ring(data, offset);
 	CHECK_RES(res);
 
 	/*
@@ -4495,7 +4493,7 @@ FILLER(sys_llseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 4);
 	flags = lseek_whence_to_scap(val);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u8_to_ring(data, flags);
 
 	return res;
 }
@@ -4504,33 +4502,33 @@ FILLER(sys_eventfd_e, true)
 {
 	/* Parameter 1: initval (type: PT_UINT64) */
 	unsigned long val = bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, val);
+	int res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */
 	/* The syscall eventfd has no flags! only `eventfd2` has the `flags` param.
 	 * For compatibility with the event definition here we send `0` as flags.
 	 */
-	return bpf_val_to_ring(data, 0);
+	return bpf_push_u32_to_ring(data, 0);
 }
 
 FILLER(sys_eventfd2_e, true)
 {
 	/* Parameter 1: initval (type: PT_UINT64) */
 	unsigned long val = bpf_syscall_get_argument(data, 0);
-	return bpf_val_to_ring(data, val);
+	return bpf_push_s64_to_ring(data, val);
 }
 
 FILLER(sys_eventfd2_x, true)
 {
 	/* Parameter 1: res (type: PT_FD) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring(data, retval);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
 	s32 flags = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, eventfd2_flags_to_scap(flags));
+	return bpf_push_u16_to_ring(data, eventfd2_flags_to_scap(flags));
 }
 
 FILLER(sys_mount_e, true)
@@ -4546,7 +4544,7 @@ FILLER(sys_mount_e, true)
 	if ((val & PPM_MS_MGC_MSK) == PPM_MS_MGC_VAL)
 		val &= ~PPM_MS_MGC_MSK;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u32_to_ring(data, val);
 
 	return res;
 }
@@ -4569,19 +4567,19 @@ FILLER(sys_ppoll_e, true)
 	long unsigned int sigmask[1] = {0};
 	unsigned long sigmask_pointer = bpf_syscall_get_argument(data, 3);
 	bpf_probe_read_user(&sigmask, sizeof(sigmask), (void *)sigmask_pointer);
-	return bpf_val_to_ring_type(data, sigmask[0], PT_SIGSET);
+	return bpf_push_u32_to_ring(data, sigmask[0]);
 }
 
 FILLER(sys_semop_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: nsops (type: PT_UINT32) */
 	u32 nsops = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring_type(data, nsops, PT_UINT32);
+	res = bpf_push_u32_to_ring(data, nsops);
 	CHECK_RES(res);
 
 	/* Extract pointer to the `sembuf` struct */
@@ -4608,27 +4606,27 @@ FILLER(sys_semop_x, true)
 	}
 
 	/* Parameter 3: sem_num_0 (type: PT_UINT16) */
-	res = bpf_val_to_ring_type(data, sops[0].sem_num, PT_UINT16);
+	res = bpf_push_u16_to_ring(data, sops[0].sem_num);
 	CHECK_RES(res);
 
 	/* Parameter 4: sem_op_0 (type: PT_INT16) */
-	res = bpf_val_to_ring_type(data, sops[0].sem_op, PT_INT16);
+	res = bpf_push_s16_to_ring(data, sops[0].sem_op);
 	CHECK_RES(res);
 
 	/* Parameter 5: sem_flg_0 (type: PT_FLAGS16) */
-	res = bpf_val_to_ring_type(data, semop_flags_to_scap(sops[0].sem_flg), PT_FLAGS16);
+	res = bpf_push_u16_to_ring(data, semop_flags_to_scap(sops[0].sem_flg));
 	CHECK_RES(res);
 
 	/* Parameter 6: sem_num_1 (type: PT_UINT16) */
-	res = bpf_val_to_ring_type(data, sops[1].sem_num, PT_UINT16);
+	res = bpf_push_u16_to_ring(data, sops[1].sem_num);
 	CHECK_RES(res);
 
 	/* Parameter 7: sem_op_1 (type: PT_INT16) */
-	res = bpf_val_to_ring_type(data, sops[1].sem_op, PT_INT16);
+	res = bpf_push_s16_to_ring(data, sops[1].sem_op);
 	CHECK_RES(res);
 
 	/* Parameter 8: sem_flg_1 (type: PT_FLAGS16) */
-	return bpf_val_to_ring_type(data, semop_flags_to_scap(sops[1].sem_flg), PT_FLAGS16);
+	return bpf_push_u16_to_ring(data, semop_flags_to_scap(sops[1].sem_flg));
 }
 
 FILLER(sys_socket_x, true)
@@ -4637,7 +4635,7 @@ FILLER(sys_socket_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	if (retval >= 0 &&
@@ -4658,36 +4656,36 @@ FILLER(sys_flock_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
 	unsigned long operation = bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, flock_flags_to_scap(operation));
+	return bpf_push_u32_to_ring(data, flock_flags_to_scap(operation));
 }
 
 FILLER(sys_ioctl_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: request (type: PT_UINT64) */
 	u64 request = bpf_syscall_get_argument(data, 1);
-	res = bpf_val_to_ring(data, request);
+	res = bpf_push_u64_to_ring(data, request);
 	CHECK_RES(res);
 
 	/* Parameter 3: argument (type: PT_UINT64) */
 	u64 argument = bpf_syscall_get_argument(data, 2);
-	return bpf_val_to_ring(data, argument);
+	return bpf_push_u64_to_ring(data, argument);
 }
 
 FILLER(sys_mkdir_e, true)
 {
 	/* Parameter 1: mode (type: PT_UINT32) */
 	u32 mode = (u32)bpf_syscall_get_argument(data, 1);
-	return bpf_val_to_ring(data, mode);
+	return bpf_push_u32_to_ring(data, mode);
 }
 
 FILLER(sys_pread64_e, true)
@@ -4705,21 +4703,21 @@ FILLER(sys_pread64_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (int32_t)val;
-	res = bpf_val_to_ring(data, (int64_t)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
 	 * size
 	 */
 	val = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u32_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
 	 * pos
 	 */
 	val = bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring(data, val);
+	return bpf_push_u64_to_ring(data, val);
 }
 
 FILLER(sys_pwrite64_e, true)
@@ -4730,17 +4728,17 @@ FILLER(sys_pwrite64_e, true)
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)bpf_syscall_get_argument(data, 0);
-	int res = bpf_val_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (s64)fd);
 	CHECK_RES(res);
 	
 	/* Parameter 2: size (type: PT_UINT32) */
 	size_t size = bpf_syscall_get_argument(data, 2);
-	res = bpf_val_to_ring(data, size);
+	res = bpf_push_u32_to_ring(data, size);
 	CHECK_RES(res);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
 	u64 pos = (u64)bpf_syscall_get_argument(data, 3);
-	return bpf_val_to_ring(data, pos);
+	return bpf_push_u64_to_ring(data, pos);
 }
 
 FILLER(sys_renameat_x, true)
@@ -4750,7 +4748,7 @@ FILLER(sys_renameat_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -4761,7 +4759,7 @@ FILLER(sys_renameat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4779,7 +4777,7 @@ FILLER(sys_renameat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4798,7 +4796,7 @@ FILLER(sys_renameat2_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring(data, retval);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -4809,7 +4807,7 @@ FILLER(sys_renameat2_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4827,7 +4825,7 @@ FILLER(sys_renameat2_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4840,7 +4838,7 @@ FILLER(sys_renameat2_x, true)
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 4);
-	res = bpf_val_to_ring(data, val);
+	res = bpf_push_u32_to_ring(data, val);
 
 	return res;
 }
@@ -4852,7 +4850,7 @@ FILLER(sys_symlinkat_x, true)
 	int res;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_val_to_ring_type(data, retval, PT_ERRNO);
+	res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
 	/*
@@ -4870,7 +4868,7 @@ FILLER(sys_symlinkat_x, true)
 	if ((int)val == AT_FDCWD)
 		val = PPM_AT_FDCWD;
 
-	res = bpf_val_to_ring_type(data, val, PT_FD);
+	res = bpf_push_s64_to_ring(data, val);
 	CHECK_RES(res);
 
 	/*
@@ -4892,10 +4890,10 @@ FILLER(cpu_hotplug_e, false)
 {
 	int res;
 
-	res = bpf_val_to_ring(data, data->state->hotplug_cpu);
+	res = bpf_push_u32_to_ring(data, data->state->hotplug_cpu);
 	CHECK_RES(res);
 
-	res = bpf_val_to_ring(data, 0);
+	res = bpf_push_u32_to_ring(data, 0);
 	CHECK_RES(res);
 
 	data->state->hotplug_cpu = 0;
@@ -4910,7 +4908,7 @@ FILLER(sched_drop, false)
 	/*
 	 * ratio
 	 */
-	res = bpf_val_to_ring(data, data->settings->sampling_ratio);
+	res = bpf_push_u32_to_ring(data, data->settings->sampling_ratio);
 
 	return res;
 }
@@ -4927,24 +4925,24 @@ FILLER(sys_procexit_e, false)
 	exit_code = _READ(task->exit_code);
 
 	/* Exit status */
-	res = bpf_val_to_ring(data, exit_code);
+	res = bpf_push_s64_to_ring(data, exit_code);
 	CHECK_RES(res);
 
 	/* Ret code */
-	res = bpf_val_to_ring(data, __WEXITSTATUS(exit_code));
+	res = bpf_push_s64_to_ring(data, __WEXITSTATUS(exit_code));
 	CHECK_RES(res);
 
 	/* If signaled -> signum, else 0 */
 	if (__WIFSIGNALED(exit_code))
 	{
-		res = bpf_val_to_ring(data, __WTERMSIG(exit_code));
+		res = bpf_push_u8_to_ring(data, __WTERMSIG(exit_code));
 	} else {
-		res = bpf_val_to_ring(data, 0);
+		res = bpf_push_u8_to_ring(data, 0);
 	}
 	CHECK_RES(res);
 
 	/* Did it produce a core? */
-	res = bpf_val_to_ring(data, __WCOREDUMP(exit_code) != 0);
+	res = bpf_push_u8_to_ring(data, __WCOREDUMP(exit_code) != 0);
 	CHECK_RES(res);
 
 #ifndef BPF_SUPPORTS_RAW_TRACEPOINTS
@@ -4978,7 +4976,7 @@ FILLER(sched_switch_e, false)
 	/*
 	 * next
 	 */
-	res = bpf_val_to_ring_type(data, next_pid, PT_PID);
+	res = bpf_push_s64_to_ring(data, next_pid);
 	CHECK_RES(res);
 
 	task = (struct task_struct *)bpf_get_current_task();
@@ -4987,14 +4985,14 @@ FILLER(sched_switch_e, false)
 	 * pgft_maj
 	 */
 	maj_flt = _READ(task->maj_flt);
-	res = bpf_val_to_ring_type(data, maj_flt, PT_UINT64);
+	res = bpf_push_u64_to_ring(data, maj_flt);
 	CHECK_RES(res);
 
 	/*
 	 * pgft_min
 	 */
 	min_flt = _READ(task->min_flt);
-	res = bpf_val_to_ring_type(data, min_flt, PT_UINT64);
+	res = bpf_push_u64_to_ring(data, min_flt);
 	CHECK_RES(res);
 
 	total_vm = 0;
@@ -5012,19 +5010,19 @@ FILLER(sched_switch_e, false)
 	/*
 	 * vm_size
 	 */
-	res = bpf_val_to_ring_type(data, total_vm, PT_UINT32);
+	res = bpf_push_u32_to_ring(data, total_vm);
 	CHECK_RES(res);
 
 	/*
 	 * vm_rss
 	 */
-	res = bpf_val_to_ring_type(data, total_rss, PT_UINT32);
+	res = bpf_push_u32_to_ring(data, total_rss);
 	CHECK_RES(res);
 
 	/*
 	 * vm_swap
 	 */
-	res = bpf_val_to_ring_type(data, swap, PT_UINT32);
+	res = bpf_push_u32_to_ring(data, swap);
 
 	return res;
 }
@@ -5052,14 +5050,14 @@ FILLER(sys_pagefault_e, false)
 	error_code = ctx->error_code;
 #endif
 
-	res = bpf_val_to_ring(data, address);
+	res = bpf_push_u64_to_ring(data, address);
 	CHECK_RES(res);
 
-	res = bpf_val_to_ring(data, ip);
+	res = bpf_push_u64_to_ring(data, ip);
 	CHECK_RES(res);
 
 	flags = pf_flags_to_scap(error_code);
-	res = bpf_val_to_ring(data, flags);
+	res = bpf_push_u32_to_ring(data, flags);
 	return res;
 }
 #endif
@@ -5072,6 +5070,8 @@ static __always_inline int siginfo_not_a_pointer(struct siginfo* info)
 	return info == (struct siginfo*)SEND_SIG_NOINFO || info == (struct siginfo*)SEND_SIG_PRIV;
 #endif
 }
+
+// TODO RESUME FROM HERE
 
 FILLER(sys_signaldeliver_e, false)
 {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

/version driver-API-version-patch

**What this PR does / why we need it**:

This PR splits up all the integer-related cases from `bpf_val_to_ring`.
We still need to:
* figure out how to port `sys_autofill`
* figure out how to port `sys_single` -> we only have 3 syscalls using it nowadays; therefore it should be pretty simple to drop it completely.
* figure out what to do with `PT_DYN` params

Moreover, the PR also uses `CHECK_RES` macro in all fillers.

I think the TODO can be addressed in a subsequent PR since this is already pretty huge and will lead to multiple conflicts everytime a bpf touching PR gets merged in master.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

#940 

**Special notes for your reviewer**:

This PR already cuts down total number of bpf programs instructions by ~25%:
* Total number of bpf instructions in this branch: `insns: 158593`
* Total number of bpf instructions on master:  `insns: 212830` 

See [comment](https://github.com/falcosecurity/libs/pull/1048#issuecomment-1507216626).

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(driver/bpf): split up bpf_val_to_ring into many helpers
```
