### PR TITLE
fix(userspace/libsinsp): zero-init time before string parsing

### DIFF
--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1080,7 +1080,7 @@ void sinsp_utils::ts_to_iso_8601(uint64_t ts, OUT std::string* res)
 bool sinsp_utils::parse_iso_8601_utc_string(const std::string& time_str, uint64_t &ns)
 {
 #ifndef _WIN32
-	tm tm_time;
+	tm tm_time{0};
 	char* rem = strptime(time_str.c_str(), "%Y-%m-%dT%H:%M:", &tm_time);
 	if(rem == NULL || *rem == '\0')
 	{
@@ -1112,7 +1112,7 @@ time_t get_epoch_utc_seconds(const std::string& time_str, const std::string& fmt
 	{
 		throw sinsp_exception("get_epoch_utc_seconds(): empty time or format string.");
 	}
-	tm tm_time;
+	tm tm_time{0};
 	strptime(time_str.c_str(), fmt.c_str(), &tm_time);
 	tm_time.tm_isdst = -1; // strptime does not set this, signal timegm to determine DST
 	return timegm(&tm_time);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This zero-initializes a variable in the time parsing/formatting utility functions. This supposedly a regression after the recent compiler warning related cleanups (cc @federico-sysdig for visibility).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
