### PR TITLE
fix(container/cri-engine): populate labels field for pod sandbox containers

### DIFF
--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -212,13 +212,6 @@ public:
 	bool parse_cri_user_info(const Json::Value &info, sinsp_container_info &container);
 
 	/**
-	 * @brief check if the passed container ID is a pod sandbox (pause container)
-	 * @param container_id the container ID to check
-	 * @return true if it's a pod sandbox
-	 */
-	bool is_pod_sandbox(const std::string &container_id);
-
-	/**
 	 * @brief get pod IP address
 	 * @param resp initialized api::PodSandboxStatusResponse of the pod sandbox
 	 * @return the IP address if possible, 0 otherwise (e.g. when the pod uses host netns)

--- a/userspace/libsinsp/cri.hpp
+++ b/userspace/libsinsp/cri.hpp
@@ -465,20 +465,6 @@ bool cri_interface<api>::parse_cri_user_info(const Json::Value &info, sinsp_cont
 	return true;
 }
 
-template<typename api> bool cri_interface<api>::is_pod_sandbox(const std::string &container_id)
-{
-	typename api::PodSandboxStatusRequest req;
-	typename api::PodSandboxStatusResponse resp;
-	req.set_pod_sandbox_id(container_id);
-	req.set_verbose(true);
-	grpc::ClientContext context;
-	auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(s_cri_timeout);
-	context.set_deadline(deadline);
-	grpc::Status status = m_cri->PodSandboxStatus(&context, req, &resp);
-
-	return status.ok();
-}
-
 // TODO: Explore future schema standardizations, https://github.com/falcosecurity/falco/issues/2387
 template<typename api>
 void cri_interface<api>::get_pod_info_cniresult(typename api::PodSandboxStatusResponse &resp, std::string &cniresult)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

 /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In the CRI context, there are two types of containers: normal containers and the `pod sandbox` containers. While the labels for the normal containers are correctly populated we can't say the same for the `pod sandbox` containers.  The reason is simple: we do not need to track all the `pod sandbox` fields since they are just the `pause container` and shall not generate syscalls' events. Anyway, there is a difference between the labels attached to a `normal container`  and its `pod sandbox`:

```json

# output from crictl inspect normal container
    "labels": {
      "io.kubernetes.container.name": "nginx",
      "io.kubernetes.pod.name": "nginx-deployment-bf9dfc44-pmbt4",
      "io.kubernetes.pod.namespace": "default",
      "io.kubernetes.pod.uid": "86d2a392-ac1c-4be6-b4d4-904416e33f9d"
    },

# output from crictl inspectp pod sanbox
    "labels": {
      "app": "nginx",
      "app.kubernetes.io/name": "testing",
      "custom": "label",
      "io.kubernetes.container.name": "POD",
      "io.kubernetes.pod.name": "nginx-deployment-bf9dfc44-pmbt4",
      "io.kubernetes.pod.namespace": "default",
      "io.kubernetes.pod.uid": "86d2a392-ac1c-4be6-b4d4-904416e33f9d",
      "pod-template-hash": "bf9dfc44"
    },
```

As you can see the set of labels is not the same. The `pod sandbox` labels field contains the labels of the `kubernetes resource pod` from which it was generated.

In this PR, we ensure labels are set for `pod sanbox` containers. And at the same time, we add a custom label to normal containers `io.kubenetes.sandbox.id=podSandboxID`. The custom label is used by the filterchecks logic to retrieve the `pod sandbox` for a given `normal container` and populate the `k8s.pod.labels` field:
 https://github.com/falcosecurity/libs/blob/8eb2fc2a076887333561d98a28aa5091f1ad892d/userspace/libsinsp/sinsp_filtercheck_k8s.cpp#L245-L270

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
