### PR TITLE
fix(userspace/libsinsp): solve ambiguous move casting

### DIFF
--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -599,7 +599,7 @@ struct plugin_table_wrapper: public libsinsp::state::table<KeyType>
 		}
 		entry->m_entry = res;
 		entry->m_detached = false;
-		return std::move(e);
+		return std::shared_ptr<libsinsp::state::table_entry>(std::move(e));
 	}
 
 	bool erase_entry(const KeyType& key) override


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The changed line causes trouble when enforcing stricter compilation warnings due to an ambiguous move casting.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): solve ambiguous move casting
```
