### PR TITLE
Use pid/tid stat file for accurate thread start time calculation

### DIFF
--- a/userspace/libscap/linux/scap_machine_info.c
+++ b/userspace/libscap/linux/scap_machine_info.c
@@ -162,6 +162,17 @@ int32_t scap_os_get_machine_info(scap_machine_info* machine_info, char* lasterr)
 	machine_info->num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
 	machine_info->memory_size_bytes = (uint64_t)sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
 	scap_gethostname(machine_info->hostname, sizeof(machine_info->hostname));
+
+#ifdef _SC_CLK_TCK
+	machine_info->hz = sysconf(_SC_CLK_TCK);
+	if (machine_info->hz < 0)
+	{
+		machine_info->hz = 100;
+	}
+#else
+	machine_info->hz = 100;
+#endif
+
 	machine_info->boot_ts_epoch = scap_linux_get_host_boot_time_ns(lasterr);
 	if(machine_info->boot_ts_epoch == 0)
 	{

--- a/userspace/libscap/scap_machine_info.h
+++ b/userspace/libscap/scap_machine_info.h
@@ -43,6 +43,7 @@ typedef struct _scap_machine_info
 	uint64_t memory_size_bytes; ///< Physical memory size
 	uint64_t max_pid; ///< Highest PID number on this machine
 	char hostname[128]; ///< The machine hostname
+	uint64_t hz; ///< Clock ticks per second on this machine
 	uint64_t boot_ts_epoch; ///< Host boot ts in nanoseconds (epoch)
 	uint64_t flags; ///< flags
 	uint64_t reserved3; ///< reserved for future use


### PR DESCRIPTION
Current /proc scan logic uses the stat() system call of the cmdline file within the /proc filesystem, to determine the start time of a thread or process. This approach yields inaccurate and inconsistent results, because /proc files are created on demand (e.g. /proc directory scan, /proc file open), rather than when the process or thread is created.

The definitive approach is to read the system boot time from /proc/stat, then add the start time reported by the /proc/<pid>/stat file for a process, or the /proc/<pid>/task/<tid>/stat file for a non-process thread.

This changeset implements this definitive approach.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Fixes inaccuracy/inconsistency in the start times reported, for threads and processes discovered via scan of /proc.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
