### PR TITLE
new(build): upgrade to OpenSSL 3.1.1

### DIFF
--- a/cmake/modules/openssl.cmake
+++ b/cmake/modules/openssl.cmake
@@ -19,8 +19,8 @@ else()
 	set(OPENSSL_BUNDLE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl")
 	set(OPENSSL_INSTALL_DIR "${OPENSSL_BUNDLE_DIR}/target")
 	set(OPENSSL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/openssl-prefix/src/openssl/include/")
-	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib/libssl${OPENSSL_LIB_SUFFIX}")
-	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib/libcrypto${OPENSSL_LIB_SUFFIX}")
+	set(OPENSSL_LIBRARY_SSL "${OPENSSL_INSTALL_DIR}/lib64/libssl${OPENSSL_LIB_SUFFIX}")
+	set(OPENSSL_LIBRARY_CRYPTO "${OPENSSL_INSTALL_DIR}/lib64/libcrypto${OPENSSL_LIB_SUFFIX}")
  	set(OPENSSL_LIBRARIES ${OPENSSL_LIBRARY_SSL} ${OPENSSL_LIBRARY_CRYPTO})
 
 	if(NOT TARGET openssl)
@@ -28,8 +28,8 @@ else()
 
 		ExternalProject_Add(openssl
 			PREFIX "${PROJECT_BINARY_DIR}/openssl-prefix"
-			URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1u.tar.gz"
-			URL_HASH "SHA256=fafe27202bde4238dce258d82ec8a8592a657842e5431264620a933a0c9436b7"
+			URL "https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"
+			URL_HASH "SHA256=b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674"
 			CONFIGURE_COMMAND ./config ${OPENSSL_SHARED_OPTION} --prefix=${OPENSSL_INSTALL_DIR}
                         BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
 			BUILD_IN_SOURCE 1


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature
/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

OpenSSL 1.x will be supported until September 7th: https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/ so we need to upgrade before next release. I'm surprised to see Falco building fine with a major version bump but we need to
1. make sure that it actually works and test Falco properly before release
2. remove deprecated APIs (you can see build warnings for those)

So it's probably better to merge this sooner rather than later. I noticed some pretty long time for compiling the new OpenSSL but that's about the only difference.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1038

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(build): upgrade to OpenSSL 3.1.1
```
