### PR TITLE
fix(test/drivers): correct socketcall SYS_ACCEPT failures on s390x

### DIFF
--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -327,8 +327,8 @@ TEST(SyscallEnter, socketcall_acceptE)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, ENTER_EVENT);
-	/* The kmod can correctly handle accept also on s390x */
-	if(evt_test->is_kmod_engine())
+	/* The kmod/bpf can correctly handle accept also on s390x */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine())
 	{
 		/* we cannot set `__NR_accept` explicitly since it is not defined on s390x
 		 * we activate all syscalls.
@@ -370,9 +370,9 @@ TEST(SyscallEnter, socketcall_acceptE)
 	evt_test->assert_header();
 
 #ifdef __s390x__
-	if(!evt_test->is_kmod_engine())
+	if(evt_test->is_modern_bpf_engine())
 	{
-		/* socketcall uses accept4 event for SYS_ACCEPT */
+		/* socketcall uses accept4 event for SYS_ACCEPT for modern BPF */
 
 		/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -346,8 +346,8 @@ TEST(SyscallExit, socketcall_acceptX_INET)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
-	/* The kmod can correctly handle accept also on s390x */
-	if(evt_test->is_kmod_engine())
+	/* The kmod/bpf can correctly handle accept also on s390x */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine())
 	{
 		/* we cannot set `__NR_accept` explicitly since it is not defined on s390x
 		 * we activate all syscalls.
@@ -429,8 +429,8 @@ TEST(SyscallExit, socketcall_acceptX_INET6)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
-	/* The kmod can correctly handle accept also on s390x */
-	if(evt_test->is_kmod_engine())
+	/* The kmod/bpf can correctly handle accept also on s390x */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine())
 	{
 		/* we cannot set `__NR_accept` explicitly since it is not defined on s390x
 		 * we activate all syscalls.
@@ -513,8 +513,8 @@ TEST(SyscallExit, socketcall_acceptX_UNIX)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
-	/* The kmod can correctly handle accept also on s390x */
-	if(evt_test->is_kmod_engine())
+	/* The kmod/bpf can correctly handle accept also on s390x */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine())
 	{
 		/* we cannot set `__NR_accept` explicitly since it is not defined on s390x
 		 * we activate all syscalls.
@@ -599,8 +599,8 @@ TEST(SyscallExit, socketcall_acceptX_failure)
 {
 #ifdef __s390x__
 	auto evt_test = get_syscall_event_test(__NR_accept4, EXIT_EVENT);
-	/* The kmod can correctly handle accept also on s390x */
-	if(evt_test->is_kmod_engine())
+	/* The kmod/bpf can correctly handle accept also on s390x */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine())
 	{
 		/* we cannot set `__NR_accept` explicitly since it is not defined on s390x
 		 * we activate all syscalls.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The modern BPF driver maps the SYS_ACCEPT to SYS_ACCEPT4 which is being tested in the socketcall SYS_ACCEPT tests.

The kmod and bpf drivers do not switch directly but rather ensure to use the PPM event instead of syscall.  The socketcall SYS_ACCEPT tests contain a specific handling for kmod.  Enable this handling to also for the bpf driver.

P.S. Yet another test for self-hosted runner... tests seems to be green again for now on s390x: https://github.com/hbrueckner/falcosecurity-libs/actions/runs/7090415381/job/19297318806?pr=5

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
