### PR TITLE
[We are refactoring and getting rid of the custom logic, see PR 1533] fix(libsinsp): avoid possible underflow in rewind_to_parent_path util

### DIFF
--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -19,8 +19,153 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "utils.h"
 
-// copy_and_sanitize_path is not exported in utils.h
+// Following helpers are not exported in utils.h
 void copy_and_sanitize_path(char* target, char* targetbase, const char* path, char separator);
+void rewind_to_parent_path(char* targetbase, char** tc, const char** pc, uint32_t delta);
+
+TEST(sinsp_utils_test, concatenate_paths)
+{
+	char fullpath[SCAP_MAX_PATH_SIZE];
+	std::string path1;
+	std::string path2;
+	bool res;
+
+	/*
+	 * SUCCESS concatenate_paths
+	*/
+
+	path2 = "dir/term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									"\0",
+									0,
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ(path2, std::string(fullpath));
+	ASSERT_TRUE(res);
+
+	path1 = "//";
+	path2 = "dir/term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("//dir/term", std::string(fullpath));
+	ASSERT_TRUE(res);
+
+	path1 = "////";
+	path2 = "dir/term/";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("////dir/term", std::string(fullpath));
+	ASSERT_TRUE(res);
+
+	path1 = "///../.../../";
+	path2 = "dir/term/";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("///../.../../dir/term", std::string(fullpath));
+	ASSERT_TRUE(res);
+
+	path1 = "///../.../";
+	path2 = "dir/./././///./term/";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("///../.../dir/term", std::string(fullpath));
+	ASSERT_TRUE(res); // only path2 gets sanitized and ./ or multiple //// removed
+
+	path1 = "../.../";
+	path2 = "dir/././././../../.../term/";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("../.../term", std::string(fullpath));
+	ASSERT_TRUE(res); // only path2 gets sanitized and ./ removed and directory traversed up
+
+	path1 = "././";
+	path2 = "./dir/term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("././dir/term", std::string(fullpath));
+	ASSERT_TRUE(res); // only path2 gets sanitized and ./ removed
+
+
+	/*
+	 * FAILED concatenate_paths
+	*/
+
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									"\0",
+									0,
+									"\0",
+									0);
+	EXPECT_EQ("\0", std::string(fullpath));
+	ASSERT_FALSE(res); // nothing to concat as path2 is empty
+
+	path1 = "//";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									"\0",
+									 0);
+	EXPECT_EQ("\0", std::string(fullpath));
+	ASSERT_FALSE(res); // nothing to concat as path2 is empty
+
+	path2 = "/dir/term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									"\0",
+									0,
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ(path2, std::string(fullpath));
+	ASSERT_FALSE(res); // because path2 is absolute
+
+	path1 = "//";
+	path2 = "/dir/term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("/dir/term", std::string(fullpath));
+	ASSERT_FALSE(res); // because path2 is absolute
+
+	path1 = "//";
+	path2 = "////dir/../../././term";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("/term", std::string(fullpath));
+	ASSERT_FALSE(res); // because path2 is absolute, path2 gets directory traversed up
+
+	path1 = "//";
+	path2 = "////";
+	res = sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									path1.c_str(),
+									(uint32_t)path1.length(),
+									path2.c_str(),
+									(uint32_t)path2.length());
+	EXPECT_EQ("/", std::string(fullpath));
+	ASSERT_FALSE(res); // because not actually paths here just repeated separators
+
+}
+
 
 TEST(sinsp_utils_test, copy_and_sanitize_path)
 {

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -608,7 +608,7 @@ void rewind_to_parent_path(char* targetbase, char** tc, const char** pc, uint32_
 
 	(*tc)--;
 
-	while(*((*tc) - 1) != '/' && (*tc) >= targetbase + 1)
+	while((*tc) >= targetbase + 1 && (*((*tc) - 1) != '/' || (*tc - 1) < targetbase))
 	{
 		(*tc)--;
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Observed stack-buffer-overflow error (underflow) on real servers:

```
ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff8fe2730f at pc 0x55e12ec57717 bp 0x7fff8fe26ec0 sp 0x7fff8fe26eb8
READ of size 1 at 0x7fff8fe2730f thread T0
#0 0x55e12ec57716 in rewind_to_parent_path(char*, char**, char const**, unsigned int) /build/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libsinsp/utils.cpp:611
 #1 0x55e12ec57d6a in copy_and_sanitize_path(char*, char*, char const*, char) /build/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libsinsp/utils.cpp:678
#2 0x55e12ec58303 in sinsp_utils::concatenate_paths(char*, unsigned int, char const*, unsigned int, char const*, unsigned int) /build/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libsinsp/utils.cpp:753
#3 0x55e12ed71aa5 in sinsp_parser::parse_open_openat_creat_exit(sinsp_evt*) /build/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libsinsp/parsers.cpp:2771

Address 0x7fff8fe2730f is located in stack of thread T0 at offset 639 in frame
    #0 0x55e12ed70b7b in sinsp_parser::parse_open_openat_creat_exit(sinsp_evt*) /build/falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/userspace/libsinsp/parsers.cpp:2586

  This frame has 9 object(s):
    [48, 49) '<unknown>'
    [64, 80) 'name' (line 2588)
    [96, 112) 'enter_evt_name' (line 2589)
    [128, 160) 'sdir' (line 2594)
    [192, 224) '<unknown>'
    [256, 288) '<unknown>'
    [320, 352) '<unknown>'
    [384, 568) 'fdi' (line 2592)
    [640, 1664) 'fullpath' (line 2769) <== Memory access at offset 639 underflows this variable
```

First added few more tests to `concatenate_paths`, then I tried to fix the error at line 611, but I am not fully sure as so far I failed getting the right unit tests in place for `rewind_to_parent_path`. @LucaGuerra kindly asking for some help if possible, thank you!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
