### PR TITLE
fix(tests): use a non-null inspector for filter tests

### DIFF
--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -55,9 +55,11 @@ public:
 class mock_compiler_filter_factory: public gen_event_filter_factory
 {
 public:
+	mock_compiler_filter_factory(sinsp *inspector) : m_inspector(inspector) {}
+
 	inline gen_event_filter *new_filter() override
 	{
-		return new sinsp_filter(NULL);
+		return new sinsp_filter(m_inspector);
 	}
 
 	inline gen_event_filter_check *new_filtercheck(const char *fldname) override
@@ -71,6 +73,7 @@ public:
 	}
 
 	list<gen_event_filter_factory::filter_fieldclass_info> m_list;
+	sinsp *m_inspector;
 };
 
 // Compile a filter, pass a mock event to it, and
@@ -78,8 +81,9 @@ public:
 // the expected one
 void test_filter_run(bool result, string filter_str)
 {
+	sinsp inspector;
 	std::shared_ptr<gen_event_filter_factory> factory;
-	factory.reset(new mock_compiler_filter_factory());
+	factory.reset(new mock_compiler_filter_factory(&inspector));
 	sinsp_filter_compiler compiler(factory, filter_str);
 	try
 	{
@@ -176,7 +180,8 @@ TEST(sinsp_filter_compiler, str_escape)
 
 TEST(sinsp_filter_compiler, supported_operators)
 {
-	std::shared_ptr<gen_event_filter_factory> factory(new mock_compiler_filter_factory());
+	sinsp inspector;
+	std::shared_ptr<gen_event_filter_factory> factory(new mock_compiler_filter_factory(&inspector));
 
 	// valid operators
 	test_filter_compile(factory, "c.true exists");
@@ -210,7 +215,8 @@ TEST(sinsp_filter_compiler, supported_operators)
 
 TEST(sinsp_filter_compiler, complex_filter)
 {
-	std::shared_ptr<gen_event_filter_factory> factory(new sinsp_filter_factory(NULL));
+	sinsp inspector;
+	std::shared_ptr<gen_event_filter_factory> factory(new mock_compiler_filter_factory(&inspector));
 
 	// This is derived from the Falco default rule
 	// "Unexpected outbound connection destination" coming from here:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This moves us a step closer to testing also for undefined behavior in our unit tests. Some tests rely on calling class methods with a NULL inspector. Since technically those methods do not access the sinsp state they work at runtime but I believe it's UB according to the standard.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
