### PR TITLE
fix(libsinsp): Don't loop forever on container api

### DIFF
--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -672,6 +672,7 @@ bool docker_async_source::parse(const docker_lookup_request& request, sinsp_cont
 		}
 		/* FALLTHRU */
 	case docker_connection::docker_response::RESP_ERROR:
+	case docker_connection::docker_response::RESP_TIMEOUT:
 		g_logger.format(sinsp_logger::SEV_DEBUG,
 				"docker_async (%s): Url fetch failed, returning false",
 				request.container_id.c_str());

--- a/userspace/libsinsp/container_engine/docker/connection.h
+++ b/userspace/libsinsp/container_engine/docker/connection.h
@@ -18,7 +18,8 @@ public:
 	enum docker_response {
 		RESP_OK = 0,
 		RESP_BAD_REQUEST = 1,
-		RESP_ERROR = 2
+		RESP_ERROR = 2,
+		RESP_TIMEOUT = 3
 	};
 
 	docker_connection();


### PR DESCRIPTION
Add an escape clause on the container lookup path to make sure we're not just constantly getting timeouts.

/kind bug
/area libsinsp

```release-note
NONE
```
Signed-off-by: Nathan Baker <nathan.baker@sysdig.com>