### PR TITLE
fix(libsinsp): race condition in async event

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -264,21 +264,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, 
 	evt->m_inspector = m_inspector;
 
 	scap_evt* scapevt = evt->m_pevt;
-
-	if(m_inspector->m_lastevent_ts == 0)
-	{
-		// This can happen at startup when containers are
-		// being created as a part of the initial process
-		// scan.
-		// note: the following is only a convention and
-		// the timestamp will be setted when the event
-		// will be popped.
-		scapevt->ts = (uint64_t) - 1;
-	}
-	else
-	{
-		scapevt->ts = m_inspector->m_lastevent_ts;
-	}
+	scapevt->ts = (uint64_t) - 1;
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = PPME_CONTAINER_JSON_2_E;

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -270,7 +270,10 @@ bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, 
 		// This can happen at startup when containers are
 		// being created as a part of the initial process
 		// scan.
-		scapevt->ts = sinsp_utils::get_current_time_ns();
+		// note: the following is only a convention and
+		// the timestamp will be setted when the event
+		// will be popped.
+		scapevt->ts = (uint64_t) - 1;
 	}
 	else
 	{

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -403,9 +403,7 @@ void sinsp_container_manager::dump_containers(sinsp_dumper& dumper)
 		sinsp_evt evt;
 		if(container_to_sinsp_event(container_to_json(*it.second), &evt, it.second->get_tinfo(m_inspector)))
 		{
-			evt.m_pevt->ts = (m_inspector->m_lastevent_ts == 0)
-				? sinsp_utils::get_current_time_ns()
-				: m_inspector->m_lastevent_ts;
+			evt.m_pevt->ts = m_inspector->get_new_ts();
 			dumper.dump(&evt);
 		}
 	}

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -403,6 +403,9 @@ void sinsp_container_manager::dump_containers(sinsp_dumper& dumper)
 		sinsp_evt evt;
 		if(container_to_sinsp_event(container_to_json(*it.second), &evt, it.second->get_tinfo(m_inspector)))
 		{
+			evt.m_pevt->ts = (m_inspector->m_lastevent_ts == 0)
+				? sinsp_utils::get_current_time_ns()
+				: m_inspector->m_lastevent_ts;
 			dumper.dump(&evt);
 		}
 	}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1235,6 +1235,10 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	{
 		res = SCAP_SUCCESS;
 		evt = m_state_evt.get();
+		// NB: setting the ts here avoids any race condition.
+		evt->m_pevt->ts = (m_lastevent_ts == 0)
+			? sinsp_utils::get_current_time_ns()
+			: m_lastevent_ts;
 	}
 #endif
 	else
@@ -2851,9 +2855,6 @@ void sinsp::handle_plugin_async_event(const sinsp_plugin& p, std::unique_ptr<sin
 		auto plid = (uint32_t*)((uint8_t*) evt->m_pevt + sizeof(scap_evt) + 4+4+4);
 		*plid = cur_plugin_id;
 		evt->inspector(this);
-		evt->m_pevt->ts = (m_lastevent_ts == 0)
-			? sinsp_utils::get_current_time_ns()
-			: m_lastevent_ts;
 #ifndef __EMSCRIPTEN__				
 		m_pending_state_evts.push(std::move(evt));
 #endif

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1241,9 +1241,7 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		//       previously assigned.
 		if(evt->m_pevt->ts == (uint64_t) - 1)
 		{
-			evt->m_pevt->ts = (m_lastevent_ts == 0)
-				? sinsp_utils::get_current_time_ns()
-				: m_lastevent_ts;
+			evt->m_pevt->ts = get_new_ts();
 		}
 	}
 #endif
@@ -2876,4 +2874,14 @@ bool sinsp::get_track_connection_status()
 void sinsp::set_track_connection_status(bool enabled)
 {
 	m_parser->set_track_connection_status(enabled);
+}
+
+uint64_t sinsp::get_new_ts()
+{
+	// m_lastevent_ts = 0 at startup when containers are
+	// being created as a part of the initial process
+	// scan.
+	return (m_lastevent_ts == 0)
+			? sinsp_utils::get_current_time_ns()
+			: m_lastevent_ts;
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1235,8 +1235,10 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	{
 		res = SCAP_SUCCESS;
 		evt = m_state_evt.get();
-		// NB: setting the ts here avoids any race condition.
-		evt->m_pevt->ts = (m_lastevent_ts == 0)
+		// note: a new timestamp will be assign to the event if
+		// 			- the last event timestamp is not available or
+		// 			- the timestamp is explicitly set to (uint64_t)-1
+		evt->m_pevt->ts = (m_lastevent_ts == 0 || evt->m_pevt->ts == (uint64_t) - 1)
 			? sinsp_utils::get_current_time_ns()
 			: m_lastevent_ts;
 	}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1018,6 +1018,14 @@ public:
 	bool get_track_connection_status();
 	void set_track_connection_status(bool enabled);
 
+	/**
+	 * \brief Get a new timestamp.
+	 * 
+	 * \return The current time in nanoseconds if the last event timestamp is 0,
+	 * otherwise, the last event timestamp.
+	 */
+	uint64_t get_new_ts();
+
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);
 	void set_mode(scap_mode_t value)

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -404,7 +404,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_async)
 	// we will not use the test scap engine here, but open the no-driver instead
 	uint64_t count = 0;
 	uint64_t cycles = 0;
-	uint64_t max_cycles = max_count * 1.5; // avoid infinite loops
+	uint64_t max_cycles = max_count * 8; // avoid infinite loops
 	sinsp_evt *evt = NULL;
 	int32_t rc = SCAP_SUCCESS;
 	uint64_t last_ts = 0;

--- a/userspace/libsinsp/test/plugins/syscall_async.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_async.cpp
@@ -184,8 +184,18 @@ static ss_plugin_rc plugin_set_async_event_handler(ss_plugin_t* s, ss_plugin_own
                     exit(1);
                 }
 
-                // sleep for a period
-                std::this_thread::sleep_for(std::chrono::nanoseconds(ps->async_period));
+				// sleep for a period
+				if(i < 2)
+				{
+					// sleep for 1ms
+					std::this_thread::sleep_for(std::chrono::nanoseconds(ps->async_period));
+				}
+				else
+				{
+					// sleep for 1s
+					std::this_thread::sleep_for(std::chrono::nanoseconds(ps->async_period*1000));
+				}
+
             }
         });
     }

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -597,7 +597,10 @@ bool sinsp_usergroup_manager::user_to_sinsp_event(const scap_userinfo *user, sin
 		// This can happen at startup when containers are
 		// being created as a part of the initial process
 		// scan.
-		scapevt->ts = sinsp_utils::get_current_time_ns();
+		// note: the following is only a convention and
+		// the timestamp will be setted when the event
+		// will be popped.
+		scapevt->ts = (uint64_t) - 1;
 	}
 	else
 	{
@@ -657,7 +660,10 @@ bool sinsp_usergroup_manager::group_to_sinsp_event(const scap_groupinfo *group, 
 		// This can happen at startup when containers are
 		// being created as a part of the initial process
 		// scan.
-		scapevt->ts = sinsp_utils::get_current_time_ns();
+		// note: the following is only a convention and
+		// the timestamp will be setted when the event
+		// will be popped.
+		scapevt->ts = (uint64_t) - 1;
 	}
 	else
 	{

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -161,6 +161,7 @@ void sinsp_usergroup_manager::dump_users_groups(sinsp_dumper& dumper) {
 		for (const auto &user: usrlist) {
 			sinsp_evt evt;
 			if (user_to_sinsp_event(&user.second, &evt, container_id, PPME_USER_ADDED_E)) {
+				evt.m_pevt->ts = m_inspector->get_new_ts();
 				dumper.dump(&evt);
 			}
 		}
@@ -172,6 +173,7 @@ void sinsp_usergroup_manager::dump_users_groups(sinsp_dumper& dumper) {
 		for (const auto &group: grplist) {
 			sinsp_evt evt;
 			if (group_to_sinsp_event(&group.second, &evt, container_id, PPME_GROUP_ADDED_E)) {
+				evt.m_pevt->ts = m_inspector->get_new_ts();
 				dumper.dump(&evt);
 			}
 		}
@@ -592,9 +594,7 @@ bool sinsp_usergroup_manager::user_to_sinsp_event(const scap_userinfo *user, sin
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	scapevt->ts = (m_inspector->m_lastevent_ts == 0)
-		? sinsp_utils::get_current_time_ns()
-		: m_inspector->m_lastevent_ts;
+	scapevt->ts = m_inspector->get_new_ts();
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;
@@ -644,9 +644,7 @@ bool sinsp_usergroup_manager::group_to_sinsp_event(const scap_groupinfo *group, 
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	scapevt->ts = (m_inspector->m_lastevent_ts == 0)
-		? sinsp_utils::get_current_time_ns()
-		: m_inspector->m_lastevent_ts;
+	scapevt->ts = m_inspector->get_new_ts();
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -592,20 +592,9 @@ bool sinsp_usergroup_manager::user_to_sinsp_event(const scap_userinfo *user, sin
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	if(m_inspector->m_lastevent_ts == 0)
-	{
-		// This can happen at startup when containers are
-		// being created as a part of the initial process
-		// scan.
-		// note: the following is only a convention and
-		// the timestamp will be setted when the event
-		// will be popped.
-		scapevt->ts = (uint64_t) - 1;
-	}
-	else
-	{
-		scapevt->ts = m_inspector->m_lastevent_ts;
-	}
+	scapevt->ts = (m_inspector->m_lastevent_ts == 0)
+		? sinsp_utils::get_current_time_ns()
+		: m_inspector->m_lastevent_ts;
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;
@@ -655,20 +644,9 @@ bool sinsp_usergroup_manager::group_to_sinsp_event(const scap_groupinfo *group, 
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	if(m_inspector->m_lastevent_ts == 0)
-	{
-		// This can happen at startup when containers are
-		// being created as a part of the initial process
-		// scan.
-		// note: the following is only a convention and
-		// the timestamp will be setted when the event
-		// will be popped.
-		scapevt->ts = (uint64_t) - 1;
-	}
-	else
-	{
-		scapevt->ts = m_inspector->m_lastevent_ts;
-	}
+	scapevt->ts = (m_inspector->m_lastevent_ts == 0)
+		? sinsp_utils::get_current_time_ns()
+		: m_inspector->m_lastevent_ts;
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -594,7 +594,7 @@ bool sinsp_usergroup_manager::user_to_sinsp_event(const scap_userinfo *user, sin
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	scapevt->ts = m_inspector->get_new_ts();
+	scapevt->ts = (uint64_t) - 1;
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;
@@ -644,7 +644,7 @@ bool sinsp_usergroup_manager::group_to_sinsp_event(const scap_groupinfo *group, 
 
 	scap_evt* scapevt = evt->m_pevt;
 
-	scapevt->ts = m_inspector->get_new_ts();
+	scapevt->ts = (uint64_t) - 1;
 	scapevt->tid = -1;
 	scapevt->len = (uint32_t)totlen;
 	scapevt->type = ev_type;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Up until now, when dealing with the scenario of receiving multiple asynchronous events, there was a possibility of encountering a race condition involving the event timestamps. This could lead to inconsistent timestamps for events that are sequential. This resolves the issue.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
