### PR TITLE
new(ci): build latest mainline kernel (even RC!) in latest-kernel job.

### DIFF
--- a/.github/workflows/latest-kernel.yml
+++ b/.github/workflows/latest-kernel.yml
@@ -1,11 +1,11 @@
-name: Test build latest kernel available in archlinux
+name: Test drivers build against latest mainline kernel in archlinux
 
 on:
   workflow_dispatch:
     inputs:
       linux-version:
         description: 'Archlinux kernel version to build a driver against, eg: 6.2.arch1-1'
-        required: false
+        required: true
         type: string
   schedule:
     - cron: '0 8 * * *' # every day at 8am
@@ -17,27 +17,35 @@ jobs:
     container:
       image: falcosecurity/driverkit:latest
     steps:
-      - name: Checkout Archlinux packages ⤵️
-        uses: actions/checkout@v3
-        with:
-          repository: 'archlinux/svntogit-packages'
-          ref: 'packages/linux'
-          path: 'linux'
+      - name: Checkout Archlinux mainline package ⤵️
+        run: |
+          apk update && apk add git
+          git clone https://aur.archlinux.org/linux-mainline.git linux/
     
-      - name: Fetch latest kernel available on archlinux
+      - name: Generate driverkit config
         id: latest-version
-        run: |
+        # Note: in case we are building latest mainline,
+        # we grep the linux-mainline aur PKGBUILD "_tag" line, that is made like: "_tag=v6.4-rc1"
+        # We then need to extract the part after the "=" and finally remove the starting "v".
+        run: |    
+          cd linux/
+          echo "kernelversion: 1" > dk.yaml
+          echo "architecture: amd64" >> dk.yaml
+          echo "output:" >> dk.yaml
+          echo "  module: mod.ko" >> dk.yaml
+          echo "  probe: probe.o" >> dk.yaml
           if [ "${{ inputs.linux-version }}" = "" ]; then
-            cd linux/trunk/
-            line=$(grep "pkgver" PKGBUILD | head -n1)
-            krel=${line#*=}
-            line=$(grep "pkgrel" PKGBUILD | head -n1)
-            kver=${line#*=}
-            echo "latest_vers=${krel}-${kver}" >> $GITHUB_OUTPUT
+            krel=$(grep "_tag" PKGBUILD | head -n1 | awk -F"=" '{print $2}')
+            echo "kernelrelease: ${krel:1}" >> dk.yaml
+            echo "target: vanilla" >> dk.yaml
+            echo "kernelconfigdata: \"$(cat config | base64 | tr -d '\n')\"" >> dk.yaml
           else
-            echo "latest_vers=${{ inputs.linux-version }}" >> $GITHUB_OUTPUT
+            echo "kernelrelease: ${{ inputs.linux-version }}" >> dk.yaml
+            echo "target: arch" >> dk.yaml
           fi
+          echo "latest_vers=$(grep kernelrelease dk.yaml | awk -F": " '{print $2}')" >> $GITHUB_OUTPUT
           
-      - name: Test drivers build on latest linux with driverkit
+      - name: Test drivers build
         run: |
-          driverkit docker --kernelrelease ${{ steps.latest-version.outputs.latest_vers }} --target arch --output-module /tmp/libs.ko --output-probe /tmp/libs.o --loglevel debug  
+          echo "Testing build of drivers against: ${{ steps.latest-version.outputs.latest_vers }}"
+          driverkit docker -c linux/dk.yaml -l debug

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI Build](https://github.com/falcosecurity/libs/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/falcosecurity/libs/actions/workflows/ci.yml)
 [![Architectures](https://img.shields.io/badge/ARCHS-x86__64%7Caarch64%7Cs390x-blueviolet)](#drivers-officially-supported-architectures)
-[![Drivers build against latest kernel](https://github.com/falcosecurity/libs/actions/workflows/latest-kernel.yml/badge.svg)](https://github.com/falcosecurity/libs/actions/workflows/latest-kernel.yml)
+[![Drivers build against latest mainline kernel](https://github.com/falcosecurity/libs/actions/workflows/latest-kernel.yml/badge.svg)](https://github.com/falcosecurity/libs/actions/workflows/latest-kernel.yml)
 
 As per the [OSS Libraries Contribution Plan](https://github.com/falcosecurity/falco/blob/master/proposals/20210119-libraries-contribution.md), this repository has been chosen to be the new home for **libsinsp**, **libscap**, the **kernel module** and the **eBPF probe** sources.  
 Refer to https://falco.org/blog/contribution-drivers-kmod-ebpf-libraries/ for more information.  
@@ -57,7 +57,7 @@ Right now our drivers officially support the following architectures:
 **For a list of supported syscalls through specific events, please refer to [_report_](./driver/report.md).**
 
 > **NOTE:** while we strive to achieve maximum compatibility, we cannot assure that drivers correctly build against a new kernel version minutes after it gets released, since we might need to make some adjustments.    
-> To get properly notified whenever drivers stop building, we have a [CI workflow](.github/workflows/latest-kernel.yml) that tests the build against the latest kernel available in archlinux repositories.
+> To get properly notified whenever drivers stop building, we have a [CI workflow](.github/workflows/latest-kernel.yml) that tests the build against the [latest mainline kernel](https://www.kernel.org/) (RC too!)
 
 ## Build
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Improves `latest-kernel` CI to properly test latest mainline kernel, RC included, so that we catch drivers build issues as soon as possible.
For example, i just caught a new issue by https://github.com/torvalds/linux/commit/dcfbb67e48a2becfce7990386e985b9c45098ee5 commit:
```
DEBU + make CC=/usr/bin/gcc-12.0.0 KERNELDIR=/tmp/kernel
DEBU *make -C /tmp/kernel M=/tmp/driver modules
DEBU *make[1]: Entering directory '/tmp/kernel'
DEBU �warning: the compiler differs from the one used to build the kernel
DEBU   The kernel was built by: gcc (Debian 12.2.0-14) 12.2.0
DEBU   You are using:           gcc-12.0.0 (Debian 12.2.0-14) 12.2.0
DEBU   CC [M]  /tmp/driver/main.o
DEBU �In file included from ./include/linux/linkage.h:7,
DEBU                  from ./include/linux/kernel.h:17,
DEBU                  from ./include/linux/cpumask.h:10,
DEBU                  from ./include/linux/smp.h:13,
DEBU                  from ./include/linux/tracepoint.h:15,
DEBU                  from ./include/trace/syscall.h:5,
DEBU                  from /tmp/driver/main.c:13:
DEBU /tmp/driver/main.c: In function 'scap_init':
DEBU ./include/linux/export.h:27:22: error: passing argument 1 of 'class_create' from incompatible pointer type [-Werror=incompatible-pointer-types]
DEBU    27 | #define THIS_MODULE (&__this_module)
DEBU       |                     ~^~~~~~~~~~~~~~~
DEBU       |                      |
DEBU       |                      struct module *
DEBU /tmp/driver/main.c:2915:36: note: in expansion of macro 'THIS_MODULE'
DEBU  2915 |         g_ppm_class = class_create(THIS_MODULE, DRIVER_DEVICE_NAME);
DEBU       |                                    ^~~~~~~~~~~
DEBU �In file included from ./include/linux/device.h:31,
DEBU                  from ./include/linux/node.h:18,
DEBU                  from ./include/linux/cpu.h:17,
DEBU                  from ./include/linux/static_call.h:135,
DEBU                  from ./include/linux/tracepoint.h:22:
DEBU ./include/linux/device/class.h:229:54: note: expected 'const char *' but argument is of type 'struct module *'
DEBU   229 | struct class * __must_check class_create(const char *name);
DEBU       |                                          ~~~~~~~~~~~~^~~~
DEBU y/tmp/driver/main.c:2915:23: error: too many arguments to function 'class_create'
DEBU  2915 |         g_ppm_class = class_create(THIS_MODULE, DRIVER_DEVICE_NAME);
DEBU       |                       ^~~~~~~~~~~~
DEBU ./include/linux/device/class.h:229:29: note: declared here
DEBU   229 | struct class * __must_check class_create(const char *name);
DEBU       |                             ^~~~~~~~~~~~
DEBU +cc1: some warnings being treated as errors
DEBU Fmake[2]: *** [scripts/Makefile.build:252: /tmp/driver/main.o] Error 1
DEBU 2make[1]: *** [Makefile:2026: /tmp/driver] Error 2
DEBU )make[1]: Leaving directory '/tmp/kernel'
DEBU $make: *** [Makefile:7: all] Error 2
DEBU log pipe close                                error=EOF
DEBU context canceled
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

NOTE: we need a new driverkit release once https://github.com/falcosecurity/driverkit/pull/272 gets merged, since driverkit did not support RC releases in vanilla target.
I'll keep this wip until we have the new release out.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
