### PR TITLE
cleanup(driver): create consistencies (syscall_arg_t)

### DIFF
--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -59,8 +59,6 @@ struct ppm_ring_buffer_context {
 
 #define STR_STORAGE_SIZE PAGE_SIZE
 
-typedef unsigned long syscall_arg_t;
-
 /*
  * Global functions
  *

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -726,7 +726,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 		if(fromuser)
 		{
 			len = ppm_strncpy_from_user(args->buffer + args->arg_data_offset,
-				(const char __user *)(syscall_arg_t)val, max_arg_size);
+				(const char __user *)(unsigned long)val, max_arg_size);
 
 			if(unlikely(len < 0))
 			{
@@ -747,7 +747,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 		else
 		{
 			len = (int)strlcpy(args->buffer + args->arg_data_offset,
-							(const char *)(syscall_arg_t)val,
+							(const char *)(unsigned long)val,
 							max_arg_size);
 			/* WARNING: `strlcpy` returns the length of the string it tries to create
 			 * so `len` could also be greater than `max_arg_size`, but please note that the copied
@@ -790,7 +790,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 
 				/* Returns the number of bytes NOT read. */
 				len = (int)ppm_copy_from_user(args->buffer + args->arg_data_offset,
-						(const void __user *)(syscall_arg_t)val,
+						(const void __user *)(unsigned long)val,
 						dpi_lookahead_size);
 
 				if(unlikely(len != 0))
@@ -820,7 +820,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 
 					if (val_len > dpi_lookahead_size) {
 						len = (int)ppm_copy_from_user(args->buffer + args->arg_data_offset + dpi_lookahead_size,
-								(const uint8_t __user *)(syscall_arg_t)val + dpi_lookahead_size,
+								(const uint8_t __user *)(unsigned long)val + dpi_lookahead_size,
 								val_len - dpi_lookahead_size);
 
 						if (unlikely(len != 0))
@@ -838,7 +838,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 #ifdef UDIG
 					u32 sl = args->consumer->snaplen;
 #else
-					u32 sl = compute_snaplen(args, (char *)(syscall_arg_t)val, val_len);
+					u32 sl = compute_snaplen(args, (char *)(unsigned long)val, val_len);
 #endif
 					if (val_len > sl)
 						val_len = sl;
@@ -848,7 +848,7 @@ int val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, 
 					return PPM_FAILURE_BUFFER_FULL;
 
 				memcpy(args->buffer + args->arg_data_offset,
-					(void *)(syscall_arg_t)val, val_len);
+					(void *)(unsigned long)val, val_len);
 
 				len = val_len;
 			}
@@ -875,7 +875,7 @@ send_empty_bytebuf_param:
 			if(fromuser)
 			{
 				len = (int)ppm_copy_from_user(args->buffer + args->arg_data_offset,
-						(const void __user *)(syscall_arg_t)val,
+						(const void __user *)(unsigned long)val,
 						val_len);
 
 				if(unlikely(len != 0))
@@ -888,7 +888,7 @@ send_empty_bytebuf_param:
 			else
 			{
 				memcpy(args->buffer + args->arg_data_offset,
-					(void *)(syscall_arg_t)val, val_len);
+					(void *)(unsigned long)val, val_len);
 
 				len = val_len;
 			}
@@ -1740,7 +1740,7 @@ int32_t compat_parse_readv_writev_bufs(struct event_filler_arguments *args, cons
 int f_sys_autofill(struct event_filler_arguments *args)
 {
 	int res;
-	syscall_arg_t val;
+	unsigned long val;
 	u32 j;
 	int64_t retval;
 
@@ -1751,7 +1751,7 @@ int f_sys_autofill(struct event_filler_arguments *args)
 		if (evinfo->autofill_args[j].id >= 0) {
 #ifdef UDIG
 		{
-			syscall_arg_t syscall_args[6] = {0};
+			unsigned long syscall_args[6] = {0};
 			ppm_syscall_get_arguments(current, args->regs, syscall_args);
 			val = syscall_args[evinfo->autofill_args[j].id];
 		}

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -221,7 +221,7 @@ int f_sys_empty(struct event_filler_arguments *args)
 int f_sys_single(struct event_filler_arguments *args)
 {
 	int res;
-	syscall_arg_t val;
+	unsigned long val;
 
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	res = val_to_ring(args, val, 0, true, 0);
@@ -337,9 +337,9 @@ out_unlock:
 
 int f_sys_open_e(struct event_filler_arguments *args)
 {
-	syscall_arg_t val;
-	syscall_arg_t flags;
-	syscall_arg_t modes;
+	unsigned long val;
+	unsigned long flags;
+	unsigned long modes;
 	char *name = NULL;
 	int res;
 
@@ -375,10 +375,10 @@ int f_sys_open_e(struct event_filler_arguments *args)
 
 int f_sys_open_x(struct event_filler_arguments *args)
 {
-	syscall_arg_t val;
-	syscall_arg_t flags;
-	syscall_arg_t scap_flags;
-	syscall_arg_t modes;
+	unsigned long val;
+	unsigned long flags;
+	unsigned long scap_flags;
+	unsigned long modes;
 	uint32_t dev = 0;
 	uint64_t ino = 0;
 	int res;
@@ -1586,7 +1586,7 @@ cgroups_error:
 int f_sys_execve_e(struct event_filler_arguments *args)
 {
 	int res;
-	syscall_arg_t val;
+	unsigned long val;
 
 	/*
 	 * filename
@@ -1601,7 +1601,7 @@ int f_sys_execve_e(struct event_filler_arguments *args)
 int f_sys_execveat_e(struct event_filler_arguments *args)
 {
 	int res;
-	syscall_arg_t val;
+	unsigned long val;
 	unsigned long flags;
 	s32 fd;
 
@@ -1660,7 +1660,7 @@ int f_sys_socket_bind_x(struct event_filler_arguments *args)
 	int err = 0;
 	u16 size = 0;
 	struct sockaddr __user *usrsockaddr;
-	syscall_arg_t val;
+	unsigned long val;
 	struct sockaddr_storage address;
 	char *targetbuf = args->str_storage;
 
@@ -1720,7 +1720,7 @@ int f_sys_connect_e(struct event_filler_arguments *args)
 	u16 size = 0;
 	char *targetbuf = args->str_storage;
 	struct sockaddr_storage address;
-	syscall_arg_t val;
+	unsigned long val;
 
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
 	fd = (int)val;
@@ -1781,7 +1781,7 @@ int f_sys_connect_x(struct event_filler_arguments *args)
 	u16 size = 0;
 	char *targetbuf = args->str_storage;
 	struct sockaddr_storage address;
-	syscall_arg_t val;
+	unsigned long val;
 
 	/*
 	 * Push the result
@@ -2130,7 +2130,7 @@ int f_sys_setsockopt_x(struct event_filler_arguments *args)
 {
 	int res = 0;
 	long retval = 0;
-	syscall_arg_t val[5] = {0};
+	unsigned long val[5] = {0};
 	s32 fd = 0;
 
 	/* Parameter 1: res (type: PT_ERRNO) */
@@ -2171,7 +2171,7 @@ int f_sys_getsockopt_x(struct event_filler_arguments *args)
 	int64_t retval = 0;
 	uint32_t optlen = 0;
 	s32 fd = 0;
-	syscall_arg_t val[5] = {0};
+	unsigned long val[5] = {0};
 
 	/* Get all the five arguments */
 	syscall_get_arguments_deprecated(args, 0, 5, val);
@@ -2236,10 +2236,10 @@ int f_sys_accept_x(struct event_filler_arguments *args)
 	int fd;
 	char *targetbuf = args->str_storage;
 	u16 size = 0;
-	syscall_arg_t queuepct = 0;
-	syscall_arg_t ack_backlog = 0;
-	syscall_arg_t max_ack_backlog = 0;
-	syscall_arg_t srvskfd;
+	unsigned long queuepct = 0;
+	unsigned long ack_backlog = 0;
+	unsigned long max_ack_backlog = 0;
+	unsigned long srvskfd;
 	int err = 0;
 	struct socket *sock;
 
@@ -7808,8 +7808,8 @@ int f_sys_prctl_x(struct event_filler_arguments *args)
 {
 	int res;
 	int retval;
-	syscall_arg_t option;
-	syscall_arg_t arg2;
+	unsigned long option;
+	unsigned long arg2;
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = (int64_t)syscall_get_return_value(current, args->regs);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

Use more consistent types and standards across the dirver code base.

**Which issue(s) this PR fixes**:

part of #902
(partial fix other issues still remain in 902)

**Special notes for your reviewer**:

Tagging @dwindsor @incertum  for visibility.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
