### PR TITLE
fix(userspace/libscap): fix memleak in scap_linux_get_fdlist

### DIFF
--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1367,6 +1367,7 @@ int32_t scap_linux_get_threadlist(struct scap_platform* platform, struct ppm_pro
 
 int32_t scap_linux_get_fdlist(struct scap_platform* platform, struct scap_threadinfo *tinfo, char *lasterr)
 {
+	int res = SCAP_SUCCESS;
 	uint64_t num_fds_ret = 0;
 	char proc_dir[SCAP_MAX_PATH_SIZE];
 	struct scap_ns_socket_list* sockets_by_ns = NULL;
@@ -1375,5 +1376,10 @@ int32_t scap_linux_get_fdlist(struct scap_platform* platform, struct scap_thread
 	// We collect file descriptors only for the main thread
 	snprintf(proc_dir, sizeof(proc_dir), "%s/proc/%lu/", scap_get_host_root(), tinfo->pid);
 
-	return scap_fd_scan_fd_dir(linux_platform, &platform->m_proclist, proc_dir, tinfo, &sockets_by_ns, &num_fds_ret, lasterr);
+	res = scap_fd_scan_fd_dir(linux_platform, &platform->m_proclist, proc_dir, tinfo, &sockets_by_ns, &num_fds_ret, lasterr);	
+	if(sockets_by_ns != NULL && sockets_by_ns != (void*)-1)
+	{
+		scap_fd_free_ns_sockets_list(&sockets_by_ns);
+	}
+	return res;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes a memory leak problem.

I built `sinsp-example` from master (2d118d79e59576b2f1341798a56032b0bdf3b9cb) and tested it by following command line:

```bash
valgrind --leak-check=yes ./sinsp-example -b probe.o -f "evt.type = execve and evt.dir = < and container.id != host and proc.name = bash"
```

The output of valgrind indicated that there were some memory leaked:

```
==428618==
==428618== 346,048 (1,120 direct, 344,928 indirect) bytes in 1 blocks are definitely lost in loss record 175 of 177
==428618==    at 0x4C3BE4B: calloc (vg_replace_malloc.c:1328)
==428618==    by 0x6A61E0: scap_fd_read_netlink_sockets_from_proc_fs (scap_fds.c:598)
==428618==    by 0x6A7725: scap_fd_read_sockets (scap_fds.c:1176)
==428618==    by 0x6A7DF8: scap_fd_handle_socket (scap_fds.c:396)
==428618==    by 0x6A8462: scap_fd_scan_fd_dir (scap_fds.c:1352)
==428618==    by 0x6A4C74: scap_linux_get_fdlist (scap_procs.c:1391)
==428618==    by 0x58736F: parse_rw_exit (parsers.cpp:4949)
==428618==    by 0x58736F: sinsp_parser::parse_rw_exit(sinsp_evt*) (parsers.cpp:4780)
==428618==    by 0x58529A: sinsp_parser::process_event(sinsp_evt*) (parsers.cpp:306)
==428618==    by 0x4A6E1F: sinsp::next(sinsp_evt**) (sinsp.cpp:1469)
==428618==    by 0x47C68F: get_event(sinsp&, std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) (test.cpp:457)
==428618==    by 0x46B0F1: main (test.cpp:425)
==428618==
==428618== 1,032,448 (3,360 direct, 1,029,088 indirect) bytes in 3 blocks are definitely lost in loss record 176 of 177
==428618==    at 0x4C37135: malloc (vg_replace_malloc.c:381)
==428618==    by 0x6A5BAB: scap_fd_read_unix_sockets_from_proc_fs (scap_fds.c:465)
==428618==    by 0x6A76EB: scap_fd_read_sockets (scap_fds.c:1168)
==428618==    by 0x6A7DF8: scap_fd_handle_socket (scap_fds.c:396)
==428618==    by 0x6A8462: scap_fd_scan_fd_dir (scap_fds.c:1352)
==428618==    by 0x6A4C74: scap_linux_get_fdlist (scap_procs.c:1391)
==428618==    by 0x58736F: parse_rw_exit (parsers.cpp:4949)
==428618==    by 0x58736F: sinsp_parser::parse_rw_exit(sinsp_evt*) (parsers.cpp:4780)
==428618==    by 0x58529A: sinsp_parser::process_event(sinsp_evt*) (parsers.cpp:306)
==428618==    by 0x4A6E1F: sinsp::next(sinsp_evt**) (sinsp.cpp:1469)
==428618==    by 0x47C68F: get_event(sinsp&, std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) (test.cpp:457)
==428618==    by 0x46B0F1: main (test.cpp:425)
==428618==
==428618== LEAK SUMMARY:
==428618==    definitely lost: 10,568 bytes in 52 blocks
==428618==    indirectly lost: 1,724,672 bytes in 1,672 blocks
==428618==      possibly lost: 350,720 bytes in 316 blocks
==428618==    still reachable: 52,402 bytes in 617 blocks
==428618==         suppressed: 0 bytes in 0 blocks
==428618== Reachable blocks (those to which a pointer was found) are not shown.
==428618== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==428618==
==428618== Use --track-origins=yes to see where uninitialised values come from
==428618== For lists of detected and suppressed errors, rerun with: -s
==428618== ERROR SUMMARY: 3145 errors from 100 contexts (suppressed: 0 from 0)
```

By reading releated code thoroughly, I believed the function `scap_linux_get_fdlist` has to call `scap_fd_free_ns_sockets_list` to free its local variable `sockets_by_ns`, just like what `scap_proc_read_thread` does.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No.

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
