### PR TITLE
fix(userspace/libsinsp): properly inherit rawarg PT_DYN print format.

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -283,6 +283,7 @@ int32_t sinsp_filter_check_event::parse_field_name(const char* str, bool alloc_s
 		res = extract_arg("evt.rawarg", val, &m_arginfo);
 
 		m_customfield.m_type = m_arginfo->type;
+		m_customfield.m_print_format = m_arginfo->fmt;
 	}
 	else if(STR_MATCH("evt.around"))
 	{

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -43,3 +43,27 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_is_open_create)
 
 	ASSERT_EQ(evt->m_fdinfo->m_openflags, PPM_O_RDWR | PPM_O_CREAT | PPM_O_F_CREATED);
 }
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_int)
+{
+	add_default_init_thread();
+
+	open_inspector();
+
+	sinsp_evt* evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_E, 1, (uint32_t)1000);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.uid"), "1000");
+}
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_str)
+{
+	add_default_init_thread();
+
+	open_inspector();
+
+	std::string path = "/home/file.txt";
+
+	// In the enter event we don't send the `PPM_O_F_CREATED`
+	sinsp_evt* evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, path.c_str(),
+					      (uint32_t)0, (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.name"), path);
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

Fixes an issue preventing the print of rawarg.
Before:
```
sudo ./libsinsp/examples/sinsp-example -m -f "evt.type=setuid and evt.dir=>" -o "arg=%evt.rawarg.uid"
-- Filter AST (2) ppm sc names: setuid, setuid32
-- Try to open: 'modern_bpf' engine.
-- Engine 'modern_bpf' correctly opened.
-- Start capture
arg=
arg=
arg=
```
Because print_format is `PF_NA`.

After:
```
sudo ./libsinsp/examples/sinsp-example -m -f "evt.type=setuid and evt.dir=>" -o "arg=%evt.rawarg.uid"
-- Filter AST (2) ppm sc names: setuid, setuid32
-- Try to open: 'modern_bpf' engine.
-- Engine 'modern_bpf' correctly opened.
-- Start capture
arg=0
arg=1000
arg=1000
```
and print format is correctly set to `PF_DEC`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): properly inherit rawarg PT_DYN print format.
```
