### PR TITLE
cleanup: use header only b64 library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Install deps ⛓️
           command: |
             sudo apt update -y
-            sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev
+            sudo DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev
 
       - checkout:
           path: /tmp/libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Install deps ⛓️
         run: |
-          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
+          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Install deps ⛓️
         run: |
-          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
+          apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-amd64
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
       - name: Install deps ⛓️
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libre2-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-$(uname -r)
+          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential git clang llvm pkg-config autoconf automake libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev libre2-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev liblua5.1-dev linux-headers-$(uname -r)
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@v3
@@ -279,7 +279,7 @@ jobs:
           githubToken: ${{ github.token }}
 
           install: |
-            apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libb64-dev libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev linux-headers-generic            
+            apt update && apt install -y --no-install-recommends ca-certificates cmake build-essential clang llvm git pkg-config autoconf automake libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc libgtest-dev libprotobuf-dev linux-headers-generic            
             git clone https://github.com/libbpf/bpftool.git --branch v7.0.0 --single-branch
             cd bpftool
             git submodule update --init
@@ -331,7 +331,6 @@ jobs:
             libtool \
             libelf-dev \
             wget \
-            libb64-dev \
             libc-ares-dev \
             libbpf-dev \
             libcap-dev \

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -284,8 +284,7 @@ if(NOT WIN32)
 						"${GPR_LIB}"
 						"${PROTOBUF_LIB}"
 						"${CARES_LIB}"
-						"${JQ_LIB}"
-						"${B64_LIB}")
+						"${JQ_LIB}")
 			list(APPEND SINSP_PKGCONFIG_LIBRARIES
 						"${GRPC_LIBRARIES}"
 						"${GRPCPP_LIB}"
@@ -293,8 +292,7 @@ if(NOT WIN32)
 						"${GPR_LIB}"
 						"${PROTOBUF_LIB}"
 						"${CARES_LIB}"
-						"${JQ_LIB}"
-						"${B64_LIB}")
+						"${JQ_LIB}")
 
 			if(NOT MUSL_OPTIMIZED_BUILD)
 				target_link_libraries(sinsp INTERFACE rt anl)
@@ -302,8 +300,8 @@ if(NOT WIN32)
 			endif()
 
 		else()
-			target_link_libraries(sinsp INTERFACE "${JQ_LIB}" "${B64_LIB}" rt)
-			list(APPEND SINSP_PKGCONFIG_LIBRARIES "${JQ_LIB}" "${B64_LIB}" rt)
+			target_link_libraries(sinsp INTERFACE "${JQ_LIB}" rt)
+			list(APPEND SINSP_PKGCONFIG_LIBRARIES "${JQ_LIB}" rt)
 		endif() # NOT MINIMAL_BUILD
 		# when JQ is compiled statically, it will
 		# also compile a static object for oniguruma we need to link
@@ -312,8 +310,6 @@ if(NOT WIN32)
 			list(APPEND SINSP_PKGCONFIG_LIBRARIES "${ONIGURUMA_LIB}")
 			add_dependencies(sinsp jq)
 		endif()
-
-		add_dependencies(sinsp b64)
 	endif() # NOT APPLE
 
 	target_link_libraries(sinsp INTERFACE "${OPENSSL_LIBRARIES}")

--- a/userspace/libsinsp/marathon_http.cpp
+++ b/userspace/libsinsp/marathon_http.cpp
@@ -24,8 +24,6 @@ limitations under the License.
 #include "marathon_http.h"
 #include "curl/curl.h"
 #include "curl/easy.h"
-#define BUFFERSIZE 512 // b64 needs this macro
-#include "b64/encode.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "json_error_log.h"

--- a/userspace/libsinsp/mesos_http.cpp
+++ b/userspace/libsinsp/mesos_http.cpp
@@ -29,8 +29,8 @@ limitations under the License.
 #include "sinsp_curl.h"
 #include "json_error_log.h"
 #include "mesos.h"
-#define BUFFERSIZE 512 // b64 needs this macro
-#include "b64/encode.h"
+#define EMPTY_STRING "" // b64 needs this macro
+#include <base64.h>
 #include <sstream>
 #include <stdexcept>
 #include <unistd.h>
@@ -400,10 +400,8 @@ std::string mesos_http::make_request(uri url, curl_version_info_data* curl_versi
 	std::string creds = url.get_credentials();
 	if(!creds.empty())
 	{
-		std::istringstream is(creds);
-		std::ostringstream os;
-		base64::encoder().encode(is, os);
-		request << "Authorization: Basic " << os.str() << "\r\n";
+		auto bauth = Base64::encode(creds.c_str(), creds.length());
+		request << "Authorization: Basic " << bauth << "\r\n";
 	}
 	if(!m_token.empty())
 	{

--- a/userspace/libsinsp/socket_handler.h
+++ b/userspace/libsinsp/socket_handler.h
@@ -28,8 +28,8 @@ limitations under the License.
 #include "http_parser.h"
 #include "uri.h"
 #include "json/json.h"
-#define BUFFERSIZE 512 // b64 needs this macro
-#include "b64/encode.h"
+#define EMPTY_STRING "" // b64 needs this macro
+#include <base64.h>
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "sinsp_auth.h"
@@ -193,10 +193,7 @@ public:
 		if(!creds.empty())
 		{
 			uri::decode(creds);
-			std::istringstream is(creds);
-			std::ostringstream os;
-			base64::encoder().encode(is, os);
-			std::string bauth = os.str();
+			std::string bauth = Base64::encode(creds.c_str(), creds.length());
 			request << "Authorization: Basic " << trim(bauth) << "\r\n";
 		}
 		if(m_bt && !m_bt->get_token().empty())


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area CI

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR removes the usage of the libb64 library due to its incompatible license. From now on we will use a header-only implementation taken directly from:
https://raw.githubusercontent.com/istio/proxy/1.18.2/extensions/common/wasm/base64.h

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
