### PR TITLE
fix(userspace/libsinsp): support EOF in sinsp-example

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -409,9 +409,15 @@ sinsp_evt* get_event(sinsp& inspector, std::function<void(const std::string&)> h
 
 	int32_t res = inspector.next(&ev);
 
-	if(res == SCAP_SUCCESS)
+	if (res == SCAP_SUCCESS)
 	{
 		return ev;
+	}
+	if (res == SCAP_EOF)
+	{
+		std::cout << "-- EOF" << std::endl;
+		g_interrupted = true;
+		return nullptr;
 	}
 
 	if(res != SCAP_TIMEOUT && res != SCAP_FILTERED_EVENT)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

`sinsp-example` treats EOF as an error, whereas the expected behavior is for it to interrupt the event capture. This can be easily reproduced with a capture file or a plugin.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
