### PR TITLE
fix(test): Fix small bugs in send_x and socketcall_x

### DIFF
--- a/test/drivers/test_suites/syscall_exit_suite/send_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/send_x.cpp
@@ -12,7 +12,8 @@ TEST(SyscallExit, sendX_fail)
 	int32_t mock_fd = -1;
 	const unsigned data_len = DEFAULT_SNAPLEN * 2;
 	char buf[data_len] = "some-data";
-	int flags = 0 assert_syscall_state(SYSCALL_FAILURE, "send", syscall(__NR_send, mock_fd, (void *)buf, data_len, flags));
+	int flags = 0;
+	assert_syscall_state(SYSCALL_FAILURE, "send", syscall(__NR_send, mock_fd, (void *)buf, data_len, flags));
 	int errno_value = -errno;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -3146,7 +3146,7 @@ TEST(SyscallExit, socketcall_sendX)
 	args[2] = data_len;
 	args[3] = (unsigned long)flags;
 	assert_syscall_state(SYSCALL_FAILURE, "send", syscall(__NR_socketcall, SYS_SEND, args));
-
+	int64_t errno_value = -errno;
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	evt_test->disable_capture();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

- Adds semicolon after `int flags=0` in send_x.cpp
- Adds missing declaration for `int64_t errno_value = -errno;` in socketcall_x.cpp

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
