### PR TITLE
fix(userspace): avoid a segmentation fault when `m_input_plugin` is not  initialized

### DIFF
--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -145,8 +145,12 @@ static int close_engine(struct scap_engine_handle engine)
 {
 	struct source_plugin_engine *handle = engine.m_handle;
 
-	handle->m_input_plugin->close(handle->m_input_plugin->state, handle->m_input_plugin->handle);
-	handle->m_input_plugin->handle = NULL;
+	// We could arrive here without having initialized 'm_input_plugin'.
+	if(handle->m_input_plugin != NULL)
+	{
+		handle->m_input_plugin->close(handle->m_input_plugin->state, handle->m_input_plugin->handle);
+		handle->m_input_plugin->handle = NULL;
+	}
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -494,6 +494,10 @@ void sinsp::open_common(scap_open_args* oargs)
 		std::string error = scap_getlasterr(m_h);
 		scap_close(m_h);
 		m_h = NULL;
+		if(error.empty())
+		{
+			error = "Initialization issues during scap_init";
+		}
 		throw scap_open_exception(error, scap_rc);
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap-engine-source-plugin

/area libscap

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR adds a better error message when the "/proc" folder is not available (probably a wrong env variable HOST_ROOT is passed). Moreover, it fixes a segfault in the source plugin engine

**Which issue(s) this PR fixes**:

Fixes #1358

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
