### PR TITLE
fix(modern_bpf): fix NULL dereference in signal_deliver filler

### DIFF
--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -33,43 +33,46 @@ int BPF_PROG(signal_deliver,
 	/* Try to find the source pid */
 	pid_t spid = 0;
 
-	switch(sig)
+	if(info != NULL)
 	{
-	case SIGKILL:
-		spid = info->_sifields._kill._pid;
-		break;
-
-	case SIGTERM:
-	case SIGHUP:
-	case SIGINT:
-	case SIGTSTP:
-	case SIGQUIT:
-	{
-		int si_code = info->si_code;
-		if(si_code == SI_USER ||
-		   si_code == SI_QUEUE ||
-		   si_code <= 0)
+		switch(sig)
 		{
-			/* This is equivalent to `info->si_pid` where
-			 * `si_pid` is a macro `_sifields._kill._pid`
-			 */
+		case SIGKILL:
 			spid = info->_sifields._kill._pid;
+			break;
+
+		case SIGTERM:
+		case SIGHUP:
+		case SIGINT:
+		case SIGTSTP:
+		case SIGQUIT:
+		{
+			int si_code = info->si_code;
+			if(si_code == SI_USER ||
+			   si_code == SI_QUEUE ||
+			   si_code <= 0)
+			{
+				/* This is equivalent to `info->si_pid` where
+			 * `si_pid` is a macro `_sifields._kill._pid`
+				 */
+				spid = info->_sifields._kill._pid;
+			}
+			break;
 		}
-		break;
-	}
 
-	case SIGCHLD:
-		spid = info->_sifields._sigchld._pid;
-		break;
+		case SIGCHLD:
+			spid = info->_sifields._sigchld._pid;
+			break;
 
-	default:
-		spid = 0;
-		break;
-	}
+		default:
+			spid = 0;
+			break;
+		}
 
-	if(sig >= SIGRTMIN && sig <= SIGRTMAX)
-	{
-		spid = info->_sifields._rt._pid;
+		if(sig >= SIGRTMIN && sig <= SIGRTMAX)
+		{
+			spid = info->_sifields._rt._pid;
+		}
 	}
 
 	/* Parameter 1: spid (type: PT_PID) */


### PR DESCRIPTION
The `signal_deliver` filler can be called with info=NULL (`SEND_SIG_NOINFO`). Despite all I've been led to believe with eBPF, this does cause an actual NULL dereference in the kernel, promptly killing the machine (as the offending thread dies while holding the spinlock in get_signal).

So let's check the pointer before we dereference it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

Yeah, good question. Do we bump driver-API-version-patch?

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This makes the modern_bpf probe not crash immediately on pop_os kernel 6.2.6

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
