### PR TITLE
fix(userspace/libsinsp): don't unset async evt handler if inspector was not open

### DIFF
--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -98,6 +98,7 @@ std::unordered_set<std::string> libsinsp::events::event_set_to_names(const libsi
 	return events_names_set;
 }
 
+// todo(jasondellaluce): think about how we can handle well PPME_ASYNCEVENT_E
 libsinsp::events::set<ppm_event_code> libsinsp::events::names_to_event_set(const std::unordered_set<std::string>& events)
 {
 	std::unordered_set<std::string> remaining_events = events;

--- a/userspace/libsinsp/filter/ppm_codes.cpp
+++ b/userspace/libsinsp/filter/ppm_codes.cpp
@@ -239,6 +239,7 @@ libsinsp::filter::ast::ppm_sc_codes(const libsinsp::filter::ast::expr* e)
     return v.m_last_node_codes;
 }
 
+// todo(jasondellaluce): should we deal with PPME_ASYNCEVENT_E at this level?
 libsinsp::events::set<ppm_event_code>
 libsinsp::filter::ast::ppm_event_codes(const libsinsp::filter::ast::expr* e)
 {

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4541,7 +4541,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				// note: for async events, the event name is encoded
 				// inside the event itself. In this case libsinsp's evt.type
 				// field acts as an alias of evt.asynctype.
-				if (evt->get_type() == PPME_ASYNCEVENT_E)
+				if (etype == PPME_ASYNCEVENT_E)
 				{
 					evname = (uint8_t*) evt->get_param(1)->m_val;
 				}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -826,7 +826,7 @@ void sinsp::close()
 	}
 
 	// unset the meta-event callback to all plugins that support it
-	if (!is_capture())
+	if (!is_capture() && m_mode != SCAP_MODE_NONE)
 	{
 		std::string err;
 		for (auto& p : m_plugin_manager->plugins())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

If an inspector gets destroyed without ever being open, we don't want to reset the async event handlers on its plugins. Also, I added a couple of todos for better handling async events in the event codes <-> name conversion primitives in the future.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): don't unset async evt handler if inspector was not open
```
