### PR TITLE
fix(userspace/libsinsp): properly format double numbers as json

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -662,7 +662,15 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 				ASSERT(false);
 				return Json::nullValue;
 			}
-
+		case PT_DOUBLE:
+			if(print_format == PF_DEC)
+			{
+		 		return (Json::Value::Int64)(int64_t)*(double*)rawval;
+			}
+			else
+			{
+				return (Json::Value)*(double*)rawval;
+			}
 		case PT_INT64:
 		case PT_PID:
 		case PT_FD:

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -1917,7 +1917,7 @@ const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 	{PT_BOOL, EPF_NONE, PF_NA, "proc.is_container_readiness_probe", "Process Is Container Readiness", "'true' if this process is running as a part of the container's readiness probe."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.fdopencount", "FD Count", "Number of open FDs for the process"},
 	{PT_INT64, EPF_NONE, PF_DEC, "proc.fdlimit", "FD Limit", "Maximum number of FDs the process can open."},
-	{PT_DOUBLE, EPF_NONE, PF_DEC, "proc.fdusage", "FD Usage", "The ratio between open FDs and maximum available FDs for the process."},
+	{PT_DOUBLE, EPF_NONE, PF_NA, "proc.fdusage", "FD Usage", "The ratio between open FDs and maximum available FDs for the process."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.vmsize", "VM Size", "Total virtual memory for the process (as kb)."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.vmrss", "VM RSS", "Resident non-swapped memory for the process (as kb)."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "proc.vmswap", "VM Swap", "Swapped memory for the process (as kb)."},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Floating point numbers are not handled when formatting fields as JSON, thus causing libsinsp to throw an exception. This allows formatting them both as integer or floating point numbers, and adapts the few existing fields accordingly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): properly format double numbers as json
```
