### PR TITLE
cleanup: params inconsistencies

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2597,7 +2597,7 @@ FILLER(proc_startupdate_3, true)
 			break;
 		}
 
-		flags = clone_flags_to_scap(flags);
+		flags = clone_flags_to_scap((int) flags);
 
 		if(pidns_level != 0) {
 			flags |= PPM_CL_CHILD_IN_PIDNS;
@@ -3010,7 +3010,7 @@ FILLER(sys_setns_e, true)
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
 	unsigned long nstype = bpf_syscall_get_argument(data, 1);
-	return bpf_push_u32_to_ring(data, clone_flags_to_scap(nstype));
+	return bpf_push_u32_to_ring(data, clone_flags_to_scap((int) nstype));
 }
 
 FILLER(sys_setpgid_e, true)
@@ -3031,7 +3031,7 @@ FILLER(sys_unshare_e, true)
 	uint32_t flags;
 
 	val = bpf_syscall_get_argument(data, 0);
-	flags = clone_flags_to_scap(val);
+	flags = clone_flags_to_scap((int) val);
 	return bpf_push_u32_to_ring(data, flags);
 }
 
@@ -4777,7 +4777,7 @@ FILLER(sys_flock_e, true)
 	CHECK_RES(res);
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
-	unsigned long operation = bpf_syscall_get_argument(data, 1);
+	int operation = bpf_syscall_get_argument(data, 1);
 	return bpf_push_u32_to_ring(data, flock_flags_to_scap(operation));
 }
 

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -749,7 +749,7 @@ static __always_inline void extract__loginuid(struct task_struct *task, uint32_t
  */
 static __always_inline unsigned long extract__clone_flags(struct task_struct *task, unsigned long flags)
 {
-	unsigned long ppm_flags = clone_flags_to_scap(flags);
+	unsigned long ppm_flags = clone_flags_to_scap((int) flags);
 	struct pid *pid = extract__task_pid_struct(task, PIDTYPE_PID);
 	struct pid_namespace *ns = extract__namespace_of_pid(pid);
 	unsigned int ns_level;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/flock.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(flock_e,
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
 	unsigned long operation = extract__syscall_argument(regs, 1);
-	ringbuf__store_u32(&ringbuf, flock_flags_to_scap(operation));
+	ringbuf__store_u32(&ringbuf, flock_flags_to_scap((int) operation));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/setns.bpf.c
@@ -31,7 +31,7 @@ int BPF_PROG(setns_e,
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
 	unsigned long nstype = extract__syscall_argument(regs, 1);
-	ringbuf__store_u32(&ringbuf, clone_flags_to_scap(nstype));
+	ringbuf__store_u32(&ringbuf, clone_flags_to_scap((int) nstype));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unshare.bpf.c
@@ -27,7 +27,7 @@ int BPF_PROG(unshare_e,
 
 	/* Parameter 1: flags (type: PT_FLAGS32) */
 	unsigned long flags = extract__syscall_argument(regs, 0);
-	ringbuf__store_u32(&ringbuf, clone_flags_to_scap(flags));
+	ringbuf__store_u32(&ringbuf, clone_flags_to_scap((int) flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1210,7 +1210,7 @@ cgroups_error:
 		if(pidns != &init_pid_ns || pid_ns_for_children(current) != pidns)
 			in_pidns = PPM_CL_CHILD_IN_PIDNS;
 #endif
-		res = val_to_ring(args, (uint64_t)clone_flags_to_scap(val) | in_pidns, 0, false, 0);
+		res = val_to_ring(args, (uint64_t)clone_flags_to_scap((int) val) | in_pidns, 0, false, 0);
 		CHECK_RES(res);
 
 		/*
@@ -6331,7 +6331,7 @@ int f_sys_flock_e(struct event_filler_arguments *args)
 
 	/* Parameter 2: operation (type: PT_FLAGS32) */
 	syscall_get_arguments_deprecated(args, 1, 1, &val);
-	flags = flock_flags_to_scap(val);
+	flags = flock_flags_to_scap((int) val);
 	res = val_to_ring(args, flags, 0, false, 0);
 	CHECK_RES(res);
 
@@ -6390,7 +6390,7 @@ int f_sys_setns_e(struct event_filler_arguments *args)
 
 	/* Parameter 2: nstype (type: PT_FLAGS32) */
 	syscall_get_arguments_deprecated(args, 1, 1, &val);
-	res = val_to_ring(args, clone_flags_to_scap(val), 0, true, 0);
+	res = val_to_ring(args, clone_flags_to_scap((int) val), 0, true, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
@@ -6428,7 +6428,7 @@ int f_sys_unshare_e(struct event_filler_arguments *args)
 	 * get type, parse as clone flags as it's a subset of it
 	 */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	flags = clone_flags_to_scap(val);
+	flags = clone_flags_to_scap((int) val);
 	res = val_to_ring(args, flags, 0, true, 0);
 	CHECK_RES(res);
 

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -470,7 +470,7 @@ static __always_inline uint16_t signalfd4_flags_to_scap(int32_t flags)
 	return res;
 }
 
-static __always_inline uint32_t clone_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t clone_flags_to_scap(int flags)
 {
 	uint32_t res = 0;
 
@@ -1411,7 +1411,7 @@ static __always_inline uint32_t pf_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline uint32_t flock_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t flock_flags_to_scap(int flags)
 {
 	uint32_t res = 0;
 

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -1746,7 +1746,7 @@ static parse_result parse_clone(const char *proto, size_t proto_size, scap_sized
 		                 context_data.cwd().c_str(),
 		                 context_data.process_name().c_str(),  // comm
 		                 scap_const_sized_buffer{cgroups.c_str(), cgroups.length() + 1},
-		                 clone_flags_to_scap(gvisor_evt.flags()),
+		                 clone_flags_to_scap((int) gvisor_evt.flags()),
 		                 context_data.credentials().effective_uid(), // uid
 		                 context_data.credentials().effective_gid(), // gid
 		                 context_data.thread_id(),             // vtid


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf


**Does this PR require a change in the driver versions?**

I am not sure about this.

**What this PR does / why we need it**:

I am trying to address the issue where **flock, unshare, and setns** is handling the flag params as an unsigned integer when it should be handling it as in int.

**Which issue(s) this PR fixes**:

part of #515 
(partial fix other issues still remain in 515)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
