### PR TITLE
cleanup(modern_bpf): remove a no longer useful option in the modern bpf engine and introduce some logging functions

### DIFF
--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -29,7 +29,6 @@ scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffe
 		.cpus_for_each_buffer = cpus_for_each_buffer,
 		.allocate_online_only = online_only,
 		.buffer_bytes_dim = buffer_dim,
-		.verbose = false,
 	};
 	oargs.engine_params = &modern_bpf_params;
 

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -29,7 +29,6 @@ extern "C"
 		uint16_t cpus_for_each_buffer;	///< [EXPERIMENTAL] We will allocate a ring buffer every `cpus_for_each_buffer` CPUs. `0` is a special value and means a single ring buffer shared between all the CPUs.
 		bool allocate_online_only; ///< [EXPERIMENTAL] Allocate ring buffers only for online CPUs. The number of ring buffers allocated changes according to the `cpus_for_each_buffer` param. Please note: this buffer will be mapped twice both kernel and userspace-side, so pay attention to its size.
 		unsigned long buffer_bytes_dim; ///< Dimension of a ring buffer in bytes. The number of ring buffers allocated changes according to the `cpus_for_each_buffer` param. Please note: this buffer will be mapped twice both kernel and userspace-side, so pay attention to its size.
-		bool verbose; ///< [EXPERIMENTAL] Use libbpf in verbose mode.
 	};
 
 #ifdef __cplusplus

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -788,7 +788,6 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.cpus_for_each_buffer = cpus_for_each_buffer;
 	params.allocate_online_only = online_only;
-	params.verbose = g_logger.has_output() && g_logger.is_enabled(sinsp_logger::severity::SEV_DEBUG);
 	oargs.engine_params = &params;
 
 	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap-engine-modern-bpf

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR removes the  no longer used `verbose` option from the modern bpf engine and adds 2 logs functions for tests and scap-open to avoid log pollution during debugging

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
