### PR TITLE
new(scap,sinsp): cgroups v2 and cgroup namespace support

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -103,7 +103,7 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		tinfo.env_len = 0;
 		tinfo.vtid = -1;
 		tinfo.vpid = -1;
-		tinfo.cgroups_len = 0;
+		tinfo.cgroups.len = 0;
 		tinfo.filtered_out = 0;
 		tinfo.root[0] = 0;
 		tinfo.sid = -1;
@@ -519,11 +519,11 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 					snprintf(error, SCAP_LASTERR_SIZE, "invalid cgroupslen %d", stlen);
 					return SCAP_FAILURE;
 				}
-				tinfo.cgroups_len = stlen;
+				tinfo.cgroups.len = stlen;
 
 				subreadsize += readsize;
 
-				readsize = r->read(r, tinfo.cgroups, stlen);
+				readsize = r->read(r, tinfo.cgroups.path, stlen);
 				CHECK_READ_SIZE_ERR(readsize, stlen, error);
 
 				subreadsize += readsize;

--- a/userspace/libscap/linux/CMakeLists.txt
+++ b/userspace/libscap/linux/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(scap_platform scap_linux_platform.c scap_procs.c scap_fds.c scap_userlist.c scap_iflist.c scap_ppm_sc.c)
+add_library(scap_platform scap_linux_platform.c scap_procs.c scap_fds.c scap_userlist.c scap_iflist.c scap_ppm_sc.c scap_cgroup.c)
 target_link_libraries(scap_platform scap_error)
 set_scap_target_properties(scap_platform)

--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -417,3 +417,31 @@ int32_t scap_cgroup_get_thread(struct scap_cgroup_interface* cgi, const char* pr
 	fclose(f);
 	return SCAP_SUCCESS;
 }
+
+// Get the mountpoint and version of a particular cgroup subsystem
+//
+// Note: there's no notion of a system-wide cgroup version: each subsystem can be mounted
+// either as v1 or v2 (but once mounted, it stays there; you can't have a subsystem mounted
+// both ways)
+const char* scap_cgroup_get_subsys_mount(const struct scap_cgroup_interface* cgi, const char* subsys, int* version)
+{
+	size_t subsys_len = strlen(subsys);
+	FOR_EACH_SUBSYS(&cgi->m_mounts_v1, cgset_subsys)
+	{
+		if(strncmp(cgset_subsys, subsys, subsys_len) == 0 && cgset_subsys[subsys_len] == '=')
+		{
+			*version = 1;
+			return cgset_subsys + subsys_len + 1;
+		}
+	}
+
+	if(cgi->m_mount_v2[0])
+	{
+		*version = 2;
+		return cgi->m_mount_v2;
+	}
+
+	ASSERT(false);
+	*version = 0;
+	return NULL;
+}

--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -1,0 +1,152 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "scap_cgroup.h"
+
+#include "scap_assert.h"
+#include "scap.h"
+#include "strerror.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_threadinfo* tinfo, const char* procdirname)
+{
+	char filename[SCAP_MAX_PATH_SIZE];
+	char line[SCAP_MAX_CGROUPS_SIZE];
+
+	tinfo->cgroups_len = 0;
+	snprintf(filename, sizeof(filename), "%scgroup", procdirname);
+
+	FILE* f = fopen(filename, "r");
+	if(f == NULL)
+	{
+		if(errno == ENOENT || errno == EACCES)
+		{
+			return SCAP_SUCCESS;
+		}
+
+		ASSERT(false);
+		return scap_errprintf(error, errno, "open cgroup file %s failed", filename);
+	}
+
+	while(fgets(line, sizeof(line), f) != NULL)
+	{
+		char* token;
+		char* subsys_list;
+		char* cgroup;
+		char* scratch;
+		// Default subsys list for cgroups v2 unified hierarchy.
+		// These are the ones we actually use in cri container engine.
+		char default_subsys_list[] = "cpu,memory,cpuset";
+
+		// id
+		token = strtok_r(line, ":", &scratch);
+		if(token == NULL)
+		{
+			ASSERT(false);
+			fclose(f);
+			return scap_errprintf(error, 0, "Did not find id in cgroup file %s", filename);
+		}
+
+		// subsys
+		subsys_list = strtok_r(NULL, ":", &scratch);
+		if(subsys_list == NULL)
+		{
+			ASSERT(false);
+			fclose(f);
+			return scap_errprintf(error, 0, "Did not find subsys in cgroup file %s", filename);
+		}
+
+		// Hack to detect empty fields, because strtok does not support it
+		// strsep() should be used to fix this but it's not available
+		// on CentOS 6 (has been added from Glibc 2.19)
+		if(subsys_list - token - strlen(token) > 1)
+		{
+			// Subsys list empty (ie: it contains cgroup path instead)!
+			//
+			// See https://man7.org/linux/man-pages/man7/cgroups.7.html:
+			// 5:cpuacct,cpu,cpuset:/daemons
+			//
+			//              The colon-separated fields are, from left to right:
+			//
+			//              1. For cgroups version 1 hierarchies, this field contains
+			//                 a unique hierarchy ID number that can be matched to a
+			//                 hierarchy ID in /proc/cgroups.  For the cgroups version
+			//                 2 hierarchy, this field contains the value 0.
+			//
+			//              2. For cgroups version 1 hierarchies, this field contains
+			//                 a comma-separated list of the controllers bound to the
+			//                 hierarchy.  For the cgroups version 2 hierarchy, this
+			//                 field is empty.
+			//
+			//              3. This field contains the pathname of the control group
+			//                 in the hierarchy to which the process belongs.  This
+			//                 pathname is relative to the mount point of the
+			//                 hierarchy.
+			//
+			// -> for cgroup2: id is always 0 and subsys list is always empty (single unified hierarchy)
+			// -> for cgroup1: skip subsys empty because it means controller is not mounted on any hierarchy
+			if(cgroup_version == 2 && strcmp(token, "0") == 0)
+			{
+				cgroup = subsys_list;
+				subsys_list = default_subsys_list; // force-set a default subsys list
+
+				size_t cgroup_len = strlen(cgroup);
+				if(cgroup_len != 0 && cgroup[cgroup_len - 1] == '\n')
+				{
+					cgroup[cgroup_len - 1] = '\0';
+				}
+			}
+			else
+			{
+				// skip cgroups like this:
+				// 0::/init.scope
+				continue;
+			}
+		}
+		else
+		{
+			// cgroup should be the only thing remaining so use newline as the delimiter.
+			cgroup = strtok_r(NULL, "\n", &scratch);
+			if(cgroup == NULL)
+			{
+				ASSERT(false);
+				fclose(f);
+				return scap_errprintf(error, 0, "Did not find cgroup in cgroup file %s", filename);
+			}
+		}
+
+		while((token = strtok_r(subsys_list, ",", &scratch)) != NULL)
+		{
+			subsys_list = NULL;
+			if(strlen(cgroup) + 1 + strlen(token) + 1 > SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len)
+			{
+				ASSERT(false);
+				fclose(f);
+				return SCAP_SUCCESS;
+			}
+
+			snprintf(tinfo->cgroups + tinfo->cgroups_len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len, "%s=%s", token, cgroup);
+			tinfo->cgroups_len += strlen(cgroup) + 1 + strlen(token) + 1;
+		}
+	}
+
+	fclose(f);
+	return SCAP_SUCCESS;
+}

--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -18,7 +18,7 @@ limitations under the License.
 #include "scap_cgroup.h"
 
 #include "scap_assert.h"
-#include "scap.h"
+#include "scap_const.h"
 #include "strerror.h"
 #include "uthash.h"
 
@@ -619,9 +619,8 @@ static bool scap_in_cgroupns(const char* host_root)
 	return true;
 }
 
-int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error, bool with_self_cg)
+int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, const char* host_root, char* error, bool with_self_cg)
 {
-	const char* host_root = scap_get_host_root();
 	char filename[SCAP_MAX_PATH_SIZE];
 	bool in_cgroupns = false;
 	char pid_str[40];

--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -30,7 +30,7 @@ int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_thre
 	char filename[SCAP_MAX_PATH_SIZE];
 	char line[SCAP_MAX_CGROUPS_SIZE];
 
-	tinfo->cgroups_len = 0;
+	tinfo->cgroups.len = 0;
 	snprintf(filename, sizeof(filename), "%scgroup", procdirname);
 
 	FILE* f = fopen(filename, "r");
@@ -135,15 +135,15 @@ int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_thre
 		while((token = strtok_r(subsys_list, ",", &scratch)) != NULL)
 		{
 			subsys_list = NULL;
-			if(strlen(cgroup) + 1 + strlen(token) + 1 > SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len)
+			if(strlen(cgroup) + 1 + strlen(token) + 1 > SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups.len)
 			{
 				ASSERT(false);
 				fclose(f);
 				return SCAP_SUCCESS;
 			}
 
-			snprintf(tinfo->cgroups + tinfo->cgroups_len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len, "%s=%s", token, cgroup);
-			tinfo->cgroups_len += strlen(cgroup) + 1 + strlen(token) + 1;
+			snprintf(tinfo->cgroups.path + tinfo->cgroups.len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups.len, "%s=%s", token, cgroup);
+			tinfo->cgroups.len += strlen(cgroup) + 1 + strlen(token) + 1;
 		}
 	}
 

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "scap_cgroup_set.h"
@@ -30,6 +31,7 @@ limitations under the License.
 extern "C"
 {
 #endif
+	struct scap_cgroup_cache;
 	struct scap_threadinfo;
 
 	struct scap_cgroup_interface
@@ -41,6 +43,9 @@ extern "C"
 		// cgroupfs mount points
 		struct scap_cgroup_set m_mounts_v1;
 		char m_mount_v2[SCAP_MAX_PATH_SIZE];
+
+		bool m_use_cache;
+		struct scap_cgroup_cache* m_cache;
 	};
 
 	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error);
@@ -48,6 +53,10 @@ extern "C"
 	int32_t scap_cgroup_get_thread(struct scap_cgroup_interface* cgi, const char* procdirname, struct scap_cgroup_set* cg, char* error);
 
 	const char* scap_cgroup_get_subsys_mount(const struct scap_cgroup_interface* cgi, const char* subsys, int* version);
+
+	void scap_cgroup_enable_cache(struct scap_cgroup_interface* cgi);
+
+	void scap_cgroup_clear_cache(struct scap_cgroup_interface* cgi);
 #ifdef __cplusplus
 };
 #endif

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+	struct scap_threadinfo;
+
+	int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_threadinfo* tinfo, const char* procdirname);
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -56,7 +56,7 @@ extern "C"
 		char m_self_v2[SCAP_MAX_PATH_SIZE];
 	};
 
-	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error, bool with_self_cg);
+	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, const char* host_root, char* error, bool with_self_cg);
 
 	int32_t scap_cgroup_get_thread(struct scap_cgroup_interface* cgi, const char* procdirname, struct scap_cgroup_set* cg, char* error);
 

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -19,13 +19,35 @@ limitations under the License.
 
 #include <stdint.h>
 
+#include "scap_cgroup_set.h"
+
+#define FOR_EACH_SUBSYS(cgset, subsys) for(                                       \
+	const char *subsys = (cgset)->path, *_end = (cgset)->path + (cgset)->len; \
+	subsys < _end;                                                            \
+	subsys += strlen(subsys) + 1)
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 	struct scap_threadinfo;
 
-	int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_threadinfo* tinfo, const char* procdirname);
+	struct scap_cgroup_interface
+	{
+		// cgroup subsystems available for v1 and v2
+		struct scap_cgroup_set m_subsystems_v1;
+		struct scap_cgroup_set m_subsystems_v2;
+
+		// cgroupfs mount points
+		struct scap_cgroup_set m_mounts_v1;
+		char m_mount_v2[SCAP_MAX_PATH_SIZE];
+	};
+
+	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error);
+
+	int32_t scap_cgroup_get_thread(struct scap_cgroup_interface* cgi, const char* procdirname, struct scap_cgroup_set* cg, char* error);
+
+	const char* scap_cgroup_get_subsys_mount(const struct scap_cgroup_interface* cgi, const char* subsys, int* version);
 #ifdef __cplusplus
 };
 #endif

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -46,9 +46,17 @@ extern "C"
 
 		bool m_use_cache;
 		struct scap_cgroup_cache* m_cache;
+
+		// the cgroups of the current process, as seen from the host cgroupns
+		// empty if:
+		// - we're not running in a cgroupns
+		// - we can't escape the cgroupns
+		// - the `scap_cgroup_interface` was created `with_self_cg=false`
+		struct scap_cgroup_set m_self_v1;
+		char m_self_v2[SCAP_MAX_PATH_SIZE];
 	};
 
-	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error);
+	int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi, char* error, bool with_self_cg);
 
 	int32_t scap_cgroup_get_thread(struct scap_cgroup_interface* cgi, const char* procdirname, struct scap_cgroup_set* cg, char* error);
 

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -32,6 +32,7 @@ limitations under the License.
 
 #include "scap.h"
 #include "scap-int.h"
+#include "scap_cgroup.h"
 #include "scap_linux_int.h"
 #include "strerror.h"
 #include "clock_helpers.h"
@@ -374,130 +375,6 @@ static int32_t scap_proc_fill_flimit(uint64_t tid, struct scap_threadinfo* tinfo
 	return SCAP_SUCCESS;
 }
 #endif
-
-int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_threadinfo* tinfo, const char* procdirname)
-{
-	char filename[SCAP_MAX_PATH_SIZE];
-	char line[SCAP_MAX_CGROUPS_SIZE];
-
-	tinfo->cgroups_len = 0;
-	snprintf(filename, sizeof(filename), "%scgroup", procdirname);
-
-	FILE* f = fopen(filename, "r");
-	if(f == NULL)
-	{
-		if(errno == ENOENT || errno == EACCES)
-		{
-			return SCAP_SUCCESS;
-		}
-
-		ASSERT(false);
-		return scap_errprintf(error, errno, "open cgroup file %s failed", filename);
-	}
-
-	while(fgets(line, sizeof(line), f) != NULL)
-	{
-		char* token;
-		char* subsys_list;
-		char* cgroup;
-		char* scratch;
-		// Default subsys list for cgroups v2 unified hierarchy.
-		// These are the ones we actually use in cri container engine.
-		char default_subsys_list[] = "cpu,memory,cpuset";
-
-		// id
-		token = strtok_r(line, ":", &scratch);
-		if(token == NULL)
-		{
-			ASSERT(false);
-			fclose(f);
-			return scap_errprintf(error, 0, "Did not find id in cgroup file %s", filename);
-		}
-
-		// subsys
-		subsys_list = strtok_r(NULL, ":", &scratch);
-		if(subsys_list == NULL)
-		{
-			ASSERT(false);
-			fclose(f);
-			return scap_errprintf(error, 0, "Did not find subsys in cgroup file %s", filename);
-		}
-
-		// Hack to detect empty fields, because strtok does not support it
-		// strsep() should be used to fix this but it's not available
-		// on CentOS 6 (has been added from Glibc 2.19)
-		if(subsys_list-token-strlen(token) > 1)
-		{
-			// Subsys list empty (ie: it contains cgroup path instead)!
-			//
-			// See https://man7.org/linux/man-pages/man7/cgroups.7.html:
-			// 5:cpuacct,cpu,cpuset:/daemons
-			//
-			//              The colon-separated fields are, from left to right:
-			//
-			//              1. For cgroups version 1 hierarchies, this field contains
-			//                 a unique hierarchy ID number that can be matched to a
-			//                 hierarchy ID in /proc/cgroups.  For the cgroups version
-			//                 2 hierarchy, this field contains the value 0.
-			//
-			//              2. For cgroups version 1 hierarchies, this field contains
-			//                 a comma-separated list of the controllers bound to the
-			//                 hierarchy.  For the cgroups version 2 hierarchy, this
-			//                 field is empty.
-			//
-			//              3. This field contains the pathname of the control group
-			//                 in the hierarchy to which the process belongs.  This
-			//                 pathname is relative to the mount point of the
-			//                 hierarchy.
-			//
-			// -> for cgroup2: id is always 0 and subsys list is always empty (single unified hierarchy)
-			// -> for cgroup1: skip subsys empty because it means controller is not mounted on any hierarchy
-			if (cgroup_version == 2 && strcmp(token, "0") == 0)
-			{
-				cgroup = subsys_list;
-				subsys_list = default_subsys_list; // force-set a default subsys list
-
-				size_t cgroup_len = strlen(cgroup);
-				if (cgroup_len != 0 && cgroup[cgroup_len - 1] == '\n')
-				{
-					cgroup[cgroup_len - 1] = '\0';
-				}
-			} else
-			{
-				// skip cgroups like this:
-				// 0::/init.scope
-				continue;
-			}
-		} else
-		{
-			// cgroup should be the only thing remaining so use newline as the delimiter.
-			cgroup = strtok_r(NULL, "\n", &scratch);
-			if(cgroup == NULL)
-			{
-				ASSERT(false);
-				fclose(f);
-				return scap_errprintf(error, 0, "Did not find cgroup in cgroup file %s", filename);
-			}
-		}
-
-		while((token = strtok_r(subsys_list, ",", &scratch)) != NULL)
-		{
-			subsys_list = NULL;
-			if(strlen(cgroup) + 1 + strlen(token) + 1 > SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len)
-			{
-				ASSERT(false);
-				fclose(f);
-				return SCAP_SUCCESS;
-			}
-
-			snprintf(tinfo->cgroups + tinfo->cgroups_len, SCAP_MAX_CGROUPS_SIZE - tinfo->cgroups_len, "%s=%s", token, cgroup);
-			tinfo->cgroups_len += strlen(cgroup) + 1 + strlen(token) + 1;
-		}
-	}
-
-	fclose(f);
-	return SCAP_SUCCESS;
-}
 
 int32_t scap_proc_fill_pidns_start_ts(char* error, struct scap_threadinfo* tinfo, const char* procdirname)
 {

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1264,12 +1264,17 @@ bool scap_is_thread_alive(scap_t* handle, int64_t pid, int64_t tid, const char* 
 
 int32_t scap_refresh_proc_table(scap_t* handle)
 {
+	int ret;
 	if(handle->m_proclist.m_proclist)
 	{
 		scap_proc_free_table(&handle->m_proclist);
 		handle->m_proclist.m_proclist = NULL;
 	}
-	return scap_proc_scan_proc_dir(handle, handle->m_lasterr);
+
+	scap_cgroup_enable_cache(&handle->m_cgroups);
+	ret = scap_proc_scan_proc_dir(handle, handle->m_lasterr);
+	scap_cgroup_clear_cache(&handle->m_cgroups);
+	return ret;
 }
 
 int32_t scap_procfs_get_threadlist(struct scap_engine_handle engine, struct ppm_proclist_info **procinfo_p, char *lasterr)

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -106,8 +106,6 @@ int32_t scap_fd_allocate_fdinfo(scap_fdinfo **fdi, int64_t fd, scap_fd_type type
 // Free a file descriptor
 void scap_fd_free_fdinfo(scap_fdinfo **fdi);
 
-int32_t scap_proc_fill_cgroups(char* error, int cgroup_version, struct scap_threadinfo* tinfo, const char* procdirname);
-
 int32_t scap_proc_fill_pidns_start_ts(char* error, struct scap_threadinfo* tinfo, const char* procdirname);
 
 bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_entries, char* error);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -32,6 +32,10 @@ limitations under the License.
 #include "scap_assert.h"
 #include "scap_suppress.h"
 
+#ifdef __linux__
+#include "linux/scap_cgroup.h"
+#endif // __linux__
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -59,7 +63,9 @@ struct scap
 	struct ppm_proclist_info* m_driver_procinfo;
 	uint32_t m_fd_lookup_limit;
 	bool m_minimal_scan;
-	uint8_t m_cgroup_version;
+#ifdef __linux__
+	struct scap_cgroup_interface m_cgroups;
+#endif // __linux__
 
 	// /proc scan parameters
 	uint64_t m_proc_scan_timeout_ms;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -169,6 +169,10 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 		return rc;
 	}
 
+#ifdef __linux__
+	scap_cgroup_clear_cache(&handle->m_cgroups);
+#endif
+
 	return SCAP_SUCCESS;
 }
 #endif // HAS_LIVE_CAPTURE
@@ -294,6 +298,10 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs, struct scap_pl
 	{
 		return rc;
 	}
+
+#ifdef __linux__
+	scap_cgroup_clear_cache(&handle->m_cgroups);
+#endif
 
 	return SCAP_SUCCESS;
 }
@@ -576,6 +584,10 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct sca
 		return rc;
 	}
 
+#ifdef __linux__
+	scap_cgroup_clear_cache(&handle->m_cgroups);
+#endif
+
 	return SCAP_SUCCESS;
 }
 #endif // HAS_ENGINE_NODRIVER
@@ -848,6 +860,10 @@ void scap_deinit(scap_t* handle)
 		scap_platform_close(handle->m_platform);
 		scap_platform_free(handle->m_platform);
 	}
+
+#ifdef __linux__
+	scap_cgroup_clear_cache(&handle->m_cgroups);
+#endif // __linux__
 
 	if(handle->m_vtable)
 	{

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -99,7 +99,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;
@@ -232,7 +232,7 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs, struct scap_pl
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;
@@ -530,7 +530,7 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct sca
 	}
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -98,6 +98,14 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
+#ifdef __linux__
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	{
+		scap_close(handle);
+		return SCAP_FAILURE;
+	}
+#endif
+
 	//
 	// Create the interface list
 	//
@@ -218,6 +226,14 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs, struct scap_pl
 	//
 
 	scap_retrieve_agent_info(&handle->m_agent_info);
+
+#ifdef __linux__
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	{
+		scap_close(handle);
+		return SCAP_FAILURE;
+	}
+#endif
 
 	//
 	// Create the interface list
@@ -504,6 +520,14 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct sca
 		handle->m_minimal_scan = true;
 		handle->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP; // fd lookup is limited here because is very expensive
 	}
+
+#ifdef __linux__
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr)) != SCAP_SUCCESS)
+	{
+		scap_close(handle);
+		return SCAP_FAILURE;
+	}
+#endif
 
 	//
 	// Extract agent information

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -99,7 +99,7 @@ int32_t scap_init_live_int(scap_t* handle, scap_open_args* oargs, const struct s
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, scap_get_host_root(), handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;
@@ -232,7 +232,7 @@ int32_t scap_init_udig_int(scap_t* handle, scap_open_args* oargs, struct scap_pl
 	scap_retrieve_agent_info(&handle->m_agent_info);
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, scap_get_host_root(), handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;
@@ -530,7 +530,7 @@ int32_t scap_init_nodriver_int(scap_t* handle, scap_open_args* oargs, struct sca
 	}
 
 #ifdef __linux__
-	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, handle->m_lasterr, true)) != SCAP_SUCCESS)
+	if((rc = scap_cgroup_interface_init(&handle->m_cgroups, scap_get_host_root(), handle->m_lasterr, true)) != SCAP_SUCCESS)
 	{
 		scap_close(handle);
 		return SCAP_FAILURE;

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -71,6 +71,7 @@ typedef struct ppm_evt_hdr scap_evt;
 #include "scap_limits.h"
 #include "scap_open.h"
 #include "scap_procs.h"
+#include "scap_cgroup_set.h"
 
 /* Include engine-specific params. */
 #include <engine/bpf/bpf_public.h>
@@ -284,9 +285,8 @@ typedef struct scap_threadinfo
 	int64_t vtid;  ///< The virtual id of this thread.
 	int64_t vpid; ///< The virtual id of the process containing this thread. In single thread threads, this is equal to vtid.
 	uint64_t pidns_init_start_ts; ///<The pid_namespace init task start_time ts.
-	char cgroups[SCAP_MAX_CGROUPS_SIZE];
-	uint16_t cgroups_len;
-	char root[SCAP_MAX_PATH_SIZE+1];
+	struct scap_cgroup_set cgroups;
+	char root[SCAP_MAX_PATH_SIZE + 1];
 	int filtered_out; ///< nonzero if this entry should not be saved to file
 	scap_fdinfo* fdlist; ///< The fd table for this process
 	uint64_t clone_ts; ///< When the clone that started this process happened.

--- a/userspace/libscap/scap_cgroup_set.h
+++ b/userspace/libscap/scap_cgroup_set.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "scap_limits.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	// just a sequence of NUL-terminated strings in a single buffer
+	struct scap_cgroup_set
+	{
+		int len;
+		char path[SCAP_MAX_CGROUPS_SIZE];
+	};
+
+#ifdef __cplusplus
+};
+#endif

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -553,7 +553,7 @@ static int32_t scap_write_proclist_entry(scap_dumper_t *d, struct scap_threadinf
 {
 	struct iovec args = {tinfo->args, tinfo->args_len};
 	struct iovec env = {tinfo->env, tinfo->env_len};
-	struct iovec cgroups = {tinfo->cgroups, tinfo->cgroups_len};
+	struct iovec cgroups = {tinfo->cgroups.path, tinfo->cgroups.len};
 
 	return scap_write_proclist_entry_bufs(d, tinfo, len,
 					      tinfo->comm,

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -118,8 +118,8 @@ set(SINSP_SOURCES
 	events/sinsp_events.cpp
 	events/sinsp_events_ppm_sc.cpp)
 
-if(NOT WIN32)
-	list(APPEND SINSP_SOURCES procfs_utils.cpp)
+if(NOT WIN32 AND NOT APPLE)
+	list(APPEND SINSP_SOURCES procfs_utils.cpp sinsp_cgroup.cpp)
 endif()
 
 if(WITH_CHISEL)

--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include "cgroup_list_counter.h"
 #include "sinsp.h"
+#include "sinsp_cgroup.h"
 
 namespace {
 // to prevent 32-bit number of kilobytes from overflowing, ignore values larger than 4 TiB.
@@ -84,8 +85,9 @@ namespace cgroup_limits {
 
 bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_value& value, bool name_check)
 {
+	sinsp_cgroup& cgroups = sinsp_cgroup::instance();
 	bool found_all = true;
-	std::shared_ptr<std::string> memcg_root = sinsp::lookup_cgroup_dir("memory");
+	std::shared_ptr<std::string> memcg_root = cgroups.lookup_cgroup_dir("memory");
 	if(name_check && key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
@@ -98,7 +100,7 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 		found_all = read_cgroup_val(memcg_root, key.m_mem_cgroup, "memory.limit_in_bytes", value.m_memory_limit) && found_all;
 	}
 
-	std::shared_ptr<std::string> cpucg_root = sinsp::lookup_cgroup_dir("cpu");
+	std::shared_ptr<std::string> cpucg_root = cgroups.lookup_cgroup_dir("cpu");
 	if(name_check && key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
@@ -113,7 +115,7 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_period_us", value.m_cpu_period) && found_all;
 	}
 
-	std::shared_ptr<std::string> cpuset_root = sinsp::lookup_cgroup_dir("cpuset");
+	std::shared_ptr<std::string> cpuset_root = cgroups.lookup_cgroup_dir("cpuset");
 	if (name_check && key.m_cpuset_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) cpuset cgroup for container [%s]: %s/%s -- no per-container cpuset cgroup, ignoring",

--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -87,20 +87,23 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 {
 	sinsp_cgroup& cgroups = sinsp_cgroup::instance();
 	bool found_all = true;
-	std::shared_ptr<std::string> memcg_root = cgroups.lookup_cgroup_dir("memory");
+
+	int memcg_version;
+	std::shared_ptr<std::string> memcg_root = cgroups.lookup_cgroup_dir("memory", memcg_version);
 	if(name_check && key.m_mem_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) mem cgroup for container [%s]: %s/%s -- no per-container memory cgroup, ignoring",
-			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+				key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
 	}
 	else
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) mem cgroup for container [%s]: %s/%s",
-			key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
+				key.m_container_id.c_str(), memcg_root->c_str(), key.m_mem_cgroup.c_str());
 		found_all = read_cgroup_val(memcg_root, key.m_mem_cgroup, "memory.limit_in_bytes", value.m_memory_limit) && found_all;
 	}
 
-	std::shared_ptr<std::string> cpucg_root = cgroups.lookup_cgroup_dir("cpu");
+	int cpu_version;
+	std::shared_ptr<std::string> cpucg_root = cgroups.lookup_cgroup_dir("cpu", cpu_version);
 	if(name_check && key.m_cpu_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_INFO, "(cgroup-limits) cpu cgroup for container [%s]: %s/%s -- no per-container CPU cgroup, ignoring",
@@ -115,8 +118,9 @@ bool get_cgroup_resource_limits(const cgroup_limits_key& key, cgroup_limits_valu
 		found_all = read_cgroup_val(cpucg_root, key.m_cpu_cgroup, "cpu.cfs_period_us", value.m_cpu_period) && found_all;
 	}
 
-	std::shared_ptr<std::string> cpuset_root = cgroups.lookup_cgroup_dir("cpuset");
-	if (name_check && key.m_cpuset_cgroup.find(key.m_container_id) == std::string::npos)
+	int cpuset_version;
+	std::shared_ptr<std::string> cpuset_root = cgroups.lookup_cgroup_dir("cpuset", cpuset_version);
+	if(name_check && key.m_cpuset_cgroup.find(key.m_container_id) == std::string::npos)
 	{
 		g_logger.format(sinsp_logger::SEV_DEBUG, "(cgroup-limits) cpuset cgroup for container [%s]: %s/%s -- no per-container cpuset cgroup, ignoring",
 				key.m_container_id.c_str(), cpuset_root->c_str(), key.m_cpuset_cgroup.c_str());

--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -43,13 +43,11 @@ std::string get_systemd_cgroup(const sinsp_threadinfo *tinfo)
 	// the kernel driver does not return cgroups without subsystems (e.g. name=systemd)
 	// in the cgroups field, so we have to do a check here, and load /proc/pid/cgroups
 	// ourselves if needed
+	std::string cgroup;
 
-	for(const auto& it : tinfo->cgroups())
+	if(tinfo->get_cgroup("name=systemd", cgroup))
 	{
-		if(it.first == "name=systemd")
-		{
-			return it.second;
-		}
+		return cgroup;
 	}
 
 	std::stringstream cgroups_file;

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -3321,26 +3321,11 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			RETURN_EXTRACT_STRING(m_tstr);
 		}
 	case TYPE_CGROUP:
+		if(tinfo->get_cgroup(m_argname, m_tstr))
 		{
-			auto cgroups = tinfo->cgroups();
-			uint32_t nargs = (uint32_t)cgroups.size();
-
-			if(nargs == 0)
-			{
-				return NULL;
-			}
-
-			for(uint32_t j = 0; j < nargs; j++)
-			{
-				if(cgroups[j].first == m_argname)
-				{
-					m_tstr = cgroups[j].second;
-					RETURN_EXTRACT_STRING(m_tstr);
-				}
-			}
-
-			return NULL;
+			RETURN_EXTRACT_STRING(m_tstr);
 		}
+		return NULL;
 	case TYPE_VTID:
 		if(tinfo->m_vtid == -1)
 		{

--- a/userspace/libsinsp/procfs_utils.cpp
+++ b/userspace/libsinsp/procfs_utils.cpp
@@ -47,25 +47,6 @@ int libsinsp::procfs_utils::get_userns_root_uid(std::istream& uid_map)
 }
 
 
-std::string libsinsp::procfs_utils::get_systemd_cgroup(std::istream& cgroups)
-{
-	std::string cgroups_line;
-
-	while(std::getline(cgroups, cgroups_line))
-	{
-		size_t cgpos = cgroups_line.find(":name=systemd:");
-		if(cgpos == std::string::npos)
-		{
-			continue;
-		}
-
-		std::string systemd_cgroup = cgroups_line.substr(cgpos + strlen(":name=systemd:"), std::string::npos);
-		return systemd_cgroup;
-	}
-
-	return "";
-}
-
 //
 // ns_helper
 //
@@ -108,4 +89,3 @@ bool libsinsp::procfs_utils::ns_helper::in_own_ns_mnt(int64_t pid) const
 
 	return true;
 }
-

--- a/userspace/libsinsp/procfs_utils.h
+++ b/userspace/libsinsp/procfs_utils.h
@@ -21,13 +21,6 @@ constexpr const int NO_MATCH = -1;
 int get_userns_root_uid(std::istream& uid_map);
 
 /**
- * @brief Get the path of the `name=systemd` cgroup
- * @param cgroups a stream with the contents of /proc/<pid>/cgroup
- * @return the path of the `name=systemd` cgroup
- */
-std::string get_systemd_cgroup(std::istream& cgroups);
-
-/**
  * @brief Access container data through proc
  */
 class ns_helper

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -944,10 +944,6 @@ public:
 		m_container_manager.set_container_engine_mask(mask);
 	}
 
-#if defined(HAS_CAPTURE) && !defined(_WIN32)
-	static std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
-#endif
-
 	// Add comm to the list of comms for which the inspector
 	// should not return events.
 	bool suppress_events_comm(const std::string &comm);

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -23,9 +23,11 @@ limitations under the License.
 
 sinsp_cgroup::sinsp_cgroup() = default;
 
-std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &subsys)
+std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &subsys, int &version)
 {
 	std::shared_ptr<std::string> cgroup_dir;
+
+	version = 1;
 
 	const auto &it = m_cgroup_dir_cache.find(subsys);
 	if(it != m_cgroup_dir_cache.end())

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include "sinsp_cgroup.h"
 #include "scap_const.h"
+#include "scap.h"
+#include "sinsp.h"
 
 sinsp_cgroup::sinsp_cgroup() :
 	m_scap_cgroup({})
@@ -45,6 +47,21 @@ std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &
 	}
 
 	return nullptr;
+}
+
+void sinsp_cgroup::lookup_cgroups(sinsp_threadinfo& tinfo)
+{
+	std::string procdirname = scap_get_host_root() + std::string("/proc/") + std::to_string(tinfo.m_tid);
+	struct scap_cgroup_set thread_cgroups = {};
+	char error[SCAP_LASTERR_SIZE];
+
+	int ret = scap_cgroup_get_thread(&m_scap_cgroup, procdirname.c_str(), &thread_cgroups, error);
+	if(ret != SCAP_SUCCESS)
+	{
+		return;
+	}
+
+	tinfo.set_cgroups(thread_cgroups.path, thread_cgroups.len);
 }
 
 sinsp_cgroup &sinsp_cgroup::instance()

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -22,7 +22,7 @@ sinsp_cgroup::sinsp_cgroup() :
 	m_scap_cgroup({})
 {
 	char error[SCAP_LASTERR_SIZE];
-	scap_cgroup_interface_init(&m_scap_cgroup, error);
+	scap_cgroup_interface_init(&m_scap_cgroup, error, false);
 }
 
 std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &subsys, int &version)

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -58,3 +58,10 @@ sinsp_cgroup &sinsp_cgroup::instance()
 
 	return *instance;
 }
+
+sinsp_cgroup::~sinsp_cgroup()
+{
+#ifdef __linux__
+	scap_cgroup_clear_cache(&m_scap_cgroup);
+#endif // __linux__
+}

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sinsp_cgroup.h"
+#include "scap_const.h"
+#include "scap.h"
+
+#include <mntent.h>
+
+sinsp_cgroup::sinsp_cgroup() = default;
+
+std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &subsys)
+{
+	std::shared_ptr<std::string> cgroup_dir;
+
+	const auto &it = m_cgroup_dir_cache.find(subsys);
+	if(it != m_cgroup_dir_cache.end())
+	{
+		return it->second;
+	}
+
+	// Look for mount point of cgroup filesystem
+	// It should be already mounted on the host or by
+	// our docker-entrypoint.sh script
+	if(strcmp(scap_get_host_root(), "") != 0)
+	{
+		// We are inside our container, so we should use the directory
+		// mounted by it
+		auto cgroup = std::string(scap_get_host_root()) + "/cgroup/" + subsys;
+		cgroup_dir = std::make_shared<std::string>(cgroup);
+	}
+	else
+	{
+		struct mntent mntent_buf = {};
+		char mntent_string_buf[4096];
+		FILE *fp = setmntent("/proc/mounts", "r");
+		struct mntent *entry = getmntent_r(fp, &mntent_buf,
+						   mntent_string_buf, sizeof(mntent_string_buf));
+		while(entry != nullptr)
+		{
+			if(strcmp(entry->mnt_type, "cgroup") == 0 &&
+			   hasmntopt(entry, subsys.c_str()) != nullptr)
+			{
+				cgroup_dir = std::make_shared<std::string>(entry->mnt_dir);
+				break;
+			}
+			entry = getmntent(fp);
+		}
+		endmntent(fp);
+	}
+
+	if(cgroup_dir != nullptr)
+	{
+		m_cgroup_dir_cache[subsys] = cgroup_dir;
+	}
+	return cgroup_dir;
+}
+
+sinsp_cgroup &sinsp_cgroup::instance()
+{
+	static std::unique_ptr<sinsp_cgroup> instance;
+
+	if(instance == nullptr)
+	{
+		instance = std::make_unique<sinsp_cgroup>();
+	}
+
+	return *instance;
+}

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -21,10 +21,16 @@ limitations under the License.
 #include "sinsp.h"
 
 sinsp_cgroup::sinsp_cgroup() :
+	sinsp_cgroup(scap_get_host_root())
+{
+}
+
+sinsp_cgroup::sinsp_cgroup(std::string &&root) :
+	m_root(std::move(root)),
 	m_scap_cgroup({})
 {
 	char error[SCAP_LASTERR_SIZE];
-	scap_cgroup_interface_init(&m_scap_cgroup, error, false);
+	scap_cgroup_interface_init(&m_scap_cgroup, m_root.c_str(), error, false);
 }
 
 std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &subsys, int &version)
@@ -51,7 +57,7 @@ std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &
 
 void sinsp_cgroup::lookup_cgroups(sinsp_threadinfo& tinfo)
 {
-	std::string procdirname = scap_get_host_root() + std::string("/proc/") + std::to_string(tinfo.m_tid);
+	std::string procdirname = m_root + "/proc/" + std::to_string(tinfo.m_tid) + '/';
 	struct scap_cgroup_set thread_cgroups = {};
 	char error[SCAP_LASTERR_SIZE];
 

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -25,7 +25,7 @@ class sinsp_cgroup {
 public:
 	sinsp_cgroup();
 
-	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
+	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string &subsys, int &version);
 
 	static sinsp_cgroup &instance();
 

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+class sinsp_cgroup {
+public:
+	sinsp_cgroup();
+
+	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string& subsys);
+
+	static sinsp_cgroup &instance();
+
+protected:
+	std::unordered_map<std::string, std::shared_ptr<std::string>> m_cgroup_dir_cache;
+};

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -23,6 +23,8 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 
+class sinsp_threadinfo;
+
 class sinsp_cgroup {
 public:
 	sinsp_cgroup();
@@ -30,6 +32,8 @@ public:
 	virtual ~sinsp_cgroup();
 
 	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string &subsys, int &version);
+
+	void lookup_cgroups(sinsp_threadinfo& tinfo);
 
 	static sinsp_cgroup &instance();
 

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -27,6 +27,8 @@ class sinsp_cgroup {
 public:
 	sinsp_cgroup();
 
+	virtual ~sinsp_cgroup();
+
 	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string &subsys, int &version);
 
 	static sinsp_cgroup &instance();

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -29,6 +29,8 @@ class sinsp_cgroup {
 public:
 	sinsp_cgroup();
 
+	explicit sinsp_cgroup(std::string &&root);
+
 	virtual ~sinsp_cgroup();
 
 	std::shared_ptr<std::string> lookup_cgroup_dir(const std::string &subsys, int &version);
@@ -38,6 +40,7 @@ public:
 	static sinsp_cgroup &instance();
 
 protected:
+	std::string m_root;
 	struct scap_cgroup_interface m_scap_cgroup;
 	std::unordered_map<std::string, std::pair<std::shared_ptr<std::string>, int>> m_cgroup_dir_cache;
 };

--- a/userspace/libsinsp/sinsp_cgroup.h
+++ b/userspace/libsinsp/sinsp_cgroup.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #pragma once
 
+#include "linux/scap_cgroup.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -30,5 +32,6 @@ public:
 	static sinsp_cgroup &instance();
 
 protected:
-	std::unordered_map<std::string, std::shared_ptr<std::string>> m_cgroup_dir_cache;
+	struct scap_cgroup_interface m_scap_cgroup;
+	std::unordered_map<std::string, std::pair<std::shared_ptr<std::string>, int>> m_cgroup_dir_cache;
 };

--- a/userspace/libsinsp/sinsp_resource_utilization.cpp
+++ b/userspace/libsinsp/sinsp_resource_utilization.cpp
@@ -28,12 +28,9 @@ limitations under the License.
 
 void get_rss_vsz_pss_memory(uint32_t &rss, uint32_t &vsz, uint32_t &pss)
 {
-	char filepath[512];
 	char line[512];
-	pid_t pid = getpid();
 
-	snprintf(filepath, sizeof(filepath), "/proc/%d/status", pid);
-	FILE* f = fopen(filepath, "r");
+	FILE* f = fopen("/proc/self/status", "r");
 	if(!f)
 	{
 		ASSERT(false);
@@ -53,8 +50,7 @@ void get_rss_vsz_pss_memory(uint32_t &rss, uint32_t &vsz, uint32_t &pss)
 	}
 	fclose(f);
 
-	snprintf(filepath, sizeof(filepath), "/proc/%d/smaps_rollup", pid);
-	f = fopen(filepath, "r");
+	f = fopen("/proc/self/smaps_rollup", "r");
 	if(!f)
 	{
 		ASSERT(false);

--- a/userspace/libsinsp/test/procfs_utils.ut.cpp
+++ b/userspace/libsinsp/test/procfs_utils.ut.cpp
@@ -37,23 +37,3 @@ TEST(procfs_utils_test, get_userns_uid_root)
 
 	ASSERT_EQ(get_userns_root_uid(s), 0);
 }
-
-TEST(procfs_utils_test, get_systemd_cgroup)
-{
-	std::string cgroups = "12:perf_event:/\n"
-			      "11:memory:/user.slice/user-0.slice/session-10697.scope\n"
-			      "10:cpuset:/\n"
-			      "9:cpu,cpuacct:/user.slice/user-0.slice/session-10697.scope\n"
-			      "8:hugetlb:/\n"
-			      "7:freezer:/\n"
-			      "6:rdma:/\n"
-			      "5:devices:/user.slice/user-0.slice/session-10697.scope\n"
-			      "4:pids:/user.slice/user-0.slice/session-10697.scope\n"
-			      "3:blkio:/user.slice/user-0.slice/session-10697.scope\n"
-			      "2:net_cls,net_prio:/\n"
-			      "1:name=systemd:/user.slice/user-0.slice/session-10697.scope";
-	std::stringstream s(cgroups);
-
-	ASSERT_EQ(get_systemd_cgroup(s), "/user.slice/user-0.slice/session-10697.scope");
-}
-

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -227,8 +227,8 @@ protected:
 		tinfo.args_len = argsv.size();
 		memcpy(tinfo.env, envv.data(), envv.size());
 		tinfo.env_len = envv.size();
-		memcpy(tinfo.cgroups, cgroupsv.data(), cgroupsv.size());
-		tinfo.cgroups_len = cgroupsv.size();
+		memcpy(tinfo.cgroups.path, cgroupsv.data(), cgroupsv.size());
+		tinfo.cgroups.len = cgroupsv.size();
 
 		strlcpy(tinfo.cwd, cwd.c_str(), sizeof(tinfo.cwd));
 		strlcpy(tinfo.comm, comm.c_str(), sizeof(tinfo.comm));

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -489,7 +489,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_tty = pi->tty;
 	m_category = CAT_NONE;
 
-	set_cgroups(pi->cgroups, pi->cgroups_len);
+	set_cgroups(pi->cgroups.path, pi->cgroups.len);
 	m_root = pi->root;
 	ASSERT(m_inspector);
 	m_inspector->m_container_manager.resolve_container(this, m_inspector->is_live() || m_inspector->is_syscall_plugin());

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1189,19 +1189,6 @@ size_t sinsp_threadinfo::env_len() const
 	return strvec_len(m_env);
 }
 
-size_t sinsp_threadinfo::cgroups_len() const
-{
-	size_t totlen = 0;
-
-	for(auto &cgroup : cgroups())
-	{
-		totlen += cgroup.first.size() + 1 + cgroup.second.size();
-		totlen++; // Trailing NULL
-	}
-
-	return totlen;
-}
-
 void sinsp_threadinfo::args_to_iovec(struct iovec **iov, int *iovcnt,
 				     std::string &rem) const
 {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1043,6 +1043,20 @@ const std::string& sinsp_threadinfo::get_cgroup(const std::string& subsys) const
 	return notfound;
 }
 
+bool sinsp_threadinfo::get_cgroup(const std::string& subsys, std::string& cgroup) const
+{
+	for(const auto& it : cgroups())
+	{
+		if(it.first == subsys)
+		{
+			cgroup = it.second;
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void sinsp_threadinfo::traverse_parent_state(visitor_func_t &visitor)
 {
 	// Use two pointers starting at this, traversing the parent

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -511,6 +511,7 @@ VISIBILITY_PRIVATE
 	friend class sinsp_tracerparser;
 	friend class lua_cbacks;
 	friend class sinsp_baseliner;
+	friend class sinsp_cgroup; // for set_cgroups
 };
 
 /*@}*/

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -364,7 +364,6 @@ public:
 
 	size_t args_len() const;
 	size_t env_len() const;
-	size_t cgroups_len() const;
 
 	void args_to_iovec(struct iovec **iov, int *iovcnt,
 			   std::string &rem) const;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -228,8 +228,18 @@ public:
 
 	/*!
 	  \brief Return the cgroup name for a specific subsystem
+
+	  If the subsystem isn't mounted, return "/"
 	 */
-	 const std::string& get_cgroup(const std::string& subsys) const;
+	const std::string& get_cgroup(const std::string& subsys) const;
+
+	/*!
+	  \brief Return the cgroup name for a specific subsystem
+
+	  If the subsystem isn't mounted, return false and leave `cgroup`
+	  unchanged
+	 */
+	bool get_cgroup(const std::string& subsys, std::string& cgroup) const;
 
 	//
 	// Walk up the parent process hierarchy, calling the provided

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -121,7 +121,7 @@ sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	, m_last_flush_time_ns(0)
 	, m_inspector(inspector)
 	, m_host_root(m_inspector->get_host_root())
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+#if defined(__linux__) && (defined(HAVE_PWD_H) || defined(HAVE_GRP_H))
 	, m_ns_helper(new libsinsp::procfs_utils::ns_helper(m_host_root))
 #else
 	, m_ns_helper(nullptr)
@@ -135,7 +135,7 @@ sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 
 sinsp_usergroup_manager::~sinsp_usergroup_manager()
 {
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+#if defined(__linux__) && (defined(HAVE_PWD_H) || defined(HAVE_GRP_H))
 	delete m_ns_helper;
 #endif
 }
@@ -350,7 +350,7 @@ scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &co
 
 	scap_userinfo *retval{nullptr};
 
-#if defined HAVE_PWD_H && defined HAVE_FGET__ENT
+#if defined(__linux__) && defined HAVE_PWD_H && defined HAVE_FGET__ENT
 	if(!m_ns_helper->in_own_ns_mnt(pid))
 	{
 		return retval;
@@ -470,7 +470,7 @@ scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &
 
 	scap_groupinfo *retval{nullptr};
 
-#if defined HAVE_GRP_H && defined HAVE_FGET__ENT
+#if defined(__linux__) && defined HAVE_GRP_H && defined HAVE_FGET__ENT
 	if(!m_ns_helper->in_own_ns_mnt(pid))
 	{
 		return retval;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

1. Support cgroups v2. ~This mostly involves surfacing the cgroup version everywhere instead of hiding it and has some interesting consequences for scap files: for compatibility with existing captures, we store the cgroups in v1 format. This means that features requiring cgroup v2 one way or another won't work while reading scap files. It's easily fixable but would break compatibility when reading new scap files from old builds so I deferred it for now~. The major missing things about cgroups v2 were hardcoding a list of subsystems and assuming all subsystems have the same cgroup path. This is false, since directories in the cgroup hierarchy can have a list of controllers it supports. This patch reads the supported controllers from the cgroupfs directly, fixing both issues.

2. Support cgroup namespaces. From one commit message:

    With cgroup namespaces enabled, all /proc/<pid>/cgroup entries
    are relative to the namespace root, so we need a way to get
    the absolute paths, as well as the actual host's cgroup filesystem(s)
    to read cgroup metrics.

    Since we can't opt out of cgroup namespaces in containers (with k8s
    at least), we need a hack to break out of the namespace. For example,
    when running in a container with the following mounts:
    - host's /proc mounted at /host/proc
    - cgroup fs mounted at /cgroup
   
    we observe the following:
    - /proc/*/cgroup contains virtualized cgroup names
    - /cgroup contains only our cgroup (and its descendants)
    - /host/proc/*/cgroup *still* only contains virtualized cgroup names
    - /host/proc/1/sys/fs/cgroup (or similar) contains all cgroups

    So there's no way to get a process's full cgroup names from within
    a cgroup namespace. Thankfully, even the virtualized cgroups can be
    converted to full paths with extra context as they're not simply
    truncated to / but contain the actual path relative to the cgroup
    namespace root, e.g. /../some-other-container or /../../system.slice/...

    In order to reconstruct the full cgroup path, we need to know
    the absolute path to our own cgroup. Given the above, the only way to
    do this is to recursively look for our pid in all the cgroups.
    Sadly, this is very expensive, so also provide a way to create
    a scap_cgroup_interface without fetching our own cgroup (if you only
    need the mounts, for example).

    Why do we want a second scap_cgroup_interface? In sinsp we need to
    look up cgroup mount directories in a fairly weird context (separate
    thread during container metadata lookup without access to `sinsp`
    instance). In order to avoid lifetime issues, it's easiest to just
    create a second one for lookup_cgroup_dir().

**Special notes for your reviewer**:

There's a ton of stuff here, probably works best commit-by-commit to review. ~I marked it as WIP since I need to test it more but please take a look if you can (I don't expect any fundamental changes).~

I'm not sure about the release note for this, so let me summarize the externally-visible changes and let you decide:

* cgroups v2 should just work™️
* cgroups v1 and v2 should just work™️ in a cgroup namespace
* mixed v1/v2 setup should just work™️
* sinsp API change: lookup_cgroup_dir() moved from a static method in sinsp to an instance method of sinsp_cgroup (there's a static instance available via `sinsp_cgroup::instance()` so you don't need to maintain your own)
* ~filtercheck change: in a cgroups v2 enabled setup (but not in a scap file!), the TYPE_CGROUPS filtercheck now returns just a single path (without any subsystems etc.), i.e. `foo` instead of `cpu=foo cpuset=foo memory=foo`~
* ~filtercheck change: in a cgroups v2 enabled setup (but not in a scap file!), the TYPE_CGROUP filtercheck now returns the cgroup path for any subsystem, not just cpu, cpuset and memory~

For future improvements, we can:
* ~support mixed v1 and v2 cgroups (feels feasible with this architecture)~
* ~support v2 cgroups in scap files (I have some ideas with varying degrees of ickyness)~
* expose at least "our cgroup from the init cgroupns" via the driver so we don't need the recursive grep implementation

UPDATE: I redesigned the thing and the new approach:
* supports mixed v1/v2 with no hardcore hacks
* doesn't affect filterchecks and scap files
* limits the scope to libscap (and some minor API spills to sinsp)

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(scap): systems using cgroups v2 are now fully supported
```
