### PR TITLE
update: support iterating tables in plugin system, post-init event code filters, fixes

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -401,6 +401,13 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string &errstr)
 		errstr = "plugin provided an invalid version string: '" + version_str + "'";
 		return false;
 	}
+	std::string req_api_version_str = str_from_alloc_charbuf(m_handle->api.get_required_api_version());
+	m_required_api_version = sinsp_version(req_api_version_str);
+	if(!m_required_api_version.m_valid)
+	{
+		errstr = "plugin provided an invalid required api version string: '" + req_api_version_str + "'";
+		return false;
+	}
 
 	// read capabilities and process their info
 	m_caps = plugin_get_capabilities(m_handle, err);

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -184,10 +184,7 @@ public:
 		return m_extract_event_sources;
 	}
 
-	inline const libsinsp::events::set<ppm_event_code>& extract_event_codes() const
-	{
-		return m_extract_event_codes;
-	}
+	const libsinsp::events::set<ppm_event_code>& extract_event_codes() const;
 
 	inline const std::vector<filtercheck_field_info>& fields() const
 	{
@@ -202,10 +199,7 @@ public:
 		return m_parse_event_sources;
 	}
 
-	inline const libsinsp::events::set<ppm_event_code>& parse_event_codes() const
-	{
-		return m_parse_event_codes;
-	}
+	const libsinsp::events::set<ppm_event_code>& parse_event_codes() const;
 
 	bool parse_event(sinsp_evt* evt) const;
 
@@ -278,7 +272,7 @@ private:
 		const char *(*get_sources)(),
 		std::unordered_set<std::string>& sources);
 	void resolve_dylib_compatible_codes(
-		uint16_t *(*get_codes)(uint32_t *numtypes),
+		uint16_t *(*get_codes)(uint32_t* numtypes,ss_plugin_t* s),
 		const std::unordered_set<std::string>& sources,
 		libsinsp::events::set<ppm_event_code>& codes);
 	void validate_init_config_json_schema(std::string& config, std::string& schema);

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -254,9 +254,9 @@ private:
 	libsinsp::events::set<ppm_event_code> m_extract_event_codes;
 
 	/** Event Parsing **/
-	struct table_input_deleter { void operator()(ss_plugin_table_input* r); };
+	struct accessed_table_input_deleter { void operator()(ss_plugin_table_input* r); };
 	using owned_table_t = std::unique_ptr<libsinsp::state::base_table>;
-	using accessed_table_t = std::unique_ptr<ss_plugin_table_input, table_input_deleter>;
+	using accessed_table_t = std::unique_ptr<ss_plugin_table_input, accessed_table_input_deleter>;
 	std::unordered_set<std::string> m_parse_event_sources;
 	libsinsp::events::set<ppm_event_code> m_parse_event_codes;
 	std::shared_ptr<libsinsp::state::table_registry> m_table_registry;
@@ -285,9 +285,9 @@ private:
 	static const char* get_owner_last_error(ss_plugin_owner_t* o);
 
 	/** Event parsing helpers **/
-	static void table_field_api(ss_plugin_table_fields_vtable& out);
-	static void table_read_api(ss_plugin_table_reader_vtable& out);
-	static void table_write_api(ss_plugin_table_writer_vtable& out);
+	static void table_field_api(ss_plugin_table_fields_vtable& out, ss_plugin_table_fields_vtable_ext& extout);
+	static void table_read_api(ss_plugin_table_reader_vtable& out, ss_plugin_table_reader_vtable_ext& extout);
+	static void table_write_api(ss_plugin_table_writer_vtable& out, ss_plugin_table_writer_vtable_ext& extout);
 	static ss_plugin_table_info* table_api_list_tables(ss_plugin_owner_t* o, uint32_t* ntables);
 	static ss_plugin_table_t *table_api_get_table(ss_plugin_owner_t *o, const char *name, ss_plugin_state_type key_type);
 	static ss_plugin_rc table_api_add_table(ss_plugin_owner_t *o, const ss_plugin_table_input* in);

--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -1177,12 +1177,12 @@ ss_plugin_rc sinsp_table_wrapper::read_entry_field(ss_plugin_table_t* _t, ss_plu
 		if (a->dynamic) \
 		{ \
 			auto aa = static_cast<libsinsp::state::dynamic_struct::field_accessor<_type>*>(a->accessor); \
-			e->get_dynamic_field(*aa, out->_dtype); \
+			e->get_dynamic_field<_type>(*aa, out->_dtype); \
 		} \
 		else \
 		{ \
 			auto aa = static_cast<libsinsp::state::static_struct::field_accessor<_type>*>(a->accessor); \
-			e->get_static_field(*aa, out->_dtype); \
+			e->get_static_field<_type>(*aa, out->_dtype); \
 		} \
 		return SS_PLUGIN_SUCCESS; \
 	}
@@ -1215,7 +1215,7 @@ ss_plugin_rc sinsp_table_wrapper::write_entry_field(ss_plugin_table_t* _t, ss_pl
 		if (a->dynamic) \
 		{ \
 			auto aa = static_cast<libsinsp::state::dynamic_struct::field_accessor<_type>*>(a->accessor); \
-			e->set_dynamic_field<_type>(*aa, reinterpret_cast<const _type&>(in->_dtype)); \
+			e->set_dynamic_field<_type>(*aa, in->_dtype); \
 		} \
 		else \
 		{ \

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -528,8 +528,30 @@ TEST_F(sinsp_with_test_input, plugin_tables)
 		ASSERT_EQ(tmpstr, "hello");
 	}
 
-	// the plugin API does not support this yet
-	ASSERT_ANY_THROW(table->foreach_entry([](auto& e) { return true; }));
+	// full iteration
+	auto it = [&](libsinsp::state::table_entry& e) -> bool
+	{
+		uint64_t tmpu64;
+		std::string tmpstr;
+		e.get_dynamic_field(sfieldacc, tmpu64);
+		EXPECT_EQ(tmpu64, 5);
+		e.get_dynamic_field(dfieldacc, tmpstr);
+		EXPECT_EQ(tmpstr, "hello");
+		return true;
+	};
+	ASSERT_TRUE(table->foreach_entry(it));
+
+	// iteration with break-out
+	ASSERT_FALSE(table->foreach_entry([&](libsinsp::state::table_entry& e) -> bool
+	{
+		return false;
+	}));
+
+	// iteration with error
+	ASSERT_ANY_THROW(table->foreach_entry([&](libsinsp::state::table_entry& e) -> bool
+	{
+		throw sinsp_exception("some error");
+	}));
 
 	// erasing an unknown thread
 	ASSERT_EQ(table->erase_entry(max_iterations), false);

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -236,11 +236,13 @@ static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_
                 {
                     auto err = in->get_owner_last_error(in->owner);
                     ps->lasterr = err ? err : ("can't read ope counter from thread with tid=" + std::to_string(ev->evt->tid));
+                    in->table_reader_ext->release_table_entry(ps->thread_table, thread);
                     return SS_PLUGIN_FAILURE;
                 }
                 ps->u64storage = tmp.u64;
                 in->fields[i].res.u64 = &ps->u64storage;
                 in->fields[i].res_len = 1;
+                in->table_reader_ext->release_table_entry(ps->thread_table, thread);
                 break;
             case 2: // evt_count
                 if (!ps->evtcount_table || !ps->evtcount_count_field)
@@ -282,11 +284,13 @@ static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_
                 {
                     auto err = in->get_owner_last_error(in->owner);
                     ps->lasterr = err ? err : ("can't read event counter for type=" + std::to_string(ev->evt->type));
+                    in->table_reader_ext->release_table_entry(ps->evtcount_table, evtcount);
                     return SS_PLUGIN_FAILURE;
                 }
                 ps->u64storage = tmp.u64;
                 in->fields[i].res.u64 = &ps->u64storage;
                 in->fields[i].res_len = 1;
+                in->table_reader_ext->release_table_entry(ps->evtcount_table, evtcount);
                 break;
             case 3: // test.proc_name
                 tmp.s64 = ev->evt->tid;
@@ -302,12 +306,14 @@ static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_
                 {
                     auto err = in->get_owner_last_error(in->owner);
                     ps->lasterr = err ? err : ("can't read proc name from thread with tid=" + std::to_string(ev->evt->tid));
+                    in->table_reader_ext->release_table_entry(ps->thread_table, thread);
                     return SS_PLUGIN_FAILURE;
                 }
                 ps->strstorage = tmp.str;
                 ps->strptrstorage = ps->strstorage.c_str();
                 in->fields[i].res.str = &ps->strptrstorage;
                 in->fields[i].res_len = 1;
+                in->table_reader_ext->release_table_entry(ps->thread_table, thread);
                 break;
             case 4: // sample.tick
                 if (ev->evt->type == PPME_ASYNCEVENT_E

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -106,7 +106,7 @@ static const char* plugin_get_extract_event_sources()
     return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_extract_event_types(uint32_t* num_types)
+static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
     static uint16_t types[] = {
         PPME_SYSCALL_OPEN_E,

--- a/userspace/libsinsp/test/plugins/syscall_parse.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_parse.cpp
@@ -195,6 +195,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
             ps->event_count_table->table, evtcounter, ps->event_count_table_count_field, &tmp))
     {
         ps->lasterr = "can't read event counter in table";
+        ps->event_count_table->reader_ext->release_table_entry(ps->event_count_table->table, evtcounter);
         return SS_PLUGIN_FAILURE;
     }
     tmp.u64++;
@@ -202,8 +203,10 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
             ps->event_count_table->table, evtcounter, ps->event_count_table_count_field, &tmp))
     {
         ps->lasterr = "can't write event counter in table";
+        ps->event_count_table->reader_ext->release_table_entry(ps->event_count_table->table, evtcounter);
         return SS_PLUGIN_FAILURE;
     }
+    ps->event_count_table->reader_ext->release_table_entry(ps->event_count_table->table, evtcounter);
 
     // update counter for current thread
     if (evt_type_is_open(ev->evt->type))
@@ -221,6 +224,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
         {
             auto err = in->get_owner_last_error(in->owner);
             ps->lasterr = err ? err : ("can't read open counter from thread with tid=" + std::to_string(ev->evt->tid));
+            in->table_reader_ext->release_table_entry(ps->thread_table, thread);
             return SS_PLUGIN_FAILURE;
         }
 
@@ -230,8 +234,10 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
         {
             auto err = in->get_owner_last_error(in->owner);
             ps->lasterr = err ? err : ("can't write open counter to thread with tid=" + std::to_string(ev->evt->tid));
+            in->table_reader_ext->release_table_entry(ps->thread_table, thread);
             return SS_PLUGIN_FAILURE;
         }
+        in->table_reader_ext->release_table_entry(ps->thread_table, thread);
     }
 
     return SS_PLUGIN_SUCCESS;

--- a/userspace/libsinsp/test/plugins/syscall_parse.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_parse.cpp
@@ -86,7 +86,7 @@ static const char* plugin_get_parse_event_sources()
     return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_parse_event_types(uint32_t* num_types)
+static uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
     static uint16_t types[] = {
         PPME_SYSCALL_OPEN_E,

--- a/userspace/libsinsp/test/plugins/tables.cpp
+++ b/userspace/libsinsp/test/plugins/tables.cpp
@@ -68,7 +68,7 @@ static const char* plugin_get_parse_event_sources()
 	return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_parse_event_types(uint32_t* num_types)
+static uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
 	static uint16_t types[] = {};
 	*num_types = 0;

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -27,8 +27,7 @@ extern "C" {
 //
 // API versions of this plugin framework
 //
-// todo(jasondellaluce): when/if major changes to v4, solve all todos
-// in this file related to deprecated types.
+// todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
 #define PLUGIN_API_VERSION_MINOR 1
 #define PLUGIN_API_VERSION_PATCH 0
@@ -670,8 +669,18 @@ typedef struct
 	struct
 	{
 		//
-		// Return the list of event types that this plugin can consume
+		// Return the list of event types that this plugin will receive
 		// for field extraction. The event types follow the libscap specific.
+		// This will be invoked only once by the framework after the plugin's
+		// initialization. Events that are not included in the returned list
+		// will not be received by the plugin.
+		// 
+		// This is a non-functional filter that should not influence the plugin's
+		// functional behavior. Instead, this is a performance optimization
+		// with the goal of avoiding unnecessary communication between the
+		// framework and the plugin for events that are known to be not used for
+		// field extraction. 
+		// 
 		// Required: no
 		//
 		// This function is optional--if NULL or an empty array, then:
@@ -679,7 +688,9 @@ typedef struct
 		//   get_extract_event_sources (either default or custom) is compatible
 		//   with the "syscall" event source, otherwise
 		// - the plugin will only receive events of plugin type (code 322).
-		uint16_t* (*get_extract_event_types)(uint32_t* numtypes);
+		// todo(jasondellaluce): when/if major changes to v4, reorder the arguments
+		// and put ss_plugin_t* as first
+		uint16_t* (*get_extract_event_types)(uint32_t* numtypes, ss_plugin_t* s);
 
 		//
 		// Return a string describing the event sources that this plugin
@@ -757,8 +768,17 @@ typedef struct
 	struct
 	{
 		//
-		// Return the list of event types that this plugin is capable of parsing.
-		// The event types follow the libscap specific.
+		// Return the list of event types that this plugin will receive
+		// for event parsing. The event types follow the libscap specific.
+		// This will be invoked only once by the framework after the plugin's
+		// initialization. Events that are not included in the returned list
+		// will not be received by the plugin.
+		// 
+		// This is a non-functional filter that should not influence the plugin's
+		// functional behavior. Instead, this is a performance optimization
+		// with the goal of avoiding unnecessary communication between the
+		// framework and the plugin for events that are known to be not used for
+		// event parsing. 
 		//
 		// Required: no
 		//
@@ -767,7 +787,9 @@ typedef struct
 		//   get_parse_event_sources (either default or custom) is compatible
 		//   with the "syscall" event source, otherwise
 		// - the plugin will only receive events of plugin type (code 322).
-		uint16_t* (*get_parse_event_types)(uint32_t* numtypes);
+		// todo(jasondellaluce): when/if major changes to v4, reorder the arguments
+		// and put ss_plugin_t* as first
+		uint16_t* (*get_parse_event_types)(uint32_t* numtypes, ss_plugin_t* s);
 		//
 		// Return a string describing the event sources that this plugin
 		// is capable of parsing.

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -181,7 +181,8 @@ typedef struct
 	// with the given key. If another entry is already present with the same key,
 	// it gets replaced. After insertion, table will be come the owner of the
 	// entry's pointer. Returns an opaque pointer to the newly-added table's entry,
-	// or NULL in case of error.
+	// or NULL in case of error. Every non-NULL returned entry must be released
+	// by invoking release_table_entry() once it becomes no more used by the invoker.
 	ss_plugin_table_entry_t* (*add_table_entry)(ss_plugin_table_t* t, const ss_plugin_state_data* key, ss_plugin_table_entry_t* entry);
 	//
 	// Updates a table's entry by writing a value for one of its fields.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Yet another plugin PR. This time, we add some new features and we fix a design flaw. The plugin API has been bumped to v3.1.0 (no braking changes, current plugins will keep working as expected even after updating), bringing the following changes:
- Ability to iterate over state tables, both from plugins accessing sinsp's tables and the other way around
- When a state table entry gets acquired through the plugin API (when doing `add_entry` or `get_entry`), the invoker will now have available a `release_entry` function for releasing an entry after it becomes unused. This allows both sinsp and plugins implementing state tables to fully manage the tables' entries lifecycle, whereas before it was impossible to know when an entry accessor became unused.
- The `get_extract_event_types` and `get_parse_event_type` are now invoked by the framework after the plugin is initialized, so that their behavior can be influenced through the init config.
- A lot of tests for all the above

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Unfortunately, there was a design flaw in the plugin API in the context of the state tables vtable definitions. With what we had before, we couldn't add new operations to any of the vtables without introducing breaking API changes. As such, we introduced the workaround of deprecating the old vtables in all structs in which they were used, replacing them with new versions that allow being extended with new functions. This is accomplished by referencing the vtables by pointer instead of by state variable in the plugin API structs. Nothing fancy, just a bit ugly. We made the framework more robust in checking that all the definitions are ok depending on the API version required by each plugin. With all we had, the framework should be able to load plugins with plugin API v3.0.0 and v3.1.0 without any issue.

I'll keep testing the absence of breaking changes for few days before removing the WIP.

**Does this PR introduce a user-facing change?**:

```release-note
update: support iterating tables in plugin system, post-init event code filters, bug fixes
```
