### PR TITLE
fix(libscap): consistent SECOND_TO_NS definition

### DIFF
--- a/userspace/libscap/linux/scap_machine_info.c
+++ b/userspace/libscap/linux/scap_machine_info.c
@@ -27,7 +27,7 @@ limitations under the License.
 #include <sys/utsname.h>
 #include <unistd.h>
 
-#define SECOND_TO_NS 1000000000
+#define SECOND_TO_NS 1000000000ULL
 
 void scap_os_get_agent_info(scap_agent_info* agent_info)
 {


### PR DESCRIPTION
/kind bug
/area libscap

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

We had two definitions of `SECOND_TO_NS`, one in the driver and the other in libscap. I believe it's perfectly fine to duplicate this because this is a real physical constant that will never change (if it ever does, I will certainly not want to ever work on computers again). However, we set it to `ULL` in the driver and so we should do the same in userspace otherwise we get warnings or errors if the two header files are included at the same time.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libscap): fix warning about SECOND_TO_NS definition
```
