### PR TITLE
fix(userspace/libsinsp): solve wrong type conversion

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -890,7 +890,7 @@ bool sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT std::vector<extract_valu
 
 	if(!extract_fd(evt))
 	{
-		return NULL;
+		return false;
 	}
 
 	if(m_field_id == TYPE_FDTYPES && m_argid == -1)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This solves compilation issues related to a wrong type conversion occurring in the Falco musl static build:

```
error: converting to 'bool' from 'std::nullptr_t' requires direct-initialization [-fpermissive]
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
