### PR TITLE
fix(driver/modern-bpf): improve CO-RE detection

### DIFF
--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -626,9 +626,9 @@ static __always_inline void extract__loginuid(struct task_struct *task, u32 *log
 	{
 		struct task_struct___cos *task_cos = (void *)task;
 
-		if(bpf_core_field_exists(task_cos->audit->loginuid))
+		if(bpf_core_field_exists(struct task_struct___cos, audit))
 		{
-			READ_TASK_FIELD_INTO(loginuid, task_cos, audit, loginuid.val);
+			BPF_CORE_READ_INTO(loginuid, task_cos, audit, loginuid.val);
 		}
 	}
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf


**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

As suggested in the mailing list https://lore.kernel.org/bpf/CAGQdkDuoUp6QCztoF72uS+5OjB2PDLJ0y+aJC0Dou4iOK6MWuA@mail.gmail.com/T/#mf65b870f20b4ba367c9823a56eeb3ac1c196846b the previous approach checked only existence of
loginuid inside typeof(task_cos->audit), but it doesn't check that
task_struct has an audit field. In the end, this new approach should work better, already tested it on different GKE versions and it works :) 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
