### PR TITLE
update(cmake,driver): bumped libbpf to latest release (1.2.2).

### DIFF
--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -22,9 +22,9 @@ else()
         libbpf
         PREFIX "${PROJECT_BINARY_DIR}/libbpf-prefix"
         DEPENDS zlib libelf
-        URL "https://github.com/libbpf/libbpf/archive/refs/tags/v1.0.1.tar.gz"
+        URL "https://github.com/libbpf/libbpf/archive/refs/tags/v1.2.2.tar.gz"
         URL_HASH
-        "SHA256=3d6afde67682c909e341bf194678a8969f17628705af25f900d5f68bd299cb03"
+        "SHA256=32b0c41eabfbbe8e0c8aea784d7495387ff9171b5a338480a8fbaceb9da8d5e5"
         CONFIGURE_COMMAND mkdir -p build root
         BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} BUILD_STATIC_ONLY=y OBJDIR=${LIBBPF_BUILD_DIR}/build DESTDIR=${LIBBPF_BUILD_DIR}/root NO_PKG_CONFIG=1 "EXTRA_CFLAGS=-I${LIBELF_INCLUDE} -I${ZLIB_INCLUDE}" "LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}" -C ${LIBBPF_SRC}/libbpf/src install install_uapi_headers
         INSTALL_COMMAND ""

--- a/driver/modern_bpf/helpers/base/common.h
+++ b/driver/modern_bpf/helpers/base/common.h
@@ -21,6 +21,8 @@
  * to the others `PT_REGS_PARAM...`
  */
 
+#ifndef PT_REGS_PARM6_CORE_SYSCALL
+
 #if defined(bpf_target_x86)
 #define __PT_PARM6_REG r9
 #elif defined(bpf_target_arm64)
@@ -31,6 +33,8 @@
 
 #define PT_REGS_PARM6_CORE(x) BPF_CORE_READ(__PT_REGS_CAST(x), __PT_PARM6_REG)
 #define PT_REGS_PARM6_CORE_SYSCALL(x) PT_REGS_PARM6_CORE(x)
+
+#endif
 
 /*=============================== LIBBPF MISSING TRACING DEFINITION ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Cleaned up some now useless lines in `modern_bpf/helpers/base/common.h` to fix some build warnings when building with newer libbpf versions (see https://github.com/libbpf/libbpf/blob/master/src/bpf_tracing.h and the https://github.com/libbpf/libbpf/commit/672401ae0916d41a3626f5281988f6e763a335d3 commit)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update(cmake): bumped libbpf to 1.2.2.
```
