### PR TITLE
fix(userspace/libsinsp): make sure all destructors are invoked

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -53,10 +53,6 @@ sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_c
 {
 }
 
-sinsp_container_manager::~sinsp_container_manager()
-{
-}
-
 bool sinsp_container_manager::remove_inactive_containers()
 {
 	bool res = false;

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -59,7 +59,7 @@ public:
 	                        const std::string static_name = "",
 	                        const std::string static_image = "");
 
-	virtual ~sinsp_container_manager();
+	virtual ~sinsp_container_manager() = default;
 
 	/**
 	 * @brief Get the whole container map (read-only)

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -230,7 +230,7 @@ public:
 
 	sinsp_evt();
 	sinsp_evt(sinsp* inspector);
-	~sinsp_evt();
+	virtual ~sinsp_evt();
 
 	/*!
 	  \brief Set the inspector.

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -346,10 +346,6 @@ sinsp_evt_formatter_factory::sinsp_evt_formatter_factory(sinsp *inspector, filte
 {
 }
 
-sinsp_evt_formatter_factory::~sinsp_evt_formatter_factory()
-{
-}
-
 void sinsp_evt_formatter_factory::set_output_format(gen_event_formatter::output_format of)
 {
 	m_formatters.clear();

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -54,7 +54,7 @@ public:
 
 	void set_format(gen_event_formatter::output_format of, const std::string& fmt) override;
 
-	~sinsp_evt_formatter();
+	virtual ~sinsp_evt_formatter();
 
 	/*!
 	  \brief Resolve all the formatted tokens and return them in a key/value
@@ -121,7 +121,7 @@ class sinsp_evt_formatter_factory : public gen_event_formatter_factory
 {
 public:
 	sinsp_evt_formatter_factory(sinsp *inspector, filter_check_list &available_checks);
-	virtual ~sinsp_evt_formatter_factory();
+	virtual ~sinsp_evt_formatter_factory() = default;
 
 	void set_output_format(gen_event_formatter::output_format of) override;
 

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -40,10 +40,6 @@ sinsp_filter::sinsp_filter(sinsp *inspector)
 	m_inspector = inspector;
 }
 
-sinsp_filter::~sinsp_filter()
-{
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_filter_compiler implementation
 ///////////////////////////////////////////////////////////////////////////////
@@ -386,10 +382,6 @@ cmpop sinsp_filter_compiler::str_to_cmpop(const std::string& str)
 sinsp_filter_factory::sinsp_filter_factory(sinsp *inspector,
 					   filter_check_list &available_checks)
 	: m_inspector(inspector), m_available_checks(available_checks)
-{
-}
-
-sinsp_filter_factory::~sinsp_filter_factory()
 {
 }
 

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -38,7 +38,7 @@ class SINSP_PUBLIC sinsp_filter : public gen_event_filter
 {
 public:
 	sinsp_filter(sinsp* inspector);
-	~sinsp_filter();
+	virtual ~sinsp_filter() = default;
 
 private:
 	sinsp* m_inspector;
@@ -144,7 +144,7 @@ class sinsp_filter_factory : public gen_event_filter_factory
 public:
 	sinsp_filter_factory(sinsp *inspector, filter_check_list &available_checks);
 
-	virtual ~sinsp_filter_factory();
+	virtual ~sinsp_filter_factory() = default;
 
 	gen_event_filter* new_filter() override;
 	gen_event_filter_check* new_filtercheck(const char* fldname) override;

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -30,9 +30,6 @@ using namespace std;
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_filter_check_list implementation
 ///////////////////////////////////////////////////////////////////////////////
-filter_check_list::filter_check_list()
-{
-}
 
 filter_check_list::~filter_check_list()
 {
@@ -127,6 +124,3 @@ sinsp_filter_check_list::sinsp_filter_check_list()
 	add_filter_check(new sinsp_filter_check_evtin());
 }
 
-sinsp_filter_check_list::~sinsp_filter_check_list()
-{
-}

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -32,7 +32,7 @@ class sinsp;
 class filter_check_list
 {
 public:
-	filter_check_list();
+	filter_check_list() = default;
 	virtual ~filter_check_list();
 	void add_filter_check(sinsp_filter_check* filter_check);
 	void get_all_fields(std::vector<const filter_check_info*>& list);
@@ -48,6 +48,6 @@ class sinsp_filter_check_list : public filter_check_list
 {
 public:
 	sinsp_filter_check_list();
-	virtual ~sinsp_filter_check_list();
+	virtual ~sinsp_filter_check_list() = default;
 };
 

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -25,22 +25,6 @@ limitations under the License.
 #include "sinsp.h"
 #include "sinsp_int.h"
 
-gen_event::gen_event()
-{
-}
-
-gen_event::~gen_event()
-{
-}
-
-gen_event_filter_check::gen_event_filter_check()
-{
-}
-
-gen_event_filter_check::~gen_event_filter_check()
-{
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 // gen_event_filter_expression implementation
 ///////////////////////////////////////////////////////////////////////////////
@@ -459,18 +443,3 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool ver
 	return os.str();
 }
 
-gen_event_formatter::gen_event_formatter()
-{
-}
-
-gen_event_formatter::~gen_event_formatter()
-{
-}
-
-gen_event_formatter_factory::gen_event_formatter_factory()
-{
-}
-
-gen_event_formatter_factory::~gen_event_formatter_factory()
-{
-}

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -78,8 +78,8 @@ enum evt_src
 class gen_event
 {
 public:
-	gen_event();
-	virtual ~gen_event();
+	gen_event() = default;
+	virtual ~gen_event() = default;
 
 	// Every event must expose a timestamp
 	virtual uint64_t get_ts() const = 0;
@@ -104,8 +104,8 @@ typedef struct extract_value {
 class gen_event_filter_check
 {
 public:
-	gen_event_filter_check();
-	virtual ~gen_event_filter_check();
+	gen_event_filter_check() = default;
+	virtual ~gen_event_filter_check() = default;
 
 	boolop m_boolop;
 	cmpop m_cmpop;
@@ -275,8 +275,8 @@ public:
 		OF_JSON   = 1
 	};
 
-	gen_event_formatter();
-	virtual ~gen_event_formatter();
+	gen_event_formatter() = default;
+	virtual ~gen_event_formatter() = default;
 
 	virtual void set_format(output_format of, const std::string &format) = 0;
 
@@ -300,8 +300,8 @@ public:
 class gen_event_formatter_factory
 {
 public:
-	gen_event_formatter_factory();
-	virtual ~gen_event_formatter_factory();
+	gen_event_formatter_factory() = default;
+	virtual ~gen_event_formatter_factory() = default;
 
 	// This should be called before any calls to
 	// create_formatter(), and changes the output format of new

--- a/userspace/libsinsp/prefix_search.cpp
+++ b/userspace/libsinsp/prefix_search.cpp
@@ -22,14 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-path_prefix_search::path_prefix_search()
-{
-}
-
-path_prefix_search::~path_prefix_search()
-{
-}
-
 void path_prefix_search::add_search_path(const char *path)
 {
 	bool dummy = true;

--- a/userspace/libsinsp/prefix_search.h
+++ b/userspace/libsinsp/prefix_search.h
@@ -440,8 +440,8 @@ std::string path_prefix_map<Value>::as_string(const std::string &prefix, bool in
 class path_prefix_search : public path_prefix_map<bool>
 {
 public:
-	path_prefix_search();
-	~path_prefix_search();
+	path_prefix_search() = default;
+	virtual ~path_prefix_search() = default;
 
 	void add_search_path(const char *path);
 	void add_search_path(const filter_value_t &path);

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -203,7 +203,7 @@ public:
 		  const std::string &static_name = "",
 		  const std::string &static_image = "");
 
-	~sinsp() override;
+	virtual ~sinsp() override;
 
 
 	/* Wrappers to open a specific engine. */

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -87,7 +87,7 @@ public:
 	};
 
 	sinsp_filter_check_event();
-	~sinsp_filter_check_event();
+	virtual ~sinsp_filter_check_event();
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -71,10 +71,6 @@ sinsp_filter_check_evtin::sinsp_filter_check_evtin()
 	m_info.m_nfields = sizeof(sinsp_filter_check_evtin_fields) / sizeof(sinsp_filter_check_evtin_fields[0]);
 }
 
-sinsp_filter_check_evtin::~sinsp_filter_check_evtin()
-{
-}
-
 int32_t sinsp_filter_check_evtin::extract_arg(string fldname, string val)
 {
 	uint32_t parsed_len = 0;

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.h
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.h
@@ -57,7 +57,7 @@ public:
 	};
 
 	sinsp_filter_check_evtin();
-	~sinsp_filter_check_evtin();
+	virtual ~sinsp_filter_check_evtin() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -75,10 +75,6 @@ sinsp_filter_check_gen_event::sinsp_filter_check_gen_event()
 	m_u64val = 0;
 }
 
-sinsp_filter_check_gen_event::~sinsp_filter_check_gen_event()
-{
-}
-
 sinsp_filter_check* sinsp_filter_check_gen_event::allocate_new()
 {
 	return (sinsp_filter_check*) new sinsp_filter_check_gen_event();

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.h
@@ -46,7 +46,7 @@ public:
 	};
 
 	sinsp_filter_check_gen_event();
-	~sinsp_filter_check_gen_event();
+	virtual ~sinsp_filter_check_gen_event() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -68,10 +68,6 @@ sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 	m_cargname = NULL;
 }
 
-sinsp_filter_check_tracer::~sinsp_filter_check_tracer()
-{
-}
-
 sinsp_filter_check* sinsp_filter_check_tracer::allocate_new()
 {
 	return (sinsp_filter_check*) new sinsp_filter_check_tracer();

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.h
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.h
@@ -48,7 +48,7 @@ public:
 	};
 
 	sinsp_filter_check_tracer();
-	~sinsp_filter_check_tracer();
+	virtual ~sinsp_filter_check_tracer() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;

--- a/userspace/libsinsp/token_bucket.cpp
+++ b/userspace/libsinsp/token_bucket.cpp
@@ -35,10 +35,6 @@ token_bucket::token_bucket(std::function<uint64_t()> timer)
 	init(1, 1);
 }
 
-token_bucket::~token_bucket()
-{
-}
-
 void token_bucket::init(double rate, double max_tokens, uint64_t now)
 {
 	m_rate = rate;

--- a/userspace/libsinsp/token_bucket.h
+++ b/userspace/libsinsp/token_bucket.h
@@ -28,7 +28,7 @@ class token_bucket
 public:
 	token_bucket();
 	token_bucket(std::function<uint64_t()> timer);
-	virtual ~token_bucket();
+	virtual ~token_bucket() = default;
 
 	//
 	// Initialize the token bucket and start accumulating tokens


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

I noticed we have a bunch of classes inheriting from others that haven't defined their destructor as virtual. Not doing so makes it very unpredictable to know _which_ destructor is actually invoked at object disposal time. In general this causes segfaults or memory leaks. Looking at the code, I don't think this can be the cause of any time-growing memory leak in Falco, but my bet is that this eats some extra bytes when loading rules when not necessary. For other clients of the libs, this can potentially cause subtle issues.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
