### PR TITLE
cleanup(dup3): fix flags param

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6258,7 +6258,6 @@ FILLER(sys_dup3_x, true)
 	unsigned long val;
 	unsigned long retval;
 	unsigned long res;
-	unsigned int scap_flags;
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_push_s64_to_ring(data, retval);
@@ -6281,8 +6280,7 @@ FILLER(sys_dup3_x, true)
 	 * flags
 	 */
 	int flags = bpf_syscall_get_argument(data, 2);
-	scap_flags = dup3_flags_to_scap(flags);
-	return bpf_push_u32_to_ring(data, scap_flags);
+	return bpf_push_u32_to_ring(data, dup3_flags_to_scap(flags));
 }
 
 FILLER(sys_umount_x, true)

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -6257,8 +6257,8 @@ FILLER(sys_dup3_x, true)
 {
 	unsigned long val;
 	unsigned long retval;
-	unsigned long flags;
 	unsigned long res;
+	unsigned int scap_flags;
 
 	retval = bpf_syscall_get_retval(data->ctx);
 	res = bpf_push_s64_to_ring(data, retval);
@@ -6280,9 +6280,9 @@ FILLER(sys_dup3_x, true)
 	/*
 	 * flags
 	 */
-	val = bpf_syscall_get_argument(data, 2);
-	flags = dup3_flags_to_scap(val);
-	return bpf_push_u32_to_ring(data, flags);
+	int flags = bpf_syscall_get_argument(data, 2);
+	scap_flags = dup3_flags_to_scap(flags);
+	return bpf_push_u32_to_ring(data, scap_flags);
 }
 
 FILLER(sys_umount_x, true)

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -67,7 +67,7 @@ int BPF_PROG(dup3_x,
 	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	unsigned long flags = extract__syscall_argument(regs, 2);
+	int32_t flags = extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, dup3_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -5695,8 +5695,6 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 {
 	int res;
 	unsigned long val;
-	int flags;
-
 
 	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
@@ -5719,8 +5717,8 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(args, 2, 1, &flags);
-	res = val_to_ring(args, dup3_flags_to_scap(flags), 0, false, 0);
+	syscall_get_arguments_deprecated(args, 2, 1, &val);
+	res = val_to_ring(args, dup3_flags_to_scap((int) val), 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -5695,6 +5695,7 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 {
 	int res;
 	unsigned long val;
+	int flags;
 
 
 	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
@@ -5718,8 +5719,8 @@ int f_sys_dup3_x(struct event_filler_arguments *args)
 	/*
 	 * flags
 	 */
-	syscall_get_arguments_deprecated(args, 2, 1, &val);
-	res = val_to_ring(args, dup3_flags_to_scap(val), 0, false, 0);
+	syscall_get_arguments_deprecated(args, 2, 1, &flags);
+	res = val_to_ring(args, dup3_flags_to_scap(flags), 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -2047,7 +2047,7 @@ static __always_inline uint64_t capabilities_to_scap(unsigned long caps)
 	return res;
 }
 
-static __always_inline uint32_t dup3_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t dup3_flags_to_scap(int flags)
 {
 	uint32_t res = 0;
 #ifdef O_CLOEXEC

--- a/test/drivers/test_suites/syscall_enter_suite/dup3_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/dup3_e.cpp
@@ -14,7 +14,7 @@ TEST(SyscallEnter, dup3E)
 
 	/* If `oldfd` equals `newfd`, then dup3() fails with the error `EINVAL`. */
 	int32_t new_fd = old_fd;
-	uint32_t flags = O_CLOEXEC;
+	int32_t flags = O_CLOEXEC;
 	int32_t res = syscall(__NR_dup3, old_fd, new_fd, flags);
 	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
 

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -1472,7 +1472,7 @@ static parse_result parse_dup(const char *proto, size_t proto_size, scap_sized_b
 			                 gvisor_evt.exit().result(),
 			                 gvisor_evt.old_fd(),
 			                 gvisor_evt.new_fd(),
-			                 dup3_flags_to_scap(gvisor_evt.flags()));
+			                 dup3_flags_to_scap((int) gvisor_evt.flags()));
 			break;
 
 		default:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf


**Does this PR require a change in the driver versions?**

I am not sure about this.

**What this PR does / why we need it**:

I am trying to address the issue where dup3 is handling the flag params as an unsigned integer when it should be handling it as in int.

**Which issue(s) this PR fixes**:

part of #515 
(partial fix other issues still remain in 515)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
