### PR TITLE
cleanup(scap,sinsp): Clean up proc callback handling code

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -139,9 +139,7 @@ scap_platform* scap_gvisor_alloc_platform(proc_entry_callback proc_callback, voi
 	                 (struct scap_gvisor_platform*)calloc(sizeof(*platform), 1);
 	platform->m_generic.m_vtable = &scap_gvisor_platform_vtable;
 
-	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
-	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
-	platform->m_generic.m_proclist.m_proclist = NULL;
+	init_proclist(&platform->m_generic.m_proclist, proc_callback, proc_callback_context);
 
 	return &platform->m_generic;
 }

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2119,9 +2119,7 @@ struct scap_platform *scap_savefile_alloc_platform(proc_entry_callback proc_call
 	platform->m_generic.m_vtable = &scap_savefile_platform_vtable;
 	platform->m_generic.m_machine_info.num_cpus = (uint32_t)-1;
 
-	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
-	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
-	platform->m_generic.m_proclist.m_proclist = NULL;
+	init_proclist(&platform->m_generic.m_proclist, proc_callback, proc_callback_context);
 
 	return &platform->m_generic;
 }

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -711,15 +711,7 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		//
 		// All parsed. Add the entry to the table, or fire the notification callback
 		//
-		if(proclist->m_proc_callback == NULL)
-		{
-			default_proc_entry_callback(proclist, error, tinfo.tid, &tinfo, NULL, NULL);
-		}
-		else
-		{
-			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, NULL);
-		}
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, NULL);
 
 		if(sub_len && subreadsize != sub_len)
 		{
@@ -1627,15 +1619,7 @@ static int32_t scap_read_fdlist(scap_reader_t* r, uint32_t block_length, uint32_
 		//
 		// Add the entry to the table, or fire the notification callback
 		//
-		if(proclist->m_proc_callback == NULL)
-		{
-			default_proc_entry_callback(proclist, error, tid, NULL, &fdi, NULL);
-		}
-		else
-		{
-			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, error, tid, NULL, &fdi, NULL);
-		}
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, tid, NULL, &fdi, NULL);
 	}
 
 	//

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -738,7 +738,7 @@ static int32_t scap_read_proclist(scap_reader_t* r, uint32_t block_length, uint3
 		else
 		{
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, tinfo.tid, &tinfo, NULL);
+				proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, NULL);
 		}
 
 		if(sub_len && subreadsize != sub_len)
@@ -1701,7 +1701,7 @@ static int32_t scap_read_fdlist(scap_reader_t* r, uint32_t block_length, uint32_
 			ASSERT(tinfo == NULL);
 
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, tid, NULL, &fdi);
+				proclist->m_proc_callback_context, error, tid, NULL, &fdi, NULL);
 		}
 	}
 

--- a/userspace/libscap/engine/test_input/test_input_platform.c
+++ b/userspace/libscap/engine/test_input/test_input_platform.c
@@ -95,9 +95,7 @@ struct scap_platform* scap_test_input_alloc_platform(proc_entry_callback proc_ca
 	struct scap_platform* generic = &platform->m_generic;
 	generic->m_vtable = &scap_test_input_platform;
 
-	platform->m_generic.m_proclist.m_proc_callback = proc_callback;
-	platform->m_generic.m_proclist.m_proc_callback_context = proc_callback_context;
-	platform->m_generic.m_proclist.m_proclist = NULL;
+	init_proclist(&platform->m_generic.m_proclist, proc_callback, proc_callback_context);
 
 	return generic;
 }

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -1254,7 +1254,7 @@ int32_t scap_fd_scan_fd_dir(struct scap_linux_platform *linux_platform, struct s
 	char link_name[SCAP_MAX_PATH_SIZE];
 	struct stat sb;
 	uint64_t fd;
-	scap_fdinfo *fdi = NULL;
+	scap_fdinfo fdi = {};
 	uint64_t net_ns;
 	ssize_t r;
 	uint32_t fd_added = 0;
@@ -1293,13 +1293,13 @@ int32_t scap_fd_scan_fd_dir(struct scap_linux_platform *linux_platform, struct s
 	while((dir_entry_p = readdir(dir_p)) != NULL &&
 		(linux_platform->m_fd_lookup_limit == 0 || fd_added < linux_platform->m_fd_lookup_limit))
 	{
-		fdi = NULL;
 		snprintf(f_name, SCAP_MAX_PATH_SIZE, "%s/%s", fd_dir_name, dir_entry_p->d_name);
 
 		if(-1 == stat(f_name, &sb) || 1 != sscanf(dir_entry_p->d_name, "%"PRIu64, &fd))
 		{
 			continue;
 		}
+		fdi.fd = fd;
 
 		// In no driver mode to limit cpu usage we just parse sockets
 		// because we are interested only on them
@@ -1311,72 +1311,31 @@ int32_t scap_fd_scan_fd_dir(struct scap_linux_platform *linux_platform, struct s
 		switch(sb.st_mode & S_IFMT)
 		{
 		case S_IFIFO:
-			res = scap_fd_allocate_fdinfo(&fdi, fd, SCAP_FD_FIFO);
-			if(SCAP_FAILURE == res)
-			{
-				snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for fifo fd %" PRIu64, fd);
-				break;
-			}
-			res = scap_fd_handle_pipe(proclist, f_name, tinfo, fdi, error);
+			fdi.type = SCAP_FD_FIFO;
+			res = scap_fd_handle_pipe(proclist, f_name, tinfo, &fdi, error);
 			break;
 		case S_IFREG:
 		case S_IFBLK:
 		case S_IFCHR:
 		case S_IFLNK:
-			res = scap_fd_allocate_fdinfo(&fdi, fd, SCAP_FD_FILE_V2);
-			if(SCAP_FAILURE == res)
-			{
-				snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for file fd %" PRIu64, fd);
-				break;
-			}
-			fdi->ino = sb.st_ino;
-			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, fdi, procdir, error);
+			fdi.type = SCAP_FD_FILE_V2;
+			fdi.ino = sb.st_ino;
+			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, &fdi, procdir, error);
 			break;
 		case S_IFDIR:
-			res = scap_fd_allocate_fdinfo(&fdi, fd, SCAP_FD_DIRECTORY);
-			if(SCAP_FAILURE == res)
-			{
-				snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for dir fd %" PRIu64, fd);
-				break;
-			}
-			fdi->ino = sb.st_ino;
-			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, fdi, procdir, error);
+			fdi.type = SCAP_FD_DIRECTORY;
+			fdi.ino = sb.st_ino;
+			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, &fdi, procdir, error);
 			break;
 		case S_IFSOCK:
-			res = scap_fd_allocate_fdinfo(&fdi, fd, SCAP_FD_UNKNOWN);
-			if(SCAP_FAILURE == res)
-			{
-				snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for sock fd %" PRIu64, fd);
-				break;
-			}
-			res = scap_fd_handle_socket(proclist, f_name, tinfo, fdi, procdir, net_ns, sockets_by_ns, error);
-			if(proclist->m_proc_callback == NULL)
-			{
-				// we can land here if we've got a netlink socket
-				if(fdi->type == SCAP_FD_UNKNOWN)
-				{
-					scap_fd_free_fdinfo(&fdi);
-				}
-			}
+			fdi.type = SCAP_FD_UNKNOWN;
+			res = scap_fd_handle_socket(proclist, f_name, tinfo, &fdi, procdir, net_ns, sockets_by_ns, error);
 			break;
 		default:
-			res = scap_fd_allocate_fdinfo(&fdi, fd, SCAP_FD_UNSUPPORTED);
-			if(SCAP_FAILURE == res)
-			{
-				snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for unsupported fd %" PRIu64, fd);
-				break;
-			}
-			fdi->ino = sb.st_ino;
-			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, fdi, procdir, error);
+			fdi.type = SCAP_FD_UNSUPPORTED;
+			fdi.ino = sb.st_ino;
+			res = scap_fd_handle_regular_file(proclist, f_name, tinfo, &fdi, procdir, error);
 			break;
-		}
-
-		if(proclist->m_proc_callback != NULL)
-		{
-			if(fdi)
-			{
-				scap_fd_free_fdinfo(&fdi);
-			}
 		}
 
 		if(SCAP_SUCCESS != res)

--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -96,7 +96,8 @@ int32_t scap_fd_handle_pipe(struct scap_proclist* proclist, char *fname, scap_th
 	strlcpy(fdi->info.fname, link_name, sizeof(fdi->info.fname));
 
 	fdi->ino = ino;
-	return scap_add_fd_to_proc_table(proclist, tinfo, fdi, error);
+	proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
+	return SCAP_SUCCESS;
 }
 
 static inline uint32_t open_flags_to_scap(unsigned long flags)
@@ -354,7 +355,8 @@ int32_t scap_fd_handle_regular_file(struct scap_proclist *proclist, char *fname,
 		strlcpy(fdi->info.fname, link_name, sizeof(fdi->info.fname));
 	}
 
-	return scap_add_fd_to_proc_table(proclist, tinfo, fdi, error);
+	proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
+	return SCAP_SUCCESS;
 }
 
 int32_t scap_fd_handle_socket(struct scap_proclist *proclist, char *fname, scap_threadinfo *tinfo, scap_fdinfo *fdi, char* procdir, uint64_t net_ns, struct scap_ns_socket_list **sockets_by_ns, char *error)
@@ -417,7 +419,8 @@ int32_t scap_fd_handle_socket(struct scap_proclist *proclist, char *fname, scap_
 	{
 		// it's a kind of socket, but we don't support it right now
 		fdi->type = SCAP_FD_UNSUPPORTED;
-		return scap_add_fd_to_proc_table(proclist, tinfo, fdi, error);
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
+		return SCAP_SUCCESS;
 	}
 
 	//
@@ -429,12 +432,9 @@ int32_t scap_fd_handle_socket(struct scap_proclist *proclist, char *fname, scap_
 		memcpy(&(fdi->info), &(tfdi->info), sizeof(fdi->info));
 		fdi->ino = ino;
 		fdi->type = tfdi->type;
-		return scap_add_fd_to_proc_table(proclist, tinfo, fdi, error);
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
 	}
-	else
-	{
-		return SCAP_SUCCESS;
-	}
+	return SCAP_SUCCESS;
 }
 
 int32_t scap_fd_read_unix_sockets_from_proc_fs(const char* filename, scap_fdinfo **sockets, char *error)

--- a/userspace/libscap/linux/scap_linux_int.h
+++ b/userspace/libscap/linux/scap_linux_int.h
@@ -47,7 +47,8 @@ int32_t scap_linux_create_iflist(struct scap_platform* platform);
 int32_t scap_linux_create_userlist(struct scap_platform* platform);
 
 uint32_t scap_linux_get_device_by_mount_id(struct scap_platform* platform, const char *procdir, unsigned long requested_mount_id);
-struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
+int32_t scap_linux_proc_get(struct scap_platform* platform, int64_t tid,
+			    struct scap_threadinfo* tinfo, bool scan_sockets);
 int32_t scap_linux_refresh_proc_table(struct scap_platform* platform, struct scap_proclist* proclist);
 bool scap_linux_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm);
 int32_t scap_linux_getpid_global(struct scap_platform* platform, int64_t *pid, char* error);

--- a/userspace/libscap/linux/scap_linux_int.h
+++ b/userspace/libscap/linux/scap_linux_int.h
@@ -47,7 +47,7 @@ int32_t scap_linux_create_iflist(struct scap_platform* platform);
 int32_t scap_linux_create_userlist(struct scap_platform* platform);
 
 uint32_t scap_linux_get_device_by_mount_id(struct scap_platform* platform, const char *procdir, unsigned long requested_mount_id);
-struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, struct scap_proclist* proclist, int64_t tid, bool scan_sockets);
+struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
 int32_t scap_linux_refresh_proc_table(struct scap_platform* platform, struct scap_proclist* proclist);
 bool scap_linux_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm);
 int32_t scap_linux_getpid_global(struct scap_platform* platform, int64_t *pid, char* error);

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -133,9 +133,7 @@ struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callbac
 	struct scap_platform* generic = &platform->m_generic;
 	generic->m_vtable = &scap_linux_platform_vtable;
 
-	generic->m_proclist.m_proc_callback = proc_callback;
-	generic->m_proclist.m_proc_callback_context = proc_callback_context;
-	generic->m_proclist.m_proclist = NULL;
+	init_proclist(&generic->m_proclist, proc_callback, proc_callback_context);
 
 	return generic;
 }

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -861,7 +861,8 @@ static int32_t single_thread_proc_callback(void* context, char* error, int64_t t
 //
 // Read a single thread info from /proc
 //
-int32_t scap_proc_read_thread(struct scap_linux_platform* linux_platform, struct scap_proclist* proclist, char* procdirname, uint64_t tid, struct scap_threadinfo** pi, char *error, bool scan_sockets)
+int32_t scap_proc_read_thread(struct scap_linux_platform* linux_platform, char* procdirname, uint64_t tid,
+			      struct scap_threadinfo** pi, char* error, bool scan_sockets)
 {
 	struct scap_proclist single_thread_proclist;
 	init_proclist(&single_thread_proclist, single_thread_proc_callback, pi);
@@ -1154,7 +1155,7 @@ struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, stru
 	struct scap_threadinfo* tinfo = NULL;
 	char filename[SCAP_MAX_PATH_SIZE];
 	snprintf(filename, sizeof(filename), "%s/proc", scap_get_host_root());
-	if(scap_proc_read_thread(linux_platform, proclist, filename, tid, &tinfo, linux_platform->m_lasterr, scan_sockets) != SCAP_SUCCESS)
+	if(scap_proc_read_thread(linux_platform, filename, tid, &tinfo, linux_platform->m_lasterr, scan_sockets) != SCAP_SUCCESS)
 	{
 		free(tinfo);
 		return NULL;

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -557,7 +557,6 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 	char filename[252];
 	char line[SCAP_MAX_ENV_SIZE];
 	struct scap_threadinfo tinfo = {};
-	int32_t uth_status = SCAP_SUCCESS;
 	FILE* f;
 	size_t filesize;
 	size_t exe_len;
@@ -835,19 +834,7 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 		//
 		if(proclist->m_proc_callback == NULL)
 		{
-			new_tinfo = malloc(sizeof(*new_tinfo));
-			if(new_tinfo == NULL)
-			{
-				return scap_errprintf(error, 0, "process table allocation error (1)");
-			}
-			*new_tinfo = tinfo;
-
-			HASH_ADD_INT64(proclist->m_proclist, tid, new_tinfo);
-			if(uth_status != SCAP_SUCCESS)
-			{
-				free(new_tinfo);
-				return scap_errprintf(error, 0, "process table allocation error (2)");
-			}
+			default_proc_entry_callback(proclist, error, tid, &tinfo, NULL, NULL);
 		}
 		else
 		{

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1148,7 +1148,7 @@ int32_t scap_linux_getpid_global(struct scap_platform* platform, int64_t *pid, c
 	return scap_errprintf(error, 0, "could not find tgid in status file %s", filename);
 }
 
-struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, struct scap_proclist* proclist, int64_t tid, bool scan_sockets)
+struct scap_threadinfo* scap_linux_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets)
 {
 	struct scap_linux_platform* linux_platform = (struct scap_linux_platform*)platform;
 

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -832,15 +832,7 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 		//
 		// Done. Add the entry to the process table, or fire the notification callback
 		//
-		if(proclist->m_proc_callback == NULL)
-		{
-			default_proc_entry_callback(proclist, error, tid, &tinfo, NULL, NULL);
-		}
-		else
-		{
-			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, &new_tinfo);
-		}
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, &new_tinfo);
 	}
 	else
 	{

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -852,7 +852,7 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 		else
 		{
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, tinfo.tid, &tinfo, NULL);
+				proclist->m_proc_callback_context, error, tinfo.tid, &tinfo, NULL, &new_tinfo);
 		}
 	}
 	else

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -75,10 +75,6 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist* proclist, scap_threadinf
 void scap_free_iflist(scap_addrlist* ifhandle);
 // Free a previously allocated list of users
 void scap_free_userlist(scap_userlist* uhandle);
-// Allocate a file descriptor
-int32_t scap_fd_allocate_fdinfo(scap_fdinfo **fdi, int64_t fd, scap_fd_type type);
-// Free a file descriptor
-void scap_fd_free_fdinfo(scap_fdinfo **fdi);
 
 int32_t scap_proc_fill_pidns_start_ts(char* error, struct scap_threadinfo* tinfo, const char* procdirname);
 

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -68,9 +68,6 @@ void scap_proc_free_table(struct scap_proclist* proclist);
 void scap_fd_free_table(scap_fdinfo** fds);
 // Free a process' fd table
 void scap_fd_free_proc_fd_table(scap_threadinfo* pi);
-// Add the file descriptor info pointed by fdi to the fd table for process pi.
-// Note: silently skips if fdi->type is SCAP_FD_UNKNOWN.
-int32_t scap_add_fd_to_proc_table(struct scap_proclist* proclist, scap_threadinfo* pi, scap_fdinfo* fdi, char *error);
 // Free a previously allocated list of interfaces
 void scap_free_iflist(scap_addrlist* ifhandle);
 // Free a previously allocated list of users

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -464,39 +464,6 @@ const char* scap_get_host_root()
 	return env_str;
 }
 
-bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_entries, char* error)
-{
-	uint32_t memsize;
-
-	if(n_entries >= SCAP_DRIVER_PROCINFO_MAX_SIZE)
-	{
-		snprintf(error, SCAP_LASTERR_SIZE, "driver process list too big");
-		return false;
-	}
-
-	memsize = sizeof(struct ppm_proclist_info) +
-		sizeof(struct ppm_proc_info) * n_entries;
-
-	struct ppm_proclist_info *procinfo = (struct ppm_proclist_info*) realloc(*proclist_p, memsize);
-	if(procinfo == NULL)
-	{
-		free(*proclist_p);
-		*proclist_p = NULL;
-		snprintf(error, SCAP_LASTERR_SIZE, "driver process list allocation error");
-		return false;
-	}
-
-	if(*proclist_p == NULL)
-	{
-		procinfo->n_entries = 0;
-	}
-
-	procinfo->max_entries = n_entries;
-	*proclist_p = procinfo;
-
-	return true;
-}
-
 uint64_t scap_ftell(scap_t *handle)
 {
 	if(handle->m_vtable->savefile_ops)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -872,7 +872,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle);
 uint64_t scap_ftell(scap_t *handle);
 void scap_fseek(scap_t *handle, uint64_t off);
 int32_t scap_enable_tracers_capture(scap_t* handle);
-int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo);
+int32_t scap_fd_add(scap_threadinfo* tinfo, scap_fdinfo* fdinfo);
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret);
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -866,7 +866,7 @@ uint32_t scap_event_get_sentinel_begin(scap_evt* e);
 #endif
 
 struct scap_threadinfo *scap_proc_alloc(scap_t* handle);
-void scap_proc_free(scap_t* handle, struct scap_threadinfo* procinfo);
+void scap_proc_free(struct scap_threadinfo* procinfo);
 int32_t scap_stop_dropping_mode(scap_t* handle);
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio);
 int32_t scap_enable_dynamic_snaplen(scap_t* handle);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -865,7 +865,6 @@ extern int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT 
 uint32_t scap_event_get_sentinel_begin(scap_evt* e);
 #endif
 
-struct scap_threadinfo *scap_proc_alloc(scap_t* handle);
 void scap_proc_free(struct scap_threadinfo* procinfo);
 int32_t scap_stop_dropping_mode(scap_t* handle);
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -874,7 +874,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle);
 uint64_t scap_ftell(scap_t *handle);
 void scap_fseek(scap_t *handle, uint64_t off);
 int32_t scap_enable_tracers_capture(scap_t* handle);
-int32_t scap_fd_add(scap_t *handle, scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo);
+int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo);
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret);
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end);

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -865,7 +865,6 @@ extern int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT 
 uint32_t scap_event_get_sentinel_begin(scap_evt* e);
 #endif
 
-void scap_proc_free(struct scap_threadinfo* procinfo);
 int32_t scap_stop_dropping_mode(scap_t* handle);
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio);
 int32_t scap_enable_dynamic_snaplen(scap_t* handle);

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -59,41 +59,7 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinf
 	//
 	if(proclist->m_proc_callback == NULL)
 	{
-		int32_t uth_status = SCAP_SUCCESS;
-		scap_fdinfo *tfdi;
-
-		//
-		// Make sure this fd doesn't already exist
-		//
-		HASH_FIND_INT64(tinfo->fdlist, &(fdi->fd), tfdi);
-		if(tfdi != NULL)
-		{
-			//
-			// This can happen if:
-			//  - a close() has been dropped when capturing
-			//  - an fd has been closed by clone() or execve() (it happens when the fd is opened with the FD_CLOEXEC flag,
-			//    which we don't currently parse.
-			// In either case, removing the old fd, replacing it with the new one and keeping going is a reasonable
-			// choice.
-			//
-			HASH_DEL(tinfo->fdlist, tfdi);
-			free(tfdi);
-		}
-
-		scap_fdinfo *new_fdi = malloc(sizeof(*new_fdi));
-		if(new_fdi == NULL)
-		{
-			snprintf(error, SCAP_LASTERR_SIZE, "process table allocation error (1)");
-			return SCAP_FAILURE;
-		}
-		*new_fdi = *fdi;
-
-		HASH_ADD_INT64(tinfo->fdlist, fd, new_fdi);
-		if(uth_status != SCAP_SUCCESS)
-		{
-			snprintf(error, SCAP_LASTERR_SIZE, "process table allocation error (2)");
-			return SCAP_FAILURE;
-		}
+		return default_proc_entry_callback(proclist, error, tinfo->tid, tinfo, fdi, NULL);
 	}
 	else
 	{

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -51,7 +51,6 @@ void scap_fd_free_proc_fd_table(scap_threadinfo *tinfo)
 
 //
 // Add the file descriptor info pointed by fdi to the fd table for process tinfo.
-// Note: silently skips if fdi->type is SCAP_FD_UNKNOWN.
 //
 int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
 {

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -98,7 +98,7 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinf
 	else
 	{
 		proclist->m_proc_callback(
-			proclist->m_proc_callback_context, tinfo->tid, tinfo, fdi);
+			proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
 	}
 
 	return SCAP_SUCCESS;

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -80,7 +80,15 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinf
 	//
 	if(proclist->m_proc_callback == NULL)
 	{
-		HASH_ADD_INT64(tinfo->fdlist, fd, fdi);
+		scap_fdinfo *new_fdi = malloc(sizeof(*new_fdi));
+		if(new_fdi == NULL)
+		{
+			snprintf(error, SCAP_LASTERR_SIZE, "process table allocation error (1)");
+			return SCAP_FAILURE;
+		}
+		*new_fdi = *fdi;
+
+		HASH_ADD_INT64(tinfo->fdlist, fd, new_fdi);
 		if(uth_status != SCAP_SUCCESS)
 		{
 			snprintf(error, SCAP_LASTERR_SIZE, "process table allocation error (2)");

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -15,13 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "scap.h"
 #include "scap-int.h"
 #include "uthash_ext.h"
-#include <inttypes.h>
 #include <string.h>
 
 void scap_fd_free_table(scap_fdinfo **fds)

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -117,25 +117,3 @@ void scap_free_device_table(scap_mountinfo* dev_list)
 		free(dev);
 	}
 }
-
-int32_t scap_fd_allocate_fdinfo(scap_fdinfo **fdi, int64_t fd, scap_fd_type type)
-{
-	ASSERT(NULL == *fdi);
-	*fdi = (scap_fdinfo *)malloc(sizeof(scap_fdinfo));
-	if(*fdi == NULL)
-	{
-		return SCAP_FAILURE;
-	}
-	(*fdi)->type = type;
-	(*fdi)->fd = fd;
-	return SCAP_SUCCESS;
-}
-
-void scap_fd_free_fdinfo(scap_fdinfo **fdi)
-{
-	if(NULL != *fdi)
-	{
-		free(*fdi);
-		*fdi = NULL;
-	}
-}

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -57,15 +57,7 @@ int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinf
 	//
 	// Add the fd to the table, or fire the notification callback
 	//
-	if(proclist->m_proc_callback == NULL)
-	{
-		return default_proc_entry_callback(proclist, error, tinfo->tid, tinfo, fdi, NULL);
-	}
-	else
-	{
-		proclist->m_proc_callback(
-			proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
-	}
+	proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -48,20 +48,6 @@ void scap_fd_free_proc_fd_table(scap_threadinfo *tinfo)
 	}
 }
 
-
-//
-// Add the file descriptor info pointed by fdi to the fd table for process tinfo.
-//
-int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
-{
-	//
-	// Add the fd to the table, or fire the notification callback
-	//
-	proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid, tinfo, fdi, NULL);
-
-	return SCAP_SUCCESS;
-}
-
 //
 // Free the device table
 //

--- a/userspace/libscap/scap_fds.c
+++ b/userspace/libscap/scap_fds.c
@@ -54,32 +54,32 @@ void scap_fd_free_proc_fd_table(scap_threadinfo *tinfo)
 //
 int32_t scap_add_fd_to_proc_table(struct scap_proclist *proclist, scap_threadinfo *tinfo, scap_fdinfo *fdi, char *error)
 {
-	int32_t uth_status = SCAP_SUCCESS;
-	scap_fdinfo *tfdi;
-
-	//
-	// Make sure this fd doesn't already exist
-	//
-	HASH_FIND_INT64(tinfo->fdlist, &(fdi->fd), tfdi);
-	if(tfdi != NULL)
-	{
-		//
-		// This can happen if:
-		//  - a close() has been dropped when capturing
-		//  - an fd has been closed by clone() or execve() (it happens when the fd is opened with the FD_CLOEXEC flag,
-		//    which we don't currently parse.
-		// In either case, removing the old fd, replacing it with the new one and keeping going is a reasonable
-		// choice.
-		//
-		HASH_DEL(tinfo->fdlist, tfdi);
-		free(tfdi);
-	}
-
 	//
 	// Add the fd to the table, or fire the notification callback
 	//
 	if(proclist->m_proc_callback == NULL)
 	{
+		int32_t uth_status = SCAP_SUCCESS;
+		scap_fdinfo *tfdi;
+
+		//
+		// Make sure this fd doesn't already exist
+		//
+		HASH_FIND_INT64(tinfo->fdlist, &(fdi->fd), tfdi);
+		if(tfdi != NULL)
+		{
+			//
+			// This can happen if:
+			//  - a close() has been dropped when capturing
+			//  - an fd has been closed by clone() or execve() (it happens when the fd is opened with the FD_CLOEXEC flag,
+			//    which we don't currently parse.
+			// In either case, removing the old fd, replacing it with the new one and keeping going is a reasonable
+			// choice.
+			//
+			HASH_DEL(tinfo->fdlist, tfdi);
+			free(tfdi);
+		}
+
 		scap_fdinfo *new_fdi = malloc(sizeof(*new_fdi));
 		if(new_fdi == NULL)
 		{

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -75,9 +75,7 @@ struct scap_platform* scap_generic_alloc_platform(proc_entry_callback proc_callb
 
 	platform->m_vtable = &scap_generic_platform_vtable;
 
-	platform->m_proclist.m_proc_callback = proc_callback;
-	platform->m_proclist.m_proc_callback_context = proc_callback_context;
-	platform->m_proclist.m_proclist = NULL;
+	init_proclist(&platform->m_proclist, proc_callback, proc_callback_context);
 
 	return platform;
 }

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -62,14 +62,15 @@ uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char 
 	return 0;
 }
 
-struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets)
+int32_t scap_proc_get(struct scap_platform* platform, int64_t tid, struct scap_threadinfo* tinfo,
+		       bool scan_sockets)
 {
 	if (platform && platform->m_vtable->get_proc)
 	{
-		return platform->m_vtable->get_proc(platform, tid, scan_sockets);
+		return platform->m_vtable->get_proc(platform, tid, tinfo, scan_sockets);
 	}
 
-	return NULL;
+	return SCAP_FAILURE;
 }
 
 int32_t scap_refresh_proc_table(struct scap_platform* platform)

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -66,7 +66,7 @@ struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t ti
 {
 	if (platform && platform->m_vtable->get_proc)
 	{
-		return platform->m_vtable->get_proc(platform, &platform->m_proclist, tid, scan_sockets);
+		return platform->m_vtable->get_proc(platform, tid, scan_sockets);
 	}
 
 	return NULL;

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -65,7 +65,8 @@ uint32_t scap_get_device_by_mount_id(struct scap_platform* platform, const char 
 
 // Get the information about a process.
 // The returned pointer must be freed via scap_proc_free by the caller.
-struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
+int32_t scap_proc_get(struct scap_platform* platform, int64_t tid, struct scap_threadinfo* tinfo,
+		       bool scan_sockets);
 
 int32_t scap_refresh_proc_table(struct scap_platform* platform);
 

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -58,7 +58,7 @@ struct scap_platform_vtable
 	// XXX this is Linux-specific
 	uint32_t (*get_device_by_mount_id)(struct scap_platform*, const char *procdir, unsigned long requested_mount_id);
 
-	struct scap_threadinfo* (*get_proc)(struct scap_platform*, struct scap_proclist* proclist, int64_t tid, bool scan_sockets);
+	struct scap_threadinfo* (*get_proc)(struct scap_platform*, int64_t tid, bool scan_sockets);
 
 	int32_t (*refresh_proc_table)(struct scap_platform*, struct scap_proclist* proclist);
 	bool (*is_thread_alive)(struct scap_platform*, int64_t pid, int64_t tid, const char* comm);

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -58,7 +58,7 @@ struct scap_platform_vtable
 	// XXX this is Linux-specific
 	uint32_t (*get_device_by_mount_id)(struct scap_platform*, const char *procdir, unsigned long requested_mount_id);
 
-	struct scap_threadinfo* (*get_proc)(struct scap_platform*, int64_t tid, bool scan_sockets);
+	int32_t (*get_proc)(struct scap_platform*, int64_t tid, struct scap_threadinfo* tinfo, bool scan_sockets);
 
 	int32_t (*refresh_proc_table)(struct scap_platform*, struct scap_proclist* proclist);
 	bool (*is_thread_alive)(struct scap_platform*, int64_t pid, int64_t tid, const char* comm);

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -16,14 +16,8 @@ limitations under the License.
 
 */
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdio.h>
-
 #include "scap_proc_util.h"
 #include "scap.h"
-#include "scap-int.h"
-#include "strerror.h"
 
 int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint64_t n_tinfos, const scap_threadinfo *tinfos, void* ctx, get_fdinfos_fn get_fdinfos)
 {

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -28,35 +28,11 @@ limitations under the License.
 static int32_t scap_fd_scan_vtable(struct scap_proclist* proclist, const scap_threadinfo *src_tinfo, scap_threadinfo *dst_tinfo, uint64_t n_fdinfos, const scap_fdinfo* fdinfos, char *error)
 {
 	uint64_t i;
-	scap_fdinfo *fdi = NULL;
-	uint32_t res;
 
 	for (i = 0; i < n_fdinfos; i++)
 	{
-		res = scap_fd_allocate_fdinfo(&fdi, fdinfos[i].fd, fdinfos[i].type);
-		if (res != SCAP_SUCCESS)
-		{
-			snprintf(error, SCAP_LASTERR_SIZE, "can't allocate scap fd handle for file fd %" PRIu64, fdinfos[i].fd);
-			return res;
-		}
-
-		// copy the contents
-		*fdi = fdinfos[i];
-
-		res = scap_add_fd_to_proc_table(proclist, dst_tinfo, fdi, error);
-		if (res != SCAP_SUCCESS)
-		{
-			scap_fd_free_fdinfo(&fdi);
-			continue;
-		}
-
-		if(proclist->m_proc_callback != NULL)
-		{
-			if(fdi)
-			{
-				scap_fd_free_fdinfo(&fdi);
-			}
-		}
+		scap_fdinfo fdi = fdinfos[i];
+		scap_add_fd_to_proc_table(proclist, dst_tinfo, &fdi, error);
 	}
 
 	return SCAP_SUCCESS;

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -42,15 +42,8 @@ int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint6
 		//
 		// Add the entry to the process table, or fire the notification callback
 		//
-		if(proclist->m_proc_callback == NULL)
-		{
-			res = default_proc_entry_callback(proclist, error, tinfos[i].tid, &new_tinfo, NULL, &tinfo);
-		}
-		else
-		{
-			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, error, new_tinfo.tid, &new_tinfo, NULL, &tinfo);
-		}
+		proclist->m_proc_callback(proclist->m_proc_callback_context, error, new_tinfo.tid, &new_tinfo, NULL,
+					  &tinfo);
 
 		if(tinfo->pid == tinfo->tid)
 		{

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -58,7 +58,8 @@ int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint6
 				for(j = 0; j < n_fdinfos; j++)
 				{
 					scap_fdinfo fdi = fdinfos[j];
-					scap_add_fd_to_proc_table(proclist, tinfo, &fdi, error);
+					proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid,
+								  tinfo, &fdi, NULL);
 				}
 			}
 		}

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -25,19 +25,6 @@ limitations under the License.
 #include "scap-int.h"
 #include "strerror.h"
 
-static int32_t scap_fd_scan_vtable(struct scap_proclist* proclist, const scap_threadinfo *src_tinfo, scap_threadinfo *dst_tinfo, uint64_t n_fdinfos, const scap_fdinfo* fdinfos, char *error)
-{
-	uint64_t i;
-
-	for (i = 0; i < n_fdinfos; i++)
-	{
-		scap_fdinfo fdi = fdinfos[i];
-		scap_add_fd_to_proc_table(proclist, dst_tinfo, &fdi, error);
-	}
-
-	return SCAP_SUCCESS;
-}
-
 int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint64_t n_tinfos, const scap_threadinfo *tinfos, void* ctx, get_fdinfos_fn get_fdinfos)
 {
 	scap_threadinfo *tinfo;
@@ -92,7 +79,13 @@ int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint6
 			res = (*get_fdinfos)(ctx, &tinfos[i], &n_fdinfos, &fdinfos);
 			if(res == SCAP_SUCCESS)
 			{
-				res = scap_fd_scan_vtable(proclist, &tinfos[i], tinfo, n_fdinfos, fdinfos, error);
+				uint64_t j;
+
+				for(j = 0; j < n_fdinfos; j++)
+				{
+					scap_fdinfo fdi = fdinfos[j];
+					scap_add_fd_to_proc_table(proclist, tinfo, &fdi, error);
+				}
 			}
 		}
 	}

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -39,23 +39,26 @@ int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint6
 		proclist->m_proc_callback(proclist->m_proc_callback_context, error, new_tinfo.tid, &new_tinfo, NULL,
 					  &tinfo);
 
-		if(tinfo->pid == tinfo->tid)
+		if(tinfo->pid != tinfo->tid)
 		{
-			uint64_t n_fdinfos;
-			const scap_fdinfo *fdinfos;
+			continue;
+		}
 
-			res = (*get_fdinfos)(ctx, &tinfos[i], &n_fdinfos, &fdinfos);
-			if(res == SCAP_SUCCESS)
-			{
-				uint64_t j;
+		uint64_t n_fdinfos;
+		const scap_fdinfo *fdinfos;
 
-				for(j = 0; j < n_fdinfos; j++)
-				{
-					scap_fdinfo fdi = fdinfos[j];
-					proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid,
-								  tinfo, &fdi, NULL);
-				}
-			}
+		res = (*get_fdinfos)(ctx, &tinfos[i], &n_fdinfos, &fdinfos);
+		if(res != SCAP_SUCCESS)
+		{
+			continue;
+		}
+
+		uint64_t j;
+		for(j = 0; j < n_fdinfos; j++)
+		{
+			scap_fdinfo fdi = fdinfos[j];
+			proclist->m_proc_callback(proclist->m_proc_callback_context, error, tinfo->tid,
+						  tinfo, &fdi, NULL);
 		}
 	}
 

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -66,9 +66,7 @@ int32_t scap_proc_scan_vtable(char *error, struct scap_proclist *proclist, uint6
 			new_tinfo = tinfos[i];
 
 			proclist->m_proc_callback(
-				proclist->m_proc_callback_context, new_tinfo.tid, &new_tinfo, NULL);
-
-			tinfo = &new_tinfo;
+				proclist->m_proc_callback_context, error, new_tinfo.tid, &new_tinfo, NULL, &tinfo);
 		}
 
 		if(tinfo->pid == tinfo->tid)

--- a/userspace/libscap/scap_proc_util.h
+++ b/userspace/libscap/scap_proc_util.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -179,3 +179,35 @@ void init_proclist(struct scap_proclist* proclist, proc_entry_callback callback,
 
 	proclist->m_proclist = NULL;
 }
+bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_entries, char* error)
+{
+	uint32_t memsize;
+
+	if(n_entries >= SCAP_DRIVER_PROCINFO_MAX_SIZE)
+	{
+		snprintf(error, SCAP_LASTERR_SIZE, "driver process list too big");
+		return false;
+	}
+
+	memsize = sizeof(struct ppm_proclist_info) +
+		  sizeof(struct ppm_proc_info) * n_entries;
+
+	struct ppm_proclist_info *procinfo = (struct ppm_proclist_info*) realloc(*proclist_p, memsize);
+	if(procinfo == NULL)
+	{
+		free(*proclist_p);
+		*proclist_p = NULL;
+		snprintf(error, SCAP_LASTERR_SIZE, "driver process list allocation error");
+		return false;
+	}
+
+	if(*proclist_p == NULL)
+	{
+		procinfo->n_entries = 0;
+	}
+
+	procinfo->max_entries = n_entries;
+	*proclist_p = procinfo;
+
+	return true;
+}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -60,7 +60,7 @@ void scap_proc_free_table(struct scap_proclist* proclist)
 	}
 }
 
-int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo)
+int32_t scap_fd_add(scap_threadinfo* tinfo, scap_fdinfo* fdinfo)
 {
 	int32_t uth_status = SCAP_SUCCESS;
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -182,3 +182,11 @@ int32_t default_proc_entry_callback(void* context, char* error, int64_t tid, sca
 	}
 	return SCAP_SUCCESS;
 }
+
+void init_proclist(struct scap_proclist* proclist, proc_entry_callback callback, void* callback_context)
+{
+	proclist->m_proc_callback = callback;
+	proclist->m_proc_callback_context = callback_context;
+
+	proclist->m_proclist = NULL;
+}

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -185,8 +185,16 @@ int32_t default_proc_entry_callback(void* context, char* error, int64_t tid, sca
 
 void init_proclist(struct scap_proclist* proclist, proc_entry_callback callback, void* callback_context)
 {
-	proclist->m_proc_callback = callback;
-	proclist->m_proc_callback_context = callback_context;
+	if(callback == NULL)
+	{
+		proclist->m_proc_callback = default_proc_entry_callback;
+		proclist->m_proc_callback_context = proclist;
+	}
+	else
+	{
+		proclist->m_proc_callback = callback;
+		proclist->m_proc_callback_context = callback_context;
+	}
 
 	proclist->m_proclist = NULL;
 }

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -60,18 +60,6 @@ void scap_proc_free_table(struct scap_proclist* proclist)
 	}
 }
 
-struct scap_threadinfo *scap_proc_alloc(scap_t *handle)
-{
-	struct scap_threadinfo *tinfo = (struct scap_threadinfo*) calloc(1, sizeof(scap_threadinfo));
-	if(tinfo == NULL)
-	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "process table allocation error (1)");
-		return NULL;
-	}
-
-	return tinfo;
-}
-
 void scap_proc_free(struct scap_threadinfo* proc)
 {
 	scap_fd_free_proc_fd_table(proc);

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -72,7 +72,7 @@ struct scap_threadinfo *scap_proc_alloc(scap_t *handle)
 	return tinfo;
 }
 
-void scap_proc_free(scap_t* handle, struct scap_threadinfo* proc)
+void scap_proc_free(struct scap_threadinfo* proc)
 {
 	scap_fd_free_proc_fd_table(proc);
 	free(proc);

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -78,7 +78,7 @@ void scap_proc_free(struct scap_threadinfo* proc)
 	free(proc);
 }
 
-int32_t scap_fd_add(scap_t *handle, scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo)
+int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo)
 {
 	int32_t uth_status = SCAP_SUCCESS;
 
@@ -89,7 +89,6 @@ int32_t scap_fd_add(scap_t *handle, scap_threadinfo* tinfo, uint64_t fd, scap_fd
 	}
 	else
 	{
-		snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "Could not add fd to hash table");
 		return SCAP_FAILURE;
 	}
 }

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -60,12 +60,6 @@ void scap_proc_free_table(struct scap_proclist* proclist)
 	}
 }
 
-void scap_proc_free(struct scap_threadinfo* proc)
-{
-	scap_fd_free_proc_fd_table(proc);
-	free(proc);
-}
-
 int32_t scap_fd_add(scap_threadinfo* tinfo, uint64_t fd, scap_fdinfo* fdinfo)
 {
 	int32_t uth_status = SCAP_SUCCESS;

--- a/userspace/libscap/scap_procs.h
+++ b/userspace/libscap/scap_procs.h
@@ -26,10 +26,27 @@ typedef struct scap scap_t;
 typedef struct scap_threadinfo scap_threadinfo;
 typedef struct scap_fdinfo scap_fdinfo;
 
-typedef void (*proc_entry_callback)(void* context,
-				    int64_t tid,
-				    scap_threadinfo* tinfo,
-				    scap_fdinfo* fdinfo);
+/*!
+  @brief Callback function to be called for each thread or fd found
+
+  @param context: the context passed in scap_open_args
+  @param error: a buffer of SCAP_LASTERR_SIZE characters to store the error message in case of error
+  @param tid: the thread id
+  @param tinfo: the thread info
+  @param fdinfo: the fd info, if any (NULL if adding a thread)
+  @param new_tinfo: a pointer to a thread info pointer. If the callback returns a different thread info,
+
+  @return SCAP_* status code
+
+  *Note*: currently tinfo may be NULL if fdinfo is not NULL. This makes life harder for fd callbacks.
+
+  Memory ownership rule: tinfo and fdinfo are owned by the caller and must not be freed or stored
+  by the callback. The callback can return a different tinfo, which must not be freed or stored by the caller,
+  but can be assumed to be valid at least until the next call to the callback.
+*/
+
+typedef int32_t (*proc_entry_callback)(void* context, char* error, int64_t tid, scap_threadinfo* tinfo,
+				       scap_fdinfo* fdinfo, scap_threadinfo** new_tinfo);
 
 struct scap_proclist
 {

--- a/userspace/libscap/scap_procs.h
+++ b/userspace/libscap/scap_procs.h
@@ -48,6 +48,9 @@ typedef struct scap_fdinfo scap_fdinfo;
 typedef int32_t (*proc_entry_callback)(void* context, char* error, int64_t tid, scap_threadinfo* tinfo,
 				       scap_fdinfo* fdinfo, scap_threadinfo** new_tinfo);
 
+int32_t default_proc_entry_callback(void* context, char* error, int64_t tid, scap_threadinfo* tinfo,
+				    scap_fdinfo* fdinfo, scap_threadinfo** new_tinfo);
+
 struct scap_proclist
 {
 	proc_entry_callback m_proc_callback;

--- a/userspace/libscap/scap_procs.h
+++ b/userspace/libscap/scap_procs.h
@@ -59,6 +59,8 @@ struct scap_proclist
 	scap_threadinfo* m_proclist;
 };
 
+void init_proclist(struct scap_proclist* proclist, proc_entry_callback callback, void* callback_context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4540,24 +4540,17 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 					if(cmsg->cmsg_type == SCM_RIGHTS)
 					{
 						char error[SCAP_LASTERR_SIZE];
+						scap_threadinfo scap_tinfo {};
 
-						auto scap_tinfo = scap_proc_alloc(m_inspector->m_h);
-						if (scap_tinfo == NULL)
-						{
-							g_logger.format(sinsp_logger::SEV_CRITICAL, "scap_proc_alloc failed, proc table will not be updated with new fds.");
-							return;
-						}
-						m_inspector->m_thread_manager->thread_to_scap(*evt->m_tinfo, scap_tinfo);
+						m_inspector->m_thread_manager->thread_to_scap(*evt->m_tinfo, &scap_tinfo);
 
 						// Get the new fds. The callbacks we have registered populate the fd table
 						// with the new file descriptors.
-						if (scap_get_fdlist(m_inspector->get_scap_platform(), scap_tinfo, error) != SCAP_SUCCESS)
+						if (scap_get_fdlist(m_inspector->get_scap_platform(), &scap_tinfo, error) != SCAP_SUCCESS)
 						{
 							g_logger.format(sinsp_logger::SEV_DEBUG, "scap_get_fdlist failed: %s, proc table will not be updated with new fds.",
 									error);
 						}
-
-						scap_proc_free(m_inspector->m_h, scap_tinfo);
 					}
 				}
 			}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -70,8 +70,8 @@ struct sinsp_stats{}; // note: makes the unique_ptr static asserts happy
 */
 #define DEFAULT_ASYNC_EVENT_QUEUE_SIZE 1000
 
-void on_new_entry_from_proc(void* context, int64_t tid, scap_threadinfo* tinfo,
-							scap_fdinfo* fdinfo);
+int32_t on_new_entry_from_proc(void* context, char* error, int64_t tid, scap_threadinfo* tinfo, scap_fdinfo* fdinfo,
+			       scap_threadinfo** new_tinfo);
 
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp implementation
@@ -1108,13 +1108,18 @@ void sinsp::on_new_entry_from_proc(void* context,
 	}
 }
 
-void on_new_entry_from_proc(void* context,
-							int64_t tid,
-							scap_threadinfo* tinfo,
-							scap_fdinfo* fdinfo)
+int32_t on_new_entry_from_proc(void* context, char* error, int64_t tid, scap_threadinfo* tinfo, scap_fdinfo* fdinfo,
+			       scap_threadinfo** new_tinfo)
 {
 	sinsp* _this = (sinsp*)context;
 	_this->on_new_entry_from_proc(context, tid, tinfo, fdinfo);
+
+	if(new_tinfo != NULL)
+	{
+		*new_tinfo = tinfo;
+	}
+
+	return SCAP_SUCCESS;
 }
 
 void sinsp::import_ifaddr_list()

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2043,7 +2043,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 				//
 				// Add the new fd to the scap table.
 				//
-				if(scap_fd_add(&sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
+				if(scap_fd_add(&sctinfo, scfdinfo) != SCAP_SUCCESS)
 				{
 					scap_fd_free_proc_fd_table(&sctinfo);
 					throw sinsp_exception("Failed to add fd to hash table");

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2085,7 +2085,8 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
             return NULL;
         }
 
-        scap_threadinfo* scap_proc = NULL;
+        scap_threadinfo scap_proc {};
+	bool have_scap_proc = false;
 
 		// unfortunately, sinsp owns the threade factory
         sinsp_threadinfo* newti = m_inspector->build_threadinfo();
@@ -2126,16 +2127,18 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
 #ifdef HAS_ANALYZER
             uint64_t ts = sinsp_utils::get_current_time_ns();
 #endif
-            scap_proc = scap_proc_get(m_inspector->get_scap_platform(), tid, scan_sockets);
+            if(scap_proc_get(m_inspector->get_scap_platform(), tid, &scap_proc, scan_sockets) == SCAP_SUCCESS)
+	    {
+		have_scap_proc = true;
+	    }
 #ifdef HAS_ANALYZER
             m_n_proc_lookups_duration_ns += sinsp_utils::get_current_time_ns() - ts;
 #endif
         }
 
-        if(scap_proc)
+        if(have_scap_proc)
         {
-            newti->init(scap_proc);
-	    scap_proc_free(scap_proc);
+            newti->init(&scap_proc);
         }
         else
         {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1989,7 +1989,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 		free(envs_iov);
 		free(cgroups_iov);
 
-		scap_proc_free(m_inspector->m_h, sctinfo);
+		scap_proc_free(sctinfo);
 		return true;
 	});
 
@@ -2028,7 +2028,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 			sinsp_fdtable* fd_table_ptr = tinfo.get_fd_table();
 			if(fd_table_ptr == NULL)
 			{
-				scap_proc_free(m_inspector->m_h, sctinfo);
+				scap_proc_free(sctinfo);
 				return false;
 			}
 
@@ -2042,7 +2042,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 				scap_fdinfo* scfdinfo = (scap_fdinfo*)malloc(sizeof(scap_fdinfo));
 				if(scfdinfo == NULL)
 				{
-					scap_proc_free(m_inspector->m_h, sctinfo);
+					scap_proc_free(sctinfo);
 					return false;
 				}
 
@@ -2057,7 +2057,7 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 				//
 				if(scap_fd_add(m_inspector->m_h, sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
 				{
-					scap_proc_free(m_inspector->m_h, sctinfo);
+					scap_proc_free(sctinfo);
 					throw sinsp_exception("error calling scap_fd_add in sinsp_thread_manager::to_scap (" + std::string(scap_getlasterr(m_inspector->m_h)) + ")");
 				}
 			}
@@ -2068,11 +2068,11 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 		//
 		if(scap_write_proc_fds(dumper, sctinfo) != SCAP_SUCCESS)
 		{
-			scap_proc_free(m_inspector->m_h, sctinfo);
+			scap_proc_free(sctinfo);
 			throw sinsp_exception("error calling scap_proc_add in sinsp_thread_manager::to_scap (" + std::string(scap_dump_getlasterr(dumper)) + ")");
 		}
 
-		scap_proc_free(m_inspector->m_h, sctinfo);
+		scap_proc_free(sctinfo);
 		return true;
 	});
 }
@@ -2148,7 +2148,7 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
         if(scap_proc)
         {
             newti->init(scap_proc);
-            scap_proc_free(m_inspector->m_h, scap_proc);
+	    scap_proc_free(scap_proc);
         }
         else
         {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2055,10 +2055,10 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper)
 				//
 				// Add the new fd to the scap table.
 				//
-				if(scap_fd_add(m_inspector->m_h, sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
+				if(scap_fd_add(sctinfo, it->first, scfdinfo) != SCAP_SUCCESS)
 				{
 					scap_proc_free(sctinfo);
-					throw sinsp_exception("error calling scap_fd_add in sinsp_thread_manager::to_scap (" + std::string(scap_getlasterr(m_inspector->m_h)) + ")");
+					throw sinsp_exception("Failed to add fd to hash table");
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR aims to simplify the infrastructure around the proc callback (a function called from scap for every new thread and fd discovered during the /proc scan). The end result is:
- +274/-495: a bit of code removed, mostly in the dark corners of scap
- reduced allocations during /proc scan (we freed most of them immediately)
- fewer special cases all over the place

Summary of changes:
- every place that used to check for m_proc_callback now calls it unconditionally
- internal hash table manipulation (the m_proc_callback==NULL case) is now simply a different (default) callback
- scap_proc_read_thread is no longer a special case with the procinfo param, just uses its own temporary proclist
- scap_get_proc_table is gone (no longer used by sinsp)
- all scap_tinfo/scap_fdinfo heap allocations now happen in the proc callback, only when really needed

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I'd call the diff surprisingly readable for a PR that touches half the world. There were fairly few incidental changes (except for a massive `tinfo->foo` -> `tinfo.foo` in scap_proc_add_from_proc).

~*Note*: I may have broken something around filtering captures (the code is... interesting, with sinsp storing bits in scap_threadinfos) so I'll try to come up with some tests for it. For now, I'm just letting CI have its fun with the PR.~

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
BREAKING CHANGE: scap_get_proc_table is gone
```
