### PR TITLE
fix(userspace/libsinsp): set a timeout on the curl handle when retrieving docker info

### DIFF
--- a/userspace/libsinsp/container_engine/docker/connection_linux.cpp
+++ b/userspace/libsinsp/container_engine/docker/connection_linux.cpp
@@ -69,6 +69,7 @@ docker_connection::docker_response docker_connection::get_docker(const docker_lo
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, docker_curl_write_callback);
 	curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, docker_path.c_str());
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
 
 	std::string url = "http://localhost" + m_api_version + req_url;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Set a maximum time in seconds that you allow the entire transfer operation to take when trying to retrieve docker info.

**Which issue(s) this PR fixes**:

Fixes #1292 

**Special notes for your reviewer**:

https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html :
> Default timeout is 0 (zero) which means it never times out during transfer. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
