### PR TITLE
fix(userspace/libscap): add a CI job for musl static builds and fix issues with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,31 @@ jobs:
           KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
           make run-unit-tests
 
+  build-libs-linux-amd64-static:
+    name: build-libs-linux-amd64-static 🎃
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.17
+    steps:
+      - name: Install deps ⛓️
+        run: |
+          apk add g++ gcc cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils bpftool clang
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Git safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Build and test 🏗️🧪
+        run: |
+          mkdir -p build
+          cd build && cmake -DBUILD_BPF=On -DBUILD_DRIVER=Off -DUSE_BUNDLED_DEPS=On -DUSE_BUNDLED_LIBELF=Off -DBUILD_LIBSCAP_MODERN_BPF=ON -DMUSL_OPTIMIZED_BUILD=On ../
+          make run-unit-tests -j4
+
   build-shared-libs-linux-amd64:
     name: build-shared-libs-linux-amd64 🧐
     runs-on: ubuntu-latest

--- a/userspace/libscap/compat/misc.h
+++ b/userspace/libscap/compat/misc.h
@@ -38,4 +38,18 @@ limitations under the License.
 #define O_TMPFILE 020200000
 #endif
 
+/* This can be the case for static MUSL builds */
+#if !defined(__WEXITSTATUS) && defined(WEXITSTATUS)
+#define __WEXITSTATUS(x) WEXITSTATUS(x)
+#endif
+#if !defined(__WIFSIGNALED) && defined(WIFSIGNALED)
+#define __WIFSIGNALED(x) WIFSIGNALED(x)
+#endif
+#if !defined(__WTERMSIG) && defined(WTERMSIG)
+#define __WTERMSIG(x) WTERMSIG(x)
+#endif
+#if !defined(__WCOREDUMP) && defined(WCOREDUMP)
+#define __WCOREDUMP(x) WCOREDUMP(x)
+#endif
+
 #endif

--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -149,7 +149,7 @@ TEST_F(usergroup_manager_test, add_no_import_users)
 
 // note(jasondellaluce): emscripten has issues with fgetpwent
 // note(therealbobo): macos doesn't define fgetpwent
-#if (defined(HAVE_PWD_H) || defined(HAVE_GRP_H)) && !defined(__EMSCRIPTEN__) && !defined(__APPLE__)
+#if (defined(HAVE_PWD_H) &&  defined(HAVE_GRP_H)) && !defined(__EMSCRIPTEN__) && !defined(__APPLE__)
 class usergroup_manager_host_root_test : public sinsp_with_test_input
 {
 protected:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

In Falco our build pipeline prevents us from bumping the libs due to a failure in the MUSL static build. This PR attempts fixing that and also adds a CI job covering that compilation case for preventing future regressions.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
