### PR TITLE
cleanup(scap): remove platform handle from scap_t

### DIFF
--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -260,7 +260,7 @@ int open_engine(int argc, char** argv)
 	}
 
 	char error_buffer[FILENAME_MAX] = {0};
-	event_test::s_scap_handle = scap_open(&oargs, vtable, nullptr, error_buffer, &ret);
+	event_test::s_scap_handle = scap_open(&oargs, vtable, error_buffer, &ret);
 	if(!event_test::s_scap_handle)
 	{
 		std::cerr << "Unable to open the engine: " << error_buffer << std::endl;

--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -31,7 +31,7 @@ scap_t* open_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, 
 	};
 	oargs.engine_params = &bpf_params;
 
-	return scap_open(&oargs, &scap_bpf_engine, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_bpf_engine, error_buf, rc);
 }
 
 TEST(bpf, open_engine)

--- a/test/libscap/test_suites/engines/kmod/kmod.cpp
+++ b/test/libscap/test_suites/engines/kmod/kmod.cpp
@@ -102,7 +102,7 @@ scap_t* open_kmod_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim,
 	};
 	oargs.engine_params = &kmod_params;
 
-	return scap_open(&oargs, &scap_kmod_engine, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_kmod_engine, error_buf, rc);
 }
 
 TEST(kmod, open_engine)

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -33,7 +33,7 @@ scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffe
 	};
 	oargs.engine_params = &modern_bpf_params;
 
-	return scap_open(&oargs, &scap_modern_bpf_engine, nullptr, error_buf, rc);
+	return scap_open(&oargs, &scap_modern_bpf_engine, error_buf, rc);
 }
 
 TEST(modern_bpf, open_engine)

--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -66,19 +66,19 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scap_strl_config.h.in ${CMAKE_CURRENT
 add_library(scap
 	scap.c
 	scap_api_version.c
-	scap_fds.c
 	scap_savefile.c
-	scap_platform.c
-	scap_platform_api.c
-	scap_procs.c
-	scap_userlist.c)
+	scap_platform_api.c)
 
 set_scap_target_properties(scap)
 
 add_library(scap_platform_util
 	STATIC
+	scap_platform.c
+	scap_fds.c
 	scap_iflist.c
-	scap_proc_util.c)
+	scap_proc_util.c
+	scap_procs.c
+	scap_userlist.c)
 add_dependencies(scap_platform_util uthash)
 
 target_link_libraries(scap

--- a/userspace/libscap/engine/savefile/savefile.h
+++ b/userspace/libscap/engine/savefile/savefile.h
@@ -95,6 +95,8 @@ typedef struct scap_ifinfo_ipv6_nolinkspeed
 
 #pragma pack(pop)
 
+struct scap_platform;
+
 struct savefile_engine
 {
 	char* m_lasterr;
@@ -104,5 +106,6 @@ struct savefile_engine
 	char* m_reader_evt_buf;
 	size_t m_reader_evt_buf_size;
 	uint32_t m_last_evt_dump_flags;
+	struct scap_platform* m_platform;
 };
 

--- a/userspace/libscap/engine/savefile/savefile_public.h
+++ b/userspace/libscap/engine/savefile/savefile_public.h
@@ -23,6 +23,7 @@ limitations under the License.
 extern "C"
 {
 #endif
+	struct scap_platform;
 
 	struct scap_savefile_engine_params
 	{
@@ -30,9 +31,10 @@ extern "C"
 		const char* fname;     ///< The name of the file to open.
 		uint64_t start_offset; ///< Used to start reading a capture file from an arbitrary offset. This is leveraged when opening merged files.
 		uint32_t fbuffer_size; ///< If non-zero, offline captures will read from file using a buffer of this size.
+
+		struct scap_platform* platform;
 	};
 
-	struct scap_platform;
 	struct scap_platform* scap_savefile_alloc_platform(proc_entry_callback proc_callback,
 							   void* proc_callback_context);
 

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2210,11 +2210,13 @@ static int32_t init(struct scap* main_handle, struct scap_open_args* oargs)
 	int res;
 	struct savefile_engine *handle = main_handle->m_engine.m_handle;
 	struct scap_savefile_engine_params* params = oargs->engine_params;
-	struct scap_platform *platform = main_handle->m_platform;
 	int fd = params->fd;
 	const char* fname = params->fname;
 	uint64_t start_offset = params->start_offset;
 	uint32_t fbuffer_size = params->fbuffer_size;
+
+	struct scap_platform *platform = params->platform;
+	handle->m_platform = params->platform;
 
 	if(fd != 0)
 	{
@@ -2329,7 +2331,7 @@ static int32_t scap_savefile_close(struct scap_engine_handle engine)
 static int32_t scap_savefile_restart_capture(scap_t* handle)
 {
 	struct savefile_engine *engine = handle->m_engine.m_handle;
-	struct scap_platform *platform = handle->m_platform;
+	struct scap_platform *platform = engine->m_platform;
 	int32_t res;
 
 	scap_platform_close(platform);

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -899,7 +899,7 @@ int main(int argc, char** argv)
 
 	enable_sc_and_print();
 
-	g_h = scap_open(&oargs, vtable, NULL, error, &res);
+	g_h = scap_open(&oargs, vtable, error, &res);
 	if(g_h == NULL || res != SCAP_SUCCESS)
 	{
 		fprintf(stderr, "%s (%d)\n", error, res);

--- a/userspace/libscap/examples/02-validatebuffer/test.c
+++ b/userspace/libscap/examples/02-validatebuffer/test.c
@@ -171,7 +171,7 @@ int main()
 
 	scap_open_args args = {};
 
-	scap_t* h = scap_open(&args, &scap_kmod_engine, NULL, error, &ret);
+	scap_t* h = scap_open(&args, &scap_kmod_engine, error, &ret);
 	if(h == NULL)
 	{
 		fprintf(stderr, "%s (%d)\n", error, ret);

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -48,7 +48,6 @@ struct scap
 {
 	const struct scap_vtable *m_vtable;
 	struct scap_engine_handle m_engine;
-	struct scap_platform *m_platform;
 
 	char m_lasterr[SCAP_LASTERR_SIZE];
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -86,12 +86,9 @@ scap_t* scap_alloc(void)
 	return calloc(1, sizeof(scap_t));
 }
 
-int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable,
-		  struct scap_platform* platform)
+int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable)
 {
 	int32_t rc;
-
-	handle->m_platform = platform;
 
 	ASSERT(vtable != NULL);
 
@@ -109,20 +106,10 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtabl
 	{
 		return rc;
 	}
-
-	if(handle->m_platform)
-	{
-		if((rc = scap_platform_init(handle->m_platform, handle->m_lasterr, handle->m_engine, oargs)) != SCAP_SUCCESS)
-		{
-			return rc;
-		}
-	}
-
 	return SCAP_SUCCESS;
 }
 
-scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform, char* error,
-		  int32_t* rc)
+scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, char* error, int32_t* rc)
 {
 	scap_t* handle = scap_alloc();
 	if(!handle)
@@ -131,7 +118,7 @@ scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, struc
 		return NULL;
 	}
 
-	*rc = scap_init(handle, oargs, vtable, platform);
+	*rc = scap_init(handle, oargs, vtable);
 	if(*rc != SCAP_SUCCESS)
 	{
 		strlcpy(error, handle->m_lasterr, SCAP_LASTERR_SIZE);
@@ -157,12 +144,6 @@ uint32_t scap_restart_capture(scap_t* handle)
 
 void scap_deinit(scap_t* handle)
 {
-	if(handle->m_platform)
-	{
-		scap_platform_close(handle->m_platform);
-		scap_platform_free(handle->m_platform);
-	}
-
 	if(handle->m_vtable)
 	{
 		/* The capture should be stopped before

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -494,8 +494,7 @@ scap_t* scap_alloc(void);
   If this function fails, the only thing you can safely do with the handle is to call
   \ref scap_deinit on it.
 */
-int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable,
-		  struct scap_platform* platform);
+int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtable* vtable);
 
 /*!
   \brief Allocate and initialize a handle
@@ -516,8 +515,7 @@ int32_t scap_init(scap_t* handle, scap_open_args* oargs, const struct scap_vtabl
 
   \return The capture instance handle in case of success. NULL in case of failure.
 */
-scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform, char* error,
-		  int32_t* rc);
+scap_t* scap_open(scap_open_args* oargs, const struct scap_vtable* vtable, char* error, int32_t* rc);
 
 /*!
   \brief Deinitialize a capture handle.

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -42,11 +42,11 @@ void scap_refresh_iflist(struct scap_platform* platform)
 	}
 }
 
-scap_userlist* scap_get_user_list(scap_t* handle)
+scap_userlist* scap_get_user_list(struct scap_platform* platform)
 {
-	if (handle && handle->m_platform)
+	if (platform)
 	{
-		return handle->m_platform->m_userlist;
+		return platform->m_userlist;
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -52,11 +52,11 @@ scap_userlist* scap_get_user_list(struct scap_platform* platform)
 	return NULL;
 }
 
-uint32_t scap_get_device_by_mount_id(scap_t *handle, const char *procdir, unsigned long requested_mount_id)
+uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char *procdir, unsigned long requested_mount_id)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->get_device_by_mount_id)
+	if (platform && platform->m_vtable->get_device_by_mount_id)
 	{
-		return handle->m_platform->m_vtable->get_device_by_mount_id(handle->m_platform, procdir, requested_mount_id);
+		return platform->m_vtable->get_device_by_mount_id(platform, procdir, requested_mount_id);
 	}
 
 	return 0;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -24,11 +24,11 @@ limitations under the License.
 #include "scap.h"
 #include "scap-int.h"
 
-scap_addrlist* scap_get_ifaddr_list(scap_t* handle)
+scap_addrlist* scap_get_ifaddr_list(struct scap_platform* platform)
 {
-	if (handle && handle->m_platform)
+	if (platform)
 	{
-		return handle->m_platform->m_addrlist;
+		return platform->m_addrlist;
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -135,11 +135,11 @@ const scap_machine_info* scap_get_machine_info(struct scap_platform* platform)
 //
 // Get the agent information
 //
-const scap_agent_info* scap_get_agent_info(scap_t* handle)
+const scap_agent_info* scap_get_agent_info(struct scap_platform* platform)
 {
-	if(handle && handle->m_platform)
+	if(platform)
 	{
-		return (const scap_agent_info*)&handle->m_platform->m_agent_info;
+		return (const scap_agent_info*)&platform->m_agent_info;
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -160,14 +160,13 @@ struct ppm_proclist_info* scap_get_threadlist(struct scap_platform* platform, ch
 	return NULL;
 }
 
-
-int32_t scap_get_fdlist(struct scap* handle, struct scap_threadinfo *tinfo)
+int32_t scap_get_fdlist(struct scap_platform* platform, struct scap_threadinfo* tinfo, char* error)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->get_fdlist)
+	if (platform && platform->m_vtable->get_fdlist)
 	{	
-		return handle->m_platform->m_vtable->get_fdlist(handle->m_platform, tinfo, handle->m_lasterr);
+		return platform->m_vtable->get_fdlist(platform, tinfo, error);
 	}
 
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "operation not supported");
+	snprintf(error, SCAP_LASTERR_SIZE, "operation not supported");
 	return SCAP_FAILURE;
 }

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -145,18 +145,18 @@ const scap_agent_info* scap_get_agent_info(struct scap_platform* platform)
 	return NULL;
 }
 
-struct ppm_proclist_info* scap_get_threadlist(scap_t* handle)
+struct ppm_proclist_info* scap_get_threadlist(struct scap_platform* platform, char* error)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->get_threadlist)
+	if (platform && platform->m_vtable->get_threadlist)
 	{
-		if(handle->m_platform->m_vtable->get_threadlist(handle->m_platform, &handle->m_platform->m_driver_procinfo, handle->m_lasterr) == SCAP_SUCCESS)
+		if(platform->m_vtable->get_threadlist(platform, &platform->m_driver_procinfo, error) == SCAP_SUCCESS)
 		{
-			return handle->m_platform->m_driver_procinfo;
+			return platform->m_driver_procinfo;
 		}
 		return NULL;
 	}
 
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "operation not supported");
+	snprintf(error, SCAP_LASTERR_SIZE, "operation not supported");
 	return NULL;
 }
 

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -103,15 +103,15 @@ bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t t
 	return true;
 }
 
-int32_t scap_getpid_global(scap_t* handle, int64_t* pid)
+int32_t scap_getpid_global(struct scap_platform* platform, int64_t* pid)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->get_global_pid)
+	if (platform && platform->m_vtable->get_global_pid)
 	{
-		return handle->m_platform->m_vtable->get_global_pid(handle->m_platform, pid, handle->m_lasterr);
+		char lasterr[SCAP_LASTERR_SIZE];
+		return platform->m_vtable->get_global_pid(platform, pid, lasterr);
 	}
 
 	ASSERT(false);
-	snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Cannot get pid (capture not enabled)");
 	return SCAP_FAILURE;
 }
 

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -62,11 +62,11 @@ uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char 
 	return 0;
 }
 
-struct scap_threadinfo* scap_proc_get(scap_t* handle, int64_t tid, bool scan_sockets)
+struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->get_proc)
+	if (platform && platform->m_vtable->get_proc)
 	{
-		return handle->m_platform->m_vtable->get_proc(handle->m_platform, &handle->m_platform->m_proclist, tid, scan_sockets);
+		return platform->m_vtable->get_proc(platform, &platform->m_proclist, tid, scan_sockets);
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -92,11 +92,11 @@ scap_threadinfo* scap_get_proc_table(struct scap_platform* platform)
 	return NULL;
 }
 
-bool scap_is_thread_alive(scap_t* handle, int64_t pid, int64_t tid, const char* comm)
+bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->is_thread_alive)
+	if (platform && platform->m_vtable->is_thread_alive)
 	{
-		return handle->m_platform->m_vtable->is_thread_alive(handle->m_platform, pid, tid, comm);
+		return platform->m_vtable->is_thread_alive(platform, pid, tid, comm);
 	}
 
 	// keep on the safe side, don't consider threads dead too early

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -34,11 +34,11 @@ scap_addrlist* scap_get_ifaddr_list(struct scap_platform* platform)
 	return NULL;
 }
 
-void scap_refresh_iflist(scap_t* handle)
+void scap_refresh_iflist(struct scap_platform* platform)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->refresh_addr_list)
+	if (platform && platform->m_vtable->refresh_addr_list)
 	{
-		handle->m_platform->m_vtable->refresh_addr_list(handle->m_platform);
+		platform->m_vtable->refresh_addr_list(platform);
 	}
 }
 

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -115,11 +115,11 @@ int32_t scap_getpid_global(struct scap_platform* platform, int64_t* pid)
 	return SCAP_FAILURE;
 }
 
-const scap_machine_info* scap_get_machine_info(scap_t* handle)
+const scap_machine_info* scap_get_machine_info(struct scap_platform* platform)
 {
-	if(handle && handle->m_platform)
+	if(platform)
 	{
-		scap_machine_info* machine_info = &handle->m_platform->m_machine_info;
+		scap_machine_info* machine_info = &platform->m_machine_info;
 		if(machine_info->num_cpus != (uint32_t)-1)
 		{
 			return machine_info;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -72,11 +72,11 @@ struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t ti
 	return NULL;
 }
 
-int32_t scap_refresh_proc_table(scap_t* handle)
+int32_t scap_refresh_proc_table(struct scap_platform* platform)
 {
-	if (handle && handle->m_platform && handle->m_platform->m_vtable->refresh_proc_table)
+	if (platform && platform->m_vtable->refresh_proc_table)
 	{
-		return handle->m_platform->m_vtable->refresh_proc_table(handle->m_platform, &handle->m_platform->m_proclist);
+		return platform->m_vtable->refresh_proc_table(platform, &platform->m_proclist);
 	}
 
 	return SCAP_FAILURE;

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -82,11 +82,11 @@ int32_t scap_refresh_proc_table(struct scap_platform* platform)
 	return SCAP_FAILURE;
 }
 
-scap_threadinfo* scap_get_proc_table(scap_t* handle)
+scap_threadinfo* scap_get_proc_table(struct scap_platform* platform)
 {
-	if (handle && handle->m_platform)
+	if (platform)
 	{
-		return handle->m_platform->m_proclist.m_proclist;
+		return platform->m_proclist.m_proclist;
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -61,7 +61,7 @@ struct scap_userlist* scap_get_user_list(struct scap_platform* platform);
 
 // get the device major/minor number for the requested_mount_id, looking in procdir/mountinfo if needed
 // XXX: procdir is Linux-specific
-uint32_t scap_get_device_by_mount_id(struct scap *handle, const char *procdir, unsigned long requested_mount_id);
+uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char *procdir, unsigned long requested_mount_id);
 
 // Get the information about a process.
 // The returned pointer must be freed via scap_proc_free by the caller.

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -130,7 +130,7 @@ struct ppm_proclist_info* scap_get_threadlist(struct scap_platform* platform, ch
 /*!
   \brief Get the file descriptor list for a given pid.
 */
-int32_t scap_get_fdlist(struct scap* handle, struct scap_threadinfo* tinfo);
+int32_t scap_get_fdlist(struct scap_platform* platform, struct scap_threadinfo* tinfo, char* error);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -52,12 +52,12 @@ void scap_refresh_iflist(struct scap_platform* platform);
 /*!
   \brief Return the machine user and group lists
 
-  \param handle Handle to the capture instance.
+  \param platform Handle to the platform instance.
 
   \return The pointer to a \ref scap_userlist structure containing the user and
   group lists, or NULL if the function fails.
 */
-struct scap_userlist* scap_get_user_list(struct scap* handle);
+struct scap_userlist* scap_get_user_list(struct scap_platform* platform);
 
 // get the device major/minor number for the requested_mount_id, looking in procdir/mountinfo if needed
 // XXX: procdir is Linux-specific

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -32,6 +32,7 @@ struct ppm_proclist_info;
 struct scap;
 struct scap_addrlist;
 struct _scap_machine_info;
+struct scap_platform;
 struct scap_threadinfo;
 typedef struct _scap_agent_info scap_agent_info;
 
@@ -39,12 +40,12 @@ typedef struct _scap_agent_info scap_agent_info;
   \brief Return the list of the the user interfaces of the machine from which the
   events are being captured.
 
-  \param handle Handle to the capture instance.
+  \param platform Handle to the platform instance.
 
   \return The pointer to a \ref scap_addrlist structure containing the interface list,
   or NULL if the function fails.
 */
-struct scap_addrlist* scap_get_ifaddr_list(struct scap* handle);
+struct scap_addrlist* scap_get_ifaddr_list(struct scap_platform* platform);
 
 void scap_refresh_iflist(struct scap* handle);
 

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -65,7 +65,7 @@ uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char 
 
 // Get the information about a process.
 // The returned pointer must be freed via scap_proc_free by the caller.
-struct scap_threadinfo* scap_proc_get(struct scap* handle, int64_t tid, bool scan_sockets);
+struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
 
 int32_t scap_refresh_proc_table(struct scap* handle);
 

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -98,7 +98,7 @@ int32_t scap_refresh_proc_table(struct scap_platform* platform);
 struct scap_threadinfo* scap_get_proc_table(struct scap_platform* platform);
 
 // Check if the given thread exists in /proc
-bool scap_is_thread_alive(struct scap* handle, int64_t pid, int64_t tid, const char* comm);
+bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm);
 
 // like getpid() but returns the global PID even inside a container
 int32_t scap_getpid_global(struct scap* handle, int64_t* pid);

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -111,7 +111,7 @@ int32_t scap_getpid_global(struct scap_platform* platform, int64_t* pid);
   \note for live captures, the information is collected from the operating system. For
   offline captures, it comes from the capture file.
 */
-const struct _scap_machine_info* scap_get_machine_info(struct scap* handle);
+const struct _scap_machine_info* scap_get_machine_info(struct scap_platform* platform);
 
 /*!
   \brief Get generic agent information

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -101,7 +101,7 @@ struct scap_threadinfo* scap_get_proc_table(struct scap_platform* platform);
 bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm);
 
 // like getpid() but returns the global PID even inside a container
-int32_t scap_getpid_global(struct scap* handle, int64_t* pid);
+int32_t scap_getpid_global(struct scap_platform* platform, int64_t* pid);
 
 /*!
   \brief Get generic machine information

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -67,7 +67,7 @@ uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char 
 // The returned pointer must be freed via scap_proc_free by the caller.
 struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
 
-int32_t scap_refresh_proc_table(struct scap* handle);
+int32_t scap_refresh_proc_table(struct scap_platform* platform);
 
 /*!
   \brief Get the process list for the given capture instance

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -72,7 +72,7 @@ int32_t scap_refresh_proc_table(struct scap_platform* platform);
 /*!
   \brief Get the process list for the given capture instance
 
-  \param handle Handle to the capture instance.
+  \param platform Handle to the platform instance.
 
   \return Pointer to the process list.
 
@@ -95,7 +95,7 @@ int32_t scap_refresh_proc_table(struct scap_platform* platform);
   Refer to the documentation of the \ref scap_threadinfo struct for details about its
   content.
 */
-struct scap_threadinfo* scap_get_proc_table(struct scap* handle);
+struct scap_threadinfo* scap_get_proc_table(struct scap_platform* platform);
 
 // Check if the given thread exists in /proc
 bool scap_is_thread_alive(struct scap* handle, int64_t pid, int64_t tid, const char* comm);

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -47,7 +47,7 @@ typedef struct _scap_agent_info scap_agent_info;
 */
 struct scap_addrlist* scap_get_ifaddr_list(struct scap_platform* platform);
 
-void scap_refresh_iflist(struct scap* handle);
+void scap_refresh_iflist(struct scap_platform* platform);
 
 /*!
   \brief Return the machine user and group lists

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -125,7 +125,7 @@ const scap_agent_info* scap_get_agent_info(struct scap_platform* platform);
 /*!
   \brief Get the process list.
 */
-struct ppm_proclist_info* scap_get_threadlist(struct scap* handle);
+struct ppm_proclist_info* scap_get_threadlist(struct scap_platform* platform, char* error);
 
 /*!
   \brief Get the file descriptor list for a given pid.

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -120,7 +120,7 @@ const struct _scap_machine_info* scap_get_machine_info(struct scap_platform* pla
 
   \note for live captures only.
 */
-const scap_agent_info* scap_get_agent_info(struct scap* handle);
+const scap_agent_info* scap_get_agent_info(struct scap_platform* platform);
 
 /*!
   \brief Get the process list.

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 #include "sinsp.h"
 #include "sinsp_int.h"
 #include "scap.h"
-#include "scap-int.h" // for scap_t->m_platform
 #include "dumper.h"
 
 sinsp_dumper::sinsp_dumper()
@@ -55,12 +54,12 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 
 	if(m_target_memory_buffer)
 	{
-		m_dumper = scap_memory_dump_open(inspector->m_h->m_platform, m_target_memory_buffer, m_target_memory_buffer_size, error);
+		m_dumper = scap_memory_dump_open(inspector->get_scap_platform(), m_target_memory_buffer, m_target_memory_buffer_size, error);
 	}
 	else
 	{
 		auto compress_mode = compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE;
-		m_dumper = scap_dump_open(inspector->m_h->m_platform, filename.c_str(), compress_mode, threads_from_sinsp, error);
+		m_dumper = scap_dump_open(inspector->get_scap_platform(), filename.c_str(), compress_mode, threads_from_sinsp, error);
 	}
 
 	if(m_dumper == nullptr)
@@ -89,7 +88,7 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_
 	}
 
 	auto compress_mode = compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE;
-	m_dumper = scap_dump_open_fd(inspector->m_h->m_platform, fd, compress_mode, threads_from_sinsp, error);
+	m_dumper = scap_dump_open_fd(inspector->get_scap_platform(), fd, compress_mode, threads_from_sinsp, error);
 
 	if(m_dumper == nullptr)
 	{

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -477,7 +477,7 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo_t* fdi, uint64_t fd)
 	{
 		char procdir[SCAP_MAX_PATH_SIZE];
 		snprintf(procdir, sizeof(procdir), "%s/proc/%ld/", scap_get_host_root(), m_tid);
-		fdi->m_dev = scap_get_device_by_mount_id(m_inspector->m_h, procdir, fdi->m_mount_id);
+		fdi->m_dev = scap_get_device_by_mount_id(m_inspector->get_scap_platform(), procdir, fdi->m_mount_id);
 		fdi->m_mount_id = 0; // don't try again
 	}
 #endif // _WIN32

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4705,6 +4705,8 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 					struct cmsghdr *cmsg = (struct cmsghdr *)parinfo->m_val;
 					if(cmsg->cmsg_type == SCM_RIGHTS)
 					{
+						char error[SCAP_LASTERR_SIZE];
+
 						auto scap_tinfo = scap_proc_alloc(m_inspector->m_h);
 						if (scap_tinfo == NULL)
 						{
@@ -4715,9 +4717,10 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 
 						// Get the new fds. The callbacks we have registered populate the fd table
 						// with the new file descriptors.
-						if (scap_get_fdlist(m_inspector->m_h, scap_tinfo) != SCAP_SUCCESS)
+						if (scap_get_fdlist(m_inspector->get_scap_platform(), scap_tinfo, error) != SCAP_SUCCESS)
 						{
-							g_logger.format(sinsp_logger::SEV_DEBUG, "scap_get_fdlist failed, proc table will not be updated with new fds.");
+							g_logger.format(sinsp_logger::SEV_DEBUG, "scap_get_fdlist failed: %s, proc table will not be updated with new fds.",
+									error);
 						}
 
 						scap_proc_free(m_inspector->m_h, scap_tinfo);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -351,7 +351,7 @@ void sinsp::init()
 	//
 	// Retrieve agent information
 	//
-	m_agent_info = scap_get_agent_info(m_h);
+	m_agent_info = scap_get_agent_info(get_scap_platform());
 	if (m_agent_info == NULL)
 	{
 		ASSERT(false);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1154,7 +1154,7 @@ void sinsp::import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo)
 void sinsp::import_user_list()
 {
 	uint32_t j;
-	scap_userlist* ul = scap_get_user_list(m_h);
+	scap_userlist* ul = scap_get_user_list(get_scap_platform());
 
 	if(ul)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1122,7 +1122,7 @@ void sinsp::import_thread_table()
 	scap_threadinfo *pi;
 	scap_threadinfo *tpi;
 
-	scap_threadinfo *table = scap_get_proc_table(m_h);
+	scap_threadinfo *table = scap_get_proc_table(get_scap_platform());
 
 	//
 	// Scan the scap table and add the threads to our list

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1299,10 +1299,11 @@ void sinsp::get_procs_cpu_from_driver(uint64_t ts)
 
 	m_last_procrequest_tod = procrequest_tod;
 
-	m_meinfo.m_pli = scap_get_threadlist(m_h);
+	char error[SCAP_LASTERR_SIZE];
+	m_meinfo.m_pli = scap_get_threadlist(get_scap_platform(), error);
 	if(m_meinfo.m_pli == NULL)
 	{
-		throw sinsp_exception(std::string("scap error: ") + scap_getlasterr(m_h));
+		throw sinsp_exception(std::string("scap error: ") + error);
 	}
 
 	m_meinfo.m_n_procinfo_evts = m_meinfo.m_pli->n_entries;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -459,7 +459,7 @@ void sinsp::init()
 #if defined(HAS_CAPTURE)
 	if(is_live())
 	{
-		int32_t res = scap_getpid_global(m_h, &m_self_pid);
+		int32_t res = scap_getpid_global(get_scap_platform(), &m_self_pid);
 		ASSERT(res == SCAP_SUCCESS || res == SCAP_NOT_SUPPORTED);
 		(void)res;
 	}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1138,7 +1138,7 @@ void sinsp::import_thread_table()
 void sinsp::import_ifaddr_list()
 {
 	m_network_interfaces.clear();
-	m_network_interfaces.import_interfaces(scap_get_ifaddr_list(m_h));
+	m_network_interfaces.import_interfaces(scap_get_ifaddr_list(get_scap_platform()));
 }
 
 const sinsp_network_interfaces& sinsp::get_ifaddr_list()
@@ -1176,8 +1176,7 @@ void sinsp::refresh_ifaddr_list()
 	if(is_live() || is_syscall_plugin())
 	{
 		scap_refresh_iflist(m_h);
-		m_network_interfaces.clear();
-		m_network_interfaces.import_interfaces(scap_get_ifaddr_list(m_h));
+		import_ifaddr_list();
 	}
 #endif
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -3021,3 +3021,12 @@ uint64_t sinsp::get_new_ts()
 			? sinsp_utils::get_current_time_ns()
 			: m_lastevent_ts;
 }
+
+struct scap_platform* sinsp::get_scap_platform()
+{
+	if(!m_h)
+	{
+		return nullptr;
+	}
+	return m_h->m_platform;
+}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -337,7 +337,7 @@ void sinsp::init()
 	//
 	// Retrieve machine information
 	//
-	m_machine_info = scap_get_machine_info(m_h);
+	m_machine_info = scap_get_machine_info(get_scap_platform());
 	if(m_machine_info != NULL)
 	{
 		m_num_cpus = m_machine_info->num_cpus;
@@ -1040,7 +1040,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 	// Retrieve machine information if we don't have it yet
 	//
 	{
-		m_machine_info = scap_get_machine_info(m_h);
+		m_machine_info = scap_get_machine_info(get_scap_platform());
 		if(m_machine_info != NULL)
 		{
 			m_num_cpus = m_machine_info->num_cpus;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -706,6 +706,8 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 
 	// AFAICT this is because tinfo==NULL when calling the callback in scap_read_fdlist
 	struct scap_platform* platform = scap_savefile_alloc_platform(nullptr, nullptr);
+	params.platform = platform;
+
 	open_common(&oargs, &scap_savefile_engine, platform, SINSP_MODE_CAPTURE);
 #else
 	throw sinsp_exception("SAVEFILE engine is not supported in this build");

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1175,7 +1175,7 @@ void sinsp::refresh_ifaddr_list()
 #if defined(HAS_CAPTURE) && !defined(_WIN32)
 	if(is_live() || is_syscall_plugin())
 	{
-		scap_refresh_iflist(m_h);
+		scap_refresh_iflist(get_scap_platform());
 		import_ifaddr_list();
 	}
 #endif

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2885,7 +2885,7 @@ bool sinsp_thread_manager::remove_inactive_threads()
 		m_threadtable.loop([&] (sinsp_threadinfo& tinfo) {
 			if(tinfo.is_invalid() ||
 				((m_inspector->m_lastevent_ts > tinfo.m_lastaccess_ts + m_inspector->m_thread_timeout_ns) &&
-					!scap_is_thread_alive(m_inspector->m_h, tinfo.m_pid, tinfo.m_tid, tinfo.m_comm.c_str())))
+					!scap_is_thread_alive(m_inspector->get_scap_platform(), tinfo.m_pid, tinfo.m_tid, tinfo.m_comm.c_str())))
 			{
 				to_delete.insert(tinfo.m_tid);
 			}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1136,6 +1136,8 @@ private:
 	struct scap_platform* get_scap_platform();
 
 	scap_t* m_h;
+	struct scap_platform* m_platform {};
+	char m_platform_lasterr[SCAP_LASTERR_SIZE];
 	uint64_t m_nevts;
 	int64_t m_filesize;
 	sinsp_mode_t m_mode = SINSP_MODE_NONE;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -969,7 +969,7 @@ public:
 	}
 	void refresh_ifaddr_list();
 	void refresh_proc_list() {
-		scap_refresh_proc_table(m_h);
+		scap_refresh_proc_table(get_scap_platform());
 	}
 
 	std::vector<long> get_n_tracepoint_hit();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1133,6 +1133,8 @@ private:
 		return left == static_cast<uint64_t>(-1) || left <= right;
 	}
 
+	struct scap_platform* get_scap_platform();
+
 	scap_t* m_h;
 	uint64_t m_nevts;
 	int64_t m_filesize;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2151,7 +2151,7 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
 #ifdef HAS_ANALYZER
             uint64_t ts = sinsp_utils::get_current_time_ns();
 #endif
-            scap_proc = scap_proc_get(m_inspector->m_h, tid, scan_sockets);
+            scap_proc = scap_proc_get(m_inspector->get_scap_platform(), tid, scan_sockets);
 #ifdef HAS_ANALYZER
             m_n_proc_lookups_duration_ns += sinsp_utils::get_current_time_ns() - ts;
 #endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Another small step towards untangling platforms from libscap: remove the platform handle from scap_t and move it to the sinsp object. This is a fairly large PR as it touches a lot of places but the changes are basically:
* take the platform handle directly in all scap_platform_api wrapper functions
* explicitly pass the platform pointer to the savefile engine
* move platform initialization/cleanup to sinsp (which now owns the scap_platform pointer)

see https://github.com/falcosecurity/libs/pull/1401 for the somewhat bigger picture

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
BREAKING CHANGE: all scap_platform_api functions now take a `scap_platform*` rather than `scap_t*`
BREAKING CHANGE: scap_open no longer takes a `scap_platform*`
BREAKING CHANGE: m_h->m_platform is no longer valid inside sinsp, use scap_get_platform() instead
```
