### PR TITLE
cleanup(sinsp): move engine/platform selection code to libsinsp

### DIFF
--- a/cmake/modules/engine_config.cmake
+++ b/cmake/modules/engine_config.cmake
@@ -1,0 +1,30 @@
+option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
+
+if(CREATE_TEST_TARGETS)
+	# Add engine only used for testing
+	set(HAS_ENGINE_TEST_INPUT On)
+endif()
+
+set(HAS_ENGINE_NODRIVER On)
+set(HAS_ENGINE_SAVEFILE On)
+set(HAS_ENGINE_SOURCE_PLUGIN On)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	set(HAS_ENGINE_KMOD On)
+	set(HAS_ENGINE_UDIG On)
+	set(HAS_ENGINE_BPF On)
+
+	option(BUILD_LIBSCAP_MODERN_BPF "Enable modern bpf probe" OFF)
+	if(BUILD_LIBSCAP_MODERN_BPF)
+		set(HAS_ENGINE_MODERN_BPF On)
+	endif()
+endif()
+
+# gVisor is currently only supported on Linux x86_64
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
+	option(BUILD_LIBSCAP_GVISOR "Build gVisor support" ON)
+	if (BUILD_LIBSCAP_GVISOR)
+		set(HAS_ENGINE_GVISOR On)
+	endif()
+endif()
+

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -59,7 +59,7 @@ endif()
 
 get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSOLUTE)
 get_filename_component(LIBSCAP_COMMON_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/common ABSOLUTE)
-set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${LIBSCAP_COMMON_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
+set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${LIBSCAP_COMMON_INCLUDE_DIR} ${PROJECT_BINARY_DIR}/libscap ${DRIVER_CONFIG_DIR})
 
 function(set_scap_target_properties target)
 	set_target_properties(${target} PROPERTIES
@@ -147,5 +147,6 @@ install(DIRECTORY "${PROJECT_BINARY_DIR}/common" DESTINATION "${CMAKE_INSTALL_IN
 install(DIRECTORY "${LIBSCAP_DIR}/userspace/plugin" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/userspace"
 		COMPONENT "scap"
 		FILES_MATCHING PATTERN "*.h")
+install(FILES ${PROJECT_BINARY_DIR}/libscap/scap_config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/userspace/libscap)
 install(FILES ${PROJECT_BINARY_DIR}/libscap/libscap.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/test/drivers/CMakeLists.txt
+++ b/test/drivers/CMakeLists.txt
@@ -18,6 +18,8 @@ file(GLOB_RECURSE GENERIC_TRACEPOINTS_TEST_SUITE ${CMAKE_CURRENT_SOURCE_DIR}/tes
 ## Actions suite files
 file(GLOB_RECURSE ACTIONS_TEST_SUITE ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/actions_suite/*.cpp)
 
+include(libscap)
+
 set(DRIVERS_TEST_SOURCES
   ./start_tests.cpp
   ./event_class/event_class.cpp
@@ -34,7 +36,7 @@ set(DRIVERS_TEST_INCLUDE
   ../../userspace/common
   "${GTEST_INCLUDE}"
   "${LIBSCAP_DIR}/driver/"
-  "${LIBSCAP_DIR}/userspace/libscap"
+  "${LIBSCAP_INCLUDE_DIRS}"
 )
 
 set(DRIVERS_TEST_LINK_LIBRARIES

--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -125,7 +125,6 @@ int open_engine(int argc, char** argv)
 	int ret = 0;
 	const struct scap_vtable* vtable = nullptr;
 	scap_open_args oargs = {};
-	oargs.mode = SCAP_MODE_LIVE;
 	unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
 	std::string kmod_path;
 

--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -238,7 +238,7 @@ int open_engine(int argc, char** argv)
 	}
 
 	char error_buffer[FILENAME_MAX] = {0};
-	event_test::s_scap_handle = scap_open(&oargs, error_buffer, &ret);
+	event_test::s_scap_handle = scap_open(&oargs, nullptr, error_buffer, &ret);
 	if(!event_test::s_scap_handle)
 	{
 		std::cerr << "Unable to open the engine: " << error_buffer << std::endl;

--- a/test/libscap/CMakeLists.txt
+++ b/test/libscap/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LIBSCAP_TESTS_INCLUDE
   PRIVATE
   "${GTEST_INCLUDE}"
   "${CMAKE_CURRENT_SOURCE_DIR}" # for test helpers <helpers/...>
-  "${CMAKE_SOURCE_DIR}/userspace/libscap" # this is for libscap includes
+  "${LIBSCAP_INCLUDE_DIRS}" # this is for libscap includes
   "${CMAKE_SOURCE_DIR}/userspace/common" # used to include `strl.h`
   "${CMAKE_SOURCE_DIR}/driver" # for the event_stats.h file
   "${CMAKE_CURRENT_BINARY_DIR}" # used to include `libscap_test_var.h`

--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -7,9 +7,7 @@
 
 scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* name, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
-	struct scap_open_args oargs = {
-		.mode = SCAP_MODE_LIVE,
-	};
+	struct scap_open_args oargs {};
 
 	/* If empty we fill with all syscalls */
 	if(ppm_sc_set.empty())

--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -1,4 +1,5 @@
 #include <scap.h>
+#include <scap_engines.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include <helpers/engines.h>
@@ -7,7 +8,6 @@
 scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* name, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
 	struct scap_open_args oargs = {
-		.engine_name = BPF_ENGINE,
 		.mode = SCAP_MODE_LIVE,
 	};
 
@@ -33,7 +33,7 @@ scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, 
 	};
 	oargs.engine_params = &bpf_params;
 
-	return scap_open(&oargs, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_bpf_engine, nullptr, error_buf, rc);
 }
 
 TEST(bpf, open_engine)

--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -33,7 +33,7 @@ scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, 
 	};
 	oargs.engine_params = &bpf_params;
 
-	return scap_open(&oargs, error_buf, rc);
+	return scap_open(&oargs, nullptr, error_buf, rc);
 }
 
 TEST(bpf, open_engine)

--- a/test/libscap/test_suites/engines/kmod/kmod.cpp
+++ b/test/libscap/test_suites/engines/kmod/kmod.cpp
@@ -104,7 +104,7 @@ scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim,
 	};
 	oargs.engine_params = &kmod_params;
 
-	return scap_open(&oargs, error_buf, rc);
+	return scap_open(&oargs, nullptr, error_buf, rc);
 }
 
 TEST(kmod, open_engine)

--- a/test/libscap/test_suites/engines/kmod/kmod.cpp
+++ b/test/libscap/test_suites/engines/kmod/kmod.cpp
@@ -67,9 +67,7 @@ int insert_kmod(const char* kmod_path, char* error_buf)
 
 scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* kmod_path, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
-	struct scap_open_args oargs = {
-		.mode = SCAP_MODE_LIVE,
-	};
+	struct scap_open_args oargs {};
 
 	/* Remove previously inserted kernel module */
 	if(remove_kmod(error_buf) != EXIT_SUCCESS)

--- a/test/libscap/test_suites/engines/kmod/kmod.cpp
+++ b/test/libscap/test_suites/engines/kmod/kmod.cpp
@@ -1,4 +1,5 @@
 #include <scap.h>
+#include <scap_engines.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include <helpers/engines.h>
@@ -67,7 +68,6 @@ int insert_kmod(const char* kmod_path, char* error_buf)
 scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, const char* kmod_path, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
 	struct scap_open_args oargs = {
-		.engine_name = KMOD_ENGINE,
 		.mode = SCAP_MODE_LIVE,
 	};
 
@@ -104,7 +104,7 @@ scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim,
 	};
 	oargs.engine_params = &kmod_params;
 
-	return scap_open(&oargs, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_kmod_engine, nullptr, error_buf, rc);
 }
 
 TEST(kmod, open_engine)

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -7,9 +7,7 @@
 
 scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, uint16_t cpus_for_each_buffer, bool online_only, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
-	struct scap_open_args oargs = {
-		.mode = SCAP_MODE_LIVE,
-	};
+	struct scap_open_args oargs {};
 
 	/* If empty we fill with all syscalls */
 	if(ppm_sc_set.empty())

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -1,4 +1,5 @@
 #include <scap.h>
+#include <scap_engines.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 #include <syscall.h>
@@ -7,7 +8,6 @@
 scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, uint16_t cpus_for_each_buffer, bool online_only, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
 	struct scap_open_args oargs = {
-		.engine_name = MODERN_BPF_ENGINE,
 		.mode = SCAP_MODE_LIVE,
 	};
 
@@ -35,7 +35,7 @@ scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffe
 	};
 	oargs.engine_params = &modern_bpf_params;
 
-	return scap_open(&oargs, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_modern_bpf_engine, nullptr, error_buf, rc);
 }
 
 TEST(modern_bpf, open_engine)

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -35,7 +35,7 @@ scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffe
 	};
 	oargs.engine_params = &modern_bpf_params;
 
-	return scap_open(&oargs, error_buf, rc);
+	return scap_open(&oargs, nullptr, error_buf, rc);
 }
 
 TEST(modern_bpf, open_engine)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -17,9 +17,9 @@
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../common")
 include_directories("${PROJECT_BINARY_DIR}/libscap")
 
-option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
+include(engine_config)
 
-option(BUILD_LIBSCAP_MODERN_BPF "Enable modern bpf probe" OFF)
+option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
 include(ExternalProject)
 
@@ -92,11 +92,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	include(FindMakedev)
 endif()
 
-option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
-
-if(CREATE_TEST_TARGETS)
+if(HAS_ENGINE_TEST_INPUT)
 	# Add engine only used for testing
-	set(HAS_ENGINE_TEST_INPUT On)
 	add_subdirectory(engine/test_input)
 	target_link_libraries(scap scap_engine_test_input)
 endif()
@@ -149,61 +146,58 @@ add_subdirectory(engine/noop)
 # don't link the noop engine to libscap directly,
 # it's a helper library for other engines (it's completely useless on its own)
 
-set(HAS_ENGINE_NODRIVER On)
-add_subdirectory(engine/nodriver)
-target_link_libraries(scap scap_engine_nodriver)
-
-set(HAS_ENGINE_SAVEFILE On)
-add_subdirectory(engine/savefile)
-target_link_libraries(scap scap_engine_savefile)
-
-set(HAS_ENGINE_SOURCE_PLUGIN On)
-add_subdirectory(engine/source_plugin)
-target_link_libraries(scap scap_engine_source_plugin)
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	set(HAS_ENGINE_UDIG On)
-	add_subdirectory(engine/udig)
-	target_link_libraries(scap scap_engine_udig)
-
-	include(libelf)
-
-	set(HAS_ENGINE_BPF On)
-	add_subdirectory(engine/bpf)
-	target_link_libraries(scap scap_engine_bpf)
-
-	set(HAS_ENGINE_KMOD On)
-	add_subdirectory(engine/kmod)
-	target_link_libraries(scap scap_engine_kmod)
-
-	if(BUILD_LIBSCAP_MODERN_BPF)
-		set(HAS_ENGINE_MODERN_BPF On)
-		add_subdirectory(engine/modern_bpf)
-		target_link_libraries(scap scap_engine_modern_bpf)
-	endif()
-
+if(HAS_ENGINE_NODRIVER)
+	add_subdirectory(engine/nodriver)
+	target_link_libraries(scap scap_engine_nodriver)
 endif()
 
-# gVisor is currently only supported on Linux x86_64
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
-	option(BUILD_LIBSCAP_GVISOR "Build gVisor support" ON)
-	if (BUILD_LIBSCAP_GVISOR)
-		set(HAS_ENGINE_GVISOR On)
-		add_subdirectory(engine/gvisor)
-		# The static and shared build differs here because a shared scap_engine_gvisor
-		# will result in circular dependencies.
-		if(BUILD_SHARED_LIBS)
-			# We can move this to the gvisor CMakeFile when we use
-			# CMake 3.13 or later.
-			# https://cmake.org/cmake/help/latest/policy/CMP0079.html
-			target_link_libraries(scap
-				${CMAKE_THREAD_LIBS_INIT}
-				${PROTOBUF_LIB}
-				${JSONCPP_LIB}
+if(HAS_ENGINE_SAVEFILE)
+	add_subdirectory(engine/savefile)
+	target_link_libraries(scap scap_engine_savefile)
+endif()
+
+if(HAS_ENGINE_SOURCE_PLUGIN)
+	add_subdirectory(engine/source_plugin)
+	target_link_libraries(scap scap_engine_source_plugin)
+endif()
+
+if(HAS_ENGINE_KMOD)
+	add_subdirectory(engine/kmod)
+	target_link_libraries(scap scap_engine_kmod)
+endif()
+
+if(HAS_ENGINE_UDIG)
+	add_subdirectory(engine/udig)
+	target_link_libraries(scap scap_engine_udig)
+endif()
+
+if(HAS_ENGINE_BPF)
+	include(libelf)
+	add_subdirectory(engine/bpf)
+	target_link_libraries(scap scap_engine_bpf)
+endif()
+
+if(HAS_ENGINE_MODERN_BPF)
+	include(libelf)
+	add_subdirectory(engine/modern_bpf)
+	target_link_libraries(scap scap_engine_modern_bpf)
+endif()
+
+if(HAS_ENGINE_GVISOR)
+	add_subdirectory(engine/gvisor)
+	# The static and shared build differs here because a shared scap_engine_gvisor
+	# will result in circular dependencies.
+	if(BUILD_SHARED_LIBS)
+		# We can move this to the gvisor CMakeFile when we use
+		# CMake 3.13 or later.
+		# https://cmake.org/cmake/help/latest/policy/CMP0079.html
+		target_link_libraries(scap
+			${CMAKE_THREAD_LIBS_INIT}
+			${PROTOBUF_LIB}
+			${JSONCPP_LIB}
 			)
-		else()
-			target_link_libraries(scap scap_engine_gvisor)
-		endif()
+	else()
+		target_link_libraries(scap scap_engine_gvisor)
 	endif()
 endif()
 

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../common")
+include_directories("${PROJECT_BINARY_DIR}/libscap")
 
 option(USE_BUNDLED_DEPS "Enable bundled dependencies instead of using the system ones" ON)
 
@@ -95,7 +96,7 @@ option(CREATE_TEST_TARGETS "Enable make-targets for unit testing" ON)
 
 if(CREATE_TEST_TARGETS)
 	# Add engine only used for testing
-	add_definitions(-DHAS_ENGINE_TEST_INPUT)
+	set(HAS_ENGINE_TEST_INPUT On)
 	add_subdirectory(engine/test_input)
 	target_link_libraries(scap scap_engine_test_input)
 endif()
@@ -144,40 +145,39 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	target_link_libraries(scap scap_engine_util)
 endif()
 
-add_definitions(-DHAS_ENGINE_NOOP)
 add_subdirectory(engine/noop)
 # don't link the noop engine to libscap directly,
 # it's a helper library for other engines (it's completely useless on its own)
 
-add_definitions(-DHAS_ENGINE_NODRIVER)
+set(HAS_ENGINE_NODRIVER On)
 add_subdirectory(engine/nodriver)
 target_link_libraries(scap scap_engine_nodriver)
 
-add_definitions(-DHAS_ENGINE_SAVEFILE)
+set(HAS_ENGINE_SAVEFILE On)
 add_subdirectory(engine/savefile)
 target_link_libraries(scap scap_engine_savefile)
 
-add_definitions(-DHAS_ENGINE_SOURCE_PLUGIN)
+set(HAS_ENGINE_SOURCE_PLUGIN On)
 add_subdirectory(engine/source_plugin)
 target_link_libraries(scap scap_engine_source_plugin)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	add_definitions(-DHAS_ENGINE_UDIG)
+	set(HAS_ENGINE_UDIG On)
 	add_subdirectory(engine/udig)
 	target_link_libraries(scap scap_engine_udig)
 
 	include(libelf)
 
-	add_definitions(-DHAS_ENGINE_BPF)
+	set(HAS_ENGINE_BPF On)
 	add_subdirectory(engine/bpf)
 	target_link_libraries(scap scap_engine_bpf)
 
-	add_definitions(-DHAS_ENGINE_KMOD)
+	set(HAS_ENGINE_KMOD On)
 	add_subdirectory(engine/kmod)
 	target_link_libraries(scap scap_engine_kmod)
 
 	if(BUILD_LIBSCAP_MODERN_BPF)
-		add_definitions(-DHAS_ENGINE_MODERN_BPF)
+		set(HAS_ENGINE_MODERN_BPF On)
 		add_subdirectory(engine/modern_bpf)
 		target_link_libraries(scap scap_engine_modern_bpf)
 	endif()
@@ -188,7 +188,7 @@ endif()
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
 	option(BUILD_LIBSCAP_GVISOR "Build gVisor support" ON)
 	if (BUILD_LIBSCAP_GVISOR)
-		add_definitions(-DHAS_ENGINE_GVISOR)
+		set(HAS_ENGINE_GVISOR On)
 		add_subdirectory(engine/gvisor)
 		# The static and shared build differs here because a shared scap_engine_gvisor
 		# will result in circular dependencies.
@@ -206,6 +206,8 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SYSTEM_NAME MATCHES "Linux
 		endif()
 	endif()
 endif()
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scap_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/scap_config.h)
 
 if (BUILD_LIBSCAP_EXAMPLES)
 	add_subdirectory(examples/01-open)

--- a/userspace/libscap/engine/bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/bpf/CMakeLists.txt
@@ -16,8 +16,8 @@
 #
 include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
 add_library(scap_engine_bpf scap_bpf.c attached_prog.c)
-add_dependencies(scap_engine_bpf libelf scap_platform)
-target_link_libraries(scap_engine_bpf scap_event_schema scap_platform scap_engine_util scap_error ${LIBELF_LIB})
+add_dependencies(scap_engine_bpf libelf zlib scap_platform)
+target_link_libraries(scap_engine_bpf scap_event_schema scap_platform scap_engine_util scap_error ${LIBELF_LIB} ${ZLIB_LIB})
 target_include_directories(scap_engine_bpf PRIVATE ${LIBELF_INCLUDE})
 
 set_scap_target_properties(scap_engine_bpf)

--- a/userspace/libscap/engine/bpf/bpf.h
+++ b/userspace/libscap/engine/bpf/bpf.h
@@ -60,4 +60,5 @@ struct bpf_engine
 	bool capturing;
 	scap_stats_v2* m_stats;
 	uint32_t m_nstats;
+	uint64_t m_flags;
 };

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -2076,7 +2076,6 @@ uint64_t scap_bpf_get_schema_version(struct scap_engine_handle engine)
 
 const struct scap_vtable scap_bpf_engine = {
 	.name = BPF_ENGINE,
-	.mode = SCAP_MODE_LIVE,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -2030,7 +2030,18 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	/* Store interesting sc codes */
 	memcpy(&engine.m_handle->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
 
+	engine.m_handle->m_flags = 0;
+	if(scap_get_bpf_stats_enabled())
+	{
+		engine.m_handle->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
+	}
+
 	return SCAP_SUCCESS;
+}
+
+static uint64_t get_flags(struct scap_engine_handle engine)
+{
+	return engine.m_handle->m_flags;
 }
 
 static uint32_t get_n_devs(struct scap_engine_handle engine)
@@ -2070,6 +2081,7 @@ const struct scap_vtable scap_bpf_engine = {
 
 	.alloc_handle = alloc_handle,
 	.init = init,
+	.get_flags = get_flags,
 	.free_handle = free_handle,
 	.close = scap_bpf_close,
 	.next = next,

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -219,7 +219,6 @@ static uint64_t gvisor_get_max_buf_used(struct scap_engine_handle engine)
 
 extern const struct scap_vtable scap_gvisor_engine = {
 	.name = GVISOR_ENGINE,
-	.mode = SCAP_MODE_LIVE,
 	.savefile_ops = NULL,
 
 	.alloc_handle = gvisor_alloc_handle,

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -133,11 +133,15 @@ static const struct scap_platform_vtable scap_gvisor_platform_vtable = {
 	.free_platform = scap_gvisor_free_platform,
 };
 
-struct scap_platform* scap_gvisor_alloc_platform()
+scap_platform* scap_gvisor_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
 	struct scap_gvisor_platform* platform =
 	                 (struct scap_gvisor_platform*)calloc(sizeof(*platform), 1);
 	platform->m_generic.m_vtable = &scap_gvisor_platform_vtable;
+
+	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
+	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
+	platform->m_generic.m_proclist.m_proclist = NULL;
 
 	return &platform->m_generic;
 }

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -14,6 +14,8 @@ limitations under the License.
 
 #pragma once
 
+#include "scap_procs.h"
+
 #define GVISOR_ENGINE "gvisor"
 
 #ifdef __cplusplus
@@ -31,7 +33,7 @@ extern "C"
 	};
 
 	struct scap_platform;
-	struct scap_platform* scap_gvisor_alloc_platform();
+	struct scap_platform* scap_gvisor_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -1003,7 +1003,6 @@ const struct scap_linux_vtable scap_kmod_linux_vtable = {
 
 struct scap_vtable scap_kmod_engine = {
 	.name = KMOD_ENGINE,
-	.mode = SCAP_MODE_LIVE,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -53,6 +53,6 @@ add_library(scap_engine_modern_bpf
 )
 
 add_dependencies(scap_engine_modern_bpf pman)
-target_link_libraries(scap_engine_modern_bpf pman)
+target_link_libraries(scap_engine_modern_bpf pman scap_engine_util scap_engine_noop)
 
 set_scap_target_properties(scap_engine_modern_bpf)

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -228,7 +228,18 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	engine.m_handle->m_api_version = pman_get_probe_api_ver();
 	engine.m_handle->m_schema_version = pman_get_probe_schema_ver();
 
+	engine.m_handle->m_flags = 0;
+	if(scap_get_bpf_stats_enabled())
+	{
+		engine.m_handle->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
+	}
+
 	return SCAP_SUCCESS;
+}
+
+static uint64_t scap_modern_bpf__get_flags(struct scap_engine_handle engine)
+{
+	return engine.m_handle->m_flags;
 }
 
 int32_t scap_modern_bpf__close(struct scap_engine_handle engine)
@@ -282,6 +293,7 @@ struct scap_vtable scap_modern_bpf_engine = {
 
 	.alloc_handle = scap_modern_bpf__alloc_engine,
 	.init = scap_modern_bpf__init,
+	.get_flags = scap_modern_bpf__get_flags,
 	.free_handle = scap_modern_bpf__free_engine,
 	.close = scap_modern_bpf__close,
 	.next = scap_modern_bpf__next,

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -288,7 +288,6 @@ uint64_t scap_modern_bpf__get_schema_version(struct scap_engine_handle engine)
 
 struct scap_vtable scap_modern_bpf_engine = {
 	.name = MODERN_BPF_ENGINE,
-	.mode = SCAP_MODE_LIVE,
 	.savefile_ops = NULL,
 
 	.alloc_handle = scap_modern_bpf__alloc_engine,

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.h
@@ -34,4 +34,5 @@ struct modern_bpf_engine
 	uint64_t m_api_version;
 	uint64_t m_schema_version;
 	bool capturing;
+	uint64_t m_flags;
 };

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -63,7 +63,6 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 
 const struct scap_vtable scap_nodriver_engine = {
 	.name = NODRIVER_ENGINE,
-	.mode = SCAP_MODE_NODRIVER,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/nodriver/nodriver_public.h
+++ b/userspace/libscap/engine/nodriver/nodriver_public.h
@@ -15,17 +15,3 @@ limitations under the License.
 #pragma once
 
 #define NODRIVER_ENGINE "nodriver"
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-	struct scap_nodriver_engine_params
-	{
-		bool full_proc_scan; //< run a full /proc scan instead of the normal reduced one (no threads, no sockets)
-	};
-
-#ifdef __cplusplus
-};
-#endif

--- a/userspace/libscap/engine/noop/noop.c
+++ b/userspace/libscap/engine/noop/noop.c
@@ -111,7 +111,6 @@ uint64_t noop_get_max_buf_used(struct scap_engine_handle engine)
 
 const struct scap_vtable scap_noop_engine = {
 	.name = "noop",
-	.mode = SCAP_MODE_NODRIVER,
 	.savefile_ops = NULL,
 
 	.alloc_handle = noop_alloc_handle,

--- a/userspace/libscap/engine/savefile/savefile_public.h
+++ b/userspace/libscap/engine/savefile/savefile_public.h
@@ -15,6 +15,7 @@ limitations under the License.
 #pragma once
 
 #include <stdint.h>
+#include "scap_procs.h"
 
 #define SAVEFILE_ENGINE "savefile"
 
@@ -32,7 +33,8 @@ extern "C"
 	};
 
 	struct scap_platform;
-	struct scap_platform* scap_savefile_alloc_platform();
+	struct scap_platform* scap_savefile_alloc_platform(proc_entry_callback proc_callback,
+							   void* proc_callback_context);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2365,7 +2365,6 @@ static struct scap_savefile_vtable savefile_ops = {
 
 struct scap_vtable scap_savefile_engine = {
 	.name = SAVEFILE_ENGINE,
-	.mode = SCAP_MODE_CAPTURE,
 	.savefile_ops = &savefile_ops,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2174,9 +2174,9 @@ static const struct scap_platform_vtable scap_savefile_platform_vtable = {
 	.free_platform = scap_savefile_free_platform,
 };
 
-struct scap_platform* scap_savefile_alloc_platform()
+struct scap_platform *scap_savefile_alloc_platform(proc_entry_callback proc_callback, void *proc_callback_context)
 {
-    struct scap_savefile_platform* platform = calloc(sizeof(*platform), 1);
+	struct scap_savefile_platform *platform = calloc(sizeof(*platform), 1);
 
 	if(platform == NULL)
 	{
@@ -2185,6 +2185,10 @@ struct scap_platform* scap_savefile_alloc_platform()
 
 	platform->m_generic.m_vtable = &scap_savefile_platform_vtable;
 	platform->m_generic.m_machine_info.num_cpus = (uint32_t)-1;
+
+	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
+	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
+	platform->m_generic.m_proclist.m_proclist = NULL;
 
 	return &platform->m_generic;
 }

--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -296,7 +296,6 @@ const struct scap_stats_v2* get_source_plugin_stats_v2(struct scap_engine_handle
 
 const struct scap_vtable scap_source_plugin_engine = {
 	.name = SOURCE_PLUGIN_ENGINE,
-	.mode = SCAP_MODE_PLUGIN,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -86,7 +86,6 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 
 const struct scap_vtable scap_test_input_engine = {
 	.name = TEST_INPUT_ENGINE,
-	.mode = SCAP_MODE_TEST,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/engine/test_input/test_input_platform.c
+++ b/userspace/libscap/engine/test_input/test_input_platform.c
@@ -83,7 +83,7 @@ static const struct scap_platform_vtable scap_test_input_platform = {
 	.is_thread_alive = scap_test_input_is_thread_alive,
 };
 
-struct scap_platform* scap_test_input_alloc_platform()
+struct scap_platform* scap_test_input_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
 	struct scap_test_input_platform* platform = calloc(sizeof(*platform), 1);
 
@@ -94,6 +94,10 @@ struct scap_platform* scap_test_input_alloc_platform()
 
 	struct scap_platform* generic = &platform->m_generic;
 	generic->m_vtable = &scap_test_input_platform;
+
+	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
+	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
+	platform->m_generic.m_proclist.m_proclist = NULL;
 
 	return generic;
 }

--- a/userspace/libscap/engine/test_input/test_input_public.h
+++ b/userspace/libscap/engine/test_input/test_input_public.h
@@ -15,6 +15,7 @@ limitations under the License.
 #pragma once
 
 #include "scap_test.h"
+#include "scap_procs.h"
 
 #define TEST_INPUT_ENGINE "test_input"
 
@@ -29,7 +30,8 @@ extern "C"
 	};
 
 	struct scap_platform;
-	struct scap_platform* scap_test_input_alloc_platform();
+	struct scap_platform* scap_test_input_alloc_platform(proc_entry_callback proc_callback,
+							     void* proc_callback_context);
 #ifdef __cplusplus
 };
 #endif

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -597,7 +597,6 @@ static uint64_t get_max_buf_used(struct scap_engine_handle engine)
 
 const struct scap_vtable scap_udig_engine = {
 	.name = UDIG_ENGINE,
-	.mode = SCAP_MODE_LIVE,
 	.savefile_ops = NULL,
 
 	.alloc_handle = alloc_handle,

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -20,6 +20,7 @@ limitations under the License.
 #include <stdlib.h>
 #include <signal.h>
 #include <scap.h>
+#include <scap-int.h>
 #include <arpa/inet.h>
 #include <sys/time.h>
 #include "strl.h"
@@ -766,7 +767,7 @@ void print_stats()
 	int32_t rc;
 	const scap_stats_v2* stats_v2;
 	stats_v2 = scap_get_stats_v2(g_h, flags, &nstats, &rc);
-	const scap_machine_info* scap_machine_info = scap_get_machine_info(g_h);
+	uint64_t engine_flags = scap_get_engine_flags(g_h);
 	uint64_t n_evts = 0;
 	if (stats_v2 && nstats > 0)
 	{
@@ -800,7 +801,7 @@ void print_stats()
 	{
 		printf("[SCAP-OPEN]: [1] kernel-side counters\n");
 		printf("[SCAP-OPEN]: [2] libbpf stats (compare to `bpftool prog show` CLI)\n\n");
-		if (!(scap_machine_info->flags & PPM_BPF_STATS_ENABLED))
+		if (!(engine_flags & ENGINE_FLAG_BPF_STATS_ENABLED))
 		{
 			printf("\n[Notice]: `/proc/sys/kernel/bpf_stats_enabled` not enabled, no `libbpf` stats retrieved.\n\n");
 		}

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -854,7 +854,7 @@ int main(int argc, char** argv)
 
 	enable_sc_and_print();
 
-	g_h = scap_open(&oargs, error, &res);
+	g_h = scap_open(&oargs, NULL, error, &res);
 	if(g_h == NULL || res != SCAP_SUCCESS)
 	{
 		fprintf(stderr, "%s (%d)\n", error, res);

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -648,7 +648,6 @@ void parse_CLI_options(int argc, char** argv)
 		if(!strcmp(argv[i], KMOD_OPTION))
 		{
 			vtable = &scap_kmod_engine;
-			oargs.mode = SCAP_MODE_LIVE;
 			kmod_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &kmod_params;
 		}
@@ -662,7 +661,6 @@ void parse_CLI_options(int argc, char** argv)
 				exit(EXIT_FAILURE);
 			}
 			vtable = &scap_bpf_engine;
-			oargs.mode = SCAP_MODE_LIVE;
 			bpf_params.bpf_probe = argv[++i];
 			bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &bpf_params;
@@ -672,7 +670,6 @@ void parse_CLI_options(int argc, char** argv)
 		if(!strcmp(argv[i], MODERN_BPF_OPTION))
 		{
 			vtable = &scap_modern_bpf_engine;
-			oargs.mode = SCAP_MODE_LIVE;
 			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			modern_bpf_params.cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER;
 			modern_bpf_params.allocate_online_only = true;
@@ -688,7 +685,6 @@ void parse_CLI_options(int argc, char** argv)
 				exit(EXIT_FAILURE);
 			}
 			vtable = &scap_savefile_engine;
-			oargs.mode = SCAP_MODE_CAPTURE;
 			savefile_params.fname = argv[++i];
 			oargs.engine_params = &savefile_params;
 		}

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -170,7 +170,7 @@ int main()
 
 	scap_open_args args = {.mode = SCAP_MODE_LIVE};
 
-	scap_t* h = scap_open(&args, error, &ret);
+	scap_t* h = scap_open(&args, NULL, error, &ret);
 	if(h == NULL)
 	{
 		fprintf(stderr, "%s (%d)\n", error, ret);

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include <scap.h>
 #include "../../../../driver/ppm_events_public.h"
+#include "scap_engines.h"
 
 extern const struct ppm_event_info g_event_info[];
 
@@ -170,7 +171,7 @@ int main()
 
 	scap_open_args args = {.mode = SCAP_MODE_LIVE};
 
-	scap_t* h = scap_open(&args, NULL, error, &ret);
+	scap_t* h = scap_open(&args, &scap_kmod_engine, NULL, error, &ret);
 	if(h == NULL)
 	{
 		fprintf(stderr, "%s (%d)\n", error, ret);

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -169,7 +169,7 @@ int main()
 			&new_mask);
 	*/
 
-	scap_open_args args = {.mode = SCAP_MODE_LIVE};
+	scap_open_args args = {};
 
 	scap_t* h = scap_open(&args, &scap_kmod_engine, NULL, error, &ret);
 	if(h == NULL)

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -121,7 +121,7 @@ static const struct scap_platform_vtable scap_linux_platform = {
 	.free_platform = scap_linux_free_platform,
 };
 
-struct scap_platform* scap_linux_alloc_platform()
+struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
 	struct scap_linux_platform* platform = calloc(sizeof(*platform), 1);
 
@@ -132,6 +132,10 @@ struct scap_platform* scap_linux_alloc_platform()
 
 	struct scap_platform* generic = &platform->m_generic;
 	generic->m_vtable = &scap_linux_platform;
+
+	generic->m_proclist.m_proc_callback = proc_callback;
+	generic->m_proclist.m_proc_callback_context = proc_callback_context;
+	generic->m_proclist.m_proclist = NULL;
 
 	return generic;
 }

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -107,7 +107,7 @@ int32_t scap_linux_init_platform(struct scap_platform* platform, char* lasterr, 
 	return SCAP_SUCCESS;
 }
 
-static const struct scap_platform_vtable scap_linux_platform = {
+static const struct scap_platform_vtable scap_linux_platform_vtable = {
 	.init_platform = scap_linux_init_platform,
 	.refresh_addr_list = scap_linux_create_iflist,
 	.get_device_by_mount_id = scap_linux_get_device_by_mount_id,
@@ -131,7 +131,7 @@ struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callbac
 	}
 
 	struct scap_platform* generic = &platform->m_generic;
-	generic->m_vtable = &scap_linux_platform;
+	generic->m_vtable = &scap_linux_platform_vtable;
 
 	generic->m_proclist.m_proc_callback = proc_callback;
 	generic->m_proclist.m_proc_callback_context = proc_callback_context;

--- a/userspace/libscap/linux/scap_linux_platform.h
+++ b/userspace/libscap/linux/scap_linux_platform.h
@@ -101,7 +101,7 @@ struct scap_linux_platform
 	const struct scap_linux_vtable* m_linux_vtable;
 };
 
-struct scap_platform* scap_linux_alloc_platform();
+struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/linux/scap_machine_info.c
+++ b/userspace/libscap/linux/scap_machine_info.c
@@ -122,24 +122,6 @@ static uint64_t scap_linux_get_host_boot_time_ns(char* last_err)
 	return 0;
 }
 
-static void scap_get_bpf_stats_enabled(scap_machine_info* machine_info)
-{
-	machine_info->flags &= ~PPM_BPF_STATS_ENABLED;
-	FILE* f;
-	if((f = fopen("/proc/sys/kernel/bpf_stats_enabled", "r")))
-	{
-		uint32_t bpf_stats_enabled = 0;
-		if(fscanf(f, "%u", &bpf_stats_enabled) == 1)
-		{
-			if (bpf_stats_enabled != 0)
-			{
-				machine_info->flags |= PPM_BPF_STATS_ENABLED;
-			}
-		}
-		fclose(f);
-	}
-}
-
 static void scap_gethostname(char* buf, size_t size)
 {
 	char *env_hostname = getenv(SCAP_HOSTNAME_ENV_VAR);
@@ -185,7 +167,6 @@ int32_t scap_os_get_machine_info(scap_machine_info* machine_info, char* lasterr)
 	{
 		return SCAP_FAILURE;
 	}
-	scap_get_bpf_stats_enabled(machine_info);
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -37,7 +37,7 @@ limitations under the License.
 //
 // Still, to compile properly on non-Linux, provide an implementation
 // of scap_linux_alloc_platform() that always fails at runtime.
-struct scap_platform* scap_linux_alloc_platform()
+struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
 	return NULL;
 }
@@ -89,6 +89,8 @@ scap_t* scap_alloc(void)
 int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 {
 	const char* engine_name = oargs->engine_name;
+	proc_entry_callback proc_callback = oargs->proc_callback;
+	void* proc_callback_context = oargs->proc_callback_context;
 	struct scap_platform* platform = NULL;
 	const struct scap_vtable* vtable = NULL;
 	int32_t rc;
@@ -103,21 +105,21 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 	if(strcmp(engine_name, SAVEFILE_ENGINE) == 0)
 	{
 		vtable = &scap_savefile_engine;
-		platform = scap_savefile_alloc_platform();
+		platform = scap_savefile_alloc_platform(proc_callback, proc_callback_context);
 	}
 #endif
 #ifdef HAS_ENGINE_UDIG
 	if(strcmp(engine_name, UDIG_ENGINE) == 0)
 	{
 		vtable = &scap_udig_engine;
-		platform = scap_linux_alloc_platform();
+		platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 	}
 #endif
 #ifdef HAS_ENGINE_GVISOR
 	if(strcmp(engine_name, GVISOR_ENGINE) == 0)
 	{
 		vtable = &scap_gvisor_engine;
-		platform = scap_gvisor_alloc_platform();
+		platform = scap_gvisor_alloc_platform(proc_callback, proc_callback_context);
 	}
 #endif
 #ifdef HAS_ENGINE_TEST_INPUT
@@ -126,11 +128,11 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 		vtable = &scap_test_input_engine;
 		if(oargs->mode == SCAP_MODE_LIVE)
 		{
-			platform = scap_linux_alloc_platform();
+			platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 		}
 		else
 		{
-			platform = scap_test_input_alloc_platform();
+			platform = scap_test_input_alloc_platform(proc_callback, proc_callback_context);
 		}
 	}
 #endif
@@ -138,7 +140,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 	if(strcmp(engine_name, KMOD_ENGINE) == 0)
 	{
 		vtable = &scap_kmod_engine;
-		platform = scap_linux_alloc_platform();
+		platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 		if(platform)
 		{
 			((struct scap_linux_platform*)platform)->m_linux_vtable = &scap_kmod_linux_vtable;
@@ -149,21 +151,21 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 	if(strcmp(engine_name, BPF_ENGINE) == 0)
 	{
 		vtable = &scap_bpf_engine;
-		platform = scap_linux_alloc_platform();
+		platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 	}
 #endif
 #ifdef HAS_ENGINE_MODERN_BPF
 	if(strcmp(engine_name, MODERN_BPF_ENGINE) == 0)
 	{
 		vtable = &scap_modern_bpf_engine;
-		platform = scap_linux_alloc_platform();
+		platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 	}
 #endif
 #ifdef HAS_ENGINE_NODRIVER
 	if(strcmp(engine_name, NODRIVER_ENGINE) == 0)
 	{
 		vtable = &scap_nodriver_engine;
-		platform = scap_linux_alloc_platform();
+		platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 		struct scap_nodriver_engine_params* engine_params = oargs->engine_params;
 
 		if(platform)
@@ -176,7 +178,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 		}
 		else
 		{
-			platform = scap_generic_alloc_platform();
+			platform = scap_generic_alloc_platform(proc_callback, proc_callback_context);
 		}
 	}
 #endif
@@ -186,11 +188,11 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 		vtable = &scap_source_plugin_engine;
 		if(oargs->mode == SCAP_MODE_LIVE)
 		{
-			platform = scap_linux_alloc_platform();
+			platform = scap_linux_alloc_platform(proc_callback, proc_callback_context);
 		}
 		else
 		{
-			platform = scap_generic_alloc_platform();
+			platform = scap_generic_alloc_platform(proc_callback, proc_callback_context);
 		}
 	}
 #endif

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -253,6 +253,16 @@ void scap_close(scap_t* handle)
 	scap_deinit(handle);
 	scap_free(handle);
 }
+
+uint64_t scap_get_engine_flags(scap_t* handle)
+{
+	if(handle && handle->m_vtable && handle->m_vtable->get_flags)
+	{
+		return handle->m_vtable->get_flags(handle->m_engine);
+	}
+	return 0;
+}
+
 uint32_t scap_get_ndevs(scap_t* handle)
 {
 	if(handle->m_vtable)

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -95,6 +95,15 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtabl
 
 	ASSERT(vtable != NULL);
 
+	// Initialize the engine before the platform
+	//
+	// While the two would ideally be independent, the linux platform can delegate some
+	// functionality to an engine through a scap_linux_vtable (currently only the kmod
+	// engine provides this).
+	//
+	// The kmod hooks in the scap_linux_vtable need an initialized engine, since they call
+	// ioctls on the driver fd, so we need to initialize the engine before the platform.
+
 	rc = scap_init_engine(handle, oargs, vtable);
 	if(rc != SCAP_SUCCESS)
 	{

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -207,11 +207,6 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 		return scap_errprintf(handle->m_lasterr, 0, "failed to allocate platform data");
 	}
 
-	if((rc = scap_generic_init_platform(platform, handle->m_lasterr, oargs)) != SCAP_SUCCESS)
-	{
-		platform->m_vtable->free_platform(platform);
-		return rc;
-	}
 	handle->m_platform = platform;
 
 	rc = scap_init_int(handle, oargs, vtable);

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -48,7 +48,7 @@ const char* scap_getlasterr(scap_t* handle)
 	return handle ? handle->m_lasterr : "null scap handle";
 }
 
-int32_t scap_init_int(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable)
+int32_t scap_init_engine(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable)
 {
 	int32_t rc;
 
@@ -95,7 +95,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtabl
 
 	ASSERT(vtable != NULL);
 
-	rc = scap_init_int(handle, oargs, vtable);
+	rc = scap_init_engine(handle, oargs, vtable);
 	if(rc != SCAP_SUCCESS)
 	{
 		return rc;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -97,10 +97,6 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs)
 
 	memset(handle, 0, sizeof(*handle));
 
-	/* At the end of the `v-table` work we can use just one function
-	 * with an internal switch that selects the right vtable! For the moment
-	 * let's keep different functions.
-	 */
 #ifdef HAS_ENGINE_SAVEFILE
 	if(strcmp(engine_name, SAVEFILE_ENGINE) == 0)
 	{

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -850,6 +850,9 @@ int32_t scap_event_encode_params_v(struct scap_sized_buffer event_buf, size_t *e
 // Non public functions
 ///////////////////////////////////////////////////////////////////////////////
 
+// get the features supported by the engine (bitmask of ENGINE_FLAG_* flags)
+uint64_t scap_get_engine_flags(scap_t* handle);
+
 //
 // Return the number of event capture devices that the library is handling. Each processor
 // has its own event capture device.

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -495,8 +495,8 @@ scap_t* scap_alloc(void);
   If this function fails, the only thing you can safely do with the handle is to call
   \ref scap_deinit on it.
 */
-int32_t scap_init(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform);
-int32_t scap_handle_init_engine(scap_t* handle, scap_open_args* oargs);
+int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable,
+		  struct scap_platform* platform);
 
 /*!
   \brief Allocate and initialize a handle
@@ -517,7 +517,8 @@ int32_t scap_handle_init_engine(scap_t* handle, scap_open_args* oargs);
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open(scap_open_args* oargs, struct scap_platform* platform, char* error, int32_t* rc);
+scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform, char* error,
+		  int32_t* rc);
 
 /*!
   \brief Deinitialize a capture handle.

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -55,6 +55,7 @@ extern "C" {
 //
 typedef struct scap scap_t;
 typedef struct ppm_evt_hdr scap_evt;
+struct scap_vtable;
 
 //
 // Core types

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -55,6 +55,7 @@ extern "C" {
 //
 typedef struct scap scap_t;
 typedef struct ppm_evt_hdr scap_evt;
+struct scap_platform;
 struct scap_vtable;
 
 //
@@ -495,6 +496,8 @@ scap_t* scap_alloc(void);
   \ref scap_deinit on it.
 */
 int32_t scap_init(scap_t* handle, scap_open_args* oargs);
+struct scap_platform* scap_handle_alloc_platform(scap_t* handle, scap_open_args* oargs);
+int32_t scap_handle_init_engine(scap_t* handle, scap_open_args* oargs);
 
 /*!
   \brief Allocate and initialize a handle

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -495,8 +495,7 @@ scap_t* scap_alloc(void);
   If this function fails, the only thing you can safely do with the handle is to call
   \ref scap_deinit on it.
 */
-int32_t scap_init(scap_t* handle, scap_open_args* oargs);
-struct scap_platform* scap_handle_alloc_platform(scap_t* handle, scap_open_args* oargs);
+int32_t scap_init(scap_t* handle, scap_open_args* oargs, struct scap_platform* platform);
 int32_t scap_handle_init_engine(scap_t* handle, scap_open_args* oargs);
 
 /*!
@@ -518,7 +517,7 @@ int32_t scap_handle_init_engine(scap_t* handle, scap_open_args* oargs);
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open(scap_open_args* oargs, char *error, int32_t *rc);
+scap_t* scap_open(scap_open_args* oargs, struct scap_platform* platform, char* error, int32_t* rc);
 
 /*!
   \brief Deinitialize a capture handle.

--- a/userspace/libscap/scap_config.h.in
+++ b/userspace/libscap/scap_config.h.in
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#cmakedefine HAS_ENGINE_TEST_INPUT
+#cmakedefine HAS_ENGINE_NODRIVER
+#cmakedefine HAS_ENGINE_SAVEFILE
+#cmakedefine HAS_ENGINE_SOURCE_PLUGIN
+#cmakedefine HAS_ENGINE_UDIG
+#cmakedefine HAS_ENGINE_BPF
+#cmakedefine HAS_ENGINE_KMOD
+#cmakedefine HAS_ENGINE_MODERN_BPF
+#cmakedefine HAS_ENGINE_GVISOR

--- a/userspace/libscap/scap_engine_util.c
+++ b/userspace/libscap/scap_engine_util.c
@@ -48,3 +48,21 @@ int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time)
 	*boot_time = timespec_to_nsec(&wall_ts) - timespec_to_nsec(&boot_ts);
 	return SCAP_SUCCESS;
 }
+
+bool scap_get_bpf_stats_enabled()
+{
+	FILE* f;
+	if((f = fopen("/proc/sys/kernel/bpf_stats_enabled", "r")))
+	{
+		uint32_t bpf_stats_enabled = 0;
+		if(fscanf(f, "%u", &bpf_stats_enabled) == 1)
+		{
+			fclose(f);
+			return bpf_stats_enabled;
+		}
+
+		fclose(f);
+	}
+	return false;
+}
+

--- a/userspace/libscap/scap_engine_util.h
+++ b/userspace/libscap/scap_engine_util.h
@@ -34,3 +34,5 @@ limitations under the License.
  * - needs as much accuracy as we can get (otherwise eBPF event timestamps will be wrong)
  */
 int32_t scap_get_precise_boot_time(char* last_err, uint64_t *boot_time);
+
+bool scap_get_bpf_stats_enabled();

--- a/userspace/libscap/scap_engines.h
+++ b/userspace/libscap/scap_engines.h
@@ -19,6 +19,7 @@ limitations under the License.
 #pragma once
 
 #include "scap_vtable.h"
+#include "scap_config.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/userspace/libscap/scap_engines.h
+++ b/userspace/libscap/scap_engines.h
@@ -18,6 +18,10 @@ limitations under the License.
 
 #pragma once
 
+#ifndef SCAP_HANDLE_T
+#define SCAP_HANDLE_T void
+#endif
+
 #include "scap_vtable.h"
 #include "scap_config.h"
 

--- a/userspace/libscap/scap_engines.h
+++ b/userspace/libscap/scap_engines.h
@@ -20,6 +20,10 @@ limitations under the License.
 
 #include "scap_vtable.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef HAS_ENGINE_NODRIVER
 extern const struct scap_vtable scap_nodriver_engine;
 #endif
@@ -54,4 +58,8 @@ extern const struct scap_vtable scap_modern_bpf_engine;
 
 #ifdef HAS_ENGINE_TEST_INPUT
 extern const struct scap_vtable scap_test_input_engine;
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -81,7 +81,6 @@ extern "C"
 
 	typedef struct scap_open_args
 	{
-		scap_mode_t mode;					 ///< scap-mode required by the engine.
 		bool import_users;					 ///< true if the user list should be created when opening the capture.
 		interesting_ppm_sc_set ppm_sc_of_interest; ///< syscalls of interest.
                 falcosecurity_log_fn log_fn; //< Function which SCAP may use to log messages

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -83,8 +83,6 @@ extern "C"
 	{
 		const char* engine_name;				 ///< engine name ("kmod", "bpf", ...).
 		scap_mode_t mode;					 ///< scap-mode required by the engine.
-		proc_entry_callback proc_callback;			 ///< Callback to be invoked for each thread/fd that is extracted from /proc, or NULL if no callback is needed.
-		void* proc_callback_context;				 ///< Opaque pointer that will be included in the calls to proc_callback. Ignored if proc_callback is NULL.
 		bool import_users;					 ///< true if the user list should be created when opening the capture.
 		interesting_ppm_sc_set ppm_sc_of_interest; ///< syscalls of interest.
                 falcosecurity_log_fn log_fn; //< Function which SCAP may use to log messages

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -36,40 +36,6 @@ extern "C"
 #endif
 
 	/*!
-	  \brief Scap possible modes
-	*/
-	typedef enum
-	{
-		/*!
-		 * Default value that mostly exists so that sinsp can have a valid value
-		 * before it is initialized.
-		 */
-		SCAP_MODE_NONE = 0,
-		/*!
-		 * Read system call data from a capture file.
-		 */
-		SCAP_MODE_CAPTURE,
-		/*!
-		 * Read system call data from the underlying operating system.
-		 */
-		SCAP_MODE_LIVE,
-		/*!
-		 * Do not read system call data. If next is called, a dummy event is
-		 * returned.
-		 */
-		SCAP_MODE_NODRIVER,
-		/*!
-		 * Do not read system call data. Events come from the configured input plugin.
-		 */
-		SCAP_MODE_PLUGIN,
-		/*!
-		 * Read system call and event data from the test event generator.
-		 * Do not attempt to query the underlying system.
-		 */
-		SCAP_MODE_TEST,
-	} scap_mode_t;
-
-	/*!
 	 * \brief Argument for scap_open
 	 * Set any PPM_SC syscall idx to true to enable its tracing at driver level,
 	 * otherwise syscalls are not traced (so called "uninteresting syscalls").

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -81,7 +81,6 @@ extern "C"
 
 	typedef struct scap_open_args
 	{
-		const char* engine_name;				 ///< engine name ("kmod", "bpf", ...).
 		scap_mode_t mode;					 ///< scap-mode required by the engine.
 		bool import_users;					 ///< true if the user list should be created when opening the capture.
 		interesting_ppm_sc_set ppm_sc_of_interest; ///< syscalls of interest.

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -92,6 +92,13 @@ int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct
 		return SCAP_SUCCESS;
 	}
 
+	rc = scap_generic_init_platform(platform, lasterr, oargs);
+	if(rc != SCAP_SUCCESS)
+	{
+		scap_platform_close(platform);
+		return rc;
+	}
+
 	if(platform->m_vtable && platform->m_vtable->init_platform)
 	{
 		rc = platform->m_vtable->init_platform(platform, lasterr, engine, oargs);

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -26,9 +26,6 @@ int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr
 {
 	memset(&platform->m_machine_info, 0, sizeof(platform->m_machine_info));
 	memset(&platform->m_agent_info, 0, sizeof(platform->m_agent_info));
-	platform->m_proclist.m_proc_callback = oargs->proc_callback;
-	platform->m_proclist.m_proc_callback_context = oargs->proc_callback_context;
-	platform->m_proclist.m_proclist = NULL;
 
 	return SCAP_SUCCESS;
 }
@@ -67,7 +64,7 @@ struct scap_platform_vtable scap_generic_platform_vtable = {
 	.free_platform = scap_generic_free_platform,
 };
 
-struct scap_platform* scap_generic_alloc_platform()
+struct scap_platform* scap_generic_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
 	struct scap_platform* platform = calloc(sizeof(*platform), 1);
 
@@ -77,6 +74,11 @@ struct scap_platform* scap_generic_alloc_platform()
 	}
 
 	platform->m_vtable = &scap_generic_platform_vtable;
+
+	platform->m_proclist.m_proc_callback = proc_callback;
+	platform->m_proclist.m_proc_callback_context = proc_callback_context;
+	platform->m_proclist.m_proclist = NULL;
+
 	return platform;
 }
 

--- a/userspace/libscap/scap_platform.h
+++ b/userspace/libscap/scap_platform.h
@@ -25,6 +25,8 @@ limitations under the License.
 #endif
 #include "engine_handle.h"
 
+#include "scap_procs.h"
+
 // this header is designed to be useful to platform *users*
 
 #ifdef __cplusplus
@@ -36,16 +38,16 @@ struct scap_open_args;
 struct scap_platform;
 
 // allocate a generic platform handle with no behavior (no platform data is returned)
-struct scap_platform* scap_generic_alloc_platform();
+// Note: every platform alloc function needs to set up the proc_callback, since
+// this needs to be called before opening the engine; otherwise the proclist callback
+// won't be set up in time (for the savefile engine)
+struct scap_platform* scap_generic_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context);
 
 // initialize the common part of the platform handle
-// this needs to be called before opening the engine
-// as otherwise the proclist callback won't be set up in time
-// (for the savefile engine)
 int32_t scap_generic_init_platform(struct scap_platform* platform, char* lasterr, struct scap_open_args* oargs);
 
 // initialize a platform handle
-// this calls `init_platform` from the vtable
+// this calls `scap_generic_init_platform` and `init_platform` from the vtable
 int32_t scap_platform_init(struct scap_platform *platform, char *lasterr, struct scap_engine_handle engine,
 			   struct scap_open_args *oargs);
 

--- a/userspace/libscap/scap_stats_v2.h
+++ b/userspace/libscap/scap_stats_v2.h
@@ -32,11 +32,6 @@ extern "C" {
 #define STATS_NAME_MAX 512
 
 //
-// machine_info flags
-//
-#define PPM_BPF_STATS_ENABLED (1 << 0)
-
-//
 // scap_stats_v2 flags
 //
 #define PPM_SCAP_STATS_KERNEL_COUNTERS (1 << 0)

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -118,6 +118,8 @@ struct scap_savefile_vtable {
 	int64_t (*get_readfile_offset)(struct scap_engine_handle engine);
 };
 
+#define ENGINE_FLAG_BPF_STATS_ENABLED (1<<0)
+
 struct scap_vtable {
 	/**
 	 * @brief name of the engine
@@ -149,6 +151,13 @@ struct scap_vtable {
 	 * @return SCAP_SUCCESS or a failure code
 	 */
 	int32_t (*init)(scap_t* main_handle, scap_open_args* open_args);
+
+	/**
+	 * @brief get features supported by the engine
+	 * @param engine wraps the pointer to the engine-specific handle
+	 * @return a bitmask of ENGINE_FLAGS_*
+	 */
+	uint64_t (*get_flags)(struct scap_engine_handle engine);
 
 	/**
 	 * @brief free the engine-specific handle

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -126,12 +126,6 @@ struct scap_vtable {
 	 */
 	const char* name;
 
-	/**
-	 * @brief one of the SCAP_MODE_* constants, designating the purpose
-	 * of the engine (live capture, capture files, etc.)
-	 */
-	scap_mode_t mode;
-
 	const struct scap_savefile_vtable *savefile_ops;
 
 	/**

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 include_directories(./)
 include_directories(../common)
-include_directories(${LIBSCAP_INCLUDE_DIR})
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 include_directories(../async)
 include_directories(./include)
 include_directories(../plugin)

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #endif // _WIN32
 #include <csignal>
 #include <sinsp.h>
+#include <scap_engines.h>
 #include <functional>
 #include <memory>
 #include "util.h"
@@ -265,10 +266,17 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 		}
 	}
 
-	if(!engine_string.compare(KMOD_ENGINE))
+	if(false)
+	{
+
+	}
+#ifdef HAS_ENGINE_KMOD
+	else if(!engine_string.compare(KMOD_ENGINE))
 	{
 		inspector.open_kmod(buffer_bytes_dim, ppm_sc);
 	}
+#endif
+#ifdef HAS_ENGINE_BPF
 	else if(!engine_string.compare(BPF_ENGINE))
 	{
 		if(bpf_path.empty())
@@ -282,6 +290,8 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 		}
 		inspector.open_bpf(bpf_path.c_str(), buffer_bytes_dim, ppm_sc);
 	}
+#endif
+#ifdef HAS_ENGINE_SAVEFILE
 	else if(!engine_string.compare(SAVEFILE_ENGINE))
 	{
 		if(file_path.empty())
@@ -291,10 +301,13 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 		}
 		inspector.open_savefile(file_path.c_str(), 0);
 	}
+#endif
+#ifdef HAS_ENGINE_MODERN_BPF
 	else if(!engine_string.compare(MODERN_BPF_ENGINE))
 	{
 		inspector.open_modern_bpf(buffer_bytes_dim, DEFAULT_CPU_FOR_EACH_BUFFER, true, ppm_sc);
 	}
+#endif
 	else
 	{
 		std::cerr << "Unknown engine" << std::endl;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -642,11 +642,6 @@ void sinsp::open_nodriver(bool full_proc_scan)
 {
 #ifdef HAS_ENGINE_NODRIVER
 	scap_open_args oargs = factory_open_args(NODRIVER_ENGINE, SCAP_MODE_NODRIVER);
-	struct scap_nodriver_engine_params params;
-	params.full_proc_scan = full_proc_scan;
-
-	oargs.engine_params = &params;
-
 	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 	if(platform)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -464,7 +464,7 @@ void sinsp::set_import_users(bool import_users)
 /*=============================== OPEN METHODS ===============================*/
 
 void sinsp::open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform,
-			scap_mode_t mode)
+			sinsp_mode_t mode)
 {
 	g_logger.log("Trying to open the right engine!");
 
@@ -586,7 +586,7 @@ void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const libsinsp::eve
 		linux_plat->m_linux_vtable = &scap_kmod_linux_vtable;
 	}
 
-	open_common(&oargs, &scap_kmod_engine, platform, SCAP_MODE_LIVE);
+	open_common(&oargs, &scap_kmod_engine, platform, SINSP_MODE_LIVE);
 #else
 	throw sinsp_exception("KMOD engine is not supported in this build");
 #endif
@@ -613,7 +613,7 @@ void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_by
 	oargs.engine_params = &params;
 
 	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
-	open_common(&oargs, &scap_bpf_engine, platform, SCAP_MODE_LIVE);
+	open_common(&oargs, &scap_bpf_engine, platform, SINSP_MODE_LIVE);
 #else
 	throw sinsp_exception("BPF engine is not supported in this build");
 #endif
@@ -625,7 +625,7 @@ void sinsp::open_udig()
 	scap_open_args oargs {};
 
 	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
-	open_common(&oargs, &scap_udig_engine, platform, SCAP_MODE_LIVE);
+	open_common(&oargs, &scap_udig_engine, platform, SINSP_MODE_LIVE);
 
 #else
 	throw sinsp_exception("UDIG engine is not supported in this build");
@@ -651,7 +651,7 @@ void sinsp::open_nodriver(bool full_proc_scan)
 		platform = scap_generic_alloc_platform(::on_new_entry_from_proc, this);
 	}
 
-	open_common(&oargs, &scap_nodriver_engine, platform, SCAP_MODE_NODRIVER);
+	open_common(&oargs, &scap_nodriver_engine, platform, SINSP_MODE_NODRIVER);
 #else
 	throw sinsp_exception("NODRIVER engine is not supported in this build");
 #endif
@@ -697,13 +697,13 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 
 	// AFAICT this is because tinfo==NULL when calling the callback in scap_read_fdlist
 	struct scap_platform* platform = scap_savefile_alloc_platform(nullptr, nullptr);
-	open_common(&oargs, &scap_savefile_engine, platform, SCAP_MODE_CAPTURE);
+	open_common(&oargs, &scap_savefile_engine, platform, SINSP_MODE_CAPTURE);
 #else
 	throw sinsp_exception("SAVEFILE engine is not supported in this build");
 #endif
 }
 
-void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params, scap_mode_t mode)
+void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params, sinsp_mode_t mode)
 {
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
 	scap_open_args oargs {};
@@ -716,10 +716,10 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 	struct scap_platform* platform;
 	switch(mode)
 	{
-		case SCAP_MODE_PLUGIN:
+		case SINSP_MODE_PLUGIN:
 			platform = scap_generic_alloc_platform(::on_new_entry_from_proc, this);
 			break;
-		case SCAP_MODE_LIVE:
+		case SINSP_MODE_LIVE:
 			platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 			break;
 		default:
@@ -748,7 +748,7 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	oargs.engine_params = &params;
 
 	struct scap_platform* platform = scap_gvisor_alloc_platform(::on_new_entry_from_proc, this);
-	open_common(&oargs, &scap_gvisor_engine, platform, SCAP_MODE_LIVE);
+	open_common(&oargs, &scap_gvisor_engine, platform, SINSP_MODE_LIVE);
 
 	set_get_procs_cpu_from_driver(false);
 #else
@@ -773,13 +773,13 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	oargs.engine_params = &params;
 
 	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
-	open_common(&oargs, &scap_modern_bpf_engine, platform, SCAP_MODE_LIVE);
+	open_common(&oargs, &scap_modern_bpf_engine, platform, SINSP_MODE_LIVE);
 #else
 	throw sinsp_exception("MODERN_BPF engine is not supported in this build");
 #endif
 }
 
-void sinsp::open_test_input(scap_test_input_data* data, scap_mode_t mode)
+void sinsp::open_test_input(scap_test_input_data* data, sinsp_mode_t mode)
 {
 #ifdef HAS_ENGINE_TEST_INPUT
 	scap_open_args oargs {};
@@ -790,10 +790,10 @@ void sinsp::open_test_input(scap_test_input_data* data, scap_mode_t mode)
 	struct scap_platform* platform;
 	switch(mode)
 	{
-	case SCAP_MODE_TEST:
+	case SINSP_MODE_TEST:
 		platform = scap_test_input_alloc_platform(::on_new_entry_from_proc, this);
 		break;
-	case SCAP_MODE_LIVE:
+	case SINSP_MODE_LIVE:
 		platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 		break;
 	default:
@@ -928,7 +928,7 @@ void sinsp::close()
 	}
 
 	// unset the meta-event callback to all plugins that support it
-	if (!is_capture() && m_mode != SCAP_MODE_NONE)
+	if (!is_capture() && m_mode != SINSP_MODE_NONE)
 	{
 		std::string err;
 		// note(jasondellaluce,rohith-raju): for now the emscripten build does not support
@@ -956,7 +956,7 @@ void sinsp::close()
 		}
 	}
 
-	m_mode = SCAP_MODE_NONE;
+	m_mode = SINSP_MODE_NONE;
 }
 
 //

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include <sys/time.h>
 #endif // _WIN32
 
+#include "scap_config.h"
 #include "scap_open_exception.h"
 #include "sinsp.h"
 #include "sinsp_int.h"
@@ -577,6 +578,7 @@ static void fill_ppm_sc_of_interest(scap_open_args *oargs, const libsinsp::event
 
 void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
 {
+#ifdef HAS_ENGINE_KMOD
 	scap_open_args oargs = factory_open_args(KMOD_ENGINE, SCAP_MODE_LIVE);
 
 	/* Set interesting syscalls and tracepoints. */
@@ -587,10 +589,14 @@ void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const libsinsp::eve
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("KMOD engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_bytes_dim, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
 {
+#ifdef HAS_ENGINE_BPF
 	/* Validate the BPF path. */
 	if(bpf_path.empty())
 	{
@@ -608,26 +614,38 @@ void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_by
 	params.bpf_probe = bpf_path.data();
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("BPF engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_udig()
 {
+#ifdef HAS_ENGINE_UDIG
 	scap_open_args oargs = factory_open_args(UDIG_ENGINE, SCAP_MODE_LIVE);
 	open_common(&oargs);
+#else
+	throw sinsp_exception("UDIG engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_nodriver(bool full_proc_scan)
 {
+#ifdef HAS_ENGINE_NODRIVER
 	scap_open_args oargs = factory_open_args(NODRIVER_ENGINE, SCAP_MODE_NODRIVER);
 	struct scap_nodriver_engine_params params;
 	params.full_proc_scan = full_proc_scan;
 
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("NODRIVER engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_savefile(const std::string& filename, int fd)
 {
+#ifdef HAS_ENGINE_SAVEFILE
 	scap_open_args oargs = factory_open_args(SAVEFILE_ENGINE, SCAP_MODE_CAPTURE);
 	struct scap_savefile_engine_params params;
 
@@ -663,10 +681,14 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 	params.fbuffer_size = 0;
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("SAVEFILE engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugin_open_params, scap_mode_t mode)
 {
+#ifdef HAS_ENGINE_SOURCE_PLUGIN
 	scap_open_args oargs = factory_open_args(SOURCE_PLUGIN_ENGINE, mode);
 	struct scap_source_plugin_engine_params params;
 	set_input_plugin(plugin_name, plugin_open_params);
@@ -674,10 +696,14 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 	params.input_plugin_params = (char*)m_input_plugin_open_params.c_str();
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("SOURCE_PLUGIN engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_gvisor(const std::string& config_path, const std::string& root_path, bool no_events, int epoll_timeout)
 {
+#ifdef HAS_ENGINE_GVISOR
 	if(config_path.empty())
 	{
 		throw sinsp_exception("When you use the 'gvisor' engine you need to provide a path to the config file.");
@@ -693,10 +719,14 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	open_common(&oargs);
 
 	set_get_procs_cpu_from_driver(false);
+#else
+	throw sinsp_exception("GVISOR engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus_for_each_buffer, bool online_only, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest)
 {
+#ifdef HAS_ENGINE_MODERN_BPF
 	scap_open_args oargs = factory_open_args(MODERN_BPF_ENGINE, SCAP_MODE_LIVE);
 
 	/* Set interesting syscalls and tracepoints. */
@@ -710,10 +740,14 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	params.verbose = g_logger.has_output() && g_logger.is_enabled(sinsp_logger::severity::SEV_DEBUG);
 	oargs.engine_params = &params;
 	open_common(&oargs);
+#else
+	throw sinsp_exception("MODERN_BPF engine is not supported in this build");
+#endif
 }
 
 void sinsp::open_test_input(scap_test_input_data* data, scap_mode_t mode)
 {
+#ifdef HAS_ENGINE_TEST_INPUT
 	scap_open_args oargs = factory_open_args(TEST_INPUT_ENGINE, mode);
 	struct scap_test_input_engine_params params;
 	params.test_input_data = data;
@@ -721,6 +755,9 @@ void sinsp::open_test_input(scap_test_input_data* data, scap_mode_t mode)
 	open_common(&oargs);
 
 	set_get_procs_cpu_from_driver(false);
+#else
+	throw sinsp_exception("TEST_INPUT engine is not supported in this build");
+#endif
 }
 
 /*=============================== OPEN METHODS ===============================*/

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -472,11 +472,6 @@ void sinsp::open_common(scap_open_args* oargs, struct scap_platform* platform)
 	/* We need to save the actual mode and the engine used by the inspector. */
 	m_mode = oargs->mode;
 
-	if(oargs->mode != SCAP_MODE_CAPTURE)
-	{
-		oargs->proc_callback = ::on_new_entry_from_proc;
-		oargs->proc_callback_context = this;
-	}
 	oargs->import_users = m_usergroup_manager.m_import_users;
 	// We need to subscribe to container manager notifiers before
 	// scap starts scanning proc.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -193,6 +193,40 @@ public:
 	ppm_proclist_info* m_pli;
 };
 
+/*!
+  \brief Scap possible modes
+*/
+typedef enum
+{
+	/*!
+		 * Default value that mostly exists so that sinsp can have a valid value
+		 * before it is initialized.
+	 */
+	SCAP_MODE_NONE = 0,
+	/*!
+		 * Read system call data from a capture file.
+	 */
+	SCAP_MODE_CAPTURE,
+	/*!
+		 * Read system call data from the underlying operating system.
+	 */
+	SCAP_MODE_LIVE,
+	/*!
+		 * Do not read system call data. If next is called, a dummy event is
+		 * returned.
+	 */
+	SCAP_MODE_NODRIVER,
+	/*!
+		 * Do not read system call data. Events come from the configured input plugin.
+	 */
+	SCAP_MODE_PLUGIN,
+	/*!
+		 * Read system call and event data from the test event generator.
+		 * Do not attempt to query the underlying system.
+	 */
+	SCAP_MODE_TEST,
+} scap_mode_t;
+
 /** @defgroup inspector Main library
  @{
 */

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -194,7 +194,7 @@ public:
 };
 
 /*!
-  \brief Scap possible modes
+  \brief Sinsp possible modes
 */
 typedef enum
 {
@@ -202,30 +202,30 @@ typedef enum
 		 * Default value that mostly exists so that sinsp can have a valid value
 		 * before it is initialized.
 	 */
-	SCAP_MODE_NONE = 0,
+	SINSP_MODE_NONE = 0,
 	/*!
 		 * Read system call data from a capture file.
 	 */
-	SCAP_MODE_CAPTURE,
+	SINSP_MODE_CAPTURE,
 	/*!
 		 * Read system call data from the underlying operating system.
 	 */
-	SCAP_MODE_LIVE,
+	SINSP_MODE_LIVE,
 	/*!
 		 * Do not read system call data. If next is called, a dummy event is
 		 * returned.
 	 */
-	SCAP_MODE_NODRIVER,
+	SINSP_MODE_NODRIVER,
 	/*!
 		 * Do not read system call data. Events come from the configured input plugin.
 	 */
-	SCAP_MODE_PLUGIN,
+	SINSP_MODE_PLUGIN,
 	/*!
 		 * Read system call and event data from the test event generator.
 		 * Do not attempt to query the underlying system.
 	 */
-	SCAP_MODE_TEST,
-} scap_mode_t;
+	SINSP_MODE_TEST,
+} sinsp_mode_t;
 
 /** @defgroup inspector Main library
  @{
@@ -261,14 +261,14 @@ public:
 	virtual void open_nodriver(bool full_proc_scan = false);
 	virtual void open_savefile(const std::string &filename, int fd = 0);
 	virtual void open_plugin(const std::string& plugin_name, const std::string& plugin_open_params,
-				 scap_mode_t mode = SCAP_MODE_PLUGIN);
+				 sinsp_mode_t mode = SINSP_MODE_PLUGIN);
 	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, bool no_events = false, int epoll_timeout = -1);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.
 	 */
 	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});
-	virtual void open_test_input(scap_test_input_data* data, scap_mode_t mode = SCAP_MODE_TEST);
+	virtual void open_test_input(scap_test_input_data* data, sinsp_mode_t mode = SINSP_MODE_TEST);
 
 	void fseek(uint64_t filepos)
 	{
@@ -644,7 +644,7 @@ public:
 	*/
 	inline bool is_capture()
 	{
-		return m_mode == SCAP_MODE_CAPTURE;
+		return m_mode == SINSP_MODE_CAPTURE;
 	}
 
 	/*!
@@ -652,7 +652,7 @@ public:
 	*/
 	inline bool is_offline()
 	{
-		return is_capture() || m_mode == SCAP_MODE_TEST;
+		return is_capture() || m_mode == SINSP_MODE_TEST;
 	}
 
 	/*!
@@ -660,7 +660,7 @@ public:
 	*/
 	inline bool is_live()
 	{
-		return m_mode == SCAP_MODE_LIVE;
+		return m_mode == SINSP_MODE_LIVE;
 	}
 
 	/*!
@@ -668,7 +668,7 @@ public:
 	*/
 	inline bool is_nodriver()
 	{
-		return m_mode == SCAP_MODE_NODRIVER;
+		return m_mode == SINSP_MODE_NODRIVER;
 	}
 
 	/*!
@@ -676,7 +676,7 @@ public:
 	*/
 	inline bool is_plugin()
 	{
-		return m_mode == SCAP_MODE_PLUGIN && m_input_plugin != nullptr;
+		return m_mode == SINSP_MODE_PLUGIN && m_input_plugin != nullptr;
 	}
 
 	/*!
@@ -1061,7 +1061,7 @@ public:
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);
-	void set_mode(scap_mode_t value)
+	void set_mode(sinsp_mode_t value)
 	{
 		m_mode = value;
 	}
@@ -1075,7 +1075,7 @@ private:
 
 	void set_input_plugin(const std::string& name, const std::string& params);
 	void open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform,
-			 scap_mode_t mode);
+			 sinsp_mode_t mode);
 	void init();
 	void deinit_state();
 	void consume_initialstate_events();
@@ -1128,7 +1128,7 @@ private:
 	scap_t* m_h;
 	uint64_t m_nevts;
 	int64_t m_filesize;
-	scap_mode_t m_mode = SCAP_MODE_NONE;
+	sinsp_mode_t m_mode = SINSP_MODE_NONE;
 
 	// If non-zero, reading from this fd and m_input_filename contains "fd
 	// <m_input_fd>". Otherwise, reading from m_input_filename.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1042,7 +1042,7 @@ private:
 #endif
 
 	void set_input_plugin(const std::string& name, const std::string& params);
-	void open_common(scap_open_args* oargs, struct scap_platform* platform);
+	void open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform);
 	void init();
 	void deinit_state();
 	void consume_initialstate_events();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -241,8 +241,6 @@ public:
 		scap_fseek(m_h, filepos);
 	}
 
-	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);
-
 	std::string generate_gvisor_config(std::string socket_path);
 
 
@@ -1042,7 +1040,8 @@ private:
 #endif
 
 	void set_input_plugin(const std::string& name, const std::string& params);
-	void open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform);
+	void open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform,
+			 scap_mode_t mode);
 	void init();
 	void deinit_state();
 	void consume_initialstate_events();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1042,7 +1042,7 @@ private:
 #endif
 
 	void set_input_plugin(const std::string& name, const std::string& params);
-	void open_common(scap_open_args* oargs);
+	void open_common(scap_open_args* oargs, struct scap_platform* platform);
 	void init();
 	void deinit_state();
 	void consume_initialstate_events();

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -138,8 +138,10 @@ TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo)
 	tinfo->m_pid = 51003;
 	tinfo->m_ptid = 51004; /* we won't find it in the table, so we will default to 1 */
 
-	auto tginfo = std::make_shared<thread_group_info>(tinfo->m_pid, false, tinfo);
-	m_inspector.m_thread_manager->set_thread_group_info(tinfo->m_pid, tginfo);
+	{
+		auto tginfo = std::make_shared<thread_group_info>(tinfo->m_pid, false, tinfo);
+		m_inspector.m_thread_manager->set_thread_group_info(tinfo->m_pid, tginfo);
+	}
 
 	auto other_tinfo = std::make_shared<sinsp_threadinfo>();
 	other_tinfo->m_tid = 51003;

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -56,7 +56,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_null_pointer)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
+	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo.reset();
@@ -71,7 +71,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_invalid_tinfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
+	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 4;
@@ -89,7 +89,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_tginfo_already_there)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
+	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 4;
@@ -110,7 +110,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_new_tginfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
+	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 51000;
@@ -131,7 +131,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
+	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 51000;

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -56,7 +56,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_null_pointer)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_NODRIVER);
+	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo.reset();
@@ -71,7 +71,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_invalid_tinfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_NODRIVER);
+	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 4;
@@ -89,7 +89,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_tginfo_already_there)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_NODRIVER);
+	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 4;
@@ -110,7 +110,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_new_tginfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_NODRIVER);
+	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 51000;
@@ -131,7 +131,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo)
 	struct scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
-	m_inspector.open_test_input(&data, SCAP_MODE_NODRIVER);
+	m_inspector.open_test_input(&data, SCAP_MODE_TEST);
 
 	auto tinfo = std::make_shared<sinsp_threadinfo>();
 	tinfo->m_tid = 51000;

--- a/userspace/libsinsp/test/events_evt.ut.cpp
+++ b/userspace/libsinsp/test/events_evt.ut.cpp
@@ -70,7 +70,7 @@ TEST_F(sinsp_with_test_input, event_hostname)
 
 	add_default_init_thread();
 
-	open_inspector(SCAP_MODE_LIVE);
+	open_inspector(SINSP_MODE_LIVE);
 	sinsp_evt *evt = NULL;
 
 	/* Toy event example from a previous test. */

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -58,7 +58,7 @@ protected:
 
 	sinsp m_inspector;
 
-	void open_inspector(scap_mode_t mode = SCAP_MODE_TEST) {
+	void open_inspector(sinsp_mode_t mode = SINSP_MODE_TEST) {
 		m_inspector.open_test_input(m_test_data.get(), mode);
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR continues the work of decoupling libscap from platform code. The motivation is to (eventually):
* move all the parsing/data structure heavy code to C++
* strip down libscap to the bare essentials for getting events
* remove code duplication for platform data structures (scap_threadinfo vs sinsp_threadinfo etc.)
* kill uthash :)

Baby steps though, this PR moves the code responsible for engine/platform selection to libsinsp (in particular, sinsp::open_* methods). All the platform code still lives in libscap for the time being.

I'm planning some follow up PRs (though this one feels okay as a standalone submission too):
* make sinsp own the m_platform pointer (remove it from scap_t)
* make savefile code independent of platform specifics (delegate platform data save/load to platforms)
* build a C++ interface to the platform code
* move over the platform code to sinsp (with no substantial modifications)
* actually rewrite into C++; this is probably going to take a while :)

All but the last one are more or less done, for the actual rewrite I have some sketches but not yet finished code as I'd rather avoid rebasing the inevitable giant patch set over and over :)

In the end, I see the platform class as owning ~all the syscall parser code, with e.g. container/k8s support building on top of that. It's going to substantially change the center of gravity of libsinsp, which would become a pipeline for events into various "plugins" (using the term very loosely), but also enables us to e.g. support non-Linux OSes cleanly.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This PR does not affect any sinsp APIs but does affect scap. Not sure whether we consider this an API change: does anybody use raw libscap in the real world?

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
BREAKING CHANGE: scap_init (and related functions) no longer initialize the platform
BREAKING CHANGE: scap_mode_t and its values are now renamed to sinsp_mode_t and SINSP_MODE_*
```
