### PR TITLE
update(libsinsp/tests): support async event generation from sinsp_with_test_input

### DIFF
--- a/userspace/libsinsp/test/events_injection.ut.cpp
+++ b/userspace/libsinsp/test/events_injection.ut.cpp
@@ -4,83 +4,16 @@
 #include "test_utils.h"
 
 
-static void encode_async_event(scap_evt* scapevt, uint64_t tid, const char* data)
-{
-	struct scap_plugin_params
-	{};
-
-	static uint32_t plug_id[2] = {sizeof (uint32_t), 0};
-
-	size_t totlen = sizeof(scap_evt) + sizeof(plug_id)  + sizeof(uint32_t) + strlen(data) + 1;
-
-	scapevt->tid = -1;
-	scapevt->len = (uint32_t)totlen;
-	scapevt->type = PPME_ASYNCEVENT_E;
-	scapevt->nparams = 2;
-
-	char* buff = (char *)scapevt + sizeof(struct ppm_evt_hdr);
-	memcpy(buff, (char*)plug_id, sizeof(plug_id));
-	buff += sizeof(plug_id);
-
-	char* valptr = buff + sizeof(uint32_t);
-
-	auto* data_len_ptr = (uint32_t*)buff;
-	*data_len_ptr = (uint32_t)strlen(data) + 1;
-	memcpy(valptr, data, *data_len_ptr);
-}
-
-class sinsp_evt_generator
-{
-private:
-	struct scap_buff
-	{
-		uint8_t data[128];
-	};
-
-public:
-	sinsp_evt_generator() = default;
-	sinsp_evt_generator(sinsp_evt_generator&&) = default;
-	~sinsp_evt_generator() = default;
-
-	scap_evt* get(size_t idx)
-	{
-		return scap_ptrs[idx];
-	}
-
-	scap_evt* back()
-	{
-		return scap_ptrs.back();
-	}
-
-	std::unique_ptr<sinsp_evt> next(uint64_t ts = (uint64_t) -1)
-	{
-		scaps.emplace_back(new scap_buff());
-		scap_ptrs.emplace_back((scap_evt*)scaps.back()->data);
-
-		encode_async_event(scap_ptrs.back(), 1, "dummy_data");
-
-		auto event = std::make_unique<sinsp_evt>();
-		event->m_pevt = scap_ptrs.back();
-		event->m_cpuid = 0;
-		event->m_pevt->ts = ts;
-		return event;
-	};
-
-private:
-	std::vector<std::shared_ptr<scap_buff> > scaps;
-	std::vector<scap_evt*> scap_ptrs; // gdb watch helper
-};
-
 TEST_F(sinsp_with_test_input, event_async_queue)
 {
 	open_inspector();
 	m_inspector.m_lastevent_ts = 123;
 
-	sinsp_evt_generator evt_gen;
 	sinsp_evt* evt{};
+	const scap_evt *scap_evt;
 
-	// inject event
-	m_inspector.handle_async_event(evt_gen.next());
+	scap_evt = add_async_event(-1, -1, PPME_ASYNCEVENT_E, 3,
+		100, "event_name", scap_const_sized_buffer{NULL, 0});
 
 	// create test input event
 	auto* scap_evt0 = add_event(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file",
@@ -90,7 +23,7 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 	auto res = m_inspector.next(&evt);
 	ASSERT_EQ(res, SCAP_SUCCESS);
 	ASSERT_NE(evt, nullptr);
-	ASSERT_EQ(evt->m_pevt, evt_gen.back());
+	ASSERT_EQ(evt->m_pevt, scap_evt);
 	ASSERT_EQ(evt->m_pevt->ts, 123);
 	ASSERT_TRUE(m_inspector.m_async_events_queue.empty());
 
@@ -100,7 +33,8 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 	uint64_t injected_ts = scap_evt0->ts + 10;
 	for (int i = 0; i < 10; ++i)
 	{
-		m_inspector.handle_async_event(evt_gen.next(injected_ts + i));
+		add_async_event(injected_ts + i, -1, PPME_ASYNCEVENT_E, 3,
+			100, "event_name", scap_const_sized_buffer{NULL, 0});
 	}
 
 	// create input[1] ivent
@@ -118,7 +52,7 @@ TEST_F(sinsp_with_test_input, event_async_queue)
 	{
 		res = m_inspector.next(&evt);
 		ASSERT_EQ(res, SCAP_SUCCESS);
-		ASSERT_EQ(evt->m_pevt, evt_gen.get(i+1));
+		ASSERT_EQ(evt->m_pevt, m_async_events[i+1]);
 		ASSERT_TRUE(last_ts <= evt->m_pevt->ts);
 		last_ts = evt->m_pevt->ts;
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:
/area libsinsp

/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

It was not possible to send async events to the inspector from the `sinsp_with_test_input` test class, as it only supported sending regular events. This PR includes a new function `add_async_event()` to do exactly this, and updates the relevant tests. This should make it easier to write tests that involve async events.

Also, this removes potential UB in the code that was generating the async event so that we get closer to solving https://github.com/falcosecurity/libs/issues/1470 .

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
