### PR TITLE
fix(driver): fixed build against linux 6.6.

### DIFF
--- a/.github/workflows/latest-kernel.yml
+++ b/.github/workflows/latest-kernel.yml
@@ -31,6 +31,7 @@ jobs:
           cd linux/
           echo "kernelversion: 1" > dk.yaml
           echo "architecture: amd64" >> dk.yaml
+          echo "driverversion: ${{ github.sha }}" >> dk.yaml
           echo "output:" >> dk.yaml
           echo "  module: mod.ko" >> dk.yaml
           echo "  probe: probe.o" >> dk.yaml

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2839,7 +2839,6 @@ FILLER(execve_extra_tail_1, true)
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
-	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
 #else
 	time = _READ(inode->i_ctime);
 #endif
@@ -6695,7 +6694,6 @@ FILLER(sched_prog_exec_4, false)
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
-	time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED; // See https://elixir.bootlin.com/linux/v6.6-rc1/source/include/linux/fs.h#L1544
 #else
 	time = _READ(inode->i_ctime);
 #endif

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -586,13 +586,6 @@
 #define FMODE_CREATED		(/*(__force fmode_t) */0x100000)
 
 //////////////////////////
-// ctime flags
-//////////////////////////
-
-/* `include/linux/fs.h` from kernel source tree. */
-#define I_CTIME_QUERIED		(1L<<30)
-
-//////////////////////////
 // flock flags
 //////////////////////////
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -222,7 +222,6 @@ int BPF_PROG(t1_sched_p_exec,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -286,7 +286,6 @@ int BPF_PROG(t1_execve_x,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -302,7 +302,6 @@ int BPF_PROG(t1_execveat_x,
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
 		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
-		time.tv_nsec = time.tv_nsec & ~I_CTIME_QUERIED;
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf
/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fixes build against linux 6.6, partly reverting https://github.com/falcosecurity/libs/pull/1349.
The kernel changes that https://github.com/falcosecurity/libs/pull/1349 addressed were dropped at the `rc3` kernel stage, and we do not need them anymore (https://www.phoronix.com/news/Linux-Revert-MG-Timestamps).
We are not at kernel rc6, therefore we expect the 6.6 release next week and no further breaking changes.
Basically, `I_CTIME_QUERIED` disappeared from kernel sources at `rc3`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): fixed build against linux 6.6.
```
