### PR TITLE
update(userspace/libsinsp): fix data race in async event queue and avoid potential extra allocation

### DIFF
--- a/userspace/libsinsp/mpsc_priority_queue.h
+++ b/userspace/libsinsp/mpsc_priority_queue.h
@@ -67,7 +67,7 @@ public:
 	 * @brief Pops the highest priority element from the queue. Returns false
 	 * in case of empty queue.
 	 */
-	inline bool pop(OUT Elm& res)
+	inline bool pop(Elm& res)
 	{
 		// we check that the queue is not empty before acquiring the lock
 		if (m_queue_top == nullptr)
@@ -92,7 +92,7 @@ public:
 	 * element is not popped from the queue and this method returns false.
 	 */
 	template <typename Callable>
-	inline bool pop_if(const Callable& pred, OUT Elm& res)
+	inline bool pop_if(const Callable& pred, Elm& res)
 	{
 		// we check that the queue is not empty before acquiring the lock
 		if (m_queue_top == nullptr)

--- a/userspace/libsinsp/mpsc_priority_queue.h
+++ b/userspace/libsinsp/mpsc_priority_queue.h
@@ -135,9 +135,9 @@ public:
 				std::scoped_lock<Mtx> lk(m_mtx);
 
 				// while the lock is held no element can be pushed between
-				// our checks, so we verify that the actual top element is
-				// the one we wish to pop, otherwise release the lock and
-				// keep looping
+				// our checks, so we verify one last time that the actual
+				// top element is the one we wish to pop, otherwise release
+				// the lock and keep looping
 				if (m_queue.top().elm.get() != top)
 				{
 					continue;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1337,14 +1337,10 @@ int32_t sinsp::fetch_next_event(sinsp_evt*& evt)
 	{
 		if (!m_async_events_queue.empty())
 		{
-			const auto check_ts = [this](const sinsp_evt& evt)
-			{
-				return compare_evt_timestamps(evt.m_pevt->ts, m_delayed_scap_evt.m_pevt->ts);
-			};
-
 			// This is thread-safe as we're in a MPSC case in which
 			// sinsp::next is the single consumer
-			if (m_async_events_queue.try_pop_if(m_async_evt, check_ts))
+			m_async_events_checker.ts = m_delayed_scap_evt.m_pevt->ts;
+			if (m_async_events_queue.try_pop_if(m_async_evt, m_async_events_checker))
 			{
 				// the async event is the one with most priority
 				evt = m_async_evt.get();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1319,7 +1319,7 @@ int32_t sinsp::fetch_next_event(sinsp_evt*& evt)
 	// event queue. If none is available, we just return the timeout.
 	// note: the queue is optimized for checking for emptyness before popping
 	if (res == SCAP_TIMEOUT &&
-		!m_async_events_queue.empty() && m_async_events_queue.pop(m_async_evt))
+		!m_async_events_queue.empty() && m_async_events_queue.try_pop(m_async_evt))
 	{
 		evt = m_async_evt.get();
 		if(evt->m_pevt->ts == (uint64_t) -1)
@@ -1337,14 +1337,14 @@ int32_t sinsp::fetch_next_event(sinsp_evt*& evt)
 	{
 		if (!m_async_events_queue.empty())
 		{
-			const auto check_ts = [this](const sinsp_evt* evt)
+			const auto check_ts = [this](const sinsp_evt& evt)
 			{
-				return compare_evt_timestamps(evt->m_pevt->ts, m_delayed_scap_evt.m_pevt->ts);
+				return compare_evt_timestamps(evt.m_pevt->ts, m_delayed_scap_evt.m_pevt->ts);
 			};
 
 			// This is thread-safe as we're in a MPSC case in which
 			// sinsp::next is the single consumer
-			if (m_async_events_queue.pop_if(check_ts, m_async_evt))
+			if (m_async_events_queue.try_pop_if(m_async_evt, check_ts))
 			{
 				// the async event is the one with most priority
 				evt = m_async_evt.get();

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1234,6 +1234,19 @@ public:
 	// priority queue to hold injected events
 	mpsc_priority_queue<sinsp_evt_ptr, state_evts_less> m_async_events_queue;
 
+	// predicate struct for checking the head of the async events queue.
+	// keeping a struct in the internal state makes sure that we don't do
+	// any extra allocation by creating a lambda and its closure
+	struct
+	{
+		uint64_t ts{0};
+
+		bool operator()(const sinsp_evt& evt) const
+		{
+			return compare_evt_timestamps(evt.m_pevt->ts, ts);
+		};
+	} m_async_events_checker;
+
 	// Holds an event dequeued from the above queue
 	sinsp_evt_ptr m_async_evt;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1223,11 +1223,11 @@ public:
 	using sinsp_evt_ptr = std::unique_ptr<sinsp_evt>;
 	struct state_evts_less
 	{
-		bool operator()(const sinsp_evt_ptr& l, const sinsp_evt_ptr& r)
+		bool operator()(const sinsp_evt& l, const sinsp_evt& r)
 		{
 			// order events in reverse-order as the lowest timestamp
 			// has the highest priority
-			return !compare_evt_timestamps(l->get_ts(), r->get_ts());
+			return !compare_evt_timestamps(l.get_ts(), r.get_ts());
 		}
 	};
 

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -94,6 +94,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	events_proc.ut.cpp
 	events_user.ut.cpp
 	external_processor.ut.cpp
+	mpsc_priority_queue.ut.cpp
 	token_bucket.ut.cpp
 	ppm_api_version.ut.cpp
 	plugins.ut.cpp

--- a/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
+++ b/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "mpsc_priority_queue.h"
+#include <gtest/gtest.h>
+#include <thread>
+
+using val_t = std::unique_ptr<int>;
+
+struct val_asc_order
+{
+    bool operator()(const val_t& a, const val_t& b) const 
+    {
+        return std::less<int>{}(*b.get(), *a.get());
+    }
+};
+
+TEST(mpsc_priority_queue, single_producer)
+{
+    const int max_value = 1000;
+    mpsc_priority_queue<val_t, val_asc_order> q;
+
+    // single producer
+    auto p = std::thread([&](){
+        for (int i = 0; i < max_value; i++)
+        {
+            q.push(std::make_unique<int>(i));
+        }
+    });
+
+    // single consumer
+    val_t v;
+    int i = 0;
+    int failed = 0;
+    while (i < max_value)
+    {
+        if (q.pop(v))
+        {
+            failed += (*v.get() != i) ? 1 : 0;
+            i++;
+        }
+    }
+
+    // wait for producer to stop
+    p.join();
+
+    // check we received everything in order
+    ASSERT_EQ(failed, 0);
+}
+
+// note: emscripten does not support multi-threading
+#ifndef __EMSCRIPTEN__
+TEST(mpsc_priority_queue, multi_producer)
+{
+	const int num_values = 1000;
+    const int num_producers = 20;
+    mpsc_priority_queue<val_t, val_asc_order> q;
+    std::atomic<int> counter{1};
+
+    // multiple producer
+    std::vector<std::thread> producers;
+    for (int i = 0; i < num_producers; i++)
+    {
+        producers.emplace_back([&](){
+            for (int i = 0; i <= num_values; i++)
+            {
+                q.push(std::make_unique<int>(counter++));
+            }
+        });
+    }
+
+    // single consumer
+    val_t v;
+    int i = 0;
+    int failed = 0;
+    int last_val = 0;
+    while (i < num_values * num_producers)
+    {
+        if (q.empty())
+        {
+            continue;
+        }
+
+        if (!q.pop_if([&](int* n) { return *n >= last_val; }, v))
+        {
+            failed++;
+            continue;
+        }
+
+        last_val = *v.get();
+        i++;
+    }
+
+    // wait for producers to stop
+    for (int i = 0; i < num_producers; i++)
+    {
+        producers[i].join();
+    }
+
+    // check we received everything in order
+    ASSERT_EQ(failed, 0);
+}
+#endif // __EMSCRIPTEN__

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -114,9 +114,9 @@ protected:
 		va_list args2;
 		va_copy(args2, args);
 
-		if (ts <= m_last_recorded_timestamp) {
+		if (ts < m_last_recorded_timestamp) {
 			va_end(args2);
-			throw std::runtime_error("the test framework does not currently support equal timestamps or out of order events");
+			throw std::runtime_error("the test framework does not currently support out of order events with decreasing timestamps");
 		}
 
 		int32_t ret = scap_event_encode_params_v(event_buf, &event_size, error, event_type, n, args);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The current async queue implementation introduces a data race that can cause the ordering guarantee of the queue to not be respected when using `pop_if`. Also, using a lambda for encoding the predicate can cause (depending on the compiler) an extra heap allocation for storing the lambda's closure, which would happen in the critical path every time we attempt popping from the async queue with a predicate. Unit tests have been refactored to avoid being flaky.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): fix data race in async event queue and avoid potential extra allocation
```
