### PR TITLE
new: return ENOTSUP when the modern probe is not supported

### DIFF
--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -167,12 +167,12 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	 */
 	if(check_buffer_bytes_dim(handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
 	{
-		return SCAP_FAILURE;
+		return ENOTSUP;
 	}
 
 	if(!pman_check_support())
 	{
-		return SCAP_FAILURE;
+		return ENOTSUP;
 	}
 
 	/* Initialize the libpman internal state.

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -856,7 +856,7 @@ int main(int argc, char** argv)
 	if(g_h == NULL || res != SCAP_SUCCESS)
 	{
 		fprintf(stderr, "%s (%d)\n", error, res);
-		return EXIT_FAILURE;
+		return res;
 	}
 
 	print_start_capture();


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

A different return code in case of failed validation allows consumers (like scap-open) to understand that the modern bpf is not supported due to missing requirements

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
