### PR TITLE
chore: enforce `b64` include at every cmake build

### DIFF
--- a/cmake/modules/b64.cmake
+++ b/cmake/modules/b64.cmake
@@ -24,5 +24,6 @@ if(NOT EXISTS "${B64_INCLUDE}/base64.h")
 	"${B64_DOWNLOAD_URL}"
 	"${B64_INCLUDE}/base64.h"
 	)
-	include_directories("${B64_INCLUDE}")
 endif()
+
+include_directories("${B64_INCLUDE}")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR enforce a more safe behavior, setting the b64 include at every cmake rebuild

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
