### PR TITLE
fix: remove an unused variable in the kmod

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -7364,7 +7364,6 @@ int f_sys_getdents64_e(struct event_filler_arguments *args)
 int f_sched_prog_exec(struct event_filler_arguments *args)
 {
 	int res = 0;
-	unsigned long val = 0;
 	struct mm_struct *mm = current->mm;
 	int args_len = 0;
 	int correctly_read = 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area API-version

/area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This unused variable causes a build failure when we use warning as errors

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
