### PR TITLE
cleanup(integer consistencies): use only int_t types

### DIFF
--- a/driver/bpf/bpf_helpers.h
+++ b/driver/bpf/bpf_helpers.h
@@ -74,22 +74,22 @@ static int (*bpf_probe_read_str)(void *dst, uint64_t size, const void *unsafe_pt
 	(void *)BPF_FUNC_probe_read_str;
 
 #if defined(USE_BPF_PROBE_KERNEL_USER_VARIANTS)
-static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_user)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_user;
-static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_kernel)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_kernel;
-static int (*bpf_probe_read_user_str)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_user_str)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_user_str;
-static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_kernel_str)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_kernel_str;
 #else
-static int (*bpf_probe_read_user)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_user)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read;
-static int (*bpf_probe_read_kernel)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_kernel)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read;
-static int (*bpf_probe_read_user_str)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_user_str)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
-static int (*bpf_probe_read_kernel_str)(void *dst, u32 size, const void *unsafe_ptr) =
+static int (*bpf_probe_read_kernel_str)(void *dst, uint32_t size, const void *unsafe_ptr) =
 	(void *)BPF_FUNC_probe_read_str;
 #endif
 

--- a/driver/bpf/maps.h
+++ b/driver/bpf/maps.h
@@ -23,70 +23,70 @@ struct bpf_map_def {
 #ifdef __KERNEL__
 struct bpf_map_def __bpf_section("maps") perf_map = {
 	.type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-	.key_size = sizeof(u32),
-	.value_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
+	.value_size = sizeof(uint32_t),
 	.max_entries = 0,
 };
 
 struct bpf_map_def __bpf_section("maps") tail_map = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,
-	.key_size = sizeof(u32),
-	.value_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
+	.value_size = sizeof(uint32_t),
 	.max_entries = PPM_FILLER_MAX,
 };
 
 struct bpf_map_def __bpf_section("maps") syscall_table = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(struct syscall_evt_pair),
 	.max_entries = SYSCALL_TABLE_SIZE,
 };
 
 struct bpf_map_def __bpf_section("maps") event_info_table = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(struct ppm_event_info),
 	.max_entries = PPM_EVENT_MAX,
 };
 
 struct bpf_map_def __bpf_section("maps") fillers_table = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(struct ppm_event_entry),
 	.max_entries = PPM_EVENT_MAX,
 };
 
 struct bpf_map_def __bpf_section("maps") frame_scratch_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = SCRATCH_SIZE,
 	.max_entries = 0,
 };
 
 struct bpf_map_def __bpf_section("maps") tmp_scratch_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = SCRATCH_SIZE,
 	.max_entries = 0,
 };
 
 struct bpf_map_def __bpf_section("maps") settings_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(struct scap_bpf_settings),
 	.max_entries = 1,
 };
 
 struct bpf_map_def __bpf_section("maps") local_state_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(struct scap_bpf_per_cpu_state),
 	.max_entries = 0,
 };
 
 struct bpf_map_def __bpf_section("maps") interesting_syscalls_table = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
 	.value_size = sizeof(bool),
 	.max_entries = SYSCALL_TABLE_SIZE,
 };
@@ -94,8 +94,8 @@ struct bpf_map_def __bpf_section("maps") interesting_syscalls_table = {
 // The key is the 32-bit syscall code while the value is 64-bit one
 struct bpf_map_def __bpf_section("maps") ia32_64_map = {
 	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(u32),
-	.value_size = sizeof(u32),
+	.key_size = sizeof(uint32_t),
+	.value_size = sizeof(uint32_t),
 	.max_entries = SYSCALL_TABLE_SIZE,
 };
 

--- a/driver/bpf/plumbing_helpers.h
+++ b/driver/bpf/plumbing_helpers.h
@@ -95,7 +95,7 @@ static __always_inline long bpf_syscall_get_retval(void *ctx)
 static __always_inline bool bpf_in_ia32_syscall()
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-	u32 status = 0;
+	uint32_t status = 0;
 
 #ifdef CONFIG_X86_64
 
@@ -327,7 +327,7 @@ static __always_inline unsigned long bpf_syscall_get_socketcall_arg(void *ctx, i
 	args_pointer = bpf_syscall_get_argument_from_ctx(ctx, 1);
 	if (bpf_in_ia32_syscall())
 	{
-		bpf_probe_read_user(&arg, sizeof(u32), (void*)(args_pointer + (idx * sizeof(u32))));
+		bpf_probe_read_user(&arg, sizeof(uint32_t), (void*)(args_pointer + (idx * sizeof(uint32_t))));
 	}
 	else
 	{

--- a/driver/main.c
+++ b/driver/main.c
@@ -139,7 +139,7 @@ struct event_data_t {
  */
 static int ppm_open(struct inode *inode, struct file *filp);
 static int ppm_release(struct inode *inode, struct file *filp);
-static int force_tp_set(struct ppm_consumer_t *consumer, u32 new_tp_set);
+static int force_tp_set(struct ppm_consumer_t *consumer, uint32_t new_tp_set);
 static long ppm_ioctl(struct file *f, unsigned int cmd, unsigned long arg);
 static int ppm_mmap(struct file *filp, struct vm_area_struct *vma);
 static int record_event_consumer(struct ppm_consumer_t *consumer,
@@ -217,8 +217,8 @@ static const struct file_operations g_ppm_fops = {
 
 LIST_HEAD(g_consumer_list);
 static DEFINE_MUTEX(g_consumer_mutex);
-static u32 g_tracepoints_attached; // list of attached tracepoints; bitmask using ppm_tp.h enum
-static u32 g_tracepoints_refs[KMOD_PROG_ATTACHED_MAX];
+static uint32_t g_tracepoints_attached; // list of attached tracepoints; bitmask using ppm_tp.h enum
+static uint32_t g_tracepoints_refs[KMOD_PROG_ATTACHED_MAX];
 static unsigned long g_buffer_bytes_dim = DEFAULT_BUFFER_BYTES_DIM; // dimension of a single per-CPU buffer in bytes.
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 20)
 static struct tracepoint *tp_sys_enter;
@@ -307,7 +307,7 @@ static void compat_unregister_trace(void *func, const char *probename, struct tr
 #endif
 }
 
-static void set_consumer_tracepoints(struct ppm_consumer_t *consumer, u32 tp_set)
+static void set_consumer_tracepoints(struct ppm_consumer_t *consumer, uint32_t tp_set)
 {
 	int i;
 	int bits_processed;
@@ -630,11 +630,11 @@ static int compat_set_tracepoint(void *func, const char *probename, struct trace
 	return ret;
 }
 
-static int force_tp_set(struct ppm_consumer_t *consumer, u32 new_tp_set)
+static int force_tp_set(struct ppm_consumer_t *consumer, uint32_t new_tp_set)
 {
-	u32 idx;
-	u32 new_val;
-	u32 curr_val;
+	uint32_t idx;
+	uint32_t new_val;
+	uint32_t curr_val;
 	int cpu;
 	int ret;
 
@@ -796,7 +796,7 @@ static long ppm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		struct task_struct *p, *t;
 		uint64_t nentries = 0;
 		struct ppm_proclist_info pli;
-		u32 memsize;
+		uint32_t memsize;
 
 		if (copy_from_user(&pli, (void *)arg, sizeof(pli))) {
 			ret = -EINVAL;
@@ -957,12 +957,12 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_ENABLE_DROPPING_MODE:
 	{
-		u32 new_sampling_ratio;
+		uint32_t new_sampling_ratio;
 
 		consumer->dropping_mode = 1;
 		vpr_info("PPM_IOCTL_ENABLE_DROPPING_MODE, consumer %p\n", consumer_id);
 
-		new_sampling_ratio = (u32)arg;
+		new_sampling_ratio = (uint32_t)arg;
 
 		if (new_sampling_ratio != 1 &&
 			new_sampling_ratio != 2 &&
@@ -987,10 +987,10 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_SET_SNAPLEN:
 	{
-		u32 new_snaplen;
+		uint32_t new_snaplen;
 
 		vpr_info("PPM_IOCTL_SET_SNAPLEN, consumer %p\n", consumer_id);
-		new_snaplen = (u32)arg;
+		new_snaplen = (uint32_t)arg;
 
 		if (new_snaplen > SNAPLEN_MAX) {
 			pr_err("invalid snaplen %u\n", new_snaplen);
@@ -1007,10 +1007,10 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_SET_FULLCAPTURE_PORT_RANGE:
 	{
-		u32 encoded_port_range;
+		uint32_t encoded_port_range;
 
 		vpr_info("PPM_IOCTL_SET_FULLCAPTURE_PORT_RANGE, consumer %p\n", consumer_id);
-		encoded_port_range = (u32)arg;
+		encoded_port_range = (uint32_t)arg;
 
 		consumer->fullcapture_port_range_start = encoded_port_range & 0xFFFF;
 		consumer->fullcapture_port_range_end = encoded_port_range >> 16;
@@ -1032,7 +1032,7 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_ENABLE_SYSCALL:
 	{
-		u32 syscall_to_set = (u32)arg - SYSCALL_TABLE_ID0;
+		uint32_t syscall_to_set = (uint32_t)arg - SYSCALL_TABLE_ID0;
 
 		vpr_info("PPM_IOCTL_ENABLE_SYSCALL (%u), consumer %p\n", syscall_to_set, consumer_id);
 
@@ -1049,7 +1049,7 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_DISABLE_SYSCALL:
 	{
-		u32 syscall_to_unset = (u32)arg - SYSCALL_TABLE_ID0;
+		uint32_t syscall_to_unset = (uint32_t)arg - SYSCALL_TABLE_ID0;
 
 		vpr_info("PPM_IOCTL_DISABLE_SYSCALL (%u), consumer %p\n", syscall_to_unset, consumer_id);
 
@@ -1136,28 +1136,28 @@ cleanup_ioctl_procinfo:
 	}
 	case PPM_IOCTL_ENABLE_TP:
 	{
-		u32 new_tp_set;
-		if ((u32)arg >= KMOD_PROG_ATTACHED_MAX) {
-			pr_err("invalid tp %u\n", (u32)arg);
+		uint32_t new_tp_set;
+		if ((uint32_t)arg >= KMOD_PROG_ATTACHED_MAX) {
+			pr_err("invalid tp %u\n", (uint32_t)arg);
 			ret = -EINVAL;
 			goto cleanup_ioctl;
 		}
 		new_tp_set = consumer->tracepoints_attached;
-		new_tp_set |= 1 << (u32)arg;
+		new_tp_set |= 1 << (uint32_t)arg;
 		set_consumer_tracepoints(consumer, new_tp_set);
 		ret = 0;
 		goto cleanup_ioctl;
 	}
 	case PPM_IOCTL_DISABLE_TP:
 	{
-		u32 new_tp_set;
-		if ((u32)arg >= KMOD_PROG_ATTACHED_MAX) {
-			pr_err("invalid tp %u\n", (u32)arg);
+		uint32_t new_tp_set;
+		if ((uint32_t)arg >= KMOD_PROG_ATTACHED_MAX) {
+			pr_err("invalid tp %u\n", (uint32_t)arg);
 			ret = -EINVAL;
 			goto cleanup_ioctl;
 		}
 		new_tp_set = consumer->tracepoints_attached;
-		new_tp_set &= ~(1 << (u32)arg);
+		new_tp_set &= ~(1 << (uint32_t)arg);
 		set_consumer_tracepoints(consumer, new_tp_set);
 		ret = 0;
 		goto cleanup_ioctl;
@@ -1761,12 +1761,12 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	int res = 0;
 	size_t event_size = 0;
 	int next;
-	u32 freespace;
-	u32 usedspace;
-	u32 delta_from_end;
+	uint32_t freespace;
+	uint32_t usedspace;
+	uint32_t delta_from_end;
 	struct event_filler_arguments args = {};
-	u32 ttail;
-	u32 head;
+	uint32_t ttail;
+	uint32_t head;
 	struct ppm_ring_buffer_context *ring;
 	struct ppm_ring_buffer_info *ring_info;
 	int drop = 1;

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -80,12 +80,12 @@ static __always_inline void maps__set_is_dropping(bool value)
 
 /*=============================== SAMPLING TABLES ===========================*/
 
-static __always_inline uint8_t maps__64bit_sampling_syscall_table(u32 syscall_id)
+static __always_inline uint8_t maps__64bit_sampling_syscall_table(uint32_t syscall_id)
 {
 	return g_64bit_sampling_syscall_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
 }
 
-static __always_inline uint8_t maps__64bit_sampling_tracepoint_table(u32 event_id)
+static __always_inline uint8_t maps__64bit_sampling_tracepoint_table(uint32_t event_id)
 {
 	return g_64bit_sampling_tracepoint_table[event_id < PPM_EVENT_MAX ? event_id : PPM_EVENT_MAX-1];
 }
@@ -94,7 +94,7 @@ static __always_inline uint8_t maps__64bit_sampling_tracepoint_table(u32 event_i
 
 /*=============================== SYSCALL-64 INTERESTING TABLE ===========================*/
 
-static __always_inline bool maps__64bit_interesting_syscall(u32 syscall_id)
+static __always_inline bool maps__64bit_interesting_syscall(uint32_t syscall_id)
 {
 	return g_64bit_interesting_syscalls_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
 }
@@ -103,7 +103,7 @@ static __always_inline bool maps__64bit_interesting_syscall(u32 syscall_id)
 
 /*=============================== IA32 to 64 TABLE ===========================*/
 
-static __always_inline u32 maps__ia32_to_64(u32 syscall_id)
+static __always_inline uint32_t maps__ia32_to_64(uint32_t syscall_id)
 {
 	return g_ia32_to_64_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
 }
@@ -112,7 +112,7 @@ static __always_inline u32 maps__ia32_to_64(u32 syscall_id)
 
 /*=============================== EVENT NUM PARAMS TABLE ===========================*/
 
-static __always_inline u8 maps__get_event_num_params(u32 event_id)
+static __always_inline uint8_t maps__get_event_num_params(uint32_t event_id)
 {
 	if(event_id < 0 || event_id >= PPM_EVENT_MAX)
 	{
@@ -136,7 +136,7 @@ static __always_inline uint16_t maps__get_ppm_sc(uint16_t syscall_id)
 
 static __always_inline struct auxiliary_map *maps__get_auxiliary_map()
 {
-	u32 cpu_id = (u32)bpf_get_smp_processor_id();
+	uint32_t cpu_id = (uint32_t)bpf_get_smp_processor_id();
 	return (struct auxiliary_map *)bpf_map_lookup_elem(&auxiliary_maps, &cpu_id);
 }
 
@@ -146,7 +146,7 @@ static __always_inline struct auxiliary_map *maps__get_auxiliary_map()
 
 static __always_inline struct counter_map *maps__get_counter_map()
 {
-	u32 cpu_id = (u32)bpf_get_smp_processor_id();
+	uint32_t cpu_id = (uint32_t)bpf_get_smp_processor_id();
 	return (struct counter_map *)bpf_map_lookup_elem(&counter_maps, &cpu_id);
 }
 
@@ -156,7 +156,7 @@ static __always_inline struct counter_map *maps__get_counter_map()
 
 static __always_inline struct ringbuf_map *maps__get_ringbuf_map()
 {
-	u32 cpu_id = (u32)bpf_get_smp_processor_id();
+	uint32_t cpu_id = (uint32_t)bpf_get_smp_processor_id();
 	return (struct ringbuf_map *)bpf_map_lookup_elem(&ringbuf_maps, &cpu_id);
 }
 

--- a/driver/modern_bpf/helpers/base/push_data.h
+++ b/driver/modern_bpf/helpers/base/push_data.h
@@ -109,7 +109,7 @@ enum read_memory
  * @param lengths_pos pointer to the first empty slot into the `lengths_arr`.
  * @param len length to store inside the array (16 bit).
  */
-static __always_inline void push__param_len(u8 *data, u8 *lengths_pos, uint16_t len)
+static __always_inline void push__param_len(uint8_t *data, uint8_t *lengths_pos, uint16_t len)
 {
 	*((uint16_t *)&data[SAFE_ACCESS(*lengths_pos)]) = len;
 	*lengths_pos += sizeof(uint16_t);
@@ -135,55 +135,55 @@ static __always_inline void push__param_len(u8 *data, u8 *lengths_pos, uint16_t 
 // PUSH FIXED DIMENSIONS
 ///////////////////////////
 
-static __always_inline void push__u8(u8 *data, uint64_t *payload_pos, u8 param)
+static __always_inline void push__u8(uint8_t *data, uint64_t *payload_pos, uint8_t param)
 {
-	*((u8 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
-	*payload_pos += sizeof(u8);
+	*((uint8_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(uint8_t);
 }
 
-static __always_inline void push__u16(u8 *data, uint64_t *payload_pos, uint16_t param)
+static __always_inline void push__u16(uint8_t *data, uint64_t *payload_pos, uint16_t param)
 {
 	*((uint16_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(uint16_t);
 }
 
-static __always_inline void push__u32(u8 *data, uint64_t *payload_pos, u32 param)
+static __always_inline void push__u32(uint8_t *data, uint64_t *payload_pos, uint32_t param)
 {
-	*((u32 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
-	*payload_pos += sizeof(u32);
+	*((uint32_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(uint32_t);
 }
 
-static __always_inline void push__u64(u8 *data, uint64_t *payload_pos, uint64_t param)
+static __always_inline void push__u64(uint8_t *data, uint64_t *payload_pos, uint64_t param)
 {
 	*((uint64_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(uint64_t);
 }
 
-static __always_inline void push__s16(u8 *data, uint64_t *payload_pos, int16_t param)
+static __always_inline void push__s16(uint8_t *data, uint64_t *payload_pos, int16_t param)
 {
 	*((int16_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(int16_t);
 }
 
-static __always_inline void push__s32(u8 *data, uint64_t *payload_pos, s32 param)
+static __always_inline void push__s32(uint8_t *data, uint64_t *payload_pos, int32_t param)
 {
-	*((s32 *)&data[SAFE_ACCESS(*payload_pos)]) = param;
-	*payload_pos += sizeof(s32);
+	*((int32_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
+	*payload_pos += sizeof(int32_t);
 }
 
-static __always_inline void push__s64(u8 *data, uint64_t *payload_pos, int64_t param)
+static __always_inline void push__s64(uint8_t *data, uint64_t *payload_pos, int64_t param)
 {
 	*((int64_t *)&data[SAFE_ACCESS(*payload_pos)]) = param;
 	*payload_pos += sizeof(int64_t);
 }
 
-static __always_inline void push__ipv6(u8 *data, uint64_t *payload_pos, u32 ipv6[4])
+static __always_inline void push__ipv6(uint8_t *data, uint64_t *payload_pos, uint32_t ipv6[4])
 {
 	__builtin_memcpy(&data[SAFE_ACCESS(*payload_pos)], ipv6, 16);
 	*payload_pos += 16;
 }
 
-static __always_inline void push__new_character(u8 *data, uint64_t *payload_pos, char character)
+static __always_inline void push__new_character(uint8_t *data, uint64_t *payload_pos, char character)
 {
 	*((char *)&data[SAFE_ACCESS(*payload_pos)]) = character;
 	*payload_pos += sizeof(char);
@@ -193,7 +193,7 @@ static __always_inline void push__new_character(u8 *data, uint64_t *payload_pos,
  * a previous character. Since we overwrite it we don't need to update
  * `payload_pos`.
  */
-static __always_inline void push__previous_character(u8 *data, uint64_t *payload_pos, char character)
+static __always_inline void push__previous_character(uint8_t *data, uint64_t *payload_pos, char character)
 {
 	*((char *)&data[SAFE_ACCESS(*payload_pos - 1)]) = character;
 }
@@ -216,7 +216,7 @@ static __always_inline void push__previous_character(u8 *data, uint64_t *payload
  * @param mem tell where it must read: user-space or kernel-space.
  * @return (uint16_t) the number of bytes written in the buffer. Could be '0' if the passed pointer is not valid.
  */
-static __always_inline uint16_t push__charbuf(u8 *data, uint64_t *payload_pos, unsigned long charbuf_pointer, uint16_t limit, enum read_memory mem)
+static __always_inline uint16_t push__charbuf(uint8_t *data, uint64_t *payload_pos, unsigned long charbuf_pointer, uint16_t limit, enum read_memory mem)
 {
 	int written_bytes = 0;
 
@@ -258,7 +258,7 @@ static __always_inline uint16_t push__charbuf(u8 *data, uint64_t *payload_pos, u
  * @param mem from which memory we need to read: user-space or kernel-space.
  * @return (uint16_t) the number of bytes written in the buffer. Could be '0' if the passed pointer is not valid.
  */
-static __always_inline uint16_t push__bytebuf(u8 *data, uint64_t *payload_pos, unsigned long bytebuf_pointer, uint16_t len_to_read, enum read_memory mem)
+static __always_inline uint16_t push__bytebuf(uint8_t *data, uint64_t *payload_pos, unsigned long bytebuf_pointer, uint16_t len_to_read, enum read_memory mem)
 {
 	if(mem == KERNEL)
 	{

--- a/driver/modern_bpf/helpers/base/shared_size.h
+++ b/driver/modern_bpf/helpers/base/shared_size.h
@@ -54,11 +54,11 @@
 #define USEC_FACTOR 1000
 
 /* Network components size. */
-#define FAMILY_SIZE sizeof(u8)
-#define IPV4_SIZE sizeof(u32)
+#define FAMILY_SIZE sizeof(uint8_t)
+#define IPV4_SIZE sizeof(uint32_t)
 #define IPV6_SIZE 16
 #define PORT_SIZE sizeof(uint16_t)
-#define KERNEL_POINTER sizeof(u64)
+#define KERNEL_POINTER sizeof(uint64_t)
 
 /* This enum is used to tell network helpers if the connection outbound
  * or inbound

--- a/driver/modern_bpf/helpers/interfaces/attached_programs.h
+++ b/driver/modern_bpf/helpers/interfaces/attached_programs.h
@@ -21,7 +21,7 @@ enum intrumentation_type
  * We treat the syscalls tracepoints in a dedicated way because they could generate
  * more than one event (1 for each syscall) for this reason we need a dedicated table.
  */
-static __always_inline bool sampling_logic(void* ctx, u32 id, enum intrumentation_type type)
+static __always_inline bool sampling_logic(void* ctx, uint32_t id, enum intrumentation_type type)
 {
 	/* If dropping mode is not enabled we don't perform any sampling
 	 * false: means don't drop the syscall

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -13,12 +13,12 @@
 #include <helpers/base/read_from_task.h>
 #include <helpers/extract/extract_from_kernel.h>
 
-static __always_inline bool syscalls_dispatcher__64bit_interesting_syscall(u32 syscall_id)
+static __always_inline bool syscalls_dispatcher__64bit_interesting_syscall(uint32_t syscall_id)
 {
 	return maps__64bit_interesting_syscall(syscall_id);
 }
 
-static __always_inline u32 syscalls_dispatcher__convert_ia32_to_64(u32 syscall_id)
+static __always_inline uint32_t syscalls_dispatcher__convert_ia32_to_64(uint32_t syscall_id)
 {
 	return maps__ia32_to_64(syscall_id);
 }

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -38,9 +38,9 @@
  *
  * struct ringbuf_struct
  * {
- *	  u8 *data;	   // pointer to the space reserved in the ring buffer.
+ *	  uint8_t *data;	   // pointer to the space reserved in the ring buffer.
  *	  uint64_t payload_pos; // position of the first empty byte in the `data` buf.
- *	  u8 lengths_pos;  // position the first empty slot into the lengths array of the event.
+ *	  uint8_t lengths_pos;  // position the first empty slot into the lengths array of the event.
  * };
  *
  * To better understand the two indexes `payload_pos` and `lengths_pos`
@@ -65,9 +65,9 @@
 
 struct ringbuf_struct
 {
-	u8 *data;		 /* pointer to the space reserved in the ring buffer. */
+	uint8_t *data;		 /* pointer to the space reserved in the ring buffer. */
 	uint64_t payload_pos;	 /* position of the first empty byte in the `data` buf.*/
-	u8 lengths_pos;		 /* position the first empty slot into the lengths array of the event. */
+	uint8_t lengths_pos;		 /* position the first empty slot into the lengths array of the event. */
 	uint16_t reserved_event_size; /* reserved size in the ringbuf. */
 	uint16_t event_type; /* event type we want to send to userspace */
 };
@@ -89,7 +89,7 @@ struct ringbuf_struct
  * @param event_size exact size of the fixed-size event
  * @return `1` in case of success, `0` in case of failure.
  */
-static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf, void* ctx, u32 event_size, uint16_t event_type)
+static __always_inline uint32_t ringbuf__reserve_space(struct ringbuf_struct *ringbuf, void* ctx, uint32_t event_size, uint16_t event_type)
 {
 	struct ringbuf_map *rb = maps__get_ringbuf_map();
 	if(!rb)
@@ -111,7 +111,7 @@ static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf
 	/* If we are not able to reserve space we stop here
 	 * the event collection.
 	 */
-	u8 *space = bpf_ringbuf_reserve(rb, event_size, 0);
+	uint8_t *space = bpf_ringbuf_reserve(rb, event_size, 0);
 	if(!space)
 	{
 		counter->n_drops_buffer++;
@@ -137,7 +137,7 @@ static __always_inline u32 ringbuf__reserve_space(struct ringbuf_struct *ringbuf
 static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf)
 {
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)ringbuf->data;
-	u8 nparams = maps__get_event_num_params(ringbuf->event_type);
+	uint8_t nparams = maps__get_event_num_params(ringbuf->event_type);
 	hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 	hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
 	hdr->type = ringbuf->event_type;
@@ -200,9 +200,9 @@ static __always_inline void ringbuf__store_s16(struct ringbuf_struct *ringbuf, i
  * @param ringbuf pointer to the `ringbuf_struct`.
  * @param param param to store.
  */
-static __always_inline void ringbuf__store_s32(struct ringbuf_struct *ringbuf, s32 param)
+static __always_inline void ringbuf__store_s32(struct ringbuf_struct *ringbuf, int32_t param)
 {
-	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(s32));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(int32_t));
 }
 
 /**
@@ -231,9 +231,9 @@ static __always_inline void ringbuf__store_s64(struct ringbuf_struct *ringbuf, i
  * @param ringbuf pointer to the `ringbuf_struct`.
  * @param param param to store
  */
-static __always_inline void ringbuf__store_u8(struct ringbuf_struct *ringbuf, u8 param)
+static __always_inline void ringbuf__store_u8(struct ringbuf_struct *ringbuf, uint8_t param)
 {
-	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(u8));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(uint8_t));
 }
 
 /**
@@ -265,9 +265,9 @@ static __always_inline void ringbuf__store_u16(struct ringbuf_struct *ringbuf, u
  * @param ringbuf pointer to the `ringbuf_struct`.
  * @param param param to store
  */
-static __always_inline void ringbuf__store_u32(struct ringbuf_struct *ringbuf, u32 param)
+static __always_inline void ringbuf__store_u32(struct ringbuf_struct *ringbuf, uint32_t param)
 {
-	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(u32));
+	PUSH_FIXED_SIZE_TO_RINGBUF(ringbuf, param, sizeof(uint32_t));
 }
 
 /**
@@ -308,7 +308,7 @@ static __always_inline void ringbuf__store_iovec_size_param(struct ringbuf_struc
 		return;
 	}
 
-	u32 total_iovec_size = iov_cnt * bpf_core_type_size(struct iovec);
+	uint32_t total_iovec_size = iov_cnt * bpf_core_type_size(struct iovec);
 	if(bpf_probe_read_user((void *)&auxmap->data[0],
 			       SAFE_ACCESS(total_iovec_size),
 			       (void *)iov_pointer))
@@ -317,7 +317,7 @@ static __always_inline void ringbuf__store_iovec_size_param(struct ringbuf_struc
 		return;
 	}
 
-	u32 total_size_to_read = 0;
+	uint32_t total_size_to_read = 0;
 
 	/* Pointer to iovec structs */
 	const struct iovec *iovec = (const struct iovec *)&auxmap->data[0];

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -105,8 +105,8 @@ struct
 {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, SYSCALL_TABLE_SIZE);
-	__type(key, u32);
-	__type(value, u32);
+	__type(key, uint32_t);
+	__type(value, uint32_t);
 } syscall_enter_tail_table __weak SEC(".maps");
 
 /**
@@ -118,8 +118,8 @@ struct
 {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, SYSCALL_TABLE_SIZE);
-	__type(key, u32);
-	__type(value, u32);
+	__type(key, uint32_t);
+	__type(value, uint32_t);
 } syscall_exit_tail_table __weak SEC(".maps");
 
 /**
@@ -135,8 +135,8 @@ struct
 {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, TAIL_EXTRA_EVENT_PROG_MAX);
-	__type(key, u32);
-	__type(value, u32);
+	__type(key, uint32_t);
+	__type(value, uint32_t);
 } extra_event_prog_tail_table __weak SEC(".maps");
 
 /*=============================== BPF_MAP_TYPE_PROG_ARRAY ===============================*/
@@ -163,7 +163,7 @@ struct
 struct
 {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
+	__type(key, uint32_t);
 	__type(value, struct auxiliary_map);
 } auxiliary_maps __weak SEC(".maps");
 
@@ -175,7 +175,7 @@ struct
 struct
 {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
+	__type(key, uint32_t);
 	__type(value, struct counter_map);
 } counter_maps __weak SEC(".maps");
 
@@ -199,8 +199,8 @@ struct ringbuf_map
 struct
 {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
-	__type(key, u32);
-	__type(value, u32);
+	__type(key, uint32_t);
+	__type(value, uint32_t);
 	__array(values, struct ringbuf_map);
 } ringbuf_maps __weak SEC(".maps");
 

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_enter.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(sys_enter,
 		{
 			syscall_id = syscalls_dispatcher__convert_ia32_to_64(syscall_id);
 			// syscalls defined only on 32 bits are dropped here.
-			if(syscall_id == (u32)-1)
+			if(syscall_id == (uint32_t)-1)
 			{
 				return 0;
 			}

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -23,7 +23,7 @@ int BPF_PROG(sys_exit,
 {
 	int socketcall_syscall_id = -1;
 
-	u32 syscall_id = extract__syscall_id(regs);
+	uint32_t syscall_id = extract__syscall_id(regs);
 
 	if(bpf_in_ia32_syscall())
 	{
@@ -43,7 +43,7 @@ int BPF_PROG(sys_exit,
 			if(syscall_id != X86_64_NR_EXECVE && syscall_id != X86_64_NR_EXECVEAT)
 			{
 				syscall_id = syscalls_dispatcher__convert_ia32_to_64(syscall_id);
-				if(syscall_id == (u32)-1)
+				if(syscall_id == (uint32_t)-1)
 				{
 					return 0;
 				}

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -108,15 +108,15 @@ int BPF_PROG(sched_p_exec,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -163,20 +163,20 @@ int BPF_PROG(t1_sched_p_exec,
 	auxmap__store_bytebuf_param(auxmap, env_start_pointer, total_env_len & (MAX_PROC_ARG_ENV - 1), USER);
 
 	/* Parameter 17: tty (type: PT_UINT32) */
-	u32 tty = exctract__tty(task);
-	auxmap__store_u32_param(auxmap, (u32)tty);
+	uint32_t tty = exctract__tty(task);
+	auxmap__store_u32_param(auxmap, (uint32_t)tty);
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
-	u32 loginuid;
+	uint32_t loginuid;
 	extract__loginuid(task, &loginuid);
-	auxmap__store_u32_param(auxmap, (u32)loginuid);
+	auxmap__store_u32_param(auxmap, (uint32_t)loginuid);
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	u32 flags = 0;
+	uint32_t flags = 0;
 	struct inode *exe_inode = extract__exe_inode_from_task(task);
 	struct file *exe_file = extract__exe_file_from_task(task);
 
@@ -230,7 +230,7 @@ int BPF_PROG(t1_sched_p_exec,
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 27: euid (type: PT_UID) */
-	u32 euid;
+	uint32_t euid;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -118,15 +118,15 @@ int BPF_PROG(sched_p_fork,
 	READ_TASK_FIELD_INTO(&mm, child, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -154,7 +154,7 @@ int BPF_PROG(t1_sched_p_fork,
 	auxmap__store_cgroups_param(auxmap, child);
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
-	u32 flags = 0;
+	uint32_t flags = 0;
 
 	/* Since Linux 2.5.35, the flags mask must also include
 	 * CLONE_SIGHAND if CLONE_THREAD is specified (and note that,
@@ -196,12 +196,12 @@ int BPF_PROG(t1_sched_p_fork,
 	auxmap__store_u32_param(auxmap, flags);
 
 	/* Parameter 17: uid (type: PT_UINT32) */
-	u32 euid = 0;
+	uint32_t euid = 0;
 	extract__euid(child, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
-	u32 egid = 0;
+	uint32_t egid = 0;
 	extract__egid(child, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 

--- a/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_switch.bpf.c
@@ -53,15 +53,15 @@ int BPF_PROG(sched_switch,
 	READ_TASK_FIELD_INTO(&mm, prev, mm);
 
 	/* Parameter 4: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	ringbuf__store_u32(&ringbuf, vm_size);
 
 	/* Parameter 5: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	ringbuf__store_u32(&ringbuf, vm_rss);
 
 	/* Parameter 6: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	ringbuf__store_u32(&ringbuf, vm_swap);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/signal_deliver.bpf.c
@@ -83,7 +83,7 @@ int BPF_PROG(signal_deliver,
 	ringbuf__store_u64(&ringbuf, (int64_t)bpf_get_current_pid_tgid() & 0xffffffff);
 
 	/* Parameter 3: sig (type: PT_SIGTYPE) */
-	ringbuf__store_u8(&ringbuf, (u8)sig);
+	ringbuf__store_u8(&ringbuf, (uint8_t)sig);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/custom_logic/hotplug.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/custom_logic/hotplug.bpf.c
@@ -14,7 +14,7 @@ int BPF_PROG(t1_hotplug_e)
 	/* We assume that the ring buffer for CPU 0 is always there so we send the
 	 * HOT-PLUG event through this buffer.
 	 */
-	u32 cpu_0 = 0;
+	uint32_t cpu_0 = 0;
 	struct ringbuf_map *rb = bpf_map_lookup_elem(&ringbuf_maps, &cpu_0);
 	if(!rb)
 	{
@@ -50,7 +50,7 @@ int BPF_PROG(t1_hotplug_e)
 	/*=============================== COLLECT PARAMETERS ===========================*/
 
 	/* Parameter 1: cpu (type: PT_UINT32) */
-	u32 current_cpu_id = (u32)bpf_get_smp_processor_id();
+	uint32_t current_cpu_id = (uint32_t)bpf_get_smp_processor_id();
 	ringbuf__store_u32(&ringbuf, current_cpu_id);
 
 	/* Parameter 2: action (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -63,18 +63,18 @@ int BPF_PROG(accept_x,
 	 */
 
 	/* actual dimension of the server queue. */
-	u32 queuelen = 0;
+	uint32_t queuelen = 0;
 
 	/* max dimension of the server queue. */
-	u32 queuemax = 0;
+	uint32_t queuemax = 0;
 
 	/* occupancy percentage of the server queue. */
-	u8 queuepct = 0;
+	uint8_t queuepct = 0;
 
 	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
 	if(ret >= 0)
 	{
-		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
+		auxmap__store_socktuple_param(auxmap, (int32_t)ret, INBOUND);
 
 		/* Collect parameters at the beginning to  manage socketcalls */
 		unsigned long args[1];
@@ -85,7 +85,7 @@ int BPF_PROG(accept_x,
 		 * to extract information from the listening socket, not from the
 		 * new one.
 		 */
-		s32 sockfd = (s32)args[0];
+		int32_t sockfd = (int32_t)args[0];
 		struct file *file = NULL;
 		file = extract__file_struct_from_fd(sockfd);
 		struct socket *socket = BPF_CORE_READ(file, private_data);
@@ -94,7 +94,7 @@ int BPF_PROG(accept_x,
 		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
 		if(queuelen && queuemax)
 		{
-			queuepct = (u8)((uint64_t)queuelen * 100 / queuemax);
+			queuepct = (uint8_t)((uint64_t)queuelen * 100 / queuemax);
 		}
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept4.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(accept4_e,
 	/* Parameter 1: flags (type: PT_FLAGS32) */
 	/// TODO: we don't support flags yet and so we just return zero.
 	///    If implemented, special handling for SYS_ACCEPT socketcall is needed.
-	u32 flags = 0;
+	uint32_t flags = 0;
 	ringbuf__store_u32(&ringbuf, flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -67,18 +67,18 @@ int BPF_PROG(accept4_x,
 	 */
 
 	/* actual dimension of the server queue. */
-	u32 queuelen = 0;
+	uint32_t queuelen = 0;
 
 	/* max dimension of the server queue. */
-	u32 queuemax = 0;
+	uint32_t queuemax = 0;
 
 	/* occupancy percentage of the server queue. */
-	u8 queuepct = 0;
+	uint8_t queuepct = 0;
 
 	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
 	if(ret >= 0)
 	{
-		auxmap__store_socktuple_param(auxmap, (s32)ret, INBOUND);
+		auxmap__store_socktuple_param(auxmap, (int32_t)ret, INBOUND);
 
 		/* Collect parameters at the beginning to  manage socketcalls */
 		unsigned long args[1];
@@ -89,7 +89,7 @@ int BPF_PROG(accept4_x,
 		 * to extract information from the listening socket, not from the
 		 * new one.
 		 */
-		s32 sockfd = (s32)args[0];
+		int32_t sockfd = (int32_t)args[0];
 		struct file *file = NULL;
 		file = extract__file_struct_from_fd(sockfd);
 		struct socket *socket = BPF_CORE_READ(file, private_data);
@@ -98,7 +98,7 @@ int BPF_PROG(accept4_x,
 		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
 		if(queuelen && queuemax)
 		{
-			queuepct = (u8)((uint64_t)queuelen * 100 / queuemax);
+			queuepct = (uint8_t)((uint64_t)queuelen * 100 / queuemax);
 		}
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/access.bpf.c
@@ -28,7 +28,7 @@ int BPF_PROG(access_e,
 
 	/* Parameter 1: mode (type: PT_UINT32) */
 	int mode = (int)extract__syscall_argument(regs, 1);
-	ringbuf__store_u32(&ringbuf, (u32)access_flags_to_scap(mode));
+	ringbuf__store_u32(&ringbuf, (uint32_t)access_flags_to_scap(mode));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(bind_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bpf.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(bpf_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: cmd (type: PT_INT64) */
-	s32 cmd = (s32)extract__syscall_argument(regs, 0);
+	int32_t cmd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)cmd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/brk.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/brk.bpf.c
@@ -63,9 +63,9 @@ int BPF_PROG(brk_x,
 	struct mm_struct *mm = NULL;
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
-	u32 vm_size = extract__vm_size(mm);
-	u32 rss_size = extract__vm_rss(mm);
-	u32 swap_size = extract__vm_swap(mm);
+	uint32_t vm_size = extract__vm_size(mm);
+	uint32_t rss_size = extract__vm_rss(mm);
+	uint32_t swap_size = extract__vm_swap(mm);
 
 	/* Parameter 2: vm_size (type: PT_UINT32) */
 	ringbuf__store_u32(&ringbuf, vm_size);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -149,15 +149,15 @@ int BPF_PROG(clone_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -203,15 +203,15 @@ int BPF_PROG(t1_clone_x,
 #else
 	unsigned long flags = extract__syscall_argument(regs, 0);
 #endif
-	auxmap__store_u32_param(auxmap, (u32)extract__clone_flags(task, flags));
+	auxmap__store_u32_param(auxmap, (uint32_t)extract__clone_flags(task, flags));
 
 	/* Parameter 17: uid (type: PT_UINT32) */
-	u32 euid = 0;
+	uint32_t euid = 0;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
-	u32 egid = 0;
+	uint32_t egid = 0;
 	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -149,15 +149,15 @@ int BPF_PROG(clone3_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -200,15 +200,15 @@ int BPF_PROG(t1_clone3_x,
 		bpf_probe_read_user((void *)&cl_args, bpf_core_type_size(struct clone_args), (void *)cl_args_pointer);
 		flags = extract__clone_flags(task, cl_args.flags);
 	}
-	auxmap__store_u32_param(auxmap, (u32)flags);
+	auxmap__store_u32_param(auxmap, (uint32_t)flags);
 
 	/* Parameter 17: uid (type: PT_UINT32) */
-	u32 euid = 0;
+	uint32_t euid = 0;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
-	u32 egid = 0;
+	uint32_t egid = 0;
 	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/close.bpf.c
@@ -17,7 +17,7 @@ int BPF_PROG(close_e,
 {
 	if(maps__get_dropping_mode())
 	{
-		s32 fd = (s32)extract__syscall_argument(regs, 0);
+		int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 		/* We drop the event if we are closing a negative file descriptor */
 		if(fd < 0)
 		{
@@ -25,7 +25,7 @@ int BPF_PROG(close_e,
 		}
 
 		struct task_struct *task = get_current_task();
-		u32 max_fds = 0;
+		uint32_t max_fds = 0;
 		BPF_CORE_READ_INTO(&max_fds, task, files, fdt, max_fds);
 		/* We drop the event if the fd is >= than `max_fds` */
 		if(fd >= max_fds)
@@ -60,7 +60,7 @@ int BPF_PROG(close_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/connect.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(connect_e,
 	extract__network_args(args, 3, regs);
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 socket_fd = (s32)args[0];
+	int32_t socket_fd = (int32_t)args[0];
 	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: addr (type: PT_SOCKADDR)*/
@@ -71,7 +71,7 @@ int BPF_PROG(connect_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	auxmap__store_s64_param(auxmap, ret);
 
-	s32 socket_fd = (s32)args[0];
+	int32_t socket_fd = (int32_t)args[0];
 
 	/* Parameter 2: tuple (type: PT_SOCKTUPLE) */
 	/* We need a valid sockfd to extract source data.*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/copy_file_range.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(copy_file_range_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fdin (type: PT_FD) */
-	s32 fdin = (s32)extract__syscall_argument(regs, 0);
+	int32_t fdin = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fdin);
 
 	/* Parameter 2: offin (type: PT_UINT64) */
@@ -67,7 +67,7 @@ int BPF_PROG(copy_file_range_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fdout (type: PT_FD) */
-	s32 fdout = (s32)extract__syscall_argument(regs, 2);
+	int32_t fdout = (int32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_s64(&ringbuf, (int64_t)fdout);
 
 	/* Parameter 3: offout (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(dup_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -59,7 +59,7 @@ int BPF_PROG(dup_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(dup2_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -59,11 +59,11 @@ int BPF_PROG(dup2_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
-	s32 newfd = (s32)extract__syscall_argument(regs, 1);
+	int32_t newfd = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(dup3_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -59,11 +59,11 @@ int BPF_PROG(dup3_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	s32 oldfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
-	s32 newfd = (s32)extract__syscall_argument(regs, 1);
+	int32_t newfd = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(epoll_create_e,
        /*=============================== COLLECT PARAMETERS  ===========================*/
 
        /* Parameter 1: size (type: PT_INT32) */
-       s32 size = (s32)extract__syscall_argument(regs, 0);
+       int32_t size = (int32_t)extract__syscall_argument(regs, 0);
        ringbuf__store_s32(&ringbuf, size);
 
        /*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/epoll_create1.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(epoll_create1_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
-	s32 flags = (s32)extract__syscall_argument(regs, 0);
+	int32_t flags = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, epoll_create1_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(eventfd_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: initval (type: PT_UINT64) */
-	u32 initval = (u32)extract__syscall_argument(regs, 0);
+	uint32_t initval = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, (uint64_t)initval);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/eventfd2.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(eventfd2_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: initval (type: PT_UINT64) */
-	u32 initval = (u32)extract__syscall_argument(regs, 0);
+	uint32_t initval = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, (uint64_t)initval);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -59,7 +59,7 @@ int BPF_PROG(eventfd2_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	s32 flags = (s32)extract__syscall_argument(regs, 1);
+	int32_t flags = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u16(&ringbuf, eventfd2_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -157,15 +157,15 @@ int BPF_PROG(execve_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -227,20 +227,20 @@ int BPF_PROG(t1_execve_x,
 	}
 
 	/* Parameter 17: tty (type: PT_INT32) */
-	u32 tty = exctract__tty(task);
-	auxmap__store_u32_param(auxmap, (u32)tty);
+	uint32_t tty = exctract__tty(task);
+	auxmap__store_u32_param(auxmap, (uint32_t)tty);
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
-	u32 loginuid;
+	uint32_t loginuid;
 	extract__loginuid(task, &loginuid);
-	auxmap__store_u32_param(auxmap, (u32)loginuid);
+	auxmap__store_u32_param(auxmap, (uint32_t)loginuid);
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	u32 flags = 0;
+	uint32_t flags = 0;
 	struct inode *exe_inode = extract__exe_inode_from_task(task);
 	struct file *exe_file = extract__exe_file_from_task(task);
 
@@ -294,7 +294,7 @@ int BPF_PROG(t1_execve_x,
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 27: euid (type: PT_UID) */
-	u32 euid;
+	uint32_t euid;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -25,7 +25,7 @@ int BPF_PROG(execveat_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -174,15 +174,15 @@ int BPF_PROG(execveat_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -244,20 +244,20 @@ int BPF_PROG(t1_execveat_x,
 	}
 
 	/* Parameter 17: tty (type: PT_UID) */
-	u32 tty = exctract__tty(task);
-	auxmap__store_u32_param(auxmap, (u32)tty);
+	uint32_t tty = exctract__tty(task);
+	auxmap__store_u32_param(auxmap, (uint32_t)tty);
 
 	/* Parameter 18: pgid (type: PT_PID) */
 	pid_t pgid = extract__task_xid_vnr(task, PIDTYPE_PGID);
 	auxmap__store_s64_param(auxmap, (int64_t)pgid);
 
 	/* Parameter 19: loginuid (type: PT_UID) */
-	u32 loginuid;
+	uint32_t loginuid;
 	extract__loginuid(task, &loginuid);
-	auxmap__store_u32_param(auxmap, (u32)loginuid);
+	auxmap__store_u32_param(auxmap, (uint32_t)loginuid);
 
 	/* Parameter 20: flags (type: PT_FLAGS32) */
-	u32 flags = 0;
+	uint32_t flags = 0;
 	struct inode *exe_inode = extract__exe_inode_from_task(task);
 	struct file *exe_file = extract__exe_file_from_task(task);
 
@@ -310,7 +310,7 @@ int BPF_PROG(t1_execveat_x,
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
 	/* Parameter 27: euid (type: PT_UID) */
-	u32 euid;
+	uint32_t euid;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchdir.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(fchdir_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmod.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(fchmod_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: mode (type: PT_MODE) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchmodat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(fchmodat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchown.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(fchown_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: uid (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fchownat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(fchownat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fcntl.bpf.c
@@ -10,7 +10,7 @@
 
 static __always_inline bool check_fcntl_dropping(struct pt_regs *regs)
 {
-	int cmd = (s32)extract__syscall_argument(regs, 1);
+	int cmd = (int32_t)extract__syscall_argument(regs, 1);
 	if(cmd != F_DUPFD && cmd != F_DUPFD_CLOEXEC)
 	{
 		return true;
@@ -41,11 +41,11 @@ int BPF_PROG(fcntl_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: cmd (type: PT_ENUMFLAGS8) */
-	int cmd = (s32)extract__syscall_argument(regs, 1);
+	int cmd = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u8(&ringbuf, fcntl_cmd_to_scap(cmd));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -83,11 +83,11 @@ int BPF_PROG(fcntl_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS8) */
-	int cmd = (s32)extract__syscall_argument(regs, 1);
+	int cmd = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u8(&ringbuf, fcntl_cmd_to_scap(cmd));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/finit_module.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/finit_module.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(finit_module_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: uargs (type: PT_CHARBUF) */
@@ -68,7 +68,7 @@ int BPF_PROG(finit_module_x,
 	auxmap__store_charbuf_param(auxmap, uargs_ptr, MAX_PROC_ARG_ENV, USER);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	u32 flags = extract__syscall_argument(regs, 2);
+	uint32_t flags = extract__syscall_argument(regs, 2);
 	auxmap__store_s32_param(auxmap, finit_module_flags_to_scap(flags));
 
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(flock_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -151,15 +151,15 @@ int BPF_PROG(fork_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -194,16 +194,16 @@ int BPF_PROG(t1_fork_x,
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
 	/* In `fork`/`vfork` we don't have `flags` from syscall arguments. */
-	u32 flags = 0;
-	auxmap__store_u32_param(auxmap, (u32)extract__clone_flags(task, flags));
+	uint32_t flags = 0;
+	auxmap__store_u32_param(auxmap, (uint32_t)extract__clone_flags(task, flags));
 
 	/* Parameter 17: uid (type: PT_UINT32) */
-	u32 euid = 0;
+	uint32_t euid = 0;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
-	u32 egid = 0;
+	uint32_t egid = 0;
 	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fsconfig.bpf.c
@@ -59,12 +59,12 @@ int BPF_PROG(fsconfig_x,
 
 	/* Parameter 2: fd (type: PT_FD) */
 	/* This is the file-system fd */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: cmd (type: PT_ENUMFLAGS32) */
-	u32 cmd = (u32)extract__syscall_argument(regs, 1);
-	u32 scap_cmd = fsconfig_cmds_to_scap(cmd);
+	uint32_t cmd = (uint32_t)extract__syscall_argument(regs, 1);
+	uint32_t scap_cmd = fsconfig_cmds_to_scap(cmd);
 	auxmap__store_u32_param(auxmap, scap_cmd);
 
 	/* Parameter 4: key (type: PT_CHARBUF) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fstat.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(fstat_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/futex.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(futex_e,
 	ringbuf__store_u64(&ringbuf, addr);
 
 	/* Parameter 2: op (type: PT_ENUMFLAGS16) */
-	s32 op = (s32)extract__syscall_argument(regs, 1);
+	int32_t op = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u16(&ringbuf, futex_op_to_scap((unsigned long)op));
 
 	/* Parameter 3: val (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(getdents_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getdents64.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(getdents64_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getegid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getegid.bpf.c
@@ -53,7 +53,7 @@ int BPF_PROG(getegid_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
         /* Parameter 1: egid (type: PT_GID) */
-        ringbuf__store_u32(&ringbuf, (u32)ret);
+        ringbuf__store_u32(&ringbuf, (uint32_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/geteuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/geteuid.bpf.c
@@ -53,7 +53,7 @@ int BPF_PROG(geteuid_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
         /* Parameter 1: euid (type: PT_UID) */
-        ringbuf__store_u32(&ringbuf, (u32)ret);
+        ringbuf__store_u32(&ringbuf, (uint32_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getgid.bpf.c
@@ -53,7 +53,7 @@ int BPF_PROG(getgid_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
         /* Parameter 1: gid (type: PT_GID) */
-        ringbuf__store_u32(&ringbuf, (u32)ret);
+        ringbuf__store_u32(&ringbuf, (uint32_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresgid.bpf.c
@@ -58,19 +58,19 @@ int BPF_PROG(getresgid_x,
 	unsigned long rgid_pointer = extract__syscall_argument(regs, 0);
 	gid_t rgid;
 	bpf_probe_read_user((void *)&rgid, sizeof(rgid), (void *)rgid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)rgid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)rgid);
 
 	/* Parameter 3: egid (type: PT_GID) */
 	unsigned long egid_pointer = extract__syscall_argument(regs, 1);
 	gid_t egid;
 	bpf_probe_read_user((void *)&egid, sizeof(egid), (void *)egid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)egid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)egid);
 
 	/* Parameter 4: sgid (type: PT_GID) */
 	unsigned long sgid_pointer = extract__syscall_argument(regs, 2);
 	gid_t sgid;
 	bpf_probe_read_user((void *)&sgid, sizeof(sgid), (void *)sgid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)sgid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)sgid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getresuid.bpf.c
@@ -58,19 +58,19 @@ int BPF_PROG(getresuid_x,
 	unsigned long ruid_pointer = extract__syscall_argument(regs, 0);
 	uid_t ruid;
 	bpf_probe_read_user((void *)&ruid, sizeof(ruid), (void *)ruid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)ruid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)ruid);
 
 	/* Parameter 3: euid (type: PT_UID) */
 	unsigned long euid_pointer = extract__syscall_argument(regs, 1);
 	uid_t euid;
 	bpf_probe_read_user((void *)&euid, sizeof(euid), (void *)euid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)euid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)euid);
 
 	/* Parameter 4: suid (type: PT_UID) */
 	unsigned long suid_pointer = extract__syscall_argument(regs, 2);
 	uid_t suid;
 	bpf_probe_read_user((void *)&suid, sizeof(suid), (void *)suid_pointer);
-	ringbuf__store_u32(&ringbuf, (u32)suid);
+	ringbuf__store_u32(&ringbuf, (uint32_t)suid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getsockopt.bpf.c
@@ -62,7 +62,7 @@ int BPF_PROG(getsockopt_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
@@ -85,7 +85,7 @@ int BPF_PROG(getsockopt_x,
 	auxmap__store_sockopt_param(auxmap, level, optname, optlen, optval);
 
 	/* Parameter 6: optlen (type: PT_UINT32) */
-	auxmap__store_u32_param(auxmap, (u32)optlen);
+	auxmap__store_u32_param(auxmap, (uint32_t)optlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/getuid.bpf.c
@@ -53,7 +53,7 @@ int BPF_PROG(getuid_x,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
         /* Parameter 1: uid (type: PT_UID) */
-        ringbuf__store_u32(&ringbuf, (u32)ret);
+        ringbuf__store_u32(&ringbuf, (uint32_t)ret);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(inotify_init_e,
 	/* We have nothing to extract from the kernel here so we send `0`.
 	 * This is done to preserve the `PPME_SYSCALL_INOTIFY_INIT_E` event with 1 param.
 	 */
-	u8 flags = 0;
+	uint8_t flags = 0;
 	ringbuf__store_u8(&ringbuf, flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init1.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/inotify_init1.bpf.c
@@ -57,7 +57,7 @@ int BPF_PROG(inotify_init1_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	s32 flags = (s32)extract__syscall_argument(regs, 0);
+	int32_t flags = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u16(&ringbuf, inotify_init1_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_enter.bpf.c
@@ -57,26 +57,26 @@ int BPF_PROG(io_uring_enter_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: to_submit (type: PT_UINT32) */
-	u32 to_submit = (u32)extract__syscall_argument(regs, 1);
+	uint32_t to_submit = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, to_submit);
 
 	/* Parameter 4: min_complete (type: PT_UINT32) */
-	u32 min_complete = (u32)extract__syscall_argument(regs, 2);
+	uint32_t min_complete = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, min_complete);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 3);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u32(&ringbuf, io_uring_enter_flags_to_scap(flags));
 
 	/* Parameter 6: sig (type: PT_SIGSET) */
 	/* This is unclear, why we store only the first 32 bit? this is a pointer!
 	 * It could be also a pointer to a `struct io_uring_getevents_args`.
 	 */
-	u32 sig = (u32)extract__syscall_argument(regs, 4);
+	uint32_t sig = (uint32_t)extract__syscall_argument(regs, 4);
 	ringbuf__store_u32(&ringbuf, sig);
 
 	/// TODO: We miss the last parameter `size_t argsz`

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_register.bpf.c
@@ -57,11 +57,11 @@ int BPF_PROG(io_uring_register_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 3: opcode (type: PT_ENUMFLAGS16) */
-	u32 opcode = (u32)extract__syscall_argument(regs, 1);
+	uint32_t opcode = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u16(&ringbuf, (uint16_t)io_uring_register_opcodes_to_scap(opcode));
 
 	/* Parameter 4: arg (type: PT_UINT64) */
@@ -72,7 +72,7 @@ int BPF_PROG(io_uring_register_x,
 	ringbuf__store_u64(&ringbuf, arg);
 
 	/* Parameter 5: nr_args (type: PT_UINT32) */
-	u32 nr_args = (u32)extract__syscall_argument(regs, 3);
+	uint32_t nr_args = (uint32_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u32(&ringbuf, nr_args);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_setup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/io_uring_setup.bpf.c
@@ -57,7 +57,7 @@ int BPF_PROG(io_uring_setup_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: entries (type: PT_UINT32) */
-	u32 entries = (u32)extract__syscall_argument(regs, 0);
+	uint32_t entries = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, entries);
 
 	/* Get the second syscall argument that is a `struct io_uring_params*`
@@ -79,7 +79,7 @@ int BPF_PROG(io_uring_setup_x,
 		ringbuf__store_u32(&ringbuf, params.cq_entries);
 
 		/* Parameter 5: flags (type: PT_FLAGS32) */
-		ringbuf__store_u32(&ringbuf, (u32)io_uring_setup_flags_to_scap(params.flags));
+		ringbuf__store_u32(&ringbuf, (uint32_t)io_uring_setup_flags_to_scap(params.flags));
 
 		/* Parameter 6: sq_thread_cpu (type: PT_UINT32) */
 		ringbuf__store_u32(&ringbuf, params.sq_thread_cpu);
@@ -88,7 +88,7 @@ int BPF_PROG(io_uring_setup_x,
 		ringbuf__store_u32(&ringbuf, params.sq_thread_idle);
 
 		/* Parameter 8: features (type: PT_FLAGS32) */
-		ringbuf__store_u32(&ringbuf, (u32)io_uring_setup_feats_to_scap(params.features));
+		ringbuf__store_u32(&ringbuf, (uint32_t)io_uring_setup_feats_to_scap(params.features));
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ioctl.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(ioctl_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: request (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/kill.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(kill_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: pid (type: PT_PID) */
-	pid_t pid = (s32)extract__syscall_argument(regs, 0);
+	pid_t pid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: sig (type: PT_SIGTYPE) */
-	u8 sig = (u8)extract__syscall_argument(regs, 1);
+	uint8_t sig = (uint8_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u8(&ringbuf, sig);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(linkat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: olddirfd (type: PT_FD) */
-	s32 olddirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t olddirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(olddirfd == AT_FDCWD)
 	{
 		olddirfd = PPM_AT_FDCWD;
@@ -70,7 +70,7 @@ int BPF_PROG(linkat_x,
 	auxmap__store_charbuf_param(auxmap, old_path_pointer, MAX_PATH, USER);
 
 	/* Parameter 4: newdirfd (type: PT_FD) */
-	s32 newdirfd = (s32)extract__syscall_argument(regs, 2);
+	int32_t newdirfd = (int32_t)extract__syscall_argument(regs, 2);
 	if(newdirfd == AT_FDCWD)
 	{
 		newdirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -30,11 +30,11 @@ int BPF_PROG(listen_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: backlog (type: PT_INT32) */
-	s32 backlog = (s32)args[1];
+	int32_t backlog = (int32_t)args[1];
 	ringbuf__store_s32(&ringbuf, backlog);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/llseek.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(llseek_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: offset (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/lseek.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(lseek_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: offset (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/memfd_create.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/memfd_create.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(memfd_create_x,
     auxmap__store_charbuf_param(auxmap, name_pointer, MAX_PATH, USER);
 
     /* Parameter 3: flags (type: PT_FLAGS32) */
-    u32 flags = (u32)extract__syscall_argument(regs, 1);
+    uint32_t flags = (uint32_t)extract__syscall_argument(regs, 1);
     auxmap__store_u32_param(auxmap, memfd_create_flags_to_scap(flags));
     /*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdir.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(mkdir_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: mode (type: PT_UINT32) */
-	u32 mode = (u32)extract__syscall_argument(regs, 1);
+	uint32_t mode = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, mode);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mkdirat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(mkdirat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -70,7 +70,7 @@ int BPF_PROG(mkdirat_x,
 	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/* Parameter 4: mode (type: PT_UINT32) */
-	u32 mode = (u32)extract__syscall_argument(regs, 2);
+	uint32_t mode = (uint32_t)extract__syscall_argument(regs, 2);
 	auxmap__store_u32_param(auxmap, mode);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknod.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknod.bpf.c
@@ -64,11 +64,11 @@ int BPF_PROG(mknod_x,
 	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/* Parameter 3: mode (type: PT_MODE) */
-	u32 mode = (u32)extract__syscall_argument(regs, 1);
+	uint32_t mode = (uint32_t)extract__syscall_argument(regs, 1);
 	auxmap__store_u32_param(auxmap,mknod_mode_to_scap(mode));
 
 	/* Parameter 4: dev (type: PT_UINT32) */
-	u32 dev = (u32)extract__syscall_argument(regs, 2);
+	uint32_t dev = (uint32_t)extract__syscall_argument(regs, 2);
 	auxmap__store_u32_param(auxmap, encode_dev(dev));
 
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknodat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mknodat.bpf.c
@@ -60,7 +60,7 @@ int BPF_PROG(mknodat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -72,11 +72,11 @@ int BPF_PROG(mknodat_x,
 	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/* Parameter 3: mode (type: PT_MODE) */
-	u32 mode = (u32)extract__syscall_argument(regs, 2);
+	uint32_t mode = (uint32_t)extract__syscall_argument(regs, 2);
 	auxmap__store_u32_param(auxmap, mknod_mode_to_scap(mode));
 
 	/* Parameter 4: dev (type: PT_UINT32) */
-	u32 dev = (u32)extract__syscall_argument(regs, 3);
+	uint32_t dev = (uint32_t)extract__syscall_argument(regs, 3);
 	auxmap__store_u32_param(auxmap, encode_dev(dev));
 
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap.bpf.c
@@ -42,7 +42,7 @@ int BPF_PROG(mmap_e,
 	ringbuf__store_u32(&ringbuf, mmap_flags_to_scap(flags));
 
 	/* Paremeter 5: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 4);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 4);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 6: offset (type: PT_UINT64) */
@@ -82,9 +82,9 @@ int BPF_PROG(mmap_x,
 	struct mm_struct *mm = NULL;
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
-	u32 vm_size = extract__vm_size(mm);
-	u32 rss_size = extract__vm_rss(mm);
-	u32 swap_size = extract__vm_swap(mm);
+	uint32_t vm_size = extract__vm_size(mm);
+	uint32_t rss_size = extract__vm_rss(mm);
+	uint32_t swap_size = extract__vm_swap(mm);
 
 	/* Parameter 2: vm_size (type: PT_UINT32) */
 	ringbuf__store_u32(&ringbuf, vm_size);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mmap2.bpf.c
@@ -42,7 +42,7 @@ int BPF_PROG(mmap2_e,
 	ringbuf__store_u32(&ringbuf, mmap_flags_to_scap(flags));
 
 	/* Paremeter 5: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 4);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 4);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 6: pgoffset (type: PT_UINT64) */
@@ -82,9 +82,9 @@ int BPF_PROG(mmap2_x,
 	struct mm_struct *mm = NULL;
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
-	u32 vm_size = extract__vm_size(mm);
-	u32 rss_size = extract__vm_rss(mm);
-	u32 swap_size = extract__vm_swap(mm);
+	uint32_t vm_size = extract__vm_size(mm);
+	uint32_t rss_size = extract__vm_rss(mm);
+	uint32_t swap_size = extract__vm_swap(mm);
 
 	/* Parameter 2: vm_size (type: PT_UINT32) */
 	ringbuf__store_u32(&ringbuf, vm_size);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mount.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(mount_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 3);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 3);
 
 	/* The `mountflags` argument may have the magic number 0xC0ED
 	 * (MS_MGC_VAL) in the top 16 bits. (All of the other flags

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/mprotect.bpf.c
@@ -34,7 +34,7 @@ int BPF_PROG(mprotect_e,
 	ringbuf__store_u64(&ringbuf, length);
 
 	/* Parameter 3: prot (type: PT_FLAGS32) */
-	u32 flags = extract__syscall_argument(regs, 2);
+	uint32_t flags = extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, prot_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munmap.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/munmap.bpf.c
@@ -66,9 +66,9 @@ int BPF_PROG(munmap_x,
 	struct mm_struct *mm = NULL;
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
-	u32 vm_size = extract__vm_size(mm);
-	u32 rss_size = extract__vm_rss(mm);
-	u32 swap_size = extract__vm_swap(mm);
+	uint32_t vm_size = extract__vm_size(mm);
+	uint32_t rss_size = extract__vm_rss(mm);
+	uint32_t swap_size = extract__vm_swap(mm);
 
 	/* Parameter 2: vm_size (type: PT_UINT32) */
 	ringbuf__store_u32(&ringbuf, vm_size);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open.bpf.c
@@ -30,7 +30,7 @@ int BPF_PROG(open_e,
 	auxmap__store_charbuf_param(auxmap, name_pointer, MAX_PATH, USER);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 1);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 1);
 	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
 
 	/* Parameter 3: mode (type: PT_UINT32) */
@@ -73,8 +73,8 @@ int BPF_PROG(open_x,
 	auxmap__store_charbuf_param(auxmap, name_pointer, MAX_PATH, USER);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 1);
-	u32 scap_flags = (u32)open_flags_to_scap(flags);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 1);
+	uint32_t scap_flags = (uint32_t)open_flags_to_scap(flags);
 	/* update scap flags if file is created */
 	scap_flags |= extract__fmode_created_from_fd(ret);
 	auxmap__store_u32_param(auxmap, scap_flags);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/open_by_handle_at.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(open_by_handle_at_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: mountfd (type: PT_FD) */
-	s32 mountfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t mountfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(mountfd == AT_FDCWD)
 	{
 		mountfd = PPM_AT_FDCWD;
@@ -66,8 +66,8 @@ int BPF_PROG(open_by_handle_at_x,
 	auxmap__store_s64_param(auxmap, (int64_t)mountfd);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 2);
-	flags = (u32)open_flags_to_scap(flags);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 2);
+	flags = (uint32_t)open_flags_to_scap(flags);
 	/* update flags if file is created */
 	flags |= extract__fmode_created_from_fd(ret);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(openat_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -38,7 +38,7 @@ int BPF_PROG(openat_e,
 	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/* Parameter 3: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 2);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 2);
 	auxmap__store_u32_param(auxmap, open_flags_to_scap(flags));
 
 	/* Parameter 4: mode (type: PT_UINT32) */
@@ -77,7 +77,7 @@ int BPF_PROG(openat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -89,8 +89,8 @@ int BPF_PROG(openat_x,
 	auxmap__store_charbuf_param(auxmap, path_pointer, MAX_PATH, USER);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 2);
-	u32 scap_flags = (u32)open_flags_to_scap(flags);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 2);
+	uint32_t scap_flags = (uint32_t)open_flags_to_scap(flags);
 	/* update flags if file is created */
 	scap_flags |= extract__fmode_created_from_fd(ret);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/openat2.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(openat2_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;
@@ -83,7 +83,7 @@ int BPF_PROG(openat2_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_getfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_getfd.bpf.c
@@ -59,15 +59,15 @@ int BPF_PROG(pidfd_getfd_x,
     ringbuf__store_s64(&ringbuf, ret);
 
     /* Parameter 2: pidfd (type: PT_FD) */
-    s32 pidfd = (s32)extract__syscall_argument(regs, 0);
+    int32_t pidfd = (int32_t)extract__syscall_argument(regs, 0);
     ringbuf__store_s64(&ringbuf, (int64_t)pidfd);
 
     /* Parameter 3: targetfd (type: PT_FD) */
-    s32 targetfd = (s32)extract__syscall_argument(regs, 1);
+    int32_t targetfd = (int32_t)extract__syscall_argument(regs, 1);
     ringbuf__store_s64(&ringbuf, (int64_t)targetfd);
 
     /* Parameter 4: flags (type: PT_FLAGS32)*/
-    u32 flags = (u32)extract__syscall_argument(regs, 2);
+    uint32_t flags = (uint32_t)extract__syscall_argument(regs, 2);
     ringbuf__store_u32(&ringbuf, flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_open.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pidfd_open.bpf.c
@@ -57,11 +57,11 @@ int BPF_PROG(pidfd_open_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
     /* Parameter 2: pid (type: PT_PID)*/
-    pid_t pid = (s32)extract__syscall_argument(regs, 0);
+    pid_t pid = (int32_t)extract__syscall_argument(regs, 0);
     ringbuf__store_s64(&ringbuf, (int64_t)pid); 
 
     /* Parameter 3: pid (type: PT_FLAGS32)*/
-    u32 flags = (u32)extract__syscall_argument(regs, 1);
+    uint32_t flags = (uint32_t)extract__syscall_argument(regs, 1);
     ringbuf__store_u32(&ringbuf, pidfd_open_flags_to_scap(flags));
 
     /*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe.bpf.c
@@ -56,7 +56,7 @@ int BPF_PROG(pipe_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	ringbuf__store_s64(&ringbuf, ret);
 
-	s32 pipefd[2] = {-1, -1};
+	int32_t pipefd[2] = {-1, -1};
 	/* This is a pointer to the vector with the 2 file descriptors. */
 	unsigned long fd_vector_pointer = extract__syscall_argument(regs, 0);
 	if(bpf_probe_read_user((void *)pipefd, sizeof(pipefd), (void *)fd_vector_pointer) != 0)

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pipe2.bpf.c
@@ -56,7 +56,7 @@ int BPF_PROG(pipe2_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	ringbuf__store_s64(&ringbuf, ret);
 
-	s32 pipefd[2] = {-1, -1};
+	int32_t pipefd[2] = {-1, -1};
 	/* This is a pointer to the vector with the 2 file descriptors. */
 	unsigned long fd_vector_pointer = extract__syscall_argument(regs, 0);
 	if(bpf_probe_read_user((void *)pipefd, sizeof(pipefd), (void *)fd_vector_pointer) != 0)
@@ -82,7 +82,7 @@ int BPF_PROG(pipe2_x,
 	ringbuf__store_u64(&ringbuf, ino);
 
 	/* Parameter 5: flags (type: PT_FLAGS32) */
-	s32 flags = extract__syscall_argument(regs, 1);
+	int32_t flags = extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, pipe2_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/poll.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(poll_e,
 
 	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
 	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
-	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+	uint32_t nfds = (uint32_t)extract__syscall_argument(regs, 1);
 
 	/* Parameter 1: fds (type: PT_FDLIST) */
 	/* We are in the enter event so we get the requested events, the returned events are only available
@@ -37,7 +37,7 @@ int BPF_PROG(poll_e,
 
 	/* Parameter 2: timeout (type: PT_INT64) */
 	/* This is an `int` in the syscall signature but we push it as an `int64` */
-	u32 timeout_msecs = (s32)extract__syscall_argument(regs, 2);
+	uint32_t timeout_msecs = (int32_t)extract__syscall_argument(regs, 2);
 	auxmap__store_s64_param(auxmap, (int64_t)timeout_msecs);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -73,7 +73,7 @@ int BPF_PROG(poll_x,
 
 	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
 	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
-	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+	uint32_t nfds = (uint32_t)extract__syscall_argument(regs, 1);
 
 	/* Parameter 2: fds (type: PT_FDLIST) */
 	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, RETURNED_EVENTS);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ppoll.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(ppoll_e,
 
 	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
 	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
-	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+	uint32_t nfds = (uint32_t)extract__syscall_argument(regs, 1);
 
 	/* Parameter 1: fds (type: PT_FDLIST) */
 	/* We are in the enter event so we get the requested events, the returned events are only available
@@ -58,11 +58,11 @@ int BPF_PROG(ppoll_e,
 	if(bpf_probe_read_user(&sigmask, sizeof(sigmask), (void *)sigmask_pointer))
 	{
 		/* In case of invalid pointer, return 0 */
-		auxmap__store_u32_param(auxmap, (u32)0);
+		auxmap__store_u32_param(auxmap, (uint32_t)0);
 	}
 	else
 	{
-		auxmap__store_u32_param(auxmap, (u32)sigmask[0]);
+		auxmap__store_u32_param(auxmap, (uint32_t)sigmask[0]);
 	}
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -98,7 +98,7 @@ int BPF_PROG(ppoll_x,
 
 	/* Get the `fds_pointer` and the number of `fds` from the syscall arguments */
 	unsigned long fds_pointer = extract__syscall_argument(regs, 0);
-	u32 nfds = (u32)extract__syscall_argument(regs, 1);
+	uint32_t nfds = (uint32_t)extract__syscall_argument(regs, 1);
 
 	/* Parameter 2: fds (type: PT_FDLIST) */
 	auxmap__store_fdlist_param(auxmap, fds_pointer, nfds, RETURNED_EVENTS);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prctl.bpf.c
@@ -62,7 +62,7 @@ int BPF_PROG(prctl_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: option (type: PT_ENUMFLAGS32) */
-	u32 option = (u32)prctl_options_to_scap(extract__syscall_argument(regs, 0));
+	uint32_t option = (uint32_t)prctl_options_to_scap(extract__syscall_argument(regs, 0));
 	auxmap__store_u32_param(auxmap, option);
 
 	unsigned long arg2 = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -27,12 +27,12 @@ int BPF_PROG(pread64_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)extract__syscall_argument(regs, 2);
-	ringbuf__store_u32(&ringbuf, (u32)size);
+	uint32_t size = (uint32_t)extract__syscall_argument(regs, 2);
+	ringbuf__store_u32(&ringbuf, (uint32_t)size);
 
 	/* Parameter 3: pos (type: PT_UINT64) */
 	uint64_t pos = (uint64_t)extract__syscall_argument(regs, 3);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(preadv_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: pos (type: PT_UINT64) */
@@ -66,7 +66,7 @@ int BPF_PROG(preadv_x,
 	if(ret > 0)
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-		auxmap__store_u32_param(auxmap, (u32)ret);
+		auxmap__store_u32_param(auxmap, (uint32_t)ret);
 
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/prlimit64.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(prlimit64_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: pid (type: PT_PID) */
-	pid_t pid = (s32)extract__syscall_argument(regs, 0);
+	pid_t pid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: resource (type: PT_ENUMFLAGS8) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/ptrace.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(ptrace_e,
 	ringbuf__store_u16(&ringbuf, ptrace_requests_to_scap(request));
 
 	/* Parameter 2: pid (type: PT_PID) */
-	pid_t pid = (s32)extract__syscall_argument(regs, 1);
+	pid_t pid = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(pwrite64_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(pwritev_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/quotactl.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(quotactl_e,
 	ringbuf__store_u8(&ringbuf, quotactl_type_to_scap(cmd));
 
 	/* Parameter 3: id (type: PT_UINT32) */
-	u32 id = (u32)extract__syscall_argument(regs, 2);
+	uint32_t id = (uint32_t)extract__syscall_argument(regs, 2);
 	if(scap_cmd != PPM_Q_GETQUOTA &&
 	   scap_cmd != PPM_Q_SETQUOTA &&
 	   scap_cmd != PPM_Q_XGETQUOTA &&
@@ -50,7 +50,7 @@ int BPF_PROG(quotactl_e,
 	}
 
 	/* Parameter 4: quota_fmt (type: PT_FLAGS8) */
-	u8 quota_fmt = PPM_QFMT_NOT_USED;
+	uint8_t quota_fmt = PPM_QFMT_NOT_USED;
 	if(scap_cmd == PPM_Q_QUOTAON)
 	{
 		quota_fmt = quotactl_fmt_to_scap(id);
@@ -233,10 +233,10 @@ int BPF_PROG(quotactl_x,
 	}
 
 	/* Parameter 14: quota_fmt_out (type: PT_FLAGS8) */
-	u32 quota_fmt_out = PPM_QFMT_NOT_USED;
+	uint32_t quota_fmt_out = PPM_QFMT_NOT_USED;
 	if(scap_cmd == PPM_Q_GETFMT)
 	{
-		u32 quota_fmt_out_tmp = 0;
+		uint32_t quota_fmt_out_tmp = 0;
 		bpf_probe_read_user(&quota_fmt_out_tmp, sizeof(quota_fmt_out_tmp), (void *)addr_pointer);
 		quota_fmt_out = quotactl_fmt_to_scap(quota_fmt_out_tmp);
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -27,11 +27,11 @@ int BPF_PROG(read_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)extract__syscall_argument(regs, 2);
+	uint32_t size = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(readv_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -62,7 +62,7 @@ int BPF_PROG(readv_x,
 	if(ret > 0)
 	{
 		/* Parameter 2: size (type: PT_UINT32) */
-		auxmap__store_u32_param(auxmap, (u32)ret);
+		auxmap__store_u32_param(auxmap, (uint32_t)ret);
 
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -31,11 +31,11 @@ int BPF_PROG(recv_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)args[2];
+	uint32_t size = (uint32_t)args[2];
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -31,11 +31,11 @@ int BPF_PROG(recvfrom_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)args[0];
+	int32_t socket_fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)args[2];
+	uint32_t size = (uint32_t)args[2];
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -92,7 +92,7 @@ int BPF_PROG(recvfrom_x,
 		auxmap__store_bytebuf_param(auxmap, received_data_pointer, snaplen, USER);
 
 		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
-		u32 socket_fd = (u32)args[0];
+		uint32_t socket_fd = (uint32_t)args[0];
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(recvmsg_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD)*/
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -71,7 +71,7 @@ int BPF_PROG(recvmsg_x,
 	{
 
 		/* Parameter 2: size (type: PT_UINT32) */
-		auxmap__store_u32_param(auxmap, (u32)ret);
+		auxmap__store_u32_param(auxmap, (uint32_t)ret);
 
 		/* We read the minimum between `snaplen` and what we really
 		 * have in the buffer.
@@ -92,7 +92,7 @@ int BPF_PROG(recvmsg_x,
 		struct user_msghdr msghhdr = auxmap__store_msghdr_data_param(auxmap, msghdr_pointer, snaplen);
 
 		/* Parameter 4: tuple (type: PT_SOCKTUPLE) */
-		u32 socket_fd = (u32)args[0];
+		uint32_t socket_fd = (uint32_t)args[0];
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND);
 
 		/* Parameter 5: msg_control (type: PT_BYTEBUF) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(renameat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: olddirfd (type: PT_FD) */
-	s32 olddirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t olddirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(olddirfd == AT_FDCWD)
 	{
 		olddirfd = PPM_AT_FDCWD;
@@ -70,7 +70,7 @@ int BPF_PROG(renameat_x,
 	auxmap__store_charbuf_param(auxmap, old_path_pointer, MAX_PATH, USER);
 
 	/* Parameter 4: newdirfd (type: PT_FD) */
-	s32 newdirfd = (s32)extract__syscall_argument(regs, 2);
+	int32_t newdirfd = (int32_t)extract__syscall_argument(regs, 2);
 	if(newdirfd == AT_FDCWD)
 	{
 		newdirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/renameat2.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(renameat2_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: olddirfd (type: PT_FD) */
-	s32 olddirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t olddirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(olddirfd == AT_FDCWD)
 	{
 		olddirfd = PPM_AT_FDCWD;
@@ -70,7 +70,7 @@ int BPF_PROG(renameat2_x,
 	auxmap__store_charbuf_param(auxmap, old_path_pointer, MAX_PATH, USER);
 
 	/* Parameter 4: newdirfd (type: PT_FD) */
-	s32 newdirfd = (s32)extract__syscall_argument(regs, 2);
+	int32_t newdirfd = (int32_t)extract__syscall_argument(regs, 2);
 	if(newdirfd == AT_FDCWD)
 	{
 		newdirfd = PPM_AT_FDCWD;
@@ -82,7 +82,7 @@ int BPF_PROG(renameat2_x,
 	auxmap__store_charbuf_param(auxmap, new_path_pointer, MAX_PATH, USER);
 
 	/* Parameter 6: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 4);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 4);
 	/// TODO: we have to create an helper method to convert these flags to the scap format.
 	auxmap__store_u32_param(auxmap, flags);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/seccomp.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(seccomp_e,
 	uint64_t operation = (uint64_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u64(&ringbuf, operation);
 
-	u32 flags = (u32)extract__syscall_argument(regs, 1);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u64(&ringbuf, (uint64_t)flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semctl.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(semctl_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: semid (type: PT_INT32) */
-	s32 semid = (s32)extract__syscall_argument(regs, 0);
+	int32_t semid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s32(&ringbuf, semid);
 
 	/* Parameter 2: semnum (type: PT_INT32) */
-	s32 semnum = (s32)extract__syscall_argument(regs, 1);
+	int32_t semnum = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s32(&ringbuf, semnum);
 
 	/* Parameter 3: cmd (type: PT_FLAGS16) */
@@ -38,10 +38,10 @@ int BPF_PROG(semctl_e,
 	ringbuf__store_u16(&ringbuf, semctl_cmd_to_scap(cmd));
 
 	/* Parameter 4: val (type: PT_INT32) */
-	s32 val = 0;
+	int32_t val = 0;
 	if(cmd == SETVAL)
 	{
-		val = (s32)extract__syscall_argument(regs, 3);
+		val = (int32_t)extract__syscall_argument(regs, 3);
 	}
 	ringbuf__store_s32(&ringbuf, val);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semget.bpf.c
@@ -26,15 +26,15 @@ int BPF_PROG(semget_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: key (type: PT_INT32) */
-	s32 key = (s32)extract__syscall_argument(regs, 0);
+	int32_t key = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s32(&ringbuf, key);
 
 	/* Parameter 2: nsems (type: PT_INT32) */
-	s32 nsems = (s32)extract__syscall_argument(regs, 1);
+	int32_t nsems = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s32(&ringbuf, nsems);
 
 	/* Parameter 3: semflg (type: PT_FLAGS32) */
-	u32 semflg = (u32)extract__syscall_argument(regs, 2);
+	uint32_t semflg = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, semget_flags_to_scap(semflg));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/semop.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(semop_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: semid (type: PT_INT32)*/
-	s32 semid = (s32)extract__syscall_argument(regs, 0);
+	int32_t semid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s32(&ringbuf, semid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -59,7 +59,7 @@ int BPF_PROG(semop_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: nsops (type: PT_UINT32) */
-	u32 nsops = (u32)extract__syscall_argument(regs, 2);
+	uint32_t nsops = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, nsops);
 
 	/* Extract pointer to the `sembuf` struct */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -31,11 +31,11 @@ int BPF_PROG(send_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)args[2];
+	uint32_t size = (uint32_t)args[2];
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendfile.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(sendfile_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: out_fd (type: PT_FD) */
-	s32 out_fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t out_fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)out_fd);
 
 	/* Parameter 2: in_fd (type: PT_FD) */
-	s32 in_fd = (s32)extract__syscall_argument(regs, 1);
+	int32_t in_fd = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)in_fd);
 
 	/* Parameter 3: offset (type: PT_UINT64) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -29,7 +29,7 @@ int BPF_PROG(sendmsg_e,
 	extract__network_args(args, 2, regs);
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)args[0];
+	int32_t socket_fd = (int32_t)args[0];
 	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -29,11 +29,11 @@ int BPF_PROG(sendto_e,
 	extract__network_args(args, 3, regs);
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 socket_fd = (s32)args[0];
+	int32_t socket_fd = (int32_t)args[0];
 	auxmap__store_s64_param(auxmap, (int64_t)socket_fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)args[2];
+	uint32_t size = (uint32_t)args[2];
 	auxmap__store_u32_param(auxmap, size);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE)*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setgid.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(setgid_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: gid (type: PT_GID) */
-	u32 gid = (u32)extract__syscall_argument(regs, 0);
+	uint32_t gid = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, gid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(setns_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setpgid.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(setpgid_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: pid (type: PT_FD) */
-	pid_t pid = (s32)extract__syscall_argument(regs, 0);
+	pid_t pid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)pid);
 
 	/* Parameter 2: pgid (type: PT_PID) */
-	pid_t pgid = (s32)extract__syscall_argument(regs, 1);
+	pid_t pgid = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)pgid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresgid.bpf.c
@@ -26,15 +26,15 @@ int BPF_PROG(setresgid_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: rgid (type: PT_GID) */
-	gid_t rgid = (u32)extract__syscall_argument(regs, 0);
+	gid_t rgid = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, rgid);
 
 	/* Parameter 2: egid (type: PT_GID) */
-	gid_t egid = (u32)extract__syscall_argument(regs, 1);
+	gid_t egid = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, egid);
 
 	/* Parameter 3: sgid (type: PT_GID) */
-	gid_t sgid = (u32)extract__syscall_argument(regs, 2);
+	gid_t sgid = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, sgid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setresuid.bpf.c
@@ -26,15 +26,15 @@ int BPF_PROG(setresuid_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: ruid (type: PT_GID) */
-	uid_t ruid = (u32)extract__syscall_argument(regs, 0);
+	uid_t ruid = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, ruid);
 
 	/* Parameter 2: euid (type: PT_GID) */
-	uid_t euid = (u32)extract__syscall_argument(regs, 1);
+	uid_t euid = (uint32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u32(&ringbuf, euid);
 
 	/* Parameter 3: suid (type: PT_GID) */
-	uid_t suid = (u32)extract__syscall_argument(regs, 2);
+	uid_t suid = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, suid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setsockopt.bpf.c
@@ -62,7 +62,7 @@ int BPF_PROG(setsockopt_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	auxmap__store_s64_param(auxmap, (int64_t)fd);
 
 	/* Parameter 3: level (type: PT_ENUMFLAGS8) */
@@ -79,7 +79,7 @@ int BPF_PROG(setsockopt_x,
 	auxmap__store_sockopt_param(auxmap, level, optname, optlen, optval);
 
 	/* Parameter 6: optlen (type: PT_UINT32) */
-	auxmap__store_u32_param(auxmap, (u32)optlen);
+	auxmap__store_u32_param(auxmap, (uint32_t)optlen);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setuid.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(setuid_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: uid (type: PT_UID) */
-	uid_t uid = (u32)extract__syscall_argument(regs, 0);
+	uid_t uid = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, uid);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -30,12 +30,12 @@ int BPF_PROG(shutdown_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)args[0];
+	int32_t fd = (int32_t)args[0];
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: how (type: PT_ENUMFLAGS8) */
-	int how = (s32)args[1];
-	ringbuf__store_u8(&ringbuf, (u8)shutdown_how_to_scap(how));
+	int how = (int32_t)args[1];
+	ringbuf__store_u8(&ringbuf, (uint8_t)shutdown_how_to_scap(how));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(signalfd_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: mask (type: PT_UINT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/signalfd4.bpf.c
@@ -26,7 +26,7 @@ int BPF_PROG(signalfd4_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: mask (type: PT_UINT32) */
@@ -63,7 +63,7 @@ int BPF_PROG(signalfd4_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: flags (type: PT_FLAGS16) */
-	s32 flags = (s32)extract__syscall_argument(regs, 3);
+	int32_t flags = (int32_t)extract__syscall_argument(regs, 3);
 	ringbuf__store_u16(&ringbuf, signalfd4_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -31,17 +31,17 @@ int BPF_PROG(socket_e,
 
 	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
 	/* why to send 32 bits if we need only 8 bits? */
-	u8 domain = (u8)args[0];
-	ringbuf__store_u32(&ringbuf, (u32)socket_family_to_scap(domain));
+	uint8_t domain = (uint8_t)args[0];
+	ringbuf__store_u32(&ringbuf, (uint32_t)socket_family_to_scap(domain));
 
 	/* Parameter 2: type (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 type = (u32)args[1];
+	uint32_t type = (uint32_t)args[1];
 	ringbuf__store_u32(&ringbuf, type);
 
 	/* Parameter 3: proto (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 proto = (u32)args[2];
+	uint32_t proto = (uint32_t)args[2];
 	ringbuf__store_u32(&ringbuf, proto);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -31,17 +31,17 @@ int BPF_PROG(socketpair_e,
 
 	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
 	/* why to send 32 bits if we need only 8 bits? */
-	u8 domain = (u8)args[0];
-	ringbuf__store_u32(&ringbuf, (u32)socket_family_to_scap(domain));
+	uint8_t domain = (uint8_t)args[0];
+	ringbuf__store_u32(&ringbuf, (uint32_t)socket_family_to_scap(domain));
 
 	/* Parameter 2: type (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 type = (u32)args[1];
+	uint32_t type = (uint32_t)args[1];
 	ringbuf__store_u32(&ringbuf, type);
 
 	/* Parameter 3: proto (type: PT_UINT32) */
 	/* this should be an int, not a uint32 */
-	u32 proto = (u32)args[2];
+	uint32_t proto = (uint32_t)args[2];
 	ringbuf__store_u32(&ringbuf, proto);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
@@ -73,7 +73,7 @@ int BPF_PROG(socketpair_x,
 	/* Parameter 1: res (type: PT_ERRNO) */
 	ringbuf__store_s64(&ringbuf, ret);
 
-	s32 fds[2] = {-1, -1};
+	int32_t fds[2] = {-1, -1};
 	unsigned long source = 0;
 	unsigned long peer = 0;
 	unsigned long fds_pointer = 0;
@@ -87,10 +87,10 @@ int BPF_PROG(socketpair_x,
 
 		/* Get new sockets. */
 		fds_pointer = args[3];
-		bpf_probe_read_user((void *)fds, 2 * sizeof(s32), (void *)fds_pointer);
+		bpf_probe_read_user((void *)fds, 2 * sizeof(int32_t), (void *)fds_pointer);
 
 		/* Get source and peer. */
-		struct file *file = extract__file_struct_from_fd((s32)fds[0]);
+		struct file *file = extract__file_struct_from_fd((int32_t)fds[0]);
 		struct socket *socket = BPF_CORE_READ(file, private_data);
 		BPF_CORE_READ_INTO(&source, socket, sk);
 		struct unix_sock *us = (struct unix_sock *)source;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/splice.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(splice_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd_in (type: PT_FD) */
-	s32 fd_in = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd_in = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd_in);
 
 	/* Parameter 2: fd_out (type: PT_FD) */
-	s32 fd_out = (s32)extract__syscall_argument(regs, 2);
+	int32_t fd_out = (int32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd_out);
 
 	/* Parameter 3: size (type: PT_UINT64) */
@@ -38,7 +38,7 @@ int BPF_PROG(splice_e,
 	ringbuf__store_u64(&ringbuf, size);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
-	u32 flags = extract__syscall_argument(regs, 5);
+	uint32_t flags = extract__syscall_argument(regs, 5);
 	ringbuf__store_u32(&ringbuf, splice_flags_to_scap(flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/symlinkat.bpf.c
@@ -62,7 +62,7 @@ int BPF_PROG(symlinkat_x,
 	auxmap__store_charbuf_param(auxmap, target_pointer, MAX_PATH, USER);
 
 	/* Parameter 3: linkdirfd (type: PT_FD) */
-	s32 linkdirfd = (s32)extract__syscall_argument(regs, 1);
+	int32_t linkdirfd = (int32_t)extract__syscall_argument(regs, 1);
 	if(linkdirfd == AT_FDCWD)
 	{
 		linkdirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tgkill.bpf.c
@@ -26,15 +26,15 @@ int BPF_PROG(tgkill_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: tgid (type: PT_PID) */
-	pid_t tgid = (s32)extract__syscall_argument(regs, 0);
+	pid_t tgid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)tgid);
 
 	/* Parameter 2: tid (type: PT_PID) */
-	pid_t tid = (s32)extract__syscall_argument(regs, 1);
+	pid_t tid = (int32_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_s64(&ringbuf, (int64_t)tid);
 
 	/* Parameter 3: sig (type: PT_SIGTYPE) */
-	u8 sig = (u8)extract__syscall_argument(regs, 2);
+	uint8_t sig = (uint8_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u8(&ringbuf, sig);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/tkill.bpf.c
@@ -26,11 +26,11 @@ int BPF_PROG(tkill_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: tid (type: PT_PID) */
-	pid_t tid = (s32)extract__syscall_argument(regs, 0);
+	pid_t tid = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)tid);
 
 	/* Parameter 2: sig (type: PT_SIGTYPE) */
-	u8 sig = (u8)extract__syscall_argument(regs, 1);
+	uint8_t sig = (uint8_t)extract__syscall_argument(regs, 1);
 	ringbuf__store_u8(&ringbuf, sig);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -58,7 +58,7 @@ int BPF_PROG(unlinkat_x,
 	auxmap__store_s64_param(auxmap, ret);
 
 	/* Parameter 2: dirfd (type: PT_FD) */
-	s32 dirfd = (s32)extract__syscall_argument(regs, 0);
+	int32_t dirfd = (int32_t)extract__syscall_argument(regs, 0);
 	if(dirfd == AT_FDCWD)
 	{
 		dirfd = PPM_AT_FDCWD;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/userfaultfd.bpf.c
@@ -57,7 +57,7 @@ int BPF_PROG(userfaultfd_x,
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: flags (type: PT_FLAGS32) */
-	u32 flags = (u32)extract__syscall_argument(regs, 0);
+	uint32_t flags = (uint32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_u32(&ringbuf, flags);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -149,15 +149,15 @@ int BPF_PROG(vfork_x,
 	READ_TASK_FIELD_INTO(&mm, task, mm);
 
 	/* Parameter 11: vm_size (type: PT_UINT32) */
-	u32 vm_size = extract__vm_size(mm);
+	uint32_t vm_size = extract__vm_size(mm);
 	auxmap__store_u32_param(auxmap, vm_size);
 
 	/* Parameter 12: vm_rss (type: PT_UINT32) */
-	u32 vm_rss = extract__vm_rss(mm);
+	uint32_t vm_rss = extract__vm_rss(mm);
 	auxmap__store_u32_param(auxmap, vm_rss);
 
 	/* Parameter 13: vm_swap (type: PT_UINT32) */
-	u32 vm_swap = extract__vm_swap(mm);
+	uint32_t vm_swap = extract__vm_swap(mm);
 	auxmap__store_u32_param(auxmap, vm_swap);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
@@ -192,16 +192,16 @@ int BPF_PROG(t1_vfork_x,
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
 	/* In `fork`/`vfork` we don't have `flags` from syscall arguments. */
-	u32 flags = 0;
-	auxmap__store_u32_param(auxmap, (u32)extract__clone_flags(task, flags));
+	uint32_t flags = 0;
+	auxmap__store_u32_param(auxmap, (uint32_t)extract__clone_flags(task, flags));
 
 	/* Parameter 17: uid (type: PT_UINT32) */
-	u32 euid = 0;
+	uint32_t euid = 0;
 	extract__euid(task, &euid);
 	auxmap__store_u32_param(auxmap, euid);
 
 	/* Parameter 18: gid (type: PT_UINT32) */
-	u32 egid = 0;
+	uint32_t egid = 0;
 	extract__egid(task, &egid);
 	auxmap__store_u32_param(auxmap, egid);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -27,11 +27,11 @@ int BPF_PROG(write_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	/* Parameter 2: size (type: PT_UINT32) */
-	u32 size = (u32)extract__syscall_argument(regs, 2);
+	uint32_t size = (uint32_t)extract__syscall_argument(regs, 2);
 	ringbuf__store_u32(&ringbuf, size);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(writev_e,
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-	s32 fd = (s32)extract__syscall_argument(regs, 0);
+	int32_t fd = (int32_t)extract__syscall_argument(regs, 0);
 	ringbuf__store_s64(&ringbuf, (int64_t)fd);
 
 	unsigned long iov_pointer = extract__syscall_argument(regs, 1);

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -50,7 +50,7 @@ struct ppm_ring_buffer_context {
 	struct ppm_ring_buffer_info *info;
 	char *buffer;
 	nanoseconds last_print_time;
-	u32 nevents;
+	uint32_t nevents;
 #ifndef UDIG
 	atomic_t preempt_count;
 #endif	

--- a/driver/ppm_consumer.h
+++ b/driver/ppm_consumer.h
@@ -21,10 +21,10 @@ struct ppm_consumer_t {
 #else
 	struct ppm_ring_buffer_context *ring_buffers;
 #endif
-	u32 snaplen;
-	u32 sampling_ratio;
+	uint32_t snaplen;
+	uint32_t sampling_ratio;
 	bool do_dynamic_snaplen;
-	u32 sampling_interval;
+	uint32_t sampling_interval;
 	int is_dropping;
 	int dropping_mode;
 	bool drop_failed;
@@ -36,7 +36,7 @@ struct ppm_consumer_t {
 	uint16_t statsd_port;
 	unsigned long buffer_bytes_dim; /* Every consumer will have its per-CPU buffer dim in bytes. */
 	DECLARE_BITMAP(syscalls_mask, SYSCALL_TABLE_SIZE);
-	u32 tracepoints_attached;
+	uint32_t tracepoints_attached;
 };
 
 typedef struct ppm_consumer_t ppm_consumer_t;

--- a/driver/ppm_cputime.c
+++ b/driver/ppm_cputime.c
@@ -206,7 +206,7 @@ drop_precision:
 	 * Make sure gcc understands that this is a 32x32->64 multiply,
 	 * followed by a 64/32->64 divide.
 	 */
-	scaled = div_u64((uint64_t) (u32) stime * (uint64_t) (u32) rtime, (u32)total);
+	scaled = div_u64((uint64_t) (uint32_t) stime * (uint64_t) (uint32_t) rtime, (uint32_t)total);
 	return (__force cputime_t) scaled;
 }
 
@@ -307,7 +307,7 @@ static cputime_t scale_utime(cputime_t utime, cputime_t rtime, cputime_t total)
 	temp *= (__force uint64_t) utime;
 
 	if (sizeof(cputime_t) == 4)
-		temp = div_u64(temp, (__force u32) total);
+		temp = div_u64(temp, (__force uint32_t) total);
 	else
 		temp = div64_u64(temp, (__force uint64_t) total);
 

--- a/driver/ppm_events.h
+++ b/driver/ppm_events.h
@@ -34,16 +34,16 @@ struct fault_data_t {
 struct event_filler_arguments {
 	ppm_consumer_t *consumer;
 	char *buffer; /* the buffer that will be filled with the data */
-	u32 buffer_size; /* the space in the ring buffer available for this event */
-	u32 syscall_id; /* the system call ID */
+	uint32_t buffer_size; /* the space in the ring buffer available for this event */
+	uint32_t syscall_id; /* the system call ID */
 #ifdef PPM_ENABLE_SENTINEL
-	u32 sentinel;
+	uint32_t sentinel;
 #endif
-	u32 nevents;
-	u32 curarg;
-	u32 nargs;
-	u32 arg_data_offset;
-	u32 arg_data_size;
+	uint32_t nevents;
+	uint32_t curarg;
+	uint32_t nargs;
+	uint32_t arg_data_offset;
+	uint32_t arg_data_size;
 	ppm_event_code event_type;	/* the event type */
 	/* Eventually convert this to an event_info union and move all the
 	 * below per-event params in this union, it's not good to waste kernel
@@ -96,7 +96,7 @@ extern const struct ppm_event_entry g_ppm_events[];
  */
 int32_t dpi_lookahead_init(void);
 int32_t push_empty_param(struct event_filler_arguments *args);
-int32_t val_to_ring(struct event_filler_arguments *args, uint64_t val, u32 val_len, bool fromuser, u8 dyn_idx);
+int32_t val_to_ring(struct event_filler_arguments *args, uint64_t val, uint32_t val_len, bool fromuser, uint8_t dyn_idx);
 uint16_t pack_addr(struct sockaddr *usrsockaddr, int ulen, char *targetbuf, uint16_t targetbufsize);
 uint16_t fd_to_socktuple(int fd, struct sockaddr *usrsockaddr, int ulen, bool use_userdata, bool is_inbound, char *targetbuf, uint16_t targetbufsize);
 int addr_to_kernel(void __user *uaddr, int ulen, struct sockaddr *kaddr);
@@ -109,8 +109,8 @@ int32_t compat_parse_readv_writev_bufs(struct event_filler_arguments *args, cons
 static inline int add_sentinel(struct event_filler_arguments *args)
 {
 #ifdef PPM_ENABLE_SENTINEL
-	if (likely(args->arg_data_size >= sizeof(u32))) {
-		*(u32 *)(args->buffer + args->arg_data_offset) = args->sentinel;
+	if (likely(args->arg_data_size >= sizeof(uint32_t))) {
+		*(uint32_t *)(args->buffer + args->arg_data_offset) = args->sentinel;
 		args->arg_data_offset += 4;
 		args->arg_data_size -= 4;
 		return PPM_SUCCESS;

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -124,7 +124,7 @@ static __always_inline uint32_t open_flags_to_scap(uint32_t flags)
 	return res;
 }
 
-static __always_inline u32 open_modes_to_scap(unsigned long flags,
+static __always_inline uint32_t open_modes_to_scap(unsigned long flags,
 					      unsigned long modes)
 {
 #ifdef UDIG
@@ -136,7 +136,7 @@ static __always_inline u32 open_modes_to_scap(unsigned long flags,
 	unsigned long flags_mask = O_CREAT;
 #endif
 #endif /* UDIG */
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if ((flags & flags_mask) == 0)
 		return res;
@@ -192,9 +192,9 @@ static __always_inline u32 open_modes_to_scap(unsigned long flags,
 	return res;
 }
 
-static __always_inline u32 openat2_resolve_to_scap(unsigned long flags)
+static __always_inline uint32_t openat2_resolve_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 #ifdef RESOLVE_NO_XDEV
 	if (flags & RESOLVE_NO_XDEV)
 		res |= PPM_RESOLVE_NO_XDEV;
@@ -227,8 +227,8 @@ static __always_inline u32 openat2_resolve_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 io_uring_setup_flags_to_scap(unsigned long flags){
-	u32 res = 0;
+static __always_inline uint32_t io_uring_setup_flags_to_scap(unsigned long flags){
+	uint32_t res = 0;
 
 #ifdef IORING_SETUP_IOPOLL
 	if (flags & IORING_SETUP_IOPOLL)
@@ -272,8 +272,8 @@ static __always_inline u32 io_uring_setup_flags_to_scap(unsigned long flags){
 	return res;
 }
 
-static __always_inline u32 io_uring_setup_feats_to_scap(unsigned long flags){
-	u32 res = 0;
+static __always_inline uint32_t io_uring_setup_feats_to_scap(unsigned long flags){
+	uint32_t res = 0;
 
 #ifdef IORING_FEAT_SINGLE_MMAP
 	if (flags & IORING_FEAT_SINGLE_MMAP)
@@ -333,9 +333,9 @@ static __always_inline u32 io_uring_setup_feats_to_scap(unsigned long flags){
 	return res;
 }
 
-static __always_inline u32 io_uring_enter_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t io_uring_enter_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 #ifdef IORING_ENTER_GETEVENTS
 	if (flags & IORING_ENTER_GETEVENTS)
@@ -359,7 +359,7 @@ static __always_inline u32 io_uring_enter_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 io_uring_register_opcodes_to_scap(unsigned long flags)
+static __always_inline uint32_t io_uring_register_opcodes_to_scap(unsigned long flags)
 {
 	/*
 	 * io_uring_register opcodes are defined via enum in io_uring.h.
@@ -462,9 +462,9 @@ static __always_inline uint16_t signalfd4_flags_to_scap(int32_t flags)
 	return res;
 }
 
-static __always_inline u32 clone_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t clone_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & CLONE_FILES)
 		res |= PPM_CL_CLONE_FILES;
@@ -556,7 +556,7 @@ static __always_inline u32 clone_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u8 socket_family_to_scap(u8 family)
+static __always_inline uint8_t socket_family_to_scap(uint8_t family)
 {
 	if (family == AF_INET)
 		return PPM_AF_INET;
@@ -714,9 +714,9 @@ static __always_inline u8 socket_family_to_scap(u8 family)
 	}
 }
 
-static __always_inline u32 prot_flags_to_scap(int prot)
+static __always_inline uint32_t prot_flags_to_scap(int prot)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (prot & PROT_READ)
 		res |= PPM_PROT_READ;
@@ -746,9 +746,9 @@ static __always_inline u32 prot_flags_to_scap(int prot)
 	return res;
 }
 
-static __always_inline u32 mmap_flags_to_scap(int flags)
+static __always_inline uint32_t mmap_flags_to_scap(int flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & MAP_SHARED)
 		res |= PPM_MAP_SHARED;
@@ -804,7 +804,7 @@ static __always_inline u32 mmap_flags_to_scap(int flags)
 	return res;
 }
 
-static __always_inline u8 fcntl_cmd_to_scap(unsigned long cmd)
+static __always_inline uint8_t fcntl_cmd_to_scap(unsigned long cmd)
 {
 	switch (cmd) {
 	case F_DUPFD:
@@ -888,7 +888,7 @@ static __always_inline u8 fcntl_cmd_to_scap(unsigned long cmd)
 }
 
 
-static __always_inline u8 sockopt_level_to_scap(int level)
+static __always_inline uint8_t sockopt_level_to_scap(int level)
 {
 	switch (level) {
 		case SOL_SOCKET:
@@ -903,7 +903,7 @@ static __always_inline u8 sockopt_level_to_scap(int level)
 	}
 }
 
-static __always_inline u8 sockopt_optname_to_scap(int level, int optname)
+static __always_inline uint8_t sockopt_optname_to_scap(int level, int optname)
 {
 	if (level != SOL_SOCKET)
 	{
@@ -1261,9 +1261,9 @@ static __always_inline uint16_t futex_op_to_scap(unsigned long op)
 	return res;
 }
 
-static __always_inline u32 access_flags_to_scap(unsigned flags)
+static __always_inline uint32_t access_flags_to_scap(unsigned flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags == 0/*F_OK*/) {
 		res = PPM_F_OK;
@@ -1288,7 +1288,7 @@ static __always_inline u32 access_flags_to_scap(unsigned flags)
 	return res;
 }
 
-static __always_inline u8 rlimit_resource_to_scap(unsigned long rresource)
+static __always_inline uint8_t rlimit_resource_to_scap(unsigned long rresource)
 {
 	switch (rresource) {
 	case RLIMIT_CPU:
@@ -1372,9 +1372,9 @@ static __always_inline uint16_t semop_flags_to_scap(short flags)
 	return res;
 }
 
-static __always_inline u32 pf_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t pf_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	/* Page fault error codes don't seem to be clearly defined in header
 	 * files throughout the kernel except in some emulation modes (e.g. kvm)
@@ -1406,9 +1406,9 @@ static __always_inline u32 pf_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 flock_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t flock_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & LOCK_EX)
 		res |= PPM_LOCK_EX;
@@ -1513,9 +1513,9 @@ static __always_inline uint8_t quotactl_fmt_to_scap(unsigned long fmt)
 	}
 }
 
-static __always_inline u32 semget_flags_to_scap(unsigned flags)
+static __always_inline uint32_t semget_flags_to_scap(unsigned flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & IPC_CREAT)
 		res |= PPM_IPC_CREAT;
@@ -1526,7 +1526,7 @@ static __always_inline u32 semget_flags_to_scap(unsigned flags)
 	return res;
 }
 
-static __always_inline u32 semctl_cmd_to_scap(unsigned cmd)
+static __always_inline uint32_t semctl_cmd_to_scap(unsigned cmd)
 {
 	switch (cmd) {
 	case IPC_STAT: return PPM_IPC_STAT;
@@ -1681,9 +1681,9 @@ static __always_inline uint16_t ptrace_requests_to_scap(unsigned long req)
 	}
 }
 
-static __always_inline u32 execveat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t execveat_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 #ifdef AT_EMPTY_PATH
 	if (flags & AT_EMPTY_PATH)
@@ -1698,7 +1698,7 @@ static __always_inline u32 execveat_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 fsconfig_cmds_to_scap(u32 cmd)
+static __always_inline uint32_t fsconfig_cmds_to_scap(uint32_t cmd)
 {
 	/*
 	 * fsconfig opcodes are defined via enum in uapi/linux/mount.h.
@@ -1710,9 +1710,9 @@ static __always_inline u32 fsconfig_cmds_to_scap(u32 cmd)
 	return cmd;
 }
 
-static __always_inline u32 mlockall_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t mlockall_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 #ifdef MCL_CURRENT
 	if (flags & MCL_CURRENT)
 		res |= PPM_MLOCKALL_MCL_CURRENT;
@@ -1728,9 +1728,9 @@ static __always_inline u32 mlockall_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 mlock2_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t mlock2_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 #ifdef MLOCK_ONFAULT
 	if (flags & MLOCK_ONFAULT)
 		res |= PPM_MLOCK_ONFAULT;
@@ -1738,9 +1738,9 @@ static __always_inline u32 mlock2_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 memfd_create_flags_to_scap(u32 flags)
+static __always_inline uint32_t memfd_create_flags_to_scap(uint32_t flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 #ifdef MFD_CLOEXEC
 		if(flags & MFD_CLOEXEC) res |= PPM_MFD_CLOEXEC;
 #endif
@@ -1753,9 +1753,9 @@ static __always_inline u32 memfd_create_flags_to_scap(u32 flags)
 return res;
 }
 
-static __always_inline u32 unlinkat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t unlinkat_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & AT_REMOVEDIR)
 		res |= PPM_AT_REMOVEDIR;
@@ -1763,9 +1763,9 @@ static __always_inline u32 unlinkat_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 linkat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t linkat_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	if (flags & AT_SYMLINK_FOLLOW)
 		res |= PPM_AT_SYMLINK_FOLLOW;
@@ -1778,9 +1778,9 @@ static __always_inline u32 linkat_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 chmod_mode_to_scap(unsigned long modes)
+static __always_inline uint32_t chmod_mode_to_scap(unsigned long modes)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 	if (modes & S_IRUSR)
 		res |= PPM_S_IRUSR;
 
@@ -1832,9 +1832,9 @@ static __always_inline u32 chmod_mode_to_scap(unsigned long modes)
 	return res;
 }
 
-static __always_inline u32 umount2_flags_to_scap(int flags)
+static __always_inline uint32_t umount2_flags_to_scap(int flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 #ifdef MNT_FORCE
 	if (flags & MNT_FORCE)
@@ -1855,9 +1855,9 @@ static __always_inline u32 umount2_flags_to_scap(int flags)
 	return res;
 }
 
-static __always_inline u32 fchownat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t fchownat_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 #ifdef AT_SYMLINK_FOLLOW
 	if (flags & AT_SYMLINK_FOLLOW)
@@ -2044,9 +2044,9 @@ static __always_inline uint64_t capabilities_to_scap(unsigned long caps)
 	return res;
 }
 
-static __always_inline u32 dup3_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t dup3_flags_to_scap(unsigned long flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 #ifdef O_CLOEXEC
 	if (flags & O_CLOEXEC)
 		res |= PPM_O_CLOEXEC;
@@ -2054,9 +2054,9 @@ static __always_inline u32 dup3_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline u32 pipe2_flags_to_scap(int32_t flags)
+static __always_inline uint32_t pipe2_flags_to_scap(int32_t flags)
 {
-	u32 res = 0;
+	uint32_t res = 0;
 
 	/* We need to explicitly handle the negative case otherwise `-1` will match all `flags & ...` */
 	if(flags < 0)
@@ -2127,9 +2127,9 @@ static __always_inline uint32_t pidfd_open_flags_to_scap(uint32_t flags)
 #define PPM_OVERLAYFS_SUPER_MAGIC 0x794c7630
 #endif
 
-static __always_inline u32 prctl_options_to_scap(int options)
+static __always_inline uint32_t prctl_options_to_scap(int options)
 {
-	return (u32)options;
+	return (uint32_t)options;
 }
 
 static __always_inline uint32_t finit_module_flags_to_scap(int32_t flags)
@@ -2153,9 +2153,9 @@ static __always_inline uint32_t finit_module_flags_to_scap(int32_t flags)
 	return res;
 }
 
-static __always_inline uint32_t mknod_mode_to_scap(u32 modes)
+static __always_inline uint32_t mknod_mode_to_scap(uint32_t modes)
 {
-	u32 res = chmod_mode_to_scap(modes);
+	uint32_t res = chmod_mode_to_scap(modes);
 
 	/*
 	 * mknod modes

--- a/proposals/20220329-modern-bpf-probe.md
+++ b/proposals/20220329-modern-bpf-probe.md
@@ -143,7 +143,7 @@ int catch_syscall_exit_event(struct sys_exit_args * ctx):
    6: (bf) r3 = r0
    7: (85) call bpf_probe_read_kernel#-64432
    8: (b7) r1 = 944
-   9: (79) r3 = *(u64 *)(r10 -16)
+   9: (79) r3 = *(uint64_t *)(r10 -16)
   10: (0f) r3 += r1
   11: (bf) r1 = r10
 ; 
@@ -185,9 +185,9 @@ int catch_syscall_exit_event(struct sys_exit_args * ctx):
 ; struct task_struct *t = bpf_get_current_task_btf();
    0: (85) call bpf_get_current_task_btf#-61936
 ; struct file * f = t->mm->exe_file;
-   1: (79) r1 = *(u64 *)(r0 +2192)
+   1: (79) r1 = *(uint64_t *)(r0 +2192)
 ; struct file * f = t->mm->exe_file;
-   2: (79) r1 = *(u64 *)(r1 +944)
+   2: (79) r1 = *(uint64_t *)(r1 +944)
    3: (b7) r0 = 1
 ; if(!f)
    4: (15) if r1 == 0x0 goto pc+1

--- a/userspace/libscap/compat/bpf.h
+++ b/userspace/libscap/compat/bpf.h
@@ -615,7 +615,7 @@ union bpf_attr {
  * 		Map value associated to *key*, or **NULL** if no entry was
  * 		found.
  *
- * int bpf_map_update_elem(struct bpf_map *map, const void *key, const void *value, u64 flags)
+ * int bpf_map_update_elem(struct bpf_map *map, const void *key, const void *value, uint64_t flags)
  * 	Description
  * 		Add or update the value of the entry associated to *key* in
  * 		*map* with *value*. *flags* is one of:
@@ -639,7 +639,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		For tracing programs, safely attempt to read *size* bytes from
  * 		kernel space address *unsafe_ptr* and store the data in *dst*.
@@ -649,7 +649,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * u64 bpf_ktime_get_ns(void)
+ * uint64_t bpf_ktime_get_ns(void)
  * 	Description
  * 		Return the time elapsed since system boot, in nanoseconds.
  * 		Does not include time the system was suspended.
@@ -657,12 +657,12 @@ union bpf_attr {
  * 	Return
  * 		Current *ktime*.
  *
- * int bpf_trace_printk(const char *fmt, u32 fmt_size, ...)
+ * int bpf_trace_printk(const char *fmt, uint32_t fmt_size, ...)
  * 	Description
  * 		This helper is a "printk()-like" facility for debugging. It
  * 		prints a message defined by format *fmt* (of size *fmt_size*)
  * 		to file *\/sys/kernel/debug/tracing/trace* from DebugFS, if
- * 		available. It can take up to three additional **u64**
+ * 		available. It can take up to three additional **uint64_t**
  * 		arguments (as an eBPF helpers, the total number of arguments is
  * 		limited to five).
  *
@@ -716,7 +716,7 @@ union bpf_attr {
  * 		The number of bytes written to the buffer, or a negative error
  * 		in case of failure.
  *
- * u32 bpf_get_prandom_u32(void)
+ * uint32_t bpf_get_prandom_u32(void)
  * 	Description
  * 		Get a pseudo-random number.
  *
@@ -728,7 +728,7 @@ union bpf_attr {
  * 	Return
  * 		A random 32-bit unsigned value.
  *
- * u32 bpf_get_smp_processor_id(void)
+ * uint32_t bpf_get_smp_processor_id(void)
  * 	Description
  * 		Get the SMP (symmetric multiprocessing) processor id. Note that
  * 		all programs run with preemption disabled, which means that the
@@ -737,7 +737,7 @@ union bpf_attr {
  * 	Return
  * 		The SMP id of the processor running the program.
  *
- * int bpf_skb_store_bytes(struct sk_buff *skb, u32 offset, const void *from, u32 len, u64 flags)
+ * int bpf_skb_store_bytes(struct sk_buff *skb, uint32_t offset, const void *from, uint32_t len, uint64_t flags)
  * 	Description
  * 		Store *len* bytes from address *from* into the packet
  * 		associated to *skb*, at *offset*. *flags* are a combination of
@@ -754,7 +754,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_l3_csum_replace(struct sk_buff *skb, u32 offset, u64 from, u64 to, u64 size)
+ * int bpf_l3_csum_replace(struct sk_buff *skb, uint32_t offset, uint64_t from, uint64_t to, uint64_t size)
  * 	Description
  * 		Recompute the layer 3 (e.g. IP) checksum for the packet
  * 		associated to *skb*. Computation is incremental, so the helper
@@ -779,7 +779,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_l4_csum_replace(struct sk_buff *skb, u32 offset, u64 from, u64 to, u64 flags)
+ * int bpf_l4_csum_replace(struct sk_buff *skb, uint32_t offset, uint64_t from, uint64_t to, uint64_t flags)
  * 	Description
  * 		Recompute the layer 4 (e.g. TCP, UDP or ICMP) checksum for the
  * 		packet associated to *skb*. Computation is incremental, so the
@@ -811,7 +811,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_tail_call(void *ctx, struct bpf_map *prog_array_map, u32 index)
+ * int bpf_tail_call(void *ctx, struct bpf_map *prog_array_map, uint32_t index)
  * 	Description
  * 		This special helper is used to trigger a "tail call", or in
  * 		other words, to jump into another eBPF program. The same stack
@@ -842,7 +842,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_clone_redirect(struct sk_buff *skb, u32 ifindex, u64 flags)
+ * int bpf_clone_redirect(struct sk_buff *skb, uint32_t ifindex, uint64_t flags)
  * 	Description
  * 		Clone and redirect the packet associated to *skb* to another
  * 		net device of index *ifindex*. Both ingress and egress
@@ -866,19 +866,19 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * u64 bpf_get_current_pid_tgid(void)
+ * uint64_t bpf_get_current_pid_tgid(void)
  * 	Return
  * 		A 64-bit integer containing the current tgid and pid, and
  * 		created as such:
  * 		*current_task*\ **->tgid << 32 \|**
  * 		*current_task*\ **->pid**.
  *
- * u64 bpf_get_current_uid_gid(void)
+ * uint64_t bpf_get_current_uid_gid(void)
  * 	Return
  * 		A 64-bit integer containing the current GID and UID, and
  * 		created as such: *current_gid* **<< 32 \|** *current_uid*.
  *
- * int bpf_get_current_comm(void *buf, u32 size_of_buf)
+ * int bpf_get_current_comm(void *buf, uint32_t size_of_buf)
  * 	Description
  * 		Copy the **comm** attribute of the current task into *buf* of
  * 		*size_of_buf*. The **comm** attribute contains the name of
@@ -889,7 +889,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * u32 bpf_get_cgroup_classid(struct sk_buff *skb)
+ * uint32_t bpf_get_cgroup_classid(struct sk_buff *skb)
  * 	Description
  * 		Retrieve the classid for the current task, i.e. for the net_cls
  * 		cgroup to which *skb* belongs.
@@ -915,7 +915,7 @@ union bpf_attr {
  * 	Return
  * 		The classid, or 0 for the default unconfigured classid.
  *
- * int bpf_skb_vlan_push(struct sk_buff *skb, __be16 vlan_proto, u16 vlan_tci)
+ * int bpf_skb_vlan_push(struct sk_buff *skb, __be16 vlan_proto, uint16_t vlan_tci)
  * 	Description
  * 		Push a *vlan_tci* (VLAN tag control information) of protocol
  * 		*vlan_proto* to the packet associated to *skb*, then update
@@ -943,7 +943,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_get_tunnel_key(struct sk_buff *skb, struct bpf_tunnel_key *key, u32 size, u64 flags)
+ * int bpf_skb_get_tunnel_key(struct sk_buff *skb, struct bpf_tunnel_key *key, uint32_t size, uint64_t flags)
  * 	Description
  * 		Get tunnel metadata. This helper takes a pointer *key* to an
  * 		empty **struct bpf_tunnel_key** of **size**, that will be
@@ -994,7 +994,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_set_tunnel_key(struct sk_buff *skb, struct bpf_tunnel_key *key, u32 size, u64 flags)
+ * int bpf_skb_set_tunnel_key(struct sk_buff *skb, struct bpf_tunnel_key *key, uint32_t size, uint64_t flags)
  * 	Description
  * 		Populate tunnel metadata for packet associated to *skb.* The
  * 		tunnel metadata is set to the contents of *key*, of *size*. The
@@ -1031,7 +1031,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * u64 bpf_perf_event_read(struct bpf_map *map, u64 flags)
+ * uint64_t bpf_perf_event_read(struct bpf_map *map, uint64_t flags)
  * 	Description
  * 		Read the value of a perf event counter. This helper relies on a
  * 		*map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. The nature of
@@ -1060,7 +1060,7 @@ union bpf_attr {
  * 		The value of the perf event counter read from the map, or a
  * 		negative error code in case of failure.
  *
- * int bpf_redirect(u32 ifindex, u64 flags)
+ * int bpf_redirect(uint32_t ifindex, uint64_t flags)
  * 	Description
  * 		Redirect the packet to another net device of index *ifindex*.
  * 		This helper is somewhat similar to **bpf_clone_redirect**\
@@ -1083,7 +1083,7 @@ union bpf_attr {
  * 		are **TC_ACT_REDIRECT** on success or **TC_ACT_SHOT** on
  * 		error.
  *
- * u32 bpf_get_route_realm(struct sk_buff *skb)
+ * uint32_t bpf_get_route_realm(struct sk_buff *skb)
  * 	Description
  * 		Retrieve the realm or the route, that is to say the
  * 		**tclassid** field of the destination for the *skb*. The
@@ -1107,7 +1107,7 @@ union bpf_attr {
  * 		The realm of the route for the packet associated to *skb*, or 0
  * 		if none was found.
  *
- * int bpf_perf_event_output(void *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
+ * int bpf_perf_event_output(void *ctx, struct bpf_map *map, uint64_t flags, void *data, uint64_t size)
  * 	Description
  * 		Write raw *data* blob into a special BPF perf event held by
  * 		*map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. This perf
@@ -1152,7 +1152,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32 len)
+ * int bpf_skb_load_bytes(const void *skb, uint32_t offset, void *to, uint32_t len)
  * 	Description
  * 		This helper was provided as an easy way to load data from a
  * 		packet. It can be used to load *len* bytes from *offset* from
@@ -1169,7 +1169,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_get_stackid(void *ctx, struct bpf_map *map, u64 flags)
+ * int bpf_get_stackid(void *ctx, struct bpf_map *map, uint64_t flags)
  * 	Description
  * 		Walk a user or a kernel stack and return its id. To achieve
  * 		this, the helper needs *ctx*, which is a pointer to the context
@@ -1211,7 +1211,7 @@ union bpf_attr {
  * 		The positive or null stack id on success, or a negative error
  * 		in case of failure.
  *
- * s64 bpf_csum_diff(__be32 *from, u32 from_size, __be32 *to, u32 to_size, __wsum seed)
+ * int64_t bpf_csum_diff(__be32 *from, uint32_t from_size, __be32 *to, uint32_t to_size, __wsum seed)
  * 	Description
  * 		Compute a checksum difference, from the raw buffer pointed by
  * 		*from*, of length *from_size* (that must be a multiple of 4),
@@ -1238,7 +1238,7 @@ union bpf_attr {
  * 		The checksum result, or a negative error code in case of
  * 		failure.
  *
- * int bpf_skb_get_tunnel_opt(struct sk_buff *skb, void *opt, u32 size)
+ * int bpf_skb_get_tunnel_opt(struct sk_buff *skb, void *opt, uint32_t size)
  * 	Description
  * 		Retrieve tunnel options metadata for the packet associated to
  * 		*skb*, and store the raw tunnel option data to the buffer *opt*
@@ -1256,7 +1256,7 @@ union bpf_attr {
  * 	Return
  * 		The size of the option data retrieved.
  *
- * int bpf_skb_set_tunnel_opt(struct sk_buff *skb, void *opt, u32 size)
+ * int bpf_skb_set_tunnel_opt(struct sk_buff *skb, void *opt, uint32_t size)
  * 	Description
  * 		Set tunnel options metadata for the packet associated to *skb*
  * 		to the option data contained in the raw buffer *opt* of *size*.
@@ -1266,7 +1266,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_change_proto(struct sk_buff *skb, __be16 proto, u64 flags)
+ * int bpf_skb_change_proto(struct sk_buff *skb, __be16 proto, uint64_t flags)
  * 	Description
  * 		Change the protocol of the *skb* to *proto*. Currently
  * 		supported are transition from IPv4 to IPv6, and from IPv6 to
@@ -1293,7 +1293,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_change_type(struct sk_buff *skb, u32 type)
+ * int bpf_skb_change_type(struct sk_buff *skb, uint32_t type)
  * 	Description
  * 		Change the packet type for the packet associated to *skb*. This
  * 		comes down to setting *skb*\ **->pkt_type** to *type*, except
@@ -1320,7 +1320,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_under_cgroup(struct sk_buff *skb, struct bpf_map *map, u32 index)
+ * int bpf_skb_under_cgroup(struct sk_buff *skb, struct bpf_map *map, uint32_t index)
  * 	Description
  * 		Check whether *skb* is a descendant of the cgroup2 held by
  * 		*map* of type **BPF_MAP_TYPE_CGROUP_ARRAY**, at *index*.
@@ -1331,7 +1331,7 @@ union bpf_attr {
  * 		* 1, if the *skb* succeeded the cgroup2 descendant test.
  * 		* A negative error code, if an error occurred.
  *
- * u32 bpf_get_hash_recalc(struct sk_buff *skb)
+ * uint32_t bpf_get_hash_recalc(struct sk_buff *skb)
  * 	Description
  * 		Retrieve the hash of the packet, *skb*\ **->hash**. If it is
  * 		not set, in particular if the hash was cleared due to mangling,
@@ -1347,11 +1347,11 @@ union bpf_attr {
  * 	Return
  * 		The 32-bit hash.
  *
- * u64 bpf_get_current_task(void)
+ * uint64_t bpf_get_current_task(void)
  * 	Return
  * 		A pointer to the current task struct.
  *
- * int bpf_probe_write_user(void *dst, const void *src, u32 len)
+ * int bpf_probe_write_user(void *dst, const void *src, uint32_t len)
  * 	Description
  * 		Attempt in a safe way to write *len* bytes from the buffer
  * 		*src* to *dst* in memory. It only works for threads that are in
@@ -1370,7 +1370,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_current_task_under_cgroup(struct bpf_map *map, u32 index)
+ * int bpf_current_task_under_cgroup(struct bpf_map *map, uint32_t index)
  * 	Description
  * 		Check whether the probe is being run is the context of a given
  * 		subset of the cgroup2 hierarchy. The cgroup2 to test is held by
@@ -1382,7 +1382,7 @@ union bpf_attr {
  * 		* 1, if the *skb* task does not belong to the cgroup2.
  * 		* A negative error code, if an error occurred.
  *
- * int bpf_skb_change_tail(struct sk_buff *skb, u32 len, u64 flags)
+ * int bpf_skb_change_tail(struct sk_buff *skb, uint32_t len, uint64_t flags)
  * 	Description
  * 		Resize (trim or grow) the packet associated to *skb* to the
  * 		new *len*. The *flags* are reserved for future usage, and must
@@ -1406,7 +1406,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_pull_data(struct sk_buff *skb, u32 len)
+ * int bpf_skb_pull_data(struct sk_buff *skb, uint32_t len)
  * 	Description
  * 		Pull in non-linear data in case the *skb* is non-linear and not
  * 		all of *len* are part of the linear section. Make *len* bytes
@@ -1442,7 +1442,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * s64 bpf_csum_update(struct sk_buff *skb, __wsum csum)
+ * int64_t bpf_csum_update(struct sk_buff *skb, __wsum csum)
  * 	Description
  * 		Add the checksum *csum* into *skb*\ **->csum** in case the
  * 		driver has supplied a checksum for the entire packet into that
@@ -1473,7 +1473,7 @@ union bpf_attr {
  * 	Return
  * 		The id of current NUMA node.
  *
- * int bpf_skb_change_head(struct sk_buff *skb, u32 len, u64 flags)
+ * int bpf_skb_change_head(struct sk_buff *skb, uint32_t len, uint64_t flags)
  * 	Description
  * 		Grows headroom of packet associated to *skb* and adjusts the
  * 		offset of the MAC header accordingly, adding *len* bytes of
@@ -1509,7 +1509,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read_str(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		Copy a NUL terminated string from an unsafe kernel address
  * 		*unsafe_ptr* to *dst*. See bpf_probe_read_kernel_str() for
@@ -1522,7 +1522,7 @@ union bpf_attr {
  * 		including the trailing NUL character. On error, a negative
  * 		value.
  *
- * u64 bpf_get_socket_cookie(struct sk_buff *skb)
+ * uint64_t bpf_get_socket_cookie(struct sk_buff *skb)
  * 	Description
  * 		If the **struct sk_buff** pointed by *skb* has a known socket,
  * 		retrieve the cookie (generated by the kernel) of this socket.
@@ -1535,21 +1535,21 @@ union bpf_attr {
  * 		A 8-byte long non-decreasing number on success, or 0 if the
  * 		socket field is missing inside *skb*.
  *
- * u64 bpf_get_socket_cookie(struct bpf_sock_addr *ctx)
+ * uint64_t bpf_get_socket_cookie(struct bpf_sock_addr *ctx)
  * 	Description
  * 		Equivalent to bpf_get_socket_cookie() helper that accepts
  * 		*skb*, but gets socket from **struct bpf_sock_addr** context.
  * 	Return
  * 		A 8-byte long non-decreasing number.
  *
- * u64 bpf_get_socket_cookie(struct bpf_sock_ops *ctx)
+ * uint64_t bpf_get_socket_cookie(struct bpf_sock_ops *ctx)
  * 	Description
  * 		Equivalent to bpf_get_socket_cookie() helper that accepts
  * 		*skb*, but gets socket from **struct bpf_sock_ops** context.
  * 	Return
  * 		A 8-byte long non-decreasing number.
  *
- * u32 bpf_get_socket_uid(struct sk_buff *skb)
+ * uint32_t bpf_get_socket_uid(struct sk_buff *skb)
  * 	Return
  * 		The owner UID of the socket associated to *skb*. If the socket
  * 		is **NULL**, or if it is not a full socket (i.e. if it is a
@@ -1557,7 +1557,7 @@ union bpf_attr {
  * 		is returned (note that **overflowuid** might also be the actual
  * 		UID value for the socket).
  *
- * u32 bpf_set_hash(struct sk_buff *skb, u32 hash)
+ * uint32_t bpf_set_hash(struct sk_buff *skb, uint32_t hash)
  * 	Description
  * 		Set the full hash for *skb* (set the field *skb*\ **->hash**)
  * 		to value *hash*.
@@ -1586,7 +1586,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_adjust_room(struct sk_buff *skb, s32 len_diff, u32 mode, u64 flags)
+ * int bpf_skb_adjust_room(struct sk_buff *skb, int32_t len_diff, uint32_t mode, uint64_t flags)
  * 	Description
  * 		Grow or shrink the room for data in the packet associated to
  * 		*skb* by *len_diff*, and according to the selected *mode*.
@@ -1625,7 +1625,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_redirect_map(struct bpf_map *map, u32 key, u64 flags)
+ * int bpf_redirect_map(struct bpf_map *map, uint32_t key, uint64_t flags)
  * 	Description
  * 		Redirect the packet to the endpoint referenced by *map* at
  * 		index *key*. Depending on its type, this *map* can contain
@@ -1646,7 +1646,7 @@ union bpf_attr {
  * 		**XDP_REDIRECT** on success, or the value of the two lower bits
  * 		of the *flags* argument on error.
  *
- * int bpf_sk_redirect_map(struct sk_buff *skb, struct bpf_map *map, u32 key, u64 flags)
+ * int bpf_sk_redirect_map(struct sk_buff *skb, struct bpf_map *map, uint32_t key, uint64_t flags)
  * 	Description
  * 		Redirect the packet to the socket referenced by *map* (of type
  * 		**BPF_MAP_TYPE_SOCKMAP**) at index *key*. Both ingress and
@@ -1657,7 +1657,7 @@ union bpf_attr {
  * 	Return
  * 		**SK_PASS** on success, or **SK_DROP** on error.
  *
- * int bpf_sock_map_update(struct bpf_sock_ops *skops, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_sock_map_update(struct bpf_sock_ops *skops, struct bpf_map *map, void *key, uint64_t flags)
  * 	Description
  * 		Add an entry to, or update a *map* referencing sockets. The
  * 		*skops* is used as a new value for the entry associated to
@@ -1705,7 +1705,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_perf_event_read_value(struct bpf_map *map, u64 flags, struct bpf_perf_event_value *buf, u32 buf_size)
+ * int bpf_perf_event_read_value(struct bpf_map *map, uint64_t flags, struct bpf_perf_event_value *buf, uint32_t buf_size)
  * 	Description
  * 		Read the value of a perf event counter, and store it into *buf*
  * 		of size *buf_size*. This helper relies on a *map* of type
@@ -1755,7 +1755,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_perf_prog_read_value(struct bpf_perf_event_data *ctx, struct bpf_perf_event_value *buf, u32 buf_size)
+ * int bpf_perf_prog_read_value(struct bpf_perf_event_data *ctx, struct bpf_perf_event_value *buf, uint32_t buf_size)
  * 	Description
  * 		For en eBPF program attached to a perf event, retrieve the
  * 		value of the event counter associated to *ctx* and store it in
@@ -1785,7 +1785,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_override_return(struct pt_regs *regs, u64 rc)
+ * int bpf_override_return(struct pt_regs *regs, uint64_t rc)
  * 	Description
  * 		Used for error injection, this helper uses kprobes to override
  * 		the return value of the probed function, and to set it to *rc*.
@@ -1854,7 +1854,7 @@ union bpf_attr {
  * 		be set is returned (which comes down to 0 if all bits were set
  * 		as required).
  *
- * int bpf_msg_redirect_map(struct sk_msg_buff *msg, struct bpf_map *map, u32 key, u64 flags)
+ * int bpf_msg_redirect_map(struct sk_msg_buff *msg, struct bpf_map *map, uint32_t key, uint64_t flags)
  * 	Description
  * 		This helper is used in programs implementing policies at the
  * 		socket level. If the message *msg* is allowed to pass (i.e. if
@@ -1868,7 +1868,7 @@ union bpf_attr {
  * 	Return
  * 		**SK_PASS** on success, or **SK_DROP** on error.
  *
- * int bpf_msg_apply_bytes(struct sk_msg_buff *msg, u32 bytes)
+ * int bpf_msg_apply_bytes(struct sk_msg_buff *msg, uint32_t bytes)
  * 	Description
  * 		For socket policies, apply the verdict of the eBPF program to
  * 		the next *bytes* (number of bytes) of message *msg*.
@@ -1902,7 +1902,7 @@ union bpf_attr {
  * 	Return
  * 		0
  *
- * int bpf_msg_cork_bytes(struct sk_msg_buff *msg, u32 bytes)
+ * int bpf_msg_cork_bytes(struct sk_msg_buff *msg, uint32_t bytes)
  * 	Description
  * 		For socket policies, prevent the execution of the verdict eBPF
  * 		program for message *msg* until *bytes* (byte number) have been
@@ -1920,7 +1920,7 @@ union bpf_attr {
  * 	Return
  * 		0
  *
- * int bpf_msg_pull_data(struct sk_msg_buff *msg, u32 start, u32 end, u64 flags)
+ * int bpf_msg_pull_data(struct sk_msg_buff *msg, uint32_t start, uint32_t end, uint64_t flags)
  * 	Description
  * 		For socket policies, pull in non-linear data from user space
  * 		for *msg* and set pointers *msg*\ **->data** and *msg*\
@@ -1982,7 +1982,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_skb_get_xfrm_state(struct sk_buff *skb, u32 index, struct bpf_xfrm_state *xfrm_state, u32 size, u64 flags)
+ * int bpf_skb_get_xfrm_state(struct sk_buff *skb, uint32_t index, struct bpf_xfrm_state *xfrm_state, uint32_t size, uint64_t flags)
  * 	Description
  * 		Retrieve the XFRM state (IP transform framework, see also
  * 		**ip-xfrm(8)**) at *index* in XFRM "security path" for *skb*.
@@ -1998,7 +1998,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_get_stack(void *ctx, void *buf, u32 size, u64 flags)
+ * int bpf_get_stack(void *ctx, void *buf, uint32_t size, uint64_t flags)
  * 	Description
  * 		Return a user or a kernel stack in bpf program provided buffer.
  * 		To achieve this, the helper needs *ctx*, which is a pointer
@@ -2031,7 +2031,7 @@ union bpf_attr {
  * 		A non-negative value equal to or less than *size* on success,
  * 		or a negative error in case of failure.
  *
- * int bpf_skb_load_bytes_relative(const void *skb, u32 offset, void *to, u32 len, u32 start_header)
+ * int bpf_skb_load_bytes_relative(const void *skb, uint32_t offset, void *to, uint32_t len, uint32_t start_header)
  * 	Description
  * 		This helper is similar to **bpf_skb_load_bytes**\ () in that
  * 		it provides an easy way to load *len* bytes from *offset*
@@ -2053,7 +2053,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_fib_lookup(void *ctx, struct bpf_fib_lookup *params, int plen, u32 flags)
+ * int bpf_fib_lookup(void *ctx, struct bpf_fib_lookup *params, int plen, uint32_t flags)
  *	Description
  *		Do FIB lookup in kernel tables using parameters in *params*.
  *		If lookup is successful and result shows packet is to be
@@ -2084,7 +2084,7 @@ union bpf_attr {
  *		* > 0 one of **BPF_FIB_LKUP_RET_** codes explaining why the
  *		  packet is not forwarded or needs assist from full stack
  *
- * int bpf_sock_hash_update(struct bpf_sock_ops *skops, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_sock_hash_update(struct bpf_sock_ops *skops, struct bpf_map *map, void *key, uint64_t flags)
  *	Description
  *		Add an entry to, or update a sockhash *map* referencing sockets.
  *		The *skops* is used as a new value for the entry associated to
@@ -2103,7 +2103,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * int bpf_msg_redirect_hash(struct sk_msg_buff *msg, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_msg_redirect_hash(struct sk_msg_buff *msg, struct bpf_map *map, void *key, uint64_t flags)
  *	Description
  *		This helper is used in programs implementing policies at the
  *		socket level. If the message *msg* is allowed to pass (i.e. if
@@ -2117,7 +2117,7 @@ union bpf_attr {
  *	Return
  *		**SK_PASS** on success, or **SK_DROP** on error.
  *
- * int bpf_sk_redirect_hash(struct sk_buff *skb, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_sk_redirect_hash(struct sk_buff *skb, struct bpf_map *map, void *key, uint64_t flags)
  *	Description
  *		This helper is used in programs implementing policies at the
  *		skb socket level. If the sk_buff *skb* is allowed to pass (i.e.
@@ -2131,7 +2131,7 @@ union bpf_attr {
  *	Return
  *		**SK_PASS** on success, or **SK_DROP** on error.
  *
- * int bpf_lwt_push_encap(struct sk_buff *skb, u32 type, void *hdr, u32 len)
+ * int bpf_lwt_push_encap(struct sk_buff *skb, uint32_t type, void *hdr, uint32_t len)
  *	Description
  *		Encapsulate the packet associated to *skb* within a Layer 3
  *		protocol header. This header is provided in the buffer at
@@ -2168,7 +2168,7 @@ union bpf_attr {
  *	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_lwt_seg6_store_bytes(struct sk_buff *skb, u32 offset, const void *from, u32 len)
+ * int bpf_lwt_seg6_store_bytes(struct sk_buff *skb, uint32_t offset, const void *from, uint32_t len)
  *	Description
  *		Store *len* bytes from address *from* into the packet
  *		associated to *skb*, at *offset*. Only the flags, tag and TLVs
@@ -2183,7 +2183,7 @@ union bpf_attr {
  *	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_lwt_seg6_adjust_srh(struct sk_buff *skb, u32 offset, s32 delta)
+ * int bpf_lwt_seg6_adjust_srh(struct sk_buff *skb, uint32_t offset, int32_t delta)
  *	Description
  *		Adjust the size allocated to TLVs in the outermost IPv6
  *		Segment Routing Header contained in the packet associated to
@@ -2199,7 +2199,7 @@ union bpf_attr {
  *	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_lwt_seg6_action(struct sk_buff *skb, u32 action, void *param, u32 param_len)
+ * int bpf_lwt_seg6_action(struct sk_buff *skb, uint32_t action, void *param, uint32_t param_len)
  *	Description
  *		Apply an IPv6 Segment Routing action of type *action* to the
  *		packet associated to *skb*. Each action takes a parameter
@@ -2247,7 +2247,7 @@ union bpf_attr {
  *	Return
  *		0
  *
- * int bpf_rc_keydown(void *ctx, u32 protocol, u64 scancode, u32 toggle)
+ * int bpf_rc_keydown(void *ctx, uint32_t protocol, uint64_t scancode, uint32_t toggle)
  *	Description
  *		This helper is used in programs implementing IR decoding, to
  *		report a successfully decoded key press with *scancode*,
@@ -2273,7 +2273,7 @@ union bpf_attr {
  *	Return
  *		0
  *
- * u64 bpf_skb_cgroup_id(struct sk_buff *skb)
+ * uint64_t bpf_skb_cgroup_id(struct sk_buff *skb)
  * 	Description
  * 		Return the cgroup v2 id of the socket associated with the *skb*.
  * 		This is roughly similar to the **bpf_get_cgroup_classid**\ ()
@@ -2289,12 +2289,12 @@ union bpf_attr {
  * 	Return
  * 		The id is returned or 0 in case the id could not be retrieved.
  *
- * u64 bpf_get_current_cgroup_id(void)
+ * uint64_t bpf_get_current_cgroup_id(void)
  * 	Return
  * 		A 64-bit integer containing the current cgroup id based
  * 		on the cgroup within which the current task is running.
  *
- * void *bpf_get_local_storage(void *map, u64 flags)
+ * void *bpf_get_local_storage(void *map, uint64_t flags)
  *	Description
  *		Get the pointer to the local storage area.
  *		The type and the size of the local storage is defined
@@ -2312,7 +2312,7 @@ union bpf_attr {
  *	Return
  *		A pointer to the local storage area.
  *
- * int bpf_sk_select_reuseport(struct sk_reuseport_md *reuse, struct bpf_map *map, void *key, u64 flags)
+ * int bpf_sk_select_reuseport(struct sk_reuseport_md *reuse, struct bpf_map *map, void *key, uint64_t flags)
  *	Description
  *		Select a **SO_REUSEPORT** socket from a
  *		**BPF_MAP_TYPE_REUSEPORT_ARRAY** *map*.
@@ -2321,7 +2321,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * u64 bpf_skb_ancestor_cgroup_id(struct sk_buff *skb, int ancestor_level)
+ * uint64_t bpf_skb_ancestor_cgroup_id(struct sk_buff *skb, int ancestor_level)
  *	Description
  *		Return id of cgroup v2 that is ancestor of cgroup associated
  *		with the *skb* at the *ancestor_level*.  The root cgroup is at
@@ -2339,7 +2339,7 @@ union bpf_attr {
  *	Return
  *		The id is returned or 0 in case the id could not be retrieved.
  *
- * struct bpf_sock *bpf_sk_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
+ * struct bpf_sock *bpf_sk_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, uint32_t tuple_size, uint64_t netns, uint64_t flags)
  *	Description
  *		Look for TCP socket matching *tuple*, optionally in a child
  *		network namespace *netns*. The return value must be checked,
@@ -2376,7 +2376,7 @@ union bpf_attr {
  *		result is from *reuse*\ **->socks**\ [] using the hash of the
  *		tuple.
  *
- * struct bpf_sock *bpf_sk_lookup_udp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
+ * struct bpf_sock *bpf_sk_lookup_udp(void *ctx, struct bpf_sock_tuple *tuple, uint32_t tuple_size, uint64_t netns, uint64_t flags)
  *	Description
  *		Look for UDP socket matching *tuple*, optionally in a child
  *		network namespace *netns*. The return value must be checked,
@@ -2421,7 +2421,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * int bpf_map_push_elem(struct bpf_map *map, const void *value, u64 flags)
+ * int bpf_map_push_elem(struct bpf_map *map, const void *value, uint64_t flags)
  * 	Description
  * 		Push an element *value* in *map*. *flags* is one of:
  *
@@ -2443,7 +2443,7 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_msg_push_data(struct sk_msg_buff *msg, u32 start, u32 len, u64 flags)
+ * int bpf_msg_push_data(struct sk_msg_buff *msg, uint32_t start, uint32_t len, uint64_t flags)
  *	Description
  *		For socket policies, insert *len* bytes into *msg* at offset
  *		*start*.
@@ -2459,7 +2459,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * int bpf_msg_pop_data(struct sk_msg_buff *msg, u32 start, u32 len, u64 flags)
+ * int bpf_msg_pop_data(struct sk_msg_buff *msg, uint32_t start, uint32_t len, uint64_t flags)
  *	Description
  *		Will remove *len* bytes from a *msg* starting at byte *start*.
  *		This may result in **ENOMEM** errors under certain situations if
@@ -2471,7 +2471,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * int bpf_rc_pointer_rel(void *ctx, s32 rel_x, s32 rel_y)
+ * int bpf_rc_pointer_rel(void *ctx, int32_t rel_x, int32_t rel_y)
  *	Description
  *		This helper is used in programs implementing IR decoding, to
  *		report a successfully decoded pointer movement.
@@ -2574,7 +2574,7 @@ union bpf_attr {
  *		A **struct bpf_sock** pointer on success, or **NULL** in
  *		case of failure.
  *
- * struct bpf_sock *bpf_skc_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, u32 tuple_size, u64 netns, u64 flags)
+ * struct bpf_sock *bpf_skc_lookup_tcp(void *ctx, struct bpf_sock_tuple *tuple, uint32_t tuple_size, uint64_t netns, uint64_t flags)
  *	Description
  *		Look for TCP socket matching *tuple*, optionally in a child
  *		network namespace *netns*. The return value must be checked,
@@ -2593,7 +2593,7 @@ union bpf_attr {
  *		result is from *reuse*\ **->socks**\ [] using the hash of the
  *		tuple.
  *
- * int bpf_tcp_check_syncookie(struct bpf_sock *sk, void *iph, u32 iph_len, struct tcphdr *th, u32 th_len)
+ * int bpf_tcp_check_syncookie(struct bpf_sock *sk, void *iph, uint32_t iph_len, struct tcphdr *th, uint32_t th_len)
  * 	Description
  * 		Check whether *iph* and *th* contain a valid SYN cookie ACK for
  * 		the listening socket in *sk*.
@@ -2609,7 +2609,7 @@ union bpf_attr {
  * 		0 if *iph* and *th* are a valid SYN cookie ACK, or a negative
  * 		error otherwise.
  *
- * int bpf_sysctl_get_name(struct bpf_sysctl *ctx, char *buf, size_t buf_len, u64 flags)
+ * int bpf_sysctl_get_name(struct bpf_sysctl *ctx, char *buf, size_t buf_len, uint64_t flags)
  *	Description
  *		Get name of sysctl in /proc/sys/ and copy it into provided by
  *		program buffer *buf* of size *buf_len*.
@@ -2678,7 +2678,7 @@ union bpf_attr {
  *
  *		**-EINVAL** if sysctl is being read.
  *
- * int bpf_strtol(const char *buf, size_t buf_len, u64 flags, long *res)
+ * int bpf_strtol(const char *buf, size_t buf_len, uint64_t flags, long *res)
  *	Description
  *		Convert the initial part of the string from buffer *buf* of
  *		size *buf_len* to a long integer according to the given base
@@ -2702,7 +2702,7 @@ union bpf_attr {
  *
  *		**-ERANGE** if resulting value was out of range.
  *
- * int bpf_strtoul(const char *buf, size_t buf_len, u64 flags, unsigned long *res)
+ * int bpf_strtoul(const char *buf, size_t buf_len, uint64_t flags, unsigned long *res)
  *	Description
  *		Convert the initial part of the string from buffer *buf* of
  *		size *buf_len* to an unsigned long integer according to the
@@ -2725,7 +2725,7 @@ union bpf_attr {
  *
  *		**-ERANGE** if resulting value was out of range.
  *
- * void *bpf_sk_storage_get(struct bpf_map *map, struct bpf_sock *sk, void *value, u64 flags)
+ * void *bpf_sk_storage_get(struct bpf_map *map, struct bpf_sock *sk, void *value, uint64_t flags)
  *	Description
  *		Get a bpf-local-storage from a *sk*.
  *
@@ -2761,7 +2761,7 @@ union bpf_attr {
  *
  *		**-ENOENT** if the bpf-local-storage cannot be found.
  *
- * int bpf_send_signal(u32 sig)
+ * int bpf_send_signal(uint32_t sig)
  *	Description
  *		Send signal *sig* to the process of the current task.
  *		The signal may be delivered to any of this process's threads.
@@ -2776,7 +2776,7 @@ union bpf_attr {
  *
  *		**-EAGAIN** if bpf program can try again.
  *
- * s64 bpf_tcp_gen_syncookie(struct bpf_sock *sk, void *iph, u32 iph_len, struct tcphdr *th, u32 th_len)
+ * int64_t bpf_tcp_gen_syncookie(struct bpf_sock *sk, void *iph, uint32_t iph_len, struct tcphdr *th, uint32_t th_len)
  *	Description
  *		Try to issue a SYN cookie for the packet with corresponding
  *		IP/TCP headers, *iph* and *th*, on the listening socket in *sk*.
@@ -2803,7 +2803,7 @@ union bpf_attr {
  *
  *		**-EPROTONOSUPPORT** IP packet version is not 4 or 6
  *
- * int bpf_skb_output(void *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
+ * int bpf_skb_output(void *ctx, struct bpf_map *map, uint64_t flags, void *data, uint64_t size)
  * 	Description
  * 		Write raw *data* blob into a special BPF perf event held by
  * 		*map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. This perf
@@ -2827,21 +2827,21 @@ union bpf_attr {
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read_user(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read_user(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		Safely attempt to read *size* bytes from user space address
  * 		*unsafe_ptr* and store the data in *dst*.
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read_kernel(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read_kernel(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		Safely attempt to read *size* bytes from kernel space address
  * 		*unsafe_ptr* and store the data in *dst*.
  * 	Return
  * 		0 on success, or a negative error in case of failure.
  *
- * int bpf_probe_read_user_str(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read_user_str(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		Copy a NUL terminated string from an unsafe user address
  * 		*unsafe_ptr* to *dst*. The *size* should include the
@@ -2885,7 +2885,7 @@ union bpf_attr {
  * 		including the trailing NUL character. On error, a negative
  * 		value.
  *
- * int bpf_probe_read_kernel_str(void *dst, u32 size, const void *unsafe_ptr)
+ * int bpf_probe_read_kernel_str(void *dst, uint32_t size, const void *unsafe_ptr)
  * 	Description
  * 		Copy a NUL terminated string from an unsafe kernel address *unsafe_ptr*
  * 		to *dst*. Same semantics as with bpf_probe_read_user_str() apply.
@@ -2893,14 +2893,14 @@ union bpf_attr {
  * 		On success, the strictly positive length of the string,	including
  * 		the trailing NUL character. On error, a negative value.
  *
- * int bpf_tcp_send_ack(void *tp, u32 rcv_nxt)
+ * int bpf_tcp_send_ack(void *tp, uint32_t rcv_nxt)
  *	Description
  *		Send out a tcp-ack. *tp* is the in-kernel struct tcp_sock.
  *		*rcv_nxt* is the ack_seq to be sent out.
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * int bpf_send_signal_thread(u32 sig)
+ * int bpf_send_signal_thread(uint32_t sig)
  *	Description
  *		Send signal *sig* to the thread corresponding to the current task.
  *	Return
@@ -2914,13 +2914,13 @@ union bpf_attr {
  *
  *		**-EAGAIN** if bpf program can try again.
  *
- * u64 bpf_jiffies64(void)
+ * uint64_t bpf_jiffies64(void)
  *	Description
  *		Obtain the 64bit jiffies
  *	Return
  *		The 64 bit jiffies
  *
- * int bpf_read_branch_records(struct bpf_perf_event_data *ctx, void *buf, u32 size, u64 flags)
+ * int bpf_read_branch_records(struct bpf_perf_event_data *ctx, void *buf, uint32_t size, uint64_t flags)
  *	Description
  *		For an eBPF program attached to a perf event, retrieve the
  *		branch records (struct perf_branch_entry) associated to *ctx*
@@ -2939,7 +2939,7 @@ union bpf_attr {
  *
  *		**-ENOENT** if architecture does not support branch records.
  *
- * int bpf_get_ns_current_pid_tgid(u64 dev, u64 ino, struct bpf_pidns_info *nsdata, u32 size)
+ * int bpf_get_ns_current_pid_tgid(uint64_t dev, uint64_t ino, struct bpf_pidns_info *nsdata, uint32_t size)
  *	Description
  *		Returns 0 on success, values for *pid* and *tgid* as seen from the current
  *		*namespace* will be returned in *nsdata*.
@@ -2951,7 +2951,7 @@ union bpf_attr {
  *
  *		**-ENOENT** if pidns does not exists for the current task.
  *
- * int bpf_xdp_output(void *ctx, struct bpf_map *map, u64 flags, void *data, u64 size)
+ * int bpf_xdp_output(void *ctx, struct bpf_map *map, uint64_t flags, void *data, uint64_t size)
  *	Description
  *		Write raw *data* blob into a special BPF perf event held by
  *		*map* of type **BPF_MAP_TYPE_PERF_EVENT_ARRAY**. This perf
@@ -2975,7 +2975,7 @@ union bpf_attr {
  *	Return
  *		0 on success, or a negative error in case of failure.
  *
- * u64 bpf_get_netns_cookie(void *ctx)
+ * uint64_t bpf_get_netns_cookie(void *ctx)
  * 	Description
  * 		Retrieve the cookie (generated by the kernel) of the network
  * 		namespace the input *ctx* is associated with. The network
@@ -2988,7 +2988,7 @@ union bpf_attr {
  * 	Return
  * 		A 8-byte long opaque number.
  *
- * u64 bpf_get_current_ancestor_cgroup_id(int ancestor_level)
+ * uint64_t bpf_get_current_ancestor_cgroup_id(int ancestor_level)
  * 	Description
  * 		Return id of cgroup v2 that is ancestor of the cgroup associated
  * 		with the current task at the *ancestor_level*. The root cgroup
@@ -3006,7 +3006,7 @@ union bpf_attr {
  * 	Return
  * 		The id is returned or 0 in case the id could not be retrieved.
  *
- * int bpf_sk_assign(struct sk_buff *skb, struct bpf_sock *sk, u64 flags)
+ * int bpf_sk_assign(struct sk_buff *skb, struct bpf_sock *sk, uint64_t flags)
  *	Description
  *		Assign the *sk* to the *skb*. When combined with appropriate
  *		routing configuration to receive the packet towards the socket,
@@ -3028,7 +3028,7 @@ union bpf_attr {
  *					call from outside of TC ingress.
  *		* **-ESOCKTNOSUPPORT**	Socket type not supported (reuseport).
  *
- * u64 bpf_ktime_get_boot_ns(void)
+ * uint64_t bpf_ktime_get_boot_ns(void)
  * 	Description
  * 		Return the time elapsed since system boot, in nanoseconds.
  * 		Does include the time the system was suspended.

--- a/userspace/libscap/compat/perf_event.h
+++ b/userspace/libscap/compat/perf_event.h
@@ -269,17 +269,17 @@ enum {
  * as specified by attr.read_format:
  *
  * struct read_format {
- *	{ u64		value;
- *	  { u64		time_enabled; } && PERF_FORMAT_TOTAL_TIME_ENABLED
- *	  { u64		time_running; } && PERF_FORMAT_TOTAL_TIME_RUNNING
- *	  { u64		id;           } && PERF_FORMAT_ID
+ *	{ uint64_t		value;
+ *	  { uint64_t		time_enabled; } && PERF_FORMAT_TOTAL_TIME_ENABLED
+ *	  { uint64_t		time_running; } && PERF_FORMAT_TOTAL_TIME_RUNNING
+ *	  { uint64_t		id;           } && PERF_FORMAT_ID
  *	} && !PERF_FORMAT_GROUP
  *
- *	{ u64		nr;
- *	  { u64		time_enabled; } && PERF_FORMAT_TOTAL_TIME_ENABLED
- *	  { u64		time_running; } && PERF_FORMAT_TOTAL_TIME_RUNNING
- *	  { u64		value;
- *	    { u64	id;           } && PERF_FORMAT_ID
+ *	{ uint64_t		nr;
+ *	  { uint64_t		time_enabled; } && PERF_FORMAT_TOTAL_TIME_ENABLED
+ *	  { uint64_t		time_running; } && PERF_FORMAT_TOTAL_TIME_RUNNING
+ *	  { uint64_t		value;
+ *	    { uint64_t	id;           } && PERF_FORMAT_ID
  *	  }		cntr[nr];
  *	} && PERF_FORMAT_GROUP
  * };
@@ -477,10 +477,10 @@ struct perf_event_mmap_page {
 	/*
 	 * Bits needed to read the hw events in user-space.
 	 *
-	 *   u32 seq, time_mult, time_shift, index, width;
-	 *   u64 count, enabled, running;
-	 *   u64 cyc, time_offset;
-	 *   s64 pmc = 0;
+	 *   uint32_t seq, time_mult, time_shift, index, width;
+	 *   uint64_t count, enabled, running;
+	 *   uint64_t cyc, time_offset;
+	 *   int64_t pmc = 0;
 	 *
 	 *   do {
 	 *     seq = pc->lock;
@@ -542,11 +542,11 @@ struct perf_event_mmap_page {
 	 * If cap_usr_time the below fields can be used to compute the time
 	 * delta since time_enabled (in ns) using rdtsc or similar.
 	 *
-	 *   u64 quot, rem;
-	 *   u64 delta;
+	 *   uint64_t quot, rem;
+	 *   uint64_t delta;
 	 *
 	 *   quot = (cyc >> time_shift);
-	 *   rem = cyc & (((u64)1 << time_shift) - 1);
+	 *   rem = cyc & (((uint64_t)1 << time_shift) - 1);
 	 *   delta = time_offset + quot * time_mult +
 	 *              ((rem * time_mult) >> time_shift);
 	 *
@@ -577,7 +577,7 @@ struct perf_event_mmap_page {
 	 * And vice versa:
 	 *
 	 *   quot = cyc >> time_shift;
-	 *   rem  = cyc & (((u64)1 << time_shift) - 1);
+	 *   rem  = cyc & (((uint64_t)1 << time_shift) - 1);
 	 *   timestamp = time_zero + quot * time_mult +
 	 *               ((rem * time_mult) >> time_shift);
 	 */
@@ -710,12 +710,12 @@ enum perf_event_type {
 	 * optional fields being ignored.
 	 *
 	 * struct sample_id {
-	 * 	{ u32			pid, tid; } && PERF_SAMPLE_TID
-	 * 	{ u64			time;     } && PERF_SAMPLE_TIME
-	 * 	{ u64			id;       } && PERF_SAMPLE_ID
-	 * 	{ u64			stream_id;} && PERF_SAMPLE_STREAM_ID
-	 * 	{ u32			cpu, res; } && PERF_SAMPLE_CPU
-	 *	{ u64			id;	  } && PERF_SAMPLE_IDENTIFIER
+	 * 	{ uint32_t			pid, tid; } && PERF_SAMPLE_TID
+	 * 	{ uint64_t			time;     } && PERF_SAMPLE_TIME
+	 * 	{ uint64_t			id;       } && PERF_SAMPLE_ID
+	 * 	{ uint64_t			stream_id;} && PERF_SAMPLE_STREAM_ID
+	 * 	{ uint32_t			cpu, res; } && PERF_SAMPLE_CPU
+	 *	{ uint64_t			id;	  } && PERF_SAMPLE_IDENTIFIER
 	 * } && perf_event_attr::sample_id_all
 	 *
 	 * Note that PERF_SAMPLE_IDENTIFIER duplicates PERF_SAMPLE_ID.  The
@@ -730,10 +730,10 @@ enum perf_event_type {
 	 * struct {
 	 *	struct perf_event_header	header;
 	 *
-	 *	u32				pid, tid;
-	 *	u64				addr;
-	 *	u64				len;
-	 *	u64				pgoff;
+	 *	uint32_t				pid, tid;
+	 *	uint64_t				addr;
+	 *	uint64_t				len;
+	 *	uint64_t				pgoff;
 	 *	char				filename[];
 	 * 	struct sample_id		sample_id;
 	 * };
@@ -743,8 +743,8 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u64				id;
-	 *	u64				lost;
+	 *	uint64_t				id;
+	 *	uint64_t				lost;
 	 * 	struct sample_id		sample_id;
 	 * };
 	 */
@@ -754,7 +754,7 @@ enum perf_event_type {
 	 * struct {
 	 *	struct perf_event_header	header;
 	 *
-	 *	u32				pid, tid;
+	 *	uint32_t				pid, tid;
 	 *	char				comm[];
 	 * 	struct sample_id		sample_id;
 	 * };
@@ -764,9 +764,9 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				pid, ppid;
-	 *	u32				tid, ptid;
-	 *	u64				time;
+	 *	uint32_t				pid, ppid;
+	 *	uint32_t				tid, ptid;
+	 *	uint64_t				time;
 	 * 	struct sample_id		sample_id;
 	 * };
 	 */
@@ -775,9 +775,9 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u64				time;
-	 *	u64				id;
-	 *	u64				stream_id;
+	 *	uint64_t				time;
+	 *	uint64_t				id;
+	 *	uint64_t				stream_id;
 	 * 	struct sample_id		sample_id;
 	 * };
 	 */
@@ -787,9 +787,9 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				pid, ppid;
-	 *	u32				tid, ptid;
-	 *	u64				time;
+	 *	uint32_t				pid, ppid;
+	 *	uint32_t				tid, ptid;
+	 *	uint64_t				time;
 	 * 	struct sample_id		sample_id;
 	 * };
 	 */
@@ -798,7 +798,7 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				pid, tid;
+	 *	uint32_t				pid, tid;
 	 *
 	 *	struct read_format		values;
 	 * 	struct sample_id		sample_id;
@@ -816,20 +816,20 @@ enum perf_event_type {
 	 *	# is fixed relative to header.
 	 *	#
 	 *
-	 *	{ u64			id;	  } && PERF_SAMPLE_IDENTIFIER
-	 *	{ u64			ip;	  } && PERF_SAMPLE_IP
-	 *	{ u32			pid, tid; } && PERF_SAMPLE_TID
-	 *	{ u64			time;     } && PERF_SAMPLE_TIME
-	 *	{ u64			addr;     } && PERF_SAMPLE_ADDR
-	 *	{ u64			id;	  } && PERF_SAMPLE_ID
-	 *	{ u64			stream_id;} && PERF_SAMPLE_STREAM_ID
-	 *	{ u32			cpu, res; } && PERF_SAMPLE_CPU
-	 *	{ u64			period;   } && PERF_SAMPLE_PERIOD
+	 *	{ uint64_t			id;	  } && PERF_SAMPLE_IDENTIFIER
+	 *	{ uint64_t			ip;	  } && PERF_SAMPLE_IP
+	 *	{ uint32_t			pid, tid; } && PERF_SAMPLE_TID
+	 *	{ uint64_t			time;     } && PERF_SAMPLE_TIME
+	 *	{ uint64_t			addr;     } && PERF_SAMPLE_ADDR
+	 *	{ uint64_t			id;	  } && PERF_SAMPLE_ID
+	 *	{ uint64_t			stream_id;} && PERF_SAMPLE_STREAM_ID
+	 *	{ uint32_t			cpu, res; } && PERF_SAMPLE_CPU
+	 *	{ uint64_t			period;   } && PERF_SAMPLE_PERIOD
 	 *
 	 *	{ struct read_format	values;	  } && PERF_SAMPLE_READ
 	 *
-	 *	{ u64			nr,
-	 *	  u64			ips[nr];  } && PERF_SAMPLE_CALLCHAIN
+	 *	{ uint64_t			nr,
+	 *	  uint64_t			ips[nr];  } && PERF_SAMPLE_CALLCHAIN
 	 *
 	 *	#
 	 *	# The RAW record below is opaque data wrt the ABI
@@ -842,25 +842,25 @@ enum perf_event_type {
 	 *	# In other words, PERF_SAMPLE_RAW contents are not an ABI.
 	 *	#
 	 *
-	 *	{ u32			size;
+	 *	{ uint32_t			size;
 	 *	  char                  data[size];}&& PERF_SAMPLE_RAW
 	 *
-	 *	{ u64                   nr;
-	 *        { u64 from, to, flags } lbr[nr];} && PERF_SAMPLE_BRANCH_STACK
+	 *	{ uint64_t                   nr;
+	 *        { uint64_t from, to, flags } lbr[nr];} && PERF_SAMPLE_BRANCH_STACK
 	 *
-	 * 	{ u64			abi; # enum perf_sample_regs_abi
-	 * 	  u64			regs[weight(mask)]; } && PERF_SAMPLE_REGS_USER
+	 * 	{ uint64_t			abi; # enum perf_sample_regs_abi
+	 * 	  uint64_t			regs[weight(mask)]; } && PERF_SAMPLE_REGS_USER
 	 *
-	 * 	{ u64			size;
+	 * 	{ uint64_t			size;
 	 * 	  char			data[size];
-	 * 	  u64			dyn_size; } && PERF_SAMPLE_STACK_USER
+	 * 	  uint64_t			dyn_size; } && PERF_SAMPLE_STACK_USER
 	 *
-	 *	{ u64			weight;   } && PERF_SAMPLE_WEIGHT
-	 *	{ u64			data_src; } && PERF_SAMPLE_DATA_SRC
-	 *	{ u64			transaction; } && PERF_SAMPLE_TRANSACTION
-	 *	{ u64			abi; # enum perf_sample_regs_abi
-	 *	  u64			regs[weight(mask)]; } && PERF_SAMPLE_REGS_INTR
-	 *	{ u64			phys_addr;} && PERF_SAMPLE_PHYS_ADDR
+	 *	{ uint64_t			weight;   } && PERF_SAMPLE_WEIGHT
+	 *	{ uint64_t			data_src; } && PERF_SAMPLE_DATA_SRC
+	 *	{ uint64_t			transaction; } && PERF_SAMPLE_TRANSACTION
+	 *	{ uint64_t			abi; # enum perf_sample_regs_abi
+	 *	  uint64_t			regs[weight(mask)]; } && PERF_SAMPLE_REGS_INTR
+	 *	{ uint64_t			phys_addr;} && PERF_SAMPLE_PHYS_ADDR
 	 * };
 	 */
 	PERF_RECORD_SAMPLE			= 9,
@@ -872,15 +872,15 @@ enum perf_event_type {
 	 * struct {
 	 *	struct perf_event_header	header;
 	 *
-	 *	u32				pid, tid;
-	 *	u64				addr;
-	 *	u64				len;
-	 *	u64				pgoff;
-	 *	u32				maj;
-	 *	u32				min;
-	 *	u64				ino;
-	 *	u64				ino_generation;
-	 *	u32				prot, flags;
+	 *	uint32_t				pid, tid;
+	 *	uint64_t				addr;
+	 *	uint64_t				len;
+	 *	uint64_t				pgoff;
+	 *	uint32_t				maj;
+	 *	uint32_t				min;
+	 *	uint64_t				ino;
+	 *	uint64_t				ino_generation;
+	 *	uint32_t				prot, flags;
 	 *	char				filename[];
 	 * 	struct sample_id		sample_id;
 	 * };
@@ -893,9 +893,9 @@ enum perf_event_type {
 	 * struct {
 	 * 	struct perf_event_header	header;
 	 *
-	 * 	u64				aux_offset;
-	 * 	u64				aux_size;
-	 *	u64				flags;
+	 * 	uint64_t				aux_offset;
+	 * 	uint64_t				aux_size;
+	 *	uint64_t				flags;
 	 * 	struct sample_id		sample_id;
 	 * };
 	 */
@@ -906,8 +906,8 @@ enum perf_event_type {
 	 *
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				pid;
-	 *	u32				tid;
+	 *	uint32_t				pid;
+	 *	uint32_t				tid;
 	 *	struct sample_id		sample_id;
 	 * };
 	 */
@@ -919,7 +919,7 @@ enum perf_event_type {
 	 * struct {
 	 *	struct perf_event_header	header;
 	 *
-	 *	u64				lost;
+	 *	uint64_t				lost;
 	 *	struct sample_id		sample_id;
 	 * };
 	 */
@@ -944,8 +944,8 @@ enum perf_event_type {
 	 *
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				next_prev_pid;
-	 *	u32				next_prev_tid;
+	 *	uint32_t				next_prev_pid;
+	 *	uint32_t				next_prev_tid;
 	 *	struct sample_id		sample_id;
 	 * };
 	 */
@@ -954,10 +954,10 @@ enum perf_event_type {
 	/*
 	 * struct {
 	 *	struct perf_event_header	header;
-	 *	u32				pid;
-	 *	u32				tid;
-	 *	u64				nr_namespaces;
-	 *	{ u64				dev, inode; } [nr_namespaces];
+	 *	uint32_t				pid;
+	 *	uint32_t				tid;
+	 *	uint64_t				nr_namespaces;
+	 *	{ uint64_t				dev, inode; } [nr_namespaces];
 	 *	struct sample_id		sample_id;
 	 * };
 	 */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf


**Does this PR require a change in the driver versions?**

I am not sure about this.

**What this PR does / why we need it**:

This resolves **ALL** inconsistencies using s/u type integers. The only instances that remain are either apart of vmlinux.h (which I believe we do not want to change) and instances inside a few structs. This should now allow us to close 902. The remaining should probably handled in a new issue if decided.

**Which issue(s) this PR fixes**:

part of #902 

**Special notes for your reviewer**:
@incertum 
This resolves **ALL** inconsistencies using s/u type integers. The only instances that remain are either apart of vmlinux.h (which I believe we do not want to change) and instances inside a few structs. This should now allow us to close 902. The remaining should probably be handled in a new issue if decided.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
