### PR TITLE
fix(cmake): solve win32 linking issues with zlib

### DIFF
--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -66,13 +66,18 @@ else()
 			install(FILES ${ZLIB_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 					COMPONENT "libs-deps")
 		else()
-			set(ZLIB_LIB "${ZLIB_SRC}/zlib.lib")
+			if(BUILD_SHARED_LIBS)
+				set(ZLIB_LIB_SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+			else()
+				set(ZLIB_LIB_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+			endif()
+			set(ZLIB_LIB "${ZLIB_SRC}/zlib${ZLIB_LIB_SUFFIX}")
 			ExternalProject_Add(zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
 				URL "https://github.com/madler/zlib/archive/v1.2.13.tar.gz"
 				URL_HASH "SHA256=1525952a0a567581792613a9723333d7f8cc20b87a81f920fb8bc7e3f2251428"
 				CONFIGURE_COMMAND ""
-				BUILD_COMMAND nmake -f win32/Makefile.msc
+				BUILD_COMMAND nmake -f win32/Makefile.msc LOC=-DZLIB_WINAPI
 				BUILD_IN_SOURCE 1
 				BUILD_BYPRODUCTS ${ZLIB_LIB}
 				INSTALL_COMMAND "")

--- a/userspace/libscap/scap_zlib.h
+++ b/userspace/libscap/scap_zlib.h
@@ -20,7 +20,10 @@ limitations under the License.
 
 #include "settings.h"
 
-#if defined(USE_ZLIB) && !defined(UDIG) && !defined(_WIN32)
+#if defined(USE_ZLIB) && !defined(UDIG)
+#ifdef _WIN32
+#define ZLIB_WINAPI
+#endif
 #include <zlib.h>
 #else
 #include <stdio.h>

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -51,8 +51,9 @@ if(WITH_CHISEL)
 	include(tinydir)
 endif()
 
+include(zlib)
+
 if(NOT MINIMAL_BUILD)
-	include(zlib)
 	if (NOT WIN32 AND NOT EMSCRIPTEN)
 		include(curl)
 		include(cares)
@@ -194,6 +195,7 @@ target_link_libraries(sinsp
 
 set(SINSP_PKGCONFIG_LIBRARIES
 	scap
+	"${ZLIB_LIB}"
 	"${CURL_LIBRARIES}"
 	"${JSONCPP_LIB}"
 	"${RE2_LIB}"

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -23,9 +23,7 @@ if(NOT MINIMAL_BUILD AND NOT EMSCRIPTEN)
 	include(curl)
 endif() # MINIMAL_BUILD
 
-if(NOT MINIMAL_BUILD)
-	include(zlib)
-endif()
+include(zlib)
 
 if(WIN32)
 	set(CMAKE_CXX_FLAGS "-D_CRT_SECURE_NO_WARNINGS -DWIN32 -DMINIMAL_BUILD /EHsc /W3 /Zi /std:c++17")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since https://github.com/falcosecurity/libs/pull/1325, we now link and use zlib also when in MINIMAL_BUILD. Our windows build relies on MINIMAL_BUILD too, so now my question was: why are we not using zlib on windows too? Turns out there are some linking issues involved, which hopefully this PR will solve.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(cmake): solve win32 linking issues with zlib
```
