### PR TITLE
fix(libsinsp,libscap): return value and fscanf warnings

### DIFF
--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -830,7 +830,7 @@ const struct ppm_event_info* scap_get_event_info_table();
   
   With this method, we are retrieving the syscall category
 */
-const enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev);
+enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev);
 
 /*!
   \brief Retrieve the event category of the event
@@ -845,7 +845,7 @@ const enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_cod
   
   With this method, we are retrieving the event category
 */
-const enum ppm_event_category scap_get_event_category_from_event(ppm_event_code ev);
+enum ppm_event_category scap_get_event_category_from_event(ppm_event_code ev);
 
 /*!
   \brief Retrieve the name associated with the specified ppm_sc.

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -38,13 +38,13 @@ const struct ppm_event_info* scap_get_event_info_table()
 	return g_event_info;
 }
 
-const enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev)
+enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev)
 {
 	ASSERT(ev < PPM_EVENT_MAX);
 	return g_event_info[ev].category & (EC_SYSCALL -1);
 }
 
-const enum ppm_event_category scap_get_event_category_from_event(ppm_event_code ev)
+enum ppm_event_category scap_get_event_category_from_event(ppm_event_code ev)
 {
 	ASSERT(ev < PPM_EVENT_MAX);
 	return g_event_info[ev].category & ~(EC_SYSCALL -1);

--- a/userspace/libscap/scap_machine_agent.c
+++ b/userspace/libscap/scap_machine_agent.c
@@ -37,12 +37,13 @@ static void scap_get_bpf_stats_enabled(scap_machine_info* machine_info)
 	if((f = fopen("/proc/sys/kernel/bpf_stats_enabled", "r")))
 	{
 		uint32_t bpf_stats_enabled = 0;
-		fscanf(f, "%u", &bpf_stats_enabled);
-		fclose(f);
-		if (bpf_stats_enabled != 0)
-		{
-			machine_info->flags |= PPM_BPF_STATS_ENABLED;
+		if(fscanf(f, "%u", &bpf_stats_enabled) == 1) {
+			if (bpf_stats_enabled != 0)
+			{
+				machine_info->flags |= PPM_BPF_STATS_ENABLED;
+			}
 		}
+		fclose(f);
 	}
 }
 
@@ -112,7 +113,7 @@ void scap_retrieve_agent_info(scap_agent_info* agent_info)
 			hz = 100;
 		}
 #endif
-		if(fscanf(f, "%*d %*s %*c %*d %*d %*d %*d %*d %*lu %*lu %*lu %*lu %*lu %*llu %*llu %*llu %*llu %*d %*d %*d %*lu %llu", &stat_start_time))
+		if(fscanf(f, "%*d %*s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %*u %*u %*u %*u %*d %*d %*d %*u %llu", &stat_start_time))
 		{
 			agent_info->start_time = (double)stat_start_time / hz; // unit: seconds as type (double)
 		}

--- a/userspace/libsinsp/sinsp_resource_utilization.cpp
+++ b/userspace/libsinsp/sinsp_resource_utilization.cpp
@@ -111,8 +111,12 @@ double get_cpu_usage(double start_time)
 		return 0;
 	}
 
-	fscanf(f, "%lf", &machine_uptime_sec);
+	int matched = fscanf(f, "%lf", &machine_uptime_sec);
 	fclose(f);
+
+	if (matched != 1) {
+		return 0;
+	}
 
 	/* CPU usage as percentage is computed by dividing the time the process uses the CPU by the
 	 * currently elapsed time of the calling process. Compare to `ps` linux util. */
@@ -150,8 +154,14 @@ uint64_t get_container_memory_usage()
 		return 0;
 	}
 	unsigned long long memory_used = 0;
-	fscanf(f, "%llu", &memory_used);		/* memory size returned in bytes */
+
+	/* memory size returned in bytes */
+	int fscanf_matched = fscanf(f, "%llu", &memory_used);
 	fclose(f);
+
+	if (fscanf_matched != 1) {
+		return 0;
+	}
 
 	return memory_used;
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/area libsinsp
/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

When building Falco with warnings as errors these are halting the build.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
