### PR TITLE
cleanup(libsinsp): remove a few more UB warnings from integer copies

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1879,10 +1879,10 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 			if(payload_len == 1 + 4 + 2 + 4 + 2)
 			{
 				ipv4tuple addr;
-				addr.m_fields.m_sip = *(uint32_t*)(payload + 1);
-				addr.m_fields.m_sport = *(uint16_t*)(payload+5);
-				addr.m_fields.m_dip = *(uint32_t*)(payload + 7);
-				addr.m_fields.m_dport = *(uint16_t*)(payload+11);
+				memcpy(&addr.m_fields.m_sip, payload + 1, sizeof(uint32_t));
+				memcpy(&addr.m_fields.m_sport, payload + 5, sizeof(uint16_t));
+				memcpy(&addr.m_fields.m_dip, payload + 7, sizeof(uint32_t));
+				memcpy(&addr.m_fields.m_dport, payload + 11, sizeof(uint16_t));
 				addr.m_fields.m_l4proto = (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 				std::string straddr = ipv4tuple_to_string(&addr, m_inspector->m_hostname_and_port_resolution_enabled);
 				snprintf(&m_paramstr_storage[0],
@@ -1910,10 +1910,10 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				if(sinsp_utils::is_ipv4_mapped_ipv6(sip6) && sinsp_utils::is_ipv4_mapped_ipv6(dip6))
 				{
 					ipv4tuple addr;
-					addr.m_fields.m_sip = *(uint32_t*)sip;
-					addr.m_fields.m_sport = *(uint16_t*)(payload+17);
-					addr.m_fields.m_dip = *(uint32_t*)dip;
-					addr.m_fields.m_dport = *(uint16_t*)(payload+35);
+					memcpy(&addr.m_fields.m_sip, sip, sizeof(uint32_t));
+					memcpy(&addr.m_fields.m_sport, payload + 17, sizeof(uint16_t));
+					memcpy(&addr.m_fields.m_dip, dip, sizeof(uint32_t));
+					memcpy(&addr.m_fields.m_dport, payload + 35, sizeof(uint16_t));
 					addr.m_fields.m_l4proto = (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 					std::string straddr = ipv4tuple_to_string(&addr, m_inspector->m_hostname_and_port_resolution_enabled);
 
@@ -1954,14 +1954,18 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 			//
 			// Sanitize the file string.
 			//
-            std::string sanitized_str = payload + 17;
-	    sanitize_string(sanitized_str);
+			std::string sanitized_str = payload + 17;
+			sanitize_string(sanitized_str);
+
+			uint64_t src, dst;
+			memcpy(&src, payload + 1, sizeof(uint64_t));
+			memcpy(&dst, payload + 9, sizeof(uint64_t));
 
 			snprintf(&m_paramstr_storage[0],
 				m_paramstr_storage.size(),
 				"%" PRIx64 "->%" PRIx64 " %s",
-				*(uint64_t*)(payload + 1),
-				*(uint64_t*)(payload + 9),
+				src,
+				dst,
 				sanitized_str.c_str());
 		}
 		else

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -479,9 +479,9 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 			sinfo->m_ipv4info.m_fields.m_l4proto == SCAP_L4_UDP)
 		{
 			ipv4tuple addr;
-			addr.m_fields.m_sip = *(uint32_t*)sb;
+			addr.m_fields.m_sip = sinfo->m_ipv4info.m_fields.m_sip;
 			addr.m_fields.m_sport = sinfo->m_ipv4info.m_fields.m_sport;
-			addr.m_fields.m_dip = *(uint32_t*)db;
+			addr.m_fields.m_dip = sinfo->m_ipv4info.m_fields.m_dip;
 			addr.m_fields.m_dport = sinfo->m_ipv4info.m_fields.m_dport;
 			addr.m_fields.m_l4proto = sinfo->m_ipv4info.m_fields.m_l4proto;
 			std::string straddr = ipv4tuple_to_string(&addr, resolve);
@@ -525,9 +525,9 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 			if(sinsp_utils::is_ipv4_mapped_ipv6(sip6) && sinsp_utils::is_ipv4_mapped_ipv6(dip6))
 			{
 				ipv4tuple addr;
-				addr.m_fields.m_sip = *(uint32_t*)sip;
+				memcpy(&addr.m_fields.m_sip, sip, sizeof(uint32_t));
 				addr.m_fields.m_sport = sinfo->m_ipv4info.m_fields.m_sport;
-				addr.m_fields.m_dip = *(uint32_t*)dip;
+				memcpy(&addr.m_fields.m_dip, dip, sizeof(uint32_t));
 				addr.m_fields.m_dport = sinfo->m_ipv4info.m_fields.m_dport;
 				addr.m_fields.m_l4proto = sinfo->m_ipv4info.m_fields.m_l4proto;
 				std::string straddr = ipv4tuple_to_string(&addr, resolve);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

One (of many) changes for this: https://github.com/falcosecurity/libs/issues/1470 . In this case, we're removing a few warnings that are not concerning `get_param()`. We will be back with more refactorings there.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
