### PR TITLE
cleanup(build): Use a single cmake module for driver_config.h

### DIFF
--- a/cmake/modules/driver_config.cmake
+++ b/cmake/modules/driver_config.cmake
@@ -1,0 +1,14 @@
+include(compute_versions RESULT_VARIABLE RESULT)
+if(RESULT STREQUAL NOTFOUND)
+    message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
+endif()
+
+set(DRIVER_CONFIG_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../driver)
+get_filename_component(DRIVER_CONFIG_OUTPUT_DIR ${CMAKE_BINARY_DIR}/driver_config ABSOLUTE)
+
+compute_versions(${DRIVER_CONFIG_SOURCE_DIR}/API_VERSION ${DRIVER_CONFIG_SOURCE_DIR}/SCHEMA_VERSION)
+configure_file(${DRIVER_CONFIG_SOURCE_DIR}/driver_config.h.in ${DRIVER_CONFIG_OUTPUT_DIR}/driver_config.h.tmp)
+execute_process(
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different driver_config.h.tmp driver_config.h
+        WORKING_DIRECTORY ${DRIVER_CONFIG_OUTPUT_DIR}
+)

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -44,7 +44,7 @@ else()
 endif()
 
 get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSOLUTE)
-set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
+set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR})
 
 function(set_scap_target_properties target)
 	set_target_properties(${target} PROPERTIES

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -80,15 +80,9 @@ endif()
 # ${CMAKE_CURRENT_BINARY_DIR}/src. To maintain compatibility with older versions,
 # after the build we copy the compiled module one directory up,
 # to ${CMAKE_CURRENT_BINARY_DIR}.
-include(compute_versions RESULT_VARIABLE RESULT)
-if(RESULT STREQUAL NOTFOUND)
-  message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
-endif()
-compute_versions(API_VERSION SCHEMA_VERSION)
-
 configure_file(dkms.conf.in src/dkms.conf)
 configure_file(Makefile.in src/Makefile)
-configure_file(driver_config.h.in src/driver_config.h)
+include(driver_config)
 
 set(DRIVER_SOURCES
 	dynamic_params_table.c
@@ -160,7 +154,7 @@ add_custom_target(install_driver
 if(ENABLE_DKMS)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/Makefile
 		${CMAKE_CURRENT_BINARY_DIR}/src/dkms.conf
-		${CMAKE_CURRENT_BINARY_DIR}/src/driver_config.h
+		${CMAKE_BINARY_DIR}/driver_config/driver_config.h
 		${DRIVER_SOURCES}
 		DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}"
 		COMPONENT ${DRIVER_COMPONENT_NAME})

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
+include(driver_config)
 
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
@@ -22,7 +22,7 @@ set(BPF_SOURCES
 	quirks.h
 	ring_helpers.h
 	types.h
-	${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h
+	${DRIVER_CONFIG_OUTPUT_DIR}/driver_config.h
 	../ppm_api_version.h
 	../ppm_events_public.h
 	../feature_gates.h

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -9,6 +9,32 @@ configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_confi
 
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 
+# Note: probe.c *must* be the first entry to generate a proper Makefile
+set(BPF_SOURCES
+	probe.c
+	bpf_helpers.h
+	builtins.h
+	filler_helpers.h
+	fillers.h
+	maps.h
+	missing_definitions.h
+	plumbing_helpers.h
+	quirks.h
+	ring_helpers.h
+	types.h
+	${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h
+	../ppm_api_version.h
+	../ppm_events_public.h
+	../feature_gates.h
+	../ppm_version.h
+	../ppm_fillers.h
+	../ppm_flag_helpers.h
+	../ppm.h
+	../ppm_consumer.h
+	../capture_macro.h
+	../systype_compat.h
+	)
+
 if(BUILD_BPF)
 	# Check minimum kernel version
 	set(bpf_min_kver_map_x86_64 4.14)
@@ -18,25 +44,21 @@ if(BUILD_BPF)
 		message(WARNING "[BPF] To run this driver you need a Linux kernel version >= ${bpf_min_kver_map_${TARGET_ARCH}} but actual kernel version is: ${UNAME_RESULT}")
 	endif()
 
+	foreach(FILENAME IN LISTS BPF_SOURCES)
+		get_filename_component(BASENAME ${FILENAME} NAME)
+		configure_file(${FILENAME} src/${BASENAME} COPYONLY)
+		string(APPEND BPF_DEPENDENCIES "$(src)/${BASENAME} ")
+	endforeach()
+
 	add_custom_target(bpf ALL
 		COMMAND make
 		COMMAND "${CMAKE_COMMAND}" -E copy_if_different probe.o "${CMAKE_CURRENT_BINARY_DIR}"
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src"
 		VERBATIM)
 endif()
 
 install(FILES
-	bpf_helpers.h
-	builtins.h
-	filler_helpers.h
-	fillers.h
+	${BPF_SOURCES}
 	Makefile
-	maps.h
-	plumbing_helpers.h
-	probe.c
-	quirks.h
-	ring_helpers.h
-	missing_definitions.h
-	types.h
 	DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}/bpf"
 	COMPONENT ${DRIVER_COMPONENT_NAME})

--- a/driver/bpf/Makefile.in
+++ b/driver/bpf/Makefile.in
@@ -41,16 +41,7 @@ clean:
 	$(MAKE) -C $(KERNELDIR) M=$$PWD clean
 	@rm -f *~
 
-$(obj)/probe.o: $(src)/probe.c \
-		$(src)/bpf_helpers.h \
-		$(src)/filler_helpers.h \
-		$(src)/fillers.h \
-		$(src)/maps.h \
-		$(src)/plumbing_helpers.h \
-		$(src)/quirks.h \
-		$(src)/ring_helpers.h \
-		$(src)/missing_definitions.h \
-		$(src)/types.h
+$(obj)/probe.o: @BPF_DEPENDENCIES@
 	$(CLANG) $(LINUXINCLUDE) \
 		$(KBUILD_CPPFLAGS) \
 		$(KBUILD_EXTRA_CPPFLAGS) \

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -18,7 +18,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/fdtable.h>
 #include <linux/net.h>
 
-#include "../ppm_flag_helpers.h"
+#include "ppm_flag_helpers.h"
 #include "builtins.h"
 #include "missing_definitions.h"
 

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -9,9 +9,9 @@ or GPL2.txt for full copies of the license.
 #ifndef __FILLERS_H
 #define __FILLERS_H
 
-#include "../systype_compat.h"
-#include "../ppm_flag_helpers.h"
-#include "../ppm_version.h"
+#include "systype_compat.h"
+#include "ppm_flag_helpers.h"
+#include "ppm_version.h"
 #include "bpf_helpers.h"
 
 #include <linux/tty.h>

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -15,8 +15,8 @@ or GPL2.txt for full copies of the license.
 #endif
 #include <linux/sched.h>
 
-#include "../driver_config.h"
-#include "../ppm_events_public.h"
+#include "driver_config.h"
+#include "ppm_events_public.h"
 #include "bpf_helpers.h"
 #include "types.h"
 #include "maps.h"

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -47,7 +47,6 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 compute_versions(../API_VERSION ../SCHEMA_VERSION)
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
 
 ########################
 # Check clang version.

--- a/userspace/libscap/engine/bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/bpf/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR} ../noop)
 add_library(scap_engine_bpf scap_bpf.c attached_prog.c)
 add_dependencies(scap_engine_bpf libelf scap_platform)
 target_link_libraries(scap_engine_bpf scap_event_schema scap_platform scap_engine_util scap_error ${LIBELF_LIB})

--- a/userspace/libscap/engine/kmod/CMakeLists.txt
+++ b/userspace/libscap/engine/kmod/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS})
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR})
 add_library(scap_engine_kmod scap_kmod.c)
 target_link_libraries(scap_engine_kmod scap_event_schema scap_platform scap_engine_util scap_error)
 add_dependencies(scap_engine_kmod scap_event_schema scap_platform scap_engine_util scap_error)

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR} ../noop)
 
 message(STATUS "Build modern BPF engine")
 option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)


### PR DESCRIPTION
Instead of manually generating driver_config.h when needed (approximately, since the libscap engines do not generate it, even though they rely on it), encapsulate all the logic in a single cmake module.

Note: this removes the driver_config directory from LIBSCAP_INCLUDE_DIRS. If you actually need driver_config.h, add this to your CMakeLists.txt:

    include(driver_config)
    include_directories(${DRIVER_CONFIG_OUTPUT_DIR})

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**What this PR does / why we need it**:

driver_config.h is generated in three different places, in different ways, into two target locations (including the source directory). Clean this up and use just one well-defined place we can refer to later.

Also, (as it turned out to be a prerequisite for the fix), the BPF build now no longer touches the source directory and does not depend on any files outside the (generated) source directory.

**Does this PR introduce a user-facing change?**:

(I'm not sure about user-facing, but it *is* a change for libscap consumers, even though driver_config.h is generally not needed)

```release-note
action required: driver_config.h is no longer available in ${LIBSCAP_INCLUDE_DIRS}
```
