### PR TITLE
fix(CI): partially revert `404e649`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
             .github/install-deps.sh
             mkdir -p build
             cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=OFF -DMODERN_PROBE_INCLUDE="-I/usr/include/${{env.PLATFORM}}-linux-gnu" -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DENABLE_DRIVERS_TESTS=On -DCREATE_TEST_TARGETS=On -DBUILD_LIBSCAP_GVISOR=OFF ../
-            make driver bpf drivers_test -j6
+            KERNELDIR=/lib/modules/$(ls /lib/modules)/build make driver bpf drivers_test -j6
 
   # This job checks that a bundled deps of libs is as static as possible
   test-libs-static:


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR partially reverts https://github.com/falcosecurity/libs/commit/404e6491b83944653b251cff29523bd2defe898e since `KERNELDIR` is still needed when using QEMU as you can see from this PR https://github.com/falcosecurity/libs/pull/1566. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
