### PR TITLE
chore(userspace/libsinsp): remove mesos fields from `--list`

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -55,6 +55,7 @@ typedef enum filtercheck_field_flags
 	EPF_ARG_ALLOWED       = 1 << 7, ///< this field optionally includes an argument.
 	EPF_ARG_INDEX         = 1 << 8, ///< this field accepts numeric arguments.
 	EPF_ARG_KEY           = 1 << 9, ///< this field accepts string arguments.
+	EPF_DEPRECATED        = 1 << 10,///< this field is deprecated.
 }filtercheck_field_flags;
 
 /*!
@@ -63,7 +64,7 @@ typedef enum filtercheck_field_flags
 typedef struct filtercheck_field_info
 {
 	ppm_param_type m_type; ///< Field type.
-	filtercheck_field_flags m_flags;  ///< Field flags.
+	uint32_t m_flags;  ///< Field flags.
 	ppm_print_format m_print_format;  ///< If this is a numeric field, this flag specifies if it should be rendered as octal, decimal or hex.
 	char m_name[64];  ///< Field name.
 	char m_display[64];  ///< Field display name (short description). May be empty.

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1933,6 +1933,11 @@ std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory
 				info.tags.insert("EPF_TABLE_ONLY");
 			}
 
+			if(fld->m_flags & EPF_DEPRECATED)
+			{
+				info.tags.insert("EPF_DEPRECATED");
+			}
+
 			if(fld->m_flags & EPF_ARG_REQUIRED)
 			{
 				info.tags.insert("ARG_REQUIRED");

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -8477,18 +8477,18 @@ uint8_t* sinsp_filter_check_k8s::extract(sinsp_evt *evt, OUT uint32_t* len, bool
 
 const filtercheck_field_info sinsp_filter_check_mesos_fields[] =
 {
-	{PT_CHARBUF, EPF_NONE, PF_NA, "mesos.task.name", "Task Name", "Mesos task name."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "mesos.task.id", "Task ID", "Mesos task id."},
-	{PT_CHARBUF, EPF_ARG_REQUIRED, PF_NA, "mesos.task.label", "Task Label", "Mesos task label. E.g. 'mesos.task.label.foo'."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "mesos.task.labels", "Task Labels", "Mesos task comma-separated key/value labels. E.g. 'foo1:bar1,foo2:bar2'."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "mesos.framework.name", "Framework Name", "Mesos framework name."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "mesos.framework.id", "Framework ID", "Mesos framework id."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "marathon.app.name", "App Name", "Marathon app name."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "marathon.app.id", "App ID", "Marathon app id."},
-	{PT_CHARBUF, EPF_ARG_REQUIRED, PF_NA, "marathon.app.label", "App Label", "Marathon app label. E.g. 'marathon.app.label.foo'."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "marathon.app.labels", "App Labels", "Marathon app comma-separated key/value labels. E.g. 'foo1:bar1,foo2:bar2'."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "marathon.group.name", "Group Name", "Marathon group name."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "marathon.group.id", "Group ID", "Marathon group id."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "mesos.task.name", "Task Name", "Mesos task name."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "mesos.task.id", "Task ID", "Mesos task id."},
+	{PT_CHARBUF, EPF_ARG_REQUIRED|EPF_DEPRECATED, PF_NA, "mesos.task.label", "Task Label", "Mesos task label. E.g. 'mesos.task.label.foo'."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "mesos.task.labels", "Task Labels", "Mesos task comma-separated key/value labels. E.g. 'foo1:bar1,foo2:bar2'."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "mesos.framework.name", "Framework Name", "Mesos framework name."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "mesos.framework.id", "Framework ID", "Mesos framework id."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "marathon.app.name", "App Name", "Marathon app name."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "marathon.app.id", "App ID", "Marathon app id."},
+	{PT_CHARBUF, EPF_ARG_REQUIRED|EPF_DEPRECATED, PF_NA, "marathon.app.label", "App Label", "Marathon app label. E.g. 'marathon.app.label.foo'."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "marathon.app.labels", "App Labels", "Marathon app comma-separated key/value labels. E.g. 'foo1:bar1,foo2:bar2'."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "marathon.group.name", "Group Name", "Marathon group name."},
+	{PT_CHARBUF, EPF_NONE|EPF_DEPRECATED, PF_NA, "marathon.group.id", "Group ID", "Marathon group id."},
 };
 
 sinsp_filter_check_mesos::sinsp_filter_check_mesos()

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -308,7 +308,7 @@ void gen_event_filter_factory::filter_fieldclass_info::wrapstring(const std::str
 	}
 }
 
-std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const std::set<std::string>& event_sources)
+std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const std::set<std::string>& event_sources, bool include_deprecated)
 {
 	std::ostringstream os;
 	uint32_t deprecated_count = 0;
@@ -343,7 +343,7 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const 
 		{
 			continue;
 		}
-		if(fld_info.is_deprecated())
+		if(!include_deprecated && fld_info.is_deprecated())
 		{
 			deprecated_count++;
 			continue;
@@ -360,7 +360,7 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const 
 	return os.str();
 }
 
-std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool verbose, const std::set<std::string>& event_sources)
+std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool verbose, const std::set<std::string>& event_sources, bool include_deprecated)
 {
 	std::ostringstream os;
 	uint32_t deprecated_count = 0;
@@ -404,7 +404,7 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool ver
 		{
 			continue;
 		}
-		if(fld_info.is_deprecated())
+		if(!include_deprecated && fld_info.is_deprecated())
 		{
 			deprecated_count++;
 			continue;

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -273,6 +273,12 @@ bool gen_event_filter_factory::filter_field_info::is_skippable()
 	return (tags.find("EPF_TABLE_ONLY") != tags.end());
 }
 
+bool gen_event_filter_factory::filter_field_info::is_deprecated()
+{
+	// Skip fields with the EPF_DEPRECATED flag.
+	return (tags.find("EPF_DEPRECATED") != tags.end());
+}
+
 uint32_t gen_event_filter_factory::filter_fieldclass_info::s_rightblock_start = 30;
 uint32_t gen_event_filter_factory::filter_fieldclass_info::s_width = 120;
 
@@ -346,6 +352,7 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const 
 std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool verbose, const std::set<std::string>& event_sources)
 {
 	std::ostringstream os;
+	uint32_t deprecated_count = 0;
 
 	os << "-------------------------------" << std::endl;
 
@@ -384,6 +391,11 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool ver
 		// (e.g. hidden fields)
 		if(fld_info.is_skippable())
 		{
+			continue;
+		}
+		if(fld_info.is_deprecated())
+		{
+			deprecated_count++;
 			continue;
 		}
 
@@ -425,6 +437,11 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool ver
 
 		wrapstring(desc, os);
 		os << std::endl;
+	}
+
+	if(deprecated_count == fields.size())
+	{
+		return "";
 	}
 
 	return os.str();

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -311,6 +311,7 @@ void gen_event_filter_factory::filter_fieldclass_info::wrapstring(const std::str
 std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const std::set<std::string>& event_sources)
 {
 	std::ostringstream os;
+	uint32_t deprecated_count = 0;
 
 	os << "## Field Class: " << name << std::endl << std::endl;
 
@@ -342,8 +343,18 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_markdown(const 
 		{
 			continue;
 		}
+		if(fld_info.is_deprecated())
+		{
+			deprecated_count++;
+			continue;
+		}
 
 		os << "`" << fld_info.name << "` | " << fld_info.data_type << " | " << fld_info.desc << std::endl;
+	}
+
+	if(deprecated_count == fields.size())
+	{
+		return "";
 	}
 
 	return os.str();

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -216,6 +216,7 @@ public:
 		std::set<std::string> tags;
 
 		bool is_skippable();
+		bool is_deprecated();
 	};
 
 	// Describes a group of filtercheck fields ("ka")

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -237,12 +237,12 @@ public:
 		// Print a terminal-friendly representation of this
 		// field class, including name, description, supported
 		// event sources, and the name and description of each field.
-		std::string as_string(bool verbose, const std::set<std::string>& event_sources = std::set<std::string>());
+		std::string as_string(bool verbose, const std::set<std::string>& event_sources = std::set<std::string>(), bool include_deprecated=false);
 
 		// Print a markdown representation of this
 		// field class, suitable for publication on the documentation
 		// website.
-		std::string as_markdown(const std::set<std::string>& event_sources = std::set<std::string>());
+		std::string as_markdown(const std::set<std::string>& event_sources = std::set<std::string>(), bool include_deprecated=false);
 
 		// How far to right-justify the name/description/etc block.
 		static uint32_t s_rightblock_start;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The mesos support has been deprecated: the mesos fields should no longer appear using `--list`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
