### PR TITLE
fix: ignore whitespace only cpuset.cpus entries

### DIFF
--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -104,6 +104,12 @@ bool read_cgroup_list_count(const std::string& subsys,
 		return false;
 	}
 
+	// Is the file just whitespace?
+	if (cpuset_cpus.find_last_not_of(" \r\t\n") == std::string::npos)
+	{
+		return false;
+	}
+
  	libsinsp::cgroup_list_counter counter;
 	out = counter(cpuset_cpus.c_str());
 


### PR DESCRIPTION
Certain distros have cpuset.cpus files under a cgroup that contain a single whitespace character. This is not, strictly speaking, compliant with the list format mentioned in
https://man7.org/linux/man-pages/man7/cpuset.7.html, but it is a small enough exception that we could possibly preemptively guard against?


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals


**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch


**What this PR does / why we need it**:
This PR adds a simple check in `cgroup_limits.cpp` to skip over `cpuset.cpus` files that aren't empty, but are purely whitespace characters. This prevents the `cgroup_list_counter` parsing mechanism from throwing an exception.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
