### PR TITLE
build: remove some warning suppressions

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -41,7 +41,7 @@ if(NOT MSVC)
 
 	if(BUILD_WARNINGS_AS_ERRORS)
 		set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
-		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
+		set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-sign-compare -Wno-implicit-fallthrough -Wno-format-truncation")
 		set(FALCOSECURITY_LIBS_COMMON_FLAGS "${FALCOSECURITY_LIBS_COMMON_FLAGS} -Wextra ${CMAKE_SUPPRESSED_WARNINGS}")
 	endif()
 

--- a/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
+++ b/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
@@ -316,7 +316,7 @@ TEST(gvisor_parsers, parse_socketpair_x)
     EXPECT_EQ(res.scap_events.size(), 1);
 
     EXPECT_EQ(res.scap_events[0]->type, PPME_SOCKET_SOCKETPAIR_X);
-    
+
     struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 5);
@@ -405,7 +405,7 @@ TEST(gvisor_parsers, small_buffer)
 
 TEST(gvisor_parsers, procfs_entry)
 {
-    scap_gvisor::parsers::procfs_result res = {0};
+    scap_gvisor::parsers::procfs_result res;
     std::string not_json = "not a json string";
     std::string sandbox_id = "deadbeef";
 
@@ -504,7 +504,7 @@ TEST(gvisor_parsers, config_socket)
         "name": "Default",
         "points": [
         {
-            "name": "container/start", 
+            "name": "container/start",
             "context_fields": [
                 "cwd",
                 "time"

--- a/userspace/chisel/chisel_viewinfo.cpp
+++ b/userspace/chisel/chisel_viewinfo.cpp
@@ -77,7 +77,7 @@ chisel_view_info::chisel_view_info()
 	m_valid = false;
 }
 
-chisel_view_info::chisel_view_info(viewtype type, 
+chisel_view_info::chisel_view_info(viewtype type,
 	string id,
 	string name,
 	string description,
@@ -99,7 +99,7 @@ chisel_view_info::chisel_view_info(viewtype type,
 	m_description = description;
 	m_does_groupby = false;
 	m_type = type;
-	m_tags = tags;	
+	m_tags = tags;
 	m_tips = tips;
 	m_columns = columns;
 	m_drilldown_target = drilldown_target;
@@ -110,7 +110,7 @@ chisel_view_info::chisel_view_info(viewtype type,
 	m_propagate_filter = propagate_filter;
 
 	m_use_defaults = use_defaults;
-	
+
 	//
 	// Make sure the keys go at the beginning
 	//
@@ -133,9 +133,9 @@ void chisel_view_info::set_col_sorting_hotkeys()
 {
 	const char shift_number_keys [] = {'!', '@', '#', '$', '%', '^', '&', '*', '('};
 	uint32_t size = sizeof(shift_number_keys) / sizeof(shift_number_keys[0]);
-	for(uint32_t i=0; i<size; i++) 
+	for(uint32_t i=0; i<size; i++)
 	{
-		m_col_sort_hotkeys.push_back(shift_number_keys[i]); 
+		m_col_sort_hotkeys.push_back(shift_number_keys[i]);
 	}
 	max_col_sort_hotkeys = m_col_sort_hotkeys.size();
 }
@@ -179,7 +179,7 @@ void chisel_view_info::set_sorting_col()
 		throw sinsp_exception("view format error: more than one sorting column");
 	}
 
-	if((int64_t)m_sortingcol < 0)
+	if(m_sortingcol < 0)
 	{
 		ASSERT(false);
 		throw sinsp_exception("view sorting column configuration error");

--- a/userspace/chisel/chisel_viewinfo.h
+++ b/userspace/chisel/chisel_viewinfo.h
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-#pragma once	
+#pragma once
 
 #define VIEW_ID_SPY -1
 #define VIEW_ID_DIG -2
@@ -32,7 +32,7 @@ typedef enum chisel_field_aggregation
 	A_AVG,
 	A_TIME_AVG,
 	A_MIN,
-	A_MAX,		
+	A_MAX,
 } chisel_field_aggregation;
 
 //
@@ -53,7 +53,7 @@ public:
 	chisel_view_column_info()
 	{
 	}
-	
+
 	chisel_view_column_info(std::string field,
 		std::string name,
 		std::string description,
@@ -169,7 +169,7 @@ public:
 	std::string m_description;
 	std::vector<std::string> m_tags;
 	std::vector<std::string> m_tips;
-	uint32_t m_sortingcol;
+	int32_t m_sortingcol;
 	std::vector<std::string> m_applies_to;
 	std::vector<chisel_view_column_info> m_columns;
 	bool m_use_defaults;

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -22,25 +22,24 @@ namespace scap_gvisor {
 
 #define SCAP_HANDLE_T scap_gvisor::engine
 
-#include "scap.h"
 #include "gvisor.h"
 #include "gvisor_platform.h"
+#include "scap.h"
 #include "scap-int.h"
 #include "scap_proc_util.h"
+#include "strerror.h"
+#include "strl.h"
 
-#include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/epoll.h>
 #include <sys/stat.h>
-#include <stdint.h>
+#include <unistd.h>
 #include <utility>
-
-#include "strerror.h"
-#include "strl.h"
 
 #ifdef __cplusplus
 extern "C"{
@@ -217,10 +216,11 @@ static uint64_t gvisor_get_max_buf_used(struct scap_engine_handle engine)
 
 extern const struct scap_vtable scap_gvisor_engine = {
 	.name = GVISOR_ENGINE,
-	.savefile_ops = NULL,
+	.savefile_ops = nullptr,
 
 	.alloc_handle = gvisor_alloc_handle,
 	.init = gvisor_init,
+	.get_flags = nullptr,
 	.free_handle = gvisor_free_handle,
 	.close = gvisor_close,
 	.next = gvisor_next,
@@ -232,6 +232,6 @@ extern const struct scap_vtable scap_gvisor_engine = {
 	.get_n_tracepoint_hit = gvisor_get_n_tracepoint_hit,
 	.get_n_devs = gvisor_get_n_devs,
 	.get_max_buf_used = gvisor_get_max_buf_used,
-	.get_api_version = NULL,
-	.get_schema_version = NULL,
+	.get_api_version = nullptr,
+	.get_schema_version = nullptr
 };

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 #include <stdint.h>
 #include <string>
-#include <thread> 
+#include <thread>
 #include <atomic>
 #include <deque>
 #include <vector>
@@ -46,7 +46,7 @@ namespace parsers {
 
 struct parse_result {
     // the scap status of the operation
-	uint32_t status;
+	uint32_t status = 0;
     // description of the error in case of failure
 	std::string error;
     // the total encoded event(s) size
@@ -59,7 +59,7 @@ struct parse_result {
 
 struct procfs_result {
     // the scap status of the operation
-    uint32_t status;
+    uint32_t status = 0;
     // description of the error in case of failure
     std::string error;
     // the resulting thread information
@@ -81,7 +81,7 @@ struct config_result {
     \brief Translate a gVisor seccheck protobuf into one, or more, scap events
     \param gvisor_buf the source buffer that contains the raw event coming from gVisor
     \param scap_buf the buffer that will be used to store the encoded scap events
-    \return a parse_result struct. 
+    \return a parse_result struct.
         If the encoding is successful:
             - the status field will be set as SCAP_SUCCESS
             - the scap_events vector will contain pointers to each encoded event, all located within scap_buf's memory
@@ -107,7 +107,7 @@ namespace runsc
 {
 
     struct result {
-        int error;
+        int error = 0;
         std::vector<std::string> output;
     };
 

--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -95,7 +95,7 @@ static int32_t process_unhandled_syscall(uint64_t sysno, char* error_buf)
 
 static parse_result parse_container_start(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -123,14 +123,14 @@ static parse_result parse_container_start(const char *proto, size_t proto_size, 
 		env += gvisor_evt.env(j);
 		env.push_back('\0');
 	}
-	
+
 	std::string container_id = gvisor_evt.id();
 
 	std::string cgroups = "gvisor_container_id=/";
 	cgroups += container_id;
 
 	std::string exe, comm;
-	exe = gvisor_evt.args(0).c_str(); // exe, best available info from gVisor evt 
+	exe = gvisor_evt.args(0).c_str(); // exe, best available info from gVisor evt
 	size_t pos = exe.find_last_of("/");
 	if (pos != std::string::npos)
 	{
@@ -245,7 +245,7 @@ static parse_result parse_container_start(const char *proto, size_t proto_size, 
 	                 scap_const_sized_buffer{cgroups.c_str(), cgroups.length() + 1},
 	                 scap_const_sized_buffer{env.data(), env.size()},
 	                 context_data.credentials().effective_uid()); // uid
-	
+
 	if (ret.status == SCAP_FAILURE) {
 		ret.error = scap_err;
 		return ret;
@@ -270,7 +270,7 @@ static parse_result parse_container_start(const char *proto, size_t proto_size, 
 
 static parse_result parse_execve(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -401,7 +401,7 @@ static parse_result parse_execve(const char *proto, size_t proto_size, scap_size
 
 static parse_result parse_sentry_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	ret.status = SCAP_SUCCESS;
 	ret.size = 0;
 	char scap_err[SCAP_LASTERR_SIZE];
@@ -446,7 +446,7 @@ static parse_result parse_sentry_clone(const char *proto, size_t proto_size, sca
 		ret.error = scap_err;
 		return ret;
 	}
-	
+
 	scap_evt *evt = static_cast<scap_evt*>(scap_buf.buf);
 	evt->ts = context_data.time_ns();
 	evt->tid = tid_field;
@@ -458,7 +458,7 @@ static parse_result parse_sentry_clone(const char *proto, size_t proto_size, sca
 
 static parse_result parse_read(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Read gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -659,7 +659,7 @@ static size_t pack_sockaddr_to_remote_tuple(sockaddr *sa, char *targetbuf)
 		case AF_UNIX:
 		{
 			size += pack_sock_family(sa, buf);
-			memset(targetbuf + 1, 0, sizeof(uint64_t)); // TODO: understand how to fill this 
+			memset(targetbuf + 1, 0, sizeof(uint64_t)); // TODO: understand how to fill this
 			memset(targetbuf + 1 + 8, 0, sizeof(uint64_t));
 			size += sizeof(uint64_t) + sizeof(uint64_t);
 			buf = targetbuf + size;
@@ -684,7 +684,7 @@ static size_t pack_sockaddr(sockaddr *sa, char *targetbuf)
 
 static parse_result parse_connect(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Connect gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -753,7 +753,7 @@ static parse_result parse_connect(const char *proto, size_t proto_size, scap_siz
 
 static parse_result parse_socket(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Socket gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -793,7 +793,7 @@ static parse_result parse_socket(const char *proto, size_t proto_size, scap_size
 
 static parse_result parse_generic_syscall(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Syscall gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -866,7 +866,7 @@ static parse_result parse_generic_syscall(const char *proto, size_t proto_size, 
 
 static parse_result parse_accept(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Accept gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -951,7 +951,7 @@ static parse_result parse_accept(const char *proto, size_t proto_size, scap_size
 
 static parse_result parse_fcntl(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Fcntl gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -989,7 +989,7 @@ static parse_result parse_fcntl(const char *proto, size_t proto_size, scap_sized
 
 static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Bind gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1045,7 +1045,7 @@ static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_
 
 static parse_result parse_pipe(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Pipe gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1083,7 +1083,7 @@ static parse_result parse_pipe(const char *proto, size_t proto_size, scap_sized_
 
 static parse_result parse_open(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Open gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1181,7 +1181,7 @@ static parse_result parse_open(const char *proto, size_t proto_size, scap_sized_
 
 static parse_result parse_chdir(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Chdir gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1249,7 +1249,7 @@ static parse_result parse_chdir(const char *proto, size_t proto_size, scap_sized
 
 static parse_result parse_setresid(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Setresid gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1321,7 +1321,7 @@ static parse_result parse_setresid(const char *proto, size_t proto_size, scap_si
 
 static parse_result parse_setid(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Setid gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1400,7 +1400,7 @@ static parse_result parse_setid(const char *proto, size_t proto_size, scap_sized
 
 static parse_result parse_chroot(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Chroot gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1437,7 +1437,7 @@ static parse_result parse_chroot(const char *proto, size_t proto_size, scap_size
 
 static parse_result parse_dup(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Dup gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1523,7 +1523,7 @@ static parse_result parse_dup(const char *proto, size_t proto_size, scap_sized_b
 
 static parse_result parse_sentry_task_exit(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 
 	gvisor::sentry::TaskExit gvisor_evt;
@@ -1557,7 +1557,7 @@ static parse_result parse_sentry_task_exit(const char *proto, size_t proto_size,
 
 static parse_result parse_prlimit64(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Prlimit gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1600,7 +1600,7 @@ static parse_result parse_prlimit64(const char *proto, size_t proto_size, scap_s
 
 static parse_result parse_signalfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Signalfd gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1640,7 +1640,7 @@ static parse_result parse_signalfd(const char *proto, size_t proto_size, scap_si
 
 static parse_result parse_eventfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Eventfd gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1679,7 +1679,7 @@ static parse_result parse_eventfd(const char *proto, size_t proto_size, scap_siz
 
 static parse_result parse_close(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Close gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1716,7 +1716,7 @@ static parse_result parse_close(const char *proto, size_t proto_size, scap_sized
 
 static parse_result parse_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Clone gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1774,7 +1774,7 @@ static parse_result parse_clone(const char *proto, size_t proto_size, scap_sized
 
 static parse_result parse_timerfd_create(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::TimerfdCreate gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1813,7 +1813,7 @@ static parse_result parse_timerfd_create(const char *proto, size_t proto_size, s
 
 static parse_result parse_fork(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Fork gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1912,7 +1912,7 @@ static parse_result parse_fork(const char *proto, size_t proto_size, scap_sized_
 
 static parse_result parse_inotify_init(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Eventfd gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1950,7 +1950,7 @@ static parse_result parse_inotify_init(const char *proto, size_t proto_size, sca
 
 static parse_result parse_socketpair(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::SocketPair gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -1991,7 +1991,7 @@ static parse_result parse_socketpair(const char *proto, size_t proto_size, scap_
 
 static parse_result parse_write(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	char scap_err[SCAP_LASTERR_SIZE];
 	gvisor::syscall::Write gvisor_evt;
 	if(!gvisor_evt.ParseFromArray(proto, proto_size))
@@ -2088,7 +2088,7 @@ static parse_result parse_write(const char *proto, size_t proto_size, scap_sized
 
 parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_buffer scap_buf)
 {
-	parse_result ret = {0};
+	parse_result ret;
 	const char *buf = static_cast<const char*>(gvisor_buf.buf);
 
 	const header *hdr = reinterpret_cast<const header *>(buf);
@@ -2130,7 +2130,7 @@ parse_result parse_gvisor_proto(scap_const_sized_buffer gvisor_buf, scap_sized_b
 
 procfs_result parse_procfs_json(const std::string &input, const std::string &sandbox)
 {
-	procfs_result res = {0};
+	procfs_result res;
 	Json::Value root;
 	Json::CharReaderBuilder builder;
 	std::string err;
@@ -2253,8 +2253,8 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	}
 	strlcpy(tinfo.cwd, root["cwd"].asCString(), SCAP_MAX_PATH_SIZE + 1);
 
-	// uid 
-	if(!status.isMember("uid") || !status["uid"].isMember("effective") || 
+	// uid
+	if(!status.isMember("uid") || !status["uid"].isMember("effective") ||
 		!status["uid"]["effective"].isUInt64())
 	{
 		return res;
@@ -2262,7 +2262,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	tinfo.uid = status["uid"]["effective"].asUInt64();
 
 	// gid
-	if(!status.isMember("gid") || !status["gid"].isMember("effective") || 
+	if(!status.isMember("gid") || !status["gid"].isMember("effective") ||
 		!status["gid"]["effective"].isUInt64())
 	{
 		return res;
@@ -2289,7 +2289,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	}
 	tinfo.clone_ts = root["clone_ts"].asUInt64();
 
-	// fdinfos 
+	// fdinfos
 
 	// set error so that we can understand that parsing failed here
 	res.error = "Error parsing fdlist";
@@ -2303,7 +2303,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 	{
 		Json::Value &entry = root["fdlist"][i];
 		scap_fdinfo fdinfo;
-		
+
 		if(!entry.isMember("number") || !entry["number"].isUInt64())
 		{
 			return res;
@@ -2314,7 +2314,7 @@ procfs_result parse_procfs_json(const std::string &input, const std::string &san
 		{
 			return res;
 		}
-		
+
 		if(!entry.isMember("path") || !entry["path"].isString())
 		{
 			return res;
@@ -2345,13 +2345,13 @@ config_result parse_config(std::string config)
 	config_result res;
 	res.socket_path = "";
 	res.error = "";
-	res.status = SCAP_FAILURE;	
+	res.status = SCAP_FAILURE;
 
 	std::string err;
 	Json::Value root;
 	Json::CharReaderBuilder builder;
 	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
-	
+
 	bool json_parse = reader->parse(config.c_str(), config.c_str() + config.size(), &root, &err);
 	if(!json_parse)
 	{
@@ -2394,7 +2394,7 @@ config_result parse_config(std::string config)
 		res.error = "Could not find endpoint in sink configuration";
 		return res;
 	}
-	
+
 	res.socket_path = sink_config["endpoint"].asString();
 	res.status = SCAP_SUCCESS;
 	return res;

--- a/userspace/libscap/engine/gvisor/runsc.cpp
+++ b/userspace/libscap/engine/gvisor/runsc.cpp
@@ -30,7 +30,7 @@ namespace runsc {
 
 result runsc(char *argv[])
 {
-	result res = {0};
+	result res;
 	int pipefds[2];
 
 	int ret = pipe(pipefds);
@@ -43,7 +43,7 @@ result runsc(char *argv[])
 	if(pid > 0)
 	{
 		int status;
-		
+
 		close(pipefds[1]);
 		wait(&status);
 		if(!WIFEXITED(status) || WEXITSTATUS(status) != 0)
@@ -85,11 +85,11 @@ result version()
 
 result list(const std::string &root_path)
 {
-	result res = {0};
+	result res;
 	std::vector<std::string> running_sandboxes;
 
 	const char *argv[] = {
-		"runsc", 
+		"runsc",
 		"--root",
 		root_path.c_str(),
 		"list",
@@ -118,13 +118,13 @@ result list(const std::string &root_path)
 result trace_create(const std::string &root_path, const std::string &trace_session_path, const std::string &sandbox_id, bool force)
 {
 	const char *argv[] = {
-		"runsc", 
+		"runsc",
 		"--root",
 		root_path.c_str(),
 		"trace",
 		"create",
 		force ? "--force" : "",
-		"--config", 
+		"--config",
 		trace_session_path.c_str(),
 		sandbox_id.c_str(),
 		NULL
@@ -136,7 +136,7 @@ result trace_create(const std::string &root_path, const std::string &trace_sessi
 result trace_delete(const std::string &root_path, const std::string &session_name, const std::string &sandbox_id)
 {
 	const char *argv[] = {
-		"runsc", 
+		"runsc",
 		"--root",
 		root_path.c_str(),
 		"trace",
@@ -153,13 +153,13 @@ result trace_delete(const std::string &root_path, const std::string &session_nam
 result trace_procfs(const std::string &root_path, const std::string &sandbox_id)
 {
 	const char *argv[] = {
-		"runsc", 
+		"runsc",
 		"--root",
 		root_path.c_str(),
 		"trace",
 		"procfs",
 		sandbox_id.c_str(),
-		NULL, 
+		NULL,
 	};
 
 	return runsc((char **)argv);

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -18,20 +18,21 @@ limitations under the License.
 
 #pragma once
 
-#include <string>
-#include <vector>
-#include <list>
-#include <set>
-#include <unordered_set>
-#include <cctype>
-#include <algorithm>
-#include <locale>
-#include <sstream>
-
-#include <tuples.h>
-#include <scap.h>
-#include "json/json.h"
+#include "scap.h"
 #include "sinsp_public.h"
+#include "tuples.h"
+
+#include <json/json.h>
+
+#include <algorithm>
+#include <cctype>
+#include <list>
+#include <locale>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
@@ -53,7 +54,6 @@ class sinsp_initializer
 {
 public:
 	sinsp_initializer();
-	~sinsp_initializer();
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -78,7 +78,7 @@ public:
 	static bool sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, char* targetbuf, uint32_t targetbuf_size, bool resolve = false);
 
 	//
-	// Check if string ends with another 
+	// Check if string ends with another
 	//
 	static bool endswith(const std::string& str, const std::string& ending);
 	static bool endswith(const char *str, const char *ending, uint32_t lstr, uint32_t lend);
@@ -89,7 +89,7 @@ public:
 	static bool startswith(const std::string& s, const std::string& prefix);
 
 	//
-	// Transform a hex string into bytes 
+	// Transform a hex string into bytes
 	//
 	static bool unhex(const std::vector<char> &hex_chars, std::vector<char> &hex_bytes);
 
@@ -151,7 +151,7 @@ public:
 	// Convert caps from their numeric representation to a space-separated string list
 	//
 	static std::string caps_to_string(const uint64_t caps);
-	
+
 	static uint64_t get_max_caps();
 };
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
The build of this library, when performed with warnings-as-errors enabled, suppresses a number of warnings to be able to get to the end of the build successfully. Some of these suppressions are best avoided and the root cause addressed in order not to have the warnings in the first place. The rationale is that, though more restrictive, compiler warnings are a way to keep code more closely checked and, ultimately, at a higher quality.
FTR, the warnings that the PR re-enables are the following.
- `missing-field-initializers`
- `type-limits`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
