### PR TITLE
fix(userspace/libsinsp): remove warning in scanf on uint64_t

### DIFF
--- a/userspace/libsinsp/stats.cpp
+++ b/userspace/libsinsp/stats.cpp
@@ -151,7 +151,7 @@ void get_rss_vsz_pss_total_memory_and_open_fds(uint32_t &rss, uint32_t &vsz, uin
 		ASSERT(false);
 		return;
 	}
-	int matched_fds = fscanf(f, "%llu", &open_fds_host);
+	int matched_fds = fscanf(f, "%lu", &open_fds_host);
 	fclose(f);
 
 	if (matched_fds != 1) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This solves a stubborn formatting-related warning that would prevent compilation with WARNINGS_AS_ERRORS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
