### PR TITLE
fix compiler -Wsign-compare warnings

### DIFF
--- a/userspace/libsinsp/cyclewriter.cpp
+++ b/userspace/libsinsp/cyclewriter.cpp
@@ -121,7 +121,7 @@ cycle_writer::conclusion cycle_writer::consider(sinsp_evt* evt, uint64_t written
 		}
 	}
 
-	if(m_rollover_mb > 0 && written_bytes > m_rollover_mb)
+	if(m_rollover_mb > 0 && written_bytes > (uint64_t)m_rollover_mb)
 	{
 		m_last_reason = "Maximum File Size Reached";
 		return next_file();

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -262,7 +262,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 			{
 				ret = snprintf(row + k, sizeof(row) - k, " %.4x", chunk);
 			}
-			if (ret < 0 || ret >= sizeof(row) - k)
+			if (ret < 0 || (unsigned int)ret >= sizeof(row) - k)
 			{
 				dst[0] = 0;
 				return 0;

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -355,13 +355,13 @@ public:
 		}
 	}
 
-	int get_all_data_secure(std::vector<char> &buf)
+	unsigned int get_all_data_secure(std::vector<char> &buf)
 	{
-		int processed = 0;
+		unsigned int processed = 0;
 		int rec = SSL_read(m_ssl_connection, &buf[0], buf.size());
 		if (rec > 0)
 		{
-			processed += rec;
+			processed += (unsigned int)rec;
 		}
 		int err = SSL_get_error(m_ssl_connection, rec);
 		switch (err) {
@@ -381,9 +381,9 @@ public:
 		return processed;
 	}
 
-	int get_all_data_unsecure(std::vector<char> &buf) {
+	unsigned int get_all_data_unsecure(std::vector<char> &buf) {
 		int rec;
-		int processed = 0;
+		unsigned int processed = 0;
 		int count = 0;
 		int ioret = ioctl(m_socket, FIONREAD, &count);
 		if(ioret >= 0 && count > 0)
@@ -399,7 +399,7 @@ public:
 				break;
 			default:
 				process(&buf[0], rec, false);
-				processed = rec;
+				processed = (unsigned int)rec;
 				break;
 			}
 		}
@@ -408,7 +408,7 @@ public:
 
 	int get_all_data()
 	{
-		int processed = 0;
+		unsigned int processed = 0;
 		int counter = 0;
 		std::vector<char> buf(1024, 0);
 

--- a/userspace/libsinsp/tuples.cpp
+++ b/userspace/libsinsp/tuples.cpp
@@ -124,7 +124,7 @@ bool ipv6net::in_cidr(const ipv6addr &other) const
 	auto this_bytes  = (const uint8_t*)(&m_addr.m_b);
 	auto other_bytes = (const uint8_t*)(&other.m_b);
 
-	int i = 0;
+	unsigned int i = 0;
 	for (; i < m_mask_len_bytes; i++)
 	{
 		if(this_bytes[i] != other_bytes[i])


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**: this PR fixes compiler warnings related to signed vs unsigned comparison (-Wsign-compare)

**Which issue(s) this PR fixes**: removes some build warnings

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
