### PR TITLE
cleanup(sinsp,scap): switch to sinsp thread table for savefiles

### DIFF
--- a/userspace/libscap/scap.def
+++ b/userspace/libscap/scap.def
@@ -17,7 +17,6 @@ EXPORTS
 		scap_dump_ftell
 		scap_dump
 		scap_event_get_num
-		scap_get_proc_table
 		scap_event_getinfo
 		scap_stop_capture
 		scap_get_ifaddr_list

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -82,16 +82,6 @@ int32_t scap_refresh_proc_table(struct scap_platform* platform)
 	return SCAP_FAILURE;
 }
 
-scap_threadinfo* scap_get_proc_table(struct scap_platform* platform)
-{
-	if (platform)
-	{
-		return platform->m_proclist.m_proclist;
-	}
-
-	return NULL;
-}
-
 bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm)
 {
 	if (platform && platform->m_vtable->is_thread_alive)

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -69,34 +69,6 @@ struct scap_threadinfo* scap_proc_get(struct scap_platform* platform, int64_t ti
 
 int32_t scap_refresh_proc_table(struct scap_platform* platform);
 
-/*!
-  \brief Get the process list for the given capture instance
-
-  \param platform Handle to the platform instance.
-
-  \return Pointer to the process list.
-
-  for live captures, the process list is created when the capture starts by scanning the
-  proc file system. For offline captures, it is retrieved from the file.
-  The process list contains information about the processes that were already open when
-  the capture started. It can be traversed with uthash, using the following syntax:
-
-  \code
-  scap_threadinfo *pi;
-  scap_threadinfo *tpi;
-  scap_threadinfo *table = scap_get_proc_table(phandle);
-
-  HASH_ITER(hh, table, pi, tpi)
-  {
-    // do something with pi
-  }
-  \endcode
-
-  Refer to the documentation of the \ref scap_threadinfo struct for details about its
-  content.
-*/
-struct scap_threadinfo* scap_get_proc_table(struct scap_platform* platform);
-
 // Check if the given thread exists in /proc
 bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm);
 

--- a/userspace/libscap/scap_savefile_api.h
+++ b/userspace/libscap/scap_savefile_api.h
@@ -91,7 +91,8 @@ int32_t scap_write_proclist_entry_bufs(scap_dumper_t *d, struct scap_threadinfo 
 
   \return Dump handle that can be used to identify this specific dump instance.
 */
-scap_dumper_t *scap_dump_open(struct scap_platform* platform, const char *fname, compression_mode compress, bool skip_proc_scan, char* lasterr);
+scap_dumper_t *scap_dump_open(struct scap_platform *platform, const char *fname, compression_mode compress,
+			      char *lasterr);
 
 /*!
   \brief Open a trace file for writing, using the provided fd.

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -74,7 +74,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	m_nevts = 0;
 }
 
-void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_from_sinsp)
+void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress)
 {
 	char error[SCAP_LASTERR_SIZE];
 	if(inspector->m_h == NULL)
@@ -83,20 +83,15 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress, bool threads_
 	}
 
 	auto compress_mode = compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE;
-	m_dumper = scap_dump_open_fd(inspector->get_scap_platform(), fd, compress_mode, threads_from_sinsp, error);
+	m_dumper = scap_dump_open_fd(inspector->get_scap_platform(), fd, compress_mode, true, error);
 
 	if(m_dumper == nullptr)
 	{
 		throw sinsp_exception(error);
 	}
 
-	if(threads_from_sinsp)
-	{
-		inspector->m_thread_manager->dump_threads_to_file(m_dumper);
-	}
-
+	inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	inspector->m_container_manager.dump_containers(*this);
-
 	inspector->m_usergroup_manager.dump_users_groups(*this);
 
 	m_nevts = 0;

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -44,7 +44,7 @@ sinsp_dumper::~sinsp_dumper()
 	}
 }
 
-void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool compress, bool threads_from_sinsp)
+void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool compress)
 {
 	char error[SCAP_LASTERR_SIZE];
 	if(inspector->m_h == NULL)
@@ -59,7 +59,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	else
 	{
 		auto compress_mode = compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE;
-		m_dumper = scap_dump_open(inspector->get_scap_platform(), filename.c_str(), compress_mode, threads_from_sinsp, error);
+		m_dumper = scap_dump_open(inspector->get_scap_platform(), filename.c_str(), compress_mode, true, error);
 	}
 
 	if(m_dumper == nullptr)
@@ -67,13 +67,8 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 		throw sinsp_exception(error);
 	}
 
-	if(threads_from_sinsp)
-	{
-		inspector->m_thread_manager->dump_threads_to_file(m_dumper);
-	}
-
+	inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	inspector->m_container_manager.dump_containers(*this);
-
 	inspector->m_usergroup_manager.dump_users_groups(*this);
 
 	m_nevts = 0;

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -59,7 +59,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	else
 	{
 		auto compress_mode = compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE;
-		m_dumper = scap_dump_open(inspector->get_scap_platform(), filename.c_str(), compress_mode, true, error);
+		m_dumper = scap_dump_open(inspector->get_scap_platform(), filename.c_str(), compress_mode, error);
 	}
 
 	if(m_dumper == nullptr)

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -72,10 +72,7 @@ public:
 	*/
 	void open(sinsp* inspector, const std::string& filename, bool compress);
 
-	void fdopen(sinsp* inspector,
-		int fd,
-		bool compress,
-		bool threads_from_sinsp=false);
+	void fdopen(sinsp* inspector, int fd, bool compress);
 
 	/*!
 	  \brief Closes the dump file.

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -70,10 +70,7 @@ public:
 	  \note There's no close() because the file is closed when the dumper is
 	   destroyed.
 	*/
-	void open(sinsp* inspector,
-		const std::string& filename,
-		bool compress,
-		bool threads_from_sinsp=false);
+	void open(sinsp* inspector, const std::string& filename, bool compress);
 
 	void fdopen(sinsp* inspector,
 		int fd,

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -406,11 +406,6 @@ void sinsp::init()
 		consume_initialstate_events();
 	}
 
-	if(is_capture())
-	{
-		import_thread_table();
-	}
-
 	import_ifaddr_list();
 
 	import_user_list();
@@ -1149,24 +1144,6 @@ void on_new_entry_from_proc(void* context,
 {
 	sinsp* _this = (sinsp*)context;
 	_this->on_new_entry_from_proc(context, tid, tinfo, fdinfo);
-}
-
-void sinsp::import_thread_table()
-{
-	scap_threadinfo *pi;
-	scap_threadinfo *tpi;
-
-	scap_threadinfo *table = scap_get_proc_table(get_scap_platform());
-
-	//
-	// Scan the scap table and add the threads to our list
-	//
-	HASH_ITER(hh, table, pi, tpi)
-	{
-		sinsp_threadinfo* newti = build_threadinfo();
-		newti->init(pi);
-		m_thread_manager->add_thread(newti, true);
-	}
 }
 
 void sinsp::import_ifaddr_list()

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1108,6 +1108,9 @@ void sinsp::on_new_entry_from_proc(void* context,
 				// we'll run the filter when we see the fds and possibly clear the filtered_out flag
 				newti->m_filtered_out = true;
 			}
+
+			// we shouldn't see any fds yet
+			ASSERT(tinfo->fdlist == nullptr);
 		}
 	}
 	else

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1006,11 +1006,11 @@ void sinsp::autodump_start(const std::string& dump_filename, bool compress)
 
 	if(compress)
 	{
-		dumper->open(this, dump_filename.c_str(), SCAP_COMPRESSION_GZIP, true);
+		dumper->open(this, dump_filename.c_str(), SCAP_COMPRESSION_GZIP);
 	}
 	else
 	{
-		dumper->open(this, dump_filename.c_str(), SCAP_COMPRESSION_NONE, true);
+		dumper->open(this, dump_filename.c_str(), SCAP_COMPRESSION_NONE);
 	}
 
 	m_is_dumping = true;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1098,8 +1098,17 @@ void sinsp::on_new_entry_from_proc(void* context,
 		{
 			thread_added = m_thread_manager->add_thread(newti, true);
 		}
-		if (!thread_added) {
+		if (!thread_added)
+		{
 			delete newti;
+		}
+		else
+		{
+			if(m_filter != nullptr && is_capture())
+			{
+				// we'll run the filter when we see the fds and possibly clear the filtered_out flag
+				newti->m_filtered_out = true;
+			}
 		}
 	}
 	else

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1079,7 +1079,6 @@ private:
 	void deinit_state();
 	void consume_initialstate_events();
 	bool is_initialstate_event(scap_evt* pevent);
-	void import_thread_table();
 	void import_ifaddr_list();
 	void import_user_list();
 	void add_protodecoders();

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -447,6 +447,7 @@ public:
 	std::shared_ptr<thread_group_info> m_tginfo;
 	std::list<std::weak_ptr<sinsp_threadinfo>> m_children;
 	uint64_t m_not_expired_children;
+	bool m_filtered_out; ///< True if this thread is filtered out by the inspector filter from saving to a capture
 
 	// In some cases, a threadinfo has a category that identifies
 	// why it was run. Descriptions:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes one fairly significant way the savefile support was special cased: effectively it was the only one that still relied on the scap thread table, effectively for the single bit of the `filtered_out` flag.

Note, all this only applies to cature-to-capture filtering, i.e. reading a capture, applying a filter and writing out the result to another capture.

We now move (add) the filter flag to sinsp_threadinfo and rearrange the filtering code a bit. The way it works is a bit peculiar, though fixing this feels out of scope:
* for every fd of each thread, run a fake read event of that fd through the filter; if the event is filtered out, drop the fd
* if there are no fds left after the filtering stage (even if we never actually ran the filter because we have no fds, for example), filter out the thread from subsequent captures

We used to so this when adding a threadinfo (via import_thread_table), when the threadinfos already had all their fds scanned. Now, the threadinfo is added first, and only then we discover the fds, so we tentatively treat all threads as filtered out in the proc callback and clear the flag in add_fd_from_scap later.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This started as a quick win on top of https://github.com/falcosecurity/libs/pull/1471 but it turns out it's: 1. not as quick and 2. mostly independent from that PR.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
BREAKING CHANGE: sinsp_dumper::open* and scap_dump_open* no longer take a `threads_from_sinsp`/`skip_proc_scan` param
```
