### PR TITLE
fix(driver): remove useless include which causes compilation issues on Centos6

### DIFF
--- a/driver/socketcall_to_syscall.c
+++ b/driver/socketcall_to_syscall.c
@@ -7,7 +7,6 @@ or GPL2.txt for full copies of the license.
 
 */
 
-#include <linux/kconfig.h>
 #include "ppm_events_public.h"
 
 /* Right now we don't support architectures that have

--- a/driver/syscall_table32.c
+++ b/driver/syscall_table32.c
@@ -7,8 +7,6 @@ or GPL2.txt for full copies of the license.
 
 */
 
-#include <linux/kconfig.h>
-
 #if defined(__KERNEL__) && defined(CONFIG_IA32_EMULATION)
 
 #include <asm/unistd_32.h>


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

/version driver-API-version-patch 

but we already bumped it in https://github.com/falcosecurity/libs/pull/1147

**What this PR does / why we need it**:

This PR fixes the build on old Centos6 kernels

```
2023-06-14 10:54:53,213  fatal error: linux/kconfig.h: No such file or directory
2023-06-14 10:54:53,213  #include <linux/kconfig.h>
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
