### PR TITLE
fix(scap): fix platform initalization order (again)

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -63,7 +63,7 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 		return SCAP_FAILURE;
 	}
 
-	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
+	if((rc = scap_generic_init_platform(handle->m_platform, handle->m_lasterr, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}
@@ -71,6 +71,11 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 	handle->m_debug_log_fn = oargs->debug_log_fn;
 
 	if(handle->m_vtable->init && (rc = handle->m_vtable->init(handle, oargs)) != SCAP_SUCCESS)
+	{
+		return rc;
+	}
+
+	if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -23,7 +23,7 @@ limitations under the License.
 #include "scap-int.h"
 #include "scap_os_machine_info.h"
 
-static int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs)
+int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs)
 {
 	memset(&platform->m_machine_info, 0, sizeof(platform->m_machine_info));
 	if(scap_os_get_machine_info(&platform->m_machine_info, lasterr) != SCAP_SUCCESS)
@@ -97,13 +97,6 @@ int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct
 	if(!platform)
 	{
 		return SCAP_SUCCESS;
-	}
-
-	rc = scap_generic_init_platform(platform, lasterr, oargs);
-	if(rc != SCAP_SUCCESS)
-	{
-		scap_platform_close(platform);
-		return rc;
 	}
 
 	if(platform->m_vtable && platform->m_vtable->init_platform)

--- a/userspace/libscap/scap_platform.h
+++ b/userspace/libscap/scap_platform.h
@@ -37,9 +37,14 @@ struct scap_platform;
 // allocate a generic platform handle with no behavior (no platform data is returned)
 struct scap_platform* scap_generic_alloc_platform();
 
+// initialize the common part of the platform handle
+// this needs to be called before opening the engine
+// as otherwise the proclist callback won't be set up in time
+// (for the savefile engine)
+int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs);
+
 // initialize a platform handle
-// this calls `init_platform` from the vtable and also
-// does any common initialization
+// this calls `init_platform` from the vtable
 int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct scap_engine_handle engine,
 			   struct scap_open_args *oargs);
 

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -47,9 +47,7 @@ struct ppm_proclist_info;
 struct scap_platform_vtable
 {
 	// initialize the platform-specific structure
-	// at this point the engine is allocated but *not initialized yet*
-	// so it can only be stored away for future use
-	// (the engine will be initialized before any other platform method is called)
+	// at this point the engine is fully initialized and operational
 	int32_t (*init_platform)(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs);
 
 	// refresh the interface list and place it inside


### PR DESCRIPTION
While we need the proclist callback to be initialized before the engine (which calls for initializing the platform first), we also call linux_vtable methods (get_vtid) during the /proc scan (which happens inside linux platform_init). That implies initializing the engine first. Given this situation, we can only split the platform setup into two parts:

- initializing the generic part (which engines may depend on)
- initializing the platform specific part (on which no engine should ever depend)

With the engine initialization in between the two. 656be921a5a6ab7cacb1cd4b370c1593a2c2a02f was a previous attempt to fix the initialization order and this commit (mostly) reverts it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
