### PR TITLE
fix(userspace): avoid scanning proc when not in `SCAP_MODE_LIVE`

### DIFF
--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -63,7 +63,7 @@ int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_v
 		return SCAP_FAILURE;
 	}
 
-	if((rc = scap_generic_init_platform(handle->m_platform, handle->m_lasterr, oargs)) != SCAP_SUCCESS)
+	if((rc = scap_common_init_platform(handle->m_platform, handle->m_lasterr, oargs)) != SCAP_SUCCESS)
 	{
 		return rc;
 	}

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -23,10 +23,10 @@ limitations under the License.
 #include "scap-int.h"
 #include "scap_os_machine_info.h"
 
-int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs)
+int32_t scap_common_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs)
 {
 	memset(&platform->m_machine_info, 0, sizeof(platform->m_machine_info));
-	if(scap_os_get_machine_info(&platform->m_machine_info, lasterr) != SCAP_SUCCESS)
+	if(oargs->mode == SCAP_MODE_LIVE && (scap_os_get_machine_info(&platform->m_machine_info, lasterr) != SCAP_SUCCESS))
 	{
 		return SCAP_FAILURE;
 	}

--- a/userspace/libscap/scap_platform.h
+++ b/userspace/libscap/scap_platform.h
@@ -41,7 +41,7 @@ struct scap_platform* scap_generic_alloc_platform();
 // this needs to be called before opening the engine
 // as otherwise the proclist callback won't be set up in time
 // (for the savefile engine)
-int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs);
+int32_t scap_common_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs);
 
 // initialize a platform handle
 // this calls `init_platform` from the vtable


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Source plugins don't need to scan /proc when they are opened in `SCAP_MODE_PLUGIN` mode.
Renamed `scap_generic_init_platform` into `scap_common_init_platform`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
