### PR TITLE
fix(ci): force tag_name in release-body workflow.

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -46,3 +46,4 @@ jobs:
         with:
           body_path: ./release-body.md
           generate_release_notes: true
+          tag_name: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Workarounds a limitation of `workflow_run` workflows: they do not inherit `github` context (thus no `github.{ref,ref_name,...}`
We were seeing this error in the ci: https://github.com/softprops/action-gh-release/blob/master/src/main.ts#L23
For more info about the limitation, see: https://github.com/orgs/community/discussions/27124
For the solution, see: https://github.com/orgs/community/discussions/27124#discussioncomment-3254715

For the full properties of `workflow_run` event, see: https://github.com/github/docs/issues/4612#issuecomment-856182852

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
