### PR TITLE
fix umount2 syscall flags type, add conversion helper function

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6214,8 +6214,8 @@ FILLER(sys_umount_x, true)
 FILLER(sys_umount2_e, true)
 {
 	/* Parameter 1: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)bpf_syscall_get_argument(data, 1);
-	return bpf_push_u32_to_ring(data, flags);
+	int flags = (int)bpf_syscall_get_argument(data, 1);
+	return bpf_push_u32_to_ring(data, umount2_flags_to_scap(flags));
 }
 
 FILLER(sys_umount2_x, true)

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -553,6 +553,17 @@
 #define MAY_READ 0x00000004
 
 //////////////////////////
+// umount options
+//////////////////////////
+
+/* `include/linux/fs.h` from kernel source tree. */
+
+#define MNT_FORCE       0x00000001      /* Attempt to forcibily umount */
+#define MNT_DETACH      0x00000002      /* Just detach from the tree */
+#define MNT_EXPIRE      0x00000004      /* Mark for expiry */
+#define UMOUNT_NOFOLLOW 0x00000008      /* Don't follow symlink on umount */
+
+//////////////////////////
 // lseek whence
 //////////////////////////
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/umount2.bpf.c
@@ -26,8 +26,8 @@ int BPF_PROG(umount2_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 1);
-	ringbuf__store_u32(&ringbuf, flags);
+	int flags = (int)extract__syscall_argument(regs, 1);
+	ringbuf__store_u32(&ringbuf, umount2_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -7278,7 +7278,7 @@ int f_sys_umount2_e(struct event_filler_arguments *args)
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
 	syscall_get_arguments_deprecated(args, 1, 1, &val);
-	res = val_to_ring(args, val, 0, true, 0);
+	res = val_to_ring(args, umount2_flags_to_scap(val), 0, true, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -34,6 +34,9 @@ or GPL2.txt for full copies of the license.
 #ifdef __NR_io_uring_register
 #include <uapi/linux/io_uring.h>
 #endif
+#ifdef __NR_umount2
+#include <linux/fs.h>
+#endif
 #endif // ifndef UDIG
 
 #ifndef __always_inline
@@ -1825,6 +1828,29 @@ static __always_inline u32 chmod_mode_to_scap(unsigned long modes)
 	if (modes & S_ISVTX)
 		res |= PPM_S_ISVTX;
 
+	return res;
+}
+
+static __always_inline u32 umount2_flags_to_scap(int flags)
+{
+	u32 res = 0;
+
+#ifdef MNT_FORCE
+	if (flags & MNT_FORCE)
+		res |= PPM_MNT_FORCE;
+#endif
+#ifdef MNT_DETACH
+	if (flags & MNT_DETACH)
+		res |= PPM_MNT_DETACH;
+#endif
+#ifdef MNT_EXPIRE
+	if (flags & MNT_EXPIRE)
+		res |= PPM_MNT_EXPIRE;
+#endif
+#ifdef UMOUNT_NOFOLLOW
+	if (flags & UMOUNT_NOFOLLOW)
+		res |= PPM_UMOUNT_NOFOLLOW;
+#endif
 	return res;
 }
 


### PR DESCRIPTION
- change the flags (param 1) from u32 to s32
- add a userspace to scap flag conversion helper routine

Reported by: github issue #515

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

 /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

 /area driver-bpf

 /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

 /area libscap

> /area libpman

> /area libsinsp

 /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**: fix umount2 syscall flags type and add conversion helper function

**Which issue(s) this PR fixes**: github issue #515

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
