### PR TITLE
cleanup(driver/bpf/filler_helpers.h) inconsistent int types

### DIFF
--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -70,7 +70,7 @@ static unsigned long long (*bpf_get_prandom_u32)(void) =
 	(void *)BPF_FUNC_get_prandom_u32;
 static int (*bpf_xdp_adjust_head)(void *ctx, int offset) =
 	(void *)BPF_FUNC_xdp_adjust_head;
-static int (*bpf_probe_read_str)(void *dst, u64 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_str)(void *dst, uint64_tt64_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
 
 #if defined(USE_BPF_PROBE_KERNEL_USER_VARIANTS)
@@ -93,7 +93,7 @@ static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_
 	(void *)BPF_FUNC_probe_read_str;
 #endif
 
-static u64 (*bpf_get_current_task)(void) =
+static uint64_tt64_t (*bpf_get_current_task)(void) =
 	(void *)BPF_FUNC_get_current_task;
 static int (*bpf_skb_load_bytes)(void *ctx, int off, void *to, int len) =
 	(void *)BPF_FUNC_skb_load_bytes;

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -71,7 +71,7 @@ static __always_inline struct file *bpf_fget(int fd)
 	return fil;
 }
 
-static __always_inline u32 bpf_get_fd_fmode_created(int fd)
+static __always_inline uint32_t bpf_get_fd_fmode_created(int fd)
 {
 	if(fd < 0)
     {
@@ -151,12 +151,12 @@ static __always_inline char *bpf_d_path_approx(struct filler_data *data, struct 
 	bpf_probe_read_kernel(&mnt_root_p, sizeof(struct dentry *), &(vfsmnt->mnt_root));
 
 	/* This is the max length of the buffer in which we will write the full path. */
-	u32 max_buf_len = MAX_TMP_SCRATCH_LEN;
+	uint32_t max_buf_len = MAX_TMP_SCRATCH_LEN;
 
 	/* Populated inside the loop */
 	struct dentry *d_parent = NULL;
 	struct qstr d_name = {};
-	u32 current_off = 0;
+	uint32_t current_off = 0;
 	int effective_name_len = 0;
 	char slash = '/';
 	char terminator = '\0';
@@ -339,7 +339,7 @@ static __always_inline bool bpf_getsockname(struct socket *sock,
 			sin->sin_port = _READ(inet->inet_dport);
 			sin->sin_addr.s_addr = _READ(inet->inet_daddr);
 		} else {
-			u32 addr = _READ(inet->inet_rcv_saddr);
+			uint32_t addr = _READ(inet->inet_rcv_saddr);
 
 			if (!addr)
 				addr = _READ(inet->inet_saddr);
@@ -430,16 +430,16 @@ static __always_inline int bpf_addr_to_kernel(void *uaddr, int ulen,
 
 #define get_buf(x) data->buf[(data->state->tail_ctx.curoff + (x)) & SCRATCH_SIZE_HALF]
 
-static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
-					       u32 lookahead_size)
+static __always_inline uint32_t bpf_compute_snaplen(struct filler_data *data,
+					       uint32_t lookahead_size)
 {
 	struct sockaddr_storage *sock_address;
 	struct sockaddr_storage *peer_address;
-	u32 res = data->settings->snaplen;
+	uint32_t res = data->settings->snaplen;
 	struct socket *sock;
 	struct sock *sk;
-	u16 sport;
-	u16 dport;
+	uint16_t sport;
+	uint16_t dport;
 
 	if (data->settings->tracers_enabled &&
 	    data->state->tail_ctx.evt_type == PPME_SYSCALL_WRITE_X) {
@@ -571,20 +571,20 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 			}
 		}
 	} else if ((sport == PPM_PORT_MONGODB || dport == PPM_PORT_MONGODB) ||
-			(lookahead_size >= 16 && (*(s32 *)&get_buf(12) == 1 || /* matches header */
-						  *(s32 *)&get_buf(12) == 2001 ||
-						  *(s32 *)&get_buf(12) == 2002 ||
-						  *(s32 *)&get_buf(12) == 2003 ||
-						  *(s32 *)&get_buf(12) == 2004 ||
-						  *(s32 *)&get_buf(12) == 2005 ||
-						  *(s32 *)&get_buf(12) == 2006 ||
-						  *(s32 *)&get_buf(12) == 2007))) {
+			(lookahead_size >= 16 && (*(int32_t *)&get_buf(12) == 1 || /* matches header */
+						  *(int32_t *)&get_buf(12) == 2001 ||
+						  *(int32_t *)&get_buf(12) == 2002 ||
+						  *(int32_t *)&get_buf(12) == 2003 ||
+						  *(int32_t *)&get_buf(12) == 2004 ||
+						  *(int32_t *)&get_buf(12) == 2005 ||
+						  *(int32_t *)&get_buf(12) == 2006 ||
+						  *(int32_t *)&get_buf(12) == 2007))) {
 		return SNAPLEN_EXTENDED;
 	} else if (dport == data->settings->statsd_port) {
 		return SNAPLEN_EXTENDED;
 	} else {
 		if (lookahead_size >= 5) {
-			u32 buf = *(u32 *)&get_buf(0);
+			uint32_t buf = *(uint32_t *)&get_buf(0);
 
 #ifdef CONFIG_S390
 			buf = __builtin_bswap32(buf);
@@ -627,17 +627,17 @@ static __always_inline int unix_socket_path(char *dest, const char *user_ptr, si
 	return res;
 }
 
-static __always_inline u16 bpf_pack_addr(struct filler_data *data,
+static __always_inline uint16_t bpf_pack_addr(struct filler_data *data,
 					 struct sockaddr *usrsockaddr,
 					 int ulen)
 {
-	u32 ip;
-	u16 port;
+	uint32_t ip;
+	uint16_t port;
 	sa_family_t family = usrsockaddr->sa_family;
 	struct sockaddr_in *usrsockaddr_in;
 	struct sockaddr_in6 *usrsockaddr_in6;
 	struct sockaddr_un *usrsockaddr_un;
-	u16 size;
+	uint16_t size;
 	char *dest;
 	int res;
 
@@ -758,10 +758,10 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 	switch (family) {
 	case AF_INET:
 	{
-		u32 sip;
-		u32 dip;
-		u16 sport;
-		u16 dport;
+		uint32_t sip;
+		uint32_t dip;
+		uint16_t sport;
+		uint16_t dport;
 
 		if (!use_userdata) {
 			if (bpf_getsockname(sock, peer_address, 1)) {
@@ -828,10 +828,10 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 	}
 	case AF_INET6:
 	{
-		u8 *sip6;
-		u8 *dip6;
-		u16 sport;
-		u16 dport;
+		uint8_t *sip6;
+		uint8_t *dip6;
+		uint16_t sport;
+		uint16_t dport;
 
 		if (!use_userdata) {
 			if (bpf_getsockname(sock, peer_address, 1)) {
@@ -848,8 +848,8 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 				}
 			} else {
 				memset(peer_address, 0, 16);
-				sip6 = (u8 *)peer_address;
-				dip6 = (u8 *)peer_address;
+				sip6 = (uint8_t *)peer_address;
+				dip6 = (uint8_t *)peer_address;
 				sport = 0;
 				dport = 0;
 			}
@@ -965,7 +965,7 @@ static __always_inline long bpf_fd_to_socktuple(struct filler_data *data,
 static __always_inline int __bpf_read_val_into(struct filler_data *data,
 					       unsigned long curoff_bounded,
 					       unsigned long val,
-					       volatile u16 read_size,
+					       volatile uint16_t read_size,
 					       enum read_memory mem)
 {
 	int rc;
@@ -996,7 +996,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 					     unsigned long val,
 					     unsigned long val_len,
 					     enum ppm_param_type type,
-					     u8 dyn_idx,
+					     uint8_t dyn_idx,
 					     bool enforce_snaplen,
 					     enum read_memory mem)
 {
@@ -1010,9 +1010,9 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
 
-	if (dyn_idx != (u8)-1) {
-		*((u8 *)&data->buf[curoff_bounded]) = dyn_idx;
-		len_dyn = sizeof(u8);
+	if (dyn_idx != (uint8_t)-1) {
+		*((uint8_t *)&data->buf[curoff_bounded]) = dyn_idx;
+		len_dyn = sizeof(uint8_t);
 		data->state->tail_ctx.curoff += len_dyn;
 		data->state->tail_ctx.len += len_dyn;
 	}
@@ -1062,7 +1062,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 			if(enforce_snaplen) 
 			{
-				u32 dpi_lookahead_size = DPI_LOOKAHEAD_SIZE;
+				uint32_t dpi_lookahead_size = DPI_LOOKAHEAD_SIZE;
 				unsigned int sl;
 
 				if(dpi_lookahead_size > len)
@@ -1076,7 +1076,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 					 * If we are not able to read at least `dpi_lookahead_size` 
 					 * we send an empty param `len=0`.
 					 */
-					volatile u16 read_size = dpi_lookahead_size;
+					volatile uint16_t read_size = dpi_lookahead_size;
 					int rc = 0;
 
 					rc = __bpf_read_val_into(data, curoff_bounded, val, read_size, mem);
@@ -1102,7 +1102,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 			if(!data->curarg_already_on_frame)
 			{
-				volatile u16 read_size = len;
+				volatile uint16_t read_size = len;
 				int rc = 0;
 
 				curoff_bounded = data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF;
@@ -1151,15 +1151,15 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_ENUMFLAGS8:
 	case PT_UINT8:
 	case PT_SIGTYPE:
-		*((u8 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(u8);
+		*((uint8_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(uint8_t);
 		break;
 	case PT_FLAGS16:
 	case PT_ENUMFLAGS16:
 	case PT_UINT16:
 	case PT_SYSCALLID:
-		*((u16 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(u16);
+		*((uint16_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(uint16_t);
 		break;
 	case PT_FLAGS32:
 	case PT_MODE:
@@ -1168,33 +1168,33 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_GID:
 	case PT_SIGSET:
 	case PT_ENUMFLAGS32:
-		*((u32 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(u32);
+		*((uint32_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(uint32_t);
 		break;
 	case PT_RELTIME:
 	case PT_ABSTIME:
 	case PT_UINT64:
-		*((u64 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(u64);
+		*((uint64_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(uint64_t);
 		break;
 	case PT_INT8:
-		*((s8 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(s8);
+		*((int8_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(int8_t);
 		break;
 	case PT_INT16:
-		*((s16 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(s16);
+		*((int16_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(int16_t);
 		break;
 	case PT_INT32:
-		*((s32 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(s32);
+		*((int32_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(int32_t);
 		break;
 	case PT_INT64:
 	case PT_ERRNO:
 	case PT_FD:
 	case PT_PID:
-		*((s64 *)&data->buf[curoff_bounded]) = val;
-		len = sizeof(s64);
+		*((int64_t *)&data->buf[curoff_bounded]) = val;
+		len = sizeof(int64_t);
 		break;
 	default: {
 		bpf_printk("unhandled type in bpf_val_to_ring: evt_type %d, curarg %d, type %d\n",
@@ -1270,15 +1270,15 @@ static __always_inline int bpf_val_to_ring_mem(struct filler_data *data,
 }
 
 /// TODO: @Andreagit97 these functions should return void
-static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, s64 val)
+static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, int64_t val)
 {
 	/// TODO: @Andreagit97 this could be removed in a second iteration.
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(s64);
-	*((s64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(int64_t);
+	*((int64_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	/// TODO: @Andreagit97 this could be simplified
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
@@ -1289,14 +1289,14 @@ static __always_inline int bpf_push_s64_to_ring(struct filler_data *data, s64 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, u64 val)
+static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, uint64_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(u64);
-	*((u64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(uint64_t);
+	*((uint64_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1306,14 +1306,14 @@ static __always_inline int bpf_push_u64_to_ring(struct filler_data *data, u64 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 val)
+static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, uint32_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(u32);
-	*((u32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(uint32_t);
+	*((uint32_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1323,14 +1323,14 @@ static __always_inline int bpf_push_u32_to_ring(struct filler_data *data, u32 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, s32 val)
+static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, int32_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(s32);
-	*((s32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(int32_t);
+	*((int32_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1340,14 +1340,14 @@ static __always_inline int bpf_push_s32_to_ring(struct filler_data *data, s32 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, u16 val)
+static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, uint16_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(u16);
-	*((u16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(uint16_t);
+	*((uint16_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1357,14 +1357,14 @@ static __always_inline int bpf_push_u16_to_ring(struct filler_data *data, u16 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, s16 val)
+static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, int16_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(s16);
-	*((s16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(int16_t);
+	*((int16_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1374,14 +1374,14 @@ static __always_inline int bpf_push_s16_to_ring(struct filler_data *data, s16 va
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, u8 val)
+static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, uint8_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(u8);
-	*((u8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(uint8_t);
+	*((uint8_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1391,14 +1391,14 @@ static __always_inline int bpf_push_u8_to_ring(struct filler_data *data, u8 val)
 	return PPM_SUCCESS;
 }
 
-static __always_inline int bpf_push_s8_to_ring(struct filler_data *data, s16 val)
+static __always_inline int bpf_push_s8_to_ring(struct filler_data *data, int16_t val)
 {
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 	{
 		return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 	}
-	const unsigned int len = sizeof(s8);
-	*((s8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+	const unsigned int len = sizeof(int8_t);
+	*((int8_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
@@ -1445,7 +1445,7 @@ static __always_inline int bpf_val_to_ring_len(struct filler_data *data,
 static __always_inline int bpf_val_to_ring_dyn(struct filler_data *data,
 					       unsigned long val,
 					       enum ppm_param_type type,
-					       u8 dyn_idx)
+					       uint8_t dyn_idx)
 {
 	return __bpf_val_to_ring(data, val, 0, type, dyn_idx, false, param_type_to_mem(type));
 }

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -319,14 +319,14 @@ FILLER(sys_single_x, true)
 	long retval;
 
 	retval = bpf_syscall_get_retval(data->ctx);
-	return bpf_push_s64_to_ring(data, (s64)retval);
+	return bpf_push_s64_to_ring(data, (int64_t)retval);
 }
 
 FILLER(sys_fstat_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_open_e, true)
@@ -365,7 +365,7 @@ FILLER(sys_open_x, true)
 
 	/* Parameter 1: ret (type: PT_FD) */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, (s64)retval);
+	res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: name (type: PT_FSPATH) */
@@ -394,14 +394,14 @@ FILLER(sys_open_x, true)
 	CHECK_RES(res);
 
 	/* Parameter 6: ino (type: PT_UINT64) */
-	return bpf_push_u64_to_ring(data, (u64)ino);;
+	return bpf_push_u64_to_ring(data, (uint64_t)ino);;
 }
 
 FILLER(sys_read_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
@@ -418,7 +418,7 @@ FILLER(sys_read_x, true)
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, (s64)retval);
+	res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	if (retval < 0)
@@ -439,7 +439,7 @@ FILLER(sys_write_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
@@ -509,7 +509,7 @@ static __always_inline int bpf_poll_parse_fds(struct filler_data *data,
 	/* `data->state->tail_ctx.curoff` will always point to the beginning of the space
 	 * in this way we can fill `nfds` after the for loop.
 	 */
-	off = data->state->tail_ctx.curoff + sizeof(u16);
+	off = data->state->tail_ctx.curoff + sizeof(uint16_t);
 	fds_count = 0;
 
 	#pragma unroll
@@ -522,26 +522,26 @@ static __always_inline int bpf_poll_parse_fds(struct filler_data *data,
 		if (j == nfds)
 			break;
 
-		u16 flags;
+		uint16_t flags;
 		if (enter_event) {
 			flags = poll_events_to_scap(fds[j].events);
 		} else {
 			flags = poll_events_to_scap(fds[j].revents);
 		}
 
-		*(s64 *)&data->buf[off & SCRATCH_SIZE_HALF] = (s64)fds[j].fd;
-		off += sizeof(s64);
+		*(int64_t *)&data->buf[off & SCRATCH_SIZE_HALF] = (int64_t)fds[j].fd;
+		off += sizeof(int64_t);
 		if (off > SCRATCH_SIZE_HALF)
 		{
 			return PPM_FAILURE_FRAME_SCRATCH_MAP_FULL;
 		}
 
-		*(s16 *)&data->buf[off & SCRATCH_SIZE_HALF] = flags;
-		off += sizeof(s16);
+		*(int16_t *)&data->buf[off & SCRATCH_SIZE_HALF] = flags;
+		off += sizeof(int16_t);
 		++fds_count;
 	}
 
-	*((u16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = fds_count;
+	*((uint16_t *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = fds_count;
 	data->curarg_already_on_frame = true;
 	return __bpf_val_to_ring(data, 0, off - data->state->tail_ctx.curoff, PT_FDLIST, -1, false, KERNEL);
 }
@@ -555,14 +555,14 @@ FILLER(sys_poll_e, true)
 	/* Parameter 2: timeout (type: PT_INT64) */
 	/* This is an `int` in the syscall signature but we push it as an `int64` */
 	uint32_t timeout_msecs = (int32_t)bpf_syscall_get_argument(data, 2);
-	return bpf_push_s64_to_ring(data, (s64)timeout_msecs);
+	return bpf_push_s64_to_ring(data, (int64_t)timeout_msecs);
 }
 
 FILLER(sys_poll_x, true)
 {
 	/* Parameter 1: ret (type: PT_FD) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_push_s64_to_ring(data, (s64)retval);
+	int res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fds (type: PT_FDLIST) */
@@ -682,7 +682,7 @@ FILLER(sys_readv_e, true)
 
 	/* Parameter 1: fd (type: PT_FD) */
 	fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_preadv_e, true)
@@ -696,12 +696,12 @@ FILLER(sys_preadv_e, true)
 
 	/* Parameter 1: fd (type: PT_FD) */
 	fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 	
 	/* Parameter 2: pos (type: PT_UINT64) */
 	val = bpf_syscall_get_argument(data, 3);
-	return bpf_push_u64_to_ring(data, (u64)val);
+	return bpf_push_u64_to_ring(data, (uint64_t)val);
 }
 
 FILLER(sys_readv_preadv_x, true)
@@ -713,7 +713,7 @@ FILLER(sys_readv_preadv_x, true)
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, (s64)retval);
+	res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/*
@@ -749,7 +749,7 @@ FILLER(sys_writev_e, true)
 #endif
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	unsigned long iov_pointer = bpf_syscall_get_argument(data, 1);
@@ -781,7 +781,7 @@ FILLER(sys_writev_pwritev_x, true)
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, (s64)retval);
+	res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/*
@@ -815,7 +815,7 @@ static __always_inline int timespec_parse(struct filler_data *data,
 	struct timespec ts = {};
 #endif	
 	bpf_probe_read_user(&ts, sizeof(ts), (void *)val);
-	return bpf_push_u64_to_ring(data, ((u64)ts.tv_sec) * 1000000000 + ts.tv_nsec);
+	return bpf_push_u64_to_ring(data, ((uint64_t)ts.tv_sec) * 1000000000 + ts.tv_nsec);
 }
 
 FILLER(sys_nanosleep_e, true)
@@ -836,7 +836,7 @@ FILLER(sys_futex_e, true)
 
 	/* Parameter 1: addr (type: PT_UINT64) */
 	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_push_u64_to_ring(data, (u64)val);
+	res = bpf_push_u64_to_ring(data, (uint64_t)val);
 	CHECK_RES(res);
 
 	/* Parameter 2: op (type: PT_ENUMFLAGS16) */
@@ -846,7 +846,7 @@ FILLER(sys_futex_e, true)
 
 	/* Parameter 3: val (type: PT_UINT64) */
 	val = bpf_syscall_get_argument(data, 2);
-	return bpf_push_u64_to_ring(data, (u64)val);
+	return bpf_push_u64_to_ring(data, (uint64_t)val);
 }
 
 static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
@@ -953,7 +953,7 @@ FILLER(sys_mmap_e, true)
 	 * fd
 	 */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 4);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -994,7 +994,7 @@ FILLER(sys_fcntl_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
@@ -1008,12 +1008,12 @@ FILLER(sys_fcntl_x, true)
 
 	/* Parameter 1: Return Value */
 	retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_push_s64_to_ring(data, (s64)retval);
+	int res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS8) */
@@ -1039,8 +1039,8 @@ FILLER(sys_getrlimit_setrlrimit_x, true)
 {
 	unsigned long val;
 	long retval;
-	s64 cur;
-	s64 max;
+	int64_t cur;
+	int64_t max;
 	int res;
 
 	/* Parameter 1: ret (type: PT_ERRNO) */
@@ -1210,11 +1210,11 @@ FILLER(sys_socketpair_x, true)
 		}
 	}
 	/* fd1 */
-	res = bpf_push_s64_to_ring(data, (s64)fds[0]);
+	res = bpf_push_s64_to_ring(data, (int64_t)fds[0]);
 	CHECK_RES(res);
 
 	/* fd2 */
-	res = bpf_push_s64_to_ring(data, (s64)fds[1]);
+	res = bpf_push_s64_to_ring(data, (int64_t)fds[1]);
 	CHECK_RES(res);
 
 	/* source */
@@ -1248,7 +1248,7 @@ static int __always_inline parse_sockopt(struct filler_data *data, int level, in
 			 * a `memset` so no need to check return value.
 			 */
 			bpf_probe_read_user(&val32, sizeof(val32), optval);
-			return bpf_val_to_ring_dyn(data, (s64)-val32, PT_ERRNO, PPM_SOCKOPT_IDX_ERRNO);
+			return bpf_val_to_ring_dyn(data, (int64_t)-val32, PT_ERRNO, PPM_SOCKOPT_IDX_ERRNO);
 #endif
 
 #ifdef SO_RCVTIMEO
@@ -1416,12 +1416,12 @@ FILLER(sys_setsockopt_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_push_s64_to_ring(data, (s64)retval);
+	int res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
@@ -1436,7 +1436,7 @@ FILLER(sys_setsockopt_x, true)
 
 	/* Parameter 5: optval (type: PT_DYN) */
 	unsigned long optval = bpf_syscall_get_argument(data, 3);
-	u16 optlen = (u16)bpf_syscall_get_argument(data, 4);
+	uint16_t optlen = (uint16_t)bpf_syscall_get_argument(data, 4);
 	res = parse_sockopt(data, level, optname, (void*)optval, optlen);
 	CHECK_RES(res);
 
@@ -1448,12 +1448,12 @@ FILLER(sys_getsockopt_x, true)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
 	long retval = bpf_syscall_get_retval(data->ctx);
-	int res = bpf_push_s64_to_ring(data, (s64)retval);
+	int res = bpf_push_s64_to_ring(data, (int64_t)retval);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
@@ -1491,7 +1491,7 @@ static __always_inline int f_sys_send_e_common(struct filler_data *data, int fd)
 	/*
 	 * fd
 	 */
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -1609,7 +1609,7 @@ FILLER(sys_execveat_e, true)
 		fd = PPM_AT_FDCWD;
 	}
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -2627,7 +2627,7 @@ FILLER(proc_startupdate_3, true)
 
 		/* Parameter 21: pid_namespace init task start_time monotonic time in ns (type: PT_UINT64) */
 		// only perform lookup when clone/vfork/fork returns 0 (child process / childtid)
-		u64 pidns_init_start_time = 0;
+		uint64_t pidns_init_start_time = 0;
 		if(retval == 0 && pidns)
 		{
 			struct task_struct *child_reaper = (struct task_struct *)_READ(pidns->child_reaper);
@@ -2902,12 +2902,12 @@ FILLER(sys_accept_x, true)
 	 * in the stack, and therefore we can consume them.
 	 */
 	int32_t fd = (int32_t)bpf_syscall_get_retval(data->ctx);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	uint32_t queuelen = 0;
 	uint32_t queuemax = 0;
-	u8 queuepct = 0;
+	uint8_t queuepct = 0;
 
 	if (fd >= 0)
 	{
@@ -2925,7 +2925,7 @@ FILLER(sys_accept_x, true)
 		queuemax = _READ(sk->sk_max_ack_backlog);
 		if(queuelen && queuemax)
 		{
-			queuepct = (u8)((u64)queuelen * 100 / queuemax);
+			queuepct = (uint8_t)((uint64_t)queuelen * 100 / queuemax);
 		}
 	}
 	else
@@ -2950,7 +2950,7 @@ FILLER(sys_close_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_close_x, true)
@@ -2964,7 +2964,7 @@ FILLER(sys_fchdir_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_fchdir_x, true)
@@ -2978,7 +2978,7 @@ FILLER(sys_setns_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
@@ -2990,12 +2990,12 @@ FILLER(sys_setpgid_e, true)
 {
 	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)pid);
+	int res = bpf_push_s64_to_ring(data, (int64_t)pid);
 	CHECK_RES(res);
 
 	/* Parameter 2: pgid (type: PT_PID) */
 	pid_t pgid = (int32_t)bpf_syscall_get_argument(data, 1);
-	return bpf_push_s64_to_ring(data, (s64)pgid);
+	return bpf_push_s64_to_ring(data, (int64_t)pgid);
 }
 
 FILLER(sys_unshare_e, true)
@@ -3057,7 +3057,7 @@ FILLER(sys_openat_e, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -3106,7 +3106,7 @@ FILLER(sys_openat_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -3167,7 +3167,7 @@ FILLER(sys_openat2_e, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -3240,7 +3240,7 @@ FILLER(sys_openat2_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -3303,7 +3303,7 @@ FILLER(sys_open_by_handle_at_x, true)
 	{
 		mountfd = PPM_AT_FDCWD;
 	}
-	res = bpf_push_s64_to_ring(data, (s64)mountfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)mountfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
@@ -3428,7 +3428,7 @@ FILLER(sys_io_uring_enter_x, true)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: to_submit (type: PT_UINT32) */
@@ -3463,7 +3463,7 @@ FILLER(sys_io_uring_register_x, true)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: opcode (type: PT_ENUMFLAGS16) */
@@ -3610,7 +3610,7 @@ FILLER(sys_fsconfig_x, true)
 	/* Parameter 2: fd (type: PT_FD) */
 	/* This is the file-system fd */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS32) */
@@ -3707,7 +3707,7 @@ FILLER(sys_signalfd_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
@@ -3726,7 +3726,7 @@ FILLER(sys_signalfd4_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
@@ -3778,12 +3778,12 @@ FILLER(sys_sendfile_e, true)
 {
 	/* Parameter 1: out_fd (type: PT_FD) */
 	int32_t out_fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)out_fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)out_fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: in_fd (type: PT_FD) */
 	int32_t in_fd = (int32_t)bpf_syscall_get_argument(data, 1);
-	res = bpf_push_s64_to_ring(data, (s64)in_fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)in_fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: offset (type: PT_UINT64) */
@@ -3794,7 +3794,7 @@ FILLER(sys_sendfile_e, true)
 	CHECK_RES(res);
 
 	/* Parameter 4: size (type: PT_UINT64) */
-	u64 size = bpf_syscall_get_argument(data, 3);
+	uint64_t size = bpf_syscall_get_argument(data, 3);
 	return bpf_push_u64_to_ring(data, size);
 }
 
@@ -3816,7 +3816,7 @@ FILLER(sys_prlimit_e, true)
 {
 	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)pid);
+	int res = bpf_push_s64_to_ring(data, (int64_t)pid);
 	CHECK_RES(res);
 
 	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
@@ -3829,10 +3829,10 @@ FILLER(sys_prlimit_x, true)
 	unsigned long val;
 	struct rlimit rl;
 	long retval;
-	s64 newcur;
-	s64 newmax;
-	s64 oldcur;
-	s64 oldmax;
+	int64_t newcur;
+	int64_t newmax;
+	int64_t oldcur;
+	int64_t oldmax;
 	int res;
 
 	/*
@@ -3896,7 +3896,7 @@ FILLER(sys_pwritev_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	unsigned long iov_pointer = bpf_syscall_get_argument(data, 1);
@@ -3919,7 +3919,7 @@ FILLER(sys_pwritev_e, true)
 	CHECK_RES(res);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	u64 pos = (u64)bpf_syscall_get_argument(data, 3);
+	uint64_t pos = (uint64_t)bpf_syscall_get_argument(data, 3);
 	return bpf_push_u64_to_ring(data, pos);
 }
 
@@ -3968,14 +3968,14 @@ FILLER(sys_socket_bind_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_socket_bind_x, true)
 {
 	struct sockaddr *usrsockaddr;
 	unsigned long val;
-	u16 size = 0;
+	uint16_t size = 0;
 	int err = 0;
 	long retval;
 	int res;
@@ -4070,7 +4070,7 @@ FILLER(sys_recvfrom_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: size (type: PT_UINT32) */
@@ -4082,7 +4082,7 @@ FILLER(sys_recvfrom_x, true)
 {
 	struct sockaddr *usrsockaddr;
 	unsigned long val;
-	u16 size = 0;
+	uint16_t size = 0;
 	long retval;
 	int addrlen;
 	int err = 0;
@@ -4147,19 +4147,19 @@ FILLER(sys_shutdown_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
 	int how = (int32_t)bpf_syscall_get_argument(data, 1);
-	return bpf_push_u8_to_ring(data, (u8)shutdown_how_to_scap(how));
+	return bpf_push_u8_to_ring(data, (uint8_t)shutdown_how_to_scap(how));
 }
 
 FILLER(sys_listen_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: backlog (type: PT_INT32) */
@@ -4171,7 +4171,7 @@ FILLER(sys_recvmsg_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_recvmsg_x, true)
@@ -4233,7 +4233,7 @@ FILLER(sys_recvmsg_x_2, true)
 	struct sockaddr *usrsockaddr;
 	struct user_msghdr mh;
 	unsigned long val;
-	u16 size = 0;
+	uint16_t size = 0;
 	long retval;
 	int addrlen;
 	int res;
@@ -4304,7 +4304,7 @@ FILLER(sys_sendmsg_e, true)
 	struct user_msghdr mh;
 	unsigned long iovcnt;
 	unsigned long val;
-	u16 size = 0;
+	uint16_t size = 0;
 	int addrlen;
 	int err = 0;
 	int res;
@@ -4473,11 +4473,11 @@ FILLER(sys_pipe_x, true)
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	res = bpf_push_s64_to_ring(data, (s64)pipefd[0]);
+	res = bpf_push_s64_to_ring(data, (int64_t)pipefd[0]);
 	CHECK_RES(res);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	res = bpf_push_s64_to_ring(data, (s64)pipefd[1]);
+	res = bpf_push_s64_to_ring(data, (int64_t)pipefd[1]);
 	CHECK_RES(res);
 
 	unsigned long ino = 0;
@@ -4510,11 +4510,11 @@ FILLER(sys_pipe2_x, true)
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	res = bpf_push_s64_to_ring(data, (s64)pipefd[0]);
+	res = bpf_push_s64_to_ring(data, (int64_t)pipefd[0]);
 	CHECK_RES(res);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	res = bpf_push_s64_to_ring(data, (s64)pipefd[1]);
+	res = bpf_push_s64_to_ring(data, (int64_t)pipefd[1]);
 	CHECK_RES(res);
 
 	unsigned long ino = 0;
@@ -4547,7 +4547,7 @@ FILLER(sys_lseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (int32_t)val;
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4571,7 +4571,7 @@ FILLER(sys_llseek_e, true)
 	unsigned long val;
 	unsigned long oh;
 	unsigned long ol;
-	u64 offset;
+	uint64_t offset;
 	int32_t fd;
 	int res;
 
@@ -4580,7 +4580,7 @@ FILLER(sys_llseek_e, true)
 	 */
 	val = bpf_syscall_get_argument(data, 0);
 	fd = (int32_t)val;
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4590,7 +4590,7 @@ FILLER(sys_llseek_e, true)
 	 */
 	oh = bpf_syscall_get_argument(data, 1);
 	ol = bpf_syscall_get_argument(data, 2);
-	offset = (((u64)oh) << 32) + ((u64)ol);
+	offset = (((uint64_t)oh) << 32) + ((uint64_t)ol);
 	res = bpf_push_u64_to_ring(data, offset);
 	CHECK_RES(res);
 
@@ -4755,7 +4755,7 @@ FILLER(sys_flock_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
@@ -4767,16 +4767,16 @@ FILLER(sys_ioctl_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: request (type: PT_UINT64) */
-	u64 request = bpf_syscall_get_argument(data, 1);
+	uint64_t request = bpf_syscall_get_argument(data, 1);
 	res = bpf_push_u64_to_ring(data, request);
 	CHECK_RES(res);
 
 	/* Parameter 3: argument (type: PT_UINT64) */
-	u64 argument = bpf_syscall_get_argument(data, 2);
+	uint64_t argument = bpf_syscall_get_argument(data, 2);
 	return bpf_push_u64_to_ring(data, argument);
 }
 
@@ -4801,7 +4801,7 @@ FILLER(sys_pread64_e, true)
 	 * fd
 	 */
 	fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4826,7 +4826,7 @@ FILLER(sys_pwrite64_e, true)
 
 	/* Parameter 1: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	int res = bpf_push_s64_to_ring(data, (s64)fd);
+	int res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 	
 	/* Parameter 2: size (type: PT_UINT32) */
@@ -4835,7 +4835,7 @@ FILLER(sys_pwrite64_e, true)
 	CHECK_RES(res);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	u64 pos = (u64)bpf_syscall_get_argument(data, 3);
+	uint64_t pos = (uint64_t)bpf_syscall_get_argument(data, 3);
 	return bpf_push_u64_to_ring(data, pos);
 }
 
@@ -4858,7 +4858,7 @@ FILLER(sys_renameat_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4876,7 +4876,7 @@ FILLER(sys_renameat_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4907,7 +4907,7 @@ FILLER(sys_renameat2_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4925,7 +4925,7 @@ FILLER(sys_renameat2_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -4969,7 +4969,7 @@ FILLER(sys_symlinkat_x, true)
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
 
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/*
@@ -5033,7 +5033,7 @@ static __always_inline pid_t find_alive_thread(struct task_struct *father)
 	struct list_head *head = &(signal->thread_head);
 	struct list_head *next_thread = (struct list_head *)_READ(head->next);
 
-	u8 cnt = 0;
+	uint8_t cnt = 0;
 	uint32_t flags = 0;
 
 #pragma unroll MAX_THREADS_GROUPS
@@ -5127,7 +5127,7 @@ static __always_inline pid_t find_new_reaper_pid(struct filler_data *data, struc
 	 * We check pid->level, this is slightly more efficient than
 	 * task_active_pid_ns(reaper) != task_active_pid_ns(father).
 	 */
-	u8 cnt = 0;
+	uint8_t cnt = 0;
 	pid_t sub_reaper_pid = 0;
 
 #pragma unroll MAX_HIERARCHY_TRAVERSE
@@ -5220,7 +5220,7 @@ FILLER(sys_procexit_e, false)
 	/* Please note here `pid` is in kernel-lingo so it is a thread id.
 	 * the thread group id is `tgid`.
 	 */
-	res = bpf_push_s64_to_ring(data, (s64)reaper_pid);
+	res = bpf_push_s64_to_ring(data, (int64_t)reaper_pid);
 	CHECK_RES(res);
 
 #ifndef BPF_SUPPORTS_RAW_TRACEPOINTS
@@ -5403,7 +5403,7 @@ FILLER(sys_quotactl_e, true)
 {
 	/* Parameter 1: cmd (type: PT_FLAGS16) */
 	uint32_t cmd = (uint32_t)bpf_syscall_get_argument(data, 0);
-	u16 scap_cmd = quotactl_cmd_to_scap(cmd);
+	uint16_t scap_cmd = quotactl_cmd_to_scap(cmd);
 	int res = bpf_push_u16_to_ring(data, scap_cmd);
 	CHECK_RES(res);
 
@@ -5427,7 +5427,7 @@ FILLER(sys_quotactl_e, true)
 	}
 
 	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
-	u8 quota_fmt = PPM_QFMT_NOT_USED;
+	uint8_t quota_fmt = PPM_QFMT_NOT_USED;
 	if(scap_cmd == PPM_Q_QUOTAON)
 	{
 		quota_fmt = quotactl_fmt_to_scap(id);
@@ -5443,7 +5443,7 @@ FILLER(sys_quotactl_x, true)
 	unsigned long val;
 	long retval;
 	int res;
-	u16 cmd;
+	uint16_t cmd;
 
 	/*
 	 * extract cmd
@@ -5657,14 +5657,14 @@ FILLER(sys_ptrace_e, true)
 
 	/* Parameter 2: pid (type: PT_PID) */
 	pid_t pid = (int32_t) bpf_syscall_get_argument(data, 1);
-	return bpf_push_s64_to_ring(data, (s64)pid);
+	return bpf_push_s64_to_ring(data, (int64_t)pid);
 }
 
-static __always_inline int bpf_parse_ptrace_addr(struct filler_data *data, u16 request)
+static __always_inline int bpf_parse_ptrace_addr(struct filler_data *data, uint16_t request)
 {
 	enum ppm_param_type type;
 	unsigned long val;
-	u8 idx;
+	uint8_t idx;
 
 	val = bpf_syscall_get_argument(data, 2);
 	switch (request) {
@@ -5676,12 +5676,12 @@ static __always_inline int bpf_parse_ptrace_addr(struct filler_data *data, u16 r
 	return bpf_val_to_ring_dyn(data, val, type, idx);
 }
 
-static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, u16 request)
+static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, uint16_t request)
 {
 	enum ppm_param_type type;
 	unsigned long val;
-	u64 dst;
-	u8 idx;
+	uint64_t dst;
+	uint8_t idx;
 
 	val = bpf_syscall_get_argument(data, 3);
 	switch (request) {
@@ -5700,7 +5700,7 @@ static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, u16 r
 	case PPM_PTRACE_SYSCALL:
 		idx = PPM_PTRACE_IDX_SIGTYPE;
 		type = PT_SIGTYPE;
-		dst = (u64)val;
+		dst = (uint64_t)val;
 		break;
 	case PPM_PTRACE_ATTACH:
 	case PPM_PTRACE_TRACEME:
@@ -5710,7 +5710,7 @@ static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, u16 r
 	default:
 		idx = PPM_PTRACE_IDX_UINT64;
 		type = PT_UINT64;
-		dst = (u64)val;
+		dst = (uint64_t)val;
 		break;
 	}
 
@@ -5720,7 +5720,7 @@ static __always_inline int bpf_parse_ptrace_data(struct filler_data *data, u16 r
 FILLER(sys_ptrace_x, true)
 {
 	unsigned long val;
-	u16 request;
+	uint16_t request;
 	long retval;
 	int res;
 
@@ -5755,7 +5755,7 @@ FILLER(sys_bpf_e, true)
 {
 	/* Parameter 1: cmd (type: PT_INT64) */
 	int32_t cmd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)cmd);
+	return bpf_push_s64_to_ring(data, (int64_t)cmd);
 }
 
 FILLER(sys_bpf_x, true)
@@ -5780,7 +5780,7 @@ FILLER(sys_unlinkat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_push_s64_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
@@ -5806,7 +5806,7 @@ FILLER(sys_mkdirat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_push_s64_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
@@ -5926,7 +5926,7 @@ FILLER(sys_fchmodat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_push_s64_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: filename (type: PT_FSRELPATH) */
@@ -5970,7 +5970,7 @@ FILLER(sys_fchmod_x, true)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: mode (type: PT_MODE) */
@@ -6031,7 +6031,7 @@ FILLER(sys_fchown_x, true)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
@@ -6057,7 +6057,7 @@ FILLER(sys_fchownat_x, true)
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	res = bpf_push_s64_to_ring(data, (s64)dirfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)dirfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: pathname (type: PT_FSRELPATH) */
@@ -6086,16 +6086,16 @@ FILLER(sys_copy_file_range_e, true)
 
 	/* Parameter 1: fdin (type: PT_FD) */
 	int32_t fdin = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fdin);
+	res = bpf_push_s64_to_ring(data, (int64_t)fdin);
 	CHECK_RES(res);
 
 	/* Parameter 2: offin (type: PT_UINT64) */
-	u64 offin = bpf_syscall_get_argument(data, 1);
+	uint64_t offin = bpf_syscall_get_argument(data, 1);
 	res = bpf_push_u64_to_ring(data, offin);
 	CHECK_RES(res);
 
 	/* Parameter 3: len (type: PT_UINT64) */
-	u64 len = bpf_syscall_get_argument(data, 4);
+	uint64_t len = bpf_syscall_get_argument(data, 4);
 	return bpf_push_u64_to_ring(data, len);
 }
 
@@ -6175,12 +6175,12 @@ FILLER(sys_splice_e, true)
 
 	/* Parameter 1: fd_in (type: PT_FD) */
 	fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
 	fd = (int32_t)bpf_syscall_get_argument(data, 2);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: size (type: PT_UINT64) */
@@ -6197,7 +6197,7 @@ FILLER(sys_dup_e, true)
 {
 	/* Parameter 1: oldfd (type: PT_FD) */
 	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)oldfd);
+	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
 }
 
 FILLER(sys_dup_x, true)
@@ -6220,7 +6220,7 @@ FILLER(sys_dup2_e, true)
 {
 	/* Parameter 1: oldfd (type: PT_FD) */
 	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)oldfd);
+	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
 }
 
 FILLER(sys_dup2_x, true)
@@ -6250,7 +6250,7 @@ FILLER(sys_dup3_e, true)
 {
 	/* Parameter 1: oldfd (type: PT_FD) */
 	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)oldfd);
+	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
 }
 
 FILLER(sys_dup3_x, true)
@@ -6342,14 +6342,14 @@ FILLER(sys_getdents_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 FILLER(sys_getdents64_e, true)
 {
 	/* Parameter 1: fd (type: PT_FD)*/
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (s64)fd);
+	return bpf_push_s64_to_ring(data, (int64_t)fd);
 }
 
 #ifdef CAPTURE_SCHED_PROC_EXEC
@@ -7011,7 +7011,7 @@ FILLER(sched_prog_fork_3, false)
 	CHECK_RES(res);
 
 	/* Parameter 21: pid_namespace init task start_time monotonic time in ns (type: PT_UINT64) */
-	u64 pidns_init_start_time = 0;
+	uint64_t pidns_init_start_time = 0;
 	if (pidns)
 	{
 		struct task_struct *child_reaper = (struct task_struct *)_READ(pidns->child_reaper);
@@ -7068,7 +7068,7 @@ FILLER(sys_prctl_x, true)
 			 */
 			reaper_attr = 0;
 			bpf_probe_read_user(&reaper_attr, sizeof(reaper_attr), (void*)arg2);
-			res = bpf_push_s64_to_ring(data, (s64)reaper_attr);
+			res = bpf_push_s64_to_ring(data, (int64_t)reaper_attr);
 			CHECK_RES(res);
 			break;
 		case PPM_PR_SET_CHILD_SUBREAPER:
@@ -7115,12 +7115,12 @@ FILLER(sys_pidfd_getfd_x, true)
 
 	/* Parameter 2: pidfd (type: PT_FD) */
 	int32_t pidfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)pidfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)pidfd);
 	CHECK_RES(res);
 
 	/* Parameter 3: targetfd (type: PT_FD) */
 	int32_t targetfd = bpf_syscall_get_argument(data, 1);
-	res = bpf_push_s64_to_ring(data, (s64)targetfd);
+	res = bpf_push_s64_to_ring(data, (int64_t)targetfd);
 	CHECK_RES(res);
 	
 	/* Parameter 4: flags (type: PT_FLAGS32) */
@@ -7142,7 +7142,7 @@ FILLER(sys_pidfd_open_x, true)
 
 	/* Parameter 2: pid (type: PT_PID)*/
 	pid_t pid = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)pid);
+	res = bpf_push_s64_to_ring(data, (int64_t)pid);
 	CHECK_RES(res);
 
 	/* Parameter 3: flags (type: PT_FLAGS32)*/
@@ -7159,7 +7159,7 @@ FILLER(sys_init_module_x, true)
 	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
-	u64 len = bpf_syscall_get_argument(data, 1);
+	uint64_t len = bpf_syscall_get_argument(data, 1);
 
 	/* Parameter 2: img (type: PT_BYTEBUF) */
 	long img = bpf_syscall_get_argument(data, 0);
@@ -7185,7 +7185,7 @@ FILLER(sys_finit_module_x, true)
 
 	/* Parameter 2: fd (type: PT_FD) */
 	int32_t fd = (int32_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: uargs (type: PT_CHARBUF) */
@@ -7235,7 +7235,7 @@ FILLER(sys_mknodat_x, true)
 	fd = (int32_t)bpf_syscall_get_argument(data, 0);
 	if (fd == AT_FDCWD)
 		fd = PPM_AT_FDCWD;
-	res = bpf_push_s64_to_ring(data, (s64)fd);
+	res = bpf_push_s64_to_ring(data, (int64_t)fd);
 	CHECK_RES(res);
 
 	/* Parameter 3: path (type: PT_CHARBUF) */

--- a/driver/bpf/maps.h
+++ b/driver/bpf/maps.h
@@ -102,7 +102,7 @@ struct bpf_map_def __bpf_section("maps") ia32_64_map = {
 #ifndef BPF_SUPPORTS_RAW_TRACEPOINTS
 struct bpf_map_def __bpf_section("maps") stash_map = {
 	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(u64),
+	.key_size = sizeof(uint64_t),
 	.value_size = sizeof(struct sys_stash_args),
 	.max_entries = 65535,
 };

--- a/driver/main.c
+++ b/driver/main.c
@@ -794,7 +794,7 @@ static long ppm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	if (cmd == PPM_IOCTL_GET_PROCLIST) {
 		struct ppm_proclist_info *proclist_info = NULL;
 		struct task_struct *p, *t;
-		u64 nentries = 0;
+		uint64_t nentries = 0;
 		struct ppm_proclist_info pli;
 		u32 memsize;
 
@@ -839,7 +839,7 @@ static long ppm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0))
 					cputime_t utime, stime;
 #else
-					u64 utime, stime;
+					uint64_t utime, stime;
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0))

--- a/driver/modern_bpf/definitions/struct_flavors.h
+++ b/driver/modern_bpf/definitions/struct_flavors.h
@@ -24,7 +24,7 @@ struct mm_struct___v6_2
 
 typedef struct
 {
-	u64 val;
+	uint64_t val;
 } kernel_cap_t___v6_3;
 
 /* COS kernels handle audit field differently, see [1]. To support both

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -17,7 +17,7 @@
 
 /*=============================== SETTINGS ===========================*/
 
-static __always_inline u64 maps__get_boot_time()
+static __always_inline uint64_t maps__get_boot_time()
 {
 	return g_settings.boot_time;
 }

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -135,55 +135,55 @@ static __always_inline void push__param_len(u8 *data, u8 *lengths_pos, u16 len)
 // PUSH FIXED DIMENSIONS
 ///////////////////////////
 
-static __always_inline void push__u8(u8 *data, u64 *payload_pos, u8 param)
+static __always_inline void push__u8(u8 *data, uint64_t *payload_pos, u8 param)
 {
 	*((u8 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(u8);
 }
 
-static __always_inline void push__u16(u8 *data, u64 *payload_pos, u16 param)
+static __always_inline void push__u16(u8 *data, uint64_t *payload_pos, u16 param)
 {
 	*((u16 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(u16);
 }
 
-static __always_inline void push__u32(u8 *data, u64 *payload_pos, u32 param)
+static __always_inline void push__u32(u8 *data, uint64_t *payload_pos, u32 param)
 {
 	*((u32 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(u32);
 }
 
-static __always_inline void push__u64(u8 *data, u64 *payload_pos, u64 param)
+static __always_inline void push__u64(u8 *data, uint64_t *payload_pos, uint64_t param)
 {
-	*((u64 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
-	*payload_pos += sizeof(u64);
+	*((uint64_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(uint64_t);
 }
 
-static __always_inline void push__s16(u8 *data, u64 *payload_pos, s16 param)
+static __always_inline void push__s16(u8 *data, uint64_t *payload_pos, s16 param)
 {
 	*((s16 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(s16);
 }
 
-static __always_inline void push__s32(u8 *data, u64 *payload_pos, s32 param)
+static __always_inline void push__s32(u8 *data, uint64_t *payload_pos, s32 param)
 {
 	*((s32 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(s32);
 }
 
-static __always_inline void push__s64(u8 *data, u64 *payload_pos, s64 param)
+static __always_inline void push__s64(u8 *data, uint64_t *payload_pos, int64_t param)
 {
-	*((s64 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
-	*payload_pos += sizeof(s64);
+	*((int64_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(int64_t);
 }
 
-static __always_inline void push__ipv6(u8 *data, u64 *payload_pos, u32 ipv6[4])
+static __always_inline void push__ipv6(u8 *data, uint64_t *payload_pos, u32 ipv6[4])
 {
 	__builtin_memcpy(&data[SAFE_ACCESS(*payload_pos)], ipv6, 16);
 	*payload_pos += 16;
 }
 
-static __always_inline void push__new_character(u8 *data, u64 *payload_pos, char character)
+static __always_inline void push__new_character(u8 *data, uint64_t *payload_pos, char character)
 {
 	*((char *)&data[SAFE_ACCESS(*payload_pos)]) = character;
 	*payload_pos += sizeof(char);
@@ -193,7 +193,7 @@ static __always_inline void push__new_character(u8 *data, u64 *payload_pos, char
  * a previous character. Since we overwrite it we don't need to update
  * `payload_pos`.
  */
-static __always_inline void push__previous_character(u8 *data, u64 *payload_pos, char character)
+static __always_inline void push__previous_character(u8 *data, uint64_t *payload_pos, char character)
 {
 	*((char *)&data[SAFE_ACCESS(*payload_pos - 1)]) = character;
 }
@@ -216,7 +216,7 @@ static __always_inline void push__previous_character(u8 *data, u64 *payload_pos,
  * @param mem tell where it must read: user-space or kernel-space.
  * @return (u16) the number of bytes written in the buffer. Could be '0' if the passed pointer is not valid.
  */
-static __always_inline u16 push__charbuf(u8 *data, u64 *payload_pos, unsigned long charbuf_pointer, u16 limit, enum read_memory mem)
+static __always_inline u16 push__charbuf(u8 *data, uint64_t *payload_pos, unsigned long charbuf_pointer, u16 limit, enum read_memory mem)
 {
 	int written_bytes = 0;
 
@@ -258,7 +258,7 @@ static __always_inline u16 push__charbuf(u8 *data, u64 *payload_pos, unsigned lo
  * @param mem from which memory we need to read: user-space or kernel-space.
  * @return (u16) the number of bytes written in the buffer. Could be '0' if the passed pointer is not valid.
  */
-static __always_inline u16 push__bytebuf(u8 *data, u64 *payload_pos, unsigned long bytebuf_pointer, u16 len_to_read, enum read_memory mem)
+static __always_inline u16 push__bytebuf(u8 *data, uint64_t *payload_pos, unsigned long bytebuf_pointer, u16 len_to_read, enum read_memory mem)
 {
 	if(mem == KERNEL)
 	{

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -242,7 +242,7 @@ static __always_inline struct file *extract__file_struct_from_fd(s32 file_descri
  * @param fd generic file descriptor.
  * @param ino pointer to the inode number we have to fill.
  */
-static __always_inline void extract__ino_from_fd(s32 fd, u64 *ino)
+static __always_inline void extract__ino_from_fd(s32 fd, uint64_t *ino)
 {
 	struct file *f = extract__file_struct_from_fd(fd);
 	if(!f)
@@ -282,7 +282,7 @@ static __always_inline struct file *extract__exe_file_from_task(struct task_stru
  * @param ino pointer to the inode number we have to fill.
  * @return `i_ino` from f_inode.
  */
-static __always_inline void extract__ino_from_inode(struct inode *f_inode, u64 *ino)
+static __always_inline void extract__ino_from_inode(struct inode *f_inode, uint64_t *ino)
 {
 	BPF_CORE_READ_INTO(ino, f_inode, i_ino);
 }
@@ -293,7 +293,7 @@ static __always_inline void extract__ino_from_inode(struct inode *f_inode, u64 *
  * @param time timespec64 struct.
  * @return epoch in ns.
  */
-static __always_inline u64 extract__epoch_ns_from_time(struct timespec64 time)
+static __always_inline uint64_t extract__epoch_ns_from_time(struct timespec64 time)
 {
 	time64_t tv_sec = time.tv_sec;
 	if (tv_sec < 0)
@@ -310,7 +310,7 @@ static __always_inline u64 extract__epoch_ns_from_time(struct timespec64 time)
  * @param dev pointer to the device number we have to fill.
  * @param ino pointer to the inode number we have to fill.
  */
-static __always_inline void extract__dev_and_ino_from_fd(s32 fd, dev_t *dev, u64 *ino)
+static __always_inline void extract__dev_and_ino_from_fd(s32 fd, dev_t *dev, uint64_t *ino)
 {
 	struct file *f = extract__file_struct_from_fd(fd);
 	if(!f)
@@ -383,7 +383,7 @@ static __always_inline void extract__fdlimit(struct task_struct *task, unsigned 
  * @param capability_type type of capability to extract defined by us.
  * @return PPM encoded capability value
  */
-static __always_inline u64 extract__capability(struct task_struct *task, enum capability_type capability_type)
+static __always_inline uint64_t extract__capability(struct task_struct *task, enum capability_type capability_type)
 {
 	kernel_cap_t cap_struct;
 	unsigned long capability;
@@ -407,7 +407,7 @@ static __always_inline u64 extract__capability(struct task_struct *task, enum ca
 		break;
 	}
 
-	// Kernel 6.3 changed the kernel_cap_struct type from u32[2] to u64.
+	// Kernel 6.3 changed the kernel_cap_struct type from u32[2] to uint64_t.
 	// Luckily enough, it also changed field name from cap to val.
 	if(bpf_core_field_exists(((struct kernel_cap_struct *)0)->cap))
 	{
@@ -550,7 +550,7 @@ static __always_inline pid_t extract__task_xid_vnr(struct task_struct *task, enu
  * @param type pid type.
  * @return `start_time` of init task struct from pid namespace seen from current task pid namespace.
  */
-static __always_inline u64 extract__task_pidns_start_time(struct task_struct *task, enum pid_type type, long in_childtid)
+static __always_inline uint64_t extract__task_pidns_start_time(struct task_struct *task, enum pid_type type, long in_childtid)
 {
 	// only perform lookup when clone/vfork/fork returns 0 (child process / childtid)
 	if (in_childtid == 0)
@@ -609,9 +609,9 @@ static __always_inline unsigned long extract__vm_size(struct mm_struct *mm)
  */
 static __always_inline unsigned long extract__vm_rss(struct mm_struct *mm)
 {
-	s64 file_pages = 0;
-	s64 anon_pages = 0;
-	s64 shmem_pages = 0;
+	int64_t file_pages = 0;
+	int64_t anon_pages = 0;
+	int64_t shmem_pages = 0;
 
 	/* In recent kernel versions (https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25)
 	 * `struct mm_rss_stat` doesn't exist anymore.
@@ -640,7 +640,7 @@ static __always_inline unsigned long extract__vm_rss(struct mm_struct *mm)
  */
 static __always_inline unsigned long extract__vm_swap(struct mm_struct *mm)
 {
-	s64 swap_entries = 0;
+	int64_t swap_entries = 0;
 	if(bpf_core_type_exists(struct mm_rss_stat))
 	{
 		BPF_CORE_READ_INTO(&swap_entries, mm, rss_stat.count[MM_SWAPENTS].counter);
@@ -1079,7 +1079,7 @@ static __always_inline bool extract__exe_writable(struct task_struct *task, stru
 
 	kernel_cap_t cap_struct = {0};
 	READ_TASK_FIELD_INTO(&cap_struct, task, cred, cap_effective);
-	// Kernel 6.3 changed the kernel_cap_struct type from u32[2] to u64.
+	// Kernel 6.3 changed the kernel_cap_struct type from u32[2] to uint64_t.
 	// Luckily enough, it also changed field name from cap to val.
 	if(bpf_core_field_exists(((struct kernel_cap_struct *)0)->cap))
 	{

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -13,10 +13,10 @@
 #include <helpers/extract/extract_from_kernel.h>
 #include <helpers/base/stats.h>
 
-/* `reserved_size - sizeof(u64)` free space is enough because this is the max dimension
+/* `reserved_size - sizeof(uint64_t)` free space is enough because this is the max dimension
  * we put in the ring buffer in one atomic operation.
  */
-#define CHECK_RINGBUF_SPACE(pos, reserved_size) pos >= reserved_size ? reserved_size - sizeof(u64) : pos
+#define CHECK_RINGBUF_SPACE(pos, reserved_size) pos >= reserved_size ? reserved_size - sizeof(uint64_t) : pos
 
 #define PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, size)                                                                         \
 	__builtin_memcpy(&ringbuf->data[CHECK_RINGBUF_SPACE(ringbuf->payload_pos, ringbuf->reserved_event_size)], &param, size); \
@@ -39,7 +39,7 @@
  * struct ringbuf_struct
  * {
  *	  u8 *data;	   // pointer to the space reserved in the ring buffer.
- *	  u64 payload_pos; // position of the first empty byte in the `data` buf.
+ *	  uint64_t payload_pos; // position of the first empty byte in the `data` buf.
  *	  u8 lengths_pos;  // position the first empty slot into the lengths array of the event.
  * };
  *
@@ -66,7 +66,7 @@
 struct ringbuf_struct
 {
 	u8 *data;		 /* pointer to the space reserved in the ring buffer. */
-	u64 payload_pos;	 /* position of the first empty byte in the `data` buf.*/
+	uint64_t payload_pos;	 /* position of the first empty byte in the `data` buf.*/
 	u8 lengths_pos;		 /* position the first empty slot into the lengths array of the event. */
 	u16 reserved_event_size; /* reserved size in the ringbuf. */
 	u16 event_type; /* event type we want to send to userspace */
@@ -215,9 +215,9 @@ static __always_inline void ringbuf__store_s32(struct ringbuf_struct *ringbuf, s
  * @param ringbuf pointer to the `ringbuf_struct`.
  * @param param param to store
  */
-static __always_inline void ringbuf__store_s64(struct ringbuf_struct *ringbuf, s64 param)
+static __always_inline void ringbuf__store_s64(struct ringbuf_struct *ringbuf, int64_t param)
 {
-	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(s64));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(int64_t));
 }
 
 /**
@@ -280,9 +280,9 @@ static __always_inline void ringbuf__store_u32(struct ringbuf_struct *ringbuf, u
  * @param ringbuf pointer to the `ringbuf_struct`.
  * @param param param to store
  */
-static __always_inline void ringbuf__store_u64(struct ringbuf_struct *ringbuf, u64 param)
+static __always_inline void ringbuf__store_u64(struct ringbuf_struct *ringbuf, uint64_t param)
 {
-	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(u64));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(uint64_t));
 }
 
 /**

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -72,17 +72,17 @@ int BPF_PROG(sched_p_exec,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 pgid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t pgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, pgid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -168,7 +168,7 @@ int BPF_PROG(t1_sched_p_exec,
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
-	auxmap__store_s64_param(auxmap, (s64)pgid);
+	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
 	u32 loginuid;
@@ -196,19 +196,19 @@ int BPF_PROG(t1_sched_p_exec,
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
-	u64 cap_inheritable = extract__capability(task, CAP_INHERITABLE);
+	uint64_t cap_inheritable = extract__capability(task, CAP_INHERITABLE);
 	auxmap__store_u64_param(auxmap, cap_inheritable);
 
 	/* Parameter 22: cap_permitted (type: PT_UINT64) */
-	u64 cap_permitted = extract__capability(task, CAP_PERMITTED);
+	uint64_t cap_permitted = extract__capability(task, CAP_PERMITTED);
 	auxmap__store_u64_param(auxmap, cap_permitted);
 
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
-	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
+	uint64_t cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
-	u64 ino = 0;
+	uint64_tt64_t ino = 0;
 	extract__ino_from_inode(exe_inode, &ino);
 	auxmap__store_u64_param(auxmap, ino);
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -208,7 +208,7 @@ int BPF_PROG(t1_sched_p_exec,
 	auxmap__store_u64_param(auxmap, cap_effective);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
-	uint64_tt64_t ino = 0;
+	uint64_t ino = 0;
 	extract__ino_from_inode(exe_inode, &ino);
 	auxmap__store_u64_param(auxmap, ino);
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -173,11 +173,11 @@ int BPF_PROG(sched_proc_exit, struct task_struct *task)
 	/* Parameter 1: status (type: PT_ERRNO) */
 	s32 exit_code = 0;
 	READ_TASK_FIELD_INTO(&exit_code, task, exit_code);
-	auxmap__store_s64_param(auxmap, (s64)exit_code);
+	auxmap__store_s64_param(auxmap, (int64_t)exit_code);
 
 	/* Parameter 2: ret (type: PT_ERRNO) */
 	s32 ret = __WEXITSTATUS(exit_code);
-	auxmap__store_s64_param(auxmap, (s64)ret);
+	auxmap__store_s64_param(auxmap, (int64_t)ret);
 
 	/* Parameter 3: sig (type: PT_SIGTYPE) */
 	u8 sig = 0;
@@ -209,7 +209,7 @@ int BPF_PROG(sched_proc_exit, struct task_struct *task)
 	/* Please note here `pid` is in kernel-lingo so it is a thread id.
 	 * the thread group id is `tgid`.
 	 */
-	auxmap__store_s64_param(auxmap, (s64)reaper_pid);
+	auxmap__store_s64_param(auxmap, (int64_t)reaper_pid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -46,7 +46,7 @@ int BPF_PROG(sched_p_fork,
 	pid_t child_pid = 0;
 	READ_TASK_FIELD_INTO(&child_pid, child, pid);
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)auxmap->data;
-	hdr->tid = (u64)child_pid;
+	hdr->tid = (uint64_t)child_pid;
 
 	/* Parameter 1: res (type: PT_ERRNO) */
 	/* Please note: here we are in the clone child exit
@@ -82,17 +82,17 @@ int BPF_PROG(sched_p_fork,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(child, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(child, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(child, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(child, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 pgid = (s64)extract__task_xid_nr(child, PIDTYPE_PGID);
+	int64_t pgid = (int64_t)extract__task_xid_nr(child, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, pgid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -207,11 +207,11 @@ int BPF_PROG(t1_sched_p_fork,
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = extract__task_xid_vnr(child, PIDTYPE_PID);
-	auxmap__store_s64_param(auxmap, (s64)vtid);
+	auxmap__store_s64_param(auxmap, (int64_t)vtid);
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = extract__task_xid_vnr(child, PIDTYPE_TGID);
-	auxmap__store_s64_param(auxmap, (s64)vpid);
+	auxmap__store_s64_param(auxmap, (int64_t)vpid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -36,8 +36,8 @@ int BPF_PROG(sched_switch,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: next (type: PT_PID) */
-	s64 pid = (s64)extract__task_xid_nr(next, PIDTYPE_PID);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	int64_t pid = (int64_t)extract__task_xid_nr(next, PIDTYPE_PID);
+	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: pgft_maj (type: PT_UINT64) */
 	unsigned long pgft_maj = 0;

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -77,10 +77,10 @@ int BPF_PROG(signal_deliver,
 	}
 
 	/* Parameter 1: spid (type: PT_PID) */
-	ringbuf__store_u64(&ringbuf, (s64)spid);
+	ringbuf__store_u64(&ringbuf, (int64_t)spid);
 
 	/* Parameter 2: dpid (type: PT_PID) */
-	ringbuf__store_u64(&ringbuf, (s64)bpf_get_current_pid_tgid() & 0xffffffff);
+	ringbuf__store_u64(&ringbuf, (int64_t)bpf_get_current_pid_tgid() & 0xffffffff);
 
 	/* Parameter 3: sig (type: PT_SIGTYPE) */
 	ringbuf__store_u8(&ringbuf, (u8)sig);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -94,7 +94,7 @@ int BPF_PROG(accept_x,
 		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
 		if(queuelen && queuemax)
 		{
-			queuepct = (u8)((u64)queuelen * 100 / queuemax);
+			queuepct = (u8)((uint64_t)queuelen * 100 / queuemax);
 		}
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -98,7 +98,7 @@ int BPF_PROG(accept4_x,
 		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
 		if(queuelen && queuemax)
 		{
-			queuepct = (u8)((u64)queuelen * 100 / queuemax);
+			queuepct = (u8)((uint64_t)queuelen * 100 / queuemax);
 		}
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(bind_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(bpf_e,
 
 	/* Parameter 1: cmd (type: PT_INT64) */
 	s32 cmd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)cmd);
+	ringbuf__store_s64(&ringbuf, (int64_t)cmd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/capset.bpf.c
@@ -59,15 +59,15 @@ int BPF_PROG(capset_x,
 	struct task_struct *task = get_current_task();
 
 	/* Parameter 2: cap_inheritable (type: PT_UINT64) */
-	u64 cap_inheritable = extract__capability(task, CAP_INHERITABLE);
+	uint64_t cap_inheritable = extract__capability(task, CAP_INHERITABLE);
 	ringbuf__store_u64(&ringbuf, cap_inheritable);
 
 	/* Parameter 3: cap_permitted (type: PT_UINT64) */
-	u64 cap_permitted = extract__capability(task, CAP_PERMITTED);
+	uint64_t cap_permitted = extract__capability(task, CAP_PERMITTED);
 	ringbuf__store_u64(&ringbuf, cap_permitted);
 
 	/* Parameter 4: cap_effective (type: PT_UINT64) */
-	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
+	uint64_t cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	ringbuf__store_u64(&ringbuf, cap_effective);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -113,17 +113,17 @@ int BPF_PROG(clone_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 ptid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t ptid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, ptid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -217,11 +217,11 @@ int BPF_PROG(t1_clone_x,
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = extract__task_xid_vnr(task, PIDTYPE_PID);
-	auxmap__store_s64_param(auxmap, (s64)vtid);
+	auxmap__store_s64_param(auxmap, (int64_t)vtid);
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
-	auxmap__store_s64_param(auxmap, (s64)vpid);
+	auxmap__store_s64_param(auxmap, (int64_t)vpid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -113,7 +113,7 @@ int BPF_PROG(clone3_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	int64_t64_t64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -113,17 +113,17 @@ int BPF_PROG(clone3_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t64_t64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 ptid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t ptid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, ptid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -214,11 +214,11 @@ int BPF_PROG(t1_clone3_x,
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = extract__task_xid_vnr(task, PIDTYPE_PID);
-	auxmap__store_s64_param(auxmap, (s64)vtid);
+	auxmap__store_s64_param(auxmap, (int64_t)vtid);
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
-	auxmap__store_s64_param(auxmap, (s64)vpid);
+	auxmap__store_s64_param(auxmap, (int64_t)vpid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -61,7 +61,7 @@ int BPF_PROG(close_e,
 
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(connect_e,
 
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 socket_fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR)*/
 	unsigned long sockaddr_ptr = args[1];
@@ -85,7 +85,7 @@ int BPF_PROG(connect_x,
 	}
 
 	/* Parameter 3: fd (type: PT_FD)*/
-	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
@@ -27,14 +27,14 @@ int BPF_PROG(copy_file_range_e,
 
 	/* Parameter 1: fdin (type: PT_FD) */
 	s32 fdin = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fdin);
+	ringbuf__store_s64(&ringbuf, (int64_t)fdin);
 
 	/* Parameter 2: offin (type: PT_UINT64) */
-	u64 offin = extract__syscall_argument(regs, 1);
+	uint64_t offin = extract__syscall_argument(regs, 1);
 	ringbuf__store_u64(&ringbuf, offin);
 
 	/* Parameter 3: len (type: PT_UINT64) */
-	u64 len = extract__syscall_argument(regs, 4);
+	uint64_t len = extract__syscall_argument(regs, 4);
 	ringbuf__store_u64(&ringbuf, len);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -68,10 +68,10 @@ int BPF_PROG(copy_file_range_x,
 
 	/* Parameter 2: fdout (type: PT_FD) */
 	s32 fdout = (s32)extract__syscall_argument(regs, 2);
-	ringbuf__store_s64(&ringbuf, (s64)fdout);
+	ringbuf__store_s64(&ringbuf, (int64_t)fdout);
 
 	/* Parameter 3: offout (type: PT_UINT64) */
-	u64 offout = extract__syscall_argument(regs, 3);
+	uint64_t offout = extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, offout);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/creat.bpf.c
@@ -73,7 +73,7 @@ int BPF_PROG(creat_x,
 	auxmap__store_u32_param(auxmap, open_modes_to_scap(O_CREAT, mode));
 
 	dev_t dev = 0;
-	u64 ino = 0;
+	uint64_t ino = 0;
 
 	if(ret > 0)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(dup_e,
 
 	/* Parameter 1: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -60,7 +60,7 @@ int BPF_PROG(dup_x,
 
 	/* Parameter 2: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(dup2_e,
 
 	/* Parameter 1: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -60,11 +60,11 @@ int BPF_PROG(dup2_x,
 
 	/* Parameter 2: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
 	s32 newfd = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)newfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(dup3_e,
 
 	/* Parameter 1: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -60,11 +60,11 @@ int BPF_PROG(dup3_x,
 
 	/* Parameter 2: oldfd (type: PT_FD) */
 	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)oldfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
 	s32 newfd = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)newfd);
+	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	unsigned long flags = extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_wait.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_wait.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(epoll_wait_e,
 
 	/* Parameter 1: maxevents (type: PT_ERRNO)*/
 	int maxevents = (int)extract__syscall_argument(regs, 2);
-	ringbuf__store_s64(&ringbuf, (s64)maxevents);
+	ringbuf__store_s64(&ringbuf, (int64_t)maxevents);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(eventfd_e,
 
 	/* Parameter 1: initval (type: PT_UINT64) */
 	u32 initval = (u32)extract__syscall_argument(regs, 0);
-	ringbuf__store_u64(&ringbuf, (u64)initval);
+	ringbuf__store_u64(&ringbuf, (uint64_t)initval);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */
 	/* The syscall eventfd has no flags! only `eventfd2` has the `flags` param.

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(eventfd2_e,
 
 	/* Parameter 1: initval (type: PT_UINT64) */
 	u32 initval = (u32)extract__syscall_argument(regs, 0);
-	ringbuf__store_u64(&ringbuf, (u64)initval);
+	ringbuf__store_u64(&ringbuf, (uint64_tt64_t)initval);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(eventfd2_e,
 
 	/* Parameter 1: initval (type: PT_UINT64) */
 	u32 initval = (u32)extract__syscall_argument(regs, 0);
-	ringbuf__store_u64(&ringbuf, (uint64_tt64_t)initval);
+	ringbuf__store_u64(&ringbuf, (uint64_t)initval);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -121,17 +121,17 @@ int BPF_PROG(execve_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 pgid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t pgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, pgid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -232,7 +232,7 @@ int BPF_PROG(t1_execve_x,
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
-	auxmap__store_s64_param(auxmap, (s64)pgid);
+	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
 	u32 loginuid;
@@ -260,19 +260,19 @@ int BPF_PROG(t1_execve_x,
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
-	u64 cap_inheritable = extract__capability(task, CAP_INHERITABLE);
+	uint64_t cap_inheritable = extract__capability(task, CAP_INHERITABLE);
 	auxmap__store_u64_param(auxmap, cap_inheritable);
 
 	/* Parameter 22: cap_permitted (type: PT_UINT64) */
-	u64 cap_permitted = extract__capability(task, CAP_PERMITTED);
+	uint64_t cap_permitted = extract__capability(task, CAP_PERMITTED);
 	auxmap__store_u64_param(auxmap, cap_permitted);
 
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
-	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
+	uint64_t cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
-	u64 ino = 0;
+	uint64_t ino = 0;
 	extract__ino_from_inode(exe_inode, &ino);
 	auxmap__store_u64_param(auxmap, ino);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -143,7 +143,7 @@ int BPF_PROG(execveat_x,
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	int64_t tgid = (int64_t64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(execveat_e,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 2: pathname (type: PT_FSRELPATH) */
 	unsigned long pathname_pointer = extract__syscall_argument(regs, 1);
@@ -138,17 +138,17 @@ int BPF_PROG(execveat_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 pgid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t pgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, pgid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -249,7 +249,7 @@ int BPF_PROG(t1_execveat_x,
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
-	auxmap__store_s64_param(auxmap, (s64)pgid);
+	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
 	u32 loginuid;
@@ -276,19 +276,19 @@ int BPF_PROG(t1_execveat_x,
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
-	u64 cap_inheritable = extract__capability(task, CAP_INHERITABLE);
+	uint64_t cap_inheritable = extract__capability(task, CAP_INHERITABLE);
 	auxmap__store_u64_param(auxmap, cap_inheritable);
 
 	/* Parameter 22: cap_permitted (type: PT_UINT64) */
-	u64 cap_permitted = extract__capability(task, CAP_PERMITTED);
+	uint64_t cap_permitted = extract__capability(task, CAP_PERMITTED);
 	auxmap__store_u64_param(auxmap, cap_permitted);
 
 	/* Parameter 23: cap_effective (type: PT_UINT64) */
-	u64 cap_effective = extract__capability(task, CAP_EFFECTIVE);
+	uint64_t cap_effective = extract__capability(task, CAP_EFFECTIVE);
 	auxmap__store_u64_param(auxmap, cap_effective);
 
 	/* Parameter 24: exe_file ino (type: PT_UINT64) */
-	u64 ino = 0;
+	uint64_t ino = 0;
 	extract__ino_from_inode(exe_inode, &ino);
 	auxmap__store_u64_param(auxmap, ino);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(fchdir_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
@@ -59,7 +59,7 @@ int BPF_PROG(fchmod_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: mode (type: PT_MODE) */
 	unsigned long mode = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(fchmodat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: filename (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
@@ -59,7 +59,7 @@ int BPF_PROG(fchown_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: uid (type: PT_UINT32) */
 	unsigned long uid = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(fchownat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: filename (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -42,7 +42,7 @@ int BPF_PROG(fcntl_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
 	int cmd = (s32)extract__syscall_argument(regs, 1);
@@ -84,7 +84,7 @@ int BPF_PROG(fcntl_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS8) */
 	int cmd = (s32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/finit_module.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/finit_module.bpf.c
@@ -61,7 +61,7 @@ int BPF_PROG(finit_module_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	auxmap__store_s64_param(auxmap, (s64)fd);
+	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: uargs (type: PT_CHARBUF) */
 	unsigned long uargs_ptr = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(flock_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
 	unsigned long operation = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -115,17 +115,17 @@ int BPF_PROG(fork_x,
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
 	/* this is called `ptid` but it is the `pgid`. */
-	s64 ptid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t ptid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, ptid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -209,11 +209,11 @@ int BPF_PROG(t1_fork_x,
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = extract__task_xid_vnr(task, PIDTYPE_PID);
-	auxmap__store_s64_param(auxmap, (s64)vtid);
+	auxmap__store_s64_param(auxmap, (int64_t)vtid);
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
-	auxmap__store_s64_param(auxmap, (s64)vpid);
+	auxmap__store_s64_param(auxmap, (int64_t)vpid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(fsconfig_x,
 	/* Parameter 2: fd (type: PT_FD) */
 	/* This is the file-system fd */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	auxmap__store_s64_param(auxmap, (s64)fd);
+	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS32) */
 	u32 cmd = (u32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(fstat_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(futex_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: addr (type: PT_UINT64) */
-	u64 addr = extract__syscall_argument(regs, 0);
+	uint64_t addr = extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, addr);
 
 	/* Parameter 2: op (type: PT_ENUMFLAGS16) */
@@ -34,7 +34,7 @@ int BPF_PROG(futex_e,
 	ringbuf__store_u16(&ringbuf, futex_op_to_scap((unsigned long)op));
 
 	/* Parameter 3: val (type: PT_UINT64) */
-	u64 val = extract__syscall_argument(regs, 2);
+	uint64_t val = extract__syscall_argument(regs, 2);
 	ringbuf__store_u64(&ringbuf, val);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -64,7 +64,7 @@ int BPF_PROG(futex_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(getdents_e,
 
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(getdents64_e,
 
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(getsockopt_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (s64)fd);
+	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
 	int level = args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/init_module.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/init_module.bpf.c
@@ -59,14 +59,14 @@ int BPF_PROG(init_module_x,
 	/* Parameter 1: ret (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	u64 len = extract__syscall_argument(regs, 1);
+	uint64_t len = extract__syscall_argument(regs, 1);
 
 	/* Parameter 2: img (type: PT_BYTEBUF) */
 	unsigned long img_ptr = extract__syscall_argument(regs, 0);
 	auxmap__store_bytebuf_param(auxmap, img_ptr, len, USER);
 
 	/* Parameter 3: length (type: PT_UINT64) */
-	auxmap__store_u64_param(auxmap, (u64)len);
+	auxmap__store_u64_param(auxmap, (uint64_t)len);
 
 	/* Parameter 4: uargs (type: PT_CHARBUF) */
 	unsigned long uargs_ptr = extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(io_uring_enter_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: to_submit (type: PT_UINT32) */
 	u32 to_submit = (u32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(io_uring_register_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: opcode (type: PT_ENUMFLAGS16) */
 	u32 opcode = (u32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
@@ -27,14 +27,14 @@ int BPF_PROG(ioctl_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: request (type: PT_UINT64) */
-	u64 request = extract__syscall_argument(regs, 1);
+	uint64_t request = extract__syscall_argument(regs, 1);
 	ringbuf__store_u64(&ringbuf, request);
 
 	/* Parameter 3: argument (type: PT_UINT64) */
-	u64 argument = extract__syscall_argument(regs, 2);
+	uint64_t argument = extract__syscall_argument(regs, 2);
 	ringbuf__store_u64(&ringbuf, argument);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(kill_e,
 
 	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: sig (type: PT_SIGTYPE) */
 	u8 sig = (u8)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(linkat_x,
 	{
 		olddirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)olddirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)olddirfd);
 
 	/* Parameter 3: oldpath (type: PT_FSRELPATH) */
 	unsigned long old_path_pointer = extract__syscall_argument(regs, 1);
@@ -75,7 +75,7 @@ int BPF_PROG(linkat_x,
 	{
 		newdirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)newdirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)newdirfd);
 
 	/* Parameter 5: newpath (type: PT_FSRELPATH) */
 	unsigned long new_path_pointer = extract__syscall_argument(regs, 3);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(listen_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: backlog (type: PT_INT32) */
 	s32 backlog = (s32)args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(llseek_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: offset (type: PT_UINT64) */
 	unsigned long oh = extract__syscall_argument(regs, 1);
@@ -64,7 +64,7 @@ int BPF_PROG(llseek_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(lseek_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: offset (type: PT_UINT64) */
 	unsigned long offset = extract__syscall_argument(regs, 1);
@@ -62,7 +62,7 @@ int BPF_PROG(lseek_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(mkdirat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknodat.bpf.c
@@ -65,7 +65,7 @@ int BPF_PROG(mknodat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 2: path (type: PT_CHARBUF) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
@@ -43,7 +43,7 @@ int BPF_PROG(mmap_e,
 
 	/* Paremeter 5: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 4);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 6: offset (type: PT_UINT64) */
 	unsigned long offset = extract__syscall_argument(regs, 5);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
@@ -43,7 +43,7 @@ int BPF_PROG(mmap2_e,
 
 	/* Paremeter 5: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 4);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd);
 
 	/* Parameter 6: pgoffset (type: PT_UINT64) */
 	unsigned long offset = extract__syscall_argument(regs, 5);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
@@ -43,7 +43,7 @@ int BPF_PROG(mmap2_e,
 
 	/* Paremeter 5: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 4);
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 6: pgoffset (type: PT_UINT64) */
 	unsigned long offset = extract__syscall_argument(regs, 5);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(mprotect_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: addr (type: PT_UINT64) */
-	u64 addr = extract__syscall_argument(regs, 0);
+	uint64_t addr = extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, addr);
 
 	/* Parameter 2: length (type: PT_UINT64) */
-	u64 length = extract__syscall_argument(regs, 1);
+	uint64_t length = extract__syscall_argument(regs, 1);
 	ringbuf__store_u64(&ringbuf, length);
 
 	/* Parameter 3: prot (type: PT_FLAGS32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(nanosleep_e,
 	{
 		struct __kernel_timespec ts = {0};
 		bpf_probe_read_user(&ts, bpf_core_type_size(struct __kernel_timespec), (void *)ts_pointer);
-		nanosec = ((uint64_tt64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+		nanosec = ((uint64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/nanosleep.bpf.c
@@ -26,19 +26,19 @@ int BPF_PROG(nanosleep_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: req (type: PT_RELTIME) */
-	u64 nanosec = 0;
+	uint64_t nanosec = 0;
 	unsigned long ts_pointer = extract__syscall_argument(regs, 0);
 	if(bpf_core_type_exists(struct __kernel_timespec))
 	{
 		struct __kernel_timespec ts = {0};
 		bpf_probe_read_user(&ts, bpf_core_type_size(struct __kernel_timespec), (void *)ts_pointer);
-		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+		nanosec = ((uint64_tt64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
 	}
 	else
 	{
 		struct modern_bpf__kernel_timespec ts = {0};
 		bpf_probe_read_user(&ts, sizeof(ts), (void *)ts_pointer);
-		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+		nanosec = ((uint64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
 	}
 	ringbuf__store_u64(&ringbuf, nanosec);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
@@ -84,7 +84,7 @@ int BPF_PROG(open_x,
 	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
 
 	dev_t dev = 0;
-	u64 ino = 0;
+	uint64_t ino = 0;
 
 	if(ret > 0)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(open_by_handle_at_x,
 	{
 		mountfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)mountfd);
+	auxmap__store_s64_param(auxmap, (int64_t)mountfd);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
 	u32 flags = (u32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(openat_e,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 2: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
@@ -82,7 +82,7 @@ int BPF_PROG(openat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
@@ -101,7 +101,7 @@ int BPF_PROG(openat_x,
 	auxmap__store_u32_param(auxmap, open_modes_to_scap(flags, mode));
 
 	dev_t dev = 0;
-	u64 ino = 0;
+	uint64_t ino = 0;
 
 	if(ret > 0)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(openat2_e,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 2: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);
@@ -88,7 +88,7 @@ int BPF_PROG(openat2_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: name (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_getfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_getfd.bpf.c
@@ -60,11 +60,11 @@ int BPF_PROG(pidfd_getfd_x,
 
     /* Parameter 2: pidfd (type: PT_FD) */
     s32 pidfd = (s32)extract__syscall_argument(regs, 0);
-    ringbuf__store_s64(&ringbuf, (s64)pidfd);
+    ringbuf__store_s64(&ringbuf, (int64_t)pidfd);
 
     /* Parameter 3: targetfd (type: PT_FD) */
     s32 targetfd = (s32)extract__syscall_argument(regs, 1);
-    ringbuf__store_s64(&ringbuf, (s64)targetfd);
+    ringbuf__store_s64(&ringbuf, (int64_t)targetfd);
 
     /* Parameter 4: flags (type: PT_FLAGS32)*/
     u32 flags = (u32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_open.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(pidfd_open_x,
 
     /* Parameter 2: pid (type: PT_PID)*/
     pid_t pid = (s32)extract__syscall_argument(regs, 0);
-    ringbuf__store_s64(&ringbuf, (s64)pid); 
+    ringbuf__store_s64(&ringbuf, (int64_t)pid); 
 
     /* Parameter 3: pid (type: PT_FLAGS32)*/
     u32 flags = (u32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
@@ -66,12 +66,12 @@ int BPF_PROG(pipe_x,
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)pipefd[0]);
+	ringbuf__store_s64(&ringbuf, (int64_t)pipefd[0]);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)pipefd[1]);
+	ringbuf__store_s64(&ringbuf, (int64_t)pipefd[1]);
 
-	u64 ino = 0;
+	uint64_t ino = 0;
 	/* On success, pipe returns `0` */
 	if(ret == 0)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
@@ -66,12 +66,12 @@ int BPF_PROG(pipe2_x,
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)pipefd[0]);
+	ringbuf__store_s64(&ringbuf, (int64_t)pipefd[0]);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)pipefd[1]);
+	ringbuf__store_s64(&ringbuf, (int64_t)pipefd[1]);
 
-	u64 ino = 0;
+	uint64_t ino = 0;
 	/* On success, pipe returns `0` */
 	if(ret == 0)
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
@@ -38,7 +38,7 @@ int BPF_PROG(poll_e,
 	/* Parameter 2: timeout (type: PT_INT64) */
 	/* This is an `int` in the syscall signature but we push it as an `int64` */
 	u32 timeout_msecs = (s32)extract__syscall_argument(regs, 2);
-	auxmap__store_s64_param(auxmap, (s64)timeout_msecs);
+	auxmap__store_s64_param(auxmap, (int64_t)timeout_msecs);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
@@ -36,19 +36,19 @@ int BPF_PROG(ppoll_e,
 	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, REQUESTED_EVENTS);
 
 	/* Parameter 2: timeout (type: PT_RELTIME) */
-	u64 nanosec = 0;
+	uint64_t nanosec = 0;
 	unsigned long ts_pointer = extract__syscall_argument(regs, 2);
 	if(bpf_core_type_exists(struct __kernel_timespec))
 	{
 		struct __kernel_timespec ts = {0};
 		bpf_probe_read_user(&ts, bpf_core_type_size(struct __kernel_timespec), (void *)ts_pointer);
-		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+		nanosec = ((uint64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
 	}
 	else
 	{
 		struct modern_bpf__kernel_timespec ts = {0};
 		bpf_probe_read_user(&ts, sizeof(ts), (void *)ts_pointer);
-		nanosec = ((u64)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
+		nanosec = ((uint64_t)ts.tv_sec) * SECOND_TO_NS + ts.tv_nsec;
 	}
 	auxmap__store_u64_param(auxmap, nanosec);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prctl.bpf.c
@@ -80,7 +80,7 @@ int BPF_PROG(prctl_x,
 			auxmap__store_empty_param(auxmap);
 			bpf_probe_read_user(&reaper_attr, sizeof(reaper_attr), (void*)arg2);
 			/* Parameter 4: arg2_int (type: PT_INT64) */
-			auxmap__store_s64_param(auxmap, (s64)reaper_attr);
+			auxmap__store_s64_param(auxmap, (int64_t)reaper_attr);
 			break;
 		case PPM_PR_SET_CHILD_SUBREAPER:
 		default:

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(pread64_e,
 	ringbuf__store_u32(&ringbuf, (u32)size);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	uint64_t pos = (uint64_tt64_t)extract__syscall_argument(regs, 3);
+	uint64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -28,14 +28,14 @@ int BPF_PROG(pread64_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, (u32)size);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	u64 pos = (u64)extract__syscall_argument(regs, 3);
+	uint64_t pos = (uint64_tt64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -28,10 +28,10 @@ int BPF_PROG(preadv_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: pos (type: PT_UINT64) */
-	u64 pos = (u64)extract__syscall_argument(regs, 3);
+	uint64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(prlimit64_e,
 
 	/* Parameter 1: pid (type: PT_PID) */
 	pid_t pid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */
 	unsigned long resource = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(ptrace_e,
 
 	/* Parameter 2: pid (type: PT_PID) */
 	pid_t pid = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -68,11 +68,11 @@ int BPF_PROG(ptrace_x,
 	u16 scap_ptrace_request = ptrace_requests_to_scap(request);
 
 	/* Parameter 2: addr (type: PT_DYN) */
-	u64 addr_pointer = (u64)extract__syscall_argument(regs, 2);
+	uint64_t addr_pointer = (uint64_t)extract__syscall_argument(regs, 2);
 	auxmap__store_ptrace_addr_param(auxmap, ret, addr_pointer);
 
 	/* Parameter 3: data (type: PT_DYN) */
-	u64 data_pointer = (u64)extract__syscall_argument(regs, 3);
+	uint64_t data_pointer = (uint64_t)extract__syscall_argument(regs, 3);
 	auxmap__store_ptrace_data_param(auxmap, ret, scap_ptrace_request, data_pointer);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(pwrite64_e,
 	ringbuf__store_u32(&ringbuf, size);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	uint64_tt64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
+	uint64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -28,14 +28,14 @@ int BPF_PROG(pwrite64_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	size_t size = extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, size);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	u64 pos = (u64)extract__syscall_argument(regs, 3);
+	uint64_tt64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(pwritev_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 	unsigned long iov_cnt = extract__syscall_argument(regs, 2);
@@ -37,7 +37,7 @@ int BPF_PROG(pwritev_e,
 	ringbuf__store_iovec_size_param(&ringbuf, iov_pointer, iov_cnt);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
-	u64 pos = (u64)extract__syscall_argument(regs, 3);
+	uint64_t pos = (uint64_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, pos);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(read_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(readv_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(recv_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)args[2];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(recvfrom_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 socket_fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)socket_fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)args[2];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(recvmsg_e,
 
 	/* Parameter 1: fd (type: PT_FD)*/
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(renameat_x,
 	{
 		olddirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)olddirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)olddirfd);
 
 	/* Parameter 3: oldpath (type: PT_FSRELPATH) */
 	unsigned long old_path_pointer = extract__syscall_argument(regs, 1);
@@ -75,7 +75,7 @@ int BPF_PROG(renameat_x,
 	{
 		newdirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)newdirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)newdirfd);
 
 	/* Parameter 5: newpath (type: PT_FSRELPATH) */
 	unsigned long new_path_pointer = extract__syscall_argument(regs, 3);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(renameat2_x,
 	{
 		olddirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)olddirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)olddirfd);
 
 	/* Parameter 3: oldpath (type: PT_FSRELPATH) */
 	unsigned long old_path_pointer = extract__syscall_argument(regs, 1);
@@ -75,7 +75,7 @@ int BPF_PROG(renameat2_x,
 	{
 		newdirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)newdirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)newdirfd);
 
 	/* Parameter 5: newpath (type: PT_FSRELPATH) */
 	unsigned long new_path_pointer = extract__syscall_argument(regs, 3);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(seccomp_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: operation (type: PT_UINT64)*/
-	u64 operation = (u64)extract__syscall_argument(regs, 0);
+	uint64_t operation = (uint64_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, operation);
 
 	u32 flags = (u32)extract__syscall_argument(regs, 1);
-	ringbuf__store_u64(&ringbuf, (u64)flags);
+	ringbuf__store_u64(&ringbuf, (uint64_t)flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/select.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/select.bpf.c
@@ -54,7 +54,7 @@ int BPF_PROG(select_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
@@ -68,7 +68,7 @@ int BPF_PROG(semctl_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(semget_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(send_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)args[2];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -32,7 +32,7 @@ int BPF_PROG(send_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)args[2];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
@@ -27,11 +27,11 @@ int BPF_PROG(sendfile_e,
 
 	/* Parameter 1: out_fd (type: PT_FD) */
 	s32 out_fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)out_fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)out_fd);
 
 	/* Parameter 2: in_fd (type: PT_FD) */
 	s32 in_fd = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)in_fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)in_fd);
 
 	/* Parameter 3: offset (type: PT_UINT64) */
 	unsigned long offset = 0;
@@ -40,7 +40,7 @@ int BPF_PROG(sendfile_e,
 	ringbuf__store_u64(&ringbuf, offset);
 
 	/* Parameter 4: size (type: PT_UINT64) */
-	u64 size = extract__syscall_argument(regs, 3);
+	uint64_t size = extract__syscall_argument(regs, 3);
 	ringbuf__store_u64(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(sendmsg_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 socket_fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (int64_t64_t)socket_fd);
+	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	unsigned long msghdr_pointer = args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(sendmsg_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 socket_fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+	auxmap__store_s64_param(auxmap, (int64_t64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	unsigned long msghdr_pointer = args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(sendto_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 socket_fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (s64)socket_fd);
+	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)args[2];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(setns_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
 	unsigned long nstype = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
@@ -27,11 +27,11 @@ int BPF_PROG(setpgid_e,
 
 	/* Parameter 1: pid (type: PT_FD) */
 	pid_t pid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)pid);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)pid);
 
 	/* Parameter 2: pgid (type: PT_PID) */
 	pid_t pgid = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)pgid);
+	ringbuf__store_s64(&ringbuf, (int64_t)pgid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(setpgid_e,
 
 	/* Parameter 1: pid (type: PT_FD) */
 	pid_t pid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)pid);
+	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: pgid (type: PT_PID) */
 	pid_t pgid = (s32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(setsockopt_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	auxmap__store_s64_param(auxmap, (s64)fd);
+	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
 	int level = (int)args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(shutdown_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)args[0];
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
 	int how = (s32)args[1];

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(signalfd_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
 	/* Right now we are not interested in the `sigmask`, we can populate it if we need */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(signalfd4_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
 	/* Right now we are not interested in the `sigmask`, we can populate it if we need */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -98,10 +98,10 @@ int BPF_PROG(socketpair_x,
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)fds[0]);
+	ringbuf__store_s64(&ringbuf, (int64_t)fds[0]);
 
 	/* Parameter 3: fd2 (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, (s64)fds[1]);
+	ringbuf__store_s64(&ringbuf, (int64_t)fds[1]);
 
 	/* Parameter 4: source (type: PT_UINT64) */
 	ringbuf__store_u64(&ringbuf, source);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(splice_e,
 
 	/* Parameter 1: fd_in (type: PT_FD) */
 	s32 fd_in = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd_in);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd_in);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
 	s32 fd_out = (s32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
@@ -27,14 +27,14 @@ int BPF_PROG(splice_e,
 
 	/* Parameter 1: fd_in (type: PT_FD) */
 	s32 fd_in = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd_in);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)fd_in);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
 	s32 fd_out = (s32)extract__syscall_argument(regs, 2);
-	ringbuf__store_s64(&ringbuf, (s64)fd_out);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd_out);
 
 	/* Parameter 3: size (type: PT_UINT64) */
-	u64 size = extract__syscall_argument(regs, 4);
+	uint64_t size = extract__syscall_argument(regs, 4);
 	ringbuf__store_u64(&ringbuf, size);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
@@ -68,7 +68,7 @@ int BPF_PROG(splice_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
-	ringbuf__store_s64(&ringbuf, (s64)ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
@@ -67,7 +67,7 @@ int BPF_PROG(symlinkat_x,
 	{
 		linkdirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)linkdirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)linkdirfd);
 
 	/* Parameter 4: linkpath (type: PT_FSRELPATH) */
 	unsigned long linkpath_pointer = extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(tgkill_e,
 
 	/* Parameter 1: tgid (type: PT_PID) */
 	pid_t tgid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)tgid);
+	ringbuf__store_s64(&ringbuf, (int64_t)tgid);
 
 	/* Parameter 2: tid (type: PT_PID) */
 	pid_t tid = (s32)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -27,11 +27,11 @@ int BPF_PROG(tgkill_e,
 
 	/* Parameter 1: tgid (type: PT_PID) */
 	pid_t tgid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)tgid);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)tgid);
 
 	/* Parameter 2: tid (type: PT_PID) */
 	pid_t tid = (s32)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (s64)tid);
+	ringbuf__store_s64(&ringbuf, (int64_t)tid);
 
 	/* Parameter 3: sig (type: PT_SIGTYPE) */
 	u8 sig = (u8)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(tkill_e,
 
 	/* Parameter 1: tid (type: PT_PID) */
 	pid_t tid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t64_t)tid);
+	ringbuf__store_s64(&ringbuf, (int64_t)tid);
 
 	/* Parameter 2: sig (type: PT_SIGTYPE) */
 	u8 sig = (u8)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(tkill_e,
 
 	/* Parameter 1: tid (type: PT_PID) */
 	pid_t tid = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)tid);
+	ringbuf__store_s64(&ringbuf, (int64_t64_t)tid);
 
 	/* Parameter 2: sig (type: PT_SIGTYPE) */
 	u8 sig = (u8)extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(unlinkat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (int64_t64_t)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t)dirfd);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -63,7 +63,7 @@ int BPF_PROG(unlinkat_x,
 	{
 		dirfd = PPM_AT_FDCWD;
 	}
-	auxmap__store_s64_param(auxmap, (s64)dirfd);
+	auxmap__store_s64_param(auxmap, (int64_t64_t)dirfd);
 
 	/* Parameter 3: path (type: PT_FSRELPATH) */
 	unsigned long path_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -114,16 +114,16 @@ int BPF_PROG(vfork_x,
 	}
 
 	/* Parameter 4: tid (type: PT_PID) */
-	s64 pid = (s64)extract__task_xid_nr(task, PIDTYPE_PID);
+	int64_t pid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PID);
 	auxmap__store_s64_param(auxmap, pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* this is called `pid` but it is the `tgid`. */
-	s64 tgid = (s64)extract__task_xid_nr(task, PIDTYPE_TGID);
+	int64_t tgid = (int64_t)extract__task_xid_nr(task, PIDTYPE_TGID);
 	auxmap__store_s64_param(auxmap, tgid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
-	s64 ptid = (s64)extract__task_xid_nr(task, PIDTYPE_PGID);
+	int64_t ptid = (int64_t)extract__task_xid_nr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, ptid);
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
@@ -207,11 +207,11 @@ int BPF_PROG(t1_vfork_x,
 
 	/* Parameter 19: vtid (type: PT_PID) */
 	pid_t vtid = extract__task_xid_vnr(task, PIDTYPE_PID);
-	auxmap__store_s64_param(auxmap, (s64)vtid);
+	auxmap__store_s64_param(auxmap, (int64_t)vtid);
 
 	/* Parameter 20: vpid (type: PT_PID) */
 	pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
-	auxmap__store_s64_param(auxmap, (s64)vpid);
+	auxmap__store_s64_param(auxmap, (int64_t)vpid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(write_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
 	u32 size = (u32)extract__syscall_argument(regs, 2);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(writev_e,
 
 	/* Parameter 1: fd (type: PT_FD) */
 	s32 fd = (s32)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (s64)fd);
+	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);
 	unsigned long iov_cnt = extract__syscall_argument(regs, 2);

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -30,7 +30,7 @@ or GPL2.txt for full copies of the license.
 #include "capture_macro.h"
 #define PPM_NULL_RDEV MKDEV(1, 3)
 
-typedef u64 nanoseconds;
+typedef uint64_t nanoseconds;
 
 /* This is an auxiliary struct we use in setsockopt
  * when `__kernel_timex_timeval` struct is not defined.

--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -134,7 +134,7 @@ static inline void task_cputime(struct task_struct *t,
 }
 #endif /* CONFIG_VIRT_CPU_ACCOUNTING_GEN */
 
-u64 nsecs_to_jiffies64(u64 n)
+uint64_t nsecs_to_jiffies64(uint64_t n)
 {
 #if (NSEC_PER_SEC % HZ) == 0
 		/* Common case, HZ = 100, 128, 200, 250, 256, 500, 512, 1000 etc. */
@@ -151,7 +151,7 @@ u64 nsecs_to_jiffies64(u64 n)
 #endif
 }
 
-unsigned long nsecs_to_jiffies(u64 n)
+unsigned long nsecs_to_jiffies(uint64_t n)
 {
 		return (unsigned long)nsecs_to_jiffies64(n);
 }
@@ -170,9 +170,9 @@ unsigned long nsecs_to_jiffies(u64 n)
  * Perform (stime * rtime) / total, but avoid multiplication overflow by
  * loosing precision when the numbers are big.
  */
-static cputime_t scale_stime(u64 stime, u64 rtime, u64 total)
+static cputime_t scale_stime(uint64_t stime, uint64_t rtime, uint64_tt64_t total)
 {
-	u64 scaled;
+	uint64_t scaled;
 
 	for (;;) {
 		/* Make sure "rtime" is the bigger of stime/rtime */
@@ -206,7 +206,7 @@ drop_precision:
 	 * Make sure gcc understands that this is a 32x32->64 multiply,
 	 * followed by a 64/32->64 divide.
 	 */
-	scaled = div_u64((u64) (u32) stime * (u64) (u32) rtime, (u32)total);
+	scaled = div_u64((uint64_t) (u32) stime * (uint64_t) (u32) rtime, (u32)total);
 	return (__force cputime_t) scaled;
 }
 
@@ -271,8 +271,8 @@ static void cputime_adjust(struct task_cputime *curr,
 	} else {
 		cputime_t total = stime + utime;
 
-		stime = scale_stime((__force u64)stime,
-				    (__force u64)rtime, (__force u64)total);
+		stime = scale_stime((__force uint64_t)stime,
+				    (__force uint64_t)rtime, (__force uint64_t)total);
 		utime = rtime - stime;
 	}
 
@@ -302,14 +302,14 @@ void ppm_task_cputime_adjusted(struct task_struct *p, cputime_t *ut, cputime_t *
 
 static cputime_t scale_utime(cputime_t utime, cputime_t rtime, cputime_t total)
 {
-	u64 temp = (__force u64) rtime;
+	uint64_t temp = (__force uint64_t) rtime;
 
-	temp *= (__force u64) utime;
+	temp *= (__force uint64_t) utime;
 
 	if (sizeof(cputime_t) == 4)
 		temp = div_u64(temp, (__force u32) total);
 	else
-		temp = div64_u64(temp, (__force u64) total);
+		temp = div64_u64(temp, (__force uint64_t) total);
 
 	return (__force cputime_t) temp;
 }
@@ -350,7 +350,7 @@ void ppm_task_cputime_adjusted(struct task_struct *p, cputime_t *ut, cputime_t *
 /*
  * Implementation copied from kernel/time/time.c in 4.11.0
  */
-u64 nsec_to_clock_t(u64 x)
+uint64_t nsec_to_clock_t(uint64_t x)
 {
 #if (NSEC_PER_SEC % USER_HZ) == 0
 	return div_u64(x, NSEC_PER_SEC / USER_HZ);

--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -170,7 +170,7 @@ unsigned long nsecs_to_jiffies(uint64_t n)
  * Perform (stime * rtime) / total, but avoid multiplication overflow by
  * loosing precision when the numbers are big.
  */
-static cputime_t scale_stime(uint64_t stime, uint64_t rtime, uint64_tt64_t total)
+static cputime_t scale_stime(uint64_t stime, uint64_t rtime, uint64_t total)
 {
 	uint64_t scaled;
 

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -96,7 +96,7 @@ extern const struct ppm_event_entry g_ppm_events[];
  */
 int32_t dpi_lookahead_init(void);
 int32_t push_empty_param(struct event_filler_arguments *args);
-int32_t val_to_ring(struct event_filler_arguments *args, uint64_tt64_t val, u32 val_len, bool fromuser, u8 dyn_idx);
+int32_t val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, bool fromuser, u8 dyn_idx);
 u16 pack_addr(struct sockaddr *usrsockaddr, int ulen, char *targetbuf, u16 targetbufsize);
 u16 fd_to_socktuple(int fd, struct sockaddr *usrsockaddr, int ulen, bool use_userdata, bool is_inbound, char *targetbuf, u16 targetbufsize);
 int addr_to_kernel(void __user *uaddr, int ulen, struct sockaddr *kaddr);

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -50,7 +50,7 @@ struct event_filler_arguments {
 	 * stack since all this stuff is always exclusive
 	 */
 #ifdef UDIG
-	u64 *regs; /* the registers containing the call arguments */
+	uint64_t *regs; /* the registers containing the call arguments */
 #else
 	struct pt_regs *regs; /* the registers containing the call arguments */
 #endif
@@ -96,7 +96,7 @@ extern const struct ppm_event_entry g_ppm_events[];
  */
 int32_t dpi_lookahead_init(void);
 int32_t push_empty_param(struct event_filler_arguments *args);
-int32_t val_to_ring(struct event_filler_arguments *args, u64 val, u32 val_len, bool fromuser, u8 dyn_idx);
+int32_t val_to_ring(struct event_filler_arguments *args, uint64_tt64_t val, u32 val_len, bool fromuser, u8 dyn_idx);
 u16 pack_addr(struct sockaddr *usrsockaddr, int ulen, char *targetbuf, u16 targetbufsize);
 u16 fd_to_socktuple(int fd, struct sockaddr *usrsockaddr, int ulen, bool use_userdata, bool is_inbound, char *targetbuf, u16 targetbufsize);
 int addr_to_kernel(void __user *uaddr, int ulen, struct sockaddr *kaddr);

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1872,9 +1872,9 @@ static __always_inline u32 fchownat_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u64 capabilities_to_scap(unsigned long caps)
+static __always_inline uint64_t capabilities_to_scap(unsigned long caps)
 {
-	u64 res = 0;
+	uint64_t res = 0;
 	
 #ifdef CAP_CHOWN
 	if(caps & (1UL << CAP_CHOWN))

--- a/proposals/20220329-modern-bpf-probe.md
+++ b/proposals/20220329-modern-bpf-probe.md
@@ -143,7 +143,7 @@ int catch_syscall_exit_event(struct sys_exit_args * ctx):
    6: (bf) r3 = r0
    7: (85) call bpf_probe_read_kernel#-64432
    8: (b7) r1 = 944
-   9: (79) r3 = *(u64 *)(r10 -16)
+   9: (79) r3 = *(uint64_t *)(r10 -16)
   10: (0f) r3 += r1
   11: (bf) r1 = r10
 ; 
@@ -185,9 +185,9 @@ int catch_syscall_exit_event(struct sys_exit_args * ctx):
 ; struct task_struct *t = bpf_get_current_task_btf();
    0: (85) call bpf_get_current_task_btf#-61936
 ; struct file * f = t->mm->exe_file;
-   1: (79) r1 = *(u64 *)(r0 +2192)
+   1: (79) r1 = *(uint64_t *)(r0 +2192)
 ; struct file * f = t->mm->exe_file;
-   2: (79) r1 = *(u64 *)(r1 +944)
+   2: (79) r1 = *(uint64_t *)(r1 +944)
    3: (b7) r0 = 1
 ; if(!f)
    4: (15) if r1 == 0x0 goto pc+1

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -174,7 +174,7 @@ struct scap_stats_v2 *pman_get_scap_stats_v2(uint32_t flags, uint32_t *nstats, i
 		{
 			g_state.stats[stat].type = STATS_VALUE_TYPE_U64;
 			g_state.stats[stat].flags = PPM_SCAP_STATS_KERNEL_COUNTERS;
-			g_state.stats[stat].value.u64 = 0;
+			g_state.stats[stat].value.uint64_t = 0;
 			strlcpy(g_state.stats[stat].name, modern_bpf_kernel_counters_stats_names[stat], STATS_NAME_MAX);
 		}
 
@@ -191,10 +191,10 @@ struct scap_stats_v2 *pman_get_scap_stats_v2(uint32_t flags, uint32_t *nstats, i
 				close(counter_maps_fd);
 				return NULL;
 			}
-			g_state.stats[MODERN_BPF_N_EVTS].value.u64 += cnt_map.n_evts;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.u64 += cnt_map.n_drops_buffer;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_ENTER].value.u64 += cnt_map.n_drops_buffer_clone_fork_enter;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.u64 += cnt_map.n_drops_buffer_clone_fork_exit;
+			g_state.stats[MODERN_BPF_N_EVTS].value.uint64_t += cnt_map.n_evts;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.uint64_t += cnt_map.n_drops_buffer;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_ENTER].value.uint64_t += cnt_map.n_drops_buffer_clone_fork_enter;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.uint64_t += cnt_map.n_drops_buffer_clone_fork_exit;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_ENTER].value.u64 += cnt_map.n_drops_buffer_execve_enter;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_EXIT].value.u64 += cnt_map.n_drops_buffer_execve_exit;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_ENTER].value.u64 += cnt_map.n_drops_buffer_connect_enter;

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -174,7 +174,7 @@ struct scap_stats_v2 *pman_get_scap_stats_v2(uint32_t flags, uint32_t *nstats, i
 		{
 			g_state.stats[stat].type = STATS_VALUE_TYPE_U64;
 			g_state.stats[stat].flags = PPM_SCAP_STATS_KERNEL_COUNTERS;
-			g_state.stats[stat].value.uint64_t = 0;
+			g_state.stats[stat].value.u64 = 0;
 			strlcpy(g_state.stats[stat].name, modern_bpf_kernel_counters_stats_names[stat], STATS_NAME_MAX);
 		}
 
@@ -191,10 +191,10 @@ struct scap_stats_v2 *pman_get_scap_stats_v2(uint32_t flags, uint32_t *nstats, i
 				close(counter_maps_fd);
 				return NULL;
 			}
-			g_state.stats[MODERN_BPF_N_EVTS].value.uint64_t += cnt_map.n_evts;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.uint64_t += cnt_map.n_drops_buffer;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_ENTER].value.uint64_t += cnt_map.n_drops_buffer_clone_fork_enter;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.uint64_t += cnt_map.n_drops_buffer_clone_fork_exit;
+			g_state.stats[MODERN_BPF_N_EVTS].value.u64 += cnt_map.n_evts;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.u64 += cnt_map.n_drops_buffer;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_ENTER].value.u64 += cnt_map.n_drops_buffer_clone_fork_enter;
+			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.u64 += cnt_map.n_drops_buffer_clone_fork_exit;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_ENTER].value.u64 += cnt_map.n_drops_buffer_execve_enter;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_EXIT].value.u64 += cnt_map.n_drops_buffer_execve_exit;
 			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_ENTER].value.u64 += cnt_map.n_drops_buffer_connect_enter;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf


**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

Make bpf code more consistent.

**Which issue(s) this PR fixes**:

part of #902
(partial fix other issues still remain in 902)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
