### PR TITLE
fix(libsinsp): network address printing endianness

### DIFF
--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -37,14 +37,15 @@ sinsp_ipv4_ifinfo::sinsp_ipv4_ifinfo(uint32_t addr, uint32_t netmask, uint32_t b
 
 void sinsp_ipv4_ifinfo::convert_to_string(char * dest, size_t len, const uint32_t addr)
 {
+	uint32_t addr_network_byte_order = htonl(addr);
 	snprintf(
 		dest,
 		len,
 		"%d.%d.%d.%d",
-		(addr & 0xFF),
-		((addr & 0xFF00) >> 8),
-		((addr & 0xFF0000) >> 16),
-		((addr & 0xFF000000) >> 24));
+		((addr_network_byte_order & 0xFF000000) >> 24),
+		((addr_network_byte_order & 0xFF0000) >> 16),
+		((addr_network_byte_order & 0xFF00) >> 8),
+		(addr_network_byte_order & 0xFF));
 }
 
 std::string sinsp_ipv4_ifinfo::address() const
@@ -93,7 +94,7 @@ uint32_t sinsp_network_interfaces::infer_ipv4_address(uint32_t destination_addre
 	// otherwise take the first non loopback interface
 	for(it = m_ipv4_interfaces.begin(); it != m_ipv4_interfaces.end(); it++)
 	{
-		if(it->m_addr != LOOPBACK_ADDR)
+		if(it->m_addr != ntohl(INADDR_LOOPBACK))
 		{
 			return it->m_addr;
 		}
@@ -199,11 +200,15 @@ bool sinsp_network_interfaces::is_ipv4addr_in_subnet(uint32_t addr)
 	std::vector<sinsp_ipv4_ifinfo>::iterator it;
 
 	//
-	// Accept everything that comes from 192.168.0.0/16 or 10.0.0.0/8
+	// Accept everything that comes from private internets:
+	// - 10.0.0.0/8
+	// - 192.168.0.0/16
+	// - 172.16.0.0/12
 	//
-	if((addr & 0x000000ff) == 0x0000000a ||
-		(addr & 0x0000ffff) == 0x0000a8c0 ||
-		(addr & 0x00003fff) == 0x000010ac)
+	uint32_t addr_network_byte_order = htonl(addr);
+	if((addr_network_byte_order & 0xff000000) == 0x0a000000 ||
+	   (addr_network_byte_order & 0xffff0000) == 0xc0a80000 ||
+	   (addr_network_byte_order & 0xff3f0000) == 0xac100000)
 	{
 		return true;
 	}

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -19,8 +19,6 @@ limitations under the License.
 
 #include "tuples.h"
 
-#define LOOPBACK_ADDR 0x0100007f
-
 #ifndef VISIBILITY_PRIVATE
 #define VISIBILITY_PRIVATE private:
 #endif


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/area libsinsp

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->
<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Always use network byte order when processing addresses coming from the driver. This helps with big endian architectures.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This is the porting of a patch made by @jcpittman144 
cc @hbrueckner 


**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): always use network byte order when printing ip addrs
```
