### PR TITLE
new(libscap): add cache accelerating suppressed TIDs

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -110,7 +110,7 @@ void scap_free_device_table(scap_mountinfo* dev_list);
 // Returns SCAP_FAILURE if we tried to add the tid to the suppressed
 // tid set, but it could *not* be added, SCAP_SUCCESS otherwise.
 int32_t scap_check_suppressed(struct scap_suppress *suppress, scap_evt *pevent,
-			      bool *suppressed, char *error);
+			      uint16_t cpuid, bool *suppressed, char *error);
 
 int32_t scap_procfs_get_threadlist(struct scap_engine_handle engine, struct ppm_proclist_info **procinfo_p, char *lasterr);
 int32_t scap_os_getpid_global(struct scap_engine_handle engine, int64_t *pid, char* error);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -110,7 +110,7 @@ void scap_free_device_table(scap_mountinfo* dev_list);
 // Returns SCAP_FAILURE if we tried to add the tid to the suppressed
 // tid set, but it could *not* be added, SCAP_SUCCESS otherwise.
 int32_t scap_check_suppressed(struct scap_suppress *suppress, scap_evt *pevent,
-			      uint16_t cpuid, bool *suppressed, char *error);
+			      uint16_t devid, bool *suppressed, char *error);
 
 int32_t scap_procfs_get_threadlist(struct scap_engine_handle engine, struct ppm_proclist_info **procinfo_p, char *lasterr);
 int32_t scap_os_getpid_global(struct scap_engine_handle engine, int64_t *pid, char* error);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -790,7 +790,7 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 
 		// Check to see if the event should be suppressed due
 		// to coming from a supressed tid
-		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
+		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, *pcpuid, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
 		{
 			return res;
 		}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -771,12 +771,16 @@ uint64_t scap_max_buf_used(scap_t* handle)
 	return 0;
 }
 
-int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 {
+	// Note: devid is like cpuid but not 1:1, e.g. consider CPU1 offline:
+	// CPU0 CPU1 CPU2 CPU3
+	// DEV0 DEV1 DEV2 DEV3 <- CPU1  online
+	// DEV0 XXXX DEV1 DEV2 <- CPU1 offline
 	int32_t res = SCAP_FAILURE;
 	if(handle->m_vtable)
 	{
-		res = handle->m_vtable->next(handle->m_engine, pevent, pcpuid);
+		res = handle->m_vtable->next(handle->m_engine, pevent, pdevid);
 	}
 	else
 	{
@@ -790,7 +794,7 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 
 		// Check to see if the event should be suppressed due
 		// to coming from a supressed tid
-		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, *pcpuid, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
+		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, *pdevid, *pcpuid, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
 		{
 			return res;
 		}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -794,7 +794,7 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 
 		// Check to see if the event should be suppressed due
 		// to coming from a supressed tid
-		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, *pdevid, *pcpuid, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
+		if((res = scap_check_suppressed(&handle->m_platform->m_suppress, *pevent, *pdevid, &suppressed, handle->m_lasterr)) != SCAP_SUCCESS)
 		{
 			return res;
 		}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -196,15 +196,16 @@ int32_t scap_check_suppressed(struct scap_suppress* suppress, scap_evt *pevent, 
 
 		if(suppress->m_suppressed_tids)
 		{
-			if(suppress->m_cpuid_tid_stid_cache[cpuid].tid == pevent->tid)
+			uint16_t slot = (cpuid & (SCAP_CACHE_CPUID_MAX - 1));
+			if(suppress->m_cpuid_tid_stid_cache[slot].tid == pevent->tid)
 			{
 				stid = suppress->m_cpuid_tid_stid_cache[cpuid].stid; // use cached
 			}
 			else
 			{
 				HASH_FIND_INT64(suppress->m_suppressed_tids, &(pevent->tid), stid);
-				suppress->m_cpuid_tid_stid_cache[cpuid].tid = pevent->tid; //  re-cache
-				suppress->m_cpuid_tid_stid_cache[cpuid].stid = stid; // re-cache
+				suppress->m_cpuid_tid_stid_cache[slot].tid = pevent->tid; //  re-cache
+				suppress->m_cpuid_tid_stid_cache[slot].stid = stid; // re-cache
 			}
 		}
 		else

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -196,16 +196,15 @@ int32_t scap_check_suppressed(struct scap_suppress* suppress, scap_evt *pevent, 
 
 		if(suppress->m_suppressed_tids)
 		{
-			uint64_t key = pevent->tid;
-			if(suppress->m_cpuid_key_value_cache[cpuid].key == key)
+			if(suppress->m_cpuid_tid_stid_cache[cpuid].tid == pevent->tid)
 			{
-				stid = suppress->m_cpuid_key_value_cache[cpuid].val; // use cached
+				stid = suppress->m_cpuid_tid_stid_cache[cpuid].stid; // use cached
 			}
 			else
 			{
 				HASH_FIND_INT64(suppress->m_suppressed_tids, &(pevent->tid), stid);
-				suppress->m_cpuid_key_value_cache[cpuid].key = key; //  re-cache
-				suppress->m_cpuid_key_value_cache[cpuid].val = stid; // re-cache
+				suppress->m_cpuid_tid_stid_cache[cpuid].tid = pevent->tid; //  re-cache
+				suppress->m_cpuid_tid_stid_cache[cpuid].stid = stid; // re-cache
 			}
 		}
 		else

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -120,7 +120,7 @@ int32_t scap_fd_add(scap_t *handle, scap_threadinfo* tinfo, uint64_t fd, scap_fd
 	}
 }
 
-int32_t scap_check_suppressed(struct scap_suppress* suppress, scap_evt *pevent, uint16_t cpuid, bool *suppressed, char *error)
+int32_t scap_check_suppressed(struct scap_suppress* suppress, scap_evt *pevent, uint16_t devid, bool *suppressed, char *error)
 {
 	uint16_t *lens;
 	char *valptr;
@@ -196,16 +196,16 @@ int32_t scap_check_suppressed(struct scap_suppress* suppress, scap_evt *pevent, 
 
 		if(suppress->m_suppressed_tids)
 		{
-			uint16_t slot = (cpuid & (SCAP_CACHE_CPUID_MAX - 1));
-			if(suppress->m_cpuid_tid_stid_cache[slot].tid == pevent->tid)
+			uint16_t slot = (devid & (SCAP_CACHE_DEVID_MAX - 1));
+			if(suppress->m_devid_tid_stid_cache[slot].tid == pevent->tid)
 			{
-				stid = suppress->m_cpuid_tid_stid_cache[cpuid].stid; // use cached
+				stid = suppress->m_devid_tid_stid_cache[slot].stid; // use cached
 			}
 			else
 			{
 				HASH_FIND_INT64(suppress->m_suppressed_tids, &(pevent->tid), stid);
-				suppress->m_cpuid_tid_stid_cache[slot].tid = pevent->tid; //  re-cache
-				suppress->m_cpuid_tid_stid_cache[slot].stid = stid; // re-cache
+				suppress->m_devid_tid_stid_cache[slot].tid = pevent->tid; //  re-cache
+				suppress->m_devid_tid_stid_cache[slot].stid = stid; // re-cache
 			}
 		}
 		else

--- a/userspace/libscap/scap_suppress.c
+++ b/userspace/libscap/scap_suppress.c
@@ -208,10 +208,10 @@ void scap_remove_and_free_suppressed(struct scap_suppress *suppress, scap_tid *s
 	// Remove from cache around hash table.
 	for(cpuid = 0; cpuid < SCAP_CPUID_MAX; cpuid ++)
 	{
-		if(stid == suppress->m_cpuid_key_value_cache[cpuid].val)
+		if(stid == suppress->m_cpuid_tid_stid_cache[cpuid].stid)
 		{
-			suppress->m_cpuid_key_value_cache[cpuid].key = 0;
-			suppress->m_cpuid_key_value_cache[cpuid].val = NULL;
+			suppress->m_cpuid_tid_stid_cache[cpuid].tid = 0;
+			suppress->m_cpuid_tid_stid_cache[cpuid].stid = NULL;
 		}
 	}
 	// Remove / delete from hash table and free().

--- a/userspace/libscap/scap_suppress.c
+++ b/userspace/libscap/scap_suppress.c
@@ -203,18 +203,18 @@ int32_t scap_update_suppressed(struct scap_suppress *suppress,
 
 void scap_remove_and_free_suppressed(struct scap_suppress *suppress, scap_tid *stid)
 {
-	uint16_t cpuid;
+	uint16_t slot;
 
 	// Remove from cache around hash table.
-	for(cpuid = 0; cpuid < SCAP_CPUID_MAX; cpuid ++)
+	for(slot = 0; slot < SCAP_CACHE_CPUID_MAX; slot ++)
 	{
-		if(stid == suppress->m_cpuid_tid_stid_cache[cpuid].stid)
+		if(stid == suppress->m_cpuid_tid_stid_cache[slot].stid)
 		{
-			suppress->m_cpuid_tid_stid_cache[cpuid].tid = 0;
-			suppress->m_cpuid_tid_stid_cache[cpuid].stid = NULL;
+			suppress->m_cpuid_tid_stid_cache[slot].tid = 0;
+			suppress->m_cpuid_tid_stid_cache[slot].stid = NULL;
 		}
 	}
-	// Remove / delete from hash table and free().
+	// Remove from hash table and free().
 	HASH_DEL(suppress->m_suppressed_tids, stid);
 	free(stid);
 }

--- a/userspace/libscap/scap_suppress.c
+++ b/userspace/libscap/scap_suppress.c
@@ -214,7 +214,7 @@ void scap_remove_and_free_suppressed(struct scap_suppress *suppress, scap_tid *s
 			suppress->m_cpuid_key_value_cache[cpuid].val = NULL;
 		}
 	}
-	// Remove from hash table and free().
+	// Remove / delete from hash table and free().
 	HASH_DEL(suppress->m_suppressed_tids, stid);
 	free(stid);
 }

--- a/userspace/libscap/scap_suppress.c
+++ b/userspace/libscap/scap_suppress.c
@@ -206,12 +206,12 @@ void scap_remove_and_free_suppressed(struct scap_suppress *suppress, scap_tid *s
 	uint16_t slot;
 
 	// Remove from cache around hash table.
-	for(slot = 0; slot < SCAP_CACHE_CPUID_MAX; slot ++)
+	for(slot = 0; slot < SCAP_CACHE_DEVID_MAX; slot ++)
 	{
-		if(stid == suppress->m_cpuid_tid_stid_cache[slot].stid)
+		if(stid == suppress->m_devid_tid_stid_cache[slot].stid)
 		{
-			suppress->m_cpuid_tid_stid_cache[slot].tid = 0;
-			suppress->m_cpuid_tid_stid_cache[slot].stid = NULL;
+			suppress->m_devid_tid_stid_cache[slot].tid = 0;
+			suppress->m_devid_tid_stid_cache[slot].stid = NULL;
 		}
 	}
 	// Remove from hash table and free().

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -36,10 +36,10 @@ typedef struct scap_tid
 // Famous last words: will never have more than 1024 CPUs... :-)
 #define SCAP_CPUID_MAX (1024)
 
-typedef struct scap_key_value_cache {
-	uint64_t key;
-	void *val;
-} scap_key_value_cache;
+typedef struct scap_tid_stid {
+	uint64_t tid;
+	scap_tid *stid;
+} scap_tid_stid;
 
 struct scap_suppress
 {
@@ -58,7 +58,7 @@ struct scap_suppress
 	// In benchmarks as of June 2023, scap_check_suppressed() with
 	// suppressed TIDs increases speed from 17.51s to 7.24s. Why?
 	// The cache is a single cache line fetch with no hashing.
-	scap_key_value_cache m_cpuid_key_value_cache[SCAP_CPUID_MAX];
+	scap_tid_stid m_cpuid_tid_stid_cache[SCAP_CPUID_MAX];
 };
 
 int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppressed_comms);

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -52,6 +52,7 @@ int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppress
 int32_t scap_suppress_events_comm_impl(struct scap_suppress *suppress, const char *comm);
 int32_t scap_suppress_events_tid_impl(struct scap_suppress *suppress, int64_t tid);
 bool scap_check_suppressed_tid_impl(struct scap_suppress* suppress, int64_t tid);
+void scap_remove_and_free_suppressed(struct scap_suppress *suppress, scap_tid *stid);
 
 // Possibly add or remove the provided comm, tid combination to the
 // set of suppressed processes. If the ptid is currently in the

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -33,9 +33,9 @@ typedef struct scap_tid
 	UT_hash_handle hh; ///< makes this structure hashable
 } scap_tid;
 
-// SCAP_CACHE_CPUID_MAX must be a power of two.
+// SCAP_CACHE_DEVID_MAX must be a power of two.
 // Boxes with > 1024 CPUs will benefit from less suppress TID caching.
-#define SCAP_CACHE_CPUID_MAX (1024)
+#define SCAP_CACHE_DEVID_MAX (1024)
 
 typedef struct scap_tid_stid {
 	uint64_t tid;
@@ -60,7 +60,7 @@ struct scap_suppress
 	// suppressed TIDs increases speed from 17.51s to 7.24s. Why?
 	// Cache lookup is a single cache line fetch with no hashing.
 	// Avoid dynamic allocation to avoid extra cache line fetch.
-	scap_tid_stid m_cpuid_tid_stid_cache[SCAP_CACHE_CPUID_MAX];
+	scap_tid_stid m_devid_tid_stid_cache[SCAP_CACHE_DEVID_MAX];
 };
 
 int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppressed_comms);

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -33,6 +33,13 @@ typedef struct scap_tid
 	UT_hash_handle hh; ///< makes this structure hashable
 } scap_tid;
 
+// Famous last words: will never have more than 1024 CPUs... :-)
+#define SCAP_CPUID_MAX (1024)
+
+typedef struct scap_key_value_cache {
+	uint64_t key;
+	void *val;
+} scap_key_value_cache;
 
 struct scap_suppress
 {
@@ -46,6 +53,12 @@ struct scap_suppress
 	// The number of events that were skipped due to the comm
 	// matching an entry in m_suppressed_comms.
 	uint64_t m_num_suppressed_evts;
+
+	// The cache around the m_suppressed_tids hash table. Why?
+	// In benchmarks as of June 2023, scap_check_suppressed() with
+	// suppressed TIDs increases speed from 17.51s to 7.24s. Why?
+	// The cache is a single cache line fetch with no hashing.
+	scap_key_value_cache __attribute__ ((aligned (64))) m_cpuid_key_value_cache[SCAP_CPUID_MAX];
 };
 
 int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppressed_comms);

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -58,7 +58,7 @@ struct scap_suppress
 	// In benchmarks as of June 2023, scap_check_suppressed() with
 	// suppressed TIDs increases speed from 17.51s to 7.24s. Why?
 	// The cache is a single cache line fetch with no hashing.
-	scap_key_value_cache __attribute__ ((aligned (64))) m_cpuid_key_value_cache[SCAP_CPUID_MAX];
+	scap_key_value_cache m_cpuid_key_value_cache[SCAP_CPUID_MAX];
 };
 
 int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppressed_comms);

--- a/userspace/libscap/scap_suppress.h
+++ b/userspace/libscap/scap_suppress.h
@@ -33,8 +33,9 @@ typedef struct scap_tid
 	UT_hash_handle hh; ///< makes this structure hashable
 } scap_tid;
 
-// Famous last words: will never have more than 1024 CPUs... :-)
-#define SCAP_CPUID_MAX (1024)
+// SCAP_CACHE_CPUID_MAX must be a power of two.
+// Boxes with > 1024 CPUs will benefit from less suppress TID caching.
+#define SCAP_CACHE_CPUID_MAX (1024)
 
 typedef struct scap_tid_stid {
 	uint64_t tid;
@@ -57,8 +58,9 @@ struct scap_suppress
 	// The cache around the m_suppressed_tids hash table. Why?
 	// In benchmarks as of June 2023, scap_check_suppressed() with
 	// suppressed TIDs increases speed from 17.51s to 7.24s. Why?
-	// The cache is a single cache line fetch with no hashing.
-	scap_tid_stid m_cpuid_tid_stid_cache[SCAP_CPUID_MAX];
+	// Cache lookup is a single cache line fetch with no hashing.
+	// Avoid dynamic allocation to avoid extra cache line fetch.
+	scap_tid_stid m_cpuid_tid_stid_cache[SCAP_CACHE_CPUID_MAX];
 };
 
 int32_t scap_suppress_init(struct scap_suppress* suppress, const char** suppressed_comms);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

Accelerates suppressed TID lookup if used at run-time.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

In a benchmark at 300k events/s with 50k suppressed TID events/s, change reduced scap_check_suppressed() reported prof time from 17.51 to 7.24 seconds.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
