### PR TITLE
update(userspace/libsinsp): add factory method for sinsp_evt from a given scap buffer

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -532,6 +532,17 @@ private:
 		m_info = ppm_event;
 		m_errorcode = errorcode;
 	}
+
+	static std::unique_ptr<sinsp_evt> from_scap_evt(
+		std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>> scap_event)
+	{
+		auto ret = std::make_unique<sinsp_evt>();
+		auto evdata = scap_event.release();
+		ret->init(evdata, 0);
+		ret->m_pevt_storage = (char*)evdata;
+		return ret;
+	}
+
 	inline void load_params()
 	{
 		uint32_t j;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Adds a minor factory method for sinsp events that can be useful when crafting a new event that owns the memory of scap event mem buf.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp): add factory method for sinsp_evt from a given scap buffer
```
