### PR TITLE
fix(libscap,libsinsp): correctly manage memfd in scapfiles

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -1580,6 +1580,7 @@ static uint32_t scap_fd_read_from_disk(scap_fdinfo *fdi, size_t *nbytes, uint32_
 	case SCAP_FD_BPF:
 	case SCAP_FD_USERFAULTFD:
 	case SCAP_FD_IOURING:
+	case SCAP_FD_MEMFD:
 		res = scap_fd_read_fname_from_disk(fdi->info.fname, nbytes, r, error);
 		break;
 	case SCAP_FD_UNKNOWN:

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -336,6 +336,7 @@ int32_t scap_fd_handle_regular_file(struct scap_proclist *proclist, char *fname,
 		if (0 == strncmp(link_name, "/memfd:", strlen("/memfd:")))
 		{
 			fdi->type = SCAP_FD_MEMFD;
+			strlcpy(fdi->info.fname, link_name, sizeof(fdi->info.fname));
 		}
 		else
 		{

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -333,8 +333,15 @@ int32_t scap_fd_handle_regular_file(struct scap_proclist *proclist, char *fname,
 	}
 	else if(fdi->type == SCAP_FD_FILE_V2)
 	{
-		scap_fd_flags_file(fdi, procdir);
-		strlcpy(fdi->info.regularinfo.fname, link_name, sizeof(fdi->info.regularinfo.fname));
+		if (0 == strncmp(link_name, "/memfd:", strlen("/memfd:")))
+		{
+			fdi->type = SCAP_FD_MEMFD;
+		}
+		else
+		{
+			scap_fd_flags_file(fdi, procdir);
+			strlcpy(fdi->info.regularinfo.fname, link_name, sizeof(fdi->info.regularinfo.fname));
+		}
 	}
 	else
 	{

--- a/userspace/libscap/scap_savefile.c
+++ b/userspace/libscap/scap_savefile.c
@@ -198,6 +198,7 @@ static uint32_t scap_fd_info_len(scap_fdinfo *fdi)
 	case SCAP_FD_BPF:
 	case SCAP_FD_USERFAULTFD:
 	case SCAP_FD_IOURING:
+	case SCAP_FD_MEMFD:
 		res += (uint32_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE) + 2;    // 2 is the length field before the string
 		break;
 	default:
@@ -312,6 +313,7 @@ static int32_t scap_fd_write_to_disk(scap_dumper_t *d, scap_fdinfo *fdi, uint32_
 	case SCAP_FD_BPF:
 	case SCAP_FD_USERFAULTFD:
 	case SCAP_FD_IOURING:
+	case SCAP_FD_MEMFD:
 		stlen = (uint16_t)strnlen(fdi->info.fname, SCAP_MAX_PATH_SIZE);
 		if(scap_dump_write(d, &stlen,  sizeof(uint16_t)) != sizeof(uint16_t) ||
 		        (stlen > 0 && scap_dump_write(d, fdi->info.fname, stlen) != stlen))

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2656,6 +2656,7 @@ void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 				case SCAP_FD_BPF:
 				case SCAP_FD_IOURING:
 				case SCAP_FD_NETLINK:
+				case SCAP_FD_MEMFD:
 					cat->m_subcategory = SC_OTHER;
 					break;
 				case SCAP_FD_UNKNOWN:

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -389,6 +389,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi, OUT sinsp_fdinfo_t *re
 	case SCAP_FD_BPF:
 	case SCAP_FD_USERFAULTFD:
 	case SCAP_FD_IOURING:
+	case SCAP_FD_MEMFD:
 		newfdi->m_name = fdi->info.fname;
 
 		if(newfdi->m_name == USER_EVT_DEVICE_NAME)
@@ -1416,6 +1417,7 @@ void sinsp_threadinfo::fd_to_scap(scap_fdinfo *dst, sinsp_fdinfo_t* src)
 	case SCAP_FD_BPF:
 	case SCAP_FD_USERFAULTFD:
 	case SCAP_FD_IOURING:
+	case SCAP_FD_MEMFD:
 		strlcpy(dst->info.fname, src->m_name.c_str(), sizeof(dst->info.fname));
 		break;
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

New `scap_fd_type` were introduced but their parsing logic was not added to `scap_savefile.c`, breaking captures. Moreover the correspondents were missing in libsinsp.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
