### PR TITLE
cleanup(driver): unlinkat & linkat flags

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -5822,7 +5822,7 @@ FILLER(sys_unlinkat_x, true)
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	unsigned long flags = bpf_syscall_get_argument(data, 2);
-	return bpf_push_u32_to_ring(data, unlinkat_flags_to_scap(flags));
+	return bpf_push_u32_to_ring(data, unlinkat_flags_to_scap((int32_t) flags));
 }
 
 FILLER(sys_mkdirat_x, true)
@@ -5899,7 +5899,7 @@ FILLER(sys_linkat_x, true)
 	 * flags
 	 */
 	val = bpf_syscall_get_argument(data, 4);
-	return bpf_push_u32_to_ring(data, linkat_flags_to_scap(val));
+	return bpf_push_u32_to_ring(data, linkat_flags_to_scap((int32_t) val));
 }
 
 FILLER(sys_autofill, true)

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/linkat.bpf.c
@@ -83,7 +83,7 @@ int BPF_PROG(linkat_x,
 
 	/* Parameter 6: flags (type: PT_FLAGS32) */
 	unsigned long flags = extract__syscall_argument(regs, 4);
-	auxmap__store_u32_param(auxmap, linkat_flags_to_scap(flags));
+	auxmap__store_u32_param(auxmap, linkat_flags_to_scap((int32_t) flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/unlinkat.bpf.c
@@ -71,7 +71,7 @@ int BPF_PROG(unlinkat_x,
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	unsigned long flags = extract__syscall_argument(regs, 2);
-	auxmap__store_u32_param(auxmap, unlinkat_flags_to_scap(flags));
+	auxmap__store_u32_param(auxmap, unlinkat_flags_to_scap((int32_t) flags));
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -3608,7 +3608,7 @@ int f_sys_unlinkat_x(struct event_filler_arguments *args)
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	syscall_get_arguments_deprecated(args, 2, 1, &val);
-	res = val_to_ring(args, unlinkat_flags_to_scap(val), 0, false, 0);
+	res = val_to_ring(args, unlinkat_flags_to_scap((int32_t) val), 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
@@ -3666,7 +3666,7 @@ int f_sys_linkat_x(struct event_filler_arguments *args)
 	 * Note that we convert them into the ppm portable representation before pushing them to the ring
 	 */
 	syscall_get_arguments_deprecated(args, 4, 1, &flags);
-	res = val_to_ring(args, linkat_flags_to_scap(flags), 0, false, 0);
+	res = val_to_ring(args, linkat_flags_to_scap((int32_t) flags), 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -1756,7 +1756,7 @@ static __always_inline uint32_t memfd_create_flags_to_scap(uint32_t flags)
 return res;
 }
 
-static __always_inline uint32_t unlinkat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t unlinkat_flags_to_scap(int32_t flags)
 {
 	uint32_t res = 0;
 
@@ -1766,7 +1766,7 @@ static __always_inline uint32_t unlinkat_flags_to_scap(unsigned long flags)
 	return res;
 }
 
-static __always_inline uint32_t linkat_flags_to_scap(unsigned long flags)
+static __always_inline uint32_t linkat_flags_to_scap(int32_t flags)
 {
 	uint32_t res = 0;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf
/area driver-modern-bpf


**Does this PR require a change in the driver versions?**

I am not sure about this.

**What this PR does / why we need it**:

I am trying to address the issue where linkat and unlinkat is handling the flag params as an unsigned integer when it should be handling it as in int.

**Which issue(s) this PR fixes**:

part of #515 
(partial fix other issues still remain in 515)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
