### PR TITLE
cleanup(cri): enhance robustness for container image retrieval

### DIFF
--- a/userspace/libsinsp/container_engine/cri.cpp
+++ b/userspace/libsinsp/container_engine/cri.cpp
@@ -128,6 +128,7 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 	}
 
 	const auto &resp_container = resp.status();
+	const auto &resp_container_info = resp.info();
 	container.m_full_id = resp_container.id();
 	container.m_name = resp_container.metadata().name();
 
@@ -142,7 +143,7 @@ bool cri_async_source::parse(const key_type& key, sinsp_container_info& containe
 		}
 	}
 
-	m_cri->parse_cri_image(resp_container, container);
+	m_cri->parse_cri_image(resp_container, resp_container_info, container);
 	m_cri->parse_cri_mounts(resp_container, container);
 
 	if(!parse_containerd(resp, container))

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -84,10 +84,11 @@ public:
 	/**
 	 * @brief fill out container image information based on CRI response
 	 * @param status `status` field of the ContainerStatusResponse
+	 * @param info `info` field of the ContainerStatusResponse
 	 * @param container the container info to fill out
 	 * @return true if successful
 	 */
-	bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, sinsp_container_info &container);
+	bool parse_cri_image(const runtime::v1alpha2::ContainerStatus &status, const google::protobuf::Map<std::string, std::string> &info, sinsp_container_info &container);
 
 	/**
 	 * @brief fill out container mount information based on CRI response


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Attempt to enhance robustness for container image retrieval.

Did some production analyses and it seems the issue of `container.image.repository` occasionally being just `sha256` is extremely rare. I think that @gnosek previous patch https://github.com/falcosecurity/libs/pull/771 helped a lot, but most end users could not yet test it as it hasn't yet been part of a Falco release. In contrast I have that patch already running.

Since this is very critical for detection and incident response tried harder to add even more robustness. As you see in the minor code changes there are still some more places from where we can try to retrieve the container image. Fingers crossed all patches together eliminate remaining corner cases.

Verified the schemas locally with both `containerd` and `crio` runtimes, plus queried the schema for `containerd` using `crictl` on a real Kubernetes test server as well.


**Which issue(s) this PR fixes**:

https://github.com/falcosecurity/falco/issues/1187

CC @gnosek @leogr @sigurdfalk

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(cri): enhance robustness for container image retrieval
```
