### PR TITLE
fix(test/drivers): skip unimplemented syscalls tests.

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -51,6 +51,12 @@ void assert_syscall_state(int syscall_state, const char* syscall_name, long sysc
 {
 	bool match = false;
 
+	if (errno == ENOSYS)
+	{
+		GTEST_SKIP() << "Syscall " << syscall_name << " not implemented"  << std::endl;
+		return;
+	}
+
 	switch(op)
 	{
 	case EQUAL:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Issue found in https://github.com/falcosecurity/libs/pull/1497; some syscalls are defined but they just set errno to `ENOSYS` on ppc64le. 
In those cases, just skip the syscall test.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
