### PR TITLE
build: remove some gcc-13 compiler warnings

### DIFF
--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 if(NOT BUILD_BPF)
-	message(WARNING e2e tests can only be run with the eBPF probe)
+	message(WARNING "e2e tests can only be run with the eBPF probe")
 	return()
 endif()
 

--- a/userspace/libscap/ppm_sc_names.c
+++ b/userspace/libscap/ppm_sc_names.c
@@ -52,7 +52,7 @@ static void load_ppm_sc_table()
 		if(!sc_names[i])
 		{
 			continue;
-		}	
+		}
 
 		strlcpy(g_ppm_sc_names[i], sc_names[i], PPM_MAX_NAME_LEN);
 		char *p = g_ppm_sc_names[i];
@@ -70,7 +70,7 @@ const char *scap_get_ppm_sc_name(ppm_sc_code sc)
 	ASSERT(sc >= 0 && sc < PPM_SC_MAX);
 
 	/* Lazy loading */
-	if(g_ppm_sc_names[0] && (strcmp(g_ppm_sc_names[0], "") == 0))
+	if(g_ppm_sc_names[0][0] == '\0')
 	{
 		load_ppm_sc_table();
 	}

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -104,7 +104,7 @@ struct scap_vtable;
 #define SCAP_MINIMUM_DRIVER_API_VERSION PPM_API_VERSION(8, 0, 0)
 #define SCAP_MINIMUM_DRIVER_SCHEMA_VERSION PPM_API_VERSION(2, 0, 0)
 
-// 
+//
 // This is the dimension we used before introducing the variable buffer size.
 //
 #define DEFAULT_DRIVER_BUFFER_BYTES_DIM 8 * 1024 * 1024
@@ -729,9 +729,9 @@ const struct ppm_event_info* scap_get_event_info_table();
     - `EC_TRACEPOINT
     - `EC_PLUGIN`
     - `EC_METAEVENT`
- 
+
   2. The lowest bits represent the syscall category to which the specific event belongs.
-  
+
   With this method, we are retrieving the syscall category
 */
 enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev);
@@ -744,9 +744,9 @@ enum ppm_event_category scap_get_syscall_category_from_event(ppm_event_code ev);
     - `EC_TRACEPOINT
     - `EC_PLUGIN`
     - `EC_METAEVENT`
- 
+
   2. The lowest bits represent the syscall category to which the specific event belongs.
-  
+
   With this method, we are retrieving the event category
 */
 enum ppm_event_category scap_get_event_category_from_event(ppm_event_code ev);
@@ -783,7 +783,7 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen);
   \param enabled whether to enable or disable the syscall
   \note This function can only be called for live captures.
 */
-int32_t scap_set_ppm_sc(scap_t* handle, uint32_t ppm_sc, bool enabled);
+int32_t scap_set_ppm_sc(scap_t* handle, ppm_sc_code ppm_sc, bool enabled);
 
 /*!
   \brief (Un)Set the drop failed feature of the drivers.
@@ -809,7 +809,7 @@ bool scap_check_current_engine(scap_t *handle, const char* engine_name);
 
 /*!
   \brief Get (at most) n parameters for this event.
- 
+
   \param e The scap event.
   \param params An array large enough to contain at least one entry per event parameter (which is at most PPM_MAX_EVENT_PARAMS).
  */
@@ -823,7 +823,7 @@ uint32_t scap_event_decode_params(const scap_evt *e, struct scap_sized_buffer *p
    - String types (including PT_FSPATH, PT_FSRELPATH) are passed via a null-terminated char*
    - Buffer types, variable size types and similar, including PT_BYTEBUF, PT_SOCKTUPLE are passed with
      a struct scap_const_sized_buffer
-  
+
   If the event was written successfully, SCAP_SUCCESS is returned. If the supplied buffer is not large enough to contain
   the event, SCAP_INPUT_TOO_SMALL is returned and event_size is set with the required size to contain the entire event.
 

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -39,8 +39,6 @@ template<> struct hash<sinsp_container_type> {
 };
 }
 
-class sinsp_threadinfo;
-
 // Docker and CRI-compatible runtimes are very similar
 static inline bool is_docker_compatible(sinsp_container_type t)
 {
@@ -353,7 +351,7 @@ public:
 	int64_t m_created_time;
 
 	/**
-	 * The max container label length value. This is static because it is 
+	 * The max container label length value. This is static because it is
 	 * universal across all instances and needs to be set once only.
 	 */
 	static uint32_t m_container_label_max_length;

--- a/userspace/libsinsp/cri.hpp
+++ b/userspace/libsinsp/cri.hpp
@@ -18,13 +18,12 @@ limitations under the License.
 
 #include "cri.h"
 
-#include <chrono>
 #include "grpc_channel_registry.h"
-
 #include "sinsp.h"
 #include "sinsp_int.h"
 
-using namespace std;
+#include <chrono>
+
 #define MAX_CNIRESULT_LENGTH 4096
 
 namespace
@@ -40,12 +39,12 @@ namespace libsinsp
 {
 namespace cri
 {
-std::vector<std::string> s_cri_unix_socket_paths;
-int64_t s_cri_timeout = 1000;
-int64_t s_cri_size_timeout = 10000;
-sinsp_container_type s_cri_runtime_type = CT_CRI;
-std::string s_cri_unix_socket_path;
-bool s_cri_extra_queries = true;
+inline std::vector<std::string> s_cri_unix_socket_paths;
+inline int64_t s_cri_timeout = 1000;
+inline int64_t s_cri_size_timeout = 10000;
+inline sinsp_container_type s_cri_runtime_type = CT_CRI;
+inline std::string s_cri_unix_socket_path;
+inline bool s_cri_extra_queries = true;
 
 template<typename api> cri_interface<api>::cri_interface(const std::string &cri_path)
 {
@@ -190,7 +189,7 @@ bool cri_interface<api>::parse_cri_image(const typename api::ContainerStatus &st
 	case 0: // sha256:digest
 		have_digest = true;
 		break;
-	case string::npos:
+	case std::string::npos:
 		break;
 	default: // host/image@sha256:digest
 		have_digest = image_ref[digest_start - 1] == '@';
@@ -241,7 +240,7 @@ bool cri_interface<api>::parse_cri_image(const typename api::ContainerStatus &st
 	g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): parse_cri_image: have_digest=%d image_name=%s",
 			container.m_id.c_str(), have_digest, image_name.c_str());
 
-	string hostname, port, digest;
+	std::string hostname, port, digest;
 	sinsp_utils::split_container_image(image_name, hostname, port, container.m_imagerepo, container.m_imagetag,
 					   digest, false);
 
@@ -250,7 +249,7 @@ bool cri_interface<api>::parse_cri_image(const typename api::ContainerStatus &st
 		g_logger.format(sinsp_logger::SEV_DEBUG, "cri (%s): parse_cri_image: tag=%s, pulling tag from %s",
 				container.m_id.c_str(), container.m_imagetag.c_str(), status.image().image().c_str());
 
-		string digest2, repo;
+		std::string digest2, repo;
 		sinsp_utils::split_container_image(status.image().image(), hostname, port, repo, container.m_imagetag,
 						   digest2, false);
 
@@ -389,9 +388,9 @@ bool cri_interface<api>::parse_cri_json_image(const Json::Value &info, sinsp_con
 
 	auto image_str = image->asString();
 	auto pos = image_str.find(':');
-	if(pos == string::npos)
+	if(pos == std::string::npos)
 	{
-		container.m_imageid = move(image_str);
+		container.m_imageid = std::move(image_str);
 	}
 	else
 	{

--- a/userspace/libsinsp/cyclewriter.h
+++ b/userspace/libsinsp/cyclewriter.h
@@ -26,7 +26,7 @@ public:
 	//
 	// The conclusion is what consider() tells you to do
 	// after you tell it how many more bytes to consider.
-	// 
+	//
 	// We don't deal directly with file pointers here to
 	// keep the concerns separated.  This engine only advises
 	// a course of action.
@@ -57,21 +57,21 @@ public:
 	};
 
 	//
-	// Setup sets all the parameters of the 
+	// Setup sets all the parameters of the
 	// engine in one go so you don't miss anything.
 	//
-	// Also, if the engine has already started 
+	// Also, if the engine has already started
 	// (via a call to consider()), then this will
 	// be locked down and return false.
 	//
 	bool setup(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit);
-	
+
 	//
 	// Consider file size at the current time
-	// and tell us whether 
+	// and tell us whether
 	//
 	//  * a new file should be written,
-	//  * we should use the same file, or 
+	//  * we should use the same file, or
 	//  * we should quit.
 	//
 	// If we should use a new file, or should quit,
@@ -79,12 +79,12 @@ public:
 	// thought so, and in the case of a new file,
 	// get_current_file_name() will tell us the new
 	// capture file name to use.
-	// 
+	//
 	cycle_writer::conclusion consider(sinsp_evt* evt, uint64_t written_bytes);
 
 	//
-	// The yields the current file name 
-	// based on the input parameters and 
+	// The yields the current file name
+	// based on the input parameters and
 	// what has been past into consider.
 	//
 	std::string get_current_file_name();
@@ -95,7 +95,7 @@ public:
 private:
 	//
 	// This will yield a new file if
-	// needed or conclude that we need 
+	// needed or conclude that we need
 	// to exit.
 	//
 	cycle_writer::conclusion next_file();
@@ -103,12 +103,12 @@ private:
 	//
 	// These are the variables that are set
 	// to specify how the engine will work.
-	// 
+	//
 	// Use the setup() function to set them up.
 	//
 	// values <= 0 mean don't use the feature.
-	// 
-	
+	//
+
 	// The base file name to write to
 	std::string m_base_file_name; // = ""
 
@@ -142,7 +142,7 @@ private:
 	// we don't know what's what at first
 	// we just leave this hanging.
 	//
-	char m_limit_format[6];
+	char m_limit_format[16];
 
 	// The last file name that
 	// was created (mostly for debugging)
@@ -151,7 +151,7 @@ private:
 	//
 	// This is toggled to true the
 	// first time consider is run ...
-	// it will lock the setup() from 
+	// it will lock the setup() from
 	// being further run
 	//
 	bool m_first_consider; // = false
@@ -165,4 +165,3 @@ private:
 	// name format for deleting "out-of-range" files
 	std::string *m_past_names;
 };
-

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -112,7 +112,6 @@ sinsp_evt::sinsp_evt(sinsp *inspector) :
 		m_filtered_out(false),
 		m_event_info_table(g_infotables.m_event_info)
 {
-	
 }
 
 sinsp_evt::~sinsp_evt()
@@ -1025,7 +1024,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 		std::string_view path = param->as<std::string_view>();
 		strcpy_sanitized(&m_paramstr_storage[0],
 			path.data(),
-			MIN(path.size() + 1, (uint32_t)m_paramstr_storage.size()));
+			std::min(path.size() + 1, m_paramstr_storage.size()));
 
 		sinsp_threadinfo* tinfo = get_thread_info();
 
@@ -1081,7 +1080,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				blen > m_inspector->m_max_evt_output_len &&
 				fmt == PF_NORMAL)
 			{
-				uint32_t real_len = MIN(blen, m_inspector->m_max_evt_output_len);
+				uint32_t real_len = std::min(blen, m_inspector->m_max_evt_output_len);
 
 				m_rawbuf_str_len = real_len;
 				if(real_len > 3)

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -18,11 +18,21 @@ limitations under the License.
 
 #pragma once
 
+#include "settings.h"
+#include "sinsp_public.h"
 #include "tuples.h"
+
+#include <string>
+#include <vector>
 
 #ifndef VISIBILITY_PRIVATE
 #define VISIBILITY_PRIVATE private:
 #endif
+
+typedef struct scap_addrlist scap_addrlist;
+typedef struct scap_ifinfo_ipv4 scap_ifinfo_ipv4;
+typedef struct scap_ifinfo_ipv6 scap_ifinfo_ipv6;
+class sinsp_threadinfo;
 
 //
 // network interface info ipv4
@@ -30,8 +40,7 @@ limitations under the License.
 class SINSP_PUBLIC sinsp_ipv4_ifinfo
 {
 public:
-	sinsp_ipv4_ifinfo() {};
-
+	sinsp_ipv4_ifinfo() = default;
 	sinsp_ipv4_ifinfo(uint32_t addr, uint32_t netmask, uint32_t bcast, const char* name);
 
 	std::string to_string() const;
@@ -41,6 +50,7 @@ public:
 	uint32_t m_netmask;
 	uint32_t m_bcast;
 	std::string m_name;
+
 private:
 	static void convert_to_string(char * dest, size_t len, const uint32_t addr);
 };
@@ -51,7 +61,7 @@ private:
 class SINSP_PUBLIC sinsp_ipv6_ifinfo
 {
 public:
-	sinsp_ipv6_ifinfo() {};
+	sinsp_ipv6_ifinfo() = default;
 
 	ipv6addr m_net;
 

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -135,7 +135,7 @@ sinsp_plugin::~sinsp_plugin()
 {
 	destroy();
 	plugin_unload(m_handle);
-	
+
 	auto cur_async_handler = m_async_evt_handler.load();
 	if (cur_async_handler)
 	{
@@ -779,7 +779,7 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt) const
 		ret += "datalen=";
 		ret += std::to_string(datalen);
 		ret += " data=";
-		for (size_t i = 0; i < MIN(datalen, 50); ++i)
+		for (size_t i = 0; i < std::min(datalen, uint32_t(50)); ++i)
 		{
 			if (!std::isprint(data[i]))
 			{
@@ -787,7 +787,7 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt) const
 				return ret;
 			}
 		}
-		ret.append((char*) data, MIN(datalen, 50));
+		ret.append((char*) data, std::min(datalen, uint32_t(50)));
 		if (datalen > 50)
 		{
 			ret += "...";
@@ -1010,7 +1010,7 @@ bool sinsp_plugin::set_async_event_handler(async_event_handler_t handler)
 	//   - CH not-null, NH null: the handler value must be updated after setting
 	//     it to the plugin, so that any already-running thread in the plugin
 	//     can be stopped before setting the handler to null. In case of success,
-	//     we can set the handler value to null. 
+	//     we can set the handler value to null.
 	//   - CH not-null, NH not-null: not supported for now, need to reset
 	//     the current handler to null before setting a new one.
 

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -272,7 +272,7 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 				field = &container_info->m_imagedigest;
 				break;
 			default:
-				break;
+				return nullptr;
 			}
 
 			if(field->empty())

--- a/userspace/libsinsp/sinsp_int.h
+++ b/userspace/libsinsp/sinsp_int.h
@@ -16,44 +16,36 @@ limitations under the License.
 
 */
 
-
 ////////////////////////////////////////////////////////////////////////////
 // Public definitions for the scap library
 ////////////////////////////////////////////////////////////////////////////
 #pragma once
+
+#include "ifinfo.h"
+#include "scap.h"
+#include "settings.h"
+#include "sinsp_public.h"
+#include "parsers.h"
+#include "utils.h"
 
 #ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <csignal>
 #endif
-#include <assert.h>
 
-#include <string>
-#include <memory>
-#include <iostream>
-#include <fstream>
-#include <exception>
-#include <sstream>
+#include <cassert>
 #include <deque>
-#include <queue>
-#include <list>
-#include <vector>
+#include <exception>
+#include <fstream>
 #include <iostream>
 #include <limits>
-
-#include "scap.h"
-#include "settings.h"
-#include "utils.h"
-#include "scap.h"
-#include "parsers.h"
-#include "ifinfo.h"
-#include "sinsp_public.h"
-
-#ifndef MIN
-#define MIN(X,Y) ((X) < (Y)? (X):(Y))
-#define MAX(X,Y) ((X) > (Y)? (X):(Y))
-#endif
+#include <list>
+#include <memory>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <vector>
 
 //
 // The logger

--- a/userspace/libsinsp/stats.cpp
+++ b/userspace/libsinsp/stats.cpp
@@ -312,7 +312,7 @@ const scap_stats_v2* libsinsp::stats::get_sinsp_stats_v2(uint32_t flags, const s
 		double cpu_usage_perc_total_host = 0.0;
 		uint32_t procs_running_host = 0;
 
-		if(buffer[SINSP_RESOURCE_UTILIZATION_CPU_PERC].name != nullptr && strncmp(buffer[SINSP_RESOURCE_UTILIZATION_CPU_PERC].name, sinsp_stats_v2_resource_utilization_names[SINSP_RESOURCE_UTILIZATION_CPU_PERC], 15) != 0)
+		if(strncmp(buffer[SINSP_RESOURCE_UTILIZATION_CPU_PERC].name, sinsp_stats_v2_resource_utilization_names[SINSP_RESOURCE_UTILIZATION_CPU_PERC], 15) != 0)
 		{
 			// Init
 			for(uint32_t i = SINSP_RESOURCE_UTILIZATION_CPU_PERC; i < SINSP_RESOURCE_UTILIZATION_FDS_TOTAL_HOST + 1; i++)
@@ -330,7 +330,7 @@ const scap_stats_v2* libsinsp::stats::get_sinsp_stats_v2(uint32_t flags, const s
 			buffer[SINSP_RESOURCE_UTILIZATION_PROCS_HOST].type = STATS_VALUE_TYPE_U32;
 			buffer[SINSP_RESOURCE_UTILIZATION_MEMORY_TOTAL_HOST].type = STATS_VALUE_TYPE_U64;
 			buffer[SINSP_RESOURCE_UTILIZATION_FDS_TOTAL_HOST].type = STATS_VALUE_TYPE_U64;
-		} 
+		}
 
 		// Get stats / metrics snapshot
 
@@ -353,7 +353,7 @@ const scap_stats_v2* libsinsp::stats::get_sinsp_stats_v2(uint32_t flags, const s
 
 	if((flags & PPM_SCAP_STATS_STATE_COUNTERS) && stats_v2)
 	{
-		if(buffer[SINSP_STATS_V2_N_THREADS].name != nullptr && strncmp(buffer[SINSP_STATS_V2_N_THREADS].name, sinsp_stats_v2_resource_utilization_names[SINSP_STATS_V2_N_THREADS], 10) != 0)
+		if(strncmp(buffer[SINSP_STATS_V2_N_THREADS].name, sinsp_stats_v2_resource_utilization_names[SINSP_STATS_V2_N_THREADS], 10) != 0)
 		{
 			// Init
 			for(uint32_t i = SINSP_STATS_V2_N_THREADS; i < SINSP_MAX_STATS_V2; i++)
@@ -415,7 +415,7 @@ const scap_stats_v2* libsinsp::stats::get_sinsp_stats_v2(uint32_t flags, const s
 
 		*nstats = SINSP_MAX_STATS_V2;
 	}
-	
+
 	*rc = SCAP_SUCCESS;
 	return buffer;
 }

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -82,7 +82,7 @@ TEST(plugins, broken_source_capability)
 	api.get_id = NULL;
 	api.get_event_source = NULL;
 	ASSERT_NO_THROW(register_plugin_api(inspector.get(), api));
-	
+
 	// restore inspector and source API
 	inspector.reset(new sinsp());
 	get_plugin_api_sample_plugin_source(api);
@@ -92,8 +92,8 @@ TEST(plugins, broken_source_capability)
 	ASSERT_ANY_THROW(register_plugin_api(inspector.get(), api));
 	api.close = NULL;
 	ASSERT_ANY_THROW(register_plugin_api(inspector.get(), api));
-	api.next_batch = NULL; 
-	
+	api.next_batch = NULL;
+
 	// Now that all the 3 methods are NULL the plugin has no more capabilities
 	// so we should throw an exception because every plugin should implement at least one
 	// capability
@@ -121,7 +121,7 @@ TEST(plugins, broken_parsing_capability)
 	plugin_api api;
 	auto inspector = std::unique_ptr<sinsp>(new sinsp());
 	get_plugin_api_sample_syscall_parse(api);
-	
+
 	// The plugin has no capabilities
 	api.parse_event = NULL;
 	ASSERT_ANY_THROW(register_plugin_api(inspector.get(), api));
@@ -161,7 +161,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 
 	// This plugin tells that it can receive `syscall` events
 	add_plugin_filterchecks(&m_inspector, pl, sinsp_syscall_event_source_name, pl_flist);
-	
+
 	// Open the inspector in test mode
 	add_default_init_thread();
 	open_inspector();
@@ -577,7 +577,7 @@ TEST_F(sinsp_with_test_input, plugin_tables)
 		table->new_entry();
 
 		// creating and adding a thread to the table
-		auto t = table->add_entry(i, std::move(table->new_entry()));
+		auto t = table->add_entry(i, table->new_entry());
 		ASSERT_NE(t, nullptr);
 		ASSERT_NE(table->get_entry(i), nullptr);
 		ASSERT_EQ(table->entries_count(), i + 1);
@@ -635,7 +635,7 @@ TEST_F(sinsp_with_test_input, plugin_tables)
 	// erase one of the newly-created thread
 	ASSERT_EQ(table->erase_entry(0), true);
 	ASSERT_EQ(table->entries_count(), max_iterations - 1);
-	
+
 	// clear all
 	ASSERT_NO_THROW(table->clear_entries());
 	ASSERT_EQ(table->entries_count(), 0);


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
This is another fix of a number of compiler warnings that came up during a build with a recent gcc toolchain (13.2.1).
Also, the usage of macro `MIN` has been replaced with `std::min` for C++ sources. A duplicate macro and its usages for C sources have, of course, been kept.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
