### PR TITLE
fix(driver/modern_bpf): a possible NULL dereference in `signal_deliver` prog

### DIFF
--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -33,43 +33,44 @@ int BPF_PROG(signal_deliver,
 	/* Try to find the source pid */
 	pid_t spid = 0;
 
-	switch(sig)
+	if(info != NULL)
 	{
-	case SIGKILL:
-		spid = info->_sifields._kill._pid;
-		break;
-
-	case SIGTERM:
-	case SIGHUP:
-	case SIGINT:
-	case SIGTSTP:
-	case SIGQUIT:
-	{
-		int si_code = info->si_code;
-		if(si_code == SI_USER ||
-		   si_code == SI_QUEUE ||
-		   si_code <= 0)
+		switch(sig)
 		{
-			/* This is equivalent to `info->si_pid` where
-			 * `si_pid` is a macro `_sifields._kill._pid`
-			 */
+		case SIGKILL:
 			spid = info->_sifields._kill._pid;
+			break;
+
+		case SIGTERM:
+		case SIGHUP:
+		case SIGINT:
+		case SIGTSTP:
+		case SIGQUIT:
+		{
+			int si_code = info->si_code;
+			if(si_code == SI_USER || si_code == SI_QUEUE || si_code <= 0)
+			{
+				/* This is equivalent to `info->si_pid` where
+				 * `si_pid` is a macro `_sifields._kill._pid`
+				 */
+				spid = info->_sifields._kill._pid;
+			}
+			break;
 		}
-		break;
-	}
 
-	case SIGCHLD:
-		spid = info->_sifields._sigchld._pid;
-		break;
+		case SIGCHLD:
+			spid = info->_sifields._sigchld._pid;
+			break;
 
-	default:
-		spid = 0;
-		break;
-	}
+		default:
+			spid = 0;
+			break;
+		}
 
-	if(sig >= SIGRTMIN && sig <= SIGRTMAX)
-	{
-		spid = info->_sifields._rt._pid;
+		if(sig >= SIGRTMIN && sig <= SIGRTMAX)
+		{
+			spid = info->_sifields._rt._pid;
+		}
 	}
 
 	/* Parameter 1: spid (type: PT_PID) */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

when the `signal_deliver` bpf program receives a NULL `struct kernel_siginfo` from the context it could cause a crash of the machine. Thank you @gnosek for spotting this!

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
