### PR TITLE
chore(libbpf): bump libbpf to `v1.3.0`

### DIFF
--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -33,9 +33,9 @@ else()
         libbpf
         PREFIX "${PROJECT_BINARY_DIR}/libbpf-prefix"
         DEPENDS zlib libelf
-        URL "https://github.com/libbpf/libbpf/archive/refs/tags/v1.2.2.tar.gz"
+        URL "https://github.com/libbpf/libbpf/archive/refs/tags/v1.3.0.tar.gz"
         URL_HASH
-        "SHA256=32b0c41eabfbbe8e0c8aea784d7495387ff9171b5a338480a8fbaceb9da8d5e5"
+        "SHA256=11db86acd627e468bc48b7258c1130aba41a12c4d364f78e184fd2f5a913d861"
         CONFIGURE_COMMAND mkdir -p build root
         BUILD_COMMAND make BUILD_STATIC_ONLY=y OBJDIR=${LIBBPF_BUILD_DIR}/build DESTDIR=${LIBBPF_BUILD_DIR}/root NO_PKG_CONFIG=1 "EXTRA_CFLAGS=-fPIC -I${LIBELF_INCLUDE} -I${ZLIB_INCLUDE}" "LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}" -C ${LIBBPF_SRC}/libbpf/src install install_uapi_headers
         INSTALL_COMMAND ""

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -8,9 +8,6 @@
 
 option(MODERN_BPF_DEBUG_MODE "Enable BPF debug prints" OFF)
 option(MODERN_BPF_EXCLUDE_PROGS "Regex to exclude tail-called programs" "")
-# This is a temporary workaround to solve this regression https://github.com/falcosecurity/libs/issues/1157
-# We need to find a better solution
-option(MODERN_BPF_COS_WORKAROUND "Allow to correctly extract 'loginuid' from COS system, but requires at least CAP_SYS_ADMIN" OFF)
 
 ########################
 # Debug mode
@@ -22,13 +19,6 @@ else()
   set(DEBUG "")
 endif()
 message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_DEBUG_MODE: ${MODERN_BPF_DEBUG_MODE}")
-
-if(MODERN_BPF_COS_WORKAROUND)
-  set(COS_WORKAROUND "COS_WORKAROUND")
-else()
-  set(COS_WORKAROUND "")
-endif()
-message(STATUS "${MODERN_BPF_LOG_PREFIX} MODERN_BPF_COS_WORKAROUND: ${MODERN_BPF_COS_WORKAROUND}")
 
 ########################
 # Check kernel version.
@@ -192,7 +182,6 @@ list(APPEND CLANG_FLAGS
     -g -O2
     -target bpf
     -D__${DEBUG}__
-    -D__${COS_WORKAROUND}__
     -D__TARGET_ARCH_${ARCH} # Match libbpf usage in `/libbpf/src/bpf_tracing.h`
     -D__USE_VMLINUX__ # Used to compile without kernel headers.
     -I${LIBBPF_INCLUDE}

--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -723,7 +723,6 @@ static __always_inline void extract__loginuid(struct task_struct *task, uint32_t
 	{
 		READ_TASK_FIELD_INTO(loginuid, task, loginuid.val);
 	}
-#ifdef __COS_WORKAROUND__	
 	else
 	{
 		struct task_struct___cos *task_cos = (void *)task;
@@ -733,7 +732,6 @@ static __always_inline void extract__loginuid(struct task_struct *task, uint32_t
 			BPF_CORE_READ_INTO(loginuid, task_cos, audit, loginuid.val);
 		}
 	}
-#endif
 }
 
 /////////////////////////

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -297,14 +297,14 @@ static void ringbuf__consume_first_event(struct ring_buffer *rb, struct ppm_evt_
 	/* If the last consume operation was successful we can push the consumer position */
 	if(g_state.last_ring_read != -1)
 	{
-		struct ring *r = &(rb->rings[g_state.last_ring_read]);
+		struct ring *r = rb->rings[g_state.last_ring_read];
 		g_state.cons_pos[g_state.last_ring_read] += g_state.last_event_size;
 		smp_store_release(r->consumer_pos, g_state.cons_pos[g_state.last_ring_read]);
 	}
 
 	for(uint16_t pos = 0; pos < rb->ring_cnt; pos++)
 	{
-		*event_ptr = ringbuf__get_first_ring_event(&rb->rings[pos], pos);
+		*event_ptr = ringbuf__get_first_ring_event(rb->rings[pos], pos);
 
 		/* if NULL search for events in another buffer */
 		if(*event_ptr == NULL)

--- a/userspace/libpman/src/ringbuffer_definitions.h
+++ b/userspace/libpman/src/ringbuffer_definitions.h
@@ -36,7 +36,7 @@ struct ring
 struct ring_buffer
 {
 	struct epoll_event *events;
-	struct ring *rings;
+	struct ring **rings;
 	size_t page_size;
 	int epoll_fd;
 	int ring_cnt;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libpman

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR bumps libbpf to `v1.3.0` and should finally fix https://github.com/falcosecurity/libs/issues/1157. Moreover, this PR removes the workaround introduced here https://github.com/falcosecurity/libs/pull/1160 for COS systems, this is no longer needed since the solution is now provided directly from libbpf

**Which issue(s) this PR fixes**:

Fixes #1157

**Special notes for your reviewer**:

How to test:

```bash
 sudo setcap CAP_PERFMON,CAP_BPF,CAP_SYS_RESOURCE=+ep ./libscap/examples/01-open/scap-open
./libscap/examples/01-open/scap-open --modern_bpf
```
should work without issues

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
