### PR TITLE
chore(driver): avoid static_assert event_table size while building kmod.

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -455,6 +455,9 @@ const struct ppm_event_info g_event_info[] = {
 	[PPME_ASYNCEVENT_X] = {"NA", EC_UNKNOWN, EF_UNUSED, 0},
 };
 
+// We don't need this check in kmod (this source file is included during kmod compilation!)
+// This also avoids weird situation where the _Static_assert is not available in some very old compilers,
+// thus breaking the kmod build.
 #ifndef __KERNEL__
 // This code is compiled on windows and osx too!
 // Make sure to be on gcc or that the c standard is >= c11

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -455,8 +455,10 @@ const struct ppm_event_info g_event_info[] = {
 	[PPME_ASYNCEVENT_X] = {"NA", EC_UNKNOWN, EF_UNUSED, 0},
 };
 
+#ifndef __KERNEL__
 // This code is compiled on windows and osx too!
 // Make sure to be on gcc or that the c standard is >= c11
 #if defined __GNUC__ || __STDC_VERSION__ >= 201112L
 _Static_assert(sizeof(g_event_info) / sizeof(*g_event_info) == PPM_EVENT_MAX, "Missing event entries in event table.");
+#endif
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

NOPE

**What this PR does / why we need it**:

The event_table check is not important in kernel mode; we can skip it.
It might happen that `_Static_assert` is not available thus failing the kmod build.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
