### PR TITLE
fix(ci): properly skip release-body workflow in non-drivers tags.

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -7,6 +7,7 @@ on:
       
 permissions:
   contents: write
+  actions: 'write'
 
 concurrency:
   group: "release-body"
@@ -27,7 +28,11 @@ jobs:
 
       - name: Skip on non driver tag
         if: steps.regex-match.outputs.match == ''
-        run: exit 0
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Clone libs repo
         actions: checkout@v4

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -7,15 +7,17 @@ on:
       
 permissions:
   contents: write
-  actions: 'write'
 
 concurrency:
   group: "release-body"
   cancel-in-progress: true
 
 jobs:
-  release-body:
+  check-driver-tag:
     runs-on: ubuntu-latest
+    outputs:
+      driver_tag: ${{ steps.regex-match.outputs.match }}
+
     steps:
       # Note: there is no `tag` filter for `workflow_run`.
       # We need to manually check whether we are running on a tag.
@@ -26,14 +28,12 @@ jobs:
           text: ${{ github.event.workflow_run.head_branch }}
           regex: '[0-9]+.[0-9]+.[0-9]+\+driver$'
 
-      - name: Skip on non driver tag
-        if: steps.regex-match.outputs.match == ''
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+  release-body:
+    needs: check-driver-tag
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-driver-tag.outputs.driver_tag != "" }}
+
+    steps:
       - name: Clone libs repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Clone libs repo
-        actions: checkout@v4
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Per https://github.com/actions/runner/issues/662, `exit 0` won't skip subsequent jobs. Instead, we will need to forcefully skip the workflow.
https://stackoverflow.com/a/75809743/6065692

**Which issue(s) this PR fixes**:

`release-body` was creating releases when `kernel-tests` workflow was triggered against any branch since it failed to exit.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
