### PR TITLE
new(scap,gvisor): configurable epoll_wait timeout

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -148,7 +148,7 @@ static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events);
+	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -135,7 +135,7 @@ class engine {
 public:
     engine(char *lasterr);
     ~engine();
-    int32_t init(std::string config_path, std::string root_path, bool no_events);
+    int32_t init(std::string config_path, std::string root_path, bool no_events, int epoll_timeout);
     int32_t close();
 
     int32_t start_capture();
@@ -153,6 +153,7 @@ private:
     char *m_lasterr;
     int m_listenfd = 0;
     int m_epollfd = 0;
+    int m_epoll_timeout = -1;
     bool m_capture_started = false;
     bool m_no_events = false;
 

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -26,6 +26,7 @@ extern "C"
 		const char* gvisor_config_path; ///< When using gvisor, the path to the configuration file
 
 		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
+		int gvisor_epoll_timeout;	///< When using gvisor, the timeout to wait for a new event
 	};
 
 	struct scap_platform;

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -105,7 +105,7 @@ engine::~engine()
 
 }
 
-int32_t engine::init(std::string config_path, std::string root_path, bool no_events)
+int32_t engine::init(std::string config_path, std::string root_path, bool no_events, int epoll_timeout)
 {
 	if(root_path.empty())
 	{
@@ -114,6 +114,15 @@ int32_t engine::init(std::string config_path, std::string root_path, bool no_eve
 	else
 	{
 		m_root_path = root_path;
+	}
+
+	if(epoll_timeout >= 0)
+	{
+		m_epoll_timeout = epoll_timeout;
+	}
+	else
+	{
+		m_epoll_timeout = -1;
 	}
 
 	m_trace_session_path = config_path;
@@ -533,7 +542,7 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 		}
 	}
 
-	int nfds = epoll_wait(m_epollfd, evts, max_ready_sandboxes, -1);
+	int nfds = epoll_wait(m_epollfd, evts, max_ready_sandboxes, m_epoll_timeout);
 	if (nfds < 0)
 	{
 		snprintf(m_lasterr, SCAP_LASTERR_SIZE, "epoll_wait error: %s", strerror(errno));

--- a/userspace/libsinsp/gvisor_config.h
+++ b/userspace/libsinsp/gvisor_config.h
@@ -15,6 +15,8 @@ limitations under the License.
 
 */
 
+#pragma once
+
 #include <string>
 
 namespace gvisor_config 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -656,7 +656,7 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 	open_common(&oargs);
 }
 
-void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path, bool no_events)
+void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path, bool no_events, int epoll_timeout)
 {
 	if(config_path.empty())
 	{
@@ -668,6 +668,7 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	params.gvisor_root_path = root_path.c_str();
 	params.gvisor_config_path = config_path.c_str();
 	params.no_events = no_events;
+	params.gvisor_epoll_timeout = epoll_timeout;
 	oargs.engine_params = &params;
 	open_common(&oargs);
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -227,7 +227,7 @@ public:
 	virtual void open_nodriver(bool full_proc_scan = false);
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
-	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, bool no_events = false);
+	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, bool no_events = false, int epoll_timeout = -1);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.


### PR DESCRIPTION
gvisor's next() calls epoll_wait to wait for the next event,
with an infinite timeout. Other engines don't block in next()
forever, so to remain compatible (and allow other things in
the main thread except for a scap_next() loop), make the timeout
configurable (still defaults to infinite at the sinsp layer).

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

(I also rolled in a tiny patch to add a `#pragma once` to gvisor_config.h)

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
