### PR TITLE
fix(libscap): off-by-one bug in cgroup v1 parser

### DIFF
--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -338,8 +338,10 @@ static int32_t get_cgroup_subsystems_v1(struct scap_cgroup_set* subsystems)
 			fclose(cgroups);
 			return SCAP_FAILURE;
 		}
+
 		// 3:cpu,cpuacct:/user.slice/user-0.slice/session-13542.scope
-		//  ^p          ^q
+		//   ^p         ^q
+		p += 1;
 		char* q = strchr(p, ':');
 		if(!q)
 		{
@@ -348,7 +350,7 @@ static int32_t get_cgroup_subsystems_v1(struct scap_cgroup_set* subsystems)
 		}
 
 		// 3:cpu,cpuacct
-		//  ^p          ^q
+		//   ^p         ^q
 		*q = 0;
 		if(strlen(p) == 0)
 		{
@@ -358,7 +360,7 @@ static int32_t get_cgroup_subsystems_v1(struct scap_cgroup_set* subsystems)
 		while(1)
 		{
 			// 3:cpu\0cpuacct
-			//  ^p  ^q
+			//   ^p ^q
 			char* comma = strchr(p, ',');
 			if(comma)
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This off-by-one error results in an empty set of v1 cgroups. `p` points at a `:`, but then the search for another `:` causes 'q' to always point at the same one as `p`, causing `p` to always be an empty string when `q` is cleared. The loop is exited when `p` is found to be an empty string, adding no new cgroup subsystems to the set:

```c
char *p = strchr(line, ':');
if (!p)
{
    // ...
}

char *q = strchr(p, ':');
if (!q)
{
    // ...
}

*q = 0;
if (strlen(p) == 0)
{
    continue;
}
```

This patch advances `p` to point at the first character of the subsystem string, _then_ begin `q's` search, which will correctly point at the second `:`.


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
