### PR TITLE
fix(scap): remove unnecessary and harmful strchr(`=`)

### DIFF
--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -789,19 +789,13 @@ static int32_t scap_cgroup_resolve_v2(struct scap_cgroup_interface* cgi, const c
 
 		FOR_EACH_SUBSYS(&current_subsystems, cgset_subsys)
 		{
-			char subsys[SCAP_MAX_PATH_SIZE];
-			char* subsys_end = strchr(cgset_subsys, '=');
-			ASSERT(subsys_end != NULL);
-			int subsys_len = (int)(subsys_end - cgset_subsys) - 1;
-
-			snprintf(subsys, sizeof(subsys), "%.*s", subsys_len, cgset_subsys);
 			if(!scap_cgroup_find_subsys(&found_subsystems, cgset_subsys))
 			{
-				if(scap_cgroup_printf(cg, "%s=%s", subsys, full_cgroup) != SCAP_SUCCESS)
+				if(scap_cgroup_printf(cg, "%s=%s", cgset_subsys, full_cgroup) != SCAP_SUCCESS)
 				{
 					return SCAP_FAILURE;
 				}
-				if(scap_cgroup_printf(&found_subsystems, "%s", subsys) != SCAP_SUCCESS)
+				if(scap_cgroup_printf(&found_subsystems, "%s", cgset_subsys) != SCAP_SUCCESS)
 				{
 					return SCAP_FAILURE;
 				}


### PR DESCRIPTION
`get_cgroup_subsystems_v2` already returns subsystem names only, not `subsys=path`, so the strchr won't ever return anything else than NULL.

In fact, the whole `subsys` variable is unnecessary, we can use `cgset_subsys` directly.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In debug builds, `scap_cgroup_resolve_v2` never works (always hits an ASSERT). In release builds, it works because we're lucky (all entries from get_cgroup_subsystems_v2 have a trailing NUL).

**Special notes for your reviewer**:

We need this in 0.12 too :<

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
