### PR TITLE
update(ci): use BUILD_WARNINGS_AS_ERRORS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
         name: [system_deps, bundled_deps, system_deps_w_chisels, system_deps_minimal]
         include:
           - name: system_deps
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False
+            cmake_opts: -DBUILD_WARNINGS_AS_ERRORS=On -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False
           - name: bundled_deps
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=True
+            cmake_opts: -DBUILD_WARNINGS_AS_ERRORS=On -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=True
           - name: system_deps_w_chisels
-            cmake_opts: -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False -DWITH_CHISEL=True
+            cmake_opts: -DBUILD_WARNINGS_AS_ERRORS=On -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=False -DWITH_CHISEL=True
           - name: system_deps_minimal
-            cmake_opts: -DUSE_BUNDLED_DEPS=False -DMINIMAL_BUILD=True
+            cmake_opts: -DBUILD_WARNINGS_AS_ERRORS=On -DUSE_BUNDLED_DEPS=False -DMINIMAL_BUILD=True
     runs-on: ubuntu-latest
     container:
       image: debian:buster


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Recently we merged some code that had a couple minor warnings. Nothing serious but since the libs currently compile without warnings (except for a couple harmless ones we already excluded) it'd be great to keep it that way.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

@FedeDP @Andreagit97 -- I wonder if we had this flag already and disabled it on purpose? If so which one?

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
