### PR TITLE
fix(cmake/modules): make GetVersionFromGit when no git info

### DIFF
--- a/cmake/modules/GetVersionFromGit.cmake
+++ b/cmake/modules/GetVersionFromGit.cmake
@@ -161,11 +161,13 @@ function(get_version_from_git _var match_suffix exclude_suffix)
         # get the latest tag that exactly matches a version number, sorted by version number in descending order
         _falcosecurity_execute_git(tag for-each-ref --count=1 --sort=-version:refname --format "%(refname:short)" refs/tags/[0-9]*.[0-9]*.[0-9]${match_suffix})
 
-        _falcosecurity_extract_version("${tag}" x y z match_found)
+        if(tag)
+            _falcosecurity_extract_version("${tag}" x y z match_found)
 
-        if(match_found)
-            math(EXPR y_plus_one "${y} + 1")
-            set(dev_version "${x}.${y_plus_one}.0")
+            if(match_found)
+                math(EXPR y_plus_one "${y} + 1")
+                set(dev_version "${x}.${y_plus_one}.0")
+            endif()
         endif()
     endif()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.13.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
