### PR TITLE
fix(modern): perform an exact check on `BPF_TRACE_RAW_TP` attach type

### DIFF
--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -175,10 +175,10 @@ int pman_init_state(falcosecurity_log_fn log_fn, unsigned long buf_bytes_dim, ui
 
 int pman_get_required_buffers() { return g_state.n_required_buffers; }
 
-static char byte_array[] = "BPF_TRACE_RAW_TP";
-
 bool check_location(const char* path)
 {
+	static const char bpf_trace_raw_byte_array[] = "BPF_TRACE_RAW_TP";
+
 	bool res = false;
 
 	// On success `faccessat` returns 0.
@@ -230,10 +230,10 @@ bool check_location(const char* path)
 	int z = 0;
 	for(int j = 0; j< sz; j++)
 	{
-		if(file_content[j] == byte_array[z])
+		if(file_content[j] == bpf_trace_raw_byte_array[z])
 		{
 			z++;
-			if(z == sizeof(byte_array) / sizeof(*byte_array))
+			if(z == sizeof(bpf_trace_raw_byte_array) / sizeof(*bpf_trace_raw_byte_array))
 			{
 				res = true;
 				break;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR performs a more detailed check on the `BPF_TRACE_RAW_TP` attach type. Actual `libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_TRACING, NULL)` checks for the `BPF_TRACE_FENTRY` attach type presence, while we need to check for the `BPF_TRACE_RAW_TP` one. If `BPF_TRACE_FENTRY` is defined we are sure `BPF_TRACE_RAW_TP` is defined as well, in all other cases, we need to search for it in the `vmlinux` file.

**Which issue(s) this PR fixes**:

See https://github.com/falcosecurity/falco/issues/2792

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(modern): perform an exact check on `BPF_TRACE_RAW_TP` attach type
```
