### PR TITLE
fix(test): drop `socketcall`s in syscall enter events

### DIFF
--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -1093,7 +1093,7 @@ TEST(SyscallEnter, socketcall_getsocknameE)
 
 TEST(SyscallEnter, socketcall_wrong_code_socketcall_interesting)
 {
-	/* if we set the socket call as interesting we will obtain a generic event */
+	// We send a wrong code so the event will be dropped
 	auto evt_test = get_syscall_event_test(__NR_socketcall, ENTER_EVENT);
 
 	evt_test->enable_capture();
@@ -1112,36 +1112,12 @@ TEST(SyscallEnter, socketcall_wrong_code_socketcall_interesting)
 
 	evt_test->disable_capture();
 
-	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_E);
-
-	if(HasFatalFailure())
-	{
-		return;
-	}
-
-	evt_test->parse_event();
-
-	evt_test->assert_header();
-
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-	/* Parameter 1: ID (type: PT_SYSCALLID) */
-	/* this is the PPM_SC code obtained from the syscall id. */
-	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_SOCKETCALL);
-
-	/* Parameter 2: nativeID (type: PT_UINT16) */
-	evt_test->assert_numeric_param(2, (uint16_t)__NR_socketcall);
-
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-	evt_test->assert_num_params_pushed(2);
+	evt_test->assert_event_absence(CURRENT_PID, PPME_GENERIC_E);
 }
 
 TEST(SyscallEnter, socketcall_wrong_code_socketcall_not_interesting)
 {
-	/* if we don't set the socketcall as interesting we won't obtain a generic event.
-	 * In this case we set `setsockopt` as interesting
-	 */
+	// Same as the previous test
 	auto evt_test = get_syscall_event_test(__NR_setsockopt, ENTER_EVENT);
 
 	evt_test->enable_capture();
@@ -1214,6 +1190,7 @@ TEST(SyscallEnter, socketcall_null_pointer)
 
 TEST(SyscallEnter, socketcall_null_pointer_and_wrong_code_socketcall_interesting)
 {
+	// We send a wrong code so the event will be dropped
 	auto evt_test = get_syscall_event_test(__NR_socketcall, ENTER_EVENT);
 
 	evt_test->enable_capture();
@@ -1227,32 +1204,7 @@ TEST(SyscallEnter, socketcall_null_pointer_and_wrong_code_socketcall_interesting
 
 	evt_test->disable_capture();
 
-	/* Even if we have a null pointer, we will send a generic event so we don't need to preload
-	 * the socketcall params! This is the reason why we don't drop the event in this case.
-	 */
-	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_E);
-
-	if(HasFatalFailure())
-	{
-		return;
-	}
-
-	evt_test->parse_event();
-
-	evt_test->assert_header();
-
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-	/* Parameter 1: ID (type: PT_SYSCALLID) */
-	/* this is the PPM_SC code obtained from the syscall id. */
-	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_SOCKETCALL);
-
-	/* Parameter 2: nativeID (type: PT_UINT16) */
-	evt_test->assert_numeric_param(2, (uint16_t)__NR_socketcall);
-
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-	evt_test->assert_num_params_pushed(2);
+	evt_test->assert_event_absence(CURRENT_PID, PPME_GENERIC_E);
 }
 
 #endif /* __NR_socketcall */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Commit a094db8f "cleanup: align modern bpf behavior with other drivers" changed the drivers test in the system exit events.  This commit also ignores `socketcall`s with wrong call IDs in the system enter event tests.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This has been discovered as part of my native CI enablement on `s390x` [test-selfhosted-gha-runner](https://github.com/hbrueckner/falcosecurity-libs/pull/5)... modern BPF looks now fine... need some more investigation on bpf driver.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
