### PR TITLE
cleanup(scap,sinsp): return event flags directly

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -240,10 +240,11 @@ void event_test::disable_capture()
 void event_test::clear_ring_buffers()
 {
 	uint16_t cpu_id = 0;
+	uint32_t flags = 0;
 	/* First timeout means that all the buffers are empty. If the capture is not
 	 * stopped it is possible that we will never receive a `SCAP_TIMEOUT`.
 	 */
-	while(scap_next(s_scap_handle, (scap_evt**)&m_event_header, &cpu_id) != SCAP_TIMEOUT)
+	while(scap_next(s_scap_handle, (scap_evt**)&m_event_header, &cpu_id, &flags) != SCAP_TIMEOUT)
 	{
 	}
 }
@@ -253,11 +254,12 @@ struct ppm_evt_hdr* event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
 	struct ppm_evt_hdr* hdr = NULL;
 	uint16_t attempts = 0;
 	int32_t res = 0;
+	uint32_t flags = 0;
 
 	/* Try 2 times just to be sure that all the buffers are empty. */
 	while(attempts <= 1)
 	{
-		res = scap_next(s_scap_handle, (scap_evt**)&hdr, cpu_id);
+		res = scap_next(s_scap_handle, (scap_evt**)&hdr, cpu_id, &flags);
 		if(res == SCAP_SUCCESS && hdr != NULL)
 		{
 			break;

--- a/test/drivers/test_suites/syscall_exit_suite/mknod_e.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/mknod_e.cpp
@@ -13,7 +13,6 @@ TEST(SyscallEnter, mknodE_failure)
 	uint32_t mode = 0060000 | 0666;
 	uint32_t dev = 61440;
 	assert_syscall_state(SYSCALL_FAILURE, "mknod", syscall(__NR_mknod, (void *)(path), (mode_t)mode, (dev_t)dev));
-	int64_t errno_value = -errno;
 
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/

--- a/test/libscap/helpers/engines.cpp
+++ b/test/libscap/helpers/engines.cpp
@@ -50,11 +50,13 @@ void check_event_is_not_overwritten(scap_t *h)
 	 */
 	scap_evt *evt = NULL;
 	uint16_t buffer_id;
+	uint32_t flags;
 
 	/* The first 'scap_next` could return a `SCAP_TIMEOUT` according to the chosen `buffer_mode` so we ignore it. */
-	scap_next(h, &evt, &buffer_id);
+	scap_next(h, &evt, &buffer_id, &flags);
 
-	ASSERT_EQ(scap_next(h, &evt, &buffer_id), SCAP_SUCCESS) << "unable to get an event with `scap_next`: " << scap_getlasterr(h) << std::endl;
+	ASSERT_EQ(scap_next(h, &evt, &buffer_id, &flags), SCAP_SUCCESS)
+		<< "unable to get an event with `scap_next`: " << scap_getlasterr(h) << std::endl;
 
 	last_num_events = 0;
 	iterations = 0;
@@ -154,8 +156,9 @@ void check_event_order(scap_t *h)
 
 	scap_evt *evt = NULL;
 	uint16_t buffer_id = 0;
+	uint32_t flags = 0;
 	int ret = 0;
-	uint64_t acutal_pid = getpid();
+	uint64_t actual_pid = getpid();
 	/* if we hit 5 consecutive timeouts it means that all buffers are empty (approximation) */
 	uint16_t timeouts = 0;
 
@@ -163,11 +166,11 @@ void check_event_order(scap_t *h)
 	{
 		while(true)
 		{
-			ret = scap_next(h, &evt, &buffer_id);
+			ret = scap_next(h, &evt, &buffer_id, &flags);
 			if(ret == SCAP_SUCCESS)
 			{
 				timeouts = 0;
-				if(evt->tid == acutal_pid && evt->type == events_to_assert[i])
+				if(evt->tid == actual_pid && evt->type == events_to_assert[i])
 				{
 					/* We found our event */
 					break;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1865,9 +1865,9 @@ int32_t scap_bpf_get_n_tracepoint_hit(struct scap_engine_handle engine, long* re
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid, OUT uint32_t *pflags)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid, pflags);
 }
 
 static int32_t unsupported_config(struct scap_engine_handle engine, const char* msg)

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1865,9 +1865,9 @@ int32_t scap_bpf_get_n_tracepoint_hit(struct scap_engine_handle engine, long* re
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pcpuid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
 }
 
 static int32_t unsupported_config(struct scap_engine_handle engine, const char* msg)

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -173,9 +173,9 @@ static int32_t gvisor_stop_capture(struct scap_engine_handle engine)
 	return engine.m_handle->stop_capture();
 }
 
-static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pcpuid)
+static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid)
 {
-	return engine.m_handle->next(pevent, pcpuid);
+	return engine.m_handle->next(pevent, pdevid);
 }
 
 static int32_t gvisor_configure(struct scap_engine_handle engine, enum scap_setting setting, unsigned long arg1, unsigned long arg2)

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -173,9 +173,9 @@ static int32_t gvisor_stop_capture(struct scap_engine_handle engine)
 	return engine.m_handle->stop_capture();
 }
 
-static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid)
+static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
-	return engine.m_handle->next(pevent, pdevid);
+	return engine.m_handle->next(pevent, pdevid, pflags);
 }
 
 static int32_t gvisor_configure(struct scap_engine_handle engine, enum scap_setting setting, unsigned long arg1, unsigned long arg2)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -142,7 +142,7 @@ public:
     int32_t start_capture();
     int32_t stop_capture();
 
-    int32_t next(scap_evt **pevent, uint16_t *pdevid);
+    int32_t next(scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags);
 
     uint32_t get_vxid(uint64_t pid);
     int32_t get_stats(scap_stats *stats);

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -142,7 +142,7 @@ public:
     int32_t start_capture();
     int32_t stop_capture();
 
-    int32_t next(scap_evt **pevent, uint16_t *pcpuid);
+    int32_t next(scap_evt **pevent, uint16_t *pdevid);
 
     uint32_t get_vxid(uint64_t pid);
     int32_t get_stats(scap_stats *stats);

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -506,7 +506,7 @@ int32_t engine::process_message_from_fd(int fd)
 	return parse_result.status;
 }
 
-int32_t engine::next(scap_evt **pevent, uint16_t *pdevid)
+int32_t engine::next(scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags)
 {
 	if(m_no_events)
 	{
@@ -600,6 +600,7 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pdevid)
 	if(!m_event_queue.empty())
 	{
 		*pevent = m_event_queue.front();
+		*pflags = 0;
 		m_event_queue.pop_front();
 		m_gvisor_stats.n_evts++;
 		return SCAP_SUCCESS;

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -506,7 +506,7 @@ int32_t engine::process_message_from_fd(int fd)
 	return parse_result.status;
 }
 
-int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
+int32_t engine::next(scap_evt **pevent, uint16_t *pdevid)
 {
 	if(m_no_events)
 	{
@@ -514,7 +514,7 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pcpuid)
 	}
 
 	epoll_event evts[max_ready_sandboxes];
-	*pcpuid = 0;
+	*pdevid = 0;
 
 	// if there are still events to process do it before getting more
 	if(!m_event_queue.empty())

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -541,9 +541,9 @@ int32_t scap_kmod_close(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-int32_t scap_kmod_next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+int32_t scap_kmod_next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pcpuid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
 }
 
 uint32_t scap_kmod_get_n_devs(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -541,9 +541,10 @@ int32_t scap_kmod_close(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-int32_t scap_kmod_next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid)
+int32_t scap_kmod_next(struct scap_engine_handle engine, OUT scap_evt **pevent, OUT uint16_t *pdevid,
+		       OUT uint32_t *pflags)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid, pflags);
 }
 
 uint32_t scap_kmod_get_n_devs(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -49,7 +49,8 @@ static void scap_modern_bpf__free_engine(struct scap_engine_handle engine)
 /* The third parameter is not the CPU number from which we extract the event but the ring buffer number.
  * For the old BPF probe and the kernel module the number of CPUs is equal to the number of buffers since we always use a per-CPU approach.
  */
-static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* buffer_id)
+static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* buffer_id,
+				     OUT uint32_t* pflags)
 {
 	pman_consume_first_event((void**)pevent, (int16_t*)buffer_id);
 
@@ -64,6 +65,7 @@ static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, OUT scap_
 	{
 		engine.m_handle->m_retry_us = BUFFER_EMPTY_WAIT_TIME_US_START;
 	}
+	*pflags = 0;
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -44,7 +44,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid)
+static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
 	static scap_evt evt;
 	evt.len = 0;
@@ -56,6 +56,8 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 
 	evt.ts = get_timestamp_ns();
 	*pevent = &evt;
+	*pdevid = 0;
+	*pflags = 0;
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -44,7 +44,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid)
+static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid)
 {
 	static scap_evt evt;
 	evt.len = 0;

--- a/userspace/libscap/engine/noop/noop.c
+++ b/userspace/libscap/engine/noop/noop.c
@@ -50,7 +50,10 @@ int noop_close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid) { return SCAP_EOF; }
+int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
+{
+	return SCAP_EOF;
+}
 
 int32_t noop_start_capture(struct scap_engine_handle engine)
 {

--- a/userspace/libscap/engine/noop/noop.c
+++ b/userspace/libscap/engine/noop/noop.c
@@ -50,10 +50,7 @@ int noop_close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid)
-{
-	return SCAP_EOF;
-}
+int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid) { return SCAP_EOF; }
 
 int32_t noop_start_capture(struct scap_engine_handle engine)
 {

--- a/userspace/libscap/engine/noop/noop.h
+++ b/userspace/libscap/engine/noop/noop.h
@@ -29,7 +29,7 @@ typedef struct scap_stats_v2 scap_stats_v2;
 struct noop_engine* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr);
 void noop_free_handle(struct scap_engine_handle engine);
 int noop_close_engine(struct scap_engine_handle engine);
-int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid);
+int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid);
 int32_t noop_start_capture(struct scap_engine_handle engine);
 int32_t noop_stop_capture(struct scap_engine_handle engine);
 int32_t unimplemented_op(char* err, size_t err_size);

--- a/userspace/libscap/engine/noop/noop.h
+++ b/userspace/libscap/engine/noop/noop.h
@@ -29,7 +29,7 @@ typedef struct scap_stats_v2 scap_stats_v2;
 struct noop_engine* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr);
 void noop_free_handle(struct scap_engine_handle engine);
 int noop_close_engine(struct scap_engine_handle engine);
-int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid);
+int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags);
 int32_t noop_start_capture(struct scap_engine_handle engine);
 int32_t noop_stop_capture(struct scap_engine_handle engine);
 int32_t unimplemented_op(char* err, size_t err_size);

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -1925,7 +1925,7 @@ static int32_t scap_read_init(struct savefile_engine *handle, scap_reader_t* r, 
 //
 // Read an event from disk
 //
-static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pdevid)
+static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags)
 {
 	struct savefile_engine* handle = engine.m_handle;
 	block_header bh;
@@ -2039,12 +2039,12 @@ static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_
 
 		if(bh.block_type == EVF_BLOCK_TYPE || bh.block_type == EVF_BLOCK_TYPE_V2 || bh.block_type == EVF_BLOCK_TYPE_V2_LARGE)
 		{
-			handle->m_last_evt_dump_flags = *(uint32_t*)(handle->m_reader_evt_buf + sizeof(uint16_t));
+			*pflags = *(uint32_t *)(handle->m_reader_evt_buf + sizeof(uint16_t));
 			*pevent = (struct ppm_evt_hdr *)(handle->m_reader_evt_buf + sizeof(uint16_t) + sizeof(uint32_t));
 		}
 		else
 		{
-			handle->m_last_evt_dump_flags = 0;
+			*pflags = 0;
 			*pevent = (struct ppm_evt_hdr *)(handle->m_reader_evt_buf + sizeof(uint16_t));
 		}
 
@@ -2351,18 +2351,12 @@ static int64_t get_readfile_offset(struct scap_engine_handle engine)
 	return engine.m_handle->m_reader->offset(engine.m_handle->m_reader);
 }
 
-static uint32_t get_event_dump_flags(struct scap_engine_handle engine)
-{
-	return engine.m_handle->m_last_evt_dump_flags;
-}
-
 static struct scap_savefile_vtable savefile_ops = {
 	.ftell_capture = scap_savefile_ftell,
 	.fseek_capture = scap_savefile_fseek,
 
 	.restart_capture = scap_savefile_restart_capture,
 	.get_readfile_offset = get_readfile_offset,
-	.get_event_dump_flags = get_event_dump_flags,
 };
 
 struct scap_vtable scap_savefile_engine = {

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -1925,7 +1925,7 @@ static int32_t scap_read_init(struct savefile_engine *handle, scap_reader_t* r, 
 //
 // Read an event from disk
 //
-static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pcpuid)
+static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pdevid)
 {
 	struct savefile_engine* handle = engine.m_handle;
 	block_header bh;
@@ -2035,7 +2035,7 @@ static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_
 		//
 		// EVF_BLOCK_TYPE has 32 bits of flags
 		//
-		*pcpuid = *(uint16_t *)handle->m_reader_evt_buf;
+		*pdevid = *(uint16_t *)handle->m_reader_evt_buf;
 
 		if(bh.block_type == EVF_BLOCK_TYPE || bh.block_type == EVF_BLOCK_TYPE_V2 || bh.block_type == EVF_BLOCK_TYPE_V2_LARGE)
 		{

--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -155,7 +155,7 @@ static int close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 {
 	struct source_plugin_engine *handle = engine.m_handle;
 	char *lasterr = engine.m_handle->m_lasterr;

--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -155,7 +155,7 @@ static int close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid, OUT uint32_t* pflags)
 {
 	struct source_plugin_engine *handle = engine.m_handle;
 	char *lasterr = engine.m_handle->m_lasterr;
@@ -255,6 +255,8 @@ static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT
 	}
 
 	*pevent = evt;
+	*pdevid = 0;
+	*pflags = 0;
 	handle->m_nevts++;
 	handle->m_input_plugin_batch_idx++;
 	return SCAP_SUCCESS;

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -52,7 +52,7 @@ static struct test_input_engine* alloc_handle(scap_t* main_handle, char* lasterr
 	return engine;
 }
 
-static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pcpuid)
+static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid)
 {
 	test_input_engine *engine = handle.m_handle;
 	scap_test_input_data *data = engine->m_data;
@@ -64,8 +64,8 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 
 	*pevent = *(data->events++);
 	data->event_count--;
-	/* All the events are sent by CPU 1 */
-	*pcpuid = 1; 
+	/* All the events are sent by device 1 */
+	*pdevid = 1;
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -52,7 +52,7 @@ static struct test_input_engine* alloc_handle(scap_t* main_handle, char* lasterr
 	return engine;
 }
 
-static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid)
+static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
 	test_input_engine *engine = handle.m_handle;
 	scap_test_input_data *data = engine->m_data;
@@ -66,6 +66,7 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 	data->event_count--;
 	/* All the events are sent by device 1 */
 	*pdevid = 1;
+	*pflags = 0;
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -400,9 +400,9 @@ static int close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pcpuid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
 }
 
 //

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -400,9 +400,9 @@ static int close_engine(struct scap_engine_handle engine)
 	return SCAP_SUCCESS;
 }
 
-static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid)
+static int32_t next(struct scap_engine_handle engine, OUT scap_evt** pevent, OUT uint16_t* pdevid, OUT uint32_t* pflags)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid);
+	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid, pflags);
 }
 
 //

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -837,6 +837,7 @@ int main(int argc, char** argv)
 	int32_t res = 0;
 	scap_evt* ev = NULL;
 	uint16_t cpuid = 0;
+	uint32_t flags = 0;
 
 	printf("\n[SCAP-OPEN]: Hello!\n");
 	if(signal(SIGINT, signal_callback) == SIG_ERR)
@@ -873,7 +874,7 @@ int main(int argc, char** argv)
 
 	while(g_nevts != num_events)
 	{
-		res = scap_next(g_h, &ev, &cpuid);
+		res = scap_next(g_h, &ev, &cpuid, &flags);
 		number_of_scap_next++;
 		if(res == SCAP_UNEXPECTED_BLOCK)
 		{

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -211,7 +211,8 @@ static inline void ringbuffer_advance_to_evt(scap_device* dev, scap_evt *event)
  * - before refilling a buffer we have to consume all the others!
  * - we perform a lot of cycles but we have to be super fast here!
  */
-static inline int32_t ringbuffer_next(struct scap_device_set* devset, OUT scap_evt** pevent, OUT uint16_t* pdevid)
+static inline int32_t ringbuffer_next(struct scap_device_set* devset, OUT scap_evt** pevent, OUT uint16_t* pdevid,
+				      OUT uint32_t* pflags)
 {
 	uint32_t j;
 	uint64_t min_ts = 0xffffffffffffffffLL;
@@ -288,6 +289,9 @@ static inline int32_t ringbuffer_next(struct scap_device_set* devset, OUT scap_e
 	 	 */
 		struct scap_device* dev = &devset->m_devs[*pdevid];
 		ADVANCE_TO_EVT(dev, (*pevent));
+
+		// we don't really store the flags in the ringbuffer anywhere
+		*pflags = 0;
 		return SCAP_SUCCESS;
 	}
 	else

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -211,14 +211,14 @@ static inline void ringbuffer_advance_to_evt(scap_device* dev, scap_evt *event)
  * - before refilling a buffer we have to consume all the others!
  * - we perform a lot of cycles but we have to be super fast here!
  */
-static inline int32_t ringbuffer_next(struct scap_device_set *devset, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
+static inline int32_t ringbuffer_next(struct scap_device_set* devset, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 {
 	uint32_t j;
 	uint64_t min_ts = 0xffffffffffffffffLL;
 	scap_evt* pe = NULL;
 	uint32_t ndevs = devset->m_ndevs;
 
-	*pcpuid = 65535;
+	*pdevid = 65535;
 
 	for(j = 0; j < ndevs; j++)
 	{
@@ -276,18 +276,17 @@ static inline int32_t ringbuffer_next(struct scap_device_set *devset, OUT scap_e
 			}
 
 			*pevent = pe;
-			*pcpuid = j;
+			*pdevid = j;
 			min_ts = pe->ts;
 		}
 	}
 
-
-	if(*pcpuid != 65535)
+	if(*pdevid != 65535)
 	{
 		/* Check from which buffer we have read and move the position inside
 	 	 * the block with `ADVANCE_TO_EVT`
 	 	 */
-		struct scap_device *dev = &devset->m_devs[*pcpuid];
+		struct scap_device* dev = &devset->m_devs[*pdevid];
 		ADVANCE_TO_EVT(dev, (*pevent));
 		return SCAP_SUCCESS;
 	}

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -312,7 +312,7 @@ uint64_t scap_max_buf_used(scap_t* handle)
 	return 0;
 }
 
-int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid)
+int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid, OUT uint32_t* pflags)
 {
 	// Note: devid is like cpuid but not 1:1, e.g. consider CPU1 offline:
 	// CPU0 CPU1 CPU2 CPU3
@@ -321,7 +321,7 @@ int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid)
 	int32_t res = SCAP_FAILURE;
 	if(handle->m_vtable)
 	{
-		res = handle->m_vtable->next(handle->m_engine, pevent, pdevid);
+		res = handle->m_vtable->next(handle->m_engine, pevent, pdevid, pflags);
 	}
 	else
 	{
@@ -549,18 +549,6 @@ int32_t scap_set_dropfailed(scap_t* handle, bool enabled) {
 
 	snprintf(handle->m_lasterr,	SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
-}
-
-uint32_t scap_event_get_dump_flags(scap_t* handle)
-{
-	if(handle->m_vtable->savefile_ops)
-	{
-		return handle->m_vtable->savefile_ops->get_event_dump_flags(handle->m_engine);
-	}
-	else
-	{
-		return 0;
-	}
 }
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -569,13 +569,14 @@ uint64_t scap_max_buf_used(scap_t* handle);
   \param pevent User-provided event pointer that will be initialized with address of the event.
   \param pdevid User-provided event pointer that will be initialized with the ID of the device
     where the event was captured.
+  \param pflags User-provided event pointer that will be initialized with the flags of the event.
 
-  \return SCAP_SUCCESS if the call is successful and pevent and pdevid contain valid data.
+  \return SCAP_SUCCESS if the call is successful and pevent, pcpuid and pflags contain valid data.
    SCAP_TIMEOUT in case the read timeout expired and no event is available.
    SCAP_EOF when the end of an offline capture is reached.
    On Failure, SCAP_FAILURE is returned and scap_getlasterr() can be used to obtain the cause of the error.
 */
-int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid);
+int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid, OUT uint32_t* pflags);
 
 /*!
   \brief Get the length of an event

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -567,15 +567,15 @@ uint64_t scap_max_buf_used(scap_t* handle);
 
   \param handle Handle to the capture instance.
   \param pevent User-provided event pointer that will be initialized with address of the event.
-  \param pcpuid User-provided event pointer that will be initialized with the ID if the CPU
+  \param pdevid User-provided event pointer that will be initialized with the ID of the device
     where the event was captured.
 
-  \return SCAP_SUCCESS if the call is successful and pevent and pcpuid contain valid data.
+  \return SCAP_SUCCESS if the call is successful and pevent and pdevid contain valid data.
    SCAP_TIMEOUT in case the read timeout expired and no event is available.
    SCAP_EOF when the end of an offline capture is reached.
    On Failure, SCAP_FAILURE is returned and scap_getlasterr() can be used to obtain the cause of the error.
 */
-int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid);
+int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pdevid);
 
 /*!
   \brief Get the length of an event

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -174,7 +174,7 @@ struct scap_vtable {
 	 * @brief fetch the next event
 	 * @param engine wraps the pointer to the engine-specific handle
 	 * @param pevent [out] where the pointer to the next event gets stored
-	 * @param pcpuid [out] where the CPU on which the event was received
+	 * @param pdevid [out] where the device on which the event was received
 	 *               gets stored
 	 * @return SCAP_SUCCESS or a failure code
 	 *
@@ -186,7 +186,7 @@ struct scap_vtable {
 	 * The memory pointed to by *pevent must be owned by the engine
 	 * and must remain valid at least until the next call to next()
 	 */
-	int32_t (*next)(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pcpuid);
+	int32_t (*next)(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid);
 
 	/**
 	 * @brief start a capture

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -116,13 +116,6 @@ struct scap_savefile_vtable {
 	 * @return the current read offset, in (compressed) bytes
 	 */
 	int64_t (*get_readfile_offset)(struct scap_engine_handle engine);
-
-	/**
-	 * @brief return the flags for the last read event
-	 * @param engine the handle to the engine
-	 * @return the flags of the event (currently only SCAP_DF_LARGE is supported)
-	 */
-	uint32_t (*get_event_dump_flags)(struct scap_engine_handle engine);
 };
 
 struct scap_vtable {
@@ -176,6 +169,7 @@ struct scap_vtable {
 	 * @param pevent [out] where the pointer to the next event gets stored
 	 * @param pdevid [out] where the device on which the event was received
 	 *               gets stored
+	 * @param pflags [out] where the flags for the event get stored
 	 * @return SCAP_SUCCESS or a failure code
 	 *
 	 * SCAP_SUCCESS: event successfully returned and stored in *pevent
@@ -186,7 +180,7 @@ struct scap_vtable {
 	 * The memory pointed to by *pevent must be owned by the engine
 	 * and must remain valid at least until the next call to next()
 	 */
-	int32_t (*next)(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid);
+	int32_t (*next)(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags);
 
 	/**
 	 * @brief start a capture

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -123,11 +123,6 @@ sinsp_evt::~sinsp_evt()
 	}
 }
 
-uint32_t sinsp_evt::get_dump_flags()
-{
-	return scap_event_get_dump_flags(m_inspector->m_h);
-}
-
 const char *sinsp_evt::get_name() const
 {
 	return m_info->name;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -562,7 +562,7 @@ private:
 	std::string get_param_value_str(const char* name, bool resolved = true);
 	char* render_fd(int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
 	int render_fd_json(Json::Value *ret, int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
-	uint32_t get_dump_flags();
+	inline uint32_t get_dump_flags() const { return m_dump_flags; }
 	static bool clone_event(sinsp_evt& dest, const sinsp_evt& src);
 	int32_t get_errorcode() { return m_errorcode; }
 
@@ -586,6 +586,7 @@ VISIBILITY_PRIVATE
 	uint16_t m_cpuid;
 	uint64_t m_evtnum;
 	uint32_t m_flags;
+	uint32_t m_dump_flags;
 	bool m_params_loaded;
 	const struct ppm_event_info* m_info;
 	std::vector<sinsp_evt_param> m_params;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -278,6 +278,7 @@ void sinsp::consume_initialstate_events()
 	scap_evt* pevent;
 	uint16_t pcpuid;
 	sinsp_evt* tevt;
+	uint32_t flags;
 
 	if (m_external_event_processor)
 	{
@@ -289,7 +290,7 @@ void sinsp::consume_initialstate_events()
 	//
 	while(true)
 	{
-		int32_t res = scap_next(m_h, &pevent, &pcpuid);
+		int32_t res = scap_next(m_h, &pevent, &pcpuid, &flags);
 
 		if(res == SCAP_SUCCESS)
 		{
@@ -298,6 +299,7 @@ void sinsp::consume_initialstate_events()
 			// once we reach a container-unrelated event.
 			m_replay_scap_evt = pevent;
 			m_replay_scap_cpuid = pcpuid;
+			m_replay_scap_flags = flags;
 			if(!is_initialstate_event(pevent))
 			{
 				break;
@@ -1277,13 +1279,14 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			res = SCAP_SUCCESS;
 			evt->m_pevt = m_replay_scap_evt;
 			evt->m_cpuid = m_replay_scap_cpuid;
+			evt->m_dump_flags = m_replay_scap_flags;
 			m_replay_scap_evt = NULL;
 		}
 		else 
 		{
 			// If no last event was saved, invoke
 			// the actual scap_next
-			res = scap_next(m_h, &(evt->m_pevt), &(evt->m_cpuid));
+			res = scap_next(m_h, &(evt->m_pevt), &(evt->m_cpuid), &(evt->m_dump_flags));
 		}
 
 		if(res != SCAP_SUCCESS)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1334,6 +1334,8 @@ public:
 	// This is related to m_replay_scap_evt, and is used to store the additional cpuid
 	// information of the replayed scap event.
 	uint16_t m_replay_scap_cpuid;
+	uint32_t m_replay_scap_flags;
+
 	//
 	// A registry that managers the state tables of this inspector
 	std::shared_ptr<libsinsp::state::table_registry> m_table_registry;


### PR DESCRIPTION
The event flags are (currently) specific to the savefile engine but accessing them requires an awkward reacharound through a dedicated vtable method to a field stored on each call to next().

We can simplify this a bit and express the intent better by simply returning the flags from next() via an out pointer.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The "rename pcpuid to pdevid" commit is a pure no-op, the second one is where things happen (as well as changes in all the engines to switch to the new signature).

Also, I pulled in the unused variable fix from #1401 as well, since this breaks the build with -Werror otherwise.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
