### PR TITLE
refactor(userspace/libsinsp): remove g_filterlist

### DIFF
--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -50,7 +50,6 @@ extern "C" {
 using namespace std;
 
 extern vector<chiseldir_info>* g_chisel_dirs;
-extern sinsp_filter_check_list g_filterlist;
 extern sinsp_evttables g_infotables;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -52,6 +52,11 @@ using namespace std;
 extern vector<chiseldir_info>* g_chisel_dirs;
 extern sinsp_evttables g_infotables;
 
+// todo(jasondellaluce): this list is static and prevents chisels from using
+// plugin-defined extraction fields. The right way would be to have a filtercheck
+// list owned by each chisel itself and populate depending on the loaded plugins.
+static sinsp_filter_check_list s_filterlist;
+
 ///////////////////////////////////////////////////////////////////////////////
 // For Lua debugging
 ///////////////////////////////////////////////////////////////////////////////
@@ -221,11 +226,11 @@ void chiselinfo::set_formatter(string formatterstr)
 
 	if(formatterstr == "" || formatterstr == "default")
 	{
-		m_formatter = new sinsp_evt_formatter(m_inspector, DEFAULT_OUTPUT_STR);
+		m_formatter = new sinsp_evt_formatter(m_inspector, DEFAULT_OUTPUT_STR, s_filterlist);
 	}
 	else
 	{
-		m_formatter = new sinsp_evt_formatter(m_inspector, formatterstr);
+		m_formatter = new sinsp_evt_formatter(m_inspector, formatterstr, s_filterlist);
 	}
 }
 

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -55,9 +55,13 @@ extern "C" {
 using namespace std;
 
 extern vector<chiseldir_info>* g_chisel_dirs;
-extern sinsp_filter_check_list g_filterlist;
 extern sinsp_evttables g_infotables;
 void lua_stackdump(lua_State *L);
+
+// todo(jasondellaluce): this list is static and prevents chisels from using
+// plugin-defined extraction fields. The right way would be to have a filtercheck
+// list owned by each chisel itself and populate depending on the loaded plugins.
+static sinsp_filter_check_list s_filterlist;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Lua callbacks
@@ -321,7 +325,7 @@ int lua_cbacks::request_field(lua_State *ls)
 		throw sinsp_exception("chisel error");
 	}
 
-	sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(fld,
+	sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(fld,
 		inspector,
 		false);
 

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -25,6 +25,11 @@ using namespace std;
 
 extern sinsp_evttables g_infotables;
 
+// todo(jasondellaluce): this list is static and prevents chisels from using
+// plugin-defined extraction fields. The right way would be to have a filtercheck
+// list owned by each chisel itself and populate depending on the loaded plugins.
+static sinsp_filter_check_list s_filterlist;
+
 //
 //
 // Table sorter functor
@@ -162,7 +167,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 
 	for(auto vit : *entries)
 	{
-		sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth), 
+		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth), 
 			m_inspector,
 			false);
 
@@ -204,7 +209,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 	}
 	else
 	{
-		sinsp_filter_check* chk = g_filterlist.new_filter_check_from_fldname("util.cnt", 
+		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname("util.cnt", 
 			m_inspector,
 			false);
 

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -339,39 +339,6 @@ bool sinsp_evt_formatter::tostring(sinsp_evt* evt, OUT std::string* res)
 	return tostring_withformat(evt, *res, m_output_format);
 }
 
-sinsp_evt_formatter_cache::sinsp_evt_formatter_cache(sinsp *inspector)
-	: m_inspector(inspector)
-{
-}
-
-sinsp_evt_formatter_cache::~sinsp_evt_formatter_cache()
-{
-}
-
-std::shared_ptr<sinsp_evt_formatter>& sinsp_evt_formatter_cache::get_cached_formatter(std::string &format)
-{
-	auto it = m_formatter_cache.lower_bound(format);
-
-	if(it == m_formatter_cache.end() ||
-	   it->first != format)
-	{
-		it = m_formatter_cache.emplace_hint(it,
-						    std::make_pair(format, std::make_shared<sinsp_evt_formatter>(m_inspector, format)));
-	}
-
-	return it->second;
-}
-
-bool sinsp_evt_formatter_cache::resolve_tokens(sinsp_evt *evt, std::string &format, std::map<std::string,std::string>& values)
-{
-	return get_cached_formatter(format)->resolve_tokens(evt, values);
-}
-
-bool sinsp_evt_formatter_cache::tostring(sinsp_evt *evt, std::string &format, OUT std::string *res)
-{
-	return get_cached_formatter(format)->tostring(evt, *res);
-}
-
 sinsp_evt_formatter_factory::sinsp_evt_formatter_factory(sinsp *inspector, filter_check_list &available_checks)
 	: m_inspector(inspector),
 	  m_available_checks(available_checks),

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -117,38 +117,6 @@ private:
 	Json::FastWriter m_writer;
 };
 
-/*!
-  \brief Caching version of sinsp_evt_formatter
-  This class is a wrapper around sinsp_evt_formatter, maintaining a
-  cache of previously seen formatters. It avoids the overhead of
-  recreating sinsp_evt_formatter objects for each event.
-*/
-class SINSP_PUBLIC sinsp_evt_formatter_cache
-{
-public:
-	sinsp_evt_formatter_cache(sinsp *inspector);
-	virtual ~sinsp_evt_formatter_cache();
-
-	// Resolve the tokens inside format and return them as a key/value map.
-	// Creates a new sinsp_evt_formatter object if necessary.
-	bool resolve_tokens(sinsp_evt *evt, std::string &format, std::map<std::string,std::string>& values);
-
-	// Fills in res with the event formatted according to
-	// format. Creates a new sinsp_evt_formatter object if
-	// necessary.
-	bool tostring(sinsp_evt *evt, std::string &format, OUT std::string *res);
-
-private:
-
-	// Get the formatter for this format string. Creates a new
-	// sinsp_evt_formatter object if necessary.
-	std::shared_ptr<sinsp_evt_formatter>& get_cached_formatter(std::string &format);
-
-	std::map<std::string,std::shared_ptr<sinsp_evt_formatter>> m_formatter_cache;
-	sinsp *m_inspector;
-};
-/*@}*/
-
 class sinsp_evt_formatter_factory : public gen_event_formatter_factory
 {
 public:

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -48,9 +48,9 @@ public:
 	   as the one of the output in Falco rules, so refer to the Falco
 	   documentation for details.
 	*/
-	sinsp_evt_formatter(sinsp* inspector, filter_check_list &available_checks = g_filterlist);
+	sinsp_evt_formatter(sinsp* inspector, filter_check_list &available_checks);
 
-	sinsp_evt_formatter(sinsp* inspector, const std::string& fmt, filter_check_list &available_checks = g_filterlist);
+	sinsp_evt_formatter(sinsp* inspector, const std::string& fmt, filter_check_list &available_checks);
 
 	void set_format(gen_event_formatter::output_format of, const std::string& fmt) override;
 
@@ -120,7 +120,7 @@ private:
 class sinsp_evt_formatter_factory : public gen_event_formatter_factory
 {
 public:
-	sinsp_evt_formatter_factory(sinsp *inspector, filter_check_list &available_checks=g_filterlist);
+	sinsp_evt_formatter_factory(sinsp *inspector, filter_check_list &available_checks);
 	virtual ~sinsp_evt_formatter_factory();
 
 	void set_output_format(gen_event_formatter::output_format of) override;

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -55,12 +55,13 @@ static bool ppm_sc_modifies_state = false;
 static bool ppm_sc_repair_state = false;
 static bool ppm_sc_state_remove_io_sc = false;
 static bool enable_glogger = false;
-string engine_string = KMOD_ENGINE; /* Default for backward compatibility. */
-string filter_string = "";
-string file_path = "";
-string bpf_path = "";
-unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
+static string engine_string = KMOD_ENGINE; /* Default for backward compatibility. */
+static string filter_string = "";
+static string file_path = "";
+static string bpf_path = "";
+static unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
 static uint64_t max_events = UINT64_MAX;
+static sinsp_filter_check_list s_filterlist;
 
 sinsp_evt* get_event(sinsp& inspector, std::function<void(const std::string&)> handle_error);
 
@@ -413,9 +414,9 @@ int main(int argc, char** argv)
 
 	inspector.start_capture();
 
-	default_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, default_output);
-	process_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, process_output);
-	net_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, net_output);
+	default_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, default_output, s_filterlist);
+	process_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, process_output, s_filterlist);
+	net_formatter = std::make_unique<sinsp_evt_formatter>(&inspector, net_output, s_filterlist);
 
 	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 	uint64_t num_events = 0;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1577,7 +1577,7 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 		const std::string& fltstr,
 		bool ttable_only)
 {
-	m_factory.reset(new sinsp_filter_factory(inspector));
+	m_factory.reset(new sinsp_filter_factory(inspector, m_default_filterlist));
 	m_filter = NULL;
 	m_flt_str = fltstr;
 	m_flt_ast = NULL;

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -22,7 +22,6 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-
 #include "filter_check_list.h"
 #include "gen_filter.h"
 #include "filter/parser.h"
@@ -133,6 +132,7 @@ private:
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 	const libsinsp::filter::ast::expr* m_flt_ast;
 	std::shared_ptr<gen_event_filter_factory> m_factory;
+	sinsp_filter_check_list m_default_filterlist;
 
 	friend class sinsp_evt_formatter;
 };
@@ -142,7 +142,7 @@ private:
 class sinsp_filter_factory : public gen_event_filter_factory
 {
 public:
-	sinsp_filter_factory(sinsp *inspector, filter_check_list &available_checks=g_filterlist);
+	sinsp_filter_factory(sinsp *inspector, filter_check_list &available_checks);
 
 	virtual ~sinsp_filter_factory();
 

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -51,5 +51,3 @@ public:
 	virtual ~sinsp_filter_check_list();
 };
 
-// This is the "default" filter check list
-extern sinsp_filter_check_list g_filterlist;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1952,11 +1952,6 @@ scap_stats_v2* sinsp::get_sinsp_stats_v2_buffer()
 	return m_sinsp_stats_v2;
 }
 
-void sinsp::get_filtercheck_fields_info(OUT std::vector<const filter_check_info*>& list)
-{
-	sinsp_utils::get_filtercheck_fields_info(list);
-}
-
 sinsp_filter_check* sinsp::new_generic_filtercheck()
 {
 	return new sinsp_filter_check_gen_event();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -469,12 +469,6 @@ public:
 	void autodump_stop();
 
 	/*!
-	  \brief Populate the given vector with the full list of filter check fields
-	   that this version of the library supports.
-	*/
-	static void get_filtercheck_fields_info(std::vector<const filter_check_info*>& list);
-
-	/*!
 	  \brief Returns a new instance of a filtercheck supporting fields for
 	  a generic event source (e.g. evt.num, evt.time, evt.pluginname...)
 	*/

--- a/userspace/libsinsp/test/eventformatter.ut.cpp
+++ b/userspace/libsinsp/test/eventformatter.ut.cpp
@@ -30,8 +30,9 @@ using namespace std;
 TEST(eventformatter, get_field_names)
 {
 	auto inspector = new sinsp();
+	sinsp_filter_check_list filterlist;
 	string output = "this is a sample output %proc.name %fd.type %proc.pid";
-	sinsp_evt_formatter fmt(inspector, output);
+	sinsp_evt_formatter fmt(inspector, output, filterlist);
 	vector<string> output_fields;
 	fmt.get_field_names(output_fields);
 	ASSERT_EQ(output_fields.size(), 3);

--- a/userspace/libsinsp/test/filter_compiler.h
+++ b/userspace/libsinsp/test/filter_compiler.h
@@ -25,7 +25,8 @@ limitations under the License.
 // passing a NULL out pointer means expecting a failure
 static void filter_compile(sinsp_filter **out, std::string filter)
 {
-	std::shared_ptr<gen_event_filter_factory> factory(new sinsp_filter_factory(NULL));
+	sinsp_filter_check_list flist;
+	std::shared_ptr<gen_event_filter_factory> factory(new sinsp_filter_factory(NULL, flist));
 	sinsp_filter_compiler compiler(factory, filter);
 	try
 	{

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -252,13 +252,13 @@ TEST_F(sinsp_with_test_input, plugin_syscall_source)
 	ASSERT_EQ(evt->get_source_idx(), syscall_source_idx);
 	ASSERT_EQ(evt->get_tid(), (uint64_t) 1);
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
-	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
-	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/tmp");
-	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "the_file");
-	ASSERT_EQ(get_field_as_string(evt, "sample.is_open"), "1");
-	ASSERT_FALSE(field_has_value(evt, "sample.open_count"));
-	ASSERT_FALSE(field_has_value(evt, "sample.evt_count"));
-	ASSERT_EQ(get_field_as_string(evt, "sample.tick"), "false");
+	ASSERT_EQ(get_field_as_string(evt, "fd.name", filterlist), "/tmp/the_file");
+	ASSERT_EQ(get_field_as_string(evt, "fd.directory", filterlist), "/tmp");
+	ASSERT_EQ(get_field_as_string(evt, "fd.filename", filterlist), "the_file");
+	ASSERT_EQ(get_field_as_string(evt, "sample.is_open", filterlist), "1");
+	ASSERT_FALSE(field_has_value(evt, "sample.open_count", filterlist));
+	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", filterlist));
+	ASSERT_EQ(get_field_as_string(evt, "sample.tick", filterlist), "false");
 
 	// We check that the plugin don't produce other events but just 1
 	size_t metaevt_count = 0;
@@ -289,9 +289,9 @@ TEST_F(sinsp_with_test_input, plugin_custom_source)
 	ASSERT_EQ(evt->get_source_idx(), 1);
 	ASSERT_EQ(evt->get_tid(), (uint64_t) -1);
 	ASSERT_EQ(std::string(evt->get_source_name()), src_pl->event_source());
-	ASSERT_FALSE(field_has_value(evt, "fd.name"));
-	ASSERT_EQ(get_field_as_string(evt, "evt.pluginname"), src_pl->name());
-	ASSERT_EQ(get_field_as_string(evt, "sample.hello"), "hello world");
+	ASSERT_FALSE(field_has_value(evt, "fd.name", filterlist));
+	ASSERT_EQ(get_field_as_string(evt, "evt.pluginname", filterlist), src_pl->name());
+	ASSERT_EQ(get_field_as_string(evt, "sample.hello", filterlist), "hello world");
 	ASSERT_EQ(next_event(), nullptr); // EOF is expected
 }
 
@@ -449,7 +449,6 @@ TEST_F(sinsp_with_test_input, plugin_syscall_async)
 	add_plugin_filterchecks(&m_inspector, ext_pl, srcname, filterlist);
 
 	// check that the async event name is an accepted evt.type value
-	sinsp_filter_check_list filterlist;
 	std::unique_ptr<sinsp_filter_check> chk(filterlist.new_filter_check_from_fldname("evt.type", &m_inspector, false));
 	ASSERT_GT(chk->parse_field_name("evt.type", true, false), 0);
 	ASSERT_NO_THROW(chk->add_filter_value("openat", strlen("openat") + 1, 0));
@@ -486,12 +485,12 @@ TEST_F(sinsp_with_test_input, plugin_syscall_async)
 		{
 			ASSERT_GE(evt->get_ts(), last_ts);
 		}
-		ASSERT_FALSE(field_has_value(evt, "evt.pluginname")); // not available for "syscall" async events
-		ASSERT_FALSE(field_has_value(evt, "evt.plugininfo"));
-		ASSERT_EQ(get_field_as_string(evt, "evt.is_async"), "true");
-		ASSERT_EQ(get_field_as_string(evt, "evt.asynctype"), "sampleticker");
-		ASSERT_EQ(get_field_as_string(evt, "evt.type"), "sampleticker");
-		ASSERT_EQ(get_field_as_string(evt, "sample.tick"), "true");
+		ASSERT_FALSE(field_has_value(evt, "evt.pluginname", filterlist)); // not available for "syscall" async events
+		ASSERT_FALSE(field_has_value(evt, "evt.plugininfo", filterlist));
+		ASSERT_EQ(get_field_as_string(evt, "evt.is_async", filterlist), "true");
+		ASSERT_EQ(get_field_as_string(evt, "evt.asynctype", filterlist), "sampleticker");
+		ASSERT_EQ(get_field_as_string(evt, "evt.type", filterlist), "sampleticker");
+		ASSERT_EQ(get_field_as_string(evt, "sample.tick", filterlist), "true");
 		last_ts = evt->get_ts();
 	}
 	m_inspector.close();

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -365,7 +365,12 @@ protected:
 
 	// Return true if `field_name` exists in the filtercheck list.
 	// The field value could also be NULL, but in this method, we are not interested in the value.
-	bool field_exists(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = m_default_filterlist)
+	bool field_exists(sinsp_evt *evt, const std::string& field_name)
+	{
+		return field_exists(evt, field_name, m_default_filterlist);
+	}
+
+	bool field_exists(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");
@@ -375,7 +380,12 @@ protected:
 	}
 
 	// Return true if `field_name` value is not NULL for this event.
-	bool field_has_value(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = g_filterlist)
+	bool field_has_value(sinsp_evt *evt, const std::string& field_name)
+	{
+		return field_has_value(evt, field_name, m_default_filterlist);
+	}
+
+	bool field_has_value(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");
@@ -392,7 +402,12 @@ protected:
 		return chk->extract(evt, values);
 	}
 
-	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = m_default_filterlist)
+	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name)
+	{
+		return get_field_as_string(evt, field_name, m_default_filterlist);
+	}
+
+	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -365,7 +365,7 @@ protected:
 
 	// Return true if `field_name` exists in the filtercheck list.
 	// The field value could also be NULL, but in this method, we are not interested in the value.
-	bool field_exists(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = g_filterlist)
+	bool field_exists(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = m_default_filterlist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");
@@ -392,7 +392,7 @@ protected:
 		return chk->extract(evt, values);
 	}
 
-	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = g_filterlist)
+	std::string get_field_as_string(sinsp_evt *evt, const std::string& field_name, filter_check_list& flist = m_default_filterlist)
 	{
 		if (evt == nullptr) {
 			throw sinsp_exception("The event class is NULL");
@@ -427,6 +427,7 @@ protected:
 	std::vector<scap_threadinfo> m_threads;
 	std::vector<std::vector<scap_fdinfo>> m_fdinfos;
 	std::vector<scap_test_fdinfo_data> m_test_fdinfo_data;
+	sinsp_filter_check_list m_default_filterlist;
 
 	uint64_t m_test_timestamp;
 	uint64_t m_last_recorded_timestamp;

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -819,11 +819,6 @@ const struct ppm_param_info* sinsp_utils::find_longest_matching_evt_param(std::s
 	return res;
 }
 
-void sinsp_utils::get_filtercheck_fields_info(OUT std::vector<const filter_check_info*>& list)
-{
-	g_filterlist.get_all_fields(list);
-}
-
 uint64_t sinsp_utils::get_current_time_ns()
 {
     struct timeval tv;

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -70,7 +70,6 @@ limitations under the License.
 sinsp_evttables g_infotables;
 sinsp_logger g_logger;
 sinsp_initializer g_initializer;
-sinsp_filter_check_list g_filterlist;
 sinsp_protodecoder_list g_decoderlist;
 
 //

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -108,11 +108,6 @@ public:
 	//
 	static const struct ppm_param_info* find_longest_matching_evt_param(std::string name);
 
-	//
-	// Get the list of filtercheck fields
-	//
-	static void get_filtercheck_fields_info(std::vector<const filter_check_info*>& list);
-
 	static uint64_t get_current_time_ns();
 
 	static bool glob_match(const char *pattern, const char *string);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This removes `g_filterlist` from the codebase. It has not been used by Falco since one year, and its existence is now effectively wrong considering the plugin system due to which filtercheck lists are now dynamic. Having a static global list is also wrong for memory allocation guarantees, is error prone, and pollutes many API methods of libsinsp.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp): remove g_filterlist
```
