### PR TITLE
update(tests): improve libscap modern bpf tests and CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,20 +63,20 @@ jobs:
           name: Run scap-open with modern bpf 🏎️
           command: |
             cd /tmp/libs/build
-            sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
+            sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 10
 
       - run:
           name: Run scap-open with bpf 🏎️
           command: |
             cd /tmp/libs/build
-            sudo ./libscap/examples/01-open/scap-open --bpf ./driver/bpf/probe.o --num_events 0
+            sudo ./libscap/examples/01-open/scap-open --bpf ./driver/bpf/probe.o --num_events 10
 
       - run:
           name: Run scap-open with kmod 🏎️
           command: |
             cd /tmp/libs/build
             sudo insmod ./driver/scap.ko || true
-            sudo ./libscap/examples/01-open/scap-open --kmod --num_events 0
+            sudo ./libscap/examples/01-open/scap-open --kmod --num_events 10
             sudo rmmod scap
 
   # Here we test libraries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,18 +262,18 @@ jobs:
       - name: Run scap-open with modern bpf 🏎️
         run: |
           cd build
-          sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 0
+          sudo ./libscap/examples/01-open/scap-open --modern_bpf --num_events 10
 
       - name: Run scap-open with bpf 🏎️
         run: |
           cd build
-          sudo ./libscap/examples/01-open/scap-open --bpf ./driver/bpf/probe.o --num_events 0
+          sudo ./libscap/examples/01-open/scap-open --bpf ./driver/bpf/probe.o --num_events 10
 
       - name: Run scap-open with kmod 🏎️
         run: |
           cd build
           sudo insmod ./driver/scap.ko
-          sudo ./libscap/examples/01-open/scap-open --kmod --num_events 0
+          sudo ./libscap/examples/01-open/scap-open --kmod --num_events 10
           sudo rmmod scap
 
       - name: Run libscap_test 🏎️

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -6,6 +6,24 @@
 #include <syscall.h>
 #include <helpers/engines.h>
 
+static enum falcosecurity_log_severity severity_level = FALCOSECURITY_LOG_SEV_WARNING;
+
+static void test_open_log_fn(const char* component, const char* msg, const enum falcosecurity_log_severity sev)
+{
+	if(sev <= severity_level)
+	{
+		if(component!= NULL)
+		{
+			printf("%s: %s", component, msg);
+		}
+		else
+		{
+			// libbpf logs have no components
+			printf("%s", msg);
+		}
+	}
+}
+
 scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffer_dim, uint16_t cpus_for_each_buffer, bool online_only, std::unordered_set<uint32_t> ppm_sc_set = {})
 {
 	struct scap_open_args oargs {};
@@ -32,6 +50,7 @@ scap_t* open_modern_bpf_engine(char* error_buf, int32_t* rc, unsigned long buffe
 		.buffer_bytes_dim = buffer_dim,
 	};
 	oargs.engine_params = &modern_bpf_params;
+	oargs.log_fn = test_open_log_fn;
 
 	return scap_open(&oargs, &scap_modern_bpf_engine, error_buf, rc);
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR allows us to debug the modern bpf probe in a more handy way adding a logging function. Moreover, this PR enforces strict checks in the CI to catch simple issues, we want to read at least 10 events before stopping the capture, in this way if we have a trivial issue in the reading phase we can catch it in CI

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
