### PR TITLE
fix(gvisor): include memory header for smart pointers

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor_platform.h
+++ b/userspace/libscap/engine/gvisor/gvisor_platform.h
@@ -18,6 +18,7 @@ limitations under the License.
 #pragma once
 
 #include "scap_platform_impl.h"
+#include <memory>
 
 namespace scap_gvisor
 {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/area libscap-engine-gvisor

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->



**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This fixes errors when including this header (namespace std does not contain make_unique)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(gvisor): fixed compilation issue due to missing memory header
```
