### PR TITLE
sync: release 0.12.x

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -3,7 +3,7 @@ on:
   workflow_run:
     workflows: ["Test drivers against a matrix of kernels/distros"]
     types: [completed]
-    branches: ['release/[0-9]+.[0-9]+.x'] # only match real release branches
+    branches-ignore: ['master'] # ignore master runs (we could skip this given the below extract semver check; still, this is a small optimization)
       
 permissions:
   contents: write
@@ -15,7 +15,20 @@ concurrency:
 jobs:
   release-body:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
+      # Note: there is no `tag` filter for `workflow_run`.
+      # We need to manually check whether we are running on a tag.
+      - name: Extract semver ℹ️
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.workflow_run.head_branch }}
+          regex: '[0-9]+.[0-9]+.[0-9]+\+driver$'
+
+      - name: Skip on non driver tag
+        if: steps.regex-match.outputs.match == ''
+        run: exit 0
+          
       - name: Download matrixes
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Cherrypicks https://github.com/falcosecurity/libs/pull/1264 onto release/0.12.x branch.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
