### PR TITLE
fix(driver): fix build on RHEL 8.9 kernels

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2732,7 +2732,16 @@ static int get_tracepoint_handles(void)
 #endif
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)) || ((PPM_RHEL_RELEASE_CODE > 0) && (PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(9, 3)))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)) || \
+	( \
+		(PPM_RHEL_RELEASE_CODE > 0) && \
+			( \
+				((PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(8, 9)) && \
+				 (PPM_RHEL_RELEASE_CODE <  PPM_RHEL_RELEASE_VERSION(9, 0))) \
+			|| \
+				(PPM_RHEL_RELEASE_CODE >= PPM_RHEL_RELEASE_VERSION(9, 3)) \
+			) \
+	)
 static char *ppm_devnode(const struct device *dev, umode_t *mode)
 #else
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0)


### PR DESCRIPTION
On recent RHEL8 kernels (namely starting with 4.18.0-506.el8) the kmod driver will fail to build with the following error:

```
  CC [M]  /code/sysdig-rw/main.o
/code/sysdig-rw/main.c: In function 'scap_init':
/code/sysdig-rw/main.c:2897:23: error: assignment to 'char * (*)(const struct device *, umode_t *)' {aka 'char * (*)(const struct device *, short unsigned int *)'} from incompatible pointer type 'char * (*)(struct device *, umode_t *)' {aka 'char * (*)(struct device *, short unsigned int *)'} [-Werror=incompatible-pointer-types]
 2897 |  g_ppm_class->devnode = ppm_devnode;
      |                       ^
cc1: some warnings being treated as errors
```

Notice how Red Hat backported that change from kernel 6.2 into what looks like 4.18 for RHEL8.9, a few months after backporting it into 5.14 for RHEL9.3.

So add the corresponding check, making sure not to break RHEL9.0-9.2 which DO NOT contain such change.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
