### PR TITLE
fix(ci): fixed release-body CI trigger.

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -3,7 +3,7 @@ on:
   workflow_run:
     workflows: ["Test drivers against a matrix of kernels/distros"]
     types: [completed]
-    branches: ['release/[0-9]+.[0-9]+.x'] # only match real release branches
+    branches-ignore: ['master'] # ignore master runs (we could skip this given the below extract semver check; still, this is a small optimization)
       
 permissions:
   contents: write
@@ -15,7 +15,20 @@ concurrency:
 jobs:
   release-body:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
+      # Note: there is no `tag` filter for `workflow_run`.
+      # We need to manually check whether we are running on a tag.
+      - name: Extract semver ℹ️
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.workflow_run.head_branch }}
+          regex: '[0-9]+.[0-9]+.[0-9]+\+driver$'
+
+      - name: Skip on non driver tag
+        if: steps.regex-match.outputs.match == ''
+        run: exit 0
+          
       - name: Download matrixes
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Ensure that `release-body` CI runs on new driver tags.
This is a bit cumbersome because `workflow_run` does not support `tags` filter.
So, we have a CI (kernel_tests` that is triggered by new drivers tags, and then we want to trigger the `release-body` workflow when it completes.
We always trigger the release-body workflow (except when coming from a `master` run of kernel_tests`, small optimization), but check that `head_ref` is indeed a driver tag.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
