### PR TITLE
Update(userspace/libsinsp): Support userspace parsers for pidfd_getfd

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -454,9 +454,9 @@ const struct ppm_event_info g_event_info[] = {
 	[PPME_ASYNCEVENT_E] = {"asyncevent", EC_OTHER | EC_METAEVENT, EF_LARGE_PAYLOAD, 3, {{"plugin_id", PT_UINT32, PF_DEC}, {"name", PT_CHARBUF, PF_NA}, {"data", PT_BYTEBUF, PF_NA} } },
 	[PPME_ASYNCEVENT_X] = {"NA", EC_UNKNOWN, EF_UNUSED, 0},
 	[PPME_SYSCALL_MEMFD_CREATE_E] = {"memfd_create", EC_MEMORY | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 0},
-	[PPME_SYSCALL_MEMFD_CREATE_X] = {"memfd_create", EC_MEMORY | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 3, {{"fd",PT_FD,PF_DEC},{"name", PT_CHARBUF, PF_NA},{"flags", PT_FLAGS32, PF_HEX, memfd_create_flags} } },
-	[PPME_SYSCALL_PIDFD_GETFD_E] = {"pidfd_getfd", EC_PROCESS | EC_SYSCALL, EF_CREATES_FD , 0},
-	[PPME_SYSCALL_PIDFD_GETFD_X] = {"pidfd_getfd", EC_PROCESS | EC_SYSCALL, EF_CREATES_FD , 4, {{"fd", PT_FD, PF_DEC}, {"pid_fd", PT_FD, PF_DEC}, {"target_fd", PT_FD, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX}}}
+	[PPME_SYSCALL_MEMFD_CREATE_X] = {"memfd_create", EC_MEMORY | EC_SYSCALL, EF_CREATES_FD| EF_MODIFIES_STATE, 3, {{"fd",PT_FD,PF_DEC},{"name", PT_CHARBUF, PF_NA},{"flags", PT_FLAGS32, PF_HEX, memfd_create_flags} } },
+	[PPME_SYSCALL_PIDFD_GETFD_E] = {"pidfd_getfd", EC_PROCESS | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 0},
+	[PPME_SYSCALL_PIDFD_GETFD_X] = {"pidfd_getfd", EC_PROCESS | EC_SYSCALL, EF_CREATES_FD | EF_MODIFIES_STATE, 4, {{"fd", PT_FD, PF_DEC}, {"pid_fd", PT_FD, PF_DEC}, {"target_fd", PT_FD, PF_DEC}, {"flags", PT_FLAGS32, PF_HEX}}}
 };
 
 // We don't need this check in kmod (this source file is included during kmod compilation!)

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -354,6 +354,9 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 	case PPME_SYSCALL_CLONE3_X:
 		parse_clone_exit(evt);
 		break;
+	case PPME_SYSCALL_PIDFD_GETFD_X:
+		parse_pidfd_getfd_exit(evt);
+		break;
 	case PPME_SYSCALL_EXECVE_8_X:
 	case PPME_SYSCALL_EXECVE_13_X:
 	case PPME_SYSCALL_EXECVE_14_X:
@@ -6084,4 +6087,56 @@ void sinsp_parser::parse_memfd_create_exit(sinsp_evt *evt, scap_fd_type type)
 	}
 
 	evt->m_fdinfo = evt->m_tinfo->add_fd(fd, &fdi);
+}
+
+void sinsp_parser::parse_pidfd_getfd_exit(sinsp_evt *evt)
+{
+
+	sinsp_evt_param* parinfo;
+	int64_t fd;
+	int64_t pidfd;
+	int64_t targetfd;
+
+	ASSERT(evt->m_tinfo)
+	if(evt->m_tinfo == nullptr)
+	{
+		return;
+	}
+
+	/* ret (fd) */
+	parinfo = evt->get_param(0);
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+	ASSERT(evt->get_param_info(0)->type == PT_FD);
+	fd = *(int64_t *)parinfo->m_val;
+
+	/* pidfd */
+	parinfo = evt->get_param(1);
+	ASSERT(parinfo->m_len == sizeof(int64_t));
+	ASSERT(evt->get_param_info(1)->type == PT_FD);
+	pidfd = *(int64_t *)parinfo->m_val;
+
+	auto target_tinfo = m_inspector->get_thread_ref(pidfd);
+
+	if(target_tinfo == nullptr)
+	{
+		return;
+	}
+
+	/* targetfd */
+	parinfo = evt->get_param(2);
+	ASSERT(parinfo->m_len == sizeof(int64_t))
+	ASSERT(evt->get_param_info(2)->type == PT_FD);
+	targetfd = *(int64_t *)parinfo->m_val;
+
+	auto target_fdinfo = target_tinfo->get_fd(targetfd);
+
+	if(target_fdinfo == nullptr)
+	{
+		return;
+	}
+
+	sinsp_fdinfo_t new_fd = *target_fdinfo;
+
+	evt->m_tinfo->add_fd(fd, &new_fd);
+
 }

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -110,6 +110,7 @@ private:
 	void parse_thread_exit(sinsp_evt* evt);
 	void parse_memfd_create_exit(sinsp_evt* evt, scap_fd_type type);
 	inline bool detect_and_process_tracer_write(sinsp_evt *evt, int64_t retval, ppm_event_flags eflags);
+	void parse_pidfd_getfd_exit(sinsp_evt* evt);
 	void parse_fspath_related_exit(sinsp_evt* evt);
 	inline void parse_rw_exit(sinsp_evt* evt);
 	void parse_sendfile_exit(sinsp_evt* evt);

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -679,3 +679,21 @@ TEST_F(sinsp_with_test_input, test_fdtypes)
 	ASSERT_EQ(get_field_as_string(evt, "fd.types[3]"), "(bpf)");
 	ASSERT_EQ(get_field_as_string(evt, "fd.types"), "(bpf,file)");
 }
+
+
+TEST_F(sinsp_with_test_input, pidfd_getfd)
+{
+	add_default_init_thread();
+	open_inspector();
+	sinsp_evt* evt = NULL;
+	int64_t fd = -1;
+	int64_t pidfd = -2;
+	int64_t targetfd = -3;
+	
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIDFD_GETFD_E, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIDFD_GETFD_X, 4, fd, pidfd, targetfd, 0);
+
+	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_PIDFD_GETFD_X);
+	ASSERT_EQ(get_field_as_string(evt,"fd.num"), std::to_string(fd));
+	
+}

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -686,14 +686,33 @@ TEST_F(sinsp_with_test_input, pidfd_getfd)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	int64_t fd = -1;
-	int64_t pidfd = -2;
-	int64_t targetfd = -3;
-	
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIDFD_GETFD_E, 0);
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PIDFD_GETFD_X, 4, fd, pidfd, targetfd, 0);
+	int targetfd = 3;
+	int fd = 1;
+
+	/* Use clone to create a child process */
+	uint64_t parent_pid = 1, parent_tid = 1;
+	uint64_t child_pid = 0x0000000100000010, child_tid = 0x0000000100000010;
+	uint64_t fdlimit = 1024, pgft_maj = 0, pgft_min = 1;
+	scap_const_sized_buffer empty_bytebuf = {.buf = nullptr, .size = 0};
+
+	std::vector<std::string> cgroups = {"cpuset=/", "cpu=/user.slice", "cpuacct=/user.slice", "io=/user.slice", "memory=/user.slice/user-1000.slice/session-1.scope", "devices=/user.slice", "freezer=/", "net_cls=/", "perf_event=/", "net_prio=/", "hugetlb=/", "pids=/user.slice/user-1000.slice/session-1.scope", "rdma=/", "misc=/"};
+	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	std::vector<std::string> env = {"SHELL=/bin/bash", "PWD=/home/user", "HOME=/home/user"};
+	std::string envv = test_utils::to_null_delimited(env);
+	std::vector<std::string> args = {"--help"};
+	std::string argsv = test_utils::to_null_delimited(args);
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, 0, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
+
+	/* Open a file descriptor in the child process */
+	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_OPEN_X, 6, (uint64_t)targetfd, "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t)123);
+
+	/* Use pidfd_getfd to target the file descriptor of the child process */
+	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_PIDFD_GETFD_E, 0);
+	evt = add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_PIDFD_GETFD_X, 4, fd, child_pid, targetfd, 0);
 
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_PIDFD_GETFD_X);
 	ASSERT_EQ(get_field_as_string(evt,"fd.num"), std::to_string(fd));
-	
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
+	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/tmp");
+	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "the_file");
 }

--- a/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
@@ -206,7 +206,9 @@ const libsinsp::events::set<ppm_event_code> expected_sinsp_state_event_set = {
 	PPME_SYSCALL_PRCTL_X,
 	PPME_ASYNCEVENT_E,
 	PPME_SYSCALL_MEMFD_CREATE_E,
-	PPME_SYSCALL_MEMFD_CREATE_X
+	PPME_SYSCALL_MEMFD_CREATE_X,
+	PPME_SYSCALL_PIDFD_GETFD_E,
+	PPME_SYSCALL_PIDFD_GETFD_X,
 };
 
 const libsinsp::events::set<ppm_sc_code> expected_sinsp_state_sc_set = {
@@ -273,7 +275,8 @@ const libsinsp::events::set<ppm_sc_code> expected_sinsp_state_sc_set = {
 	PPM_SC_EPOLL_CREATE1,
 	PPM_SC_SCHED_PROCESS_EXIT,
 	PPM_SC_PRCTL,
-	PPM_SC_MEMFD_CREATE
+	PPM_SC_MEMFD_CREATE,
+	PPM_SC_PIDFD_GETFD,
 };
 
 const libsinsp::events::set<ppm_event_code> expected_unknown_event_set = {


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
To extract information in `pidfd_getfd` syscall. i.e `pidfd` and `targetfd`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
 NO


```release-note
update(userspace/libsinsp): Support userspace parsers for pidfd_getfd
```
