### PR TITLE
fix: introduce a COS workaround to fix regression #1157

### DIFF
--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -1,5 +1,8 @@
 option(MODERN_BPF_DEBUG_MODE "Enable BPF debug prints" OFF)
 option(MODERN_BPF_EXCLUDE_PROGS "Regex to exclude tail-called programs" "")
+# This is a temporary workaround to solve this regression https://github.com/falcosecurity/libs/issues/1157
+# We need to find a better solution
+option(MODERN_BPF_COS_WORKAROUND "Allow to correctly extract 'loginuid' from COS system, but requires at least CAP_SYS_ADMIN" OFF)
 
 ########################
 # Debug mode
@@ -11,6 +14,13 @@ else()
   set(DEBUG "")
 endif()
 message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_DEBUG_MODE: ${MODERN_BPF_DEBUG_MODE}")
+
+if(MODERN_BPF_COS_WORKAROUND)
+  set(COS_WORKAROUND "COS_WORKAROUND")
+else()
+  set(COS_WORKAROUND "")
+endif()
+message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_COS_WORKAROUND: ${MODERN_BPF_COS_WORKAROUND}")
 
 ########################
 # Check kernel version.
@@ -195,6 +205,7 @@ list(APPEND CLANG_FLAGS
     -g -O2
     -target bpf
     -D__${DEBUG}__
+    -D__${COS_WORKAROUND}__
     -D__TARGET_ARCH_${ARCH} # Match libbpf usage in `/libbpf/src/bpf_tracing.h`
     -D__USE_VMLINUX__ # Used to compile without kernel headers.
     -I${LIBBPF_INCLUDE}

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -610,6 +610,7 @@ static __always_inline void extract__loginuid(struct task_struct *task, u32 *log
 	{
 		READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
 	}
+#ifdef __COS_WORKAROUND__	
 	else
 	{
 		struct task_struct___cos *task_cos = (void *)task;
@@ -619,6 +620,7 @@ static __always_inline void extract__loginuid(struct task_struct *task, u32 *log
 			READ_TASK_FIELD_INTO(loginuid, task_cos, audit, loginuid.val);
 		}
 	}
+#endif
 }
 
 /////////////////////////


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR fixes the regression reported here https://github.com/falcosecurity/libs/issues/1157 as suggested by @FedeDP.
I want to highlight that this is just a temp workaround for tag 0.11.3 we need to find for sure a better solution, hoping to receive some inputs from kernel engineers https://lore.kernel.org/bpf/CAGQdkDvYU_e=_NX+6DRkL_-TeH3p+QtsdZwHkmH0w3Fuzw0C4w@mail.gmail.com/T/#u

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
