### PR TITLE
fix(sinsp): correctly manage `runc` process in old scap-files

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1229,12 +1229,22 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	 * PPM_CL_CLONE_NEWPID is true when:
 	 * - the child is the init process of a new namespace
 	 * 
-	 * When `caller_tid != caller_tinfo->m_vtid` is true we are for sure in a container
-	 * but this is not a strict requirement (leave it here for compatibility with old
+	 * PPM_CL_CLONE_PARENT is set by `runc:[0:PARENT]` when it creates
+	 * the first process in the new pid namespace. In new sinsp versions
+	 * `PPM_CL_CHILD_IN_PIDNS` is enough but in old scap-files where we don't have
+	 * this custom flag, we leave the event to the child parser when `PPM_CL_CLONE_PARENT`
+	 * is set since we don't know if the new child is in a pid namespace or not.
+	 * Moreover when `PPM_CL_CLONE_PARENT` is set `PPM_CL_CLONE_NEWPID` cannot
+	 * be set according to the clone manual.
+	 * 
+	 * When `caller_tid != caller_tinfo->m_vtid` is true we are for
+	 * sure in a container, and so is the child.
+	 * This is not a strict requirement (leave it here for compatibility with old
 	 * scap-files)
 	 */
 	if(flags & PPM_CL_CHILD_IN_PIDNS || 
 		flags & PPM_CL_CLONE_NEWPID ||
+		flags & PPM_CL_CLONE_PARENT ||
 		caller_tid != caller_tinfo->m_vtid)
 	{
 		return;

--- a/userspace/libsinsp/test/parsers/parse_clone.cpp
+++ b/userspace/libsinsp/test/parsers/parse_clone.cpp
@@ -175,7 +175,13 @@ TEST_F(sinsp_with_test_input, CLONE_CALLER_flag_CLONE_PARENT)
 	int64_t p2_t1_ptid = INIT_TID;
 
 	/* Parent clone exit event */
+	/* When the caller event has the `PPM_CL_CLONE_PARENT` flag, it leaves to the child parser
+	 * the honor to create the thread info for the child.
+	 */
 	generate_clone_x_event(p2_t1_tid, p1_t1_tid, p1_t1_pid, p1_t1_ptid, PPM_CL_CLONE_PARENT);
+	ASSERT_MISSING_THREAD_INFO(p2_t1_tid, true);
+
+	generate_clone_x_event(0, p2_t1_tid, p2_t1_pid, p2_t1_ptid, PPM_CL_CLONE_PARENT);
 	ASSERT_THREAD_INFO_PIDS(p2_t1_tid, p2_t1_pid, p2_t1_ptid)
 	ASSERT_THREAD_GROUP_INFO(p2_t1_pid, 1, false, 1, 1, p2_t1_tid)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This is yet another corner case with clone flags :/ I discovered it by using the falco e2e framework with old scap-files.

`PPM_CL_CLONE_PARENT` is set by `runc:[0:PARENT]` when it creates the first process in the new pid namespace. In new sinsp versions `PPM_CL_CHILD_IN_PIDNS` is enough to detect this behavior but in old scap-files where we don't have this custom flag, we should leave the event to the child parser when `PPM_CL_CLONE_PARENT` is set since we don't know if the new child is in a pid namespace or not.
Moreover when `PPM_CL_CLONE_PARENT` is set, `PPM_CL_CLONE_NEWPID` cannot
be set according to the clone manual so no way to detect this behavior with other clone flags


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
