### PR TITLE
wip: feature(scap): allow custom tracepoints on ebpf probe

### DIFF
--- a/userspace/libscap/engine/bpf/attached_prog.h
+++ b/userspace/libscap/engine/bpf/attached_prog.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <stdbool.h>
 #include <limits.h>
+#include <stdint.h>
 
 typedef enum
 {
@@ -33,6 +34,7 @@ typedef enum
 	BPF_PROG_SCHED_PROC_FORK_MISSING_CHILD = 8, /* This is only used on architectures where the clone/fork child event is missing. Only when we have raw_tp */
 	BPF_PROG_SCHED_PROC_EXEC_MISSING_EXIT = 9,  /* This is only used on architectures where the execve/execveat success event is missing */
 	BPF_PROG_ATTACHED_MAX = 10,
+	BPF_PROG_CUSTOM_TRACEPOINT = 11,
 } bpf_attached_prog_codes;
 
 typedef struct bpf_attached_prog
@@ -42,6 +44,12 @@ typedef struct bpf_attached_prog
 	char name[NAME_MAX]; /* name of the program, used to attach it into the kernel */
 	bool raw_tp;	     /* tells if a program is a raw tracepoint or not */
 } bpf_attached_prog;
+
+typedef struct bpf_attached_prog_list
+{
+	bpf_attached_prog* ptr;
+	uint64_t len;
+} bpf_attached_prog_list;
 
 bool is_sys_enter(const char* name);
 bool is_sys_exit(const char* name);
@@ -54,7 +62,7 @@ bool is_sched_prog_fork_move_args(const char* name);
 bool is_sched_prog_fork_missing_child(const char* name);
 bool is_sched_prog_exec_missing_exit(const char* name);
 
-void fill_attached_prog_info(struct bpf_attached_prog* prog, bool raw_tp, const char* name, int fd);
+void fill_attached_prog_info(bpf_attached_prog_list* prog_list, uint64_t pos, bool raw_tp, const char* name, int fd);
 int attach_bpf_prog(struct bpf_attached_prog* prog, char* last_err);
 void detach_bpf_prog(struct bpf_attached_prog* prog);
 void unload_bpf_prog(struct bpf_attached_prog* prog);

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -42,7 +42,7 @@ struct bpf_engine
 
 	int m_tail_called_fds[BPF_PROGS_TAIL_CALLED_MAX];
 	int m_tail_called_cnt;
-	bpf_attached_prog m_attached_progs[BPF_PROG_ATTACHED_MAX];
+	bpf_attached_prog_list m_attached_progs;
 
 	int m_bpf_map_fds[BPF_MAPS_MAX];
 	int m_bpf_prog_array_map_idx;


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**


**What this PR does / why we need it**:

This change allows eBPF probes created with tracepoints other than the ones used by Falco to be directly attached and detached. This is useful for adopters that might want to go through the additional effort of attaching directly to the syscalls they care about, excluding sys_enter and sys_exit which could add extra computing effort, even for ignored syscalls. Because adopters need to go the extra mile to compile a probe from their own source code, I don't think a separate mechanism for controlling whether the custom tracepoints are attached or not is needed, simply finding such a tracepoint means we want it attached.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
