### PR TITLE
Fix two more build warnings

### DIFF
--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -122,7 +122,10 @@ static bool is_cpu_online(uint16_t cpu_id)
 		}
 	}
 
-	fscanf(fp, "%d", &online);
+	if(fscanf(fp, "%d", &online) != 1)
+	{
+		online = 0;
+	}
 	fclose(fp);
 	return online == 1;
 }

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -50,7 +50,7 @@ static void scap_modern_bpf__free_engine(struct scap_engine_handle engine)
  */
 static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* buffer_id)
 {
-	pman_consume_first_event((void**)pevent, buffer_id);
+	pman_consume_first_event((void**)pevent, (int16_t*)buffer_id);
 
 	if((*pevent) == NULL)
 	{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area libscap-engine-modern-bpf

/area libpman

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fix two more build warnings

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

With this PR, I can build libs with -DBUILD_WARNINGS_AS_ERRORS, though without this option tons and tons of warnings remain

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
