### PR TITLE
fix(userspace/libscap): fixed ebpf init loop on online CPUs.

### DIFF
--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -201,6 +201,16 @@ int pman_finalize_ringbuf_array_after_loading()
 			continue;
 		}
 
+		if(ringbuf_id >= g_state.n_required_buffers)
+		{
+			/* If we arrive here it means that we have too many CPUs for our allocated ring buffers
+			 * so probably we faced a CPU hotplug.
+			 */
+			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "the actual system configuration requires more than '%d' ring buffers", g_state.n_required_buffers);
+			pman_print_error((const char *)error_message);
+			goto clean_percpu_ring_buffers;
+		}
+
 		if(bpf_map_update_elem(ringubuf_array_fd, &i, &ringbufs_fds[ringbuf_id], BPF_ANY))
 		{
 			snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "failed to add the ringbuf map for CPU '%d' to ringbuf '%d'", i, ringbuf_id);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf
/area libscap-engine-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Moreover, made kmod loop more robust too.

Basically, in ebpf, do not care if some `/sys/devices/system/cpu/cpuX` folders are not present, even if configured cpus state they should be present.
All we need is for the count of online CPUs to be the same as `_NPROCESSORS_ONLN` (this is the same assumption we made in kmod and modern bpf engines!).

**Which issue(s) this PR fixes**:

See https://github.com/falcosecurity/falco/issues/2843

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
