### PR TITLE
feat(libsinsp): Track the last time a process called exec

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1299,6 +1299,12 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 	tinfo->m_tid = childtid;
 	tinfo->m_ptid = tid;
 
+	//
+	// Initialise last exec time to zero (can be overidden in the case of a
+	// thread clone
+	//
+	tinfo->m_lastexec_ts = 0;
+
 	if(valid_parent)
 	{
 		// Copy the command name from the parent
@@ -1351,6 +1357,10 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		if(!(flags & PPM_CL_CLONE_THREAD))
 		{
 			tinfo->m_env = ptinfo->m_env;
+		}
+		else
+		{
+			tinfo->m_lastexec_ts = ptinfo->m_lastexec_ts;
 		}
 	}
 	else
@@ -1817,6 +1827,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// Get the exe
 	parinfo = evt->get_param(1);
 	evt->m_tinfo->m_exe = parinfo->m_val;
+	evt->m_tinfo->m_lastexec_ts = evt->get_ts();
 
 	auto container_id = evt->m_tinfo->m_container_id;
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -115,6 +115,7 @@ void sinsp_threadinfo::init()
 	m_prevevent_ts = 0;
 	m_lastaccess_ts = 0;
 	m_clone_ts = 0;
+	m_lastexec_ts = 0;
 	m_lastevent_category.m_category = EC_UNKNOWN;
 	m_flags = PPM_CL_NAME_CHANGED;
 	m_nchilds = 0;
@@ -483,6 +484,7 @@ void sinsp_threadinfo::init(scap_threadinfo* pi)
 	m_vpid = pi->vpid;
 	m_pidns_init_start_ts = pi->pidns_init_start_ts;
 	m_clone_ts = pi->clone_ts;
+	m_lastexec_ts = 0;
 	m_tty = pi->tty;
 	m_category = CAT_NONE;
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -354,6 +354,7 @@ public:
 	uint64_t m_prevevent_ts; ///< timestamp of the event before the last for this thread.
 	uint64_t m_lastaccess_ts; ///< The last time this thread was looked up. Used when cleaning up the table.
 	uint64_t m_clone_ts; ///< When the clone that started this process happened.
+	uint64_t m_lastexec_ts; ///< The last time exec was called
 
 	//
 	// Parser for the user events. Public so that filter fields can access it


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**: The start time of a process is tracked by the last time it was cloned, however this is a bit unintuitive in the case of exec as it would look like the new executable started before the exec since the clone would have happened beforehand. This patch introduces `m_lastexec_ts` to track this last exec timestamp.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: No

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```