### PR TITLE
update: add function to retrieve fields used in output strings

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -228,6 +228,19 @@ bool sinsp_evt_formatter::get_field_values(gen_event *gevt, std::map<std::string
 	return resolve_tokens(evt, fields);
 }
 
+void sinsp_evt_formatter::get_field_names(std::vector<std::string> &fields)
+{
+	for(size_t i = 0; i < m_tokens.size(); i++)
+	{
+		if(m_tokens[i].first == "")
+		{
+			continue;
+		}
+
+		fields.emplace_back(m_tokens[i].first);
+	}
+}
+
 gen_event_formatter::output_format sinsp_evt_formatter::get_output_format()
 {
 	return m_output_format;

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -71,6 +71,8 @@ public:
 	// interface. It just calls resolve_tokens().
 	bool get_field_values(gen_event *evt, std::map<std::string, std::string> &fields) override;
 
+	void get_field_names(std::vector<std::string> &fields);
+
 	gen_event_formatter::output_format get_output_format() override;
 
 	/*!

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	container_info.ut.cpp
 	sinsp_utils.ut.cpp
 	state.ut.cpp
+	eventformatter.ut.cpp
 	"${PUBLIC_SINSP_API_SUITE}"
 	"${TEST_PLUGINS}"
 )

--- a/userspace/libsinsp/test/eventformatter.ut.cpp
+++ b/userspace/libsinsp/test/eventformatter.ut.cpp
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sinsp.h"
+#include "eventformatter.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <string>
+#include <iostream>
+
+using namespace std;
+
+TEST(eventformatter, get_field_names)
+{
+	auto inspector = new sinsp();
+	string output = "this is a sample output %proc.name %fd.type %proc.pid";
+	sinsp_evt_formatter fmt(inspector, output);
+	vector<string> output_fields;
+	fmt.get_field_names(output_fields);
+	ASSERT_EQ(output_fields.size(), 3);
+	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "proc.name"), output_fields.end());
+	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "fd.type"), output_fields.end());
+	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "proc.pid"), output_fields.end());
+	delete inspector;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds a method to `sinsp_evt_formatter` to list down all the fields used in output strings.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
