### PR TITLE
fix(driver): wrong is_exe_upper_layer on kernel <5.x

### DIFF
--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -36,6 +36,7 @@ install(FILES
 	probe.c
 	quirks.h
 	ring_helpers.h
+	missing_definitions.h
 	types.h
 	DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}/bpf"
 	COMPONENT ${DRIVER_COMPONENT_NAME})

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -49,6 +49,7 @@ $(obj)/probe.o: $(src)/probe.c \
 		$(src)/plumbing_helpers.h \
 		$(src)/quirks.h \
 		$(src)/ring_helpers.h \
+		$(src)/missing_definitions.h \
 		$(src)/types.h
 	$(CLANG) $(LINUXINCLUDE) \
 		$(KBUILD_CPPFLAGS) \

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -13,6 +13,7 @@ or GPL2.txt for full copies of the license.
 #include "../ppm_flag_helpers.h"
 #include "../ppm_version.h"
 #include "bpf_helpers.h"
+#include "missing_definitions.h"
 
 #include <linux/tty.h>
 #include <linux/audit.h>
@@ -49,36 +50,6 @@ struct timeval {
 };
 #else
 #define timeval64 timeval
-#endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long has_upper;
-			bool opaque;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	struct path lowerstack[];
-};
-#else
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long flags;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	struct ovl_path lowerstack[];
-};
-
-enum ovl_entry_flag {
-	OVL_E_UPPER_ALIAS,
-	OVL_E_OPAQUE,
-	OVL_E_CONNECTED,
-};
 #endif
 
 #define FILLER_RAW(x)							\
@@ -2189,7 +2160,7 @@ static __always_inline bool get_exe_upper_layer(struct dentry *dentry, struct su
 		unsigned long has_upper = (unsigned long)_READ(oe->has_upper);
 #else
 		unsigned long flags = _READ(oe->flags);
-		unsigned long has_upper = test_bit(flags, OVL_E_UPPER_ALIAS);
+		unsigned long has_upper = (flags & (1U << (OVL_E_UPPER_ALIAS)));
 #endif
 		// Pointer arithmetics due to unexported ovl_inode struct
 		// warning: this works if and only if the dentry pointer is placed right after the inode struct
@@ -2708,11 +2679,11 @@ FILLER(execve_family_flags, true)
 	struct cred *cred = (struct cred *)_READ(task->cred);
 	struct inode *inode = get_exe_inode(task);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
 	struct mm_struct *mm = (struct mm_struct*)_READ(task->mm);
 	struct file *exe_file = (struct file*)_READ(mm->exe_file);
 	struct path f_path = (struct path)_READ(exe_file->f_path);
 	struct dentry* dentry = f_path.dentry;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
 	struct super_block* sb = _READ(dentry->d_sb);
 #else
 	struct super_block *sb = _READ(inode->i_sb);
@@ -6289,12 +6260,12 @@ FILLER(sched_prog_exec_4, false)
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	struct cred *cred = (struct cred *)_READ(task->cred);
 	struct inode *inode = get_exe_inode(task);
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
 	struct mm_struct *mm = (struct mm_struct*)_READ(task->mm);
 	struct file *exe_file = (struct file*)_READ(mm->exe_file);
 	struct path f_path = (struct path)_READ(exe_file->f_path);
 	struct dentry* dentry = f_path.dentry;
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
 	struct super_block* sb = _READ(dentry->d_sb);
 #else
 	struct super_block *sb = _READ(inode->i_sb);

--- a/driver/bpf/missing_definitions.h
+++ b/driver/bpf/missing_definitions.h
@@ -1,0 +1,39 @@
+/*
+
+Copyright (C) 2023 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+struct ovl_entry {
+	union {
+		struct {
+			unsigned long has_upper;
+			bool opaque;
+		};
+		struct rcu_head rcu;
+	};
+	unsigned numlower;
+	struct path lowerstack[];
+};
+#else
+struct ovl_entry {
+	union {
+		struct {
+			unsigned long flags;
+		};
+		struct rcu_head rcu;
+	};
+	unsigned numlower;
+	//struct ovl_path lowerstack[];
+};
+
+enum ovl_entry_flag {
+	OVL_E_UPPER_ALIAS,
+	OVL_E_OPAQUE,
+	OVL_E_CONNECTED,
+};
+#endif

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1418,7 +1418,7 @@ cgroups_error:
 	#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 							unsigned long has_upper = oe->has_upper;
 	#else
-							unsigned long has_upper = test_bit(flags, &(oe->flags));
+							unsigned long has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
 	#endif
 
 							if(*upper_dentry && (has_upper || disconnected))
@@ -7677,8 +7677,7 @@ cgroups_error:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 							unsigned long has_upper = oe->has_upper;
 #else
-							unsigned long flags = oe->flags;
-							unsigned long has_upper = test_bit(flags, OVL_E_UPPER_ALIAS);
+							unsigned long has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
 #endif
 
 							if(*upper_dentry && (has_upper || disconnected))

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1415,11 +1415,11 @@ cgroups_error:
 							// is placed right after the inode struct
 							upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
 
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 							unsigned long has_upper = oe->has_upper;
-	#else
+#else
 							unsigned long has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
-	#endif
+#endif
 
 							if(*upper_dentry && (has_upper || disconnected))
 							{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1400,6 +1400,7 @@ cgroups_error:
 						if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 						{
 							struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
+							unsigned long has_upper = 0;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 							if(oe->__upperdentry)
 							{
@@ -1416,9 +1417,9 @@ cgroups_error:
 							upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-							unsigned long has_upper = oe->has_upper;
+							has_upper = oe->has_upper;
 #else
-							unsigned long has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
+							has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
 #endif
 
 							if(*upper_dentry && (has_upper || disconnected))
@@ -7659,6 +7660,7 @@ cgroups_error:
 					if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
 					{
 							struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
+							unsigned long has_upper = 0;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 							if(oe->__upperdentry)
 							{
@@ -7675,9 +7677,9 @@ cgroups_error:
 							upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-							unsigned long has_upper = oe->has_upper;
+							has_upper = oe->has_upper;
 #else
-							unsigned long has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
+							has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
 #endif
 
 							if(*upper_dentry && (has_upper || disconnected))

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -924,8 +924,8 @@ bool ppm_is_upper_layer(struct file *exe_file){
 #endif
 		}
 	}
-	return false;
 #endif
+	return false;
 }
 
 int f_proc_startupdate(struct event_filler_arguments *args)

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -880,6 +880,54 @@ static int ppm_get_tty(void)
 
 #endif /* UDIG */
 
+bool ppm_is_upper_layer(struct file *exe_file){
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
+	struct super_block *sb = NULL;
+	unsigned long sb_magic = 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
+	sb = exe_file->f_path.dentry->d_sb;
+#else
+	sb = exe_file->f_inode->i_sb;
+#endif
+	if(sb)
+	{
+		sb_magic = sb->s_magic;
+		if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
+		{
+			struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
+			unsigned long has_upper = 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
+			if(oe->__upperdentry)
+			{
+				return true;
+			}
+#else
+			struct dentry **upper_dentry = NULL;
+			unsigned int d_flags = exe_file->f_path.dentry->d_flags;
+			bool disconnected = (d_flags & DCACHE_DISCONNECTED);
+
+			// Pointer arithmetics due to unexported ovl_inode struct
+			// warning: this works if and only if the dentry pointer
+			// is placed right after the inode struct
+			upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+			has_upper = oe->has_upper;
+#else
+			has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
+#endif
+
+			if(*upper_dentry && (has_upper || disconnected))
+			{
+				return true;
+			}
+#endif
+		}
+	}
+	return false;
+#endif
+}
+
 int f_proc_startupdate(struct event_filler_arguments *args)
 {
 #ifdef UDIG
@@ -1385,52 +1433,7 @@ cgroups_error:
 #endif
 
 				/* Support exe_upper_layer */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
-				{
-					struct super_block *sb = NULL;
-					unsigned long sb_magic = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
-					sb = exe_file->f_path.dentry->d_sb;
-#else
-					sb = exe_file->f_inode->i_sb;
-#endif
-					if(sb)
-					{
-						sb_magic = sb->s_magic;
-						if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
-						{
-							struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
-							unsigned long has_upper = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
-							if(oe->__upperdentry)
-							{
-								exe_upper_layer = true;
-							}
-#else
-							struct dentry **upper_dentry = NULL;
-							unsigned int d_flags = exe_file->f_path.dentry->d_flags;
-							bool disconnected = (d_flags & DCACHE_DISCONNECTED);
-
-							// Pointer arithmetics due to unexported ovl_inode struct
-							// warning: this works if and only if the dentry pointer
-							// is placed right after the inode struct
-							upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-							has_upper = oe->has_upper;
-#else
-							has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
-#endif
-
-							if(*upper_dentry && (has_upper || disconnected))
-							{
-								exe_upper_layer = true;
-							}
-#endif
-						}
-					}
-				}
-#endif
+				exe_upper_layer = ppm_is_upper_layer(exe_file);
 
 				/* Support inode number */
 				i_ino = file_inode(exe_file)->i_ino;
@@ -7644,53 +7647,8 @@ cgroups_error:
 #endif
 
 			/* Support exe_upper_layer */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
-			{
-				struct super_block *sb = NULL;
-				unsigned long sb_magic = 0;
+			exe_upper_layer = ppm_is_upper_layer(exe_file);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
-				sb = exe_file->f_path.dentry->d_sb;
-#else
-				sb = exe_file->f_inode->i_sb;
-#endif
-				if(sb)
-				{
-					sb_magic = sb->s_magic;
-					if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC)
-					{
-							struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
-							unsigned long has_upper = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
-							if(oe->__upperdentry)
-							{
-								exe_upper_layer = true;
-							}
-#else
-							struct dentry **upper_dentry = NULL;
-							unsigned int d_flags = exe_file->f_path.dentry->d_flags;
-							bool disconnected = (d_flags & DCACHE_DISCONNECTED);
-
-							// Pointer arithmetics due to unexported ovl_inode struct
-							// warning: this works if and only if the dentry pointer
-							// is placed right after the inode struct
-							upper_dentry = (struct dentry **)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-							has_upper = oe->has_upper;
-#else
-							has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
-#endif
-
-							if(*upper_dentry && (has_upper || disconnected))
-							{
-								exe_upper_layer = true;
-							}
-#endif
-					}
-				}
-			}
-#endif
 			/* Support inode number */
 			i_ino = file_inode(exe_file)->i_ino;
 

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -1,6 +1,7 @@
 #include "../../event_class/event_class.h"
 #include "../../flags/flags_definitions.h"
 #include "../../helpers/proc_parsing.h"
+#include "sys/mount.h"
 
 #if defined(__NR_execve) && defined(__NR_capget) && defined(__NR_clone3) && defined(__NR_wait4)
 
@@ -259,6 +260,198 @@ TEST(SyscallExit, execveX_success)
 	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+
+	/* Parameter 27: uid (type: PT_UINT32) */
+	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(27);
+}
+
+TEST(SyscallExit, execveX_upperlayer_success)
+{
+	auto evt_test = get_syscall_event_test(__NR_execve, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	const char lowerdir[] = "/bin";
+	const char upperdir[] = "/tmp/upper";
+	const char target[]   = "/tmp/merged";
+	char tmp_template[]  = "/tmp/tmpdir.XXXXXX";
+	char *mntopts;
+
+	/* Create a temporary directory for the work layer */
+	char *workdir = mkdtemp(tmp_template);
+
+    /* Create the overlay mount target directory */
+    mkdir(upperdir, 0777);
+    mkdir(target, 0777);
+
+	/* Construct the mount options string */
+    asprintf(&mntopts, "lowerdir=%s,upperdir=%s,workdir=%s", lowerdir, upperdir, workdir);
+
+    /* Mount the overlayfs */
+	if (mount("overlay", target, "overlay", MS_MGC_VAL, mntopts) != 0)
+	{
+		FAIL() << "Cannot mount overlay." << std::endl;
+    }
+
+	/* Copy /bin/true to /tmp/merged/uppertrue in the overlay file system */
+    char true_path[1024], upper_exe_path[1024];
+    sprintf(true_path, "%s/true", lowerdir);
+    sprintf(upper_exe_path, "%s/uppertrue", target);
+
+    int true_fd = open(true_path, O_RDONLY);
+    if (true_fd == -1)
+	{
+		FAIL() << "Cannot open /bin/true." << std::endl;
+    }
+
+    int upper_exe_fd = open(upper_exe_path, O_WRONLY|O_CREAT, 0777);
+    if (upper_exe_fd == -1)
+	{
+		FAIL() << "Cannot open /tmp/merged/uppertrue." << std::endl;
+    }
+
+    char buf[1024];
+    ssize_t bytes_read;
+    while ((bytes_read = read(true_fd, buf, sizeof(buf))) > 0)
+	{
+        if (write(upper_exe_fd, buf, bytes_read) != bytes_read)
+		{
+			FAIL() << "Cannot write /tmp/merged/uppertrue." << std::endl;
+        }
+    }
+
+    if (bytes_read == -1)
+	{
+		FAIL() << "Error copying /bin/true" << std::endl;
+    }
+
+    if (close(true_fd) == -1)
+	{
+		FAIL() << "Error closing /bin/true" << std::endl;
+    }
+
+    if (close(upper_exe_fd) == -1)
+	{
+		FAIL() << "Error closing /tmp/merged/uppertrue" << std::endl;
+    }
+
+	/* Prepare the execve args */
+	const char *pathname = upper_exe_path;
+	const char *comm = "uppertrue";
+	const char *argv[] = {upper_exe_path, "randomarg", NULL};
+	const char *envp[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", NULL};
+
+	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
+	 * when the child terminates.
+	 */
+	struct clone_args cl_args = {0};
+	cl_args.exit_signal = SIGCHLD;
+	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
+
+	/*
+	 * Call the `execve`
+	 */
+	if(ret_pid == 0)
+	{
+		syscall(__NR_execve, pathname, argv, envp);
+		exit(EXIT_FAILURE);
+	}
+
+	assert_syscall_state(SYSCALL_SUCCESS, "clone3", ret_pid, NOT_EQUAL, -1);
+
+	/* Catch the child before doing anything else. */
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "The child execve failed." << std::endl;
+	}
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	/* Unmount the overlay file system */
+    if (umount(target))
+	{
+		FAIL() << "Cannot unmount target dir." << std::endl;
+    }
+
+    /* Remove the upper and work directories */
+    rmdir(upperdir);
+    rmdir(workdir);
+    rmdir(target);
+
+	/* We search for a child event. */
+	evt_test->assert_event_presence(ret_pid);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Please note here we cannot assert all the params, we check only the possible ones. */
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)0);
+
+	/* Parameter 2: exe (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
+	/* Starting from `1` because the first is `exe`. */
+	evt_test->assert_charbuf_array_param(3, &argv[1]);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)ret_pid);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	/* We are the main thread of the process so it's equal to `tid`. */
+	evt_test->assert_numeric_param(5, (int64_t)ret_pid);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)::getpid());
+
+	/* Parameter 7: cwd (type: PT_CHARBUF) */
+	/* leave the current working directory empty like in the old probe. */
+	evt_test->assert_empty_param(7);
+
+	/* Parameter 14: comm (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(14, comm);
+
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
+	evt_test->assert_cgroup_param(15);
+
+	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
+	evt_test->assert_charbuf_array_param(16, &envp[0]);
+
+	/* PPM_EXE_WRITABLE is set when the user that executed a process can also write to the executable
+	 * file that is used to spawn it or is its owner or otherwise capable.
+	 */
+	evt_test->assert_numeric_param(20, (uint32_t)PPM_EXE_WRITABLE|PPM_EXE_UPPER_LAYER);
+
+	/* Parameter 24: exe_file ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(24, (uint64_t)1, GREATER_EQUAL);
+
+	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+
+	/* Parameter 26: exe_file mtime (last modifitrueion time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
 
 	/* Parameter 27: uid (type: PT_UINT32) */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area driver-kmod

/area driver-bpf

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

On kernels <5.x the field `is_exe_upper_layer` shows a wrong value. Prior of 5.x kernel the implementation of the overlayfs changed a couple of times and the previous implementation didn't take this problematic into account.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
