### PR TITLE
chore(build): update libelf to 0.189

### DIFF
--- a/cmake/modules/libelf.cmake
+++ b/cmake/modules/libelf.cmake
@@ -34,9 +34,9 @@ else()
             libelf
             PREFIX "${PROJECT_BINARY_DIR}/libelf-prefix"
             DEPENDS zlib
-            URL "https://sourceware.org/elfutils/ftp/0.187/elfutils-0.187.tar.bz2"
-            URL_HASH "SHA256=e70b0dfbe610f90c4d1fe0d71af142a4e25c3c4ef9ebab8d2d72b65159d454c8"
-            CONFIGURE_COMMAND ./configure LDFLAGS=-L${ZLIB_SRC} "CFLAGS=-I${ZLIB_INCLUDE}" --enable-deterministic-archives --disable-debuginfod --disable-libdebuginfod
+            URL "https://sourceware.org/elfutils/ftp/0.189/elfutils-0.189.tar.bz2"
+            URL_HASH "SHA256=39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8"
+            CONFIGURE_COMMAND ./configure LDFLAGS=-L${ZLIB_SRC} "CFLAGS=-I${ZLIB_INCLUDE}" --enable-deterministic-archives --disable-debuginfod --disable-libdebuginfod --without-zstd
             BUILD_IN_SOURCE 1
             BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C lib libeu.a
             COMMAND ${CMAKE_MAKE_PROGRAM} -C libelf libelf${LIBELF_LIB_SUFFIX}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature
/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Update libelf to version 0.189. Fixes the following (potential) vulnerabilities:
* ~[CVE-2021-33294](http://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-33294)~ (edit: my bad, no known vulnerabilities actually affect the current version)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
update(build): update libelf to 0.189
```
