### PR TITLE
update(userspace/libsinsp): bidirectional state access with plugins, bug fixes, improved error reporting

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -2704,7 +2704,8 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 
 		tcpu = user + system;
 
-		uint64_t last_t_tot_cpu = tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get());
+		uint64_t last_t_tot_cpu = 0;
+		tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get(), last_t_tot_cpu);
 		if(last_t_tot_cpu != 0)
 		{
 			uint64_t deltaval = tcpu - last_t_tot_cpu;
@@ -3137,7 +3138,8 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 
 			if(tinfo != NULL)
 			{
-				uint64_t ptot = tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get());
+				uint64_t ptot = 0;
+				tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get(), ptot);
 				m_u64val += ptot;
 				tinfo->set_dynamic_field(*m_thread_dyn_field_accessor.get(), m_u64val);
 				RETURN_EXTRACT_VAR(m_u64val);

--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -55,8 +55,8 @@ limitations under the License.
 
 static inline ss_plugin_state_type typeinfo_to_state_type(const libsinsp::state::typeinfo& i)
 {
-    switch(i.index())
-    {
+	switch(i.index())
+	{
 		case libsinsp::state::typeinfo::index_t::PT_INT8:
 			return ss_plugin_state_type::SS_PLUGIN_ST_INT8;
 		case libsinsp::state::typeinfo::index_t::PT_INT16:
@@ -77,9 +77,9 @@ static inline ss_plugin_state_type typeinfo_to_state_type(const libsinsp::state:
 			return ss_plugin_state_type::SS_PLUGIN_ST_STRING;
 		case libsinsp::state::typeinfo::index_t::PT_BOOL:
 			return ss_plugin_state_type::SS_PLUGIN_ST_BOOL;
-        default:
-            throw sinsp_exception("can't convert typeinfo to plugin state type: " + std::string(i.name()));
-    }
+		default:
+			throw sinsp_exception("can't convert typeinfo to plugin state type: " + std::string(i.name()));
+	}
 }
 
 template<typename From, typename To> static inline void convert_types(const From& from, To& to)
@@ -96,7 +96,7 @@ template<> inline void convert_types(const char* const& from, std::string& to)
 {
 	if (!from || *from == '\0')
 	{
-		to = "";
+		to.clear();
 	}
 	else
 	{
@@ -119,10 +119,10 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			const sinsp_plugin* o,
 			const std::shared_ptr<ss_plugin_table_input>& i)
 				: field_infos(), m_owner(o), m_input(i), m_accessors() {};
-        plugin_field_infos(plugin_field_infos&&) = default;
-        plugin_field_infos& operator = (plugin_field_infos&&) = default;
-        plugin_field_infos(const plugin_field_infos& s) = delete;
-        plugin_field_infos& operator = (const plugin_field_infos& s) = delete;
+		plugin_field_infos(plugin_field_infos&&) = default;
+		plugin_field_infos& operator = (plugin_field_infos&&) = default;
+		plugin_field_infos(const plugin_field_infos& s) = delete;
+		plugin_field_infos& operator = (const plugin_field_infos& s) = delete;
 		virtual ~plugin_field_infos() = default;
 
 		const sinsp_plugin* m_owner;
@@ -130,7 +130,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 		std::vector<ss_plugin_table_field_t*> m_accessors;
 
 		virtual const std::unordered_map<std::string, ds::field_info>& fields() override
-        {
+		{
 			uint32_t nfields = 0;
 			auto res = m_input->fields.list_table_fields(m_input->table, &nfields);
 			if (res == NULL)
@@ -153,7 +153,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			}
 
 			// make sure we have accessors for all of these fields
-            const auto& ret = ds::field_infos::fields();
+			const auto& ret = ds::field_infos::fields();
 			for (const auto& it : ret)
 			{
 				const auto& f = it.second;
@@ -172,7 +172,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 				}
 			}
 			return ret;
-        }
+		}
 
 		virtual const ds::field_info& add_field(const ds::field_info& field) override
 		{
@@ -217,7 +217,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			m_entry = o.m_entry;
 			m_destroy_entry = o.m_destroy_entry;
 		};
-        plugin_table_entry& operator = (const plugin_table_entry& o)
+		plugin_table_entry& operator = (const plugin_table_entry& o)
 		{
 			ASSERT(!o.m_destroy_entry);
 			if (o.m_destroy_entry)
@@ -229,7 +229,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			m_entry = o.m_entry;
 			m_destroy_entry = o.m_destroy_entry;
 		}
-        plugin_table_entry(plugin_table_entry&& o)
+		plugin_table_entry(plugin_table_entry&& o)
 		{
 			m_owner = o.m_owner;
 			m_input = o.m_input;
@@ -237,7 +237,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			m_destroy_entry = o.m_destroy_entry;
 			o.m_destroy_entry = false;
 		};
-        plugin_table_entry& operator = (plugin_table_entry&& o)
+		plugin_table_entry& operator = (plugin_table_entry&& o)
 		{
 			m_owner = o.m_owner;
 			m_input = o.m_input;
@@ -321,24 +321,24 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 	};
 
 	plugin_table_wrapper(const sinsp_plugin* o, const ss_plugin_table_input* i)
-        : libsinsp::state::table<KeyType>(i->name, ss::field_infos()),
+		: libsinsp::state::table<KeyType>(i->name, ss::field_infos()),
 		  m_owner(o),
 		  m_input(std::make_shared<ss_plugin_table_input>(*i)),
 		  m_static_fields(),
 		  m_dyn_fields(std::make_shared<plugin_field_infos>(o, m_input))
-    {
-        auto t = libsinsp::state::typeinfo::of<KeyType>();
-        if (m_input->key_type != typeinfo_to_state_type(t))
-        {
-            throw sinsp_exception("invalid key type for plugin-owned table: " + std::string(t.name()));
-        }
-    }
+	{
+		auto t = libsinsp::state::typeinfo::of<KeyType>();
+		if (m_input->key_type != typeinfo_to_state_type(t))
+		{
+			throw sinsp_exception("invalid key type for plugin-owned table: " + std::string(t.name()));
+		}
+	}
 
-    virtual ~plugin_table_wrapper() = default;
-    plugin_table_wrapper(plugin_table_wrapper&&) = default;
-    plugin_table_wrapper& operator = (plugin_table_wrapper&&) = default;
-    plugin_table_wrapper(const plugin_table_wrapper& s) = delete;
-    plugin_table_wrapper& operator = (const plugin_table_wrapper& s) = delete;
+	virtual ~plugin_table_wrapper() = default;
+	plugin_table_wrapper(plugin_table_wrapper&&) = default;
+	plugin_table_wrapper& operator = (plugin_table_wrapper&&) = default;
+	plugin_table_wrapper(const plugin_table_wrapper& s) = delete;
+	plugin_table_wrapper& operator = (const plugin_table_wrapper& s) = delete;
 
 	const sinsp_plugin* m_owner;
 	std::shared_ptr<ss_plugin_table_input> m_input;
@@ -351,16 +351,16 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 	}
 
 	const libsinsp::state::static_struct::field_infos& static_fields() const override
-    {
+	{
 		// note: always empty, plugin-defined table have no "static" fields,
 		// all of them are dynamically-discovered at runtime
-        return m_static_fields;
-    }
+		return m_static_fields;
+	}
 
-    std::shared_ptr<ds::field_infos> dynamic_fields() const override
-    {
-        return m_dyn_fields;
-    }
+	std::shared_ptr<ds::field_infos> dynamic_fields() const override
+	{
+		return m_dyn_fields;
+	}
 
 	size_t entries_count() const override
 	{
@@ -386,7 +386,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 		throw sinsp_exception(invalid_access_msg("foreach"));
 	}
 
-    std::unique_ptr<libsinsp::state::table_entry> new_entry() const override
+	std::unique_ptr<libsinsp::state::table_entry> new_entry() const override
 	{
 		auto res = m_input->writer.create_table_entry(m_input->table);
 		if (res == NULL)
@@ -408,7 +408,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 		return std::shared_ptr<libsinsp::state::table_entry>(new plugin_table_entry(m_owner, m_input, m_dyn_fields, res, false));
 	}
 
-    std::shared_ptr<libsinsp::state::table_entry> add_entry(const KeyType& key, std::unique_ptr<libsinsp::state::table_entry> e) override
+	std::shared_ptr<libsinsp::state::table_entry> add_entry(const KeyType& key, std::unique_ptr<libsinsp::state::table_entry> e) override
 	{
 		ASSERT(dynamic_cast<plugin_table_entry*>(e.get()) != nullptr);
 		plugin_table_entry* entry = static_cast<plugin_table_entry*>(e.get());
@@ -424,7 +424,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 		return std::move(e);
 	}
 
-    bool erase_entry(const KeyType& key) override
+	bool erase_entry(const KeyType& key) override
 	{
 		ss_plugin_state_data keydata;
 		get_key_data(key, keydata);
@@ -491,16 +491,16 @@ template<> void plugin_table_wrapper<bool>::get_key_data(const bool& key, ss_plu
 struct sinsp_table_wrapper
 {
 	// wraps a dynamic or a static field accessor and its type
-    struct field_accessor_wrapper
-    {
+	struct field_accessor_wrapper
+	{
 		void* accessor;
 		bool dynamic;
 		ss_plugin_state_type data_type;
-    };
+	};
 
 	template <typename T>
 	explicit sinsp_table_wrapper(sinsp_plugin* p, libsinsp::state::table<T>* t)
-        : m_owner_plugin(p), m_key_type(typeinfo_to_state_type(t->key_info())),
+		: m_owner_plugin(p), m_key_type(typeinfo_to_state_type(t->key_info())),
 		  m_table(t), m_field_list(), m_table_plugin_owner(nullptr), m_table_plugin_input(nullptr)
 	{
 		// note: if the we're wrapping a plugin-implemented table under the hood,
@@ -516,11 +516,11 @@ struct sinsp_table_wrapper
 		}
 	}
 
-    sinsp_table_wrapper() = delete;
-    sinsp_table_wrapper(sinsp_table_wrapper&&) = default;
-    sinsp_table_wrapper& operator = (sinsp_table_wrapper&&) = default;
-    sinsp_table_wrapper(const sinsp_table_wrapper& s) = delete;
-    sinsp_table_wrapper& operator = (const sinsp_table_wrapper& s) = delete;
+	sinsp_table_wrapper() = delete;
+	sinsp_table_wrapper(sinsp_table_wrapper&&) = default;
+	sinsp_table_wrapper& operator = (sinsp_table_wrapper&&) = default;
+	sinsp_table_wrapper(const sinsp_table_wrapper& s) = delete;
+	sinsp_table_wrapper& operator = (const sinsp_table_wrapper& s) = delete;
 	virtual ~sinsp_table_wrapper()
 	{
 		for (auto& acc : m_field_accessors)
@@ -546,10 +546,10 @@ struct sinsp_table_wrapper
 	}
 
 	sinsp_plugin* m_owner_plugin;
-    ss_plugin_state_type m_key_type;
-    libsinsp::state::base_table* m_table;
-    std::vector<ss_plugin_table_fieldinfo> m_field_list;
-    std::unordered_map<std::string, field_accessor_wrapper> m_field_accessors;
+	ss_plugin_state_type m_key_type;
+	libsinsp::state::base_table* m_table;
+	std::vector<ss_plugin_table_fieldinfo> m_field_list;
+	std::unordered_map<std::string, field_accessor_wrapper> m_field_accessors;
 	const sinsp_plugin* m_table_plugin_owner;
 	ss_plugin_table_input* m_table_plugin_input;
 
@@ -1126,8 +1126,8 @@ ss_plugin_table_info* sinsp_plugin::table_api_list_tables(ss_plugin_owner_t* o, 
 
 void sinsp_plugin::table_input_deleter::operator()(ss_plugin_table_input* in)
 {
-    delete static_cast<sinsp_table_wrapper*>(in->table);
-    delete in;
+	delete static_cast<sinsp_table_wrapper*>(in->table);
+	delete in;
 }
 
 ss_plugin_table_t* sinsp_plugin::table_api_get_table(ss_plugin_owner_t *o, const char *name, ss_plugin_state_type key_type)

--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -93,17 +93,6 @@ template<> inline void convert_types(const std::string& from, const char*& to)
 	to = from.c_str();
 }
 
-template<> inline void convert_types(const char* const& from, std::string& to)
-{
-	if (!from || *from == '\0')
-	{
-		to.clear();
-	}
-	else
-	{
-		to = from;
-	}
-}
 
 static inline std::string table_input_error_prefix(const sinsp_plugin* o, ss_plugin_table_input* i)
 {
@@ -325,7 +314,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			{
 				#define _X(_type, _dtype) \
 				{ \
-					convert_types(dout._dtype, *(_type*) out); \
+					*((_type*) out) = dout._dtype; \
 				}
 				__PLUGIN_STATETYPE_SWITCH(typeinfo_to_state_type(i.info()));
 				#undef _X
@@ -350,7 +339,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 			{
 				#define _X(_type, _dtype) \
 				{ \
-					convert_types(*(_type*) in, v._dtype); \
+					convert_types(*((_type*) in), v._dtype); \
 				}
 				__PLUGIN_STATETYPE_SWITCH(typeinfo_to_state_type(i.info()));
 				#undef _X
@@ -1006,7 +995,7 @@ ss_plugin_rc sinsp_table_wrapper::read_entry_field(ss_plugin_table_t* _t, ss_plu
 		else \
 		{ \
 			auto aa = static_cast<libsinsp::state::static_struct::field_accessor<_type>*>(a->accessor); \
-			convert_types(e->get_static_field(*aa), out->_dtype); \
+			e->get_static_field(*aa, out->_dtype); \
 		} \
 		return SS_PLUGIN_SUCCESS; \
 	}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -998,6 +998,11 @@ public:
 		return m_event_sources;
 	}
 
+	inline const std::shared_ptr<libsinsp::state::table_registry>& get_table_registry() const
+	{
+		return m_table_registry;
+	}
+
 	uint64_t get_lastevent_ts() const { return m_lastevent_ts; }
 
 	const std::string& get_host_root() const { return m_host_root; }

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -41,7 +41,20 @@ public:
     class field_info
     {
     public:
+        template<typename T>
+        static field_info build(const std::string& name, size_t index, void* defsptr, bool readonly=false)
+        {
+            return field_info(name, index, libsinsp::state::typeinfo::of<T>(), defsptr, readonly);
+        }
+
+        field_info(const std::string& n, size_t in, const typeinfo& i, void* defsptr, bool r)
+            : m_readonly(r),
+              m_index(in),
+              m_name(n),
+              m_info(i),
+              m_defsptr(defsptr) {}
         field_info():
+            m_readonly(true),
             m_index((size_t) -1),
             m_name(""),
             m_info(typeinfo::of<uint8_t>()),
@@ -66,6 +79,14 @@ public:
         };
 
         /**
+         * @brief Returns true if the field is read only.
+         */
+        bool readonly() const
+        {
+            return m_readonly;
+        }
+
+        /**
          * @brief Returns true if the field info is valid.
          */
         inline bool valid() const
@@ -79,6 +100,14 @@ public:
         const std::string& name() const
         {
             return m_name;
+        }
+
+        /**
+         * @brief Returns the index of the field.
+         */
+        size_t index() const
+        {
+            return m_index;
         }
 
         /**
@@ -112,18 +141,7 @@ public:
         }
 
     private:
-        field_info(const std::string& n, size_t in, const typeinfo& i, void* defsptr)
-            : m_index(in),
-              m_name(n),
-              m_info(i),
-              m_defsptr(defsptr) { }
-        
-        template<typename T>
-        static field_info _build(const std::string& name, size_t index, void* defsptr)
-        {
-            return field_info(name, index, libsinsp::state::typeinfo::of<T>(), defsptr);
-        }
-
+        bool m_readonly;
         size_t m_index;
         std::string m_name;
         libsinsp::state::typeinfo m_info;
@@ -180,11 +198,6 @@ public:
         field_infos(const field_infos& s) = delete;
         field_infos& operator = (const field_infos& s) = delete;
 
-        inline const std::unordered_map<std::string, field_info>& fields() const
-        {
-            return m_definitions;
-        }
-
         /**
          * @brief Adds metadata for a new field to the list. An exception is
          * thrown if two fields are defined with the same name and with
@@ -194,26 +207,37 @@ public:
          * @param name Display name of the field.
          */
         template<typename T>
-        const field_info& add_field(const std::string& name)
+        inline const field_info& add_field(const std::string& name)
         {
-            const auto &it = m_definitions.find(name);
+            auto field = field_info::build<T>(name, m_definitions.size(), this);
+            return add_field(field);
+        }
+
+        virtual const std::unordered_map<std::string, field_info>& fields()
+        {
+            return m_definitions;
+        }
+
+protected:
+        virtual const field_info& add_field(const field_info& field)
+        {
+            const auto &it = m_definitions.find(field.name());
             if (it != m_definitions.end())
             {
-                auto t = libsinsp::state::typeinfo::of<T>();
+                const auto& t = field.info();
                 if (it->second.info() != t)
                 {
                     throw sinsp_exception("multiple definitions of dynamic field with different types in struct: "
-                    + name + ", prevtype=" + it->second.info().name() + ", newtype=" + t.name());
+                    + field.name() + ", prevtype=" + it->second.info().name() + ", newtype=" + t.name());
                 }
                 return it->second;
             }
-            m_definitions.insert({ name, field_info::_build<T>(name, m_definitions.size(), this) });
-            const auto& def = m_definitions.at(name);
+            m_definitions.insert({ field.name(), field });
+            const auto& def = m_definitions.at(field.name());
             m_definitions_ordered.push_back(&def);
             return def;
         }
 
-    private:
         std::unordered_map<std::string, field_info> m_definitions;
         std::vector<const field_info*> m_definitions_ordered;
         friend class dynamic_struct;
@@ -241,28 +265,32 @@ public:
      * @brief Accesses a field with the given accessor and reads its value.
      */
     template <typename T>
-    inline const T& get_dynamic_field(const field_accessor<T>& a)
+    inline void get_dynamic_field(const field_accessor<T>& a, T& out)
     {
         if (!a.info().valid())
         {
             throw sinsp_exception("can't get invalid field in dynamic struct");
         }
         _check_defsptr(a.info().m_defsptr);
-        return *(reinterpret_cast<T*>(_access_dynamic_field(a.info().m_index)));
+        get_dynamic_field(a.info(), reinterpret_cast<void*>(&out));
     }
 
     /**
      * @brief Accesses a field with the given accessor and writes its value.
      */
     template <typename T>
-    inline void set_dynamic_field(const field_accessor<T>& a, const T& v)
+    inline void set_dynamic_field(const field_accessor<T>& a, const T& in)
     {
         if (!a.info().valid())
         {
             throw sinsp_exception("can't set invalid field in dynamic struct");
         }
         _check_defsptr(a.info().m_defsptr);
-        *(reinterpret_cast<T*>(_access_dynamic_field(a.info().m_index))) = v;
+        if (a.info().readonly())
+        {
+            throw sinsp_exception("can't set a read-only dynamic struct field: " + a.info().name());
+        }
+        set_dynamic_field(a.info(), reinterpret_cast<const void*>(&in));
     }
 
     /**
@@ -278,7 +306,7 @@ public:
      * The definitions can be set to a non-null value only once, either at
      * construction time by invoking this method.
      */
-    inline void set_dynamic_fields(const std::shared_ptr<field_infos>& defs)
+    virtual void set_dynamic_fields(const std::shared_ptr<field_infos>& defs)
     {
         if (m_dynamic_fields)
         {
@@ -289,6 +317,17 @@ public:
             throw sinsp_exception("dynamic struct constructed with null field definitions");
         }
         m_dynamic_fields = defs;
+    }
+
+protected:
+    virtual void get_dynamic_field(const field_info& i, void* out)
+    {
+        i.info().copy(_access_dynamic_field(i.m_index), out);
+    }
+
+    virtual void set_dynamic_field(const field_info& i, const void* in)
+    {
+        i.info().copy(in, _access_dynamic_field(i.m_index));
     }
 
 private:

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -264,28 +264,20 @@ protected:
     /**
      * @brief Accesses a field with the given accessor and reads its value.
      */
-    template <typename T>
-    inline void get_dynamic_field(const field_accessor<T>& a, T& out)
+    template <typename T, typename Val = T>
+    inline void get_dynamic_field(const field_accessor<T>& a, Val& out)
     {
-        if (!a.info().valid())
-        {
-            throw sinsp_exception("can't get invalid field in dynamic struct");
-        }
-        _check_defsptr(a.info().m_defsptr);
+        _check_defsptr(a.info(), false);
         get_dynamic_field(a.info(), reinterpret_cast<void*>(&out));
     }
 
     /**
      * @brief Accesses a field with the given accessor and writes its value.
      */
-    template <typename T>
-    inline void set_dynamic_field(const field_accessor<T>& a, const T& in)
+    template <typename T, typename Val = T>
+    inline void set_dynamic_field(const field_accessor<T>& a, const Val& in)
     {
-        if (!a.info().valid())
-        {
-            throw sinsp_exception("can't set invalid field in dynamic struct");
-        }
-        _check_defsptr(a.info().m_defsptr);
+        _check_defsptr(a.info(), true);
         if (a.info().readonly())
         {
             throw sinsp_exception("can't set a read-only dynamic struct field: " + a.info().name());
@@ -320,22 +312,58 @@ protected:
     }
 
 protected:
+    /**
+     * @brief Gets the value of a dynamic field and writes it into "out".
+     * "out" points to a variable having the type of the field_info argument,
+     * according to the type definitions supported in libsinsp::state::typeinfo.
+     * For strings, "out" is considered of type const char**.
+    */
     virtual void get_dynamic_field(const field_info& i, void* out)
     {
-        i.info().copy(_access_dynamic_field(i.m_index), out);
+        const auto* buf = _access_dynamic_field(i.m_index);
+        if (i.info().index() == PT_CHARBUF)
+        {
+            *((const char**) out) = ((const std::string*) buf)->c_str();
+        }
+        else
+        {
+            memcpy(out, buf, i.info().size());
+        }
     }
 
+    /**
+     * @brief Sets the value of a dynamic field by reading it from "in".
+     * "in" points to a variable having the type of the field_info argument,
+     * according to the type definitions supported in libsinsp::state::typeinfo.
+     * For strings, "in" is considered of type const char**.
+    */
     virtual void set_dynamic_field(const field_info& i, const void* in)
     {
-        i.info().copy(in, _access_dynamic_field(i.m_index));
+        auto* buf = _access_dynamic_field(i.m_index);
+        if (i.info().index() == PT_CHARBUF)
+        {
+            *((std::string*) buf) = *((const char**) in);
+        }
+        else
+        {
+            memcpy(buf, in, i.info().size());
+        }
     }
 
 private:
-    inline void _check_defsptr(void* ptr) const
+    inline void _check_defsptr(const field_info& i, bool write) const
     {
-        if (m_dynamic_fields.get() != ptr)
+        if (!i.valid())
+        {
+            throw sinsp_exception("can't set invalid field in dynamic struct");
+        }
+        if (m_dynamic_fields.get() != i.m_defsptr)
         {
             throw sinsp_exception("using dynamic field accessor on struct it was not created from");
+        }
+        if (write && i.readonly())
+        {
+            throw sinsp_exception("can't set a read-only dynamic struct field: " + i.name());
         }
     }
 
@@ -368,3 +396,33 @@ private:
 
 }; // state
 }; // libsinsp
+
+// specializations for string types
+
+template<> inline void libsinsp::state::dynamic_struct::get_dynamic_field<std::string,const char*>(
+    const field_accessor<std::string>& a, const char*& out)
+{
+    _check_defsptr(a.info(), false);
+    get_dynamic_field(a.info(), reinterpret_cast<void*>(&out));
+}
+
+template<> inline void libsinsp::state::dynamic_struct::get_dynamic_field<std::string,std::string>(
+    const field_accessor<std::string>& a, std::string& out)
+{
+    const char* s = NULL;
+    get_dynamic_field(a, s);
+    out = s;
+}
+
+template <> inline void libsinsp::state::dynamic_struct::set_dynamic_field<std::string,const char*>(
+    const field_accessor<std::string>& a, const char* const& in)
+{
+    _check_defsptr(a.info(), true);
+    set_dynamic_field(a.info(), reinterpret_cast<const void*>(&in));
+}
+
+template <> inline void libsinsp::state::dynamic_struct::set_dynamic_field<std::string,std::string>(
+    const field_accessor<std::string>& a, const std::string& in)
+{
+    set_dynamic_field(a, in.c_str());
+}

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -411,7 +411,14 @@ template<> inline void libsinsp::state::dynamic_struct::get_dynamic_field<std::s
 {
     const char* s = NULL;
     get_dynamic_field(a, s);
-    out = s;
+    if (!s)
+    {
+        out.clear();
+    }
+    else
+    {
+        out = s;
+    }
 }
 
 template <> inline void libsinsp::state::dynamic_struct::set_dynamic_field<std::string,const char*>(

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -200,11 +200,20 @@ public:
     }
 
     /**
+     * @brief Accesses a field with the given accessor and reads its value.
+     */
+    template <typename T, typename Val = T>
+    inline void get_static_field(const field_accessor<T>& a, Val& out) const
+    {
+        out = get_static_field<T>(a);
+    }
+
+    /**
      * @brief Accesses a field with the given accessor and writes its value.
      * An exception is thrown if the field is read-only.
      */
-    template <typename T>
-    inline void set_static_field(const field_accessor<T>& a, const T& v)
+    template <typename T, typename Val = T>
+    inline void set_static_field(const field_accessor<T>& a, const Val& in)
     {
         if (!a.info().valid())
         {
@@ -214,7 +223,7 @@ public:
         {
             throw sinsp_exception("can't set a read-only static struct field: " + a.info().name());
         }
-        *(reinterpret_cast<T*>((void*) (((uintptr_t) this) + a.info().m_offset))) = v;
+        *(reinterpret_cast<T*>((void*) (((uintptr_t) this) + a.info().m_offset))) = in;
     }
 
     /**
@@ -260,3 +269,10 @@ private:
 
 }; // state
 }; // libsinsp
+
+// specializations for strings
+template <> inline void libsinsp::state::static_struct::get_static_field<std::string,const char*>(
+    const field_accessor<std::string>& a, const char*& out) const
+{
+    out = get_static_field<std::string>(a).c_str();
+}

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -78,7 +78,7 @@ public:
      * for the value data type of this table. This fields will be accessible
      * for all the entries of this table.
      */
-    inline virtual const static_struct::field_infos& static_fields() const
+    virtual const static_struct::field_infos& static_fields() const
     {
         return m_static_fields;
     }
@@ -91,7 +91,7 @@ public:
      * be allocated and accessible for all the present and future entries
      * present in the table.
      */
-    inline virtual const std::shared_ptr<dynamic_struct::field_infos>& dynamic_fields() const
+    virtual std::shared_ptr<dynamic_struct::field_infos> dynamic_fields() const
     {
         return m_dynamic_fields;
     }

--- a/userspace/libsinsp/state/type_info.h
+++ b/userspace/libsinsp/state/type_info.h
@@ -16,7 +16,6 @@ limitations under the License.
 */
 #pragma once
 
-#include "../sinsp_public.h"
 #include "../sinsp_exception.h"
 #include "../../driver/ppm_events_public.h"
 
@@ -109,46 +108,6 @@ public:
     inline void destroy(void* p) const noexcept 
     {
         if (p && m_destroy) m_destroy(p);
-    }
-
-    inline void copy(const void* from, void* to) const noexcept
-    {
-        switch(m_index)
-        {
-            case PT_INT8:
-                *((int8_t*) to) = *((const int8_t*) from);
-                break;
-            case PT_INT16:
-                *((int16_t*) to) = *((const int16_t*) from);
-                break;
-            case PT_INT32:
-                *((int32_t*) to) = *((const int32_t*) from);
-                break;
-            case PT_INT64:
-                *((int64_t*) to) = *((const int64_t*) from);
-                break;
-            case PT_UINT8:
-                *((uint8_t*) to) = *((const uint8_t*) from);
-                break;
-            case PT_UINT16:
-                *((uint16_t*) to) = *((const uint16_t*) from);
-                break;
-            case PT_UINT32:
-                *((uint32_t*) to) = *((const uint32_t*) from);
-                break;
-            case PT_UINT64:
-                *((uint64_t*) to) = *((const uint64_t*) from);
-                break;
-            case PT_CHARBUF:
-                *((std::string*) to) = *((const std::string*) from);
-                break;
-            case PT_BOOL:
-                *((bool*) to) = *((const bool*) from);
-                break;
-            default:
-                ASSERT(false);
-                break;
-        }
     }
 
 private:

--- a/userspace/libsinsp/state/type_info.h
+++ b/userspace/libsinsp/state/type_info.h
@@ -16,6 +16,7 @@ limitations under the License.
 */
 #pragma once
 
+#include "../sinsp_public.h"
 #include "../sinsp_exception.h"
 #include "../../driver/ppm_events_public.h"
 
@@ -108,6 +109,46 @@ public:
     inline void destroy(void* p) const noexcept 
     {
         if (p && m_destroy) m_destroy(p);
+    }
+
+    inline void copy(const void* from, void* to) const noexcept
+    {
+        switch(m_index)
+        {
+            case PT_INT8:
+                *((int8_t*) to) = *((const int8_t*) from);
+                break;
+            case PT_INT16:
+                *((int16_t*) to) = *((const int16_t*) from);
+                break;
+            case PT_INT32:
+                *((int32_t*) to) = *((const int32_t*) from);
+                break;
+            case PT_INT64:
+                *((int64_t*) to) = *((const int64_t*) from);
+                break;
+            case PT_UINT8:
+                *((uint8_t*) to) = *((const uint8_t*) from);
+                break;
+            case PT_UINT16:
+                *((uint16_t*) to) = *((const uint16_t*) from);
+                break;
+            case PT_UINT32:
+                *((uint32_t*) to) = *((const uint32_t*) from);
+                break;
+            case PT_UINT64:
+                *((uint64_t*) to) = *((const uint64_t*) from);
+                break;
+            case PT_CHARBUF:
+                *((std::string*) to) = *((const std::string*) from);
+                break;
+            case PT_BOOL:
+                *((bool*) to) = *((const bool*) from);
+                break;
+            default:
+                ASSERT(false);
+                break;
+        }
     }
 
 private:

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -479,8 +479,8 @@ TEST_F(sinsp_with_test_input, plugin_tables)
 	open_inspector();
 	auto asyncname = "sampleasync";
 	auto sample_plugin_evtdata = "hello world";
-	auto max_iterations = 10000;
-	for (int i = 0; i < max_iterations; i++)
+	uint64_t max_iterations = 10000;
+	for (uint64_t i = 0; i < max_iterations; i++)
 	{
 		auto evt = add_event_advance_ts(increasing_ts(), 1, PPME_ASYNCEVENT_E, 3, (uint32_t) 0, asyncname, scap_const_sized_buffer{&sample_plugin_evtdata, strlen(sample_plugin_evtdata) + 1});
 		ASSERT_EQ(evt->get_type(), PPME_ASYNCEVENT_E);

--- a/userspace/libsinsp/test/plugins/tables.cpp
+++ b/userspace/libsinsp/test/plugins/tables.cpp
@@ -1,0 +1,374 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <sstream>
+
+#include <ppm_events_public.h>
+#include "sample_table.h"
+#include "test_plugins.h"
+
+/**
+ * Example of plugin that accesses the thread table and that exposes its own
+ * sta table. The goal is to test all the methods of the table API.
+ */
+typedef struct plugin_state
+{
+    std::string lasterr;
+    ss_plugin_table_t* thread_table;
+    ss_plugin_table_field_t* thread_static_field;
+    ss_plugin_table_field_t* thread_dynamic_field;
+    sample_table::ptr_t internal_table;
+    ss_plugin_table_field_t* internal_dynamic_field;
+} plugin_state;
+
+static const char* plugin_get_required_api_version()
+{
+    return PLUGIN_API_VERSION_STR;
+}
+
+static const char* plugin_get_version()
+{
+    return "0.1.0";
+}
+
+static const char* plugin_get_name()
+{
+    return "sample_tables";
+}
+
+static const char* plugin_get_description()
+{
+    return "some desc";
+}
+
+static const char* plugin_get_contact()
+{
+    return "some contact";
+}
+
+static const char* plugin_get_parse_event_sources()
+{
+    return "[\"syscall\"]";
+}
+
+static uint16_t* plugin_get_parse_event_types(uint32_t* num_types)
+{
+    static uint16_t types[] = {};
+    *num_types = 0;
+    return types;
+}
+
+static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+{
+    *rc = SS_PLUGIN_SUCCESS;
+    plugin_state *ret = new plugin_state();
+
+    if (!in || !in->tables)
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        ret->lasterr = "invalid config input";
+        return ret;
+    }
+
+    // get accessor for thread table
+    ret->thread_table = in->tables->get_table(
+        in->owner, "threads", ss_plugin_state_type::SS_PLUGIN_ST_INT64);
+    if (!ret->thread_table)
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        auto err = in->get_owner_last_error(in->owner);
+        ret->lasterr = err ? err : "can't access thread table";
+        return ret;
+    }
+
+    // get an existing field from thread table entries
+    // todo(jasondellaluce): add tests for fields of other types as well
+    ret->thread_static_field = in->tables->fields.get_table_field(
+        ret->thread_table, "comm", ss_plugin_state_type::SS_PLUGIN_ST_STRING);
+    if (!ret->thread_static_field)
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        auto err = in->get_owner_last_error(in->owner);
+        ret->lasterr = err ? err : "can't get static field in thread table";
+        return ret;
+    }
+
+    // define a new field in thread table entries
+    // todo(jasondellaluce): add tests for fields of other types as well
+    ret->thread_dynamic_field = in->tables->fields.add_table_field(
+        ret->thread_table, "some_new_dynamic_field", ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
+    if (!ret->thread_dynamic_field)
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        auto err = in->get_owner_last_error(in->owner);
+        ret->lasterr = err ? err : "can't add dynamic field in thread table";
+        return ret;
+    }
+
+    // define a new table that keeps a counter for all events.
+    // todo(jasondellaluce): add tests for fields of other types as well
+    ret->internal_table = sample_table::create("plugin_sample", ret->lasterr);
+    ret->internal_dynamic_field = ret->internal_table->fields.add_table_field(
+            ret->internal_table->table, "u64_val",
+            ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
+    if (!ret->internal_dynamic_field)
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        ret->lasterr = "can't define internal table field";
+        return ret;
+    }
+
+    if (SS_PLUGIN_SUCCESS != in->tables->add_table(in->owner, ret->internal_table.get()))
+    {
+        *rc = SS_PLUGIN_FAILURE;
+        auto err = in->get_owner_last_error(in->owner);
+        ret->lasterr = err ? err : "can't add internal table";
+        return ret;
+    }
+    return ret;
+}
+
+static void plugin_destroy(ss_plugin_t* s)
+{
+    delete ((plugin_state *) s);
+}
+
+static const char* plugin_get_last_error(ss_plugin_t* s)
+{
+    return ((plugin_state *) s)->lasterr.c_str();
+}
+
+// parses events and keeps a count for each thread about the syscalls of the open family
+static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
+{
+    ss_plugin_state_data tmp;
+    plugin_state *ps = (plugin_state *) s;
+
+    // get table name
+    if (strcmp("threads", in->table_reader.get_table_name(ps->thread_table)))
+    {
+        fprintf(stderr, "table_reader.get_table_name (1) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    // check that the table contains only the init thread
+    auto size = in->table_reader.get_table_size(ps->thread_table);
+    if (size != 1)
+    {
+        fprintf(stderr, "table_reader.get_table_size (2) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    // get the init thread and read its comm
+    tmp.s64 = 1;
+    auto thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+    if (!thread)
+    {
+        fprintf(stderr, "table_reader.get_table_entry (3) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (4) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (strcmp("init", tmp.str))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (4) inconsistency\n");
+        exit(1);
+    }
+
+    // read-write dynamic field from existing thread
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (5) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (tmp.u64 != 0)
+    {
+        fprintf(stderr, "table_reader.read_entry_field (5) inconsistency\n");
+        exit(1);
+    }
+    tmp.u64 = 5;
+    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.write_entry_field (6) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (7) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (tmp.u64 != 5)
+    {
+        fprintf(stderr, "table_reader.read_entry_field (7) inconsistency\n");
+        exit(1);
+    }
+    tmp.u64 = 0;
+    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.write_entry_field (8) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    // get non-existing thread
+    tmp.s64 = 10000;
+    thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+    if (thread)
+    {
+        fprintf(stderr, "table_reader.get_table_entry (9) inconsistency\n");
+        exit(1);
+    }
+
+    // creating a destroying a thread without adding it to the table
+    thread = in->table_writer.create_table_entry(ps->thread_table);
+    if (!thread)
+    {
+        fprintf(stderr, "table_reader.create_table_entry (10) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    in->table_writer.destroy_table_entry(ps->thread_table, thread);
+
+    // creating and adding a thread to the table
+    thread = in->table_writer.create_table_entry(ps->thread_table);
+    if (!thread)
+    {
+        fprintf(stderr, "table_reader.create_table_entry (11) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    tmp.s64 = 10000;
+    thread = in->table_writer.add_table_entry(ps->thread_table, &tmp, thread);
+    if (!thread)
+    {
+        fprintf(stderr, "table_reader.add_table_entry (12) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    size = in->table_reader.get_table_size(ps->thread_table);
+    if (size != 2)
+    {
+        fprintf(stderr, "table_reader.get_table_size (13) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    // get newly-created thread
+    tmp.s64 = 10000;
+    thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+    if (!thread)
+    {
+        fprintf(stderr, "table_reader.get_table_entry (14) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    // read and write from newly-created thread (static field)
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (15) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (strcmp("", tmp.str))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (15) inconsistency\n");
+        exit(1);
+    }
+    tmp.str = "hello";
+    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.write_entry_field (16) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (17) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (strcmp("hello", tmp.str))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (17) inconsistency\n");
+        exit(1);
+    }
+
+    // read and write from newly-created thread (dynamic field)
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (18) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (tmp.u64 != 0)
+    {
+        fprintf(stderr, "table_reader.read_entry_field (18) inconsistency\n");
+        exit(1);
+    }
+    tmp.u64 = 5;
+    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.write_entry_field (19) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+    {
+        fprintf(stderr, "table_reader.read_entry_field (20) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    if (tmp.u64 != 5)
+    {
+        fprintf(stderr, "table_reader.read_entry_field (20) inconsistency\n");
+        exit(1);
+    }
+
+    // erasing an unknown thread
+    tmp.s64 = 10;
+    if (SS_PLUGIN_SUCCESS == in->table_writer.erase_table_entry(ps->thread_table, &tmp))
+    {
+        fprintf(stderr, "table_reader.erase_table_entry (21) inconsistency\n");
+        exit(1);
+    }
+
+    // erase newly-created thread
+    tmp.s64 = 10000;
+    if (SS_PLUGIN_SUCCESS != in->table_writer.erase_table_entry(ps->thread_table, &tmp))
+    {
+        fprintf(stderr, "table_reader.erase_table_entry (22) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+    size = in->table_reader.get_table_size(ps->thread_table);
+    if (size != 1)
+    {
+        fprintf(stderr, "table_reader.get_table_size (23) failure: %s\n", in->get_owner_last_error(in->owner));
+        exit(1);
+    }
+
+    return SS_PLUGIN_SUCCESS;
+}
+
+void get_plugin_api_sample_tables(plugin_api& out)
+{
+    memset(&out, 0, sizeof(plugin_api));
+	out.get_required_api_version = plugin_get_required_api_version;
+	out.get_version = plugin_get_version;
+	out.get_description = plugin_get_description;
+	out.get_contact = plugin_get_contact;
+	out.get_name = plugin_get_name;
+	out.get_last_error = plugin_get_last_error;
+	out.init = plugin_init;
+	out.destroy = plugin_destroy;
+    out.get_parse_event_sources = plugin_get_parse_event_sources;
+    out.get_parse_event_types = plugin_get_parse_event_types;
+    out.parse_event = plugin_parse_event;
+}

--- a/userspace/libsinsp/test/plugins/tables.cpp
+++ b/userspace/libsinsp/test/plugins/tables.cpp
@@ -29,337 +29,337 @@ limitations under the License.
  */
 typedef struct plugin_state
 {
-    std::string lasterr;
-    ss_plugin_table_t* thread_table;
-    ss_plugin_table_field_t* thread_static_field;
-    ss_plugin_table_field_t* thread_dynamic_field;
-    sample_table::ptr_t internal_table;
-    ss_plugin_table_field_t* internal_dynamic_field;
+	std::string lasterr;
+	ss_plugin_table_t* thread_table;
+	ss_plugin_table_field_t* thread_static_field;
+	ss_plugin_table_field_t* thread_dynamic_field;
+	sample_table::ptr_t internal_table;
+	ss_plugin_table_field_t* internal_dynamic_field;
 } plugin_state;
 
 static const char* plugin_get_required_api_version()
 {
-    return PLUGIN_API_VERSION_STR;
+	return PLUGIN_API_VERSION_STR;
 }
 
 static const char* plugin_get_version()
 {
-    return "0.1.0";
+	return "0.1.0";
 }
 
 static const char* plugin_get_name()
 {
-    return "sample_tables";
+	return "sample_tables";
 }
 
 static const char* plugin_get_description()
 {
-    return "some desc";
+	return "some desc";
 }
 
 static const char* plugin_get_contact()
 {
-    return "some contact";
+	return "some contact";
 }
 
 static const char* plugin_get_parse_event_sources()
 {
-    return "[\"syscall\"]";
+	return "[\"syscall\"]";
 }
 
 static uint16_t* plugin_get_parse_event_types(uint32_t* num_types)
 {
-    static uint16_t types[] = {};
-    *num_types = 0;
-    return types;
+	static uint16_t types[] = {};
+	*num_types = 0;
+	return types;
 }
 
 static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
-    *rc = SS_PLUGIN_SUCCESS;
-    plugin_state *ret = new plugin_state();
+	*rc = SS_PLUGIN_SUCCESS;
+	plugin_state *ret = new plugin_state();
 
-    if (!in || !in->tables)
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        ret->lasterr = "invalid config input";
-        return ret;
-    }
+	if (!in || !in->tables)
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		ret->lasterr = "invalid config input";
+		return ret;
+	}
 
-    // get accessor for thread table
-    ret->thread_table = in->tables->get_table(
-        in->owner, "threads", ss_plugin_state_type::SS_PLUGIN_ST_INT64);
-    if (!ret->thread_table)
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        auto err = in->get_owner_last_error(in->owner);
-        ret->lasterr = err ? err : "can't access thread table";
-        return ret;
-    }
+	// get accessor for thread table
+	ret->thread_table = in->tables->get_table(
+		in->owner, "threads", ss_plugin_state_type::SS_PLUGIN_ST_INT64);
+	if (!ret->thread_table)
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		auto err = in->get_owner_last_error(in->owner);
+		ret->lasterr = err ? err : "can't access thread table";
+		return ret;
+	}
 
-    // get an existing field from thread table entries
-    // todo(jasondellaluce): add tests for fields of other types as well
-    ret->thread_static_field = in->tables->fields.get_table_field(
-        ret->thread_table, "comm", ss_plugin_state_type::SS_PLUGIN_ST_STRING);
-    if (!ret->thread_static_field)
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        auto err = in->get_owner_last_error(in->owner);
-        ret->lasterr = err ? err : "can't get static field in thread table";
-        return ret;
-    }
+	// get an existing field from thread table entries
+	// todo(jasondellaluce): add tests for fields of other types as well
+	ret->thread_static_field = in->tables->fields.get_table_field(
+		ret->thread_table, "comm", ss_plugin_state_type::SS_PLUGIN_ST_STRING);
+	if (!ret->thread_static_field)
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		auto err = in->get_owner_last_error(in->owner);
+		ret->lasterr = err ? err : "can't get static field in thread table";
+		return ret;
+	}
 
-    // define a new field in thread table entries
-    // todo(jasondellaluce): add tests for fields of other types as well
-    ret->thread_dynamic_field = in->tables->fields.add_table_field(
-        ret->thread_table, "some_new_dynamic_field", ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
-    if (!ret->thread_dynamic_field)
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        auto err = in->get_owner_last_error(in->owner);
-        ret->lasterr = err ? err : "can't add dynamic field in thread table";
-        return ret;
-    }
+	// define a new field in thread table entries
+	// todo(jasondellaluce): add tests for fields of other types as well
+	ret->thread_dynamic_field = in->tables->fields.add_table_field(
+		ret->thread_table, "some_new_dynamic_field", ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
+	if (!ret->thread_dynamic_field)
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		auto err = in->get_owner_last_error(in->owner);
+		ret->lasterr = err ? err : "can't add dynamic field in thread table";
+		return ret;
+	}
 
-    // define a new table that keeps a counter for all events.
-    // todo(jasondellaluce): add tests for fields of other types as well
-    ret->internal_table = sample_table::create("plugin_sample", ret->lasterr);
-    ret->internal_dynamic_field = ret->internal_table->fields.add_table_field(
-            ret->internal_table->table, "u64_val",
-            ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
-    if (!ret->internal_dynamic_field)
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        ret->lasterr = "can't define internal table field";
-        return ret;
-    }
+	// define a new table that keeps a counter for all events.
+	// todo(jasondellaluce): add tests for fields of other types as well
+	ret->internal_table = sample_table::create("plugin_sample", ret->lasterr);
+	ret->internal_dynamic_field = ret->internal_table->fields.add_table_field(
+			ret->internal_table->table, "u64_val",
+			ss_plugin_state_type::SS_PLUGIN_ST_UINT64);
+	if (!ret->internal_dynamic_field)
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		ret->lasterr = "can't define internal table field";
+		return ret;
+	}
 
-    if (SS_PLUGIN_SUCCESS != in->tables->add_table(in->owner, ret->internal_table.get()))
-    {
-        *rc = SS_PLUGIN_FAILURE;
-        auto err = in->get_owner_last_error(in->owner);
-        ret->lasterr = err ? err : "can't add internal table";
-        return ret;
-    }
-    return ret;
+	if (SS_PLUGIN_SUCCESS != in->tables->add_table(in->owner, ret->internal_table.get()))
+	{
+		*rc = SS_PLUGIN_FAILURE;
+		auto err = in->get_owner_last_error(in->owner);
+		ret->lasterr = err ? err : "can't add internal table";
+		return ret;
+	}
+	return ret;
 }
 
 static void plugin_destroy(ss_plugin_t* s)
 {
-    delete ((plugin_state *) s);
+	delete ((plugin_state *) s);
 }
 
 static const char* plugin_get_last_error(ss_plugin_t* s)
 {
-    return ((plugin_state *) s)->lasterr.c_str();
+	return ((plugin_state *) s)->lasterr.c_str();
 }
 
 // parses events and keeps a count for each thread about the syscalls of the open family
 static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
 {
-    ss_plugin_state_data tmp;
-    plugin_state *ps = (plugin_state *) s;
+	ss_plugin_state_data tmp;
+	plugin_state *ps = (plugin_state *) s;
 
-    // get table name
-    if (strcmp("threads", in->table_reader.get_table_name(ps->thread_table)))
-    {
-        fprintf(stderr, "table_reader.get_table_name (1) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// get table name
+	if (strcmp("threads", in->table_reader.get_table_name(ps->thread_table)))
+	{
+		fprintf(stderr, "table_reader.get_table_name (1) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    // check that the table contains only the init thread
-    auto size = in->table_reader.get_table_size(ps->thread_table);
-    if (size != 1)
-    {
-        fprintf(stderr, "table_reader.get_table_size (2) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// check that the table contains only the init thread
+	auto size = in->table_reader.get_table_size(ps->thread_table);
+	if (size != 1)
+	{
+		fprintf(stderr, "table_reader.get_table_size (2) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    // get the init thread and read its comm
-    tmp.s64 = 1;
-    auto thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
-    if (!thread)
-    {
-        fprintf(stderr, "table_reader.get_table_entry (3) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// get the init thread and read its comm
+	tmp.s64 = 1;
+	auto thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+	if (!thread)
+	{
+		fprintf(stderr, "table_reader.get_table_entry (3) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (4) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (strcmp("init", tmp.str))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (4) inconsistency\n");
-        exit(1);
-    }
+	{
+		fprintf(stderr, "table_reader.read_entry_field (4) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (strcmp("init", tmp.str))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (4) inconsistency\n");
+		exit(1);
+	}
 
-    // read-write dynamic field from existing thread
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (5) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (tmp.u64 != 0)
-    {
-        fprintf(stderr, "table_reader.read_entry_field (5) inconsistency\n");
-        exit(1);
-    }
-    tmp.u64 = 5;
-    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.write_entry_field (6) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (7) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (tmp.u64 != 5)
-    {
-        fprintf(stderr, "table_reader.read_entry_field (7) inconsistency\n");
-        exit(1);
-    }
-    tmp.u64 = 0;
-    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.write_entry_field (8) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// read-write dynamic field from existing thread
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (5) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (tmp.u64 != 0)
+	{
+		fprintf(stderr, "table_reader.read_entry_field (5) inconsistency\n");
+		exit(1);
+	}
+	tmp.u64 = 5;
+	if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.write_entry_field (6) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (7) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (tmp.u64 != 5)
+	{
+		fprintf(stderr, "table_reader.read_entry_field (7) inconsistency\n");
+		exit(1);
+	}
+	tmp.u64 = 0;
+	if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.write_entry_field (8) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    // get non-existing thread
-    tmp.s64 = 10000;
-    thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
-    if (thread)
-    {
-        fprintf(stderr, "table_reader.get_table_entry (9) inconsistency\n");
-        exit(1);
-    }
+	// get non-existing thread
+	tmp.s64 = 10000;
+	thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+	if (thread)
+	{
+		fprintf(stderr, "table_reader.get_table_entry (9) inconsistency\n");
+		exit(1);
+	}
 
-    // creating a destroying a thread without adding it to the table
-    thread = in->table_writer.create_table_entry(ps->thread_table);
-    if (!thread)
-    {
-        fprintf(stderr, "table_reader.create_table_entry (10) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    in->table_writer.destroy_table_entry(ps->thread_table, thread);
+	// creating a destroying a thread without adding it to the table
+	thread = in->table_writer.create_table_entry(ps->thread_table);
+	if (!thread)
+	{
+		fprintf(stderr, "table_reader.create_table_entry (10) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	in->table_writer.destroy_table_entry(ps->thread_table, thread);
 
-    // creating and adding a thread to the table
-    thread = in->table_writer.create_table_entry(ps->thread_table);
-    if (!thread)
-    {
-        fprintf(stderr, "table_reader.create_table_entry (11) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    tmp.s64 = 10000;
-    thread = in->table_writer.add_table_entry(ps->thread_table, &tmp, thread);
-    if (!thread)
-    {
-        fprintf(stderr, "table_reader.add_table_entry (12) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    size = in->table_reader.get_table_size(ps->thread_table);
-    if (size != 2)
-    {
-        fprintf(stderr, "table_reader.get_table_size (13) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// creating and adding a thread to the table
+	thread = in->table_writer.create_table_entry(ps->thread_table);
+	if (!thread)
+	{
+		fprintf(stderr, "table_reader.create_table_entry (11) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	tmp.s64 = 10000;
+	thread = in->table_writer.add_table_entry(ps->thread_table, &tmp, thread);
+	if (!thread)
+	{
+		fprintf(stderr, "table_reader.add_table_entry (12) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	size = in->table_reader.get_table_size(ps->thread_table);
+	if (size != 2)
+	{
+		fprintf(stderr, "table_reader.get_table_size (13) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    // get newly-created thread
-    tmp.s64 = 10000;
-    thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
-    if (!thread)
-    {
-        fprintf(stderr, "table_reader.get_table_entry (14) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// get newly-created thread
+	tmp.s64 = 10000;
+	thread = in->table_reader.get_table_entry(ps->thread_table, &tmp);
+	if (!thread)
+	{
+		fprintf(stderr, "table_reader.get_table_entry (14) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    // read and write from newly-created thread (static field)
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (15) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (strcmp("", tmp.str))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (15) inconsistency\n");
-        exit(1);
-    }
-    tmp.str = "hello";
-    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.write_entry_field (16) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (17) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (strcmp("hello", tmp.str))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (17) inconsistency\n");
-        exit(1);
-    }
+	// read and write from newly-created thread (static field)
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (15) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (strcmp("", tmp.str))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (15) inconsistency\n");
+		exit(1);
+	}
+	tmp.str = "hello";
+	if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.write_entry_field (16) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_static_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (17) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (strcmp("hello", tmp.str))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (17) inconsistency\n");
+		exit(1);
+	}
 
-    // read and write from newly-created thread (dynamic field)
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (18) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (tmp.u64 != 0)
-    {
-        fprintf(stderr, "table_reader.read_entry_field (18) inconsistency\n");
-        exit(1);
-    }
-    tmp.u64 = 5;
-    if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.write_entry_field (19) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
-    {
-        fprintf(stderr, "table_reader.read_entry_field (20) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    if (tmp.u64 != 5)
-    {
-        fprintf(stderr, "table_reader.read_entry_field (20) inconsistency\n");
-        exit(1);
-    }
+	// read and write from newly-created thread (dynamic field)
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (18) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (tmp.u64 != 0)
+	{
+		fprintf(stderr, "table_reader.read_entry_field (18) inconsistency\n");
+		exit(1);
+	}
+	tmp.u64 = 5;
+	if (SS_PLUGIN_SUCCESS != in->table_writer.write_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.write_entry_field (19) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (SS_PLUGIN_SUCCESS != in->table_reader.read_entry_field(ps->thread_table, thread, ps->thread_dynamic_field, &tmp))
+	{
+		fprintf(stderr, "table_reader.read_entry_field (20) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	if (tmp.u64 != 5)
+	{
+		fprintf(stderr, "table_reader.read_entry_field (20) inconsistency\n");
+		exit(1);
+	}
 
-    // erasing an unknown thread
-    tmp.s64 = 10;
-    if (SS_PLUGIN_SUCCESS == in->table_writer.erase_table_entry(ps->thread_table, &tmp))
-    {
-        fprintf(stderr, "table_reader.erase_table_entry (21) inconsistency\n");
-        exit(1);
-    }
+	// erasing an unknown thread
+	tmp.s64 = 10;
+	if (SS_PLUGIN_SUCCESS == in->table_writer.erase_table_entry(ps->thread_table, &tmp))
+	{
+		fprintf(stderr, "table_reader.erase_table_entry (21) inconsistency\n");
+		exit(1);
+	}
 
-    // erase newly-created thread
-    tmp.s64 = 10000;
-    if (SS_PLUGIN_SUCCESS != in->table_writer.erase_table_entry(ps->thread_table, &tmp))
-    {
-        fprintf(stderr, "table_reader.erase_table_entry (22) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
-    size = in->table_reader.get_table_size(ps->thread_table);
-    if (size != 1)
-    {
-        fprintf(stderr, "table_reader.get_table_size (23) failure: %s\n", in->get_owner_last_error(in->owner));
-        exit(1);
-    }
+	// erase newly-created thread
+	tmp.s64 = 10000;
+	if (SS_PLUGIN_SUCCESS != in->table_writer.erase_table_entry(ps->thread_table, &tmp))
+	{
+		fprintf(stderr, "table_reader.erase_table_entry (22) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
+	size = in->table_reader.get_table_size(ps->thread_table);
+	if (size != 1)
+	{
+		fprintf(stderr, "table_reader.get_table_size (23) failure: %s\n", in->get_owner_last_error(in->owner));
+		exit(1);
+	}
 
-    return SS_PLUGIN_SUCCESS;
+	return SS_PLUGIN_SUCCESS;
 }
 
 void get_plugin_api_sample_tables(plugin_api& out)
 {
-    memset(&out, 0, sizeof(plugin_api));
+	memset(&out, 0, sizeof(plugin_api));
 	out.get_required_api_version = plugin_get_required_api_version;
 	out.get_version = plugin_get_version;
 	out.get_description = plugin_get_description;
@@ -368,7 +368,7 @@ void get_plugin_api_sample_tables(plugin_api& out)
 	out.get_last_error = plugin_get_last_error;
 	out.init = plugin_init;
 	out.destroy = plugin_destroy;
-    out.get_parse_event_sources = plugin_get_parse_event_sources;
-    out.get_parse_event_types = plugin_get_parse_event_types;
-    out.parse_event = plugin_parse_event;
+	out.get_parse_event_sources = plugin_get_parse_event_sources;
+	out.get_parse_event_types = plugin_get_parse_event_types;
+	out.parse_event = plugin_parse_event;
 }

--- a/userspace/libsinsp/test/plugins/test_plugins.h
+++ b/userspace/libsinsp/test/plugins/test_plugins.h
@@ -24,3 +24,4 @@ void get_plugin_api_sample_syscall_parse(plugin_api& out);
 void get_plugin_api_sample_syscall_async(plugin_api& out);
 void get_plugin_api_sample_plugin_source(plugin_api& out);
 void get_plugin_api_sample_plugin_extract(plugin_api& out);
+void get_plugin_api_sample_tables(plugin_api& out);

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -104,7 +104,9 @@ TEST(static_struct, defs_and_access)
     ASSERT_EQ(s.get_static_field(acc_num), 0);
     s.set_num(5);
     ASSERT_EQ(s.get_num(), 5);
-    ASSERT_EQ(s.get_static_field(acc_num), 5);
+    uint32_t u32tmp = 0;
+    s.get_static_field(acc_num, u32tmp);
+    ASSERT_EQ(u32tmp, 5);
     s.set_static_field(acc_num, (uint32_t) 6);
     ASSERT_EQ(s.get_num(), 6);
     ASSERT_EQ(s.get_static_field(acc_num), 6);
@@ -115,8 +117,20 @@ TEST(static_struct, defs_and_access)
     str = "hello";
     s.set_str("hello");
     ASSERT_EQ(s.get_str(), str);
-    ASSERT_EQ(s.get_static_field(acc_str), str);
-    ASSERT_ANY_THROW(s.set_static_field(acc_str, str)); // readonly
+    s.get_static_field(acc_str, str);
+    ASSERT_EQ(str, "hello");
+    ASSERT_ANY_THROW(s.set_static_field(acc_str, "hello")); // readonly
+
+    const char* cstr = "sample";
+    s.set_str("");
+    s.get_static_field(acc_str, cstr);
+    ASSERT_EQ(strcmp(cstr, ""), 0);
+    s.set_str("hello");
+    s.get_static_field(acc_str, cstr);
+    ASSERT_EQ(strcmp(cstr, "hello"), 0);
+    ASSERT_EQ(cstr, s.get_str().c_str());
+    ASSERT_ANY_THROW(s.set_static_field(acc_str, cstr)); // readonly
+
 
     // illegal access from an accessor created from different definition list
     // note: this should supposedly be checked for and throw an exception,
@@ -187,6 +201,16 @@ TEST(dynamic_struct, defs_and_access)
     s.set_dynamic_field(acc_str, std::string("hello"));
     s.get_dynamic_field(acc_str, tmpstr);
     ASSERT_EQ(tmpstr, std::string("hello"));
+    
+    s.set_dynamic_field(acc_str, std::string(""));
+    const char* ctmpstr = "sample";
+    s.get_dynamic_field(acc_str, ctmpstr);
+    ASSERT_EQ(strcmp(ctmpstr, ""), 0);
+    ctmpstr = "hello";
+    s.set_dynamic_field(acc_str, ctmpstr);
+    ctmpstr = "";
+    s.get_dynamic_field(acc_str, ctmpstr);
+    ASSERT_EQ(strcmp(ctmpstr, "hello"), 0);
 
     // illegal access from an accessor created from different definition list
     auto fields2 = std::make_shared<libsinsp::state::dynamic_struct::field_infos>();

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -174,19 +174,25 @@ TEST(dynamic_struct, defs_and_access)
     ASSERT_ANY_THROW(field_num.new_accessor<uint32_t>());
     ASSERT_ANY_THROW(field_str.new_accessor<uint32_t>());
 
-    ASSERT_EQ(s.get_dynamic_field(acc_num), 0);
+    uint64_t tmp;
+    s.get_dynamic_field(acc_num, tmp);
+    ASSERT_EQ(tmp, 0);
     s.set_dynamic_field(acc_num, (uint64_t) 6);
-    ASSERT_EQ(s.get_dynamic_field(acc_num), 6);
+    s.get_dynamic_field(acc_num, tmp);
+    ASSERT_EQ(tmp, 6);
 
-    ASSERT_EQ(s.get_dynamic_field(acc_str), std::string(""));
+    std::string tmpstr;
+    s.get_dynamic_field(acc_str, tmpstr);
+    ASSERT_EQ(tmpstr, std::string(""));
     s.set_dynamic_field(acc_str, std::string("hello"));
-    ASSERT_EQ(s.get_dynamic_field(acc_str), std::string("hello"));
+    s.get_dynamic_field(acc_str, tmpstr);
+    ASSERT_EQ(tmpstr, std::string("hello"));
 
     // illegal access from an accessor created from different definition list
     auto fields2 = std::make_shared<libsinsp::state::dynamic_struct::field_infos>();
     auto field_num2 = fields2->add_field<uint64_t>("num");
     auto acc_num2 = field_num2.new_accessor<uint64_t>();
-    ASSERT_ANY_THROW(s.get_dynamic_field(acc_num2));
+    ASSERT_ANY_THROW(s.get_dynamic_field(acc_num2, tmp));
 }
 
 TEST(table_registry, defs_and_access)
@@ -303,12 +309,15 @@ TEST(thread_manager, table_access)
     ASSERT_EQ(addedt->get_static_field(comm_acc), "test");
 
     // add a dynamic field to table
+    std::string tmpstr;
     auto dynf_acc = table->dynamic_fields()->add_field<std::string>("some_new_field").new_accessor<std::string>();
     ASSERT_EQ(table->dynamic_fields()->fields().size(), 1);
     ASSERT_EQ(addedt->dynamic_fields()->fields().size(), 1);
-    ASSERT_EQ(addedt->get_dynamic_field(dynf_acc), "");
+    addedt->get_dynamic_field(dynf_acc, tmpstr);
+    ASSERT_EQ(tmpstr, "");
     addedt->set_dynamic_field(dynf_acc, std::string("hello"));
-    ASSERT_EQ(addedt->get_dynamic_field(dynf_acc), "hello");
+    addedt->get_dynamic_field(dynf_acc, tmpstr);
+    ASSERT_EQ(tmpstr, "hello");
 
     // add another thread
     newt = table->new_entry();
@@ -316,9 +325,11 @@ TEST(thread_manager, table_access)
     ASSERT_NO_THROW(table->add_entry(1000, std::move(newt)));
     addedt = table->get_entry(1000);
     ASSERT_EQ(addedt->get_static_field(tid_acc), (int64_t) 1000);
-    ASSERT_EQ(addedt->get_dynamic_field(dynf_acc), "");
+    addedt->get_dynamic_field(dynf_acc, tmpstr);
+    ASSERT_EQ(tmpstr, "");
     addedt->set_dynamic_field(dynf_acc, std::string("world"));
-    ASSERT_EQ(addedt->get_dynamic_field(dynf_acc), "world");
+    addedt->get_dynamic_field(dynf_acc, tmpstr);
+    ASSERT_EQ(tmpstr, "world");
 
     // loop over entries
     int count = 0;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -718,11 +718,8 @@ public:
 		{
 			throw sinsp_exception("unknown entry type added to thread table");
 		}
-		if (tinfo->m_tid != key)
-		{
-			throw sinsp_exception("key does not match pid of entry added to thread table");
-		}
 		entry.release();
+		tinfo->m_tid = key;
 		add_thread(tinfo, false);
 		return get_entry(key);
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Since introducing the plugin API v3.0.0, and supporting the notion of "state tables" in both libsinsp and the plugin API, there was one major limitation:
- Libsinsp (and its clients) and plugins could both declare their own state tables
- Plugins could access tables declared through libsinsp
- Plugins could access tables declared by other plugins
- Libsinsp **could not** access tables declared by other plugins

This limitation was enforced as a restricted feature rollout for Falco 0.35, and was also a safety measure for potential technical issues. 

This PR contributes with the following:
- Allow Libsinsp (and its clients) to access tables declared by plugins, this making communications fully bidirectional
- Solve minor bugs related to accessing the threads table
- Optimize string-type field access to avoid memory copies wherever possible
- Improve error reporting on the state tables API
- Increasing test coverage on the involved code sections (~600 LOC are just tests here)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): bidirectional state access with plugins, bug fixes, improved error reporting
```
