### PR TITLE
new(tests): change meaning to actual `field_exists` test helper

### DIFF
--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -92,12 +92,12 @@ protected:
 	void verify_no_fields(sinsp_evt *evt)
 
 	{
-		ASSERT_FALSE(field_exists(evt, fs_path_name));
-		ASSERT_FALSE(field_exists(evt, fs_path_nameraw));
-		ASSERT_FALSE(field_exists(evt, fs_path_source));
-		ASSERT_FALSE(field_exists(evt, fs_path_sourceraw));
-		ASSERT_FALSE(field_exists(evt, fs_path_target));
-		ASSERT_FALSE(field_exists(evt, fs_path_targetraw));
+		ASSERT_FALSE(field_has_value(evt, fs_path_name));
+		ASSERT_FALSE(field_has_value(evt, fs_path_nameraw));
+		ASSERT_FALSE(field_has_value(evt, fs_path_source));
+		ASSERT_FALSE(field_has_value(evt, fs_path_sourceraw));
+		ASSERT_FALSE(field_has_value(evt, fs_path_target));
+		ASSERT_FALSE(field_has_value(evt, fs_path_targetraw));
 	}
 
 	void verify_value_using_filters(sinsp_evt *evt,

--- a/userspace/libsinsp/test/events_net.ut.cpp
+++ b/userspace/libsinsp/test/events_net.ut.cpp
@@ -66,14 +66,14 @@ TEST_F(sinsp_with_test_input, net_socket)
 	ASSERT_EQ(get_field_as_string(evt, "fd.l4proto"), "<NA>"); /// todo: probably this is not what we want
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
 	/* When the fd role is `none` all these fields return NULL */
-	ASSERT_FALSE(field_exists(evt, "fd.sip"));
-	ASSERT_FALSE(field_exists(evt, "fd.cip"));
-	ASSERT_FALSE(field_exists(evt, "fd.rip"));
-	ASSERT_FALSE(field_exists(evt, "fd.lip"));
-	ASSERT_FALSE(field_exists(evt, "fd.cport"));
-	ASSERT_FALSE(field_exists(evt, "fd.sport"));
-	ASSERT_FALSE(field_exists(evt, "fd.lport"));
-	ASSERT_FALSE(field_exists(evt, "fd.rport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.sip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.cip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.rip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.lip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.cport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.sport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.lport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.rport"));
 }
 
 TEST_F(sinsp_with_test_input, net_ipv4_connect)
@@ -123,7 +123,7 @@ TEST_F(sinsp_with_test_input, net_ipv4_connect)
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
 	ASSERT_EQ(get_field_as_string(evt, "fd.connected"), "false");
 	/* Since the role of the fd is none, all these fields are null. The fdinfo state is updated but we cannot use these info in the filterchecks */
-	ASSERT_FALSE(field_exists(evt, "fd.sip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.sip"));
 
 	/* If the exit event is immediately consecutive we can obtain some info otherwise there is the risk we cannot update the fd */
 	std::vector<uint8_t> socktuple = test_utils::pack_socktuple(reinterpret_cast<sockaddr*>(&client), reinterpret_cast<sockaddr*>(&server));
@@ -297,13 +297,13 @@ TEST_F(sinsp_with_test_input, net_bind_listen_accept_ipv4)
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), fdname);
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_server"), "true");
 	ASSERT_EQ(get_field_as_string(evt, "fd.sip"), DEFAULT_IPV4_SERVER_STRING);
-	ASSERT_FALSE(field_exists(evt, "fd.cip")); /* we are not able to retrieve the client ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
-	ASSERT_FALSE(field_exists(evt, "fd.rip")); /* we are not able to retrieve remote ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
-	ASSERT_FALSE(field_exists(evt, "fd.lip")); /* we are not able to retrieve local ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_has_value(evt, "fd.cip")); /* we are not able to retrieve the client ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_has_value(evt, "fd.rip")); /* we are not able to retrieve remote ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
+	ASSERT_FALSE(field_has_value(evt, "fd.lip")); /* we are not able to retrieve local ip, the fdinfo type is SCAP_FD_IPV4_SERVSOCK */
 	ASSERT_EQ(get_field_as_string(evt, "fd.sport"), DEFAULT_SERVER_PORT_STRING);
-	ASSERT_FALSE(field_exists(evt, "fd.cport"));
-	ASSERT_FALSE(field_exists(evt, "fd.rport"));
-	ASSERT_FALSE(field_exists(evt, "fd.lport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.cport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.rport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.lport"));
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_LISTEN_E, 2, server_fd, (uint32_t) 5);
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_LISTEN_X, 1, return_value);
@@ -601,14 +601,14 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_missing_wo_fd_param_exi
 
 	/* Check that we are not able to load any info */
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "");
-	ASSERT_FALSE(field_exists(evt, "fd.sip"));
-	ASSERT_FALSE(field_exists(evt, "fd.cip"));
-	ASSERT_FALSE(field_exists(evt, "fd.rip"));
-	ASSERT_FALSE(field_exists(evt, "fd.lip"));
-	ASSERT_FALSE(field_exists(evt, "fd.cport"));
-	ASSERT_FALSE(field_exists(evt, "fd.sport"));
-	ASSERT_FALSE(field_exists(evt, "fd.lport"));
-	ASSERT_FALSE(field_exists(evt, "fd.rport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.sip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.cip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.rip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.lip"));
+	ASSERT_FALSE(field_has_value(evt, "fd.cport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.sport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.lport"));
+	ASSERT_FALSE(field_has_value(evt, "fd.rport"));
 
 	/* The parser is not able to obtain an updated fdname because the syscall fails and the parser flow is truncated */
 	fdinfo = evt->get_fd_info();

--- a/userspace/libsinsp/test/events_plugin.ut.cpp
+++ b/userspace/libsinsp/test/events_plugin.ut.cpp
@@ -127,7 +127,7 @@ TEST_F(sinsp_with_test_input, event_sources)
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
 	ASSERT_EQ(get_field_as_string(evt, "evt.source"), syscall_source_name);
 	ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "false");
-	ASSERT_FALSE(field_exists(evt, "evt.asynctype"));
+	ASSERT_FALSE(field_has_value(evt, "evt.asynctype"));
 
 	// metaevents have the "syscall" event source
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_CONTAINER_JSON_E, 1, "{\"value\": 1}");
@@ -143,9 +143,9 @@ TEST_F(sinsp_with_test_input, event_sources)
 	ASSERT_EQ(evt->get_type(), PPME_PLUGINEVENT_E);
 	ASSERT_EQ(evt->get_source_idx(), sinsp_no_event_source_idx);
 	ASSERT_EQ(evt->get_source_name(), sinsp_no_event_source_name);
-	ASSERT_FALSE(field_exists(evt, "evt.source"));
+	ASSERT_FALSE(field_has_value(evt, "evt.source"));
 	ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "false");
-	ASSERT_FALSE(field_exists(evt, "evt.asynctype"));
+	ASSERT_FALSE(field_has_value(evt, "evt.asynctype"));
 
 	// events coming from registered plugins should have their event source
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PLUGINEVENT_E, 2, (uint32_t) 999, plugindata);
@@ -154,7 +154,7 @@ TEST_F(sinsp_with_test_input, event_sources)
 	ASSERT_EQ(std::string(evt->get_source_name()), std::string(mock_plugin_get_event_source()));
 	ASSERT_EQ(get_field_as_string(evt, "evt.source"), std::string(mock_plugin_get_event_source()));
 	ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "false");
-	ASSERT_FALSE(field_exists(evt, "evt.asynctype"));
+	ASSERT_FALSE(field_has_value(evt, "evt.asynctype"));
 
 	// async events with no plugin ID should have "syscall" source
 	auto asyncname = "sampleasync";
@@ -183,7 +183,7 @@ TEST_F(sinsp_with_test_input, event_sources)
 	ASSERT_EQ(evt->get_type(), PPME_ASYNCEVENT_E);
 	ASSERT_EQ(evt->get_source_idx(), sinsp_no_event_source_idx);
 	ASSERT_EQ(evt->get_source_name(), sinsp_no_event_source_name);
-	ASSERT_FALSE(field_exists(evt, "evt.source"));
+	ASSERT_FALSE(field_has_value(evt, "evt.source"));
 	ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "true");
 	ASSERT_EQ(get_field_as_string(evt, "evt.asynctype"), "sampleasync");
 	ASSERT_EQ(get_field_as_string(evt, "evt.type"), "sampleasync");

--- a/userspace/libsinsp/test/events_proc.ut.cpp
+++ b/userspace/libsinsp/test/events_proc.ut.cpp
@@ -379,26 +379,26 @@ TEST_F(sinsp_with_test_input, spawn_process)
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.pexepath"), "/sbin/init");
 	ASSERT_EQ(get_field_as_string(evt, "proc.aexepath[1]"), "/sbin/init");
-	ASSERT_FALSE(field_exists(evt, "proc.aexepath[2]"));
-	ASSERT_FALSE(field_exists(evt, "proc.aexepath[3]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aexepath[2]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aexepath[3]"));
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.pexe"), "/sbin/init");
 	ASSERT_EQ(get_field_as_string(evt, "proc.aexe[1]"), "/sbin/init");
-	ASSERT_FALSE(field_exists(evt, "proc.aexe[2]"));
-	ASSERT_FALSE(field_exists(evt, "proc.aexe[3]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aexe[2]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aexe[3]"));
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.aname[1]"), "init");
-	ASSERT_FALSE(field_exists(evt, "proc.aname[2]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aname[2]"));
 	ASSERT_EQ(get_field_as_string(evt, "proc.ppid"), "1");
 	ASSERT_EQ(get_field_as_string(evt, "proc.apid[1]"), "1");
 	ASSERT_EQ(get_field_as_string(evt, "proc.pvpid"), "1");
-	ASSERT_FALSE(field_exists(evt, "proc.apid[2]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.apid[2]"));
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.cmdline"), "test-exe -c 'echo aGVsbG8K | base64 -d'");
 	ASSERT_EQ(get_field_as_string(evt, "proc.pcmdline"), "init");
 	ASSERT_EQ(get_field_as_string(evt, "proc.acmdline[0]"), "test-exe -c 'echo aGVsbG8K | base64 -d'");
 	ASSERT_EQ(get_field_as_string(evt, "proc.acmdline[1]"), "init");
-	ASSERT_FALSE(field_exists(evt, "proc.acmdline[2]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.acmdline[2]"));
 
 	// check more fields
 	ASSERT_EQ(get_field_as_string(evt, "proc.args"), "-c 'echo aGVsbG8K | base64 -d'");
@@ -534,8 +534,8 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 	/* Execve exit event */
 	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, (int64_t) 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", (uint64_t) 1024, (uint64_t) 0, (uint64_t) 28, (uint32_t) 29612, (uint32_t) 4, (uint32_t) 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, (uint32_t) 34818, parent_pid, (int32_t) 1000, (uint32_t) 1);
 
-	ASSERT_FALSE(field_exists(evt, "proc.pid"));
-	ASSERT_FALSE(field_exists(evt, "thread.tid"));
+	ASSERT_FALSE(field_has_value(evt, "proc.pid"));
+	ASSERT_FALSE(field_has_value(evt, "thread.tid"));
 
 	/* In the clone caller exit event we set `vtid=tid` and `vpid=pid` since we are never in a container. */
 	ASSERT_EQ(get_field_as_string(evt, "proc.vpid"), "4294967312");
@@ -558,10 +558,10 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 	/* Execve exit event */
 	evt = add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_EXECVE_19_X, 20, (int64_t) 0, "/bin/test-exe2", scap_const_sized_buffer{argsv.data(), argsv.size()}, child2_tid, child2_pid, child_tid, "", fdlimit, pgft_maj, pgft_min, (uint32_t) 29612, (uint32_t) 4, (uint32_t) 0, "test-exe2", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, (uint32_t) 34818, child_pid, (int32_t) 1000, (uint32_t) 1);
 
-	ASSERT_FALSE(field_exists(evt, "proc.pid"));
-	ASSERT_FALSE(field_exists(evt, "thread.tid"));
-	ASSERT_FALSE(field_exists(evt, "proc.ppid"));
-	ASSERT_FALSE(field_exists(evt, "proc.apid[1]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.pid"));
+	ASSERT_FALSE(field_has_value(evt, "thread.tid"));
+	ASSERT_FALSE(field_has_value(evt, "proc.ppid"));
+	ASSERT_FALSE(field_has_value(evt, "proc.apid[1]"));
 
 	/* Now in the clone child exit event we use vtid and vpid of the event */
 	ASSERT_EQ(get_field_as_string(evt, "proc.vpid"), "3");

--- a/userspace/libsinsp/test/filterchecks/proc.cpp
+++ b/userspace/libsinsp/test/filterchecks/proc.cpp
@@ -102,5 +102,5 @@ TEST_F(sinsp_with_test_input, PROC_FILTER_pexepath_aexepath)
 	/* `init` exepath */
 	ASSERT_EQ(get_field_as_string(evt, "proc.aexepath[5]"), "/sbin/init");
 	/* this field shouldn't exist */
-	ASSERT_FALSE(field_exists(evt, "proc.aexepath[6]"));
+	ASSERT_FALSE(field_has_value(evt, "proc.aexepath[6]"));
 }

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -173,8 +173,8 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
 	ASSERT_EQ(get_field_as_string(evt, "sample.is_open", pl_flist), "1");
 	ASSERT_EQ(get_field_as_string(evt, "sample.proc_name", pl_flist), "init");
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
 	ASSERT_EQ(get_field_as_string(evt, "sample.tick", pl_flist), "false");
 
 	// Here `sample.is_open` should be false
@@ -184,8 +184,8 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_INOTIFY_INIT1_X);
 	ASSERT_EQ(get_field_as_string(evt, "sample.is_open", pl_flist), "0");
 	ASSERT_EQ(get_field_as_string(evt, "sample.proc_name", pl_flist), "init");
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
 	ASSERT_EQ(get_field_as_string(evt, "sample.tick", pl_flist), "false");
 
 	// should extract NULL for ignored event codes
@@ -194,11 +194,11 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_EQ(evt->get_source_idx(), syscall_source_idx);
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_BY_HANDLE_AT_X);
-	ASSERT_FALSE(field_exists(evt, "sample.is_open", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.proc_name", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.tick", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.is_open", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.proc_name", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.tick", pl_flist));
 
 	// should extract NULL for unknown event sources
 	const char data[2048] = "hello world";
@@ -208,11 +208,11 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_EQ(evt->get_source_idx(), sinsp_no_event_source_idx);
 	ASSERT_EQ(evt->get_source_name(), sinsp_no_event_source_name);
 	ASSERT_EQ(evt->get_type(), PPME_PLUGINEVENT_E);
-	ASSERT_FALSE(field_exists(evt, "sample.is_open", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.proc_name", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.tick", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.is_open", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.proc_name", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.tick", pl_flist));
 
 	// should extract NULL for non-compatible event sources
 	/* This source plugin generate events with a source that we cannot extract with our plugin */
@@ -221,11 +221,11 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_EQ(evt->get_source_idx(), 1);
 	ASSERT_EQ(std::string(evt->get_source_name()), std::string("sample"));
 	ASSERT_EQ(evt->get_type(), PPME_PLUGINEVENT_E);
-	ASSERT_FALSE(field_exists(evt, "sample.is_open", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.proc_name", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.tick", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.is_open", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.proc_name", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.tick", pl_flist));
 }
 
 // scenario: an event sourcing plugin should produce events of "syscall"
@@ -254,8 +254,8 @@ TEST_F(sinsp_with_test_input, plugin_syscall_source)
 	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/tmp");
 	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "the_file");
 	ASSERT_EQ(get_field_as_string(evt, "sample.is_open"), "1");
-	ASSERT_FALSE(field_exists(evt, "sample.open_count"));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count"));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count"));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count"));
 	ASSERT_EQ(get_field_as_string(evt, "sample.tick"), "false");
 
 	// We check that the plugin don't produce other events but just 1
@@ -286,7 +286,7 @@ TEST_F(sinsp_with_test_input, plugin_custom_source)
 	ASSERT_EQ(evt->get_source_idx(), 1);
 	ASSERT_EQ(evt->get_tid(), (uint64_t) -1);
 	ASSERT_EQ(std::string(evt->get_source_name()), src_pl->event_source());
-	ASSERT_FALSE(field_exists(evt, "fd.name"));
+	ASSERT_FALSE(field_has_value(evt, "fd.name"));
 	ASSERT_EQ(get_field_as_string(evt, "evt.pluginname"), src_pl->name());
 	ASSERT_EQ(get_field_as_string(evt, "sample.hello"), "hello world");
 	ASSERT_EQ(next_event(), nullptr); // EOF is expected
@@ -410,9 +410,9 @@ TEST_F(sinsp_with_test_input, plugin_syscall_parse)
 
 	// should extract NULL for ignored event codes, but should still parse it (because the parsing plugin does not ignore it)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, "/tmp/the_file.txt");
-	ASSERT_FALSE(field_exists(evt, "sample.open_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.evt_count", pl_flist));
-	ASSERT_FALSE(field_exists(evt, "sample.tick", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
+	ASSERT_FALSE(field_has_value(evt, "sample.tick", pl_flist));
 
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT1_X, 2, (int64_t)12, (uint16_t)32);
 	ASSERT_EQ(get_field_as_string(evt, "sample.open_count", pl_flist), "3");
@@ -481,8 +481,8 @@ TEST_F(sinsp_with_test_input, plugin_syscall_async)
 		{
 			ASSERT_GE(evt->get_ts(), last_ts);
 		}
-		ASSERT_FALSE(field_exists(evt, "evt.pluginname")); // not available for "syscall" async events
-		ASSERT_FALSE(field_exists(evt, "evt.plugininfo"));
+		ASSERT_FALSE(field_has_value(evt, "evt.pluginname")); // not available for "syscall" async events
+		ASSERT_FALSE(field_has_value(evt, "evt.plugininfo"));
 		ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "true");
 		ASSERT_EQ(get_field_as_string(evt, "evt.asynctype"), "sampleticker");
 		ASSERT_EQ(get_field_as_string(evt, "evt.type"), "sampleticker");

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -362,7 +362,19 @@ protected:
 		return ret;
 	}
 
+	// Return true if `field_name` exists in the filtercheck list.
+	// The field value could also be NULL, but in this method, we are not interested in the value.
 	bool field_exists(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = g_filterlist)
+	{
+		if (evt == nullptr) {
+			throw sinsp_exception("The event class is NULL");
+		}
+
+		return flist.new_filter_check_from_fldname(field_name, &m_inspector, false) != nullptr;
+	}
+
+	// Return true if `field_name` value is not NULL for this event.
+	bool field_has_value(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = g_filterlist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

The actual `field_exists` helper is not checking only the field existence but also its value, more in detail it checks that its value is not NULL. Sometimes, mainly with plugins, we want only to know if the field exists or not, and right now it's not possible, actual `field_exists` returns an exception if a field is not defined.
This PR renames the actual `field_exists` helper to `field_has_value` and adds a new helper called `field_exists` that checks only the field existence

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
