### PR TITLE
fix(libsinsp): return strings in syslog when they may be stack-allocated

### DIFF
--- a/userspace/libsinsp/sinsp_syslog.cpp
+++ b/userspace/libsinsp/sinsp_syslog.cpp
@@ -72,7 +72,7 @@ void sinsp_syslog_decoder::parse_data(char *data, uint32_t len)
 	decode_message(data, len, pri, j);
 }
 
-const std::string& sinsp_syslog_decoder::get_severity_str() const
+const std::string sinsp_syslog_decoder::get_severity_str() const
 {
 	if(!is_data_valid() || m_severity >= sizeof(s_syslog_severity_strings) / sizeof(s_syslog_severity_strings[0]))
 	{
@@ -84,7 +84,7 @@ const std::string& sinsp_syslog_decoder::get_severity_str() const
 	}
 }
 
-const std::string& sinsp_syslog_decoder::get_facility_str() const
+const std::string sinsp_syslog_decoder::get_facility_str() const
 {
 	if(!is_data_valid() || m_facility >= sizeof(s_syslog_facility_strings) / sizeof(s_syslog_facility_strings[0]))
 	{
@@ -118,7 +118,7 @@ void sinsp_syslog_decoder::decode_message(char *data, uint32_t len, char* pristr
 	m_msg.assign(data + pristrlen + 2, len - pristrlen - 2);
 }
 
-const std::string& sinsp_syslog_decoder::get_info_line()
+const std::string sinsp_syslog_decoder::get_info_line()
 {
 	if (!is_data_valid())
 	{

--- a/userspace/libsinsp/sinsp_syslog.h
+++ b/userspace/libsinsp/sinsp_syslog.h
@@ -36,11 +36,11 @@ public:
 
 	void parse_data(char *data, uint32_t len);
 
-	const std::string& get_info_line();
+	const std::string get_info_line();
 
-	const std::string& get_severity_str() const;
+	const std::string get_severity_str() const;
 
-	const std::string& get_facility_str() const;
+	const std::string get_facility_str() const;
 
 	inline void reset()
 	{
@@ -67,7 +67,7 @@ public:
 		return m_severity;
 	}
 
-	inline const std::string& get_msg() const
+	inline const std::string get_msg() const
 	{
 		return m_msg;
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**
No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In the new syslog implementation sometimes we would return references to strings that may be stack-allocated and not coming from static memory or the containing object. I propose to copy those strings directly. I don't think the performance impact is relevant in this case.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
