### PR TITLE
chore(userspace/libsinsp/test): skip scap file download if already present

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -57,10 +57,14 @@ if(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "s390x")
 	message(STATUS "Download all scap-files from: ${SCAP_FILE_DOWNLOAD_PREFIX}")
 	foreach(FILE_NAME ${SCAP_FILE_NAMES})
 		message(STATUS "Downloading scap-file: ${SCAP_FILE_DOWNLOAD_PREFIX}/${FILE_NAME}")
-		file(DOWNLOAD
-		"${SCAP_FILE_DOWNLOAD_PREFIX}/${FILE_NAME}"
-		"${CMAKE_BINARY_DIR}/scap_files/${FILE_NAME}"
-		SHOW_PROGRESS)
+		if(NOT EXISTS "${CMAKE_BINARY_DIR}/scap_files/${FILE_NAME}")
+			file(DOWNLOAD
+			"${SCAP_FILE_DOWNLOAD_PREFIX}/${FILE_NAME}"
+			"${CMAKE_BINARY_DIR}/scap_files/${FILE_NAME}"
+			SHOW_PROGRESS)
+		else()
+			message(STATUS "Skipping download, file already present")
+		endif()
 	endforeach()
 	file(GLOB_RECURSE SCAP_FILES_SUITE ${CMAKE_CURRENT_SOURCE_DIR}/scap_files/*.cpp)
 endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This avoids downloading the same SCAP files over and over everytime we configure the project with `cmake ..`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
