### PR TITLE
Add addl(test-only) way to initialize events, setting errorcode

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -438,6 +438,14 @@ private:
 		m_tinfo = threadinfo;
 		m_fdinfo = fdinfo;
 	}
+	inline void init(scap_evt* scap_event,
+			 ppm_event_info* ppm_event,
+			 int32_t errorcode)
+	{
+		m_pevt = scap_event;
+		m_info = ppm_event;
+		m_errorcode = errorcode;
+	}
 	inline void load_params()
 	{
 		uint32_t j;


### PR DESCRIPTION
Some tests rely on creating fake events without all of the overhead of an inspector, etc. To support new tests that rely on m_errorcode (generally maps to the res field of events), add a new initializer that passes in a scap + ppm header and errorcode, and just directly sets m_errorcode.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Some tests rely on creating fake events without all of the overhead of an inspector, etc. To support new tests that rely on m_errorcode (generally maps to the res field of events), add a new initializer that passes in a scap + ppm header and errorcode, and just directly sets m_errorcode.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
