### PR TITLE
fix(libsinsp): include string header in dumper.h

### DIFF
--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -22,6 +22,8 @@ class sinsp_evt;
 
 #include "scap_savefile_api.h"
 
+#include <string>
+
 typedef struct scap_dumper scap_dumper_t;
 
 /** @defgroup dump Dumping events to disk


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area libsinsp

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The file uses `std::string` but did not include it.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): include string header in dumper.h
```
