### PR TITLE
fix(userspace/libscap): avoid possible double free while loading users and groups

### DIFF
--- a/userspace/libscap/linux/scap_userlist.c
+++ b/userspace/libscap/linux/scap_userlist.c
@@ -197,12 +197,14 @@ int32_t scap_linux_create_userlist(struct scap_platform* platform)
 		endpwent();
 	}
 
+	// if userIdx == 0 -> realloc with size 0 means free, and NULL is returned.
+	// so, we will end up with userlist->nusers = 0 and userlist->users NULL.
 	userlist->nusers = useridx;
 	if (useridx < usercnt)
 	{
 		// Reduce array size
 		scap_userinfo *reduced_userinfos = realloc(userlist->users, useridx * sizeof(scap_userinfo));
-		if(reduced_userinfos == NULL)
+		if(reduced_userinfos == NULL && useridx > 0)
 		{
 			snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "userlist allocation while reducing array size");
 			free(userlist->users);
@@ -290,12 +292,14 @@ int32_t scap_linux_create_userlist(struct scap_platform* platform)
 		endgrent();
 	}
 
+	// if grpidx == 0 -> realloc with size 0 means free, and NULL is returned.
+	// so, we will end up with userlist->ngroups = 0 and userlist->groups NULL.
 	userlist->ngroups = grpidx;
 	if (grpidx < grpcnt)
 	{
 		// Reduce array size
 		scap_groupinfo *reduced_groups = realloc(userlist->groups, grpidx * sizeof(scap_groupinfo));
-		if(reduced_groups == NULL)
+		if(reduced_groups == NULL && grpidx > 0)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "grouplist allocation failed(2)");
 			free(userlist->users);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1312

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: avoid possible source of double free
```
