### PR TITLE
update(build): update curl to 8.2.0

### DIFF
--- a/cmake/modules/curl.cmake
+++ b/cmake/modules/curl.cmake
@@ -43,8 +43,8 @@ else()
 			curl
 			PREFIX "${PROJECT_BINARY_DIR}/curl-prefix"
 			DEPENDS openssl zlib
-			URL "https://github.com/curl/curl/releases/download/curl-8_1_0/curl-8.1.0.tar.bz2"
-			URL_HASH "SHA256=8439f39f0f5dd41f399cf60f3f6f5c3e47a4a41c96f99d991b77cecb921c553b"
+			URL "https://github.com/curl/curl/releases/download/curl-8_2_0/curl-8.2.0.tar.bz2"
+			URL_HASH "SHA256=080aaa5bef29ab3f592101e7a95f32ddbe88b92125cb28dde479d5a104928ea4"
 			CONFIGURE_COMMAND
 			./configure
 			${CURL_SSL_OPTION}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area build


**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Update libcURL with the latest security fixes: https://daniel.haxx.se/blog/2023/07/19/curl-8-2-0/ . There should be no breaking changes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
