### PR TITLE
fix(sinsp): don't call openat parser for fchmod

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -319,6 +319,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	case PPME_SYSCALL_FCHMOD_X:
 	case PPME_SYSCALL_FCHOWN_X:
 		parse_fchmod_fchown_exit(evt);
+		break;
 	case PPME_SYSCALL_OPENAT_X:
 		parse_fspath_related_exit(evt);
 		parse_open_openat_creat_exit(evt);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

`fchmod` is not `openat` :) We were missing a `break;` between the two switch cases

**Special notes for your reviewer**:

I found this by running the unit tests in a debug build, but we also should consider missing explicit fallthrough tags as a compile error (there's a flag for that and I have a branch somewhere that enables it but it's not quite finished IIRC)

```release-note
NONE
```
