### PR TITLE
fix: align scap_read_proclist with scap_threadinfo

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -107,6 +107,7 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		tinfo.sid = -1;
 		tinfo.vpgid = -1;
 		tinfo.clone_ts = 0;
+		tinfo.pidns_init_start_ts = 0;
 		tinfo.tty = 0;
 		tinfo.exepath[0] = 0;
 		tinfo.loginuid = -1;
@@ -114,6 +115,10 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		tinfo.cap_inheritable = 0;
 		tinfo.cap_permitted = 0;
 		tinfo.cap_effective = 0;
+		tinfo.exe_upper_layer = false;
+		tinfo.exe_ino = 0;
+		tinfo.exe_ino_ctime = 0;
+		tinfo.exe_ino_mtime = 0;
 
 		//
 		// len
@@ -563,6 +568,26 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		// }
 
 		//
+		// pidns_init_start_ts
+		//
+		if(sub_len && (subreadsize + sizeof(uint64_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.pidns_init_start_ts), sizeof(uint64_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(uint64_t), error);
+			subreadsize += readsize;
+		}
+
+		//
+		// tty
+		//
+		if(sub_len && (subreadsize + sizeof(int32_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.tty), sizeof(int32_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(int32_t), error);
+			subreadsize += readsize;
+		}
+
+		//
 		// loginuid
 		//
 		if(sub_len && (subreadsize + sizeof(int32_t)) <= sub_len)
@@ -602,6 +627,38 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		if(sub_len && (subreadsize + sizeof(uint64_t)) <= sub_len)
 		{
 			readsize = r->read(r, &(tinfo.cap_effective), sizeof(uint64_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(uint64_t), error);
+			subreadsize += readsize;
+		}
+
+		// exe_upper_layer
+		if(sub_len && (subreadsize + sizeof(uint8_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.exe_upper_layer), sizeof(uint8_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(uint8_t), error);
+			subreadsize += readsize;
+		}
+
+		// exe_ino
+		if(sub_len && (subreadsize + sizeof(uint64_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.exe_ino), sizeof(uint64_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(uint64_t), error);
+			subreadsize += readsize;
+		}
+
+		// exe_ino_ctime
+		if(sub_len && (subreadsize + sizeof(uint64_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.exe_ino_ctime), sizeof(uint64_t));
+			CHECK_READ_SIZE_ERR(readsize, sizeof(uint64_t), error);
+			subreadsize += readsize;
+		}
+
+		// exe_ino_mtime
+		if(sub_len && (subreadsize + sizeof(uint64_t)) <= sub_len)
+		{
+			readsize = r->read(r, &(tinfo.exe_ino_mtime), sizeof(uint64_t));
 			CHECK_READ_SIZE_ERR(readsize, sizeof(uint64_t), error);
 			subreadsize += readsize;
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR aligns the scap dump/write functions.

Currently, `scap_write_proclist_entry_bufs` dumps the following fields:
 - `pidns_init_start_ts`
 - `tty`
 - `exe_upper_layer`
 - `exe_ino`
 - `exe_ino_ctime`
 - `exe_ino_mtime`

As a result, the proclist block of the capture contains them. But, they are left unhandled in `scap_read_proclist`.

cc @FedeDP 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
