### PR TITLE
fix(ci): match release branches in release-body

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -45,5 +45,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: ./release-body.md
-          generate_release_notes: true
+          append_body: true
           tag_name: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -3,7 +3,7 @@ on:
   workflow_run:
     workflows: ["Test drivers against a matrix of kernels/distros"]
     types: [completed]
-    branches-ignore: [master] # only when it runs on tags
+    branches: ['release/[0-9]+.[0-9]+.x'] # only match real release branches
       
 permissions:
   contents: write


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR does 2 things:
* only trigger the release-body workflow when `kernel_tests` were triggered on a `release/` branch; before, if `kernel_tests` was triggered from a branch (and not master), this would have triggered the `release-body` workflow too...
* Always append our matrixes to existing release body, so that the releaser has added the release notes (or autogenerates them through github GUI), we do not overwrite data, instead we append matrixes. See https://github.com/softprops/action-gh-release/blob/master/src/github.ts#L241 for the behavior

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
