### PR TITLE
fix(ci): fixed release-body workflow to avoid using ed.

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -23,11 +23,6 @@ jobs:
           name: matrix_*
           name_is_regexp: true
           run_id: ${{ github.event.workflow_run.id }}
-          
-      - name: Install deps
-        run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends ed
       
       # Steps:
       # Remove everything after the table (ie: since the first line that starts with "# ",
@@ -37,8 +32,8 @@ jobs:
       # Finally, merge them together
       - name: Append matrixes to create release body
         run: |
-          printf '%s\n' '/# /,$d' 'q' '.a' '' '.' 'wq' | ed -s matrix_X64.md
-          printf '%s\n' '/# /,$d' 'q' '.a' '' '.' 'wq' | ed -s matrix_ARM64.md
+          sed -i -n '/# /q;p' matrix_X64.md
+          sed -i -n '/# /q;p' matrix_ARM64.md
           sed -i 's/\[\(.\)\]([^)]*)/\1/g' matrix_X64.md
           sed -i 's/\[\(.\)\]([^)]*)/\1/g' matrix_ARM64.md
           sed -i '1s/^/# Driver Testing Matrix amd64\n\n/' matrix_X64.md


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Do not use `ed` in release-body workflow. It was returning `1` (even if it was working!).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
