### PR TITLE
fix(modern_bpf): Fix extract__loginuid for COS

### DIFF
--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -26,6 +26,23 @@ enum capability_type
 	CAP_EFFECTIVE = 2,
 };
 
+/* COS kernels handle audit field differently, see [1]. To support both
+ * versions define COS subset of task_struct with a flavor suffix (which will
+ * be ignored during relocation matching [2]).
+ *
+ * [1]: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
+ * [2]: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/tree/tools/lib/bpf/libbpf.c#n5347
+ */
+struct audit_task_info {
+	kuid_t			loginuid;
+	unsigned int		sessionid;
+	struct audit_context	*ctx;
+};
+
+struct task_struct___cos {
+	struct audit_task_info		*audit;
+} __attribute__((preserve_access_index));
+
 /* All the functions that are called in bpf to extract parameters
  * start with the `extract` prefix.
  */
@@ -600,6 +617,12 @@ static __always_inline void extract__loginuid(struct task_struct *task, u32 *log
 	if(bpf_core_field_exists(task->loginuid))
 	{
 		READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
+	}
+	else
+	{
+		struct task_struct___cos *task_cos = (void *) task;
+
+		READ_TASK_FIELD_INTO(loginuid, task_cos, audit->loginuid.val);
 	}
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

COS kernels have task_struct that differs from the vanilla one in regards how audit information is stored, loginuid is present in an intermediate structure audit_task_info [[1]]. This mean regular CO-RE read will not pass verifier on COS kernels. To address it, check the field presence first, before extracting the value. Note, it's important that the condition is formulated this way -- the first branch should be an existing one, otherwise it will be removed as a dead code and no comparison will be made [[2]].

[1]: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/096925a44076ba5c52faa84d255a847130ff341e%5E%21/#F2
[2]: https://nakryiko.com/posts/bpf-core-reference-guide/#handling-incompatible-field-and-type-changes

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
