### PR TITLE
tests(driver): add some test to `clone3` to check ptid and flags value

### DIFF
--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
@@ -41,7 +41,8 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3)
 
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
 		FAIL() << "Something in the child failed." << std::endl;
@@ -104,6 +105,396 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3)
 
 	evt_test->assert_num_params_pushed(21);
 }
+
+/* This flag was introduced together with `set_tid` field, if there is the flag
+ * we should also have the `set_tid` field in struct `clone_args`
+ */
+#ifdef CLONE_CLEAR_SIGHAND
+TEST(GenericTracepoints, sched_proc_fork_case_clone3_create_child_with_2_threads)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process that will have:
+	 * - a leader thread with `tid` equal to `p1_t1`
+	 * - a second thread with `tid` equal to `p1_t2`.
+	 */
+	pid_t p1_t1 = 61001;
+	pid_t p1_t2 = 61004;
+
+	struct clone_args cl_args_parent = {0};
+	cl_args_parent.set_tid = (uint64_t)&p1_t1;
+	cl_args_parent.set_tid_size = 1;
+	cl_args_parent.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args_parent, sizeof(cl_args_parent));
+
+	/* Create a child process that will spawn a new thread */
+	if(ret_pid == 0)
+	{
+		/* Spawn a new thread */
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p1_t2;
+		cl_args_child.set_tid_size = 1;
+		/* CLONE_PARENT has no additional effects if we are spawning a thread
+		 * A new thread created with CLONE_THREAD has the same parent process
+		 * as the process that made the clone call (i.e., like CLONE_PARENT)
+		 */
+		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK | CLONE_PARENT;
+		pid_t child_thread = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(child_thread == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(p1_t2);
+
+	if(HasFatalFailure())
+	{
+		FAIL() << "There is a fatal failure in the child";
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	/* */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t2);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	/* the tgid is the leader one */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	/* The new thread created with CLONE_THREAD has the same parent process
+	 * as the process that made the clone call
+	 */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	/* Right now we cannot send `PPM_CL_CLONE_PARENT` in our `sched_proc_fork` hook */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_THREAD | PPM_CL_CLONE_SIGHAND | PPM_CL_CLONE_VM);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t2);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+}
+
+TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_clone_parent_flag)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process that will have:
+	 * - a leader thread with `tid` equal to `p1_t1`
+	 * - a child process with `tid` equal to `p2_t1`
+	 */
+	pid_t p1_t1 = 61024;
+	pid_t p2_t1 = 60128;
+
+	struct clone_args cl_args_parent = {0};
+	cl_args_parent.set_tid = (uint64_t)&p1_t1;
+	cl_args_parent.set_tid_size = 1;
+	cl_args_parent.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args_parent, sizeof(cl_args_parent));
+
+	if(ret_pid == 0)
+	{
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p2_t1;
+		cl_args_child.set_tid_size = 1;
+		cl_args_child.flags = CLONE_PARENT;
+		cl_args_parent.exit_signal = SIGCHLD;
+		pid_t second_child = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(second_child == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		if(second_child == -1)
+		{
+			exit(EXIT_FAILURE);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+
+	/* Wait for the first child */
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the first child failed." << std::endl;
+	}
+
+	/* Since we are using the `CLONE_PARENT` flag the currect process is signaled also for the second child  */
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, p2_t1, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the second child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(p2_t1);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p2_t1);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p2_t1);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	/* Thanks to the CLONE_PARENT flag the parent should be the actual process */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	/* we cannot get the CLONE_PARENT_FLAG in the child event */
+	evt_test->assert_numeric_param(16, (uint32_t)0);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p2_t1);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p2_t1);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+}
+
+/* here we test only the child case because the caller won't use this tracepoint */
+TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_new_namespace_from_child)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process in a new namespace. */
+	pid_t p1_t1[2] = {1, 61032};
+	struct clone_args cl_args = {0};
+	cl_args.set_tid = (uint64_t)&p1_t1;
+	cl_args.set_tid_size = 2;
+	cl_args.flags = CLONE_NEWPID;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* Child terminates immediately. */
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t1[1]);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1[1]);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	/* we cannot get the `PPM_CL_CLONE_NEWPID` flag */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CHILD_IN_PIDNS);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t1[0]);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1[0]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+}
+
+TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_new_namespace_create_thread)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process in a new namespace.
+	 * The child process will have `tid` equal to `p1_t1`.
+	 * The child process will create a new thread with `tid` equal to `p1_t2`
+	 */
+	pid_t p1_t1[2] = {1, 61032};
+	/* Please note that a process can have the same pid number in different namespaces */
+	pid_t p1_t2[2] = {61036, 61036};
+
+	struct clone_args cl_args = {0};
+	cl_args.set_tid = (uint64_t)&p1_t1;
+	cl_args.set_tid_size = 2;
+	cl_args.flags = CLONE_NEWPID;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* Spawn a new thread */
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p1_t2;
+		cl_args_child.set_tid_size = 2;
+		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK;
+		pid_t child_thread = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(child_thread == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence(p1_t2[1]);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t2[1]);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1[1]);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	/* we cannot get the `PPM_CL_CLONE_VFORK` flag here */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_THREAD | PPM_CL_CLONE_SIGHAND | PPM_CL_CLONE_VM |
+						   PPM_CL_CHILD_IN_PIDNS);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t2[0]);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1[0]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+}
+
+#endif /* CLONE_CLEAR_SIGHAND */
 #endif /* __NR_clone3 */
 
 #ifdef __NR_clone
@@ -151,7 +542,8 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone)
 
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
 		FAIL() << "Something in the child failed." << std::endl;
@@ -245,7 +637,8 @@ TEST(GenericTracepoints, sched_proc_fork_case_fork)
 
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -41,7 +41,8 @@ TEST(SyscallExit, clone3X_father)
 	/* Catch the child before doing anything else. */
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
@@ -168,7 +169,8 @@ TEST(SyscallExit, clone3X_child)
 
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -182,7 +184,9 @@ TEST(SyscallExit, clone3X_child)
 	/* In some architectures we are not able to catch the `clone exit child
 	 * event` from the `sys_exit` tracepoint. This is because there is no
 	 * default behavior among different architectures... you can find more
-	 * info in `driver/feature_gates.h`.
+	 * info in `driver/feature_gates.h`. Even if the `sched_proc_fork` tracepoint
+	 * is enabled when starting the capture it will generate a `CLONE_X` event and
+	 * not a `CLONE3_X` event so we need to assert the absence here.
 	 */
 #ifdef CAPTURE_SCHED_PROC_FORK
 	evt_test->assert_event_absence(ret_pid);
@@ -241,4 +245,485 @@ TEST(SyscallExit, clone3X_child)
 	evt_test->assert_num_params_pushed(21);
 #endif
 }
+
+/* This flag was introduced together with `set_tid` field, if there is the flag
+ * we should also have the `set_tid` field in struct `clone_args`
+ */
+#ifdef CLONE_CLEAR_SIGHAND
+TEST(SyscallExit, clone3X_create_child_with_2_threads)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process that will have:
+	 * - a leader thread with `tid` equal to `p1_t1`
+	 * - a second thread with `tid` equal to `p1_t2`.
+	 */
+	pid_t p1_t1 = 61001;
+	pid_t p1_t2 = 61004;
+
+	struct clone_args cl_args_parent = {0};
+	cl_args_parent.set_tid = (uint64_t)&p1_t1;
+	cl_args_parent.set_tid_size = 1;
+	cl_args_parent.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args_parent, sizeof(cl_args_parent));
+
+	/* Create a child process that will spawn a new thread */
+	if(ret_pid == 0)
+	{
+		/* Spawn a new thread */
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p1_t2;
+		cl_args_child.set_tid_size = 1;
+		/* CLONE_PARENT has no additional effects if we are spawning a thread
+		 * A new thread created with CLONE_THREAD has the same parent process
+		 * as the process that made the clone call (i.e., like CLONE_PARENT)
+		 */
+		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK | CLONE_PARENT;
+		pid_t child_thread = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(child_thread == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+#ifdef CAPTURE_SCHED_PROC_FORK
+	evt_test->assert_event_absence(p1_t2);
+#else
+	evt_test->assert_event_presence(p1_t2);
+
+	if(HasFatalFailure())
+	{
+		FAIL() << "There is a fatal failure in the child";
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	/* */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t2);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	/* the tgid is the leader one */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	/* The new thread created with CLONE_THREAD has the same parent process
+	 * as the process that made the clone call
+	 */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_THREAD | PPM_CL_CLONE_SIGHAND | PPM_CL_CLONE_VM |
+						   PPM_CL_CLONE_VFORK | PPM_CL_CLONE_PARENT);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t2);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+#endif
+}
+
+TEST(SyscallExit, clone3X_child_clone_parent_flag)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process that will have:
+	 * - a leader thread with `tid` equal to `p1_t1`
+	 * - a child process with `tid` equal to `p2_t1`
+	 */
+	pid_t p1_t1 = 61024;
+	pid_t p2_t1 = 60128;
+
+	struct clone_args cl_args_parent = {0};
+	cl_args_parent.set_tid = (uint64_t)&p1_t1;
+	cl_args_parent.set_tid_size = 1;
+	cl_args_parent.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args_parent, sizeof(cl_args_parent));
+
+	if(ret_pid == 0)
+	{
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p2_t1;
+		cl_args_child.set_tid_size = 1;
+		cl_args_child.flags = CLONE_PARENT;
+		cl_args_parent.exit_signal = SIGCHLD;
+		pid_t second_child = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(second_child == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		if(second_child == -1)
+		{
+			exit(EXIT_FAILURE);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+
+	/* Wait for the first child */
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the first child failed." << std::endl;
+	}
+
+	/* Since we are using the `CLONE_PARENT` flag the currect process is signaled also for the second child  */
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, p2_t1, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the second child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+#ifdef CAPTURE_SCHED_PROC_FORK
+	evt_test->assert_event_absence(p2_t1);
+#else
+	evt_test->assert_event_presence(p2_t1);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p2_t1);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p2_t1);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	/* Thanks to the CLONE_PARENT flag the parent should be the actual process */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_PARENT);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p2_t1);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p2_t1);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+#endif
+}
+
+TEST(SyscallExit, clone3X_child_new_namespace_from_child)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process in a new namespace. */
+	pid_t p1_t1[2] = {1, 61032};
+
+	struct clone_args cl_args = {0};
+	cl_args.set_tid = (uint64_t)&p1_t1;
+	cl_args.set_tid_size = 2;
+	cl_args.flags = CLONE_NEWPID;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* Child terminates immediately. */
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+#ifdef CAPTURE_SCHED_PROC_FORK
+	evt_test->assert_event_absence(ret_pid);
+#else
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t1[1]);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1[1]);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_NEWPID | PPM_CL_CHILD_IN_PIDNS);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t1[0]);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1[0]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+#endif
+}
+
+TEST(SyscallExit, clone3X_child_new_namespace_from_caller)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process in a new namespace. */
+	pid_t p1_t1[2] = {1, 61032};
+
+	struct clone_args cl_args = {0};
+	cl_args.set_tid = (uint64_t)&p1_t1;
+	cl_args.set_tid_size = 2;
+	cl_args.flags = CLONE_NEWPID;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* Child terminates immediately. */
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)p1_t1[1]);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)::gettid());
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)::getpid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	/* Please note that here we have `PPM_CL_CLONE_NEWPID` but not `PPM_CL_CHILD_IN_PIDNS`! */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_NEWPID);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)::gettid());
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)::getpid());
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+}
+
+TEST(SyscallExit, clone3X_child_new_namespace_create_thread)
+{
+	auto evt_test = get_syscall_event_test(__NR_clone3, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Here we create a child process in a new namespace.
+	 * The child process will have `tid` equal to `p1_t1`.
+	 * The child process will create a new thread with `tid` equal to `p1_t2`
+	 */
+	pid_t p1_t1[2] = {1, 61032};
+	/* Please note that a process can have the same pid number in different namespaces */
+	pid_t p1_t2[2] = {61036, 61036};
+
+	struct clone_args cl_args = {0};
+	cl_args.set_tid = (uint64_t)&p1_t1;
+	cl_args.set_tid_size = 2;
+	cl_args.flags = CLONE_NEWPID;
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	if(ret_pid == 0)
+	{
+		/* Spawn a new thread */
+		struct clone_args cl_args_child = {0};
+		cl_args_child.set_tid = (uint64_t)&p1_t2;
+		cl_args_child.set_tid_size = 2;
+		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK;
+		pid_t child_thread = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
+		if(child_thread == 0)
+		{
+			exit(EXIT_SUCCESS);
+		}
+		exit(EXIT_SUCCESS);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Something in the child failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+#ifdef CAPTURE_SCHED_PROC_FORK
+	evt_test->assert_event_absence(p1_t2[1]);
+#else
+	evt_test->assert_event_presence(p1_t2[1]);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_PID)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)p1_t2[1]);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	evt_test->assert_numeric_param(5, (int64_t)p1_t1[1]);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)::gettid());
+
+	/* Parameter 16: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(16, (uint32_t)PPM_CL_CLONE_THREAD | PPM_CL_CLONE_SIGHAND | PPM_CL_CLONE_VM |
+						   PPM_CL_CLONE_VFORK | PPM_CL_CHILD_IN_PIDNS);
+
+	/* Parameter 19: vtid (type: PT_PID) */
+	evt_test->assert_numeric_param(19, (int64_t)p1_t2[0]);
+
+	/* Parameter 20: vpid (type: PT_PID) */
+	evt_test->assert_numeric_param(20, (int64_t)p1_t1[0]);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(21);
+#endif
+}
+
+#endif /* CLONE_CLEAR_SIGHAND */
+
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:


**NEW PR SCOPE**

Add some tests to clone3 and sched_proc_fork to assert correct behavior with tid/pids and flags 

**KEEP THIS DESCRIPTION JUST FOR REFERENCE BUT IT IS OUTDATED**

Looking at how we populate the `ptid` field in our `thread_info` struct it seems we use 2 different approaches depending on whether we use `/proc` or an event generated by our drivers:
* if we use `/proc` scan, we read the field `PPid` under `/proc/${pid}/task/${tid}/status` and so the `TGID` of the parent (thread group id of the parent process) -> this is the same thing [`getppid()`](https://elixir.bootlin.com/linux/v6.2/source/kernel/sys.c#L957) syscall does, it reads the `TGID` of the parent task (`current->real_parent->tgid`)
* if we use our instrumentation (bpf, kmod) we read the `PID` of the parent (`pid` of the parent process, it could be also a not-leader thread and so != from `TGID`) -> Translating this in kernel code, we are doing something like `current->real_parent->pid`.

This PR wants to address this inconsistency by always sending the `TGID` of the parent also in our drivers, to be compliant with `/proc` and `getppid()` syscall. After this PR we should fix how sinsp handles this param, ideally a not leader thread will never be the parent of another process

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
