### PR TITLE
docs(README.VERSION.md): clarify when internal version must not be bumped and general improvements

### DIFF
--- a/driver/README.VERSION.md
+++ b/driver/README.VERSION.md
@@ -1,10 +1,16 @@
-# API version number
+# Driver internal versioning
 
-The file API_VERSION must contain a semver-like version number of the userspace<->kernel API. All other lines are ignored.
+This document explains how and when the internal [*API version number*](#api-version-number) and the [*Schema version number*](#schema-version-number) must be incremented. They do not represent the driver version associated with a driver release. For more information about the driver version, see our [release process documentation](https://github.com/falcosecurity/libs/blob/master/release.md).
 
-The version number must be incremented every time and only when a single change or an atomic group of changes - which meet the criteria described in the _When to Increment_ section below - is included in the `master` branch. Thus, a version bump can occur multiple times during the development and testing phases of a given release cycle. A given version bump must not group multiple changes that occurred sporadically during the release cycle.
+The version numbers described below must be incremented every time and only when a single change or an atomic group of changes - which meet the criteria described in the relative _When to Increment_ section below - is included in the `master` branch. Thus, a version bump can occur multiple times during the development and testing phases of a given release cycle. A given version bump must not group multiple changes that occurred sporadically during the release cycle.
 
-## When to increment
+Please, do *not* increment these versions for patches that solely address build issues on specific kernels (for example, newly supported kernels) without impacting others. In these instances, only the driver's version number must be bumped when the driver is released.
+
+## API version number
+
+The first line of [API_VERSION](API_VERSION) file contains a semver-like version number of the **userspace<->kernel API**. All other lines are ignored.
+
+### When to increment
 
 **major version**: increment when the driver API becomes incompatible with previous userspace versions
 
@@ -12,15 +18,11 @@ The version number must be incremented every time and only when a single change 
 
 **patch version**: increment when code changes don't break compatibility (e.g. bug fixes)
 
-Do *not* increment for patches that only add support for new kernels, without affecting already supported ones.
+## Schema version number
 
-# Schema version number
+The first line of [SCHEMA_VERSION](SCHEMA_VERSION) file contains a semver-like version number of the **event schema**. All other lines are ignored.
 
-The file SCHEMA_VERSION must contain a semver-like version number of the event schema. All other lines are ignored.
-
-The version number must be incremented every time and only when a single change or an atomic group of changes - which meet the criteria described in the _When to Increment_ section below - is included in the `master` branch. Thus, a version bump can occur multiple times during the development and testing phases of a given release cycle. A given version bump must not group multiple changes that occurred sporadically during the release cycle.
-
-## When to increment
+### When to increment
 
 **major version**: increment when the schema becomes incompatible with previous userspace versions
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

cc @Andreagit97 @jasondellaluce @gnosek 

/release 0.13.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
