### PR TITLE
cleanup: re-audit some critical code paths to avoid nullptr dereference

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -442,7 +442,7 @@ static __always_inline void auxmap__store_path_from_fd(struct auxiliary_map *aux
 
 	struct task_struct *t = get_current_task();
 	struct dentry *file_dentry = BPF_CORE_READ(f, f_path.dentry);
-	struct dentry *root_dentry = READ_TASK_FIELD(t, fs, root.dentry);
+	struct dentry *root_dentry = BPF_CORE_READ(t, fs, root.dentry);
 	struct vfsmount *original_mount = BPF_CORE_READ(f, f_path.mnt);
 	struct mount *mnt = container_of(original_mount, struct mount, mnt);
 	struct dentry *mount_dentry = BPF_CORE_READ(mnt, mnt.mnt_root);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -25,7 +25,7 @@ int BPF_PROG(close_e,
 
 		struct task_struct *task = get_current_task();
 		u32 max_fds = 0;
-		READ_TASK_FIELD_INTO(&max_fds, task, files, fdt, max_fds);
+		BPF_CORE_READ_INTO(&max_fds, task, files, fdt, max_fds);
 		/* We drop the event if the fd is >= than `max_fds` */
 		if(fd >= max_fds)
 		{
@@ -34,7 +34,7 @@ int BPF_PROG(close_e,
 
 		/* We drop the event if the fd is not open */
 		long unsigned int entry = 0;
-		long unsigned int *open_fds = READ_TASK_FIELD(task, files, fdt, open_fds);
+		long unsigned int *open_fds = BPF_CORE_READ(task, files, fdt, open_fds);
 		if(open_fds == NULL)
 		{
 			return 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR is a follow-up of https://github.com/falcosecurity/libs/pull/1236. While in the previous PR we really faced a bug, here we are just preventing some possible future issues. We never faced a null pointer dereference in these cases but never say never... unfortunately it has a cost in terms of perf, directly referencing memory is surely more efficient than using bpf_probe_read helpers but we need to find a good trade-off between stability and efficiency so probably here is better to be a little bit more conservative

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
