### PR TITLE
new(ci): add a release-body CI for drivers releases.

### DIFF
--- a/.github/workflows/kernel_tests.yaml
+++ b/.github/workflows/kernel_tests.yaml
@@ -11,9 +11,11 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+\+driver'
     
 concurrency:
-  group: kernel-tests-master
+  group: kernel-tests
   cancel-in-progress: true
 
 jobs:
@@ -34,7 +36,7 @@ jobs:
         working-directory: ./ansible-playbooks
         run: |
           LIBS_V=${{ github.event.inputs.libsversion }}
-          LIBS_VERSION=${LIBS_V:-"master"}
+          LIBS_VERSION=${LIBS_V:-${{ github.ref_name }}}
           cat > vars.yml <<EOF
           run_id: "id-${{ github.run_id }}"
           output_dir: "~/ansible_output_${{ github.run_id }}"

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -1,0 +1,52 @@
+name: Generate release body
+on:
+  workflow_run:
+    workflows: ["Test drivers against a matrix of kernels/distros"]
+    types: [completed]
+    branches-ignore: [master] # only when it runs on tags
+      
+permissions:
+  contents: write
+
+concurrency:
+  group: "release-body"
+  cancel-in-progress: true
+
+jobs:
+  release-body:
+    runs-on: ubuntu-latest
+    steps:      
+      - name: Download matrixes
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: kernel_tests.yaml
+          name: matrix_*
+          name_is_regexp: true
+          run_id: ${{ github.event.workflow_run.id }}
+          
+      - name: Install deps
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends ed
+      
+      # Steps:
+      # Remove everything after the table (ie: since the first line that starts with "# ",
+      # ie: a markdown section start.
+      # Remove links to the markdown sections in the table too.
+      # Then, add a small title to each matrix
+      # Finally, merge them together
+      - name: Append matrixes to create release body
+        run: |
+          printf '%s\n' '/# /,$d' 'q' '.a' '' '.' 'wq' | ed -s matrix_X64.md
+          printf '%s\n' '/# /,$d' 'q' '.a' '' '.' 'wq' | ed -s matrix_ARM64.md
+          sed -i 's/\[\(.\)\]([^)]*)/\1/g' matrix_X64.md
+          sed -i 's/\[\(.\)\]([^)]*)/\1/g' matrix_ARM64.md
+          sed -i '1s/^/# Driver Testing Matrix amd64\n\n/' matrix_X64.md
+          sed -i '1s/^/# Driver Testing Matrix arm64\n\n/' matrix_ARM64.md
+          cat matrix_X64.md matrix_ARM64.md > release-body.md
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: ./release-body.md
+          generate_release_notes: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR adds a new pipeline to generate github release body for `driver` tags.
The release-body is autogenerated from latest tag diff; moreover, [kernel testing matrixes](https://falcosecurity.github.io/libs/matrix/) are prepended, so that each driver release is quickly linked to its kernel testing matrix results.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
