### PR TITLE
fix(userspace/libsinsp): avoid a possible source of segfault in sinsp::next

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1435,8 +1435,8 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 			{
 				ptinfo->remove_fd(m_fds_to_remove->at(j));
 			}
-			m_fds_to_remove->clear();
 		}
+		m_fds_to_remove->clear();
 	}
 
 #ifdef SIMULATE_DROP_MODE

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1508,6 +1508,9 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 		m_dumper->dump(evt);
 	}
 
+	// Finally set output evt;
+	// From now on, any return must have the correct output being set.
+	*puevt = evt;
 	if(evt->m_filtered_out)
 	{
 		ppm_event_category cat = evt->get_category();
@@ -1545,7 +1548,6 @@ int32_t sinsp::next(OUT sinsp_evt **puevt)
 	//
 	// Done
 	//
-	*puevt = evt;
 	return res;
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Avoid returning SCAP_SUCCESS without setting `*puevt` pointed data.

**Which issue(s) this PR fixes**:

Refs https://github.com/falcosecurity/falco/issues/2878

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): avoid possible source of segfault in sinsp::next
```
