### PR TITLE
fix(tests, bpf): correct build and test case failures on s390x

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6676,6 +6676,7 @@ FILLER(sys_prctl_x, true)
 	unsigned long option;
 	unsigned long arg2;
 	unsigned long arg2_int;
+	int reaper_attr;
 	int res;
 	long retval;
 
@@ -6715,8 +6716,9 @@ FILLER(sys_prctl_x, true)
 			/*
 			 * arg2_int
 			 */
-			bpf_probe_read_user(&arg2_int,sizeof(arg2_int),(void*)arg2);
-			res = bpf_push_s64_to_ring(data, (int)arg2_int);
+			reaper_attr = 0;
+			bpf_probe_read_user(&reaper_attr, sizeof(reaper_attr), (void*)arg2);
+			res = bpf_push_s64_to_ring(data, (s64)reaper_attr);
 			CHECK_RES(res);
 			break;
 		case PPM_PR_SET_CHILD_SUBREAPER:

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -222,6 +222,8 @@ TEST(SyscallExit, execveatX_correct_exit)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
+	const char *comm = "echo";
+
 	/* Please note here we cannot assert all the params, we check only the possible ones. */
 
 	/* Parameter 1: res (type: PT_ERRNO)*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Correct a build break on s390x due to a undefined variable. Also correctly read the `prctl GET_CHILD_SUBREAPER` value to avoid type/endianess issues.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
