### PR TITLE
fix(sinsp): Improve podman container detection on Alpine Linux and when running in a container

### DIFF
--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -170,13 +170,16 @@ bool podman::can_api_sock_exist()
 	// If the GNU extension GLOB_BRACE were universal, we could
 	// probably do this as one glob.
 
-	if (access(m_api_sock.c_str(), R_OK|W_OK) == 0)
+	std::string api_sock = scap_get_host_root() + m_api_sock;
+	std::string user_api_sock_pattern = scap_get_host_root() + m_user_api_sock_pattern;
+
+	if (access(api_sock.c_str(), R_OK|W_OK) == 0)
 	{
 		return true;
 	}
 
 	// NULL is errfunc
-	rc = glob(m_user_api_sock_pattern.c_str(), glob_flags, NULL, &gl);
+	rc = glob(user_api_sock_pattern.c_str(), glob_flags, NULL, &gl);
 	globfree(&gl);
 
 	return (rc == 0);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes two issues in Podman container support:
1. On Alpine Linux (and presumably other non-systemd distros) Podman uses a different cgroup layout that we didn't support
2. Before attempting to detect Podman containers, we check for the existence of the API socket(s). However, when running in a container, we checked the existence of an unprefixed path (e.g. /run/podman/podman.sock) while we later accessed the path prefixed with scap_get_host_root(), e.g. /host/run/podman/podman.sock. Fix this so that we check the existence of the prefixed path.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(sinsp): Improve podman container detection on Alpine Linux and when running in a container
```
