### PR TITLE
update(userspace): standard definitions for accessing state tables dynamically at runtime

### DIFF
--- a/userspace/libsinsp/filterchecks.h
+++ b/userspace/libsinsp/filterchecks.h
@@ -217,7 +217,6 @@ protected:
 	const filtercheck_field_info* m_field;
 	filter_check_info m_info;
 	uint32_t m_field_id;
-	uint32_t m_th_state_id;
 	uint32_t m_val_storage_len;
 
 private:
@@ -428,8 +427,8 @@ private:
 	int64_t m_s64val;
 	double m_dval;
 	std::vector<uint64_t> m_last_proc_switch_times;
-	uint32_t m_th_state_id;
 	uint64_t m_cursec_ts;
+	std::unique_ptr<libsinsp::state::dynamic_struct::field_accessor<uint64_t>> m_thread_dyn_field_accessor;
 };
 
 //

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1869,16 +1869,6 @@ sinsp_filter_check* sinsp::new_generic_filtercheck()
 	return new sinsp_filter_check_gen_event();
 }
 
-uint32_t sinsp::reserve_thread_memory(uint32_t size)
-{
-	if(m_h != NULL)
-	{
-		throw sinsp_exception("reserve_thread_memory can't be called after capture starts");
-	}
-
-	return m_thread_privatestate_manager.reserve(size);
-}
-
 void sinsp::get_capture_stats(scap_stats* stats) const
 {
 	/* On purpose ignoring failures to not interrupt in case of stats retrieval failure. */

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -172,6 +172,10 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 	// and is always present
 	m_event_sources.push_back(sinsp_syscall_event_source_name);
 	m_plugin_manager = std::make_shared<sinsp_plugin_manager>(m_event_sources);
+
+	// create state tables registry
+	m_table_registry = std::make_shared<libsinsp::state::table_registry>();
+	m_table_registry->add_table(m_thread_manager);
 }
 
 sinsp::~sinsp()

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -889,7 +889,6 @@ public:
 	// Returns the ID to use when retrieving the memory area.
 	// Will fail if called after the capture starts.
 	//
-	uint32_t reserve_thread_memory(uint32_t size);
 
 	sinsp_parser* get_parser();
 
@@ -1105,7 +1104,6 @@ private:
 	const scap_agent_info* m_agent_info;
 	scap_stats_v2 m_sinsp_stats_v2[SINSP_MAX_RESOURCE_UTILIZATION];
 	uint32_t m_num_cpus;
-	sinsp_thread_privatestate_manager m_thread_privatestate_manager;
 	bool m_is_tracers_capture_enabled;
 	bool m_flush_memory_dump;
 	bool m_large_envs_enabled;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -57,6 +57,7 @@ limitations under the License.
 #include "filter/escaping.h"
 #include "filter/ppm_codes.h"
 #include "filter/parser.h"
+#include "state/table_registry.h"
 
 #include <string>
 #include <map>
@@ -996,6 +997,11 @@ public:
 		return m_event_sources;
 	}
 
+	inline std::shared_ptr<const libsinsp::state::table_registry> get_table_registry() const
+	{
+		return m_table_registry;
+	}
+
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
 	const std::string& get_host_root() const { return m_host_root; }
@@ -1318,6 +1324,9 @@ public:
 	// This is related to m_replay_scap_evt, and is used to store the additional cpuid
 	// information of the replayed scap event.
 	uint16_t m_replay_scap_cpuid;
+	//
+	// A registry that managers the state tables of this inspector
+	std::shared_ptr<libsinsp::state::table_registry> m_table_registry;
 
 	bool m_inited;
 	static std::atomic<int> instance_count;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -885,12 +885,6 @@ public:
 		m_track_tracers_state = true;
 	}
 
-	//
-	// Allocates private state in the thread info class.
-	// Returns the ID to use when retrieving the memory area.
-	// Will fail if called after the capture starts.
-	//
-
 	sinsp_parser* get_parser();
 
 	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
@@ -995,11 +989,6 @@ public:
 	inline const std::vector<std::string>& event_sources() const
 	{
 		return m_event_sources;
-	}
-
-	inline std::shared_ptr<const libsinsp::state::table_registry> get_table_registry() const
-	{
-		return m_table_registry;
 	}
 
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -550,7 +550,7 @@ public:
 	sinsp_threadinfo* build_threadinfo()
     {
         return m_external_event_processor ? m_external_event_processor->build_threadinfo(this)
-                                          : new sinsp_threadinfo(this);
+                                          : m_thread_manager->new_threadinfo().release();
     }
 
 	/*!

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -192,15 +192,8 @@ public:
             m_definitions.insert({ name, field_info::_build<T>(name, m_definitions.size(), this) });
             const auto& def = m_definitions.at(name);
             m_definitions_ordered.push_back(&def);
-            on_after_add_info(def);
             return def;
         }
-    protected:
-        /**
-         * @brief Internally-invoked everytime a new info is added to the list,
-         * can be overridden in order to add custom logic.
-         */
-        virtual void on_after_add_info(const field_info& i) { }
 
     private:
         std::unordered_map<std::string, field_info> m_definitions;

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <string>
 #include <unordered_map>
+#include <memory>
 
 namespace libsinsp {
 namespace state {

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -1,0 +1,300 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "type_info.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace libsinsp {
+namespace state {
+
+/**
+ * @brief A base class for classes and structs that allow dynamic programming
+ * by being extensible and allowing adding and accessing new data fields at runtime. 
+ */
+class dynamic_struct
+{
+public:
+    template<typename T> class field_accessor;
+
+    /**
+     * @brief Info about a given field in a dynamic struct.
+     */
+    class field_info
+    {
+    public:
+        field_info() = delete;
+        ~field_info() = default;
+        field_info(field_info&&) = default;
+        field_info& operator = (field_info&&) = default;
+        field_info(const field_info& s) = default;
+        field_info& operator = (const field_info& s) = default;
+
+        friend inline bool operator==(const field_info& a, const field_info& b)
+        {
+            return a.info() == b.info()
+                && a.name() == b.name()
+                && a.m_index == b.m_index;
+        };
+
+        friend inline bool operator!=(const field_info& a, const field_info& b)
+        {
+            return !(a == b);
+        };
+
+        /**
+         * @brief Returns the name of the field.
+         */
+        const std::string& name() const
+        {
+            return m_name;
+        }
+
+        /**
+         * @brief Returns the type info of the field.
+         */
+        const libsinsp::state::typeinfo& info() const
+        {
+            return m_info;
+        }
+
+        /**
+         * @brief Returns a strongly-typed accessor for the given field,
+         * that can be used to reading and writing the field's value in
+         * all instances of structs where it is defined.
+         */
+        template <typename T>
+        field_accessor<T> new_accessor() const
+        {
+            auto t = libsinsp::state::typeinfo::of<T>();
+            if (m_info != t)
+            {
+                throw sinsp_exception(
+                    "incompatible type for dynamic struct field accessor: field=" + m_name
+                    + ", expected_type=" + info().name() + ", actual_type=" + t.name());
+            }
+            return field_accessor<T>(*this);
+        }
+
+    private:
+        field_info(const std::string& n, size_t in, const typeinfo& i, void* defsptr)
+            : m_index(in),
+              m_name(n),
+              m_info(i),
+              m_defsptr(defsptr) { }
+        
+        template<typename T>
+        static field_info _build(const std::string& name, size_t index, void* defsptr)
+        {
+            return field_info(name, index, libsinsp::state::typeinfo::of<T>(), defsptr);
+        }
+
+        size_t m_index;
+        std::string m_name;
+        libsinsp::state::typeinfo m_info;
+        void* m_defsptr;
+
+        friend class dynamic_struct;
+    };
+
+    /**
+     * @brief An strongly-typed accessor for accessing a field of a dynamic struct.
+     * @tparam T Type of the field.
+     */
+    template<typename T>
+    class field_accessor
+    {
+    public:
+        field_accessor() = delete;
+        ~field_accessor() = default;
+        field_accessor(field_accessor&&) = default;
+        field_accessor& operator = (field_accessor&&) = default;
+        field_accessor(const field_accessor& s) = default;
+        field_accessor& operator = (const field_accessor& s) = default;
+
+        /**
+         * @brief Returns the info about the field to which this accessor is tied.
+         */
+        const field_info& info() const
+        {
+            return m_info;
+        }
+
+    private:
+        field_accessor(const field_info& info): m_info(info) { };
+
+        field_info m_info;
+
+        friend class dynamic_struct;
+        friend class dynamic_struct::field_info;
+    };
+
+    /**
+     * @brief Dynamic fields metadata of a given struct or class
+     * that are discoverable and accessible dynamically at runtime.
+     * All instances of the same struct or class must share the same
+     * instance of field_infos.
+     */
+    class field_infos
+    {
+    public:
+        field_infos() = default;
+        virtual ~field_infos() = default;
+        field_infos(field_infos&&) = default;
+        field_infos& operator = (field_infos&&) = default;
+        field_infos(const field_infos& s) = delete;
+        field_infos& operator = (const field_infos& s) = delete;
+
+        inline const std::unordered_map<std::string, field_info>& fields() const
+        {
+            return m_definitions;
+        }
+
+        /**
+         * @brief Adds metadata for a new field to the list. An exception is
+         * thrown if two fields are defined with the same name and with
+         * incompatible types, otherwise the previous definition is returned.
+         * 
+         * @tparam T Type of the field.
+         * @param name Display name of the field.
+         */
+        template<typename T>
+        const field_info& add_field(const std::string& name)
+        {
+            const auto &it = m_definitions.find(name);
+            if (it != m_definitions.end())
+            {
+                auto t = libsinsp::state::typeinfo::of<T>();
+                if (it->second.info() != t)
+                {
+                    throw sinsp_exception("multiple definitions of dynamic field with different types in struct: "
+                    + name + ", prevtype=" + it->second.info().name() + ", newtype=" + t.name());
+                }
+                return it->second;
+            }
+            m_definitions.insert({ name, field_info::_build<T>(name, m_definitions.size(), this) });
+            const auto& def = m_definitions.at(name);
+            m_definitions_ordered.push_back(&def);
+            on_after_add_info(def);
+            return def;
+        }
+    protected:
+        /**
+         * @brief Internally-invoked everytime a new info is added to the list,
+         * can be overridden in order to add custom logic.
+         */
+        virtual void on_after_add_info(const field_info& i) { }
+
+    private:
+        std::unordered_map<std::string, field_info> m_definitions;
+        std::vector<const field_info*> m_definitions_ordered;
+        friend class dynamic_struct;
+    };
+
+    dynamic_struct(const std::shared_ptr<field_infos>& dynamic_fields)
+        : m_fields_len(0), m_fields(), m_dynamic_fields(dynamic_fields)
+    {
+        if (!dynamic_fields)
+        {
+            throw sinsp_exception("dynamic struct constructed with null field definitions");
+        }
+    }
+    dynamic_struct(dynamic_struct&&) = default;
+    dynamic_struct& operator = (dynamic_struct&&) = default;
+    dynamic_struct(const dynamic_struct& s) = default;
+    dynamic_struct& operator = (const dynamic_struct& s) = default;
+    virtual ~dynamic_struct()
+    {
+        if (m_dynamic_fields)
+        {
+            for (size_t i = 0; i < m_fields.size(); i++)
+            {
+                m_dynamic_fields->m_definitions_ordered[i]->info().destroy(m_fields[i]);
+                free(m_fields[i]);
+            }
+        }
+    }
+
+    /**
+     * @brief Accesses a field with the given accessor and reads its value.
+     */
+    template <typename T>
+    inline const T& get_dynamic_field(const field_accessor<T>& a)
+    {
+        _check_defsptr(a.info().m_defsptr);
+        return *(reinterpret_cast<T*>(_access_dynamic_field(a.info().m_index)));
+    }
+
+    /**
+     * @brief Accesses a field with the given accessor and writes its value.
+     */
+    template <typename T>
+    inline void set_dynamic_field(const field_accessor<T>& a, const T& v)
+    {
+        _check_defsptr(a.info().m_defsptr);
+        *(reinterpret_cast<T*>(_access_dynamic_field(a.info().m_index))) = v;
+    }
+
+    /**
+     * @brief Returns information about all the static fields accessible in a struct.
+     */
+    inline const std::shared_ptr<field_infos>& dynamic_fields() const
+    {
+        return m_dynamic_fields;
+    }
+
+private:
+    inline void _check_defsptr(void* ptr) const
+    {
+        if (m_dynamic_fields.get() != ptr)
+        {
+            throw sinsp_exception("using dynamic field accessor on struct it was not created from");
+        }
+    }
+
+    inline void* _access_dynamic_field(size_t index)
+    {
+        if (!m_dynamic_fields)
+        {
+            throw sinsp_exception("dynamic struct has no field definitions");
+        }
+        if (index >= m_dynamic_fields->m_definitions_ordered.size())
+        {
+            throw sinsp_exception("dynamic struct access overflow: " + std::to_string(index));
+        }
+        while (m_fields_len <= index)
+        {
+            auto def = m_dynamic_fields->m_definitions_ordered[m_fields_len];
+            void* fieldbuf = malloc(def->info().size());
+            def->info().construct(fieldbuf);
+            m_fields.push_back(fieldbuf);
+            m_fields_len++;
+        }
+        return m_fields[index];
+    }
+
+    size_t m_fields_len;
+    std::vector<void*> m_fields;
+    std::shared_ptr<field_infos> m_dynamic_fields;
+};
+
+
+}; // state
+}; // libsinsp

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -88,7 +88,7 @@ public:
             {
                 throw sinsp_exception(
                     "incompatible type for dynamic struct field accessor: field=" + m_name
-                    + ", expected_type=" + info().name() + ", actual_type=" + t.name());
+                    + ", expected_type=" + t.name() + ", actual_type=" + m_info.name());
             }
             return field_accessor<T>(*this);
         }
@@ -209,13 +209,7 @@ public:
     };
 
     dynamic_struct(const std::shared_ptr<field_infos>& dynamic_fields)
-        : m_fields_len(0), m_fields(), m_dynamic_fields(dynamic_fields)
-    {
-        if (!dynamic_fields)
-        {
-            throw sinsp_exception("dynamic struct constructed with null field definitions");
-        }
-    }
+        : m_fields_len(0), m_fields(), m_dynamic_fields(dynamic_fields) { }
     dynamic_struct(dynamic_struct&&) = default;
     dynamic_struct& operator = (dynamic_struct&&) = default;
     dynamic_struct(const dynamic_struct& s) = default;
@@ -253,11 +247,29 @@ public:
     }
 
     /**
-     * @brief Returns information about all the static fields accessible in a struct.
+     * @brief Returns information about all the dynamic fields accessible in a struct.
      */
     inline const std::shared_ptr<field_infos>& dynamic_fields() const
     {
         return m_dynamic_fields;
+    }
+
+    /**
+     * @brief Sets the shared definitions for the dynamic fields accessible in a struct.
+     * The definitions can be set to a non-null value only once, either at
+     * construction time by invoking this method.
+     */
+    inline void set_dynamic_fields(const std::shared_ptr<field_infos>& defs)
+    {
+        if (m_dynamic_fields)
+        {
+            throw sinsp_exception("dynamic struct defintions set twice");
+        }
+        if (!defs)
+        {
+            throw sinsp_exception("dynamic struct constructed with null field definitions");
+        }
+        m_dynamic_fields = defs;
     }
 
 private:

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -99,7 +99,7 @@ public:
             {
                 throw sinsp_exception(
                     "incompatible type for static struct field accessor: field=" + m_name
-                    + ", expected_type=" + info().name() + ", actual_type=" + t.name());
+                    + ", expected_type=" + t.name() + ", actual_type=" + m_info.name());
             }
             return field_accessor<T>(*this);
         }

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -174,7 +174,7 @@ public:
      * @brief Accesses a field with the given accessor and reads its value.
      */
     template <typename T>
-    inline T& get_static_field(const field_accessor<T>& a) const
+    inline const T& get_static_field(const field_accessor<T>& a) const
     {
         return *(reinterpret_cast<T*>((void*) (((uintptr_t) this) + a.info().m_offset)));
     }

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -1,0 +1,238 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "type_info.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace libsinsp {
+namespace state {
+
+/**
+ * @brief A base class for classes and structs that allow dynamic programming
+ * by making part (or all) of their fields discoverable and accessible at runtime.
+ * The structure of the class is predetermined at compile-time and its fields
+ * are placed at a given offset within the class memory area.
+ */
+class static_struct
+{
+public:
+    template<typename T> class field_accessor;
+
+    /**
+     * @brief Info about a given field in a static struct.
+     */
+    class field_info
+    {
+    public:
+        field_info() = delete;
+        ~field_info() = default;
+        field_info(field_info&&) = default;
+        field_info& operator = (field_info&&) = default;
+        field_info(const field_info& s) = default;
+        field_info& operator = (const field_info& s) = default;
+
+        friend inline bool operator==(const field_info& a, const field_info& b)
+        {
+            return a.info() == b.info()
+                && a.name() == b.name()
+                && a.readonly() == b.readonly()
+                && a.m_offset == b.m_offset;
+        };
+
+        friend inline bool operator!=(const field_info& a, const field_info& b)
+        {
+            return !(a == b);
+        };
+
+        /**
+         * @brief Returns true if the field is read only.
+         */
+        bool readonly() const
+        {
+            return m_readonly;
+        }
+
+        /**
+         * @brief Returns the name of the field.
+         */
+        const std::string& name() const
+        {
+            return m_name;
+        }
+
+        /**
+         * @brief Returns the type info of the field.
+         */
+        const libsinsp::state::typeinfo& info() const
+        {
+            return m_info;
+        }
+
+        /**
+         * @brief Returns a strongly-typed accessor for the given field,
+         * that can be used to reading and writing the field's value in
+         * all instances of structs where it is defined.
+         */
+        template <typename T>
+        field_accessor<T> new_accessor() const
+        {
+            auto t = libsinsp::state::typeinfo::of<T>();
+            if (m_info != t)
+            {
+                throw sinsp_exception(
+                    "incompatible type for static struct field accessor: field=" + m_name
+                    + ", expected_type=" + info().name() + ", actual_type=" + t.name());
+            }
+            return field_accessor<T>(*this);
+        }
+
+    private:
+        field_info(const std::string& n, size_t o, const typeinfo& i, bool r)
+            : m_readonly(r),
+              m_offset(o),
+              m_name(n),
+              m_info(i) { }
+        
+        template<typename T>
+        static field_info _build(const std::string& name, size_t offset, bool readonly=false)
+        {
+            return field_info(name, offset, libsinsp::state::typeinfo::of<T>(), readonly);
+        }
+
+        bool m_readonly;
+        size_t m_offset;
+        std::string m_name;
+        libsinsp::state::typeinfo m_info;
+
+        friend class static_struct;
+    };
+
+    /**
+     * @brief An strongly-typed accessor for accessing a field of a static struct.
+     * @tparam T Type of the field.
+     */
+    template<typename T>
+    class field_accessor
+    {
+    public:
+        field_accessor() = delete;
+        ~field_accessor() = default;
+        field_accessor(field_accessor&&) = default;
+        field_accessor& operator = (field_accessor&&) = default;
+        field_accessor(const field_accessor& s) = default;
+        field_accessor& operator = (const field_accessor& s) = default;
+
+        /**
+         * @brief Returns the info about the field to which this accessor is tied.
+         */
+        const field_info& info() const
+        {
+            return m_info;
+        }
+
+    private:
+        field_accessor(const field_info& info): m_info(info) { };
+
+        field_info m_info;
+
+        friend class static_struct;
+        friend class static_struct::field_info;
+    };
+
+    /**
+     * @brief A group of field infos, describing all the ones available
+     * in a static struct.
+     */
+    using field_infos = std::unordered_map<std::string, field_info>;
+
+    static_struct() = default;
+    virtual ~static_struct() = default;
+    static_struct(static_struct&&) = default;
+    static_struct& operator = (static_struct&&) = default;
+    static_struct(const static_struct& s) = default;
+    static_struct& operator = (const static_struct& s) = default;
+
+    /**
+     * @brief Accesses a field with the given accessor and reads its value.
+     */
+    template <typename T>
+    inline T& get_static_field(const field_accessor<T>& a) const
+    {
+        return *(reinterpret_cast<T*>((void*) (((uintptr_t) this) + a.info().m_offset)));
+    }
+
+    /**
+     * @brief Accesses a field with the given accessor and writes its value.
+     * An exception is thrown if the field is read-only.
+     */
+    template <typename T>
+    inline void set_static_field(const field_accessor<T>& a, const T& v)
+    {
+        if (a.info().readonly())
+        {
+            throw sinsp_exception("can't set a read-only static struct field: " + a.info().name());
+        }
+        *(reinterpret_cast<T*>((void*) (((uintptr_t) this) + a.info().m_offset))) = v;
+    }
+
+    /**
+     * @brief Returns information about all the static fields accessible in a struct.
+     */
+    inline const field_infos& static_fields() const
+    {
+        return m_static_fields;
+    }
+
+protected:
+    /**
+     * @brief To be used in the constructor of child classes.
+     * Defines the information about a field defined in the class or struct.
+     * An exception is thrown if two fields are defined with the same name.
+     * 
+     * @tparam T Type of the field.
+     * @param thisptr "this" pointer of the struct containing the field,
+     * which is used to compute the field's memory offset in other instances
+     * of the same struct.
+     * @param v Reference to the field of which info is defined.
+     * @param name Display name of the field.
+     */
+    template<typename T>
+    const field_info& define_static_field(const void* thisptr, const T& v, const std::string& name, bool readonly=false)
+    {
+        const auto &it = m_static_fields.find(name);
+        if (it != m_static_fields.end())
+        {
+            throw sinsp_exception("multiple definitions of static field in struct: " + name);
+        }
+
+        // todo(jasondellaluce): add extra safety boundary checks here
+        size_t offset = (size_t) (((uintptr_t) &v) - (uintptr_t) thisptr);
+        m_static_fields.insert({ name, field_info::_build<T>(name, offset, readonly) });
+        return m_static_fields.at(name);
+    }
+
+private:
+    field_infos m_static_fields;
+};
+
+
+}; // state
+}; // libsinsp

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -1,0 +1,188 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "../sinsp_exception.h"
+#include "static_struct.h"
+#include "dynamic_struct.h"
+
+namespace libsinsp {
+namespace state {
+
+/**
+ * @brief Base class for entries of a state table.
+ */
+struct table_entry: public static_struct, dynamic_struct
+{
+    table_entry(const std::shared_ptr<dynamic_struct::field_infos>& dyn_fields)
+        : static_struct(), dynamic_struct(dyn_fields) { }
+    virtual ~table_entry() = default;
+    table_entry(table_entry&&) = default;
+    table_entry& operator = (table_entry&&) = default;
+    table_entry(const table_entry& s) = default;
+    table_entry& operator = (const table_entry& s) = default;
+};
+
+/**
+ * @brief Base non-templated interface for state tables, defining
+ * type-independent properties common to all tables.
+ */
+class base_table
+{
+public:
+    base_table(const std::string& name, const typeinfo& key_info,
+        const static_struct::field_infos& static_fields)
+            : m_name(name),
+              m_key_info(key_info), 
+              m_static_fields(static_fields),
+              m_dynamic_fields(std::make_shared<dynamic_struct::field_infos>()) { }
+
+    virtual ~base_table() = default;
+    base_table(base_table&&) = default;
+    base_table& operator = (base_table&&) = default;
+    base_table(const base_table& s) = delete;
+    base_table& operator = (const base_table& s) = delete;
+
+    /**
+     * @brief Returns the name of the table.
+     */
+    inline const std::string& name() const
+    {
+        return m_name;
+    }
+
+    /**
+     * @brief Returns the non-null type info about the table's key. 
+     */
+    inline const typeinfo& key_info() const
+    {
+        return m_key_info;
+    }
+
+    /**
+     * @brief Returns the fields metadata list for the static fields defined
+     * for the value data type of this table. This fields will be accessible
+     * for all the entries of this table.
+     */
+    inline const static_struct::field_infos& static_fields() const
+    {
+        return m_static_fields;
+    }
+
+    /**
+     * @brief Returns the fields metadata list for the dynamic fields defined
+     * for the value data type of this table. This fields will be accessible
+     * for all the entries of this table. The returned metadata list can
+     * be expended at runtime by adding new dynamic fields, which will then
+     * be allocated and accessible for all the present and future entries
+     * present in the table.
+     */
+    inline const std::shared_ptr<dynamic_struct::field_infos>& dynamic_fields() const
+    {
+        return m_dynamic_fields;
+    }
+
+    /**
+     * @brief Returns the number of entries present in the table.
+     */
+    virtual size_t entries_count() const = 0;
+
+    /**
+     * @brief Erase all the entries present in the table.
+     * After invoking this function, entries_count() will return true.
+     */
+    virtual void clear_entries() = 0;
+
+    /**
+     * @brief Allocates and returns a new entry for the table. This is just
+     * a factory method, the entry will not automatically added to the table.
+     * Once a new entry is allocated with this method, users must invoke
+     * add_entry() in order to actually insert it in the table.
+     */
+    virtual std::unique_ptr<table_entry> new_entry() const = 0;
+
+    /**
+     * @brief Iterates over all the entries contained in the table and invokes
+     * the given predicate for each of them.
+     * 
+     * @param pred The predicate to invoke for all the table's entries. The
+     * predicate returns true if the iteration can proceed to the next entry,
+     * and false if the iteration needs to break out.
+     * @return true If the iteration proceeded successfully for all the entries.
+     * @return false If the iteration broke out.
+     */
+    virtual bool foreach_entry(std::function<bool(table_entry& e)> pred) = 0;
+
+private:
+    std::string m_name;
+    typeinfo m_key_info;
+    static_struct::field_infos m_static_fields;
+    std::shared_ptr<dynamic_struct::field_infos> m_dynamic_fields;
+};
+
+/**
+ * @brief Base interfaces for state tables, with strong typing for tables' key.
+ */
+template <typename KeyType>
+class table: public base_table
+{
+    static_assert(std::is_default_constructible<KeyType>(),
+        "table key types must have a default constructor");
+
+public:
+    table(const std::string& name, const static_struct::field_infos& static_fields)
+            : base_table(name, typeinfo::of<KeyType>(), static_fields) {}
+    table(const std::string& name): table(name, static_struct::field_infos()) {}
+    virtual ~table() = default;
+    table(table&&) = default;
+    table& operator = (table&&) = default;
+    table(const table& s) = delete;
+    table& operator = (const table& s) = delete;
+
+    /**
+     * @brief Returns a pointer to an entry present in the table at the given
+     * key. The pointer is owned by the table, and will remain valid up until
+     * the table is destroyed or the entry is removed from the table.
+     * 
+     * @param key Key of the entry to be retrieved.
+     * @return std::shared_ptr<table_entry> Pointer to the entry if
+     * present in the table at the given key, and nullptr otherwise.
+     */
+    virtual std::shared_ptr<table_entry> get_entry(const KeyType& key) = 0;
+
+    /**
+     * @brief Inserts a new entry in the table with the given key. If another
+     * entry is already present with the same key, it gets replaced. After
+     * insertion, table will be come the owner of the entry's pointer.
+     * 
+     * @param key Key of the entry to be added.
+     * @param entry Entry to be added with the given key.
+     * @return std::shared_ptr<table_entry> Non-null pointer to the
+     * newly-added entry, which will remain valid up until the table is
+     * destroyed or the entry is removed from the table.
+     */
+    virtual std::shared_ptr<table_entry> add_entry(const KeyType& key, std::unique_ptr<table_entry> entry) = 0;
+
+    /**
+     * @brief Removes an entry from the table with the given key.
+     * 
+     * @param key Key of the entry to be removed.
+     * @return true If an entry was present at the given key.
+     * @return false If an entry was not present at the given key.
+     */
+    virtual bool erase_entry(const KeyType& key) = 0;
+};
+
+}; // state
+}; // libsinsp

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -17,6 +17,9 @@ limitations under the License.
 #include "static_struct.h"
 #include "dynamic_struct.h"
 
+#include <functional>
+#include <type_traits>
+
 namespace libsinsp {
 namespace state {
 

--- a/userspace/libsinsp/state/table_registry.h
+++ b/userspace/libsinsp/state/table_registry.h
@@ -1,0 +1,118 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "../sinsp_exception.h"
+#include "table.h"
+
+#include <unordered_map>
+
+namespace libsinsp {
+namespace state {
+
+
+/**
+ * @brief A registry for the available state tables. Table owners can register
+ * their tables and make them available for discovery and retrieval by other
+ * components.
+ * 
+ * @note The lifeto,e of the tables registered in the registry is regulated
+ * by the owner of each tables. This means that a table pointer obtained
+ * through get_table() will remain valid and available up until the owner
+ * destroys the table. For example, in the case of an inspector's own tables
+ * the lifetime of the tables will be the same as the one of the inspector. 
+ * 
+ * todo(jasondellaluce): switch from raw ptrs to shared ptrs, but the
+ * current libsinsp implementation does not allow us to
+ */
+class table_registry
+{
+public:
+    table_registry() = default;
+    ~table_registry() = default;
+    table_registry(table_registry&&) = default;
+    table_registry& operator = (table_registry&&) = default;
+    table_registry(const table_registry& s) = delete;
+    table_registry& operator = (const table_registry& s) = delete;
+
+    /**
+     * @brief Obtain a pointer to a table registered in the registry with
+     * the given name. Throws an exception if a table with the given name
+     * is defined with types incompatible with the ones provided in the
+     * template.
+     * 
+     * @tparam KeyType Type of the table's key.
+     * @param name Name of the table.
+     * @return table<KeyType>* Pointer to the registered table,
+     * or nullptr if no table is registered by the given name.
+     */
+    template <typename KeyType>
+    table<KeyType>* get_table(const std::string& name) const
+    {
+        const auto &it = m_tables.find(name);
+        if (it != m_tables.end())
+        {
+            auto t = libsinsp::state::typeinfo::of<KeyType>();
+            if (it->second->key_info() != t)
+            {
+                throw sinsp_exception(
+                    "table in registry accessed with wrong key type: table='" + name
+                    + "', requested='" + t.name() + "', actual='"
+                    + it->second->key_info().name() + "'");
+            }
+            return static_cast<table<KeyType>*>(it->second);
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Registers a table in the registry with a given name and
+     * returns a pointer to the table. Throws an exception if a table is
+     * already present with the given name.
+     * 
+     * @tparam KeyType Type of the table's key.
+     * @param name Name of the table.
+     * @param t Pointer to the table.
+     * @return table<KeyType>* Pointer to the newly-registered table.
+     */
+    template <typename KeyType>
+    table<KeyType>* add_table(table<KeyType>* t)
+    {
+        if (!t)
+        {
+            throw sinsp_exception("null table added to registry");
+        }
+        const auto &it = m_tables.find(t->name());
+        if (it != m_tables.end())
+        {
+            throw sinsp_exception("table added to registry multiple times: " + t->name());
+        }
+        m_tables.insert({ t->name(), t });
+        return t;
+    }
+
+    /**
+     * @brief Returns all the tables known in the registry.
+     */
+    const std::unordered_map<std::string, base_table*>& tables() const
+    {
+        return m_tables;
+    }
+
+private:
+    std::unordered_map<std::string, base_table*> m_tables;
+};
+
+}; // state
+}; // libsinsp

--- a/userspace/libsinsp/state/type_info.h
+++ b/userspace/libsinsp/state/type_info.h
@@ -17,7 +17,7 @@ limitations under the License.
 #pragma once
 
 #include "../sinsp_exception.h"
-#include <ppm_events_public.h>
+#include "../../driver/ppm_events_public.h"
 
 #include <string>
 #include <vector>

--- a/userspace/libsinsp/state/type_info.h
+++ b/userspace/libsinsp/state/type_info.h
@@ -1,0 +1,153 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+
+#include "../sinsp_exception.h"
+#include <ppm_events_public.h>
+
+#include <string>
+#include <vector>
+
+namespace libsinsp {
+namespace state {
+
+/**
+ * @brief Generic and agnostic information about a type, similar to
+ * std::type_info but following a restricted and controlled enumeration of
+ * the supported types for the state component of libsinsp. Enumerating
+ * the types also allows for more peformant runtime checks. Moreover, this class
+ * also provides construction and destruction utilities for each supported
+ * types for convenience.
+ */
+class typeinfo
+{
+public:
+    /**
+     * @brief Numeric identifier of a supported type.
+     * This reuses the same type enumerative provided by libscap for event
+     * params to avoid duplicating definitions.
+     */
+    using index_t = ppm_param_type;
+
+    /**
+     * @brief Returns a type info for the type T.
+     */
+    template<typename T> static inline typeinfo of()
+    {
+        throw sinsp_exception("state::typeinfo::of invoked for unsupported type");
+    }
+
+    typeinfo() = delete;
+    ~typeinfo() = default;
+    typeinfo(typeinfo&&) = default;
+    typeinfo& operator = (typeinfo&&) = default;
+    typeinfo(const typeinfo& s) = default;
+    typeinfo& operator = (const typeinfo& s) = default;
+
+    friend inline bool operator==(const typeinfo& a, const typeinfo& b)
+    {
+        return a.index() == b.index();
+    };
+
+    friend inline bool operator!=(const typeinfo& a, const typeinfo& b)
+    {
+        return a.index() != b.index();
+    };
+
+    /**
+     * @brief Returns the name of the type.
+     */
+    inline const char* name() const
+    {
+        return m_name;
+    }
+
+    /**
+     * @brief Returns the numeric representation of the type.
+     */
+    inline index_t index() const
+    {
+        return m_index;
+    }
+
+    /**
+     * @brief Returns the byte size of variables of the given type.
+     */
+    inline size_t size() const
+    {
+        return m_size;
+    }
+
+    /**
+     * @brief Constructs and initializes the given type in the passed-in
+     * memory location, which is expected to be larger or equal than size().
+     */
+    inline void construct(void* p) const noexcept 
+    {
+        if (p && m_construct) m_construct(p);
+    }
+
+    /**
+     * @brief Destructs and deinitializes the given type in the passed-in
+     * memory location, which is expected to be larger or equal than size().
+     */
+    inline void destroy(void* p) const noexcept 
+    {
+        if (p && m_destroy) m_destroy(p);
+    }
+
+private:
+    inline typeinfo(const char* n, index_t k, size_t s, void (*c)(void*), void (*d)(void*))
+        : m_name(n), m_index(k), m_size(s), m_construct(c), m_destroy(d) { }
+
+    template <typename T> static inline void _construct(void* p)
+    {
+        std::allocator<T>().construct(reinterpret_cast<T*>(p));
+    }
+
+    template <typename T> static inline void _destroy(void* p)
+    {
+        std::allocator<T>().destroy(reinterpret_cast<T*>(p));
+    }
+
+    template<typename T> static inline typeinfo _build(const char* n, index_t k)
+    {
+        return typeinfo(n, k, sizeof(T), _construct<T>, _destroy<T>);
+    }
+
+    const char* m_name;
+    index_t m_index;
+    size_t m_size;
+    void (*m_construct)(void*);
+    void (*m_destroy)(void*);
+};
+
+// below is the manually-controlled list of all the supported types
+
+template<> inline typeinfo typeinfo::of<bool>() { return _build<bool>("bool", PT_BOOL); }
+template<> inline typeinfo typeinfo::of<int8_t>() { return _build<int8_t>("int8", PT_INT8); }
+template<> inline typeinfo typeinfo::of<int16_t>() { return _build<int16_t>("int16", PT_INT16); }
+template<> inline typeinfo typeinfo::of<int32_t>() { return _build<int32_t>("int32", PT_INT32); }
+template<> inline typeinfo typeinfo::of<int64_t>() { return _build<int64_t>("int64", PT_INT64); }
+template<> inline typeinfo typeinfo::of<uint8_t>() { return _build<uint8_t>("uint8", PT_UINT8); }
+template<> inline typeinfo typeinfo::of<uint16_t>() { return _build<uint16_t>("uint16", PT_UINT16); }
+template<> inline typeinfo typeinfo::of<uint32_t>() { return _build<uint32_t>("uint32", PT_UINT32); }
+template<> inline typeinfo typeinfo::of<uint64_t>() { return _build<uint64_t>("uint64", PT_UINT64); }
+template<> inline typeinfo typeinfo::of<std::string>() { return _build<std::string>("string", PT_CHARBUF); }
+
+}; // state
+}; // libsinsp

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	user.ut.cpp
 	container_info.ut.cpp
 	sinsp_utils.ut.cpp
+	state.ut.cpp
 	"${PUBLIC_SINSP_API_SUITE}"
 	"${TEST_PLUGINS}"
 )

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -136,9 +136,15 @@ TEST(dynamic_struct, defs_and_access)
         sample_struct(const std::shared_ptr<field_infos>& i): dynamic_struct(i) { }
     };
 
+    // struct construction and setting fields definition
     sample_struct s(fields);
-    ASSERT_ANY_THROW(sample_struct(nullptr));
-    ASSERT_ANY_THROW(sample_struct(std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>()));
+    ASSERT_ANY_THROW(s.set_dynamic_fields(nullptr));
+    ASSERT_ANY_THROW(s.set_dynamic_fields(fields));
+    ASSERT_NO_THROW(sample_struct(std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>()));
+    ASSERT_NO_THROW(sample_struct(nullptr));
+    auto s2 = sample_struct(nullptr);
+    s2.set_dynamic_fields(fields);
+    ASSERT_ANY_THROW(s2.set_dynamic_fields(fields));
 
     // check field definitions
     ASSERT_EQ(fields->fields().size(), 0);

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -1,0 +1,117 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include "state/static_struct.h"
+
+TEST(static_struct, defs_and_access)
+{
+    struct err_multidef_struct: public libsinsp::state::static_struct
+    {
+        err_multidef_struct(): m_num(0)
+        {
+            define_static_field(this, m_num, "num");
+            define_static_field(this, m_num, "num");
+        }
+
+        uint32_t m_num;
+    };
+
+    class sample_struct: public libsinsp::state::static_struct
+    {
+    public:
+        sample_struct(): m_num(0), m_str()
+        {
+            define_static_field(this, m_num, "num");
+            define_static_field(this, m_str, "str", true);
+        }
+
+        uint32_t get_num() const { return m_num; }
+        void set_num(uint32_t v) { m_num = v; }
+        const std::string& get_str() const { return m_str; }
+        void set_str(const std::string& v) { m_str = v; }
+
+    private:
+        uint32_t m_num;
+        std::string m_str;
+    };
+
+    struct sample_struct2: public libsinsp::state::static_struct
+    {
+    public:
+        sample_struct2(): m_num(0)
+        {
+            define_static_field(this, m_num, "num");
+        }
+
+        uint32_t m_num;
+    };
+
+    // test construction errors
+    ASSERT_ANY_THROW(err_multidef_struct());
+
+    sample_struct s;
+    const auto& fields = s.static_fields();
+
+    // check field definitions
+    auto field_num = fields.find("num");
+    auto field_str = fields.find("str");
+    ASSERT_EQ(fields.size(), 2);
+    ASSERT_EQ(fields, sample_struct().static_fields());
+
+    ASSERT_NE(field_num, fields.end());
+    ASSERT_EQ(field_num->second.name(), "num");
+    ASSERT_EQ(field_num->second.readonly(), false);
+    ASSERT_EQ(field_num->second.info(), libsinsp::state::typeinfo::of<uint32_t>());
+
+    ASSERT_NE(field_str, fields.end());
+    ASSERT_EQ(field_str->second.name(), "str");
+    ASSERT_EQ(field_str->second.readonly(), true);
+    ASSERT_EQ(field_str->second.info(), libsinsp::state::typeinfo::of<std::string>());
+
+    // check field access
+    auto acc_num = field_num->second.new_accessor<uint32_t>();
+    auto acc_str = field_str->second.new_accessor<std::string>();
+    ASSERT_ANY_THROW(field_num->second.new_accessor<uint64_t>());
+    ASSERT_ANY_THROW(field_str->second.new_accessor<uint64_t>());
+
+    ASSERT_EQ(s.get_num(), 0);
+    ASSERT_EQ(s.get_static_field(acc_num), 0);
+    s.set_num(5);
+    ASSERT_EQ(s.get_num(), 5);
+    ASSERT_EQ(s.get_static_field(acc_num), 5);
+    s.set_static_field(acc_num, (uint32_t) 6);
+    ASSERT_EQ(s.get_num(), 6);
+    ASSERT_EQ(s.get_static_field(acc_num), 6);
+
+    std::string str = "";
+    ASSERT_EQ(s.get_str(), str);
+    ASSERT_EQ(s.get_static_field(acc_str), str);
+    str = "hello";
+    s.set_str("hello");
+    ASSERT_EQ(s.get_str(), str);
+    ASSERT_EQ(s.get_static_field(acc_str), str);
+    ASSERT_ANY_THROW(s.set_static_field(acc_str, str)); // readonly
+
+    // illegal access from an accessor created from different definition list
+    // note: this should supposedly be checked for and throw an exception,
+    // but for now we have no elegant way to do it efficiently.
+    // todo(jasondellaluce): find a good way to check for this
+    sample_struct2 s2;
+    auto acc_num2 = s2.static_fields().find("num")->second.new_accessor<uint32_t>();
+    ASSERT_NO_THROW(s.get_static_field(acc_num2));
+}

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -270,8 +270,7 @@ TEST(thread_manager, table_access)
     static const int s_threadinfo_static_fields_count = 20;
 
     sinsp inspector;
-    sinsp_thread_manager manager(&inspector);
-    auto table = static_cast<libsinsp::state::table<int64_t>*>(&manager);
+    auto table = static_cast<libsinsp::state::table<int64_t>*>(inspector.m_thread_manager);
     
     // empty table state and info
     ASSERT_EQ(table->name(), "threads");

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -19,6 +19,14 @@ limitations under the License.
 #include "state/static_struct.h"
 #include "state/dynamic_struct.h"
 
+TEST(typeinfo, basic_tests)
+{
+    struct some_unknown_type { };
+    ASSERT_ANY_THROW(libsinsp::state::typeinfo::of<some_unknown_type>());
+    ASSERT_EQ(libsinsp::state::typeinfo::of<std::string>().size(), sizeof(std::string));
+    ASSERT_EQ(libsinsp::state::typeinfo::of<std::string>(), libsinsp::state::typeinfo::of<std::string>());
+}
+
 TEST(static_struct, defs_and_access)
 {
     struct err_multidef_struct: public libsinsp::state::static_struct

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -154,14 +154,6 @@ void sinsp_threadinfo::init()
 
 sinsp_threadinfo::~sinsp_threadinfo()
 {
-	uint32_t j;
-
-	for(j = 0; j < m_private_state.size(); j++)
-	{
-		free(m_private_state[j]);
-	}
-
-	m_private_state.clear();
 	if(m_lastevent_data)
 	{
 		free(m_lastevent_data);
@@ -975,17 +967,6 @@ void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 	{
 		ASSERT(false);
 	}
-}
-
-void* sinsp_threadinfo::get_private_state(uint32_t id)
-{
-	if(id >= m_private_state.size())
-	{
-		ASSERT(false);
-		throw sinsp_exception("invalid thread state ID" + std::to_string((long long) id));
-	}
-
-	return m_private_state[id];
 }
 
 uint64_t sinsp_threadinfo::get_fd_usage_pct()

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -210,8 +210,6 @@ public:
 	*/
 	bool uses_client_port(uint16_t number);
 
-	void* get_private_state(uint32_t id);
-
 	/*!
 	  \brief Return the ratio between open FDs and maximum available FDs for this thread.
 	*/
@@ -485,7 +483,6 @@ VISIBILITY_PRIVATE
 	std::string m_cwd; // current working directory
 	mutable std::weak_ptr<sinsp_threadinfo> m_main_thread;
 	uint8_t* m_lastevent_data; // Used by some event parsers to store the last enter event
-	std::vector<void*> m_private_state;
 
 	uint16_t m_lastevent_type;
 	uint16_t m_lastevent_cpuid;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -457,7 +457,6 @@ VISIBILITY_PRIVATE
 			m_lastevent_cpuid = (uint16_t) - 1;
 		}
 	}
-	void allocate_private_state();
 	void compute_program_hash();
 	std::shared_ptr<sinsp_threadinfo> lookup_thread() const;
 
@@ -581,33 +580,6 @@ public:
 
 protected:
 	std::unordered_map<int64_t, ptr_t> m_threads;
-};
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Little class that manages the allocation of private state in the thread info class
-///////////////////////////////////////////////////////////////////////////////
-class sinsp_thread_privatestate_manager
-{
-public:
-	//
-	// The return value is the ID of the newly reserved memory area
-	//
-	uint32_t reserve(uint32_t size)
-	{
-		m_memory_sizes.push_back(size);
-		return (uint32_t)m_memory_sizes.size() - 1;
-	}
-
-	uint32_t get_size()
-	{
-		return (uint32_t)m_memory_sizes.size();
-	}
-
-private:
-	std::vector<uint32_t> m_memory_sizes;
-
-	friend class sinsp_threadinfo;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -591,6 +591,7 @@ public:
 	sinsp_thread_manager(sinsp* inspector);
 	void clear();
 
+	std::unique_ptr<sinsp_threadinfo> new_threadinfo() const;
 	bool add_thread(sinsp_threadinfo *threadinfo, bool from_scap_proctable);
 	void remove_thread(int64_t tid, bool force);
 	// Returns true if the table is actually scanned


### PR DESCRIPTION
**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR initiates the effort required to solve #991 by defining a standard way for defining and accessing state tables inside libsinsp. The proposed solution is schemaless and enables dynamic programming. At runtime, libsinsp will allow to:
- Discovering all the tables registered in an inspector (a table is defined as a key-value store)
- Discovering their structure (e.g. the key type, all the fields available in the table entries)
- Extending their structure by defining new data fields later accessible in all the table entries (e.g. attaching extra information to every thread of the thread manager)
- Defining new state tables with one single interface and registering them in an inspector

All tables will comply to the `libsinsp::state::table` interface. In this model, a libsinsp's inspector acts as a registry for state tables and as a broker. Even though the inspector is the owner of the registry, other entities will be able to register additional tables of which they are the owner. Given that tables are defined with an interface, there may be multiple potential implementation.

Currently, the first use case adopted is to make the thread table of an inspector accessible with the new interface. In the model, this will be a table of which the inspector itself is the owner. For now, a restricted set of the fields of threadinfos are made available in order to not have an overly-large surface at the first version of the feature.

Note: this is not supposed to introduce any regression either in the libsinsp's API and in the performance of the libraries. Most of these changes are additions, and the ones related to the thread table are simple class extensions implemented to comply with the new table interface. This means that consumers accessing the thread manager should not be impacted by this whatsoever. At the same time, we now open the door to an additional and standard way to access its information.

Effort has been spent to unit test all the newly-introduced components and the compliance of the thread manager towards them.

**Which issue(s) this PR fixes**:

Part of https://github.com/falcosecurity/libs/issues/991.

**Special notes for your reviewer**:

I know that the extended use of template might look like an over-engineered solution, but I want to highlight the hardship involved with introducing meta-programming and dynamic types for runtime access. With templates, we get some stronger typing protection from the compiler.

Note: there was already legacy code in place that allowed to "attach" dynamic information to a thread info. That code portion has been adapted to use the new constructs.

Note: **this does not include any contribution towards the plugin API**. That is an extra lift with different complexities that will come in a separate PR, but that will be based on the support brought by this PR.

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/): standard definitions for accessing state tables dynamically at runtime
```