### PR TITLE
cleanup(tests): do not assert_throw when we check if a field exists

### DIFF
--- a/userspace/libsinsp/test/events_net.ut.cpp
+++ b/userspace/libsinsp/test/events_net.ut.cpp
@@ -66,14 +66,14 @@ TEST_F(sinsp_with_test_input, net_socket)
 	ASSERT_EQ(get_field_as_string(evt, "fd.l4proto"), "<NA>"); /// todo: probably this is not what we want
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
 	/* When the fd role is `none` all these fields return NULL */
-	EXPECT_THROW(get_field_as_string(evt, "fd.sip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.cip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.rip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.lip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.cport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.sport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.lport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.rport"), sinsp_exception);
+	ASSERT_FALSE(field_exists(evt, "fd.sip"));
+	ASSERT_FALSE(field_exists(evt, "fd.cip"));
+	ASSERT_FALSE(field_exists(evt, "fd.rip"));
+	ASSERT_FALSE(field_exists(evt, "fd.lip"));
+	ASSERT_FALSE(field_exists(evt, "fd.cport"));
+	ASSERT_FALSE(field_exists(evt, "fd.sport"));
+	ASSERT_FALSE(field_exists(evt, "fd.lport"));
+	ASSERT_FALSE(field_exists(evt, "fd.rport"));
 }
 
 TEST_F(sinsp_with_test_input, net_ipv4_connect)
@@ -123,7 +123,7 @@ TEST_F(sinsp_with_test_input, net_ipv4_connect)
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
 	ASSERT_EQ(get_field_as_string(evt, "fd.connected"), "false");
 	/* Since the role of the fd is none, all these fields are null. The fdinfo state is updated but we cannot use these info in the filterchecks */
-	EXPECT_THROW(get_field_as_string(evt, "fd.sip"), sinsp_exception);
+	ASSERT_FALSE(field_exists(evt, "fd.sip"));
 
 	/* If the exit event is immediately consecutive we can obtain some info otherwise there is the risk we cannot update the fd */
 	std::vector<uint8_t> socktuple = test_utils::pack_socktuple(reinterpret_cast<sockaddr*>(&client), reinterpret_cast<sockaddr*>(&server));
@@ -297,13 +297,13 @@ TEST_F(sinsp_with_test_input, net_bind_listen_accept_ipv4)
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), fdname);
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_server"), "true");
 	ASSERT_EQ(get_field_as_string(evt, "fd.sip"), DEFAULT_IPV4_SERVER_STRING);
-	ASSERT_THROW(get_field_as_string(evt, "fd.cip"), sinsp_exception); /* we are not able to retrieve the client ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
-	ASSERT_THROW(get_field_as_string(evt, "fd.rip"), sinsp_exception); /* we are not able to retrieve remote ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
-	ASSERT_THROW(get_field_as_string(evt, "fd.lip"), sinsp_exception); /* we are not able to retrieve local ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_exists(evt, "fd.cip")); /* we are not able to retrieve the client ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_exists(evt, "fd.rip")); /* we are not able to retrieve remote ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_exists(evt, "fd.lip")); /* we are not able to retrieve local ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
 	ASSERT_EQ(get_field_as_string(evt, "fd.sport"), DEFAULT_SERVER_PORT_STRING);
-	ASSERT_THROW(get_field_as_string(evt, "fd.cport"), sinsp_exception);
-	ASSERT_THROW(get_field_as_string(evt, "fd.rport"), sinsp_exception);
-	ASSERT_THROW(get_field_as_string(evt, "fd.lport"), sinsp_exception);
+	ASSERT_FALSE(field_exists(evt, "fd.cport"));
+	ASSERT_FALSE(field_exists(evt, "fd.rport"));
+	ASSERT_FALSE(field_exists(evt, "fd.lport"));
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_LISTEN_E, 2, server_fd, 5);
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_LISTEN_X, 1, return_value);
@@ -601,14 +601,14 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_missing_wo_fd_param_exi
 
 	/* Check that we are not able to load any info */
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
-	EXPECT_THROW(get_field_as_string(evt, "fd.sip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.cip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.rip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.lip"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.cport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.sport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.lport"), sinsp_exception);
-	EXPECT_THROW(get_field_as_string(evt, "fd.rport"), sinsp_exception);
+	ASSERT_FALSE(field_exists(evt, "fd.sip"));
+	ASSERT_FALSE(field_exists(evt, "fd.cip"));
+	ASSERT_FALSE(field_exists(evt, "fd.rip"));
+	ASSERT_FALSE(field_exists(evt, "fd.lip"));
+	ASSERT_FALSE(field_exists(evt, "fd.cport"));
+	ASSERT_FALSE(field_exists(evt, "fd.sport"));
+	ASSERT_FALSE(field_exists(evt, "fd.lport"));
+	ASSERT_FALSE(field_exists(evt, "fd.rport"));
 
 	/* The parser is not able to obtain an updated fdname because the syscall fails and the parser flow is truncated */
 	fdinfo = evt->get_fd_info();


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

as per title

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
