### PR TITLE
update(userspace/libsinsp): support timestamp priority in async event injection

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -361,12 +361,10 @@ void sinsp_container_manager::notify_new_container(const sinsp_container_info& c
 				"notify_new_container (%s): created CONTAINER_JSON event, queuing to inspector",
 				container_info.m_id.c_str());
 
-		std::shared_ptr<sinsp_evt> cevt(evt);
+		std::unique_ptr<sinsp_evt> cevt(evt);
 
 		// Enqueue it onto the queue of pending container events for the inspector
-#ifndef __EMSCRIPTEN__	
-		m_inspector->m_pending_state_evts.push(cevt);
-#endif	
+		m_inspector->m_pending_state_evts.push(std::move(cevt));
 	}
 	else
 	{

--- a/userspace/libsinsp/mpsc_priority_queue.h
+++ b/userspace/libsinsp/mpsc_priority_queue.h
@@ -1,0 +1,81 @@
+
+#pragma once
+
+#include <mutex>
+#include <atomic>
+#include <queue>
+
+/*
+ * concurrent priority queue optimized for multiple producer/single consumer (mpsc) apps
+ * this queue checks the top against provided predicate before popping
+ * provides fast empty() method
+ * optional capacity limit could be provided
+ *
+ */
+template<typename Elm, typename Cmp, typename Mtx = std::mutex, typename Enb = void> class mpsc_priority_queue;
+
+template<typename Elm, typename Cmp, typename Mtx>
+class mpsc_priority_queue<
+	Elm, Cmp, Mtx,
+	// limit the implementation of Elm to std::shared_ptr | std::unique_ptr
+	typename std::enable_if<std::is_same_v<Elm, std::shared_ptr<typename Elm::element_type>> ||
+				std::is_same_v<Elm, std::unique_ptr<typename Elm::element_type>> >::type >
+{
+	// workaround to make unique_ptr usable when copying the queue top
+	// which is const unique<ptr>& and denies moving
+	struct queue_elm
+	{
+		inline bool operator < (const queue_elm& r) const {return Cmp{}(elm, r.elm);}
+		mutable Elm elm;
+	};
+public:
+	using elm_ptr = typename Elm::element_type*;
+
+	explicit mpsc_priority_queue(size_t capacity = 0) : m_capacity(capacity){}
+
+	inline bool empty() const { return m_queue_top == nullptr; }
+
+	/*
+	 * push an element into queue if capacity allows
+	 */
+	inline bool push(Elm e)
+	{
+		std::scoped_lock<Mtx> lk(m_mtx);
+		if (m_capacity == 0 ||  m_queue.size() < m_capacity)
+		{
+			m_queue.push(queue_elm{std::move(e)});
+			m_queue_top = m_queue.top().elm.get();
+			return true;
+		}
+		return false;
+	}
+
+	/*
+	 * check predicate before popping
+	 * first we try lock-free m_queue_top
+	 * if it passes the check, then we lock the queue and pop its top
+	 */
+	template <typename Callable>
+	inline bool pop_if(const Callable& cl, OUT Elm& res)
+	{
+		elm_ptr top = m_queue_top.load();
+		if (top == nullptr || !cl(top))
+		{
+			return false;
+		}
+
+		// at this point, we have a guarantee
+		// that queue.top() has priority not less than the local top,
+		// and we can pop the queue top safely
+		std::scoped_lock<Mtx> lk(m_mtx);
+		res = std::move(m_queue.top().elm);
+		m_queue.pop();
+		m_queue_top = m_queue.empty() ? nullptr : m_queue.top().elm.get();
+		return true;
+	}
+private:
+	const size_t m_capacity;
+	std::priority_queue<queue_elm> m_queue{};
+	std::atomic<elm_ptr> m_queue_top{nullptr};
+	Mtx m_mtx;
+};

--- a/userspace/libsinsp/mpsc_priority_queue.h
+++ b/userspace/libsinsp/mpsc_priority_queue.h
@@ -1,47 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 
 #pragma once
 
 #include <mutex>
 #include <atomic>
 #include <queue>
+#include <memory>
+#include <type_traits>
 
-/*
- * concurrent priority queue optimized for multiple producer/single consumer (mpsc) apps
- * this queue checks the top against provided predicate before popping
- * provides fast empty() method
- * optional capacity limit could be provided
- *
+/**
+ * @brief Concurrent priority queue optimized for multiple producer/single consumer
+ * (mpsc) use cases. This queue allows checking the top element against
+ * a provided predicate before popping. It is optimized for checking for
+ * emptyness before popping.
  */
-template<typename Elm, typename Cmp, typename Mtx = std::mutex, typename Enb = void> class mpsc_priority_queue;
-
-template<typename Elm, typename Cmp, typename Mtx>
-class mpsc_priority_queue<
-	Elm, Cmp, Mtx,
-	// limit the implementation of Elm to std::shared_ptr | std::unique_ptr
-	typename std::enable_if<std::is_same_v<Elm, std::shared_ptr<typename Elm::element_type>> ||
-				std::is_same_v<Elm, std::unique_ptr<typename Elm::element_type>> >::type >
+template<typename Elm, typename Cmp, typename Mtx = std::mutex>
+class mpsc_priority_queue
 {
-	// workaround to make unique_ptr usable when copying the queue top
-	// which is const unique<ptr>& and denies moving
-	struct queue_elm
-	{
-		inline bool operator < (const queue_elm& r) const {return Cmp{}(elm, r.elm);}
-		mutable Elm elm;
-	};
-public:
-	using elm_ptr = typename Elm::element_type*;
+	// limit the implementation of Elm to std::shared_ptr | std::unique_ptr
+	static_assert(
+		std::is_same<Elm, std::shared_ptr<typename Elm::element_type>>::value ||
+		std::is_same<Elm, std::unique_ptr<typename Elm::element_type>>::value,
+        "mpsc_priority_queue requires std::shared_ptr or std::unique_ptr elements");
 
+public:
 	explicit mpsc_priority_queue(size_t capacity = 0) : m_capacity(capacity){}
 
+	/**
+	 * @brief Returns true if the queue contains no elements.
+	 */
 	inline bool empty() const { return m_queue_top == nullptr; }
 
-	/*
-	 * push an element into queue if capacity allows
+	/**
+	 * @brief Push an element into queue, and returns false in case the
+	 * maximum queue capacity is met.
 	 */
 	inline bool push(Elm e)
 	{
 		std::scoped_lock<Mtx> lk(m_mtx);
-		if (m_capacity == 0 ||  m_queue.size() < m_capacity)
+		if (m_capacity == 0 || m_queue.size() < m_capacity)
 		{
 			m_queue.push(queue_elm{std::move(e)});
 			m_queue_top = m_queue.top().elm.get();
@@ -50,10 +63,31 @@ public:
 		return false;
 	}
 
-	/*
-	 * check predicate before popping
-	 * first we try lock-free m_queue_top
-	 * if it passes the check, then we lock the queue and pop its top
+	/**
+	 * @brief Pops the highest priority element from the queue. Returns false
+	 * in case of empty queue.
+	 */
+	inline bool pop(OUT Elm& res)
+	{
+		// first we try lock-free m_queue_top and if it passes the check, then
+		// we lock the queue and pop its top
+		elm_ptr top = m_queue_top.load();
+		if (top == nullptr)
+		{
+			return false;
+		}
+
+		std::scoped_lock<Mtx> lk(m_mtx);
+		res = std::move(m_queue.top().elm);
+		m_queue.pop();
+		m_queue_top = m_queue.empty() ? nullptr : m_queue.top().elm.get();
+		return true;
+	}
+
+	/**
+	 * @brief This is analoguous to pop() but evaluates the element against
+	 * a predicate before returning it. If the predicate returns false, the
+	 * element is not popped from the queue and this method returns false.
 	 */
 	template <typename Callable>
 	inline bool pop_if(const Callable& cl, OUT Elm& res)
@@ -73,7 +107,18 @@ public:
 		m_queue_top = m_queue.empty() ? nullptr : m_queue.top().elm.get();
 		return true;
 	}
+
 private:
+	using elm_ptr = typename Elm::element_type*;
+
+	// workaround to make unique_ptr usable when copying the queue top
+	// which is const unique<ptr>& and denies moving
+	struct queue_elm
+	{
+		inline bool operator < (const queue_elm& r) const {return Cmp{}(elm, r.elm);}
+		mutable Elm elm;
+	};
+
 	const size_t m_capacity;
 	std::priority_queue<queue_elm> m_queue{};
 	std::atomic<elm_ptr> m_queue_top{nullptr};

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	events_evt.ut.cpp
 	events_file.ut.cpp
 	events_fspath.ut.cpp
+	events_injection.ut.cpp
 	events_net.ut.cpp
 	events_param.ut.cpp
 	events_plugin.ut.cpp

--- a/userspace/libsinsp/test/events_injection.ut.cpp
+++ b/userspace/libsinsp/test/events_injection.ut.cpp
@@ -1,0 +1,208 @@
+#include <gtest/gtest.h>
+
+#include "sinsp_with_test_input.h"
+#include "test_utils.h"
+
+
+static void encode_async_event(scap_evt* scapevt, uint64_t tid, const char* data)
+{
+	struct scap_plugin_params
+	{};
+
+	static uint32_t plug_id[2] = {sizeof (uint32_t), 0};
+
+	size_t totlen = sizeof(scap_evt) + sizeof(plug_id)  + sizeof(uint32_t) + strlen(data) + 1;
+
+	scapevt->tid = -1;
+	scapevt->len = (uint32_t)totlen;
+	scapevt->type = PPME_ASYNCEVENT_E;
+	scapevt->nparams = 2;
+
+	char* buff = (char *)scapevt + sizeof(struct ppm_evt_hdr);
+	memcpy(buff, (char*)plug_id, sizeof(plug_id));
+	buff += sizeof(plug_id);
+
+	char* valptr = buff + sizeof(uint32_t);
+
+	auto* data_len_ptr = (uint32_t*)buff;
+	*data_len_ptr = (uint32_t)strlen(data) + 1;
+	memcpy(valptr, data, *data_len_ptr);
+}
+
+class sinsp_evt_generator
+{
+private:
+	struct scap_buff
+	{
+		uint8_t data[128];
+	};
+
+public:
+	sinsp_evt_generator() = default;
+	sinsp_evt_generator(sinsp_evt_generator&&) = default;
+	~sinsp_evt_generator()
+	{
+		if (thr.joinable())
+		{
+			thr.join();
+		}
+	}
+
+	scap_evt* get(size_t idx)
+	{
+		return scap_ptrs[idx];
+	}
+
+	scap_evt* back()
+	{
+		return scap_ptrs.back();
+	}
+
+	std::unique_ptr<sinsp_evt> next(uint64_t ts = (uint64_t) -1)
+	{
+		scaps.emplace_back(new scap_buff());
+		scap_ptrs.emplace_back((scap_evt*)scaps.back()->data);
+
+		encode_async_event(scap_ptrs.back(), 1, "dummy_data");
+
+		auto event = std::make_unique<sinsp_evt>();
+		event->m_pevt = scap_ptrs.back();
+		event->m_cpuid = 0;
+		event->m_pevt->ts = ts;
+		return event;
+	};
+
+	void run_async(size_t n_events, sinsp& inspector)
+	{
+		auto runner = [this](size_t n_events, sinsp& inspector)
+		{
+			for(size_t i = 0; i < n_events; ++i)
+			{
+				inspector.handle_async_event(next(sinsp_utils::get_current_time_ns()));
+				std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			}
+		};
+		thr = std::thread(runner, n_events, std::ref(inspector));
+	}
+
+private:
+	std::vector<std::shared_ptr<scap_buff> > scaps;
+	std::vector<scap_evt*> scap_ptrs; // gdb watch helper
+	std::thread thr;
+};
+
+TEST_F(sinsp_with_test_input, event_async_queue)
+{
+	open_inspector();
+	m_inspector.m_lastevent_ts = 123;
+
+	sinsp_evt_generator evt_gen;
+	sinsp_evt* evt{};
+
+	// inject event
+	m_inspector.handle_async_event(evt_gen.next());
+	//ASSERT_EQ(m_inspector.m_pending_state_evts.m_queue.size(), 1);
+
+	// create test input event
+	auto* scap_evt0 = add_event_with_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
+					     PPM_O_RDWR, 0, 5, (uint64_t)123);
+
+	// should pop injected event
+	auto res = m_inspector.next(&evt);
+	ASSERT_EQ(res, SCAP_SUCCESS);
+	ASSERT_NE(evt, nullptr);
+	ASSERT_EQ(evt->m_pevt, evt_gen.back());
+	ASSERT_EQ(evt->m_pevt->ts, 123);
+	ASSERT_TRUE(m_inspector.m_pending_state_evts.empty());
+
+	// multiple injected events
+	m_inspector.m_lastevent_ts = scap_evt0->ts - 10;
+
+	uint64_t injected_ts = scap_evt0->ts + 10;
+	for (int i = 0; i < 10; ++i)
+	{
+		m_inspector.handle_async_event(evt_gen.next(injected_ts + i));
+	}
+
+	// create input[1] ivent
+	auto* scap_evt1 = add_event_with_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
+					     PPM_O_RDWR, 0, 5, (uint64_t)123);
+
+	// pop scap 0 event
+	res = m_inspector.next(&evt);
+	ASSERT_EQ(res, SCAP_SUCCESS);
+	ASSERT_EQ(evt->m_pevt, scap_evt0);
+	auto last_ts = evt->m_pevt->ts;
+	
+	// pop injected
+	for (int i= 0; i < 10; ++i)
+	{
+		res = m_inspector.next(&evt);
+		ASSERT_EQ(res, SCAP_SUCCESS);
+		ASSERT_EQ(evt->m_pevt, evt_gen.get(i+1));
+		ASSERT_TRUE(last_ts <= evt->m_pevt->ts);
+		last_ts = evt->m_pevt->ts;
+	}
+	ASSERT_TRUE(m_inspector.m_pending_state_evts.empty());
+
+	// pop scap 1
+	res = m_inspector.next(&evt);
+	ASSERT_EQ(res, SCAP_SUCCESS);
+	ASSERT_EQ(evt->m_pevt, scap_evt1);
+}
+
+#ifndef __EMSCRIPTEN__
+
+// threads creation may get "resource unavailable" with __EMSCRIPTEN__
+
+/*
+ * async test with ten multithreaded producers
+ */
+TEST_F(sinsp_with_test_input, event_async_queue_mpsc)
+{
+	open_inspector();
+	m_inspector.m_lastevent_ts = sinsp_utils::get_current_time_ns();
+	const size_t n_producers = 3;
+	const size_t n_events = 30;
+
+	// start producers
+	std::vector<sinsp_evt_generator> gens;
+	gens.reserve(n_producers);
+	for (size_t i = 0; i < n_producers; ++i)
+	{
+		gens.emplace_back();
+		gens.back().run_async(n_events, m_inspector);
+	}
+
+	// receive all sinsp events
+	auto start = sinsp_utils::get_current_time_ns();
+	auto current = start;
+
+	int res  = SCAP_SUCCESS;
+	size_t n_expected = n_producers * n_events;
+	while ((current - start) / ONE_SECOND_IN_NS < 10)
+	{
+		std::this_thread::sleep_for(std::chrono::microseconds (10));
+		current = sinsp_utils::get_current_time_ns();
+
+		// generate scap input
+		add_event_with_ts(current, 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3,
+				  "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t)123);
+
+		sinsp_evt* evt;
+		res = m_inspector.next(&evt);
+		ASSERT_EQ(res, SCAP_SUCCESS);
+
+		if (evt && evt->m_pevt->type != PPME_SYSCALL_OPEN_X)
+		{
+			ASSERT_EQ(evt->m_pevt->type, PPME_ASYNCEVENT_E);
+			if(--n_expected == 0)
+			{
+				break;
+			}
+		}
+	}
+
+	ASSERT_EQ(n_expected, 0);
+}
+#endif // __EMSCRIPTEN__

--- a/userspace/libsinsp/test/events_injection.ut.cpp
+++ b/userspace/libsinsp/test/events_injection.ut.cpp
@@ -180,7 +180,8 @@ TEST_F(sinsp_with_test_input, event_async_queue_mpsc)
 
 	int res  = SCAP_SUCCESS;
 	size_t n_expected = n_producers * n_events;
-	while ((current - start) / ONE_SECOND_IN_NS < 10)
+	double time_tolerance = 1.1;
+	while ((current - start) / ONE_SECOND_IN_NS < (10 * time_tolerance))
 	{
 		std::this_thread::sleep_for(std::chrono::microseconds (10));
 		current = sinsp_utils::get_current_time_ns();

--- a/userspace/libsinsp/test/events_injection.ut.cpp
+++ b/userspace/libsinsp/test/events_injection.ut.cpp
@@ -101,10 +101,9 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 
 	// inject event
 	m_inspector.handle_async_event(evt_gen.next());
-	//ASSERT_EQ(m_inspector.m_pending_state_evts.m_queue.size(), 1);
 
 	// create test input event
-	auto* scap_evt0 = add_event_with_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
+	auto* scap_evt0 = add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
 					     PPM_O_RDWR, 0, 5, (uint64_t)123);
 
 	// should pop injected event
@@ -113,7 +112,7 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 	ASSERT_NE(evt, nullptr);
 	ASSERT_EQ(evt->m_pevt, evt_gen.back());
 	ASSERT_EQ(evt->m_pevt->ts, 123);
-	ASSERT_TRUE(m_inspector.m_pending_state_evts.empty());
+	ASSERT_TRUE(m_inspector.m_async_events_queue.empty());
 
 	// multiple injected events
 	m_inspector.m_lastevent_ts = scap_evt0->ts - 10;
@@ -125,7 +124,7 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 	}
 
 	// create input[1] ivent
-	auto* scap_evt1 = add_event_with_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
+	auto* scap_evt1 = add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
 					     PPM_O_RDWR, 0, 5, (uint64_t)123);
 
 	// pop scap 0 event
@@ -143,7 +142,7 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 		ASSERT_TRUE(last_ts <= evt->m_pevt->ts);
 		last_ts = evt->m_pevt->ts;
 	}
-	ASSERT_TRUE(m_inspector.m_pending_state_evts.empty());
+	ASSERT_TRUE(m_inspector.m_async_events_queue.empty());
 
 	// pop scap 1
 	res = m_inspector.next(&evt);
@@ -187,7 +186,7 @@ TEST_F(sinsp_with_test_input, event_async_queue_mpsc)
 		current = sinsp_utils::get_current_time_ns();
 
 		// generate scap input
-		add_event_with_ts(current, 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3,
+		add_event(current, 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3,
 				  "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t)123);
 
 		sinsp_evt* evt;

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -106,6 +106,15 @@ protected:
 		throw std::runtime_error("could not retrieve last event or internal error (event vector size: " + std::to_string(m_events.size()) + std::string(")"));
 	}
 
+	scap_evt* add_event_with_ts(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
+	{
+		va_list args;
+		va_start(args, n);
+		auto *ret = add_event_v(ts, tid, event_type, n, args);
+		va_end(args);
+		return ret;
+	};
+
 	scap_evt* add_event_v(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, va_list args)
 	{
 		struct scap_sized_buffer event_buf = {NULL, 0};

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -106,15 +106,6 @@ protected:
 		throw std::runtime_error("could not retrieve last event or internal error (event vector size: " + std::to_string(m_events.size()) + std::string(")"));
 	}
 
-	scap_evt* add_event_with_ts(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
-	{
-		va_list args;
-		va_start(args, n);
-		auto *ret = add_event_v(ts, tid, event_type, n, args);
-		va_end(args);
-		return ret;
-	};
-
 	scap_evt* add_event_v(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, va_list args)
 	{
 		struct scap_sized_buffer event_buf = {NULL, 0};

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #ifndef _WIN32
 #include <inttypes.h>
 #include <unistd.h>
+#include <limits.h>
 #endif
 #include <stdio.h>
 #include <algorithm>

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -690,10 +690,8 @@ void sinsp_usergroup_manager::notify_user_changed(const scap_userinfo *user, con
 			"notify_user_changed (%d): USER event, queuing to inspector",
 			user->uid);
 
-	std::shared_ptr<sinsp_evt> cevt(evt);
-#ifndef __EMSCRIPTEN__	
-	m_inspector->m_pending_state_evts.push(cevt);
-#endif	
+	std::unique_ptr<sinsp_evt> cevt(evt);
+	m_inspector->m_pending_state_evts.push(std::move(cevt));
 }
 
 void sinsp_usergroup_manager::notify_group_changed(const scap_groupinfo *group, const string &container_id, bool added)
@@ -717,9 +715,7 @@ void sinsp_usergroup_manager::notify_group_changed(const scap_groupinfo *group, 
 			"notify_group_changed (%d): GROUP event, queuing to inspector",
 			group->gid);
 
-	std::shared_ptr<sinsp_evt> cevt(evt);
+	std::unique_ptr<sinsp_evt> cevt(evt);
 
-#ifndef __EMSCRIPTEN__	
-	m_inspector->m_pending_state_evts.push(cevt);
-#endif
+	m_inspector->m_pending_state_evts.push(std::move(cevt));
 }

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -675,23 +675,22 @@ void sinsp_usergroup_manager::notify_user_changed(const scap_userinfo *user, con
 		return;
 	}
 
-	auto *evt = new sinsp_evt();
+	std::unique_ptr<sinsp_evt> evt(new sinsp_evt());
 
 	if (added)
 	{
-		user_to_sinsp_event(user, evt, container_id, PPME_USER_ADDED_E);
+		user_to_sinsp_event(user, evt.get(), container_id, PPME_USER_ADDED_E);
 	}
 	else
 	{
-		user_to_sinsp_event(user, evt, container_id, PPME_USER_DELETED_E);
+		user_to_sinsp_event(user, evt.get(), container_id, PPME_USER_DELETED_E);
 	}
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"notify_user_changed (%d): USER event, queuing to inspector",
 			user->uid);
 
-	std::unique_ptr<sinsp_evt> cevt(evt);
-	m_inspector->m_pending_state_evts.push(std::move(cevt));
+	m_inspector->handle_async_event(std::move(evt));
 }
 
 void sinsp_usergroup_manager::notify_group_changed(const scap_groupinfo *group, const string &container_id, bool added)
@@ -701,21 +700,19 @@ void sinsp_usergroup_manager::notify_group_changed(const scap_groupinfo *group, 
 		return;
 	}
 
-	auto *evt = new sinsp_evt();
+	std::unique_ptr<sinsp_evt> evt(new sinsp_evt());
 	if (added)
 	{
-		group_to_sinsp_event(group, evt, container_id, PPME_GROUP_ADDED_E);
+		group_to_sinsp_event(group, evt.get(), container_id, PPME_GROUP_ADDED_E);
 	}
 	else
 	{
-		group_to_sinsp_event(group, evt, container_id, PPME_GROUP_DELETED_E);
+		group_to_sinsp_event(group, evt.get(), container_id, PPME_GROUP_DELETED_E);
 	}
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
 			"notify_group_changed (%d): GROUP event, queuing to inspector",
 			group->gid);
 
-	std::unique_ptr<sinsp_evt> cevt(evt);
-
-	m_inspector->m_pending_state_evts.push(std::move(cevt));
+	m_inspector->handle_async_event(std::move(evt));
 }

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -361,6 +361,16 @@ typedef struct ss_plugin_event_parse_input
 // Function handler used by plugin for sending asynchronous events to the
 // Falcosecurity libs during a live event capture. The asynchronous events
 // must be encoded as an async event type (code 402) as for the libscap specific.
+//
+// The plugin framework will automatically set the plugin ID of the produced
+// async event depending on the running event source in which the event will
+// be injected into. The event's thread ID can be set to control the system
+// thread associated, with value (uint64_t) -1) representing no thread
+// association. The event's timestamp can be set to forcefully specify
+// the timestamp of the phenomena that the event represents, and value
+// (uint64_t) -1) will cause the plugin framework to automatically assign
+// a timestamp as the time in which the event is received asynchronously.
+//
 // The function returns SS_PLUGIN_SUCCESS in case of success, or
 // SS_PLUGIN_FAILURE otherwise. If a non-NULL char pointer is passed for
 // the "err" argument, it will be filled with an error message string

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -30,7 +30,7 @@ extern "C" {
 //
 // todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
-#define PLUGIN_API_VERSION_MINOR 1
+#define PLUGIN_API_VERSION_MINOR 2
 #define PLUGIN_API_VERSION_PATCH 0
 
 //


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This is effectively a new feature. A friction that we discovered having when generating async events, is not being able to control their timestamp.

Currently, async event producers are "passive" from this perspective, and are not able to specify any timestamp at all. The current behavior is to have multiple (potentially concurrent) async event producers, and one single consumer that is the inspector listening and owning the async queue. This is used for container events, user/group events, and plugin async events. When an event is popped from the queue by the inspector, it is assigned a new timestamp based on the current time or the most recent time seen in the event stream.

However, this is a limitation for some use cases in which the async event registers a phenomena of which the timestamp is known. In those cases, we have that:
- The inspector will overwrite the timestamp with its own logic when popping the event. Even if not doing so,
- The async queue guarantees not timestamp-ordering among the async events
- There is no way for knowing whether an async event must appear before or after the most recent libscap event in the overall event stream

Think about new fun developments in eBPF - we may have cases in which we known about some phenomena (e.g. an execution), before receiving the syscall event from the kernel ring buffer, which can't be controlled nowadays.

Moreover, further analysis (cc @VadimZy) show that the `tbb` queue is not the optimal instrument for this use case. In our case we have a Multi-Producer-Single-Consumer queue (so any optimization multiple consumers is a no-gain cost), we expect producers to not be that many (low concurrency and saturation risk), and the event throughput is orders of magnitude lower than the one of the syscall events (the queue will be empty > 50% of the time). With these assumptions, we're discovered gaining performance by simply putting an atomic check on the queue and eventually acquiring a mutex whenever necessary. This also removes the need of tbb in this codepath, which gave us many headaches in the past from a compilation perspective (e.g. welcome async events in our WASM build :)).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I propose bumping the plugin API version by a minot number to 3.2.0. Since this is effectively a new guarantee that plugins can leverage, I think it makes sense to follow the minor bumping logic as we always did. Otherwise, plugins depending on 3.1.0 will have no way to know if they can set custom timestamps or not.

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): support timestamp priority in async event injection
```
