### PR TITLE
refactor(libsinsp): safer parameter handling part 2

### DIFF
--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -272,7 +272,7 @@ int lua_cbacks::get_type(lua_State *ls)
 		 * we get the ppm_sc from the event (first param) and we consider
 		 * the syscall name as the event name.
 		 */
-		uint16_t ppm_sc = evt->get_param<uint16_t>(0);
+		uint16_t ppm_sc = evt->get_param(0)->as<uint16_t>();
 
 		evname = scap_get_ppm_sc_name((ppm_sc_code)ppm_sc);
 	}

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -188,7 +188,7 @@ uint32_t sinsp_evt::get_num_params()
 	return (uint32_t)m_params.size();
 }
 
-sinsp_evt_param *sinsp_evt::get_param(uint32_t id)
+const sinsp_evt_param *sinsp_evt::get_param(uint32_t id)
 {
 	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0)
 	{
@@ -819,7 +819,7 @@ Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_
 	//
 	// Get the parameter
 	//
-	sinsp_evt_param *param = get_param(id);
+	const sinsp_evt_param *param = get_param(id);
 	payload = param->m_val;
 	payload_len = param->m_len;
 	param_info = &(m_info->params[id]);
@@ -1566,7 +1566,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	//
 	// Get the parameter
 	//
-	sinsp_evt_param *param = get_param(id);
+	const sinsp_evt_param *param = get_param(id);
 	payload = param->m_val;
 	payload_len = param->m_len;
 	param_info = &(m_info->params[id]);

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -252,7 +252,7 @@ const struct ppm_param_info* sinsp_evt::get_param_info(uint32_t id)
 	return &(m_info->params[id]);
 }
 
-uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_hex_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k;
@@ -260,7 +260,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 	uint32_t num_chunks;
 	uint32_t row_len;
 	char row[128];
-	char *ptr;
+	const char *ptr;
 	bool truncated = false;
 
 	for(j = 0; j < srclen; j += 8 * sizeof(uint16_t))
@@ -346,7 +346,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, char *src, uint32_t dstlen, uint
 	}
 }
 
-uint32_t binary_buffer_to_asciionly_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_asciionly_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k = 0;
@@ -403,7 +403,7 @@ uint32_t binary_buffer_to_asciionly_string(char *dst, char *src, uint32_t dstlen
 	return k;
 }
 
-uint32_t binary_buffer_to_string_dots(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_string_dots(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k = 0;
@@ -446,7 +446,7 @@ uint32_t binary_buffer_to_string_dots(char *dst, char *src, uint32_t dstlen, uin
 	return k;
 }
 
-uint32_t binary_buffer_to_base64_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_base64_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	//
 	// base64 encoder, malloc-free version of:
@@ -493,7 +493,7 @@ uint32_t binary_buffer_to_base64_string(char *dst, char *src, uint32_t dstlen, u
 	return enc_dstlen;
 }
 
-uint32_t binary_buffer_to_json_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_json_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t k = 0;
 	switch(fmt)
@@ -514,7 +514,7 @@ uint32_t binary_buffer_to_json_string(char *dst, char *src, uint32_t dstlen, uin
 	return k;
 }
 
-uint32_t binary_buffer_to_string(char *dst, char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+uint32_t binary_buffer_to_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t k = 0;
 
@@ -557,7 +557,7 @@ uint32_t binary_buffer_to_string(char *dst, char *src, uint32_t dstlen, uint32_t
 	return k;
 }
 
-uint32_t strcpy_sanitized(char *dest, char *src, uint32_t dstsize)
+uint32_t strcpy_sanitized(char *dest, const char *src, uint32_t dstsize)
 {
 	volatile char* tmp = (volatile char *)dest;
 	uint32_t j = 0;
@@ -798,7 +798,7 @@ char* sinsp_evt::render_fd(int64_t fd, const char** resolved_str, sinsp_evt::par
 Json::Value sinsp_evt::get_param_as_json(uint32_t id, OUT const char** resolved_str, sinsp_evt::param_fmt fmt)
 {
 	const ppm_param_info* param_info = NULL;
-	char* payload = NULL;
+	const char* payload = NULL;
 	uint32_t payload_len = 0;
 	Json::Value ret = Json::nullValue;
 
@@ -1543,7 +1543,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 {
 	char* prfmt = NULL;
 	const ppm_param_info* param_info = NULL;
-	char* payload = NULL;
+	const char* payload = NULL;
 	uint32_t j = 0;
 	uint32_t payload_len = 0;
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2862,7 +2862,7 @@ std::optional<std::reference_wrapper<std::string>> sinsp_evt::get_enter_evt_para
 	return ret;
 }
 
-std::string sinsp_evt_param::invalid_len_error(size_t requested_length) const
+void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const
 {
 	const struct ppm_param_info* parinfo = get_info();
 
@@ -2871,7 +2871,7 @@ std::string sinsp_evt_param::invalid_len_error(size_t requested_length) const
 		<< m_evt->get_num() << " of type " << m_evt->get_type() << " (" << m_evt->get_name() << "): expected length "
 		<< requested_length << ", found " << m_len;
 
-	return std::string(ss.str());
+	throw sinsp_exception(ss.str());
 }
 
 const struct ppm_param_info* sinsp_evt_param::get_info() const

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -199,6 +199,33 @@ sinsp_evt_param *sinsp_evt::get_param(uint32_t id)
 	return &(m_params.at(id));
 }
 
+const sinsp_evt_param* sinsp_evt::get_param_by_name(const char* name)
+{
+	//
+	// Make sure the params are actually loaded
+	//
+	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0)
+	{
+		load_params();
+		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+	}
+
+	//
+	// Locate the parameter given the name
+	//
+	uint32_t np = get_num_params();
+
+	for(uint32_t j = 0; j < np; j++)
+	{
+		if(strcmp(name, get_param_name(j)) == 0)
+		{
+			return &(m_params[j]);
+		}
+	}
+
+	return NULL;
+}
+
 const char *sinsp_evt::get_param_name(uint32_t id)
 {
 	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0)
@@ -2576,33 +2603,6 @@ const char* sinsp_evt::get_param_value_str(const char* name, OUT const char** re
 	return NULL;
 }
 
-const sinsp_evt_param* sinsp_evt::get_param_value_raw(const char* name)
-{
-	//
-	// Make sure the params are actually loaded
-	//
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0)
-	{
-		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
-	}
-
-	//
-	// Locate the parameter given the name
-	//
-	uint32_t np = get_num_params();
-
-	for(uint32_t j = 0; j < np; j++)
-	{
-		if(strcmp(name, get_param_name(j)) == 0)
-		{
-			return &(m_params[j]);
-		}
-	}
-
-	return NULL;
-}
-
 void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 {
 	/* We always search the category inside the event table */
@@ -2884,7 +2884,7 @@ void sinsp_evt::save_enter_event_params(sinsp_evt* enter_evt)
 	{
 		const sinsp_evt_param *param;
 
-		param = enter_evt->get_param_value_raw(pname);
+		param = enter_evt->get_param_by_name(pname);
 		if(param)
 		{
 			std::string val;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1519,7 +1519,7 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo)
 		return cwd;
 	}
 
-	const int64_t dirfd = get_param<int64_t>(dirfd_id);
+	const int64_t dirfd = get_param(dirfd_id)->as<int64_t>();
 
 	// If the FD is special value PPM_AT_FDCWD, just use CWD
 	if (dirfd == PPM_AT_FDCWD)
@@ -2894,19 +2894,6 @@ void sinsp_evt::save_enter_event_params(sinsp_evt* enter_evt)
 	}
 }
 
-std::string sinsp_evt::invalid_param_len_error(uint32_t id, size_t requested_length)
-{
-	const sinsp_evt_param *param = get_param(id);
-	const struct ppm_param_info* parinfo = get_param_info(id);
-
-	std::stringstream ss;
-	ss << "could not parse param " << id << " (" << parinfo->name << ") for event "
-		<< get_num() << " of type " << get_type() << " (" << get_name() << "): expected length "
-		<< requested_length << ", found " << param->m_len;
-
-	return std::string(ss.str());
-}
-
 std::optional<std::reference_wrapper<std::string>> sinsp_evt::get_enter_evt_param(const std::string& param)
 {
 	std::optional<std::reference_wrapper<std::string>> ret;
@@ -2919,4 +2906,21 @@ std::optional<std::reference_wrapper<std::string>> sinsp_evt::get_enter_evt_para
 	}
 
 	return ret;
+}
+
+std::string sinsp_evt_param::invalid_len_error(size_t requested_length) const
+{
+	const struct ppm_param_info* parinfo = get_info();
+
+	std::stringstream ss;
+	ss << "could not parse param " << m_idx << " (" << parinfo->name << ") for event "
+		<< m_evt->get_num() << " of type " << m_evt->get_type() << " (" << m_evt->get_name() << "): expected length "
+		<< requested_length << ", found " << m_len;
+
+	return std::string(ss.str());
+}
+
+const struct ppm_param_info* sinsp_evt_param::get_info() const
+{
+	return &(m_evt->get_info()->params[m_idx]);
 }

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -98,16 +98,10 @@ public:
 class SINSP_PUBLIC sinsp_evt_param
 {
 public:
-	char* m_val;	///< Pointer to the event parameter data.
+	const char* m_val;	///< Pointer to the event parameter data.
 	uint32_t m_len; ///< Length of the parameter pointed by m_val.
-private:
-	inline void init(char* valptr, uint32_t len)
-	{
-		m_val = valptr;
-		m_len = len;
-	}
 
-	friend class sinsp_evt;
+	sinsp_evt_param(const char *val, uint32_t len): m_val(val), m_len(len) {}
 };
 
 /*!
@@ -546,7 +540,6 @@ private:
 	inline void load_params()
 	{
 		uint32_t j;
-		sinsp_evt_param par;
 		struct scap_sized_buffer params[PPM_MAX_EVENT_PARAMS];
 
 		m_params.clear();
@@ -617,8 +610,7 @@ private:
 				params[j].size = 5;
 			}
 
-			par.init((char*)params[j].buf, (int)params[j].size);
-			m_params.push_back(par);
+			m_params.emplace_back(static_cast<const char*>(params[j].buf), params[j].size);
 		}
 	}
 	std::string get_param_value_str(uint32_t id, bool resolved);

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -342,7 +342,7 @@ public:
 
 	  \param id The parameter number.
 	*/
-	sinsp_evt_param* get_param(uint32_t id);
+	const sinsp_evt_param* get_param(uint32_t id);
 
 	/*!
 	  \brief Get a parameter in raw format by name.

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -338,11 +338,18 @@ public:
 	const struct ppm_param_info* get_param_info(uint32_t id);
 
 	/*!
-	  \brief Get a parameter in raw format.
+	  \brief Get a parameter in raw format by position.
 
 	  \param id The parameter number.
 	*/
 	sinsp_evt_param* get_param(uint32_t id);
+
+	/*!
+	  \brief Get a parameter in raw format by name.
+
+	  \param name The parameter name.
+	*/
+	const sinsp_evt_param* get_param_by_name(const char* name);
 
 	/*!
 	  \brief Get the value of a fixed param (fixed length type or packed struct).
@@ -394,13 +401,6 @@ public:
 
 		return param->m_val;
 	}
-
-	/*!
-	  \brief Get a parameter in raw format.
-
-	  \param name The parameter name.
-	*/
-	const sinsp_evt_param* get_param_value_raw(const char* name);
 
 	/*!
 	  \brief Get a parameter as a C++ string.

--- a/userspace/libsinsp/examples/util.cpp
+++ b/userspace/libsinsp/examples/util.cpp
@@ -63,6 +63,6 @@ std::string get_event_type_name(sinsp_evt *ev)
 		return scap_get_event_info_table()[type].name;
 	}
 
-	uint16_t ppm_sc = ev->get_param<uint16_t>(0);
+	uint16_t ppm_sc = ev->get_param(0)->as<uint16_t>();
 	return scap_get_ppm_sc_name((ppm_sc_code)ppm_sc);
 }

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4106,7 +4106,7 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 
 		if(eflags & EF_READS_FROM_FD)
 		{
-			char *data;
+			const char *data;
 			uint32_t datalen;
 			int32_t tupleparam = -1;
 
@@ -4221,7 +4221,7 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 		}
 		else
 		{
-			char *data;
+			const char *data;
 			uint32_t datalen;
 			int32_t tupleparam = -1;
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -535,7 +535,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 		// we can assume it being of the "syscall" source. On the other hand,
 		// plugin events are not allowed to have a zero plugin ID, so we should
 		// be ok on that front.
-		plugin_id = evt->get_param<uint32_t>(0);
+		plugin_id = evt->get_param(0)->as<uint32_t>();
 	}
 
 	if (plugin_id != 0)
@@ -702,7 +702,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 			// The fd is always the first parameter of the enter event.
 			//
 			ASSERT(evt->get_param_info(0)->type == PT_FD);
-			evt->m_tinfo->m_lastevent_fd = evt->get_param<int64_t>(0);
+			evt->m_tinfo->m_lastevent_fd = evt->get_param(0)->as<int64_t>();
 			evt->m_fdinfo = evt->m_tinfo->get_fd(evt->m_tinfo->m_lastevent_fd);
 		}
 
@@ -755,7 +755,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 			  evt->m_info->params[0].name[1] == 'd' &&
 			  evt->m_info->params[0].name[2] == '\0')))
 		{
-			int64_t res = evt->get_param<int64_t>(0);
+			int64_t res = evt->get_param(0)->as<int64_t>();
 
 			if(res < 0)
 			{
@@ -774,7 +774,7 @@ bool sinsp_parser::reset(sinsp_evt *evt)
 			//
 			if(etype == PPME_SYSCALL_COPY_FILE_RANGE_X)
 			{
-				tinfo->m_lastevent_fd = evt->get_param<int64_t>(1);
+				tinfo->m_lastevent_fd = evt->get_param(1)->as<int64_t>();
 			}
 
 			evt->m_fdinfo = tinfo->get_fd(tinfo->m_lastevent_fd);
@@ -993,10 +993,10 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		valid_caller = false;
 
 		/* pid. */
-		caller_tinfo->m_pid = evt->get_param<int64_t>(4);
+		caller_tinfo->m_pid = evt->get_param(4)->as<int64_t>();
 
 		/* ptid */
-		caller_tinfo->m_ptid = evt->get_param<int64_t>(5);
+		caller_tinfo->m_ptid = evt->get_param(5)->as<int64_t>();
 
 		/* vtid & vpid */
 		/* We preset them for old scap-files compatibility. */
@@ -1016,9 +1016,9 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		case PPME_SYSCALL_FORK_20_X:
 		case PPME_SYSCALL_VFORK_20_X:
 		case PPME_SYSCALL_CLONE3_X:
-			caller_tinfo->m_vtid = evt->get_param<int64_t>(18);
+			caller_tinfo->m_vtid = evt->get_param(18)->as<int64_t>();
 
-			caller_tinfo->m_vpid = evt->get_param<int64_t>(19);		
+			caller_tinfo->m_vpid = evt->get_param(19)->as<int64_t>();		
 			break;
 		default:
 			ASSERT(false);
@@ -1046,23 +1046,23 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		flags = evt->get_param<uint32_t>(8);
+		flags = evt->get_param(8)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		flags = evt->get_param<uint32_t>(13);
+		flags = evt->get_param(13)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		flags = evt->get_param<uint32_t>(14);
+		flags = evt->get_param(14)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		flags = evt->get_param<uint32_t>(15);
+		flags = evt->get_param(15)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1230,7 +1230,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	child_tinfo->m_vpid = child_tinfo->m_pid;	
 
 	/* exe */
-	child_tinfo->m_exe = evt->get_param_const_char(1);
+	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
 
 	/* args */
 	parinfo = evt->get_param(2);
@@ -1252,14 +1252,14 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	case PPME_SYSCALL_VFORK_17_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		child_tinfo->m_comm = evt->get_param_const_char(13);
+		child_tinfo->m_comm = evt->get_param(13)->as<std::string_view>();
 		break;
 	default:
 		ASSERT(false);
 	}
 	
 	/* fdlimit */
-	child_tinfo->m_fdlimit = evt->get_param<int64_t>(7);
+	child_tinfo->m_fdlimit = evt->get_param(7)->as<int64_t>();
 
 	/* Generic memory info */
 	switch(etype)
@@ -1277,19 +1277,19 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
 		/* pgflt_maj */
-		child_tinfo->m_pfmajor = evt->get_param<uint64_t>(8);
+		child_tinfo->m_pfmajor = evt->get_param(8)->as<uint64_t>();
 
 		/* pgflt_min */
-		child_tinfo->m_pfminor = evt->get_param<uint64_t>(9);
+		child_tinfo->m_pfminor = evt->get_param(9)->as<uint64_t>();
 
 		/* vm_size */
-		child_tinfo->m_vmsize_kb = evt->get_param<uint32_t>(10);
+		child_tinfo->m_vmsize_kb = evt->get_param(10)->as<uint32_t>();
 
 		/* vm_rss */
-		child_tinfo->m_vmrss_kb = evt->get_param<uint32_t>(11);
+		child_tinfo->m_vmrss_kb = evt->get_param(11)->as<uint32_t>();
 
 		/* vm_swap */
-		child_tinfo->m_vmswap_kb = evt->get_param<uint32_t>(12);
+		child_tinfo->m_vmswap_kb = evt->get_param(12)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1300,23 +1300,23 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		uid = evt->get_param<int32_t>(9);
+		uid = evt->get_param(9)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		uid = evt->get_param<int32_t>(14);
+		uid = evt->get_param(14)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		uid = evt->get_param<int32_t>(15);
+		uid = evt->get_param(15)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		uid = evt->get_param<int32_t>(16);
+		uid = evt->get_param(16)->as<int32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1328,23 +1328,23 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		gid = evt->get_param<int32_t>(10);
+		gid = evt->get_param(10)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		gid = evt->get_param<int32_t>(15);
+		gid = evt->get_param(15)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		gid = evt->get_param<int32_t>(16);
+		gid = evt->get_param(16)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		gid = evt->get_param<int32_t>(17);
+		gid = evt->get_param(17)->as<int32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1529,10 +1529,10 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	child_tinfo->m_tid = child_tid;
 
 	/* pid */
-	child_tinfo->m_pid = evt->get_param<int64_t>(4);
+	child_tinfo->m_pid = evt->get_param(4)->as<int64_t>();
 
 	/* ptid. */
-	child_tinfo->m_ptid = evt->get_param<int64_t>(5);
+	child_tinfo->m_ptid = evt->get_param(5)->as<int64_t>();
 
 	/* `vtid` and `vpid`
 	 * We preset these values for old scap-files compatibility.
@@ -1553,9 +1553,9 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		child_tinfo->m_vtid = evt->get_param<int64_t>(18);
+		child_tinfo->m_vtid = evt->get_param(18)->as<int64_t>();
 
-		child_tinfo->m_vpid = evt->get_param<int64_t>(19);
+		child_tinfo->m_vpid = evt->get_param(19)->as<int64_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1566,23 +1566,23 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		flags = evt->get_param<uint32_t>(8);
+		flags = evt->get_param(8)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		flags = evt->get_param<uint32_t>(13);
+		flags = evt->get_param(13)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		flags = evt->get_param<uint32_t>(14);
+		flags = evt->get_param(14)->as<uint32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		flags = evt->get_param<uint32_t>(15);
+		flags = evt->get_param(15)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1673,7 +1673,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	 */
 
 	/* exe */
-	child_tinfo->m_exe = evt->get_param_const_char(1);
+	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
 
 	/* comm */
 	switch(etype)
@@ -1691,7 +1691,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	case PPME_SYSCALL_VFORK_17_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		child_tinfo->m_comm = evt->get_param_const_char(13);
+		child_tinfo->m_comm = evt->get_param(13)->as<std::string_view>();
 		break;
 	default:
 		ASSERT(false);
@@ -1814,7 +1814,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	}
 
 	/* fdlimit */
-	child_tinfo->m_fdlimit = evt->get_param<int64_t>(7);
+	child_tinfo->m_fdlimit = evt->get_param(7)->as<int64_t>();
 
 	/* Generic memory info */
 	switch(etype)
@@ -1832,19 +1832,19 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
 		/* pgflt_maj */
-		child_tinfo->m_pfmajor = evt->get_param<uint64_t>(8);
+		child_tinfo->m_pfmajor = evt->get_param(8)->as<uint64_t>();
 
 		/* pgflt_min */
-		child_tinfo->m_pfminor = evt->get_param<uint64_t>(9);
+		child_tinfo->m_pfminor = evt->get_param(9)->as<uint64_t>();
 
 		/* vm_size */
-		child_tinfo->m_vmsize_kb = evt->get_param<uint32_t>(10);
+		child_tinfo->m_vmsize_kb = evt->get_param(10)->as<uint32_t>();
 
 		/* vm_rss */
-		child_tinfo->m_vmrss_kb = evt->get_param<uint32_t>(11);
+		child_tinfo->m_vmrss_kb = evt->get_param(11)->as<uint32_t>();
 
 		/* vm_swap */
-		child_tinfo->m_vmswap_kb = evt->get_param<uint32_t>(12);
+		child_tinfo->m_vmswap_kb = evt->get_param(12)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1855,23 +1855,23 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		uid = evt->get_param<int32_t>(9);
+		uid = evt->get_param(9)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		uid = evt->get_param<int32_t>(14);
+		uid = evt->get_param(14)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		uid = evt->get_param<int32_t>(15);
+		uid = evt->get_param(15)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		uid = evt->get_param<int32_t>(16);
+		uid = evt->get_param(16)->as<int32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1883,23 +1883,23 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	switch(etype)
 	{
 	case PPME_SYSCALL_CLONE_11_X:
-		gid = evt->get_param<int32_t>(10);
+		gid = evt->get_param(10)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_16_X:
 	case PPME_SYSCALL_FORK_X:
 	case PPME_SYSCALL_VFORK_X:
-		gid = evt->get_param<int32_t>(15);
+		gid = evt->get_param(15)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_17_X:
 	case PPME_SYSCALL_FORK_17_X:
 	case PPME_SYSCALL_VFORK_17_X:
-		gid = evt->get_param<int32_t>(16);
+		gid = evt->get_param(16)->as<int32_t>();
 		break;
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_FORK_20_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		gid = evt->get_param<int32_t>(17);
+		gid = evt->get_param(17)->as<int32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -1931,7 +1931,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 			child_tinfo->m_tid != child_tinfo->m_vtid)
 		{
 			child_tinfo->m_pidns_init_start_ts =
-				evt->get_param<uint64_t>(20) + m_inspector->m_machine_info->boot_ts_epoch;
+				evt->get_param(20)->as<uint64_t>() + m_inspector->m_machine_info->boot_ts_epoch;
 		}
 		else
 		{
@@ -1994,7 +1994,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 
 void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 {
-	int64_t childtid = evt->get_param<int64_t>(0);
+	int64_t childtid = evt->get_param(0)->as<int64_t>();
 	/* Please note that if the child is in a namespace different from the init one
 	 * we should never use this `childtid` otherwise we will use a thread id referred to 
 	 * an internal namespace and not to the init one!
@@ -2025,7 +2025,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	sinsp_evt *enter_evt = &m_tmp_evt;
 
 	// Validate the return value
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	/* Some architectures like s390x send a `PPME_SYSCALL_EXECVEAT_X` exit event
 	 * when the `execveat` syscall succeeds, for this reason, we need to manage also
@@ -2086,7 +2086,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	case PPME_SYSCALL_EXECVE_19_X:
 	case PPME_SYSCALL_EXECVEAT_X:
 		// Get the comm
-		evt->m_tinfo->m_comm = evt->get_param_const_char(13);
+		evt->m_tinfo->m_comm = evt->get_param(13)->as<std::string_view>();
 		break;
 	default:
 		ASSERT(false);
@@ -2097,7 +2097,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	evt->m_tinfo->set_args(parinfo->m_val, parinfo->m_len);
 
 	// Get the pid
-	evt->m_tinfo->m_pid = evt->get_param<uint64_t>(4);
+	evt->m_tinfo->m_pid = evt->get_param(4)->as<uint64_t>();
 
 	//
 	// In case this thread is a fake entry,
@@ -2106,7 +2106,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	//
 	if(evt->m_tinfo->is_invalid())
 	{
-		evt->m_tinfo->m_ptid = evt->get_param<uint64_t>(5);
+		evt->m_tinfo->m_ptid = evt->get_param(5)->as<uint64_t>();
 
 		/* We are not in a namespace we recover also vtid and vpid */
 		if((evt->m_tinfo->m_flags & PPM_CL_CHILD_IN_PIDNS) == 0)
@@ -2121,7 +2121,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	}
 
 	// Get the fdlimit
-	evt->m_tinfo->m_fdlimit = evt->get_param<int64_t>(7);
+	evt->m_tinfo->m_fdlimit = evt->get_param(7)->as<int64_t>();
 
 	switch(etype)
 	{
@@ -2136,19 +2136,19 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	case PPME_SYSCALL_EXECVE_19_X:
 	case PPME_SYSCALL_EXECVEAT_X:
 		// Get the pgflt_maj
-		evt->m_tinfo->m_pfmajor = evt->get_param<uint64_t>(8);
+		evt->m_tinfo->m_pfmajor = evt->get_param(8)->as<uint64_t>();
 
 		// Get the pgflt_min
-		evt->m_tinfo->m_pfminor = evt->get_param<uint64_t>(9);
+		evt->m_tinfo->m_pfminor = evt->get_param(9)->as<uint64_t>();
 
 		// Get the vm_size
-		evt->m_tinfo->m_vmsize_kb = evt->get_param<uint32_t>(10);
+		evt->m_tinfo->m_vmsize_kb = evt->get_param(10)->as<uint32_t>();
 
 		// Get the vm_rss
-		evt->m_tinfo->m_vmrss_kb = evt->get_param<uint32_t>(11);
+		evt->m_tinfo->m_vmrss_kb = evt->get_param(11)->as<uint32_t>();
 
 		// Get the vm_swap
-		evt->m_tinfo->m_vmswap_kb = evt->get_param<uint32_t>(12);
+		evt->m_tinfo->m_vmswap_kb = evt->get_param(12)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -2213,7 +2213,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	case PPME_SYSCALL_EXECVE_19_X:
 	case PPME_SYSCALL_EXECVEAT_X:
 		// Get the tty
-		evt->m_tinfo->m_tty = evt->get_param<uint32_t>(16);
+		evt->m_tinfo->m_tty = evt->get_param(16)->as<uint32_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -2286,12 +2286,12 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 				/*
 				* Get dirfd
 				*/
-				int64_t dirfd = enter_evt->get_param<int64_t>(0);
+				int64_t dirfd = enter_evt->get_param(0)->as<int64_t>();
 
 				/*
 				* Get flags
 				*/
-				uint32_t flags = enter_evt->get_param<uint32_t>(2);
+				uint32_t flags = enter_evt->get_param(2)->as<uint32_t>();
 
 				/*
 				* Get pathname
@@ -2308,19 +2308,19 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 				* 	 Please note:
 				*   The path is empty in the kernel but in userspace, we will obtain a `<NA>`.
 				*/
-				const char *pathname = enter_evt->get_param_const_char(1);
+				std::string_view pathname = enter_evt->get_param(1)->as<std::string_view>();
 
 				/* If the pathname is `<NA>` here we shouldn't have problems during `parse_dirfd`.
 				* It doesn't start with "/" so it is not considered an absolute path.
 				*/
 				std::string sdir;
-				parse_dirfd(evt, pathname, dirfd, &sdir);
+				parse_dirfd(evt, pathname.data(), dirfd, &sdir);
 
 				/* (4) In this case, we were not able to recover the pathname from the kernel or
 				* we are not able to recover information about `dirfd` in our `sinsp` state.
 				* Fallback to `<NA>`.
 				*/
-				if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && strncmp(pathname, "<NA>", 5) == 0) ||
+				if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && strncmp(pathname.data(), "<NA>", 5) == 0) ||
 				sdir.compare("<UNKNOWN>") == 0)
 				{
 					/* we copy also the string terminator `\0`. */
@@ -2351,8 +2351,8 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 					sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
 												sdir.c_str(),
 												(uint32_t)sdir.length(),
-												pathname,
-												strlen(pathname));
+												pathname.data(),
+												pathname.size());
 				}
 			}
 			evt->m_tinfo->m_exepath = fullpath;
@@ -2372,7 +2372,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	case PPME_SYSCALL_EXECVE_19_X:
 	case PPME_SYSCALL_EXECVEAT_X:
 		// Get the vpgid
-		evt->m_tinfo->m_vpgid = evt->get_param<int64_t>(17);
+		evt->m_tinfo->m_vpgid = evt->get_param(17)->as<int64_t>();
 		break;
 	default:
 		ASSERT(false);
@@ -2392,13 +2392,13 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// Get the loginuid
 	if(evt->get_num_params() > 18)
 	{
-		evt->m_tinfo->set_loginuser(evt->get_param<uint32_t>(18));
+		evt->m_tinfo->set_loginuser(evt->get_param(18)->as<uint32_t>());
 	}
 
 	// Get execve flags
 	if(evt->get_num_params() > 19)
 	{
-		uint32_t flags = evt->get_param<uint32_t>(19);
+		uint32_t flags = evt->get_param(19)->as<uint32_t>();
 
 		evt->m_tinfo->m_exe_writable = ((flags & PPM_EXE_WRITABLE) != 0);
 		evt->m_tinfo->m_exe_upper_layer = ((flags & PPM_EXE_UPPER_LAYER) != 0);
@@ -2410,22 +2410,22 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	{
 		if(etype == PPME_SYSCALL_EXECVE_19_X || etype == PPME_SYSCALL_EXECVEAT_X)
 		{
-			evt->m_tinfo->m_cap_inheritable = evt->get_param<uint64_t>(20);
+			evt->m_tinfo->m_cap_inheritable = evt->get_param(20)->as<uint64_t>();
 
-			evt->m_tinfo->m_cap_permitted = evt->get_param<uint64_t>(21);
+			evt->m_tinfo->m_cap_permitted = evt->get_param(21)->as<uint64_t>();
 
-			evt->m_tinfo->m_cap_effective = evt->get_param<uint64_t>(22);
+			evt->m_tinfo->m_cap_effective = evt->get_param(22)->as<uint64_t>();
 		}
 	}
 
 	// Get exe ino fields
 	if(evt->get_num_params() > 25)
 	{
-		evt->m_tinfo->m_exe_ino = evt->get_param<uint64_t>(23);
+		evt->m_tinfo->m_exe_ino = evt->get_param(23)->as<uint64_t>();
 
-		evt->m_tinfo->m_exe_ino_ctime = evt->get_param<uint64_t>(24);
+		evt->m_tinfo->m_exe_ino_ctime = evt->get_param(24)->as<uint64_t>();
 
-		evt->m_tinfo->m_exe_ino_mtime = evt->get_param<uint64_t>(25);
+		evt->m_tinfo->m_exe_ino_mtime = evt->get_param(25)->as<uint64_t>();
 
 		if(evt->m_tinfo->m_clone_ts != 0)
 		{
@@ -2441,7 +2441,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// Get uid
 	if(evt->get_num_params() > 26)
 	{
-		evt->m_tinfo->m_user.uid = evt->get_param<uint32_t>(26);
+		evt->m_tinfo->m_user.uid = evt->get_param(26)->as<uint32_t>();
 	}
 
 	//
@@ -2589,8 +2589,8 @@ void sinsp_parser::parse_dirfd(sinsp_evt *evt, const char* name, int64_t dirfd, 
 void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 {
 	int64_t fd;
-	const char *name;
-	const char *enter_evt_name;
+	std::string_view name;
+	std::string_view enter_evt_name;
 	uint32_t flags;
 	uint32_t enter_evt_flags;
 	sinsp_fdinfo_t fdi;
@@ -2618,22 +2618,22 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	//
 	// Check the return value
 	//
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	//
 	// Parse the parameters, based on the event type
 	//
 	if(etype == PPME_SYSCALL_OPEN_X)
 	{
-		name = evt->get_param_const_char(1);
-		flags = evt->get_param<uint32_t>(2);
+		name = evt->get_param(1)->as<std::string_view>();
+		flags = evt->get_param(2)->as<uint32_t>();
 
 		if(evt->get_num_params() > 4)
 		{
-			dev = evt->get_param<uint32_t>(4);
+			dev = evt->get_param(4)->as<uint32_t>();
 			if (evt->get_num_params() > 5)
 			{
-				ino = evt->get_param<uint64_t>(5);
+				ino = evt->get_param(5)->as<uint64_t>();
 			}
 		}
 
@@ -2642,10 +2642,10 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		//
 		if(lastevent_retrieved && enter_evt->get_num_params() >= 2)
 		{
-			enter_evt_name = enter_evt->get_param_const_char(0);
-			enter_evt_flags = enter_evt->get_param<uint32_t>(1);
+			enter_evt_name = enter_evt->get_param(0)->as<std::string_view>();
+			enter_evt_flags = enter_evt->get_param(1)->as<uint32_t>();
 
-			if(enter_evt_name != nullptr && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 
@@ -2661,25 +2661,25 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	}
 	else if(etype == PPME_SYSCALL_CREAT_X)
 	{
-		name = evt->get_param_const_char(1);
+		name = evt->get_param(1)->as<std::string_view>();
 
 		flags = 0;
 
 		if(evt->get_num_params() > 3)
 		{
-			dev = evt->get_param<uint32_t>(3);
+			dev = evt->get_param(3)->as<uint32_t>();
 			if (evt->get_num_params() > 4)
 			{
-				ino = evt->get_param<uint64_t>(4);
+				ino = evt->get_param(4)->as<uint64_t>();
 			}
 		}
 
 		if(lastevent_retrieved && enter_evt->get_num_params() >= 1)
 		{
-			enter_evt_name = enter_evt->get_param_const_char(0);
+			enter_evt_name = enter_evt->get_param(0)->as<std::string_view>();
 			enter_evt_flags = 0;
 
-			if(enter_evt_name != nullptr && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 
@@ -2695,28 +2695,28 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	}
 	else if(etype == PPME_SYSCALL_OPENAT_X)
 	{
-		name = enter_evt->get_param_const_char(1);
+		name = enter_evt->get_param(1)->as<std::string_view>();
 
-		flags = enter_evt->get_param<uint32_t>(2);
+		flags = enter_evt->get_param(2)->as<uint32_t>();
 
-		int64_t dirfd = enter_evt->get_param<int64_t>(0);
+		int64_t dirfd = enter_evt->get_param(0)->as<int64_t>();
 
-		parse_dirfd(evt, name, dirfd, &sdir);
+		parse_dirfd(evt, name.data(), dirfd, &sdir);
 	}
 	else if(etype == PPME_SYSCALL_OPENAT_2_X || etype == PPME_SYSCALL_OPENAT2_X)
 	{
-		name = evt->get_param_const_char(2);
+		name = evt->get_param(2)->as<std::string_view>();
 
-		flags = evt->get_param<uint32_t>(3);
+		flags = evt->get_param(3)->as<uint32_t>();
 
-		int64_t dirfd = evt->get_param<int64_t>(1);
+		int64_t dirfd = evt->get_param(1)->as<int64_t>();
 
 		if(etype == PPME_SYSCALL_OPENAT_2_X && evt->get_num_params() > 5)
 		{
-			dev = evt->get_param<uint32_t>(5);
+			dev = evt->get_param(5)->as<uint32_t>();
 			if (evt->get_num_params() > 6)
 			{
-				ino = evt->get_param<uint64_t>(6);
+				ino = evt->get_param(6)->as<uint64_t>();
 			}
 		}
 
@@ -2725,11 +2725,11 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		//
 		if(lastevent_retrieved && enter_evt->get_num_params() >= 3)
 		{
-			enter_evt_name = enter_evt->get_param_const_char(1);
-			enter_evt_flags = enter_evt->get_param<uint32_t>(2);
-			int64_t enter_evt_dirfd = enter_evt->get_param<int64_t>(0);
+			enter_evt_name = enter_evt->get_param(1)->as<std::string_view>();
+			enter_evt_flags = enter_evt->get_param(2)->as<uint32_t>();
+			int64_t enter_evt_dirfd = enter_evt->get_param(0)->as<int64_t>();
 
-			if(enter_evt_name != nullptr && strncmp(enter_evt_name, "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
 			{
 				name = enter_evt_name;
 
@@ -2743,19 +2743,19 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			}
 		}
 
-		parse_dirfd(evt, name, dirfd, &sdir);
+		parse_dirfd(evt, name.data(), dirfd, &sdir);
 	}
 	else if (etype == PPME_SYSCALL_OPEN_BY_HANDLE_AT_X)
 	{
 		/*
 		 * Flags
 		 */
-		flags = evt->get_param<uint32_t>(2);
+		flags = evt->get_param(2)->as<uint32_t>();
 
 		/*
 		 * Path
 		 */
-		name = evt->get_param_const_char(3);
+		name = evt->get_param(3)->as<std::string_view>();
 
 		// since open_by_handle_at returns an absolute path we will always start at /
 		sdir = "";
@@ -2774,7 +2774,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	char fullpath[SCAP_MAX_PATH_SIZE];
 
 	sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE, sdir.c_str(), (uint32_t)sdir.length(),
-		name, strlen(name));
+		name.data(), name.size());
 
 	if(fd >= 0)
 	{
@@ -2794,7 +2794,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		fdi.m_mount_id = 0;
 		fdi.m_dev = dev;
 		fdi.m_ino = ino;
-		fdi.add_filename_raw(name);
+		fdi.add_filename_raw(name.data());
 		fdi.add_filename(fullpath);
 
 		//
@@ -2822,7 +2822,7 @@ void sinsp_parser::parse_fchmod_fchown_exit(sinsp_evt *evt)
 	}
 
 	ASSERT(evt->get_param_info(1)->type == PT_FD);
-	int64_t fd = evt->get_param<int64_t>(1);
+	int64_t fd = evt->get_param(1)->as<int64_t>();
 	evt->m_tinfo->m_lastevent_fd = fd;
 	evt->m_fdinfo = evt->m_tinfo->get_fd(fd);
 }
@@ -2957,7 +2957,7 @@ inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 	const sinsp_evt_param* parinfo = nullptr;
 
 	ASSERT(evt->get_param_info(FILE_DESCRIPTOR_PARAM)->type == PT_FD);
-	int64_t fd = evt->get_param<int64_t>(FILE_DESCRIPTOR_PARAM);
+	int64_t fd = evt->get_param(FILE_DESCRIPTOR_PARAM)->as<int64_t>();
 
 	if(fd < 0)
 	{
@@ -3006,7 +3006,7 @@ void sinsp_parser::parse_socket_exit(sinsp_evt *evt)
 	// parameters in one scan. We don't care too much because we assume that we get here
 	// seldom enough that saving few tens of CPU cycles is not important.
 	//
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	if(fd < 0)
 	{
@@ -3032,9 +3032,9 @@ void sinsp_parser::parse_socket_exit(sinsp_evt *evt)
 	//
 	// Extract the arguments
 	//
-	domain = enter_evt->get_param<uint32_t>(0);
-	type = enter_evt->get_param<uint32_t>(1);
-	protocol = enter_evt->get_param<uint32_t>(2);
+	domain = enter_evt->get_param(0)->as<uint32_t>();
+	type = enter_evt->get_param(1)->as<uint32_t>();
+	protocol = enter_evt->get_param(2)->as<uint32_t>();
 
 	//
 	// Allocate a new fd descriptor, populate it and add it to the thread fd table
@@ -3055,7 +3055,7 @@ void sinsp_parser::parse_bind_exit(sinsp_evt *evt)
 		return;
 	}
 
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
@@ -3349,7 +3349,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 		// try harder to be resilient.
 		if(evt->get_num_params() > 2)
 		{
-	                fd = evt->get_param<int64_t>(2);
+	                fd = evt->get_param(2)->as<int64_t>();
 			if(fd < 0)
 			{
 				//
@@ -3377,7 +3377,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 		}
 	}
 
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if (m_track_connection_status)
 	{
@@ -3447,7 +3447,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt *evt)
 	//
 	// Extract the fd
 	//
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	if(fd < 0)
 	{
@@ -3607,7 +3607,7 @@ void sinsp_parser::parse_close_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// If the close() was successful, do the cleanup
@@ -3702,7 +3702,7 @@ void sinsp_parser::parse_socketpair_exit(sinsp_evt *evt)
 	uint64_t source_address;
 	uint64_t peer_address;
 
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
@@ -3718,13 +3718,13 @@ void sinsp_parser::parse_socketpair_exit(sinsp_evt *evt)
 		return;
 	}
 
-	fd1 = evt->get_param<int64_t>(1);
+	fd1 = evt->get_param(1)->as<int64_t>();
 
-	fd2 = evt->get_param<int64_t>(2);
+	fd2 = evt->get_param(2)->as<int64_t>();
 
-	source_address = evt->get_param<uint64_t>(3);
+	source_address = evt->get_param(3)->as<uint64_t>();
 
-	peer_address = evt->get_param<uint64_t>(4);
+	peer_address = evt->get_param(4)->as<uint64_t>();
 
 	sinsp_fdinfo_t fdi;
 	fdi.m_type = SCAP_FD_UNIX_SOCK;
@@ -3741,7 +3741,7 @@ void sinsp_parser::parse_pipe_exit(sinsp_evt *evt)
 	uint64_t ino;
 	uint32_t openflags = 0;
 
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
@@ -3751,15 +3751,15 @@ void sinsp_parser::parse_pipe_exit(sinsp_evt *evt)
 		return;
 	}
 
-	fd1 = evt->get_param<int64_t>(1);
+	fd1 = evt->get_param(1)->as<int64_t>();
 
-	fd2 = evt->get_param<int64_t>(2);
+	fd2 = evt->get_param(2)->as<int64_t>();
 
-	ino = evt->get_param<uint64_t>(3);
+	ino = evt->get_param(3)->as<uint64_t>();
 
 	if(evt->get_type() == PPME_SYSCALL_PIPE2_X)
 	{
-		openflags = evt->get_param<uint32_t>(4);
+		openflags = evt->get_param(4)->as<uint32_t>();
 	}
 
 	add_pipe(evt, fd1, ino, openflags);
@@ -3808,7 +3808,7 @@ void sinsp_parser::parse_thread_exit(sinsp_evt *evt)
 	 */
 	if(evt->get_type() == PPME_PROCEXIT_1_E && evt->get_num_params() > 4)
 	{
-		evt->m_tinfo->m_reaper_tid = evt->get_param<int64_t>(4);
+		evt->m_tinfo->m_reaper_tid = evt->get_param(4)->as<int64_t>();
 	}
 	else
 	{
@@ -4085,7 +4085,7 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(evt->m_fdinfo == NULL)
 	{
@@ -4324,7 +4324,7 @@ void sinsp_parser::parse_sendfile_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// If the operation was successful, validate that the fd exists
@@ -4342,7 +4342,7 @@ void sinsp_parser::parse_sendfile_exit(sinsp_evt *evt)
 		//
 		// Extract the in FD
 		//
-		fdin = enter_evt->get_param<int64_t>(1);
+		fdin = enter_evt->get_param(1)->as<int64_t>();
 
 		//
 		// If there's an fd listener, call it now
@@ -4367,7 +4367,7 @@ void sinsp_parser::parse_eventfd_exit(sinsp_evt *evt)
 		return;
 	}
 
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	if(fd < 0)
 	{
@@ -4385,7 +4385,7 @@ void sinsp_parser::parse_eventfd_exit(sinsp_evt *evt)
 
 	if(evt->get_type() == PPME_SYSCALL_EVENTFD2_X)
 	{
-		fdi.m_openflags = evt->get_param<uint16_t>(1);
+		fdi.m_openflags = evt->get_param(1)->as<uint16_t>();
 	}
 
 	//
@@ -4406,7 +4406,7 @@ void sinsp_parser::parse_chdir_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// In case of success, update the thread working dir
@@ -4428,7 +4428,7 @@ void sinsp_parser::parse_fchdir_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// In case of success, update the thread working dir
@@ -4457,7 +4457,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// Check if the syscall was successful
@@ -4524,7 +4524,7 @@ void sinsp_parser::parse_shutdown_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// If the operation was successful, do the cleanup
@@ -4555,7 +4555,7 @@ void sinsp_parser::parse_dup_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// Check if the syscall was successful
@@ -4611,7 +4611,7 @@ void sinsp_parser::parse_dup_exit(sinsp_evt *evt)
 			//
 			// Get the flags parameter.
 			//
-			flags = evt->get_param<uint32_t>(3);
+			flags = evt->get_param(3)->as<uint32_t>();
 
 			//
 			// We keep the previously flags that has been set on the original file descriptor and
@@ -4645,7 +4645,7 @@ void sinsp_parser::parse_single_param_fd_exit(sinsp_evt* evt, scap_fd_type type)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(evt->m_tinfo == nullptr)
 	{
@@ -4669,12 +4669,12 @@ void sinsp_parser::parse_single_param_fd_exit(sinsp_evt* evt, scap_fd_type type)
 
 	if(evt->get_type() == PPME_SYSCALL_INOTIFY_INIT1_X)
 	{
-		fdi.m_openflags = evt->get_param<uint16_t>(1);
+		fdi.m_openflags = evt->get_param(1)->as<uint16_t>();
 	}
 
 	if(evt->get_type() == PPME_SYSCALL_SIGNALFD4_X)
 	{
-		fdi.m_openflags = evt->get_param<uint16_t>(1);
+		fdi.m_openflags = evt->get_param(1)->as<uint16_t>();
 	}
 
 	//
@@ -4698,7 +4698,7 @@ void sinsp_parser::parse_getrlimit_setrlimit_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// Check if the syscall was successful
@@ -4716,14 +4716,14 @@ void sinsp_parser::parse_getrlimit_setrlimit_exit(sinsp_evt *evt)
 		//
 		// Extract the resource number
 		//
-		resource = enter_evt->get_param<uint8_t>(0);
+		resource = enter_evt->get_param(0)->as<uint8_t>();
 
 		if(resource == PPM_RLIMIT_NOFILE)
 		{
 			//
 			// Extract the current value for the resource
 			//
-			curval = evt->get_param<uint64_t>(1);
+			curval = evt->get_param(1)->as<uint64_t>();
 
 			if(curval != -1)
 			{
@@ -4753,7 +4753,7 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// Check if the syscall was successful
@@ -4771,21 +4771,21 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt *evt)
 		//
 		// Extract the resource number
 		//
-		resource = enter_evt->get_param<uint8_t>(1);
+		resource = enter_evt->get_param(1)->as<uint8_t>();
 
 		if(resource == PPM_RLIMIT_NOFILE)
 		{
 			//
 			// Extract the current value for the resource
 			//
-			newcur = evt->get_param<uint64_t>(1);
+			newcur = evt->get_param(1)->as<uint64_t>();
 
 			if(newcur != -1)
 			{
 				//
 				// Extract the tid and look for its process info
 				//
-				tid = enter_evt->get_param<int64_t>(0);
+				tid = enter_evt->get_param(0)->as<int64_t>();
 
 				if(tid == 0)
 				{
@@ -4841,7 +4841,7 @@ void sinsp_parser::parse_fcntl_enter(sinsp_evt *evt)
 		return;
 	}
 
-	uint8_t cmd = evt->get_param<int8_t>(1);
+	uint8_t cmd = evt->get_param(1)->as<int8_t>();
 
 	if(cmd == PPM_FCNTL_F_DUPFD || cmd == PPM_FCNTL_F_DUPFD_CLOEXEC)
 	{
@@ -4857,7 +4857,7 @@ void sinsp_parser::parse_fcntl_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	//
 	// If this is not a F_DUPFD or F_DUPFD_CLOEXEC command, ignore it
@@ -4890,18 +4890,18 @@ void sinsp_parser::parse_context_switch(sinsp_evt* evt)
 {
 	if(evt->m_tinfo != nullptr)
 	{
-		evt->m_tinfo->m_pfmajor = evt->get_param<uint64_t>(1);
+		evt->m_tinfo->m_pfmajor = evt->get_param(1)->as<uint64_t>();
 
-		evt->m_tinfo->m_pfminor = evt->get_param<uint64_t>(2);
+		evt->m_tinfo->m_pfminor = evt->get_param(2)->as<uint64_t>();
 
 		auto main_tinfo = evt->m_tinfo->get_main_thread();
 		if(main_tinfo)
 		{
-			main_tinfo->m_vmsize_kb = evt->get_param<uint32_t>(3);
+			main_tinfo->m_vmsize_kb = evt->get_param(3)->as<uint32_t>();
 
-			main_tinfo->m_vmrss_kb = evt->get_param<uint32_t>(4);
+			main_tinfo->m_vmrss_kb = evt->get_param(4)->as<uint32_t>();
 
-			main_tinfo->m_vmswap_kb = evt->get_param<uint32_t>(5);
+			main_tinfo->m_vmswap_kb = evt->get_param(5)->as<uint32_t>();
 		}
 	}
 }
@@ -4911,9 +4911,9 @@ void sinsp_parser::parse_brk_munmap_mmap_exit(sinsp_evt* evt)
 	ASSERT(evt->m_tinfo);
 	if(evt->m_tinfo != nullptr)
 	{
-		evt->m_tinfo->m_vmsize_kb = evt->get_param<uint32_t>(1);
-		evt->m_tinfo->m_vmrss_kb = evt->get_param<uint32_t>(2);
-		evt->m_tinfo->m_vmswap_kb = evt->get_param<uint32_t>(3);
+		evt->m_tinfo->m_vmsize_kb = evt->get_param(1)->as<uint32_t>();
+		evt->m_tinfo->m_vmrss_kb = evt->get_param(2)->as<uint32_t>();
+		evt->m_tinfo->m_vmswap_kb = evt->get_param(3)->as<uint32_t>();
 	}
 }
 
@@ -4925,11 +4925,11 @@ void sinsp_parser::parse_setresuid_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval >= 0 && retrieve_enter_event(enter_evt, evt))
 	{
-		uint32_t new_euid = enter_evt->get_param<uint32_t>(1);
+		uint32_t new_euid = enter_evt->get_param(1)->as<uint32_t>();
 
 		if(new_euid < std::numeric_limits<uint32_t>::max())
 		{
@@ -4948,11 +4948,11 @@ void sinsp_parser::parse_setresgid_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval >= 0 && retrieve_enter_event(enter_evt, evt))
 	{
-		uint32_t new_egid = enter_evt->get_param<uint32_t>(1);
+		uint32_t new_egid = enter_evt->get_param(1)->as<uint32_t>();
 
 		if(new_egid < std::numeric_limits<uint32_t>::max())
 		{
@@ -4971,11 +4971,11 @@ void sinsp_parser::parse_setuid_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval >= 0 && retrieve_enter_event(enter_evt, evt))
 	{
-		uint32_t new_euid = enter_evt->get_param<uint32_t>(0);
+		uint32_t new_euid = enter_evt->get_param(0)->as<uint32_t>();
 		if (evt->get_thread_info()) {
 			evt->get_thread_info()->set_user(new_euid);
 		}
@@ -4990,11 +4990,11 @@ void sinsp_parser::parse_setgid_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval >= 0 && retrieve_enter_event(enter_evt, evt))
 	{
-		uint32_t new_egid = enter_evt->get_param<uint32_t>(0);
+		uint32_t new_egid = enter_evt->get_param(0)->as<uint32_t>();
 		if (evt->get_thread_info()) {
 			evt->get_thread_info()->set_group(new_egid);
 		}
@@ -5320,7 +5320,7 @@ void sinsp_parser::parse_container_evt(sinsp_evt *evt)
 	parinfo = evt->get_param(0);
 	container->m_id = parinfo->m_val;
 
-	container->m_type = (sinsp_container_type) evt->get_param<uint32_t>(1);
+	container->m_type = (sinsp_container_type) evt->get_param(1)->as<uint32_t>();
 
 	parinfo = evt->get_param(2);
 	container->m_name = parinfo->m_val;
@@ -5334,39 +5334,39 @@ void sinsp_parser::parse_container_evt(sinsp_evt *evt)
 void sinsp_parser::parse_user_evt(sinsp_evt *evt)
 {
 	uint32_t uid, gid;
-	const char *name, *home, *shell, *container_id;
+	std::string_view name, home, shell, container_id;
 
-	uid = evt->get_param<uint32_t>(0);
+	uid = evt->get_param(0)->as<uint32_t>();
 
-	gid = evt->get_param<uint32_t>(1);
+	gid = evt->get_param(1)->as<uint32_t>();
 
-	name = evt->get_param_const_char(2);
-	home = evt->get_param_const_char(3);
-	shell = evt->get_param_const_char(4);
-	container_id = evt->get_param_const_char(5);
+	name = evt->get_param(2)->as<std::string_view>();
+	home = evt->get_param(3)->as<std::string_view>();
+	shell = evt->get_param(4)->as<std::string_view>();
+	container_id = evt->get_param(5)->as<std::string_view>();
 
 	if (evt->m_pevt->type == PPME_USER_ADDED_E)
 	{
-		m_inspector->m_usergroup_manager.add_user(container_id, -1, uid, gid, name, home, shell);
+		m_inspector->m_usergroup_manager.add_user(container_id.data(), -1, uid, gid, name.data(), home.data(), shell.data());
 	} else
 	{
-		m_inspector->m_usergroup_manager.rm_user(container_id, uid);
+		m_inspector->m_usergroup_manager.rm_user(container_id.data(), uid);
 	}
 }
 
 void sinsp_parser::parse_group_evt(sinsp_evt *evt)
 {
-	uint32_t gid = evt->get_param<uint32_t>(0);
+	uint32_t gid = evt->get_param(0)->as<uint32_t>();
 
-	const char *name = evt->get_param_const_char(1);
-	const char *container_id = evt->get_param_const_char(2);
+	std::string_view name = evt->get_param(1)->as<std::string_view>();
+	std::string_view container_id = evt->get_param(2)->as<std::string_view>();
 
 	if ( evt->m_pevt->type == PPME_GROUP_ADDED_E)
 	{
-		m_inspector->m_usergroup_manager.add_group(container_id, -1, gid, name);
+		m_inspector->m_usergroup_manager.add_group(container_id.data(), -1, gid, name.data());
 	} else
 	{
-		m_inspector->m_usergroup_manager.rm_group(container_id, gid);
+		m_inspector->m_usergroup_manager.rm_group(container_id.data(), gid);
 	}
 }
 
@@ -5382,7 +5382,7 @@ void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)
 void sinsp_parser::parse_prctl_exit_event(sinsp_evt *evt)
 {
 	/* Parameter 1: res (type: PT_ERRNO) */
-	int64_t retval = evt->get_param<int64_t>(0);
+	int64_t retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
@@ -5401,7 +5401,7 @@ void sinsp_parser::parse_prctl_exit_event(sinsp_evt *evt)
 	bool child_subreaper = false;
 
 	/* Parameter 2: option (type: PT_ENUMFLAGS32) */
-	uint32_t option = evt->get_param<uint32_t>(1);
+	uint32_t option = evt->get_param(1)->as<uint32_t>();
 	switch(option)
 	{
 		case PPM_PR_SET_CHILD_SUBREAPER:
@@ -5409,14 +5409,14 @@ void sinsp_parser::parse_prctl_exit_event(sinsp_evt *evt)
 			/* If the user provided an arg2 != 0, we set the child_subreaper
 			 * attribute for the calling process. If arg2 is zero, unset the attribute
 			 */
-			child_subreaper = (evt->get_param<int64_t>(3)) != 0 ? true : false;
+			child_subreaper = (evt->get_param(3)->as<int64_t>()) != 0 ? true : false;
 			caller_tinfo->m_tginfo->set_reaper(child_subreaper);
 			break;
 
 		case PPM_PR_GET_CHILD_SUBREAPER:
 			/* Parameter 4: arg2_int (type: PT_INT64) */
 			/* arg2 != 0 means the calling process is a child_subreaper */
-			child_subreaper = (evt->get_param<int64_t>(3)) != 0 ? true : false;
+			child_subreaper = (evt->get_param(3)->as<int64_t>()) != 0 ? true : false;
 			caller_tinfo->m_tginfo->set_reaper(child_subreaper);
 			break;
 
@@ -5442,7 +5442,7 @@ uint8_t* sinsp_parser::reserve_event_buffer()
 
 void sinsp_parser::parse_chroot_exit(sinsp_evt *evt)
 {
-	int64_t retval = evt->get_param<int64_t>(0);
+	int64_t retval = evt->get_param(0)->as<int64_t>();
 	if(retval == 0 && evt->m_tinfo != nullptr)
 	{
 		const char* resolved_path;
@@ -5479,7 +5479,7 @@ void sinsp_parser::parse_setsid_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval >= 0)
 	{
@@ -5502,7 +5502,7 @@ void sinsp_parser::parse_getsockopt_exit(sinsp_evt *evt)
 		return;
 	}
 
-	fd = evt->get_param<int64_t>(1);
+	fd = evt->get_param(1)->as<int64_t>();
 
 	evt->m_tinfo->m_lastevent_fd = fd;
 
@@ -5519,16 +5519,16 @@ void sinsp_parser::parse_getsockopt_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
 		return;
 	}
 
-	level = evt->get_param<int8_t>(2);
+	level = evt->get_param(2)->as<int8_t>();
 
-	optname = evt->get_param<int8_t>(3);
+	optname = evt->get_param(3)->as<int8_t>();
 
 	if(level == PPM_SOCKOPT_LEVEL_SOL_SOCKET && optname == PPM_SOCKOPT_SO_ERROR)
 	{
@@ -5572,7 +5572,7 @@ void sinsp_parser::parse_capset_exit(sinsp_evt *evt)
 	//
 	// Extract the return value
 	//
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0 || evt->m_tinfo == nullptr)
 	{
@@ -5584,11 +5584,11 @@ void sinsp_parser::parse_capset_exit(sinsp_evt *evt)
 	//
 	// Extract and update thread capabilities
 	//
-	tinfo->m_cap_inheritable = evt->get_param<uint64_t>(1);
+	tinfo->m_cap_inheritable = evt->get_param(1)->as<uint64_t>();
 
-	tinfo->m_cap_permitted = evt->get_param<uint64_t>(2);
+	tinfo->m_cap_permitted = evt->get_param(2)->as<uint64_t>();
 
-	tinfo->m_cap_effective = evt->get_param<uint64_t>(3);
+	tinfo->m_cap_effective = evt->get_param(3)->as<uint64_t>();
 }
 
 void sinsp_parser::parse_unshare_setns_exit(sinsp_evt *evt)
@@ -5598,7 +5598,7 @@ void sinsp_parser::parse_unshare_setns_exit(sinsp_evt *evt)
 	int64_t retval;
 	uint32_t flags = 0;
 
-	retval = evt->get_param<int64_t>(0);
+	retval = evt->get_param(0)->as<int64_t>();
 
 	if(retval < 0)
 	{
@@ -5617,11 +5617,11 @@ void sinsp_parser::parse_unshare_setns_exit(sinsp_evt *evt)
 	//
 	if(etype == PPME_SYSCALL_UNSHARE_X)
 	{
-		flags = enter_evt->get_param<uint32_t>(0);
+		flags = enter_evt->get_param(0)->as<uint32_t>();
 	}
 	else if(etype == PPME_SYSCALL_SETNS_X)
 	{
-		flags = enter_evt->get_param<uint32_t>(1);
+		flags = enter_evt->get_param(1)->as<uint32_t>();
 	}
 
 	//
@@ -5663,17 +5663,17 @@ void sinsp_parser::parse_memfd_create_exit(sinsp_evt *evt, scap_fd_type type)
 
 	/* ret (fd) */
 	ASSERT(evt->get_param_info(0)->type == PT_FD);
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 	
 	/* name */
 	/*
 	Suppose you create a memfd named libstest resulting in a fd.name libstest while on disk 
 	(e.g. ls -l /proc/$PID/fd/$FD_NUM) it may look like /memfd:libstest (deleted)
 	*/
-	std::string name = std::string(evt->get_param_const_char(1));
+	std::string name = std::string(evt->get_param(1)->as<std::string_view>());
 	
 	/* flags */
-	flags = evt->get_param<uint32_t>(2);
+	flags = evt->get_param(2)->as<uint32_t>();
 
 	if(fd >= 0)
 	{
@@ -5699,14 +5699,14 @@ void sinsp_parser::parse_pidfd_open_exit(sinsp_evt *evt)
 
 	/* ret (fd) */
 	ASSERT(evt->get_param_info(0)->type == PT_FD);
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	/* pid (fd) */
 	ASSERT(evt->get_param_info(1)->type == PT_PID);
-	pid = evt->get_param<int64_t>(1);
+	pid = evt->get_param(1)->as<int64_t>();
 	
 	/* flags */
-	flags = evt->get_param<uint32_t>(2);
+	flags = evt->get_param(2)->as<uint32_t>();
 
 	if(fd >= 0)
 	{
@@ -5740,15 +5740,15 @@ void sinsp_parser::parse_pidfd_getfd_exit(sinsp_evt *evt)
 
 	/* ret (fd) */
 	ASSERT(evt->get_param_info(0)->type == PT_FD);
-	fd = evt->get_param<int64_t>(0);
+	fd = evt->get_param(0)->as<int64_t>();
 
 	/* pidfd */
 	ASSERT(evt->get_param_info(1)->type == PT_FD);
-	pidfd = evt->get_param<int64_t>(1);
+	pidfd = evt->get_param(1)->as<int64_t>();
 
 	/* targetfd */
 	ASSERT(evt->get_param_info(2)->type == PT_FD);
-	targetfd = evt->get_param<int64_t>(2);
+	targetfd = evt->get_param(2)->as<int64_t>();
 
 	/* flags */
 	// currently unused: https://man7.org/linux/man-pages/man2/pidfd_getfd.2.html

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -945,7 +945,7 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt *enter_evt, sinsp_evt *exit_ev
 
 void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 {
-	sinsp_evt_param* parinfo = nullptr;
+	const sinsp_evt_param* parinfo = nullptr;
 	uint16_t etype = evt->get_type();
 	int64_t caller_tid = evt->get_tid();
 
@@ -1467,7 +1467,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 
 void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo = nullptr;
+	const sinsp_evt_param *parinfo = nullptr;
 	uint16_t etype = evt->get_type();
 	int64_t child_tid = evt->get_tid();
 
@@ -2019,7 +2019,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t retval;
 	uint16_t etype = evt->get_type();
 	sinsp_evt *enter_evt = &m_tmp_evt;
@@ -2954,7 +2954,7 @@ inline void sinsp_parser::infer_sendto_fdinfo(sinsp_evt* const evt)
 	const uint32_t FILE_DESCRIPTOR_PARAM = 0;
 	const uint32_t SOCKET_TUPLE_PARAM = 2;
 
-	sinsp_evt_param* parinfo = nullptr;
+	const sinsp_evt_param* parinfo = nullptr;
 
 	ASSERT(evt->get_param_info(FILE_DESCRIPTOR_PARAM)->type == PT_FD);
 	int64_t fd = evt->get_param<int64_t>(FILE_DESCRIPTOR_PARAM);
@@ -3044,7 +3044,7 @@ void sinsp_parser::parse_socket_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_bind_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t retval;
 	const char *parstr;
 	uint8_t *packed_data;
@@ -3139,7 +3139,7 @@ void sinsp_parser::parse_bind_exit(sinsp_evt *evt)
  * Register a socket in pending state
  */
 void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
-    sinsp_evt_param *parinfo;
+    const sinsp_evt_param *parinfo;
     const char *parstr;
     uint8_t *packed_data;
 
@@ -3336,7 +3336,7 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt *evt, uint8_t *packe
 
 void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	uint8_t *packed_data;
 	std::unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
 	int64_t retval;
@@ -3428,7 +3428,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_accept_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t fd;
 	uint8_t* packed_data;
 	std::unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
@@ -3944,7 +3944,7 @@ bool sinsp_parser::set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t*
 
 
 // Return false if the update didn't happen (for example because the tuple is NULL)
-bool sinsp_parser::update_fd(sinsp_evt *evt, sinsp_evt_param *parinfo)
+bool sinsp_parser::update_fd(sinsp_evt *evt, const sinsp_evt_param *parinfo)
 {
 	uint8_t* packed_data = (uint8_t*)parinfo->m_val;
 	uint8_t family = *packed_data;
@@ -4076,7 +4076,7 @@ void sinsp_parser::parse_fspath_related_exit(sinsp_evt* evt)
 
 void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t retval;
 	int64_t tid = evt->get_tid();
 	sinsp_evt *enter_evt = &m_tmp_evt;
@@ -4413,7 +4413,7 @@ void sinsp_parser::parse_chdir_exit(sinsp_evt *evt)
 	//
 	if(retval >= 0)
 	{
-		sinsp_evt_param *parinfo;
+		const sinsp_evt_param *parinfo;
 
 		// Update the thread working directory
 		parinfo = evt->get_param(1);
@@ -4451,7 +4451,7 @@ void sinsp_parser::parse_fchdir_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t retval;
 
 	//
@@ -5064,7 +5064,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 		}
 	}
 
-	sinsp_evt_param *parinfo = evt->get_param(0);
+	const sinsp_evt_param *parinfo = evt->get_param(0);
 	ASSERT(parinfo);
 	ASSERT(parinfo->m_len > 0);
 	std::string json(parinfo->m_val, parinfo->m_len);
@@ -5314,7 +5314,7 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 
 void sinsp_parser::parse_container_evt(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	auto container = std::make_shared<sinsp_container_info>();
 
 	parinfo = evt->get_param(0);
@@ -5491,7 +5491,7 @@ void sinsp_parser::parse_setsid_exit(sinsp_evt *evt)
 
 void sinsp_parser::parse_getsockopt_exit(sinsp_evt *evt)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	int64_t retval;
 	int64_t err;
 	int64_t fd;

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -125,7 +125,7 @@ private:
 	inline void infer_sendto_fdinfo(sinsp_evt *evt);
 	inline void add_pipe(sinsp_evt *evt, int64_t fd, uint64_t ino, uint32_t openflags);
 	// Return false if the update didn't happen (for example because the tuple is NULL)
-	bool update_fd(sinsp_evt *evt, sinsp_evt_param* parinfo);
+	bool update_fd(sinsp_evt *evt, const sinsp_evt_param* parinfo);
 
 	// Next 4 return false if the update didn't happen because the tuple is identical to the given address
 	bool set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -758,7 +758,7 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt) const
 		throw sinsp_exception(std::string(s_not_init_err) + ": " + m_name);
 	}
 
-	if (evt->get_type() != PPME_PLUGINEVENT_E || evt->get_param<uint32_t>(0) != m_id)
+	if (evt->get_type() != PPME_PLUGINEVENT_E || evt->get_param(0)->as<uint32_t>() != m_id)
 	{
 		throw sinsp_exception("can't format unknown non-plugin event to string");
 	}

--- a/userspace/libsinsp/plugin_manager.h
+++ b/userspace/libsinsp/plugin_manager.h
@@ -141,7 +141,7 @@ public:
 	{
 		if(evt && evt->get_type() == PPME_PLUGINEVENT_E)
 		{
-			return plugin_by_id(evt->get_param<int32_t>(0));
+			return plugin_by_id(evt->get_param(0)->as<int32_t>());
 		}
 		return nullptr;
 	}

--- a/userspace/libsinsp/sinsp_debug/sinsp_debug.cpp
+++ b/userspace/libsinsp/sinsp_debug/sinsp_debug.cpp
@@ -146,7 +146,7 @@ int main(int argc, char** argv)
 		case PPME_SYSCALL_VFORK_20_X:
 		case PPME_SYSCALL_CLONE3_X:
 		{
-			int64_t child_tid = ev->get_param<int64_t>(0);
+			int64_t child_tid = ev->get_param(0)->as<int64_t>();
 			if(child_tid == 0)
 			{
 				printf("🧵 CLONE CHILD EXIT: evt_num(%ld)\n", ev->get_num());

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -424,7 +424,7 @@ const filtercheck_field_info* sinsp_filter_check_event::get_field_info()
 
 uint8_t* extract_argraw(sinsp_evt *evt, OUT uint32_t* len, const char *argname)
 {
-	const sinsp_evt_param* pi = evt->get_param_value_raw(argname);
+	const sinsp_evt_param* pi = evt->get_param_by_name(argname);
 
 	if(pi != NULL)
 	{
@@ -652,7 +652,7 @@ Json::Value sinsp_filter_check_event::extract_as_js(sinsp_evt *evt, OUT uint32_t
 
 uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint32_t* len)
 {
-	const sinsp_evt_param* pi = evt->get_param_value_raw("res");
+	const sinsp_evt_param* pi = evt->get_param_by_name("res");
 
 	if(pi != NULL)
 	{
@@ -672,7 +672,7 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint3
 
 	if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 	{
-		pi = evt->get_param_value_raw("fd");
+		pi = evt->get_param_by_name("fd");
 
 		if(pi != NULL)
 		{
@@ -1191,7 +1191,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		break;
 	case TYPE_RESRAW:
 		{
-			const sinsp_evt_param* pi = evt->get_param_value_raw("res");
+			const sinsp_evt_param* pi = evt->get_param_by_name("res");
 
 			if(pi != NULL)
 			{
@@ -1201,7 +1201,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 			{
-				pi = evt->get_param_value_raw("fd");
+				pi = evt->get_param_by_name("fd");
 
 				if(pi != NULL)
 				{
@@ -1218,7 +1218,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			const char* resolved_argstr;
 			const char* argstr;
 
-			const sinsp_evt_param* pi = evt->get_param_value_raw("res");
+			const sinsp_evt_param* pi = evt->get_param_by_name("res");
 
 			if(pi != NULL)
 			{
@@ -1249,7 +1249,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			{
 				if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 				{
-					pi = evt->get_param_value_raw("fd");
+					pi = evt->get_param_by_name("fd");
 					if (pi)
 					{
 						int64_t res = *(int64_t*)pi->m_val;
@@ -1282,7 +1282,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	case TYPE_FAILED:
 		{
 			m_u32val = 0;
-			const sinsp_evt_param* pi = evt->get_param_value_raw("res");
+			const sinsp_evt_param* pi = evt->get_param_by_name("res");
 
 			if(pi != NULL)
 			{
@@ -1294,7 +1294,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			}
 			else if((evt->get_info_flags() & EF_CREATES_FD) && PPME_IS_EXIT(evt->get_type()))
 			{
-				pi = evt->get_param_value_raw("fd");
+				pi = evt->get_param_by_name("fd");
 
 				if(pi != NULL)
 				{

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -439,7 +439,7 @@ uint8_t* extract_argraw(sinsp_evt *evt, OUT uint32_t* len, const char *argname)
 
 uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t *len)
 {
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 	string spath;
 
 	if(evt->m_tinfo == NULL)

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -267,7 +267,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 		}
 	case PPME_SYSCALL_OPEN_BY_HANDLE_AT_X:
 		{
-			m_tstr = evt->get_param_const_char(3);
+			m_tstr = evt->get_param(3)->as<std::string_view>();
 
 			if(sanitize_strings)
 			{
@@ -532,7 +532,7 @@ uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool 
 
 		if(evt->get_type() == PPME_SOCKET_CONNECT_X)
 		{
-			int64_t retval = evt->get_param<int64_t>(0);
+			int64_t retval = evt->get_param(0)->as<int64_t>();
 
 			if(retval < 0)
 			{

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -214,7 +214,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 		{
 			sinsp_evt enter_evt;
 			const sinsp_evt_param *parinfo;
-			char *name;
+			const char *name;
 			uint32_t namelen;
 			string sdir;
 

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -213,7 +213,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 	case PPME_SYSCALL_OPENAT2_X:
 		{
 			sinsp_evt enter_evt;
-			sinsp_evt_param *parinfo;
+			const sinsp_evt_param *parinfo;
 			char *name;
 			uint32_t namelen;
 			string sdir;

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -55,7 +55,7 @@ uint8_t* sinsp_filter_check_fdlist::extract(sinsp_evt *evt, OUT uint32_t* len, b
 {
 	*len = 0;
 	ASSERT(evt);
-	sinsp_evt_param *parinfo;
+	const sinsp_evt_param *parinfo;
 
 	uint16_t etype = evt->get_type();
 

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -73,7 +73,7 @@ uint8_t* sinsp_filter_check_fdlist::extract(sinsp_evt *evt, OUT uint32_t* len, b
 	}
 
 	uint32_t j = 0;
-	char* payload = parinfo->m_val;
+	const char* payload = parinfo->m_val;
 	uint16_t nfds = *(uint16_t *)payload;
 	uint32_t pos = 2;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -400,12 +400,12 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 
 		if(extract_user)
 		{
-			user = evt->get_param<uint64_t>(0);
+			user = evt->get_param(0)->as<uint64_t>();
 		}
 
 		if(extract_system)
 		{
-			system = evt->get_param<uint64_t>(1);
+			system = evt->get_param(1)->as<uint64_t>();
 		}
 
 		tcpu = user + system;

--- a/userspace/libsinsp/sinsp_observer.h
+++ b/userspace/libsinsp/sinsp_observer.h
@@ -25,8 +25,8 @@ class sinsp_observer
 public:
 	virtual ~sinsp_observer() {}
 
-	virtual void on_read(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, char *data, uint32_t original_len, uint32_t len) = 0;
-	virtual void on_write(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, char *data, uint32_t original_len, uint32_t len) = 0;
+	virtual void on_read(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
+	virtual void on_write(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
 	virtual void on_sendfile(sinsp_evt* evt, int64_t fdin, uint32_t len) = 0;
 	virtual void on_connect(sinsp_evt* evt, uint8_t* packed_data) = 0;
 	virtual void on_accept(sinsp_evt* evt, int64_t newfd, uint8_t* packed_data, sinsp_fdinfo_t* new_fdinfo) = 0;

--- a/userspace/libsinsp/sinsp_syslog.cpp
+++ b/userspace/libsinsp/sinsp_syslog.cpp
@@ -54,11 +54,11 @@ static std::string s_syslog_facility_strings[] =
 	"local7"
 };
 
-void sinsp_syslog_decoder::parse_data(char *data, uint32_t len)
+void sinsp_syslog_decoder::parse_data(const char *data, uint32_t len)
 {
 	char pri[PRI_BUF_SIZE];
-	char* tc = data + 1;
-	char* te = data + len;
+	const char* tc = data + 1;
+	const char* te = data + len;
 	uint32_t j = 0;
 
 	while(tc < te && *tc != '>' && *tc != '\0' && j < PRI_BUF_SIZE - 1)
@@ -96,7 +96,7 @@ const std::string& sinsp_syslog_decoder::get_facility_str() const
 	}
 }
 
-void sinsp_syslog_decoder::decode_message(char *data, uint32_t len, char* pristr, uint32_t pristrlen)
+void sinsp_syslog_decoder::decode_message(const char *data, uint32_t len, char* pristr, uint32_t pristrlen)
 {
 	if(len < pristrlen + 2 || pristrlen == 0)
 	{

--- a/userspace/libsinsp/sinsp_syslog.h
+++ b/userspace/libsinsp/sinsp_syslog.h
@@ -34,7 +34,7 @@ public:
     sinsp_syslog_decoder(const sinsp_syslog_decoder& s) = default;
     sinsp_syslog_decoder& operator = (const sinsp_syslog_decoder& s) = default;
 
-	void parse_data(char *data, uint32_t len);
+	void parse_data(const char *data, uint32_t len);
 
 	const std::string& get_info_line();
 
@@ -73,7 +73,7 @@ public:
 	}
 
 private:
-	void decode_message(char *data, uint32_t len, char* pristr, uint32_t pristrlen);
+	void decode_message(const char *data, uint32_t len, char* pristr, uint32_t pristrlen);
 
 	int32_t m_priority{s_invalid_priority};
 	uint32_t m_facility{0};

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -43,7 +43,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 
 	// this, and the following similar checks, verify that the internal state is set as we need right now.
 	// if the internal state changes we can remove or update this check
-	ASSERT_STREQ(evt->get_param_const_char(1), "<NA>");
+	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
 
 	/* `PPME_SYSCALL_CREAT_E` is a simple event that uses a `PT_FSPATH`
 	 * A `NULL` `PT_FSPATH` param is always converted to `<NA>`.
@@ -51,7 +51,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 2, NULL, 0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param_const_char(0), "<NA>");
+	ASSERT_STREQ(evt->get_param(0)->as<std::string_view>().data(), "<NA>");
 
 	int64_t dirfd = 0;
 
@@ -61,7 +61,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, NULL, 0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.pathname"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param_const_char(1), "<NA>");
+	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
 }
 
 /* Assert that a `PT_CHARBUF` with `len==1` (just the `\0`) is not changed. */
@@ -81,7 +81,7 @@ TEST_F(sinsp_with_test_input, param_charbuf_len_1)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "");
 
-	ASSERT_STREQ(evt->get_param_const_char(1), "");
+	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "");
 }
 
 /* Assert that a "(NULL)" `PT_CHARBUF` param is converted to `<NA>`
@@ -101,7 +101,7 @@ TEST_F(sinsp_with_test_input, charbuf_NULL_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "(NULL)");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param_const_char(1), "<NA>");
+	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
 }
 
 /* Assert that an empty `PT_BYTEBUF` param is NOT converted to `<NA>` */
@@ -305,7 +305,7 @@ TEST_F(sinsp_with_test_input, enumparams)
 	/* `PPME_SOCKET_SOCKET_E` is a simple event that uses a PT_ENUMFLAGS32 (param 1) */
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, PPM_AF_UNIX, 0, 0);
 
-	ASSERT_EQ(evt->get_param<uint32_t>(0), PPM_AF_UNIX);
+	ASSERT_EQ(evt->get_param(0)->as<uint32_t>(), PPM_AF_UNIX);
 
 	const char *val_str = NULL;
 	evt->get_param_as_str(0, &val_str);
@@ -325,7 +325,7 @@ TEST_F(sinsp_with_test_input, enumparams_fcntl_dupfd)
 	uint8_t flag = PPM_FCNTL_F_DUPFD;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_FCNTL_E, 2, (int64_t) 0, flag);
 
-	ASSERT_EQ(evt->get_param<uint8_t>(1), PPM_FCNTL_F_DUPFD);
+	ASSERT_EQ(evt->get_param(1)->as<uint8_t>(), PPM_FCNTL_F_DUPFD);
 
 	const char *val_str = NULL;
 	evt->get_param_as_str(1, &val_str);
@@ -345,7 +345,7 @@ TEST_F(sinsp_with_test_input, bitmaskparams)
 	/* `PPME_SYSCALL_OPENAT_E` is a simple event that uses a PT_FLAGS32 (param 3) */
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT_E, 4, dirfd, "/tmp/foo", PPM_O_RDONLY|PPM_O_CLOEXEC, 0);
 
-	ASSERT_EQ(evt->get_param<uint32_t>(2), PPM_O_RDONLY|PPM_O_CLOEXEC);
+	ASSERT_EQ(evt->get_param(2)->as<uint32_t>(), PPM_O_RDONLY|PPM_O_CLOEXEC);
 
 	const char *val_str = NULL;
 	evt->get_param_as_str(2, &val_str);

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -111,7 +111,7 @@ TEST_F(sinsp_with_test_input, bytebuf_empty_param)
 
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_evt_param* param = NULL;
+	const sinsp_evt_param* param = NULL;
 
 	int64_t test_errno = 0;
 
@@ -133,7 +133,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_evt_param* param = NULL;
+	const sinsp_evt_param* param = NULL;
 
 	int64_t fd = 0;
 

--- a/userspace/libsinsp/test/events_proc.ut.cpp
+++ b/userspace/libsinsp/test/events_proc.ut.cpp
@@ -394,7 +394,6 @@ TEST_F(sinsp_with_test_input, spawn_process)
 	ASSERT_EQ(get_field_as_string(evt, "proc.apid[1]"), "1");
 	ASSERT_EQ(get_field_as_string(evt, "proc.pvpid"), "1");
 	ASSERT_FALSE(field_has_value(evt, "proc.apid[2]"));
-
 	ASSERT_EQ(get_field_as_string(evt, "proc.cmdline"), "test-exe -c 'echo aGVsbG8K | base64 -d'");
 	ASSERT_EQ(get_field_as_string(evt, "proc.pcmdline"), "init");
 	ASSERT_EQ(get_field_as_string(evt, "proc.acmdline[0]"), "test-exe -c 'echo aGVsbG8K | base64 -d'");


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR continues an effort to clean up libsinsp from potential undefined behavior (see: https://github.com/falcosecurity/libs/issues/1470 ). It implements the following refactoring changes:
* Added some const correctness around the code that handles `sinsp_evt_param`s. When some raw parameter data is read from the driver it is never modified and so it should be `const` when processed.
* Modified the `sinsp_evt` class and `sinsp_evt_param`. Now `sinsp_evt_param` has more reasons to exist because it is no longer simply a "buffer + length" wrapper but it is able to convert values to appropriate types (with the `as()` method) and also point back to the original event
* Now we can use `std::string_view` in the template parameter to read string buffers
* All uses of `get_param(n)<T>` are updated to `get_param(n)->as<T>`
* The function `get_param_as_str` is updated to remove some UB according to the refactoring above

cc @FedeDP @gnosek 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
