### PR TITLE
refactor(libsinsp): rewrite concatenate_paths with std::filesystem

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1039,14 +1039,14 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					m_resolved_paramstr_storage.resize(path.length() + cwd.length() + 2, 0);
 				}
 
-				if(!sinsp_utils::concatenate_paths(&m_resolved_paramstr_storage[0],
-					(uint32_t)m_resolved_paramstr_storage.size(),
-					(char*)cwd.c_str(),
-					(uint32_t)cwd.length(),
-					path.data(),
-					path.length()))
+				if(path.length() == 0 || path[0] == '/')
 				{
 					m_resolved_paramstr_storage[0] = 0;
+				}
+				else
+				{
+					std::string concatenated_path = sinsp_utils::concatenate_paths(cwd, path);
+					strcpy_sanitized(&m_paramstr_storage[0], concatenated_path.data(), std::min(concatenated_path.size() + 1, m_paramstr_storage.size()));
 				}
 			}
 		}

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1039,7 +1039,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					m_resolved_paramstr_storage.resize(path.length() + cwd.length() + 2, 0);
 				}
 
-				if(path.length() == 0 || path[0] == '/')
+				if(path.empty() || path[0] == '/')
 				{
 					m_resolved_paramstr_storage[0] = 0;
 				}

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include <string>
 #include <optional>
 #include <functional>
+#include <filesystem>
 
 #include "sinsp.h"
 #include "sinsp_int.h"
@@ -1039,7 +1040,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					m_resolved_paramstr_storage.resize(path.length() + cwd.length() + 2, 0);
 				}
 
-				if(path.empty() || path[0] == '/')
+				if(path.empty() || std::filesystem::path(path).is_absolute())
 				{
 					m_resolved_paramstr_storage[0] = 0;
 				}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4391,11 +4391,8 @@ void sinsp_parser::parse_chdir_exit(sinsp_evt *evt)
 	//
 	if(retval >= 0)
 	{
-		const sinsp_evt_param *parinfo;
-
 		// Update the thread working directory
-		parinfo = evt->get_param(1);
-		evt->m_tinfo->set_cwd(parinfo->m_val, parinfo->m_len);
+		evt->m_tinfo->set_cwd(evt->get_param(1)->as<std::string_view>());
 	}
 }
 
@@ -4422,14 +4419,12 @@ void sinsp_parser::parse_fchdir_exit(sinsp_evt *evt)
 		}
 
 		// Update the thread working directory
-		evt->m_tinfo->set_cwd((char *)evt->m_fdinfo->m_name.c_str(),
-		                 (uint32_t)evt->m_fdinfo->m_name.size());
+		evt->m_tinfo->set_cwd(evt->m_fdinfo->m_name);
 	}
 }
 
 void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 {
-	const sinsp_evt_param *parinfo;
 	int64_t retval;
 
 	//
@@ -4452,14 +4447,12 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 			return;
 		}
 
-		parinfo = evt->get_param(1);
+		std::string cwd = std::string(evt->get_param(1)->as<std::string_view>());
 
 #ifdef _DEBUG
-		std::string chkstr = std::string(parinfo->m_val);
-
-		if(chkstr != "/")
+		if(cwd != "/")
 		{
-			if(chkstr + "/"  != evt->m_tinfo->get_cwd())
+			if(cwd + "/" != evt->m_tinfo->get_cwd())
 			{
 				//
 				// This shouldn't happen, because we should be able to stay in synch by
@@ -4470,7 +4463,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 #ifdef _DEBUG
 				int target_res;
 				char target_name[1024];
-				target_res = readlink((chkstr + "/").c_str(),
+				target_res = readlink((cwd + "/").c_str(),
 					target_name,
 					sizeof(target_name) - 1);
 
@@ -4490,7 +4483,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 		}
 #endif
 
-		evt->m_tinfo->set_cwd(parinfo->m_val, parinfo->m_len);
+		evt->m_tinfo->set_cwd(cwd);
 	}
 }
 

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -439,8 +439,7 @@ uint8_t* extract_argraw(sinsp_evt *evt, OUT uint32_t* len, const char *argname)
 
 uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t *len)
 {
-	const sinsp_evt_param *parinfo;
-	string spath;
+	std::string spath;
 
 	if(evt->m_tinfo == NULL)
 	{
@@ -476,7 +475,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 	else if(etype == PPME_SYSCALL_OPEN_BY_HANDLE_AT_X)
 	{
 		int fd = 0;
-		char fullname[SCAP_MAX_PATH_SIZE];
+		std::string fullname;
 
 		//
 		// We can extract the file path only in case of a successful file opening (fd>0).
@@ -488,12 +487,8 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 			//
 			// Get the file path directly from the ring buffer.
 			//
-			parinfo = evt->get_param(3);
+			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string_view>());
 
-			sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, "", 0,
-				parinfo->m_val, parinfo->m_len);
-
-			m_strstorage = fullname;
 			RETURN_EXTRACT_STRING(m_strstorage);
 		}
 	}
@@ -598,11 +593,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 		}
 	}
 
-	char fullname[SCAP_MAX_PATH_SIZE];
-	sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, sdir.c_str(),
-		(uint32_t)sdir.length(), path.data(), path.size());
-
-	m_strstorage = fullname;
+	m_strstorage = sinsp_utils::concatenate_paths(sdir, path);
 
 	RETURN_EXTRACT_STRING(m_strstorage);
 }

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -237,17 +237,14 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 
 			sinsp_parser::parse_dirfd(evt, name.data(), dirfd, &sdir);
 
-			char fullpath[SCAP_MAX_PATH_SIZE];
-
-			sinsp_utils::concatenate_paths(sdir, name);
-
 			if(fd_nameraw)
 			{
 				m_tstr = name;
 			}
 			else
 			{
-				m_tstr = fullpath; // here we'd like a string
+				// fullpath
+				m_tstr = sinsp_utils::concatenate_paths(sdir, name); // here we'd like a string
 			}
 
 			if(sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 */
 
-#include <filesystem>
 #include "sinsp_filtercheck_fspath.h"
 #include "sinsp_filtercheck_event.h"
 #include "sinsp_filtercheck_fd.h"
@@ -350,8 +349,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			return NULL;
 		}
 
-		std::filesystem::path tstr = tinfo->get_cwd() + m_tstr;
-		m_tstr = std::filesystem::absolute(tstr).lexically_normal().string();
+		m_tstr = sinsp_utils::concatenate_paths(tinfo->get_cwd(), m_tstr);
 	}
 
 	// If m_tstr ends in a c-style \0, remove it to be

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -19,122 +19,63 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "utils.h"
 
-// copy_and_sanitize_path is not exported in utils.h
-void copy_and_sanitize_path(char* target, char* targetbase, const char* path, char separator);
-
-TEST(sinsp_utils_test, copy_and_sanitize_path)
+TEST(sinsp_utils_test, concatenate_paths)
 {
-	char target[SCAP_MAX_PATH_SIZE];
+	std::string path1, path2, res;
 
-	std::string path = "/dir/term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ(path, std::string(target));
+	/*
+	 * SUCCESS concatenate_paths
+	*/
 
-	path = "/dir/term/";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
+	path1 = "";
+	path2 = "dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ(path2, res);
 
-	path = "/dir/../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/term", std::string(target));
+	path1 = "//";
+	path2 = "dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("//dir/term", res);
 
-	path = "/dir/dir/../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
+	path1 = "////";
+	path2 = "dir/term/";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("////dir/term", res);
 
-	path = "/dir/dir/../../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/term", std::string(target));
+	path1 = "///../.../";
+	path2 = "dir/./././///./term/";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/.../dir/term", res);
 
-	path = "/dir/term/..";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir", std::string(target));
+	path1 = "../.../";
+	path2 = "dir/././././../../.../term/";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("../.../term", res);
 
-	path = "/dir/./term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
+	/*
+	 * FAILED concatenate_paths
+	*/
 
-	path = "/dir/././term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
+	res = sinsp_utils::concatenate_paths("", "");
+	EXPECT_EQ("", res);
 
-	path = "/dir/term/.";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
+	path1 = "";
+	path2 = "/dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ(path2, res);
 
-	path = "/dir/.../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/.../term", std::string(target));
+	path1 = "//";
+	path2 = "/dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/dir/term", res);
 
-	path = "/dir/term/...";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term/...", std::string(target));
+	path1 = "//";
+	path2 = "////dir/../../././term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/term", res);
 
-	path = "/dir/term/....";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term/....", std::string(target));
-
-	path = "/dir/..../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/..../term", std::string(target));
-
-	path = "/dir/dir../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/dir../term", std::string(target));
-
-	path = "/dir/dir./term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/dir./term", std::string(target));
-
-	path = "/dir/..dir/term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/..dir/term", std::string(target));
-
-	path = "/dir/.dir/term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/.dir/term", std::string(target));
-
-	path = ".dir";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ(".dir", std::string(target));
-
-	path = "./";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = "./.";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = ".";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = "../";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = "../..";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = "..";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("", std::string(target));
-
-	path = "/dir//./term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/term", std::string(target));
-
-	path = "/dir//../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/term", std::string(target));
-
-	path = "/dir//.../term";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/.../term", std::string(target));
-
-	path = "/dir//...";
-	copy_and_sanitize_path(target, target, path.c_str(), '/');
-	EXPECT_EQ("/dir/...", std::string(target));
+	path1 = "//";
+	path2 = "////";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("///", res);
 }

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -138,4 +138,9 @@ TEST(sinsp_utils_test, concatenate_paths)
 	path2 = "../АБВЙЛж";
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/АБВЙЛж", res);
+
+	path1 = "/root";
+	path2 = "c:/hello/world/";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/root/c:/hello/world", res);
 }

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -123,4 +123,19 @@ TEST(sinsp_utils_test, concatenate_paths)
 	path2 = "////app";
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/app", res);
+
+	path1 = "/root/";
+	path2 = "../😉";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/😉", res);
+
+	path1 = "/root/";
+	path2 = "../诶比西";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/诶比西", res);
+
+	path1 = "/root/";
+	path2 = "../АБВЙЛж";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/АБВЙЛж", res);
 }

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -21,61 +21,106 @@ limitations under the License.
 
 TEST(sinsp_utils_test, concatenate_paths)
 {
+	// Some tests were motivated by this resource:
+	// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap04.html#tag_04_11
+
 	std::string path1, path2, res;
 
-	/*
-	 * SUCCESS concatenate_paths
-	*/
+	res = sinsp_utils::concatenate_paths("", "");
+	EXPECT_EQ("", res);
+
+	path1 = "";
+	path2 = "../";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("..", res);
+
+	path1 = "";
+	path2 = "./";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ(".", res);
 
 	path1 = "";
 	path2 = "dir/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ(path2, res);
 
-	path1 = "//";
+	path1 = "";
+	path2 = "//dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/dir/term", res);
+
+	path1 = "/";
 	path2 = "dir/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("//dir/term", res);
+	EXPECT_EQ("/dir/term", res);
 
-	path1 = "////";
-	path2 = "dir/term/";
+	path1 = "";
+	path2 = "///dir/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("////dir/term", res);
+	EXPECT_EQ("/dir/term", res);
 
-	path1 = "///../.../";
-	path2 = "dir/./././///./term/";
+	path1 = "";
+	path2 = "./dir/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/.../dir/term", res);
+	EXPECT_EQ("dir/term", res);
+
+	path1 = "/";
+	path2 = "//dir//////term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/dir/term", res);
+
+	path1 = "/";
+	path2 = "/dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/dir/term", res);
 
 	path1 = "../.../";
 	path2 = "dir/././././../../.../term/";
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("../.../term", res);
 
-	/*
-	 * FAILED concatenate_paths
-	*/
-
-	res = sinsp_utils::concatenate_paths("", "");
-	EXPECT_EQ("", res);
-
-	path1 = "";
-	path2 = "/dir/term";
+	path1 = "../.../";
+	path2 = "/app/custom/dir/././././../../.../term/";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ(path2, res);
+	EXPECT_EQ("/app/.../term", res);
 
-	path1 = "//";
-	path2 = "/dir/term";
+	path1 = "../.../";
+	path2 = "/app/custom/dir/././././../../term/";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/dir/term", res);
+	EXPECT_EQ("/app/term", res);
 
-	path1 = "//";
-	path2 = "////dir/../../././term";
+	path1 = "./app";
+	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/term", res);
+	EXPECT_EQ("app/custom/term", res);
 
-	path1 = "//";
-	path2 = "////";
+	path1 = "/app";
+	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("///", res);
+	EXPECT_EQ("/app/custom/term", res);
+
+	path1 = "app";
+	path2 = "custom/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("app/custom/term", res);
+
+	path1 = "app//";
+	path2 = "custom/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("app/custom/term", res);
+
+	path1 = "app/////";
+	path2 = "custom////term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("app/custom/term", res);
+
+	path1 = "/";
+	path2 = "/app/custom/dir/././././../../term/";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/app/term", res);
+
+	path1 = "/";
+	path2 = "////app";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/app", res);
 }

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -903,10 +903,11 @@ void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 
 	if(tinfo)
 	{
-		tinfo->m_cwd = sinsp_utils::concatenate_paths(m_cwd, std::string_view(cwd, cwdlen)).c_str();
-		uint32_t len = tinfo->m_cwd.length();
+		// tinfo->m_cwd is a std::string, c_str() is a workaround because of issues with appending the final slash
+		// consider properly resolving the mystery in the future
+		tinfo->m_cwd.assign(sinsp_utils::concatenate_paths(m_cwd, std::string_view(cwd, cwdlen)).c_str());
 
-		if(len == 0 || (tinfo->m_cwd[len - 1] != '/'))
+		if(tinfo->m_cwd.empty() || tinfo->m_cwd.back() != '/')
 		{
 			tinfo->m_cwd += '/';
 		}

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -899,19 +899,11 @@ std::string sinsp_threadinfo::get_cwd()
 
 void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 {
-	char tpath[SCAP_MAX_PATH_SIZE];
 	sinsp_threadinfo* tinfo = get_main_thread();
 
 	if(tinfo)
 	{
-		sinsp_utils::concatenate_paths(tpath,
-			SCAP_MAX_PATH_SIZE,
-			(char*)tinfo->m_cwd.c_str(),
-			(uint32_t)tinfo->m_cwd.size(),
-			cwd,
-			cwdlen);
-
-		tinfo->m_cwd = tpath;
+		tinfo->m_cwd = sinsp_utils::concatenate_paths(m_cwd, std::string_view(cwd, cwdlen));
 
 		uint32_t size = tinfo->m_cwd.size();
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -903,11 +903,10 @@ void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 
 	if(tinfo)
 	{
-		tinfo->m_cwd = sinsp_utils::concatenate_paths(m_cwd, std::string_view(cwd, cwdlen));
+		tinfo->m_cwd = sinsp_utils::concatenate_paths(m_cwd, std::string_view(cwd, cwdlen)).c_str();
+		uint32_t len = tinfo->m_cwd.length();
 
-		uint32_t size = tinfo->m_cwd.size();
-
-		if(size == 0 || (tinfo->m_cwd[size - 1] != '/'))
+		if(len == 0 || (tinfo->m_cwd[len - 1] != '/'))
 		{
 			tinfo->m_cwd += '/';
 		}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -564,7 +564,7 @@ VISIBILITY_PRIVATE
 	sinsp_fdinfo_t* add_fd(int64_t fd, sinsp_fdinfo_t *fdinfo);
 	void add_fd_from_scap(scap_fdinfo *fdinfo, OUT sinsp_fdinfo_t *res);
 	void remove_fd(int64_t fd);
-	void set_cwd(const char *cwd, uint32_t cwdlen);
+	void set_cwd(std::string_view cwd);
 	sinsp_threadinfo* get_cwd_root();
 	void set_args(const char* args, size_t len);
 	void set_env(const char* env, size_t len);

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -602,7 +602,7 @@ std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_v
     auto p2 = std::filesystem::path(path2, std::filesystem::path::format::generic_format);
 
 	auto path_concat = (p1 / p2).lexically_normal();
-	std::string result = path_concat;
+	std::string result = path_concat.generic_string();
 
 	//
 	// If the path ends with a separator, remove it, as the OS does.

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -596,7 +596,7 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 	return true;
 }
 
-std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_view path2, ssize_t max_len)
+std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_view path2, size_t max_len)
 {
     auto p1 = std::filesystem::path(path1, std::filesystem::path::format::generic_format);
     auto p2 = std::filesystem::path(path2, std::filesystem::path::format::generic_format);
@@ -613,7 +613,7 @@ std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_v
 		result.pop_back();
 	}
 
-	if (max_len != -1 && result.length() > max_len)
+	if (result.length() > max_len)
 	{
 		return "/PATH_TOO_LONG";
 	}

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -601,6 +601,7 @@ std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_v
     auto p1 = std::filesystem::path(path1, std::filesystem::path::format::generic_format);
     auto p2 = std::filesystem::path(path2, std::filesystem::path::format::generic_format);
 
+	// note: if p2 happens to be an absolute path, p1 / p2 == p2
 	auto path_concat = (p1 / p2).lexically_normal();
 	std::string result = path_concat.generic_string();
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include <cerrno>
 #include <functional>
 #include <sys/stat.h>
+#include <filesystem>
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -595,171 +596,30 @@ bool sinsp_utils::sockinfo_to_str(sinsp_sockinfo* sinfo, scap_fd_type stype, cha
 	return true;
 }
 
-//
-// Helper function to move a directory up in a path string
-//
-void rewind_to_parent_path(char* targetbase, char** tc, const char** pc, uint32_t delta)
+std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_view path2, ssize_t max_len)
 {
-	if(*tc <= targetbase + 1)
+    auto p1 = std::filesystem::path(path1, std::filesystem::path::format::generic_format);
+    auto p2 = std::filesystem::path(path2, std::filesystem::path::format::generic_format);
+
+	auto path_concat = (p1 / p2).lexically_normal();
+	std::string result = path_concat;
+
+	//
+	// If the path ends with a separator, remove it, as the OS does.
+	//
+	if (result.length() > 1 && result.back() == '/')
 	{
-		(*pc) += delta;
-		return;
+		result.pop_back();
 	}
 
-	(*tc)--;
-
-	while(*((*tc) - 1) != '/' && (*tc) >= targetbase + 1)
+	if (max_len != -1 && result.length() > max_len)
 	{
-		(*tc)--;
+		return "/PATH_TOO_LONG";
 	}
 
-	(*pc) += delta;
+	return result;
 }
 
-//
-// Args:
-//  - target: the string where we are supposed to start copying
-//  - targetbase: the base of the path, i.e. the furthest we can go back when
-//                following parent directories
-//  - path: the path to copy
-//
-void copy_and_sanitize_path(char* target, char* targetbase, const char* path, char separator)
-{
-	char* tc = target;
-	const char* pc = path;
-	g_invalidchar ic;
-
-	while(true)
-	{
-		if(*pc == 0)
-		{
-			*tc = 0;
-
-			//
-			// If the path ends with a separator, remove it, as the OS does.
-			//
-			if((tc > (targetbase + 1)) && (*(tc - 1) == separator))
-			{
-				*(tc - 1) = 0;
-			}
-
-			return;
-		}
-
-		if(ic(*pc))
-		{
-			//
-			// Invalid char, substitute with a '.'
-			//
-			*tc = '.';
-			tc++;
-			pc++;
-		}
-		else
-		{
-			//
-			// If path begins with '.' or '.' is the first char after a '/'
-			//
-			if(*pc == '.' && (tc == targetbase || *(tc - 1) == separator))
-			{
-				//
-				// '../', rewind to the previous separator
-				//
-				if(*(pc + 1) == '.' && *(pc + 2) == separator)
-				{
-					rewind_to_parent_path(targetbase, &tc, &pc, 3);
-				}
-				//
-				// '..', with no separator.
-				// This is valid if we are at the end of the string, and in that case we rewind.
-				//
-				else if(*(pc + 1) == '.' && *(pc + 2) == 0)
-				{
-					rewind_to_parent_path(targetbase, &tc, &pc, 2);
-				}
-				//
-				// './', just skip it
-				//
-				else if(*(pc + 1) == separator)
-				{
-					pc += 2;
-				}
-				//
-				// '.', with no separator.
-				// This is valid if we are at the end of the string, and in that case we rewind.
-				//
-				else if(*(pc + 1) == 0)
-				{
-					pc++;
-				}
-				//
-				// Otherwise, we leave the string intact.
-				//
-				else
-				{
-					*tc = *pc;
-					pc++;
-					tc++;
-				}
-			}
-			else if(*pc == separator)
-			{
-				//
-				// separator, if the last char is already a separator, skip it
-				//
-				if(tc > targetbase && *(tc - 1) == separator)
-				{
-					pc++;
-				}
-				else
-				{
-					*tc = *pc;
-					tc++;
-					pc++;
-				}
-			}
-			else
-			{
-				//
-				// Normal char, copy it
-				//
-				*tc = *pc;
-				tc++;
-				pc++;
-			}
-		}
-	}
-}
-
-//
-// Return false if path2 is an absolute path
-//
-bool sinsp_utils::concatenate_paths(char* target,
-									uint32_t targetlen,
-									const char* path1,
-									uint32_t len1,
-									const char* path2,
-									uint32_t len2)
-{
-	if(targetlen < (len1 + len2 + 1))
-	{
-		strlcpy(target, "/PATH_TOO_LONG", targetlen);
-		return false;
-	}
-
-	if(len2 != 0 && path2[0] != '/')
-	{
-		memcpy(target, path1, len1);
-		copy_and_sanitize_path(target + len1, target, path2, '/');
-		return true;
-	}
-	else
-	{
-		target[0] = 0;
-		copy_and_sanitize_path(target, target, path2, '/');
-		return false;
-	}
-}
 
 bool sinsp_utils::is_ipv4_mapped_ipv6(uint8_t* paddr)
 {

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -158,15 +158,12 @@ public:
 
 struct g_invalidchar
 {
-    bool operator()(char c) const
-    {
-	    if(c < -1)
-	    {
-		    return true;
-	    }
-
-	    return !isprint((unsigned)c);
-    }
+	bool operator()(char c) const
+	{
+		// Exclude all non-printable characters and control characters while
+		// including a wide range of languages (emojis, cyrillic, chinese etc)
+		return !(isprint((unsigned)c) || (c < 0));
+	}
 };
 
 inline void sanitize_string(std::string &str)

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -99,7 +99,7 @@ public:
 	// If path2 is absolute, the concatenation does not happen, target contains path2 and the result is false.
 	// Assumes that path1 is well formed.
 	//
-	static bool concatenate_paths(char* target, uint32_t targetlen, const char* path1, uint32_t len1, const char* path2, uint32_t len2);
+	static std::string concatenate_paths(std::string_view path1, std::string_view path2, ssize_t max_len=SCAP_MAX_PATH_SIZE-1);
 
 	//
 	// Determines if an IPv6 address is IPv4-mapped

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -94,9 +94,11 @@ public:
 	static bool unhex(const std::vector<char> &hex_chars, std::vector<char> &hex_bytes);
 
 	//
-	// Concatenate path1 and path2 using std::filesystem
+	// Concatenate posix-style path1 and path2 up to max_len in size, normalizing the result.
+	// If path2 is absolute, the result will be equivalent to path2.
+	// If the result would be too long, the output will contain the string "/PATH_TOO_LONG" instead.
 	//
-	static std::string concatenate_paths(std::string_view path1, std::string_view path2, ssize_t max_len=SCAP_MAX_PATH_SIZE-1);
+	static std::string concatenate_paths(std::string_view path1, std::string_view path2, size_t max_len=SCAP_MAX_PATH_SIZE-1);
 
 	//
 	// Determines if an IPv6 address is IPv4-mapped

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -94,10 +94,7 @@ public:
 	static bool unhex(const std::vector<char> &hex_chars, std::vector<char> &hex_bytes);
 
 	//
-	// Concatenate two paths and puts the result in "target".
-	// If path2 is relative, the concatenation happens and the result is true.
-	// If path2 is absolute, the concatenation does not happen, target contains path2 and the result is false.
-	// Assumes that path1 is well formed.
+	// Concatenate path1 and path2 using std::filesystem
 	//
 	static std::string concatenate_paths(std::string_view path1, std::string_view path2, ssize_t max_len=SCAP_MAX_PATH_SIZE-1);
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This gets rid of a scary function that was operating on path strings by hand and is prone to breakage or (worse) memory error issues and replaces with a native C++ implementation.

@incertum I still have a failing test and I would like to be more certain of when we depend on specific behaviors in libs before I go through. Can you take a look? Thanks!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
