### PR TITLE
fix(tests): return  `SCAP_TIMEOUT` instead of an `SCAP_EOF`

### DIFF
--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -59,7 +59,7 @@ static int32_t next(struct scap_engine_handle handle, scap_evt** pevent, uint16_
 
 	if (!data->events || data->event_count == 0)
 	{
-		return SCAP_EOF;
+		return SCAP_TIMEOUT;
 	}
 
 	*pevent = *(data->events++);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

When the engine test doesn't produce any events but receives events from an async plugin the events in the queue are never processed because the test engine in `fetch_next_event` will always return `SCAP_EOF` and so the events will be never dequeued...

```cpp
	int32_t res = SCAP_SUCCESS;
	if (m_delayed_scap_evt.empty())
	{
		res = m_delayed_scap_evt.next(m_h);
	}

	if (res == SCAP_TIMEOUT &&
		!m_async_events_queue.empty() && m_async_events_queue.try_pop(m_async_evt))
	{
		evt = m_async_evt.get();
		if(evt->m_pevt->ts == (uint64_t) -1)
		{
			evt->m_pevt->ts = get_new_ts();
		}
		return SCAP_SUCCESS;
	}
```

Moreover `SCAP_TIMEOUT` seems a more reasonable value to return than `SCAP_EOF`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
