### PR TITLE
fix(scap): initialize the platform before the engine

### DIFF
--- a/userspace/libscap/engine/test_input/test_input_platform.c
+++ b/userspace/libscap/engine/test_input/test_input_platform.c
@@ -64,7 +64,6 @@ int32_t scap_test_input_init_platform(struct scap_platform* platform, char* last
 		params->test_input_data->threads,
 		test_input_platform,
 		get_fdinfos);
-	return SCAP_SUCCESS;
 }
 
 static void scap_test_input_free_platform(struct scap_platform* platform)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -63,6 +63,11 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 		return SCAP_FAILURE;
 	}
 
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
 	handle->m_debug_log_fn = oargs->debug_log_fn;
 
 	if(handle->m_vtable->init && (rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
@@ -77,11 +82,6 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 	}
 
 	scap_stop_dropping_mode(handle);
-
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-	{
-		return rc;
-	}
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -47,7 +47,9 @@ struct ppm_proclist_info;
 struct scap_platform_vtable
 {
 	// initialize the platform-specific structure
-	// at this point the engine is fully initialized and operational
+	// at this point the engine is allocated but *not initialized yet*
+	// so it can only be stored away for future use
+	// (the engine will be initialized before any other platform method is called)
 	int32_t (*init_platform)(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs);
 
 	// refresh the interface list and place it inside


### PR DESCRIPTION
While it's cleaner to have the engine handle fully working before we
pass it to the platform init method, it's not strictly necessary:
the only use of the engine_handle is to store it in linux_platform
to call linux_vtable methods.
    
Initializing the platform before the engine fixes an issue with
the savefile engine, where we were putting data into the proclist
(in engine init) before the proclist callback was set (in platform init).

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Make Captures Work Again :tm: ;)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
