### PR TITLE
fix(userspace/libsinsp): make sinsp struct size independent from compilation flags

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -359,7 +359,7 @@ sinsp_fdinfo_t* sinsp_fdtable::add(int64_t fd, sinsp_fdinfo_t* fdinfo)
 			//
 			m_last_accessed_fd = -1;
 #ifdef GATHER_INTERNAL_STATS
-			m_inspector->m_stats.m_n_added_fds++;
+			m_inspector->m_stats->m_n_added_fds++;
 #endif
 			std::pair<std::unordered_map<int64_t, sinsp_fdinfo_t>::iterator, bool> insert_res = m_table.emplace(fd, *fdinfo);
 			return &(insert_res.first->second);
@@ -429,15 +429,15 @@ void sinsp_fdtable::erase(int64_t fd)
 		//
 		ASSERT(false);
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_failed_fd_lookups++;
+		m_inspector->m_stats->m_n_failed_fd_lookups++;
 #endif
 	}
 	else
 	{
 		m_table.erase(fdit);
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_noncached_fd_lookups++;
-		m_inspector->m_stats.m_n_removed_fds++;
+		m_inspector->m_stats->m_n_noncached_fd_lookups++;
+		m_inspector->m_stats->m_n_removed_fds++;
 #endif
 	}
 }

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -525,7 +525,7 @@ public:
 		if(m_last_accessed_fd != -1 && fd == m_last_accessed_fd)
 		{
 	#ifdef GATHER_INTERNAL_STATS
-			m_inspector->m_stats.m_n_cached_fd_lookups++;
+			m_inspector->m_stats->m_n_cached_fd_lookups++;
 	#endif
 			return m_last_accessed_fdinfo;
 		}
@@ -538,14 +538,14 @@ public:
 		if(fdit == m_table.end())
 		{
 	#ifdef GATHER_INTERNAL_STATS
-			m_inspector->m_stats.m_n_failed_fd_lookups++;
+			m_inspector->m_stats->m_n_failed_fd_lookups++;
 	#endif
 			return NULL;
 		}
 		else
 		{
 	#ifdef GATHER_INTERNAL_STATS
-			m_inspector->m_stats.m_n_noncached_fd_lookups++;
+			m_inspector->m_stats->m_n_noncached_fd_lookups++;
 	#endif
 			m_last_accessed_fd = fd;
 			m_last_accessed_fdinfo = &(fdit->second);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -934,7 +934,7 @@ void sinsp_parser::store_event(sinsp_evt *evt)
 		// to drop the information it carries.
 		//
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_store_drops++;
+		m_inspector->m_stats->m_n_store_drops++;
 #endif
 		return;
 	}
@@ -969,7 +969,7 @@ void sinsp_parser::store_event(sinsp_evt *evt)
 	tinfo->m_lastevent_cpuid = evt->get_cpuid();
 
 #ifdef GATHER_INTERNAL_STATS
-	m_inspector->m_stats.m_n_stored_evts++;
+	m_inspector->m_stats->m_n_stored_evts++;
 #endif
 }
 
@@ -993,7 +993,7 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt *enter_evt, sinsp_evt *exit_ev
 		// can be truncated
 		//
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_retrieve_drops++;
+		m_inspector->m_stats->m_n_retrieve_drops++;
 #endif
 		return false;
 	}
@@ -1015,7 +1015,7 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt *enter_evt, sinsp_evt *exit_ev
 		enter_evt->get_type() == PPME_SYSCALL_EXECVEAT_E)
 	{
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_retrieved_evts++;
+		m_inspector->m_stats->m_n_retrieved_evts++;
 #endif
 		return true;
 	}
@@ -1029,13 +1029,13 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt *enter_evt, sinsp_evt *exit_ev
 		//ASSERT(false);
 		exit_evt->m_tinfo->set_lastevent_data_validity(false);
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_retrieve_drops++;
+		m_inspector->m_stats->m_n_retrieve_drops++;
 #endif
 		return false;
 	}
 
 #ifdef GATHER_INTERNAL_STATS
-	m_inspector->m_stats.m_n_retrieved_evts++;
+	m_inspector->m_stats->m_n_retrieved_evts++;
 #endif
 	return true;
 }
@@ -3681,12 +3681,12 @@ void sinsp_parser::parse_close_exit(sinsp_evt *evt)
 		// increment of m_n_failed_fd_lookups (for the enter event too if there's one).
 		//
 #ifdef GATHER_INTERNAL_STATS
-		m_inspector->m_stats.m_n_failed_fd_lookups--;
+		m_inspector->m_stats->m_n_failed_fd_lookups--;
 #endif
 		if(evt->m_tinfo && evt->m_tinfo->is_lastevent_data_valid())
 		{
 #ifdef GATHER_INTERNAL_STATS
-			m_inspector->m_stats.m_n_failed_fd_lookups--;
+			m_inspector->m_stats->m_n_failed_fd_lookups--;
 #endif
 		}
 	}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -70,7 +70,6 @@ limitations under the License.
 #include "event.h"
 #include "filter.h"
 #include "dumper.h"
-#include "stats.h"
 #include "ifinfo.h"
 #include "container.h"
 #include "user.h"
@@ -107,23 +106,20 @@ class sinsp_analyzer;
 class sinsp_filter;
 class cycle_writer;
 class sinsp_protodecoder;
-#if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 class k8s;
-#endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 class sinsp_partial_tracer;
 class mesos;
 class sinsp_plugin;
 class sinsp_plugin_manager;
 class sinsp_observer;
+class sinsp_stats;
 
-#if defined(HAS_CAPTURE) && !defined(_WIN32)
 class sinsp_ssl;
 class sinsp_bearer_token;
 template <class T> class socket_data_handler;
 template <class T> class socket_collector;
 class k8s_handler;
 class k8s_api_handler;
-#endif // HAS_CAPTURE
 
 std::vector<std::string> sinsp_split(const std::string &s, char delim);
 
@@ -1138,12 +1134,10 @@ public:
 	//
 	// Kubernetes
 	//
-#if !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 	std::string* m_k8s_api_server;
 	std::string* m_k8s_api_cert;
 	std::string* m_k8s_node_name;
 	bool m_k8s_node_name_validated = false;
-#ifdef HAS_CAPTURE
 	std::shared_ptr<sinsp_ssl> m_k8s_ssl;
 	std::shared_ptr<sinsp_bearer_token> m_k8s_bt;
 	std::unique_ptr<k8s_api_handler> m_k8s_api_handler;
@@ -1157,10 +1151,8 @@ public:
 		"replicasets"
 	};
 	bool m_k8s_ext_detect_done = false;
-#endif // HAS_CAPTURE
 	k8s* m_k8s_client;
 	uint64_t m_k8s_last_watch_time_ns;
-#endif // !defined(CYGWING_AGENT) && !defined(MINIMAL_BUILD)
 
 	//
 	// Mesos/Marathon
@@ -1190,12 +1182,9 @@ public:
 	//
 	// Internal stats
 	//
-#ifdef GATHER_INTERNAL_STATS
-	sinsp_stats m_stats;
-#endif
-#ifdef HAS_ANALYZER
+	std::unique_ptr<sinsp_stats> m_stats;
+
 	std::vector<uint64_t> m_tid_collisions;
-#endif
 
 	//
 	// Saved snaplen
@@ -1242,12 +1231,10 @@ public:
 	cycle_writer* m_cycle_writer;
 	bool m_write_cycling;
 
-#ifdef SIMULATE_DROP_MODE
 	//
 	// Some dropping infrastructure
 	//
 	bool m_isdropping;
-#endif
 
 	//
 	// App events
@@ -1290,9 +1277,9 @@ public:
 	uint64_t m_next_stats_print_time_ns;
 
 	static unsigned int m_num_possible_cpus;
-#if defined(HAS_CAPTURE)
+
 	int64_t m_self_pid;
-#endif
+
 
 	//
 	// /proc scan parameters

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1414,11 +1414,11 @@ void sinsp_thread_manager::clear()
 	m_n_drops = 0;
 
 #ifdef GATHER_INTERNAL_STATS
-	m_failed_lookups = &m_inspector->m_stats.get_metrics_registry().register_counter(internal_metrics::metric_name("thread_failed_lookups","Failed thread lookups"));
-	m_cached_lookups = &m_inspector->m_stats.get_metrics_registry().register_counter(internal_metrics::metric_name("thread_cached_lookups","Cached thread lookups"));
-	m_non_cached_lookups = &m_inspector->m_stats.get_metrics_registry().register_counter(internal_metrics::metric_name("thread_non_cached_lookups","Non cached thread lookups"));
-	m_added_threads = &m_inspector->m_stats.get_metrics_registry().register_counter(internal_metrics::metric_name("thread_added","Number of added threads"));
-	m_removed_threads = &m_inspector->m_stats.get_metrics_registry().register_counter(internal_metrics::metric_name("thread_removed","Removed threads"));
+	m_failed_lookups = &m_inspector->m_stats->get_metrics_registry().register_counter(internal_metrics::metric_name("thread_failed_lookups","Failed thread lookups"));
+	m_cached_lookups = &m_inspector->m_stats->get_metrics_registry().register_counter(internal_metrics::metric_name("thread_cached_lookups","Cached thread lookups"));
+	m_non_cached_lookups = &m_inspector->m_stats->get_metrics_registry().register_counter(internal_metrics::metric_name("thread_non_cached_lookups","Non cached thread lookups"));
+	m_added_threads = &m_inspector->m_stats->get_metrics_registry().register_counter(internal_metrics::metric_name("thread_added","Number of added threads"));
+	m_removed_threads = &m_inspector->m_stats->get_metrics_registry().register_counter(internal_metrics::metric_name("thread_removed","Removed threads"));
 #endif
 }
 
@@ -1666,9 +1666,9 @@ void sinsp_thread_manager::recreate_child_dependencies()
 void sinsp_thread_manager::update_statistics()
 {
 #ifdef GATHER_INTERNAL_STATS
-	m_inspector->m_stats.m_n_threads = get_thread_count();
+	m_inspector->m_stats->m_n_threads = get_thread_count();
 
-	m_inspector->m_stats.m_n_fds = 0;
+	m_inspector->m_stats->m_n_fds = 0;
 	for(threadinfo_map_iterator_t it = m_threadtable.begin(); it != m_threadtable.end(); it++)
 	{
 		sinsp_fdtable* fd_table_ptr = it->second.get_fd_table();
@@ -1677,7 +1677,7 @@ void sinsp_thread_manager::update_statistics()
 			ASSERT(false);
 			return;
 		}
-		m_inspector->m_stats.m_n_fds += fd_table_ptr->size();
+		m_inspector->m_stats->m_n_fds += fd_table_ptr->size();
 	}
 #endif
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The libsinsp class struct size is currently dependent on some compilation flags masked under #ifdef definitions. This is troublesome for whoever imports the libs headers, as they may see a different struct size compared to the libsinsp object files, which inherently can lead to out-of-memory access and segfaults.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): make sinsp struct size independent from compilation flags
```
