### PR TITLE
chore(userspace/libsinsp): make get_field_names a property of generic formatters

### DIFF
--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -71,7 +71,7 @@ public:
 	// interface. It just calls resolve_tokens().
 	bool get_field_values(gen_event *evt, std::map<std::string, std::string> &fields) override;
 
-	void get_field_names(std::vector<std::string> &fields);
+	void get_field_names(std::vector<std::string> &fields) override;
 
 	gen_event_formatter::output_format get_output_format() override;
 

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -291,6 +291,8 @@ public:
 	// (e.g. "proc.name"), to field value (e.g. "nginx")
 	virtual bool get_field_values(gen_event *evt, std::map<std::string, std::string> &fields) = 0;
 
+	virtual void get_field_names(std::vector<std::string> &fields) = 0;
+
 	virtual output_format get_output_format() = 0;
 };
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When adding `get_field_names` to sinsp formatters, we forgot to make it a base virtual method of generic formatters.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
chore(userspace/libsinsp): make get_field_names a property of generic formatters
```
