### PR TITLE
fix(sinsp): avoid a double free when an exception is thrown

### DIFF
--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -145,4 +145,5 @@ void scap_platform_free(struct scap_platform* platform)
 	}
 
 	platform->m_vtable->free_platform(platform);
+	platform = NULL;
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -121,6 +121,7 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 	m_large_envs_enabled = false;
 	m_increased_snaplen_port_range = DEFAULT_INCREASE_SNAPLEN_PORT_RANGE;
 	m_statsd_port = -1;
+	m_platform = nullptr;
 
 	// Unless the cmd line arg "-pc" or "-pcontainer" is supplied this is false
 	m_print_container_data = false;
@@ -388,6 +389,7 @@ void sinsp::open_common(scap_open_args* oargs, const struct scap_vtable* vtable,
 	{
 		scap_platform_close(platform);
 		scap_platform_free(platform);
+		m_platform = nullptr;
 
 		std::string error = scap_getlasterr(m_h);
 		scap_close(m_h);
@@ -405,6 +407,8 @@ void sinsp::open_common(scap_open_args* oargs, const struct scap_vtable* vtable,
 	{
 		scap_platform_close(platform);
 		scap_platform_free(platform);
+		m_platform = nullptr;
+
 		scap_close(m_h);
 		m_h = NULL;
 

--- a/userspace/libsinsp/test/classes/sinsp.cpp
+++ b/userspace/libsinsp/test/classes/sinsp.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include <scap_open_exception.h>
+#include <scap.h>
+#include <sinsp.h>
+#include <scap_engines.h>
+
+#define HOST_ROOT_ENV "HOST_ROOT"
+
+#ifdef HAS_ENGINE_KMOD
+TEST(sinsp, wrong_host_root)
+{
+	ASSERT_EQ(0, setenv(HOST_ROOT_ENV, "fake_hostroot", 1));
+	sinsp inspector = {};
+
+	// We cannot scan proc we expect an exception
+	ASSERT_THROW(inspector.open_kmod(DEFAULT_DRIVER_BUFFER_BYTES_DIM), scap_open_exception);
+
+	// Clear the env variable
+	ASSERT_EQ(0, setenv(HOST_ROOT_ENV, "", 1));
+
+	// Try to close the inspector several times to avoid double frees
+	inspector.close();
+	inspector.close();
+	inspector.close();
+}
+#endif /* HAS_ENGINE_KMOD */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR sets the m_platorm to `nullptr` when we free it

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/2963

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
