### PR TITLE
fix(test,userspace): fixed strncat usage.

### DIFF
--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -170,7 +170,7 @@ int open_engine(int argc, char** argv)
 			}
 			else if(optarg == NULL)
 			{
-				bpf_params.bpf_probe = strncat(cwd, BPF_PROBE_DEFAULT_PATH, FILENAME_MAX - strlen(cwd));
+				bpf_params.bpf_probe = strncat(cwd, BPF_PROBE_DEFAULT_PATH, FILENAME_MAX - strlen(cwd) - 1);
 			}
 			else
 			{
@@ -199,7 +199,7 @@ int open_engine(int argc, char** argv)
 			}
 			else if(optarg == NULL)
 			{
-				kmod_path = strncat(cwd, KMOD_DEFAULT_PATH, FILENAME_MAX - strlen(cwd));
+				kmod_path = strncat(cwd, KMOD_DEFAULT_PATH, FILENAME_MAX - strlen(cwd) - 1);
 			}
 			else
 			{

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -246,15 +246,15 @@ struct scap_stats_v2 *pman_get_scap_stats_v2(uint32_t flags, uint32_t *nstats, i
 				switch(stat)
 				{
 				case RUN_CNT:
-					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_CNT], sizeof(g_state.stats[offset].name) - dest_len);
+					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_CNT], sizeof(g_state.stats[offset].name) - dest_len - 1);
 					g_state.stats[offset].value.u64 = info.run_cnt;
 					break;
 				case RUN_TIME_NS:
-					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(g_state.stats[offset].name) - dest_len);
+					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(g_state.stats[offset].name) - dest_len - 1);
 					g_state.stats[offset].value.u64 = info.run_time_ns;
 					break;
 				case AVG_TIME_NS:
-					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(g_state.stats[offset].name) - dest_len);
+					strncat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(g_state.stats[offset].name) - dest_len - 1);
 					g_state.stats[offset].value.u64 = 0;
 					if(info.run_cnt > 0)
 					{

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1776,15 +1776,15 @@ const struct scap_stats_v2* scap_bpf_get_stats_v2(struct scap_engine_handle engi
 				switch(stat)
 				{
 				case RUN_CNT:
-					strncat(stats[offset].name, bpf_libbpf_stats_names[RUN_CNT], sizeof(stats[offset].name) - dest_len);
+					strncat(stats[offset].name, bpf_libbpf_stats_names[RUN_CNT], sizeof(stats[offset].name) - dest_len - 1);
 					stats[offset].value.u64 = info.run_cnt;
 					break;
 				case RUN_TIME_NS:
-					strncat(stats[offset].name, bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(stats[offset].name) - dest_len);
+					strncat(stats[offset].name, bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(stats[offset].name) - dest_len - 1);
 					stats[offset].value.u64 = info.run_time_ns;
 					break;
 				case AVG_TIME_NS:
-					strncat(stats[offset].name, bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(stats[offset].name) - dest_len);
+					strncat(stats[offset].name, bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(stats[offset].name) - dest_len - 1);
 					stats[offset].value.u64 = 0;
 					if (info.run_cnt > 0)
 					{

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -46,9 +46,9 @@ static inline void err_append(char* s, const char* suffix, const char* sep)
 {
     if (*s != '\0')
     {
-        strncat(s, sep, PLUGIN_MAX_ERRLEN - strlen(sep));
+        strncat(s, sep, PLUGIN_MAX_ERRLEN - strlen(s) - 1);
     }
-    strncat(s, suffix, PLUGIN_MAX_ERRLEN - strlen(suffix));
+    strncat(s, suffix, PLUGIN_MAX_ERRLEN - strlen(s) - 1);
 }
 
 static void* getsym(library_handle_t handle, const char* name)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf
/area libscap-engine-modern-bpf
/area libsinsp
/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Correct usage of `strncat` to avoid buffer overflows:
> If src contains n or more bytes, strncat() writes n+1 bytes to dest (n from src plus the terminating null byte). Therefore, the size of dest must be at least strlen(dest)+n+1. 

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
