### PR TITLE
[4/n] new(libscap): platform abstraction support: clean up savefiles a little bit

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -49,7 +49,6 @@ struct scap
 	struct scap_engine_handle m_engine;
 	struct scap_platform *m_platform;
 
-	scap_mode_t m_mode;
 	char m_lasterr[SCAP_LASTERR_SIZE];
 
 	uint64_t m_evtcnt;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -43,7 +43,6 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 	//
 	// Preliminary initializations
 	//
-	handle->m_mode = vtable->mode;
 	handle->m_vtable = vtable;
 	handle->m_platform = platform;
 

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -34,6 +34,7 @@ struct iovec {
 #include "scap_platform_impl.h"
 #include "scap_savefile_api.h"
 #include "scap_savefile.h"
+#include "strl.h"
 
 const char* scap_dump_getlasterr(scap_dumper_t* d)
 {
@@ -1279,12 +1280,12 @@ scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compre
 //
 // Open a memory "savefile"
 //
-scap_dumper_t *scap_memory_dump_open(scap_t *handle, uint8_t* targetbuf, uint64_t targetbufsize)
+scap_dumper_t *scap_memory_dump_open(struct scap_platform* platform, uint8_t* targetbuf, uint64_t targetbufsize, char* lasterr)
 {
 	scap_dumper_t* res = (scap_dumper_t*)malloc(sizeof(scap_dumper_t));
 	if(res == NULL)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "scap_dump_memory_open memory allocation failure (1)");
+		snprintf(lasterr, SCAP_LASTERR_SIZE, "scap_dump_memory_open memory allocation failure (1)");
 		return NULL;
 	}
 
@@ -1294,9 +1295,9 @@ scap_dumper_t *scap_memory_dump_open(scap_t *handle, uint8_t* targetbuf, uint64_
 	res->m_targetbufcurpos = targetbuf;
 	res->m_targetbufend = targetbuf + targetbufsize;
 
-	if(scap_setup_dump(res, handle->m_mode == SCAP_MODE_PLUGIN ? NULL : handle->m_platform, "") != SCAP_SUCCESS)
+	if(scap_setup_dump(res, platform, "") != SCAP_SUCCESS)
 	{
-		strcpy(handle->m_lasterr, res->m_lasterr);
+		strlcpy(lasterr, res->m_lasterr, SCAP_LASTERR_SIZE);
 		free(res);
 		res = NULL;
 	}

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1109,14 +1109,17 @@ static int32_t scap_setup_dump(scap_dumper_t* d, struct scap_platform *platform,
 	return SCAP_SUCCESS;
 }
 
-static inline int32_t scap_dump_rescan_proc(scap_t *handle)
+static inline int32_t scap_dump_rescan_proc(struct scap_platform* platform)
 {
 	int32_t ret = SCAP_SUCCESS;
 #ifdef __linux__
-	proc_entry_callback tcb = handle->m_platform->m_proclist.m_proc_callback;
-	handle->m_platform->m_proclist.m_proc_callback = NULL;
-	ret = scap_refresh_proc_table(handle);
-	handle->m_platform->m_proclist.m_proc_callback = tcb;
+	if(platform && platform->m_vtable && platform->m_vtable->refresh_proc_table)
+	{
+		proc_entry_callback tcb = platform->m_proclist.m_proc_callback;
+		platform->m_proclist.m_proc_callback = NULL;
+		ret = platform->m_vtable->refresh_proc_table(platform, &platform->m_proclist);
+		platform->m_proclist.m_proc_callback = tcb;
+	}
 #endif
 	return ret;
 }
@@ -1203,7 +1206,7 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 	//
 	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
 	{
-		if(scap_dump_rescan_proc(handle) != SCAP_SUCCESS)
+		if(scap_dump_rescan_proc(handle->m_platform) != SCAP_SUCCESS)
 		{
 			return NULL;
 		}
@@ -1255,7 +1258,7 @@ scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compre
 	//
 	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
 	{
-		if(scap_dump_rescan_proc(handle) != SCAP_SUCCESS)
+		if(scap_dump_rescan_proc(handle->m_platform) != SCAP_SUCCESS)
 		{
 			return NULL;
 		}

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1227,7 +1227,7 @@ scap_dumper_t *scap_dump_open(struct scap_platform* platform, const char *fname,
 
 //
 // Open a savefile for writing, using the provided fd
-scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress, bool skip_proc_scan)
+scap_dumper_t* scap_dump_open_fd(struct scap_platform* platform, int fd, compression_mode compress, bool skip_proc_scan, char* lasterr)
 {
 	gzFile f = NULL;
 	scap_dumper_t* res;
@@ -1242,13 +1242,13 @@ scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compre
 		break;
 	default:
 		ASSERT(false);
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
+		snprintf(lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
 		return NULL;
 	}
 	
 	if(f == NULL)
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open fd %d", fd);
+		snprintf(lasterr, SCAP_LASTERR_SIZE, "can't open fd %d", fd);
 		return NULL;
 	}
 
@@ -1257,22 +1257,22 @@ scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compre
 	// so we don't lose information about processes created in the interval
 	// between opening the handle and starting the dump
 	//
-	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
+	if(!skip_proc_scan)
 	{
-		if(scap_dump_rescan_proc(handle->m_platform) != SCAP_SUCCESS)
+		if(scap_dump_rescan_proc(platform) != SCAP_SUCCESS)
 		{
 			return NULL;
 		}
 	}
 
-	res = scap_dump_open_gzfile(handle->m_platform, f, "", handle->m_lasterr);
+	res = scap_dump_open_gzfile(platform, f, "", lasterr);
 
 	//
 	// If the user doesn't need the thread table, free it
 	//
-	if(handle->m_platform->m_proclist.m_proc_callback != NULL)
+	if(platform->m_proclist.m_proc_callback != NULL)
 	{
-		scap_proc_free_table(&handle->m_platform->m_proclist);
+		scap_proc_free_table(&platform->m_proclist);
 	}
 	return res;
 }

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1148,7 +1148,7 @@ static scap_dumper_t *scap_dump_open_gzfile(struct scap_platform* platform, gzFi
 //
 // Open a "savefile" for writing.
 //
-scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mode compress, bool skip_proc_scan)
+scap_dumper_t *scap_dump_open(struct scap_platform* platform, const char *fname, compression_mode compress, bool skip_proc_scan, char* lasterr)
 {
 	gzFile f = NULL;
 	int fd = -1;
@@ -1165,7 +1165,7 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 		break;
 	default:
 		ASSERT(false);
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
+		snprintf(lasterr, SCAP_LASTERR_SIZE, "invalid compression mode");
 		return NULL;
 	}
 
@@ -1196,7 +1196,7 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 		}
 #endif
 
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "can't open %s", fname);
+		snprintf(lasterr, SCAP_LASTERR_SIZE, "can't open %s", fname);
 		return NULL;
 	}
 
@@ -1205,21 +1205,21 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 	// so we don't lose information about processes created in the interval
 	// between opening the handle and starting the dump
 	//
-	if(handle->m_mode != SCAP_MODE_CAPTURE && !skip_proc_scan)
+	if(!skip_proc_scan)
 	{
-		if(scap_dump_rescan_proc(handle->m_platform) != SCAP_SUCCESS)
+		if(scap_dump_rescan_proc(platform) != SCAP_SUCCESS)
 		{
 			return NULL;
 		}
 	}
 
-	res = scap_dump_open_gzfile(handle->m_platform, f, fname, handle->m_lasterr);
+	res = scap_dump_open_gzfile(platform, f, fname, lasterr);
 	//
 	// If the user doesn't need the thread table, free it
 	//
-	if(handle->m_platform->m_proclist.m_proc_callback != NULL)
+	if(platform->m_proclist.m_proc_callback != NULL)
 	{
-		scap_proc_free_table(&handle->m_platform->m_proclist);
+		scap_proc_free_table(&platform->m_proclist);
 	}
 
 	return res;

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1033,7 +1033,7 @@ static int32_t scap_write_userlist(scap_dumper_t* d, struct scap_userlist *userl
 //
 // Create the dump file headers and add the tables
 //
-static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fname)
+static int32_t scap_setup_dump(scap_dumper_t* d, struct scap_platform *platform, const char *fname)
 {
 	block_header bh;
 	section_header_block sh;
@@ -1060,12 +1060,12 @@ static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fna
 		return SCAP_FAILURE;
 	}
 
-	if(handle->m_mode != SCAP_MODE_PLUGIN)
+	if(platform)
 	{
 		//
 		// Write the machine info
 		//
-		if(scap_write_machine_info(d, &handle->m_platform->m_machine_info) != SCAP_SUCCESS)
+		if(scap_write_machine_info(d, &platform->m_machine_info) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}
@@ -1073,7 +1073,7 @@ static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fna
 		//
 		// Write the interface list
 		//
-		if(scap_write_iflist(d, handle->m_platform->m_addrlist) != SCAP_SUCCESS)
+		if(scap_write_iflist(d, platform->m_addrlist) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}
@@ -1081,7 +1081,7 @@ static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fna
 		//
 		// Write the user list
 		//
-		if(scap_write_userlist(d, handle->m_platform->m_userlist) != SCAP_SUCCESS)
+		if(scap_write_userlist(d, platform->m_userlist) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}
@@ -1089,7 +1089,7 @@ static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fna
 		//
 		// Write the process list
 		//
-		if(scap_write_proclist(d, &handle->m_platform->m_proclist) != SCAP_SUCCESS)
+		if(scap_write_proclist(d, &platform->m_proclist) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}
@@ -1097,7 +1097,7 @@ static int32_t scap_setup_dump(scap_t *handle, scap_dumper_t* d, const char *fna
 		//
 		// Write the fd lists
 		//
-		if(scap_write_fdlist(d, &handle->m_platform->m_proclist) != SCAP_SUCCESS)
+		if(scap_write_fdlist(d, &platform->m_proclist) != SCAP_SUCCESS)
 		{
 			return SCAP_FAILURE;
 		}
@@ -1131,7 +1131,7 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 	res->m_targetbufcurpos = NULL;
 	res->m_targetbufend = NULL;
 
-	if(scap_setup_dump(handle, res, fname) != SCAP_SUCCESS)
+	if(scap_setup_dump(res, handle->m_mode == SCAP_MODE_PLUGIN ? NULL : handle->m_platform, fname) != SCAP_SUCCESS)
 	{
 		strcpy(handle->m_lasterr, res->m_lasterr);
 		free(res);
@@ -1291,7 +1291,7 @@ scap_dumper_t *scap_memory_dump_open(scap_t *handle, uint8_t* targetbuf, uint64_
 	res->m_targetbufcurpos = targetbuf;
 	res->m_targetbufend = targetbuf + targetbufsize;
 
-	if(scap_setup_dump(handle, res, "") != SCAP_SUCCESS)
+	if(scap_setup_dump(res, handle->m_mode == SCAP_MODE_PLUGIN ? NULL : handle->m_platform, "") != SCAP_SUCCESS)
 	{
 		strcpy(handle->m_lasterr, res->m_lasterr);
 		free(res);

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -1126,7 +1126,7 @@ static inline int32_t scap_dump_rescan_proc(struct scap_platform* platform)
 }
 
 // fname is only used for log messages in scap_setup_dump
-static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const char *fname, bool skip_proc_scan)
+static scap_dumper_t *scap_dump_open_gzfile(struct scap_platform* platform, gzFile gzfile, const char *fname, char* lasterr)
 {
 	scap_dumper_t* res = (scap_dumper_t*)malloc(sizeof(scap_dumper_t));
 	res->m_f = gzfile;
@@ -1135,9 +1135,9 @@ static scap_dumper_t *scap_dump_open_gzfile(scap_t *handle, gzFile gzfile, const
 	res->m_targetbufcurpos = NULL;
 	res->m_targetbufend = NULL;
 
-	if(scap_setup_dump(res, handle->m_mode == SCAP_MODE_PLUGIN ? NULL : handle->m_platform, fname) != SCAP_SUCCESS)
+	if(scap_setup_dump(res, platform, fname) != SCAP_SUCCESS)
 	{
-		strcpy(handle->m_lasterr, res->m_lasterr);
+		strlcpy(lasterr, res->m_lasterr, SCAP_LASTERR_SIZE);
 		free(res);
 		res = NULL;
 	}
@@ -1213,7 +1213,7 @@ scap_dumper_t *scap_dump_open(scap_t *handle, const char *fname, compression_mod
 		}
 	}
 
-	res = scap_dump_open_gzfile(handle, f, fname, skip_proc_scan);
+	res = scap_dump_open_gzfile(handle->m_platform, f, fname, handle->m_lasterr);
 	//
 	// If the user doesn't need the thread table, free it
 	//
@@ -1265,7 +1265,7 @@ scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compre
 		}
 	}
 
-	res = scap_dump_open_gzfile(handle, f, "", skip_proc_scan);
+	res = scap_dump_open_gzfile(handle->m_platform, f, "", handle->m_lasterr);
 
 	//
 	// If the user doesn't need the thread table, free it

--- a/userspace/libscap/scap_savefile_api.h
+++ b/userspace/libscap/scap_savefile_api.h
@@ -49,7 +49,6 @@ typedef struct scap_dumper
 	char m_lasterr[SCAP_LASTERR_SIZE];
 } scap_dumper_t;
 
-typedef struct scap scap_t;
 struct scap_threadinfo;
 typedef struct ppm_evt_hdr scap_evt;
 struct iovec;

--- a/userspace/libscap/scap_savefile_api.h
+++ b/userspace/libscap/scap_savefile_api.h
@@ -91,7 +91,7 @@ int32_t scap_write_proclist_entry_bufs(scap_dumper_t *d, struct scap_threadinfo 
 
   \return Dump handle that can be used to identify this specific dump instance.
 */
-scap_dumper_t* scap_dump_open(scap_t *handle, const char *fname, compression_mode compress, bool skip_proc_scan);
+scap_dumper_t *scap_dump_open(struct scap_platform* platform, const char *fname, compression_mode compress, bool skip_proc_scan, char* lasterr);
 
 /*!
   \brief Open a trace file for writing, using the provided fd.

--- a/userspace/libscap/scap_savefile_api.h
+++ b/userspace/libscap/scap_savefile_api.h
@@ -27,6 +27,8 @@ limitations under the License.
 extern "C" {
 #endif
 
+struct scap_platform;
+
 typedef enum ppm_dumper_type
 {
 	DT_FILE = 0,
@@ -65,7 +67,7 @@ uint8_t* scap_get_memorydumper_curpos(scap_dumper_t *d);
 int32_t scap_write_proc_fds(scap_dumper_t *d, struct scap_threadinfo *tinfo);
 scap_dumper_t* scap_write_proclist_begin();
 int scap_write_proclist_end(scap_dumper_t *d, scap_dumper_t *proclist_dumper, uint32_t totlen);
-scap_dumper_t *scap_memory_dump_open(scap_t *handle, uint8_t* targetbuf, uint64_t targetbufsize);
+scap_dumper_t *scap_memory_dump_open(struct scap_platform* platform, uint8_t* targetbuf, uint64_t targetbufsize, char* lasterr);
 scap_dumper_t *scap_managedbuf_dump_create();
 
 // Variant of scap_write_proclist_entry where array-backed information

--- a/userspace/libscap/scap_savefile_api.h
+++ b/userspace/libscap/scap_savefile_api.h
@@ -101,7 +101,7 @@ scap_dumper_t *scap_dump_open(struct scap_platform* platform, const char *fname,
 
   \return Dump handle that can be used to identify this specific dump instance.
 */
-scap_dumper_t* scap_dump_open_fd(scap_t *handle, int fd, compression_mode compress, bool skip_proc_scan);
+scap_dumper_t* scap_dump_open_fd(struct scap_platform* platform, int fd, compression_mode compress, bool skip_proc_scan, char* lasterr);
 
 /*!
   \brief Close a trace file.

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -46,6 +46,7 @@ sinsp_dumper::~sinsp_dumper()
 
 void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool compress, bool threads_from_sinsp)
 {
+	char error[SCAP_LASTERR_SIZE];
 	if(inspector->m_h == NULL)
 	{
 		throw sinsp_exception("can't start event dump, inspector not opened yet");
@@ -53,27 +54,23 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 
 	if(m_target_memory_buffer)
 	{
-		char error[SCAP_LASTERR_SIZE];
 		m_dumper = scap_memory_dump_open(inspector->m_h->m_platform, m_target_memory_buffer, m_target_memory_buffer_size, error);
-		if(m_dumper == nullptr)
-		{
-			throw sinsp_exception(error);
-		}
 	}
 	else
 	{
 		if(compress)
 		{
-			m_dumper = scap_dump_open(inspector->m_h, filename.c_str(), SCAP_COMPRESSION_GZIP, threads_from_sinsp);
+			m_dumper = scap_dump_open(inspector->m_h->m_platform, filename.c_str(), SCAP_COMPRESSION_GZIP, threads_from_sinsp, error);
 		}
 		else
 		{
-			m_dumper = scap_dump_open(inspector->m_h, filename.c_str(), SCAP_COMPRESSION_NONE, threads_from_sinsp);
+			m_dumper = scap_dump_open(inspector->m_h->m_platform, filename.c_str(), SCAP_COMPRESSION_NONE, threads_from_sinsp, error);
 		}
-		if(m_dumper == NULL)
-		{
-			throw sinsp_exception(scap_getlasterr(inspector->m_h));
-		}
+	}
+
+	if(m_dumper == nullptr)
+	{
+		throw sinsp_exception(error);
 	}
 
 	if(threads_from_sinsp)

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -87,6 +87,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 
 void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_from_sinsp)
 {
+	char error[SCAP_LASTERR_SIZE];
 	if(inspector->m_h == NULL)
 	{
 		throw sinsp_exception("can't start event dump, inspector not opened yet");
@@ -94,16 +95,16 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_
 
 	if(compress)
 	{
-		m_dumper = scap_dump_open_fd(inspector->m_h, fd, SCAP_COMPRESSION_GZIP, threads_from_sinsp);
+		m_dumper = scap_dump_open_fd(inspector->m_h->m_platform, fd, SCAP_COMPRESSION_GZIP, threads_from_sinsp, error);
 	}
 	else
 	{
-		m_dumper = scap_dump_open_fd(inspector->m_h, fd, SCAP_COMPRESSION_NONE, threads_from_sinsp);
+		m_dumper = scap_dump_open_fd(inspector->m_h->m_platform, fd, SCAP_COMPRESSION_NONE, threads_from_sinsp, error);
 	}
 
-	if(m_dumper == NULL)
+	if(m_dumper == nullptr)
 	{
-		throw sinsp_exception(scap_getlasterr(inspector->m_h));
+		throw sinsp_exception(error);
 	}
 
 	if(threads_from_sinsp)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

This is a "silence before the storm" episode in the platform saga: a few cleanups in savefile code. One cherry on top is that we can finally remove m_mode from the scap handle (there's nothing that depends on it any more, since everything should be properly abstracted via engines and platforms by now)

**Special notes for your reviewer**:

This builds on top of #1042 so looks huge right now. BTW I expect n>=6 at least but I hope I won't go into double digits :)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
