### PR TITLE
Remove ALWAYS_DROP setting for setsid system call

### DIFF
--- a/driver/syscall_table.c
+++ b/driver/syscall_table.c
@@ -320,7 +320,7 @@ const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE] = {
 #ifdef __NR_chroot
 	[__NR_chroot - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_NEVER_DROP, PPME_SYSCALL_CHROOT_E, PPME_SYSCALL_CHROOT_X, PPM_SC_CHROOT},
 #endif
-	[__NR_setsid - SYSCALL_TABLE_ID0] =                     {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_SETSID_E, PPME_SYSCALL_SETSID_X, PPM_SC_SETSID},
+	[__NR_setsid - SYSCALL_TABLE_ID0] =                     {UF_USED, PPME_SYSCALL_SETSID_E, PPME_SYSCALL_SETSID_X, PPM_SC_SETSID},
 	[__NR_setpgid - SYSCALL_TABLE_ID0] =                    {UF_USED | UF_ALWAYS_DROP, PPME_SYSCALL_SETPGID_E, PPME_SYSCALL_SETPGID_X, PPM_SC_SETPGID},
 #ifdef __NR_bpf
 	[__NR_bpf - SYSCALL_TABLE_ID0] =                        {UF_USED, PPME_SYSCALL_BPF_2_E, PPME_SYSCALL_BPF_2_X, PPM_SC_BPF},


### PR DESCRIPTION
Libsinsp contains a parser for the SETSID_X event, and updates the m_sid for the threadinfo object.  But the current ALWAYS_DROP setting for the SETSID syscall_table entry, means this parsing never happens, in the case where dropping mode is enabled in the kernel module/BPF probe.

This change removes the ALWAYS_DROP setting for SETSID, so applications which rely on thread session IDs will have access to accurate information.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Remove ALWAYS_DROP setting for SETSID system call, so the libsinsp event parser can
maintain up-to-date session IDs for threadinfo objects.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: generate events for setsid() system call
```
