### PR TITLE
fix(libsinsp): fix some path handling in fs.path

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2326,6 +2326,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 				else if(flags & PPM_EXVAT_AT_EMPTY_PATH)
 				{
 					/* In this case `sdir` will always be an absolute path.
+					 * concatenate_paths takes care of resolving the path
 					*/
 					fullpath = sinsp_utils::concatenate_paths("", sdir);
 

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -486,6 +486,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 		{
 			//
 			// Get the file path directly from the ring buffer.
+			// concatenate_paths takes care of resolving the path
 			//
 			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string_view>());
 

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -339,8 +339,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 	// prepend the cwd of the threadinfo to the path.
 	if((m_field_id == TYPE_NAME ||
 	    m_field_id == TYPE_SOURCE ||
-	    m_field_id == TYPE_TARGET)
-	   && m_tstr.front() != '/')
+	    m_field_id == TYPE_TARGET))
 	{
 		sinsp_threadinfo* tinfo = evt->get_thread_info();
 
@@ -349,7 +348,14 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			return NULL;
 		}
 
-		m_tstr = sinsp_utils::concatenate_paths(tinfo->get_cwd(), m_tstr);
+		if(m_tstr.front() != '/')
+		{
+			m_tstr = sinsp_utils::concatenate_paths(tinfo->get_cwd(), m_tstr);
+		} else
+		{
+			// concatenate_paths takes care of resolving the path
+			m_tstr = sinsp_utils::concatenate_paths("", m_tstr);
+		}
 	}
 
 	// If m_tstr ends in a c-style \0, remove it to be

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 */
 
+#include <filesystem>
 #include "sinsp_filtercheck_fspath.h"
 #include "sinsp_filtercheck_event.h"
 #include "sinsp_filtercheck_fd.h"
@@ -348,7 +349,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			return NULL;
 		}
 
-		if(m_tstr.front() != '/')
+		if(!std::filesystem::path(m_tstr).is_absolute())
 		{
 			m_tstr = sinsp_utils::concatenate_paths(tinfo->get_cwd(), m_tstr);
 		} else

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -282,7 +282,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			{
 				return NULL;
 			}
-			m_tstr.assign((char *) extract_values[0].ptr, extract_values[0].len);
+			m_tstr.assign((const char*) extract_values[0].ptr, strnlen((const char*) extract_values[0].ptr, extract_values[0].len));
 		};
 
 		break;
@@ -305,7 +305,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			{
 				return NULL;
 			}
-			m_tstr.assign((char *) extract_values[0].ptr, extract_values[0].len);
+			m_tstr.assign((const char*) extract_values[0].ptr, strnlen((const char*) extract_values[0].ptr, extract_values[0].len));
 		};
 		break;
 	case TYPE_TARGET:
@@ -328,7 +328,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			{
 				return NULL;
 			}
-			m_tstr.assign((char *) extract_values[0].ptr, extract_values[0].len);
+			m_tstr.assign((const char*) extract_values[0].ptr, strnlen((const char*) extract_values[0].ptr, extract_values[0].len));
 		};
 		break;
 	default:
@@ -356,16 +356,6 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 			// concatenate_paths takes care of resolving the path
 			m_tstr = sinsp_utils::concatenate_paths("", m_tstr);
 		}
-	}
-
-	// If m_tstr ends in a c-style \0, remove it to be
-	// consistent. Generally, the evt.rawarg fields above *will*
-	// end in c-style \0 characters, while the ones that extract
-	// from the enter event or have values populated by parsers
-	// (e.g. fchmod/fchown) will not.
-	if(m_tstr.back() == '\0')
-	{
-		m_tstr.pop_back();
 	}
 
 	RETURN_EXTRACT_STRING(m_tstr);

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -27,9 +27,10 @@ class fspath : public sinsp_with_test_input
 {
 protected:
 
-	const char *filename = "/tmp/filename";
-	const char *rel_filename = "tmp/filename";
-	const char *resolved_rel_filename = "/root/tmp/filename";
+	const char *filename = "/tmp/random/dir.../..//../filename.txt";
+	const char *resolved_filename = "/tmp/filename.txt";
+	const char *rel_filename = "tmp/filename.txt";
+	const char *resolved_rel_filename = "/root/tmp/filename.txt";
 
 	const char *rel_filename_complex = "../\\.../../tmp/filename_complex";
 	const char *resolved_rel_filename_complex = "/tmp/filename_complex";
@@ -37,7 +38,10 @@ protected:
 	const char *rel_filename_nopath = "nopath";
 	const char *resolved_rel_filename_nopath = "/root/nopath";
 
-	const char *name = "/tmp/name";
+	const char *name = "/tmp/random/dir...///../../name/";
+	const char *resolved_name = "/tmp/name";
+	const char *rel_name = "tmp/random/dir...///../../name/";
+	const char *resolved_rel_name = "/root/tmp/name";
 	const char *path = "/tmp/path";
 	const char *oldpath = "/tmp/oldpath";
 	const char *newpath = "/tmp/newpath";
@@ -172,7 +176,7 @@ protected:
 		verify_no_fields(evt);
 	}
 
-	void test_exit_path(const char *expected_name,
+	void test_exit_path(const char *expected_name, const char *expected_name_raw,
 			    ppm_event_code event_type, uint32_t n, ...)
 	{
 
@@ -181,42 +185,10 @@ protected:
 		sinsp_evt* evt = add_event_advance_ts_v(increasing_ts(), 1, event_type, n, args);
 		va_end(args);
 
-		verify_fields(evt, expected_name, expected_name, NULL, NULL, NULL, NULL);
-	}
-
-	void test_exit_path_raw(const char *expected_name,
-				const char *expected_nameraw,
-				ppm_event_code event_type, uint32_t n, ...)
-	{
-
-		va_list args;
-		va_start(args, n);
-		sinsp_evt* evt = add_event_advance_ts_v(increasing_ts(), 1, event_type, n, args);
-		va_end(args);
-
-		verify_fields(evt,
-			      expected_name, expected_nameraw,
-			      NULL, NULL,
-			      NULL, NULL);
+		verify_fields(evt, expected_name, expected_name_raw, NULL, NULL, NULL, NULL);
 	}
 
 	void test_exit_source_target(const char *expected_source,
-				     const char *expected_target,
-				     ppm_event_code event_type, uint32_t n, ...)
-	{
-
-		va_list args;
-		va_start(args, n);
-		sinsp_evt* evt = add_event_advance_ts_v(increasing_ts(), 1, event_type, n, args);
-		va_end(args);
-
-		verify_fields(evt,
-			      NULL, NULL,
-			      expected_source, expected_source,
-			      expected_target, expected_target);
-	}
-
-	void test_exit_source_target_raw(const char *expected_source,
 					 const char *expected_sourceraw,
 					 const char *expected_target,
 					 const char *expected_targetraw,
@@ -248,130 +220,130 @@ protected:
 TEST_F(fspath, mkdir)
 {
 	test_enter(PPME_SYSCALL_MKDIR_E, 2, path, mode);
-	test_exit_path(path, PPME_SYSCALL_MKDIR_X, 1, res);
+	test_exit_path(path, path, PPME_SYSCALL_MKDIR_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_MKDIR_X, 1, failed_res);
 }
 
 TEST_F(fspath, mkdir_2)
 {
 	test_enter(PPME_SYSCALL_MKDIR_2_E, 1, mode);
-	test_exit_path(path, PPME_SYSCALL_MKDIR_2_X, 2, res, path);
+	test_exit_path(path, path, PPME_SYSCALL_MKDIR_2_X, 2, res, path);
 	test_failed_exit(PPME_SYSCALL_MKDIR_2_X, 2, failed_res, path);
 }
 
 TEST_F(fspath, mkdirat)
 {
 	test_enter(PPME_SYSCALL_MKDIRAT_E, 0);
-	test_exit_path(path, PPME_SYSCALL_MKDIRAT_X, 4, res, dirfd, path, mode);
+	test_exit_path(path, path, PPME_SYSCALL_MKDIRAT_X, 4, res, dirfd, path, mode);
 	test_failed_exit(PPME_SYSCALL_MKDIRAT_X, 4, failed_res, dirfd, path, mode);
 }
 
 TEST_F(fspath, rmdir)
 {
 	test_enter(PPME_SYSCALL_RMDIR_E, 1, path);
-	test_exit_path(path, PPME_SYSCALL_RMDIR_X, 1, res);
+	test_exit_path(path, path, PPME_SYSCALL_RMDIR_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_RMDIR_X, 1, failed_res);
 }
 
 TEST_F(fspath, rmdir_2)
 {
 	test_enter(PPME_SYSCALL_RMDIR_2_E, 0);
-	test_exit_path(path, PPME_SYSCALL_RMDIR_2_X, 2, res, path);
+	test_exit_path(path, path, PPME_SYSCALL_RMDIR_2_X, 2, res, path);
 	test_failed_exit(PPME_SYSCALL_RMDIR_2_X, 2, failed_res, path);
 }
 
 TEST_F(fspath, unlink)
 {
 	test_enter(PPME_SYSCALL_UNLINK_E, 1, path);
-	test_exit_path(path, PPME_SYSCALL_UNLINK_X, 1, res);
+	test_exit_path(path, path, PPME_SYSCALL_UNLINK_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_UNLINK_X, 1, failed_res);
 }
 
 TEST_F(fspath, unlinkat)
 {
 	test_enter(PPME_SYSCALL_UNLINKAT_E, 2, dirfd, name);
-	test_exit_path(name, PPME_SYSCALL_UNLINKAT_X, 1, res);
+	test_exit_path(resolved_name, name, PPME_SYSCALL_UNLINKAT_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_UNLINKAT_X, 1, failed_res);
 }
 
 TEST_F(fspath, unlink_2)
 {
 	test_enter(PPME_SYSCALL_UNLINK_2_E, 0);
-	test_exit_path(path, PPME_SYSCALL_UNLINK_2_X, 2, res, path);
+	test_exit_path(path, path, PPME_SYSCALL_UNLINK_2_X, 2, res, path);
 	test_failed_exit(PPME_SYSCALL_UNLINK_2_X, 2, failed_res, path);
 }
 
 TEST_F(fspath, unlinkat_2)
 {
 	test_enter(PPME_SYSCALL_UNLINKAT_2_E, 0);
-	test_exit_path(name, PPME_SYSCALL_UNLINKAT_2_X, 4, res, dirfd, name, flags);
+	test_exit_path(resolved_rel_name, rel_name, PPME_SYSCALL_UNLINKAT_2_X, 4, res, rel_dirfd, rel_name, flags);
 	test_failed_exit(PPME_SYSCALL_UNLINKAT_2_X, 4, failed_res, dirfd, name, flags);
 }
 
 TEST_F(fspath, open)
 {
 	test_enter(PPME_SYSCALL_OPEN_E, 3, name, open_flags, mode);
-	test_exit_path(name, PPME_SYSCALL_OPEN_X, 6, fd, name, open_flags, mode, dev, ino);
+	test_exit_path(resolved_name, name, PPME_SYSCALL_OPEN_X, 6, fd, name, open_flags, mode, dev, ino);
 	test_failed_exit(PPME_SYSCALL_OPEN_X, 6, failed_res, "<NA>", open_flags, mode, dev, ino);
 }
 
 TEST_F(fspath, openat)
 {
 	test_enter(PPME_SYSCALL_OPENAT_E, 4, dirfd, name, open_flags, mode);
-	test_exit_path(name, PPME_SYSCALL_OPENAT_X, 1, fd);
+	test_exit_path(resolved_name, name, PPME_SYSCALL_OPENAT_X, 1, fd);
 	test_failed_exit(PPME_SYSCALL_OPENAT_X, 6, failed_res);
 }
 
 TEST_F(fspath, openat_2)
 {
 	test_enter(PPME_SYSCALL_OPENAT_2_E, 4, dirfd, name, open_flags, mode);
-	test_exit_path(name, PPME_SYSCALL_OPENAT_2_X, 7, fd, dirfd, name, open_flags, mode, dev, ino);
+	test_exit_path(resolved_name, name, PPME_SYSCALL_OPENAT_2_X, 7, fd, dirfd, name, open_flags, mode, dev, ino);
 	test_failed_exit(PPME_SYSCALL_OPENAT_2_X, 7, failed_res, dirfd, name, open_flags, mode, dev, ino);
 }
 
 TEST_F(fspath, openat2)
 {
 	test_enter(PPME_SYSCALL_OPENAT2_E, 5, dirfd, name, open_flags, mode, resolve);
-	test_exit_path(name, PPME_SYSCALL_OPENAT2_X, 6, fd, dirfd, name, open_flags, mode, resolve);
+	test_exit_path(resolved_rel_name, rel_name, PPME_SYSCALL_OPENAT2_X, 6, fd, rel_dirfd, rel_name, open_flags, mode, resolve);
 	test_failed_exit(PPME_SYSCALL_OPENAT2_X, 6, failed_res, dirfd, name, open_flags, mode, resolve);
 }
 
 TEST_F(fspath, fchmodat)
 {
 	test_enter(PPME_SYSCALL_FCHMODAT_E, 0);
-	test_exit_path(filename, PPME_SYSCALL_FCHMODAT_X, 4, res, dirfd, filename, mode);
+	test_exit_path(resolved_filename, filename, PPME_SYSCALL_FCHMODAT_X, 4, res, dirfd, filename, mode);
 	test_failed_exit(PPME_SYSCALL_FCHMODAT_X, 4, failed_res, dirfd, filename, mode);
 }
 
 TEST_F(fspath, fchmodat_relative)
 {
 	test_enter(PPME_SYSCALL_FCHMODAT_E, 0);
-	test_exit_path_raw(resolved_rel_filename, rel_filename, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename, mode);
+	test_exit_path(resolved_rel_filename, rel_filename, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename, mode);
 }
 
 TEST_F(fspath, fchmodat_relative_complex)
 {
 	test_enter(PPME_SYSCALL_FCHMODAT_E, 0);
-	test_exit_path_raw(resolved_rel_filename_complex, rel_filename_complex, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename_complex, mode);
+	test_exit_path(resolved_rel_filename_complex, rel_filename_complex, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename_complex, mode);
 }
 
 TEST_F(fspath, fchmodat_relative_nopath)
 {
 	test_enter(PPME_SYSCALL_FCHMODAT_E, 0);
-	test_exit_path_raw(resolved_rel_filename_nopath, rel_filename_nopath, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename_nopath, mode);
+	test_exit_path(resolved_rel_filename_nopath, rel_filename_nopath, PPME_SYSCALL_FCHMODAT_X, 4, res, rel_dirfd, rel_filename_nopath, mode);
 }
 
 TEST_F(fspath, chmod)
 {
 	test_enter(PPME_SYSCALL_CHMOD_E, 0);
-	test_exit_path(filename, PPME_SYSCALL_CHMOD_X, 3, res, filename, mode);
+	test_exit_path(resolved_filename, filename, PPME_SYSCALL_CHMOD_X, 3, res, filename, mode);
 	test_failed_exit(PPME_SYSCALL_CHMOD_X, 3, failed_res, filename, mode);
 }
 
 TEST_F(fspath, chmod_relative)
 {
 	test_enter(PPME_SYSCALL_CHMOD_E, 0);
-	test_exit_path_raw(resolved_rel_filename, rel_filename, PPME_SYSCALL_CHMOD_X, 3, res, rel_filename, mode);
+	test_exit_path(resolved_rel_filename, rel_filename, PPME_SYSCALL_CHMOD_X, 3, res, rel_filename, mode);
 }
 
 TEST_F(fspath, fchmod)
@@ -380,21 +352,21 @@ TEST_F(fspath, fchmod)
 	inject_open_event();
 
 	test_enter(PPME_SYSCALL_FCHMOD_E, 0);
-	test_exit_path(path, PPME_SYSCALL_FCHMOD_X, 3, res, fd, mode);
+	test_exit_path(path, path, PPME_SYSCALL_FCHMOD_X, 3, res, fd, mode);
 	test_failed_exit(PPME_SYSCALL_FCHMOD_X, 3, failed_res, fd, mode);
 }
 
 TEST_F(fspath, chown)
 {
 	test_enter(PPME_SYSCALL_CHOWN_E, 0);
-	test_exit_path(path, PPME_SYSCALL_CHOWN_X, 4, res, path, uid, gid);
+	test_exit_path(path, path, PPME_SYSCALL_CHOWN_X, 4, res, path, uid, gid);
 	test_failed_exit(PPME_SYSCALL_CHOWN_X, 4, failed_res, path, uid, gid);
 }
 
 TEST_F(fspath, lchown)
 {
 	test_enter(PPME_SYSCALL_LCHOWN_E, 0);
-	test_exit_path(path, PPME_SYSCALL_LCHOWN_X, 4, res, path, uid, gid);
+	test_exit_path(path, path, PPME_SYSCALL_LCHOWN_X, 4, res, path, uid, gid);
 	test_failed_exit(PPME_SYSCALL_LCHOWN_X, 4, failed_res, path, uid, gid);
 }
 
@@ -404,7 +376,7 @@ TEST_F(fspath, fchown)
 	inject_open_event();
 
 	test_enter(PPME_SYSCALL_FCHOWN_E, 0);
-	test_exit_path(path, PPME_SYSCALL_FCHOWN_X, 4, res, fd, uid, gid);
+	test_exit_path(path, path, PPME_SYSCALL_FCHOWN_X, 4, res, fd, uid, gid);
 	test_failed_exit(PPME_SYSCALL_FCHOWN_X, 4, failed_res, fd, uid, gid);
 }
 
@@ -414,7 +386,7 @@ TEST_F(fspath, fchownat)
 	const char *pathname = "/tmp/pathname";
 
 	test_enter(PPME_SYSCALL_FCHOWNAT_E, 0);
-	test_exit_path(pathname, PPME_SYSCALL_FCHOWNAT_X, 6, res, dirfd, pathname, uid, gid, flags);
+	test_exit_path(pathname, pathname, PPME_SYSCALL_FCHOWNAT_X, 6, res, dirfd, pathname, uid, gid, flags);
 	test_failed_exit(PPME_SYSCALL_FCHOWNAT_X, 6, failed_res, dirfd, pathname, uid, gid, flags);
 }
 
@@ -425,7 +397,7 @@ TEST_F(fspath, fchownat_relative)
 	const char *resolved_rel_pathname = "/root/tmp/pathname";
 
 	test_enter(PPME_SYSCALL_FCHOWNAT_E, 0);
-	test_exit_path_raw(resolved_rel_pathname, rel_pathname, PPME_SYSCALL_FCHOWNAT_X, 6, res, rel_dirfd, rel_pathname, uid, gid, flags);
+	test_exit_path(resolved_rel_pathname, rel_pathname, PPME_SYSCALL_FCHOWNAT_X, 6, res, rel_dirfd, rel_pathname, uid, gid, flags);
 }
 
 TEST_F(fspath, quotactl)
@@ -449,7 +421,7 @@ TEST_F(fspath, quotactl)
 	uint8_t quota_fmt_out = 0;
 
 	test_enter(PPME_SYSCALL_QUOTACTL_E, 4, cmd, type, id, quota_fmt);
-	test_exit_path(path, PPME_SYSCALL_QUOTACTL_X, 14, res, path, quotafilepath,
+	test_exit_path(path, path, PPME_SYSCALL_QUOTACTL_X, 14, res, path, quotafilepath,
 		       dqb_bhardlimit, dqb_bsoftlimit, dqb_curspace, dqb_ihardlimit,
 		       dqb_isoftlimit, dqb_btime, dqb_itime, dqi_bgrace,
 		       dqi_igrace, dqi_flags, quota_fmt_out);
@@ -462,35 +434,35 @@ TEST_F(fspath, quotactl)
 TEST_F(fspath, rename)
 {
 	test_enter(PPME_SYSCALL_RENAME_E, 0);
-	test_exit_source_target(oldpath, newpath, PPME_SYSCALL_RENAME_X, 3, res, oldpath, newpath);
+	test_exit_source_target(oldpath, oldpath, newpath, newpath, PPME_SYSCALL_RENAME_X, 3, res, oldpath, newpath);
 	test_failed_exit(PPME_SYSCALL_RENAME_X, 3, failed_res, oldpath, newpath);
 }
 
 TEST_F(fspath, renameat)
 {
 	test_enter(PPME_SYSCALL_RENAMEAT_E, 0);
-	test_exit_source_target(oldpath, newpath, PPME_SYSCALL_RENAMEAT_X, 5, res, olddirfd, oldpath, newdirfd, newpath);
+	test_exit_source_target(oldpath, oldpath, newpath, newpath, PPME_SYSCALL_RENAMEAT_X, 5, res, olddirfd, oldpath, newdirfd, newpath);
 	test_failed_exit(PPME_SYSCALL_RENAMEAT_X, 5, failed_res, olddirfd, oldpath, newdirfd, newpath);
 }
 
 TEST_F(fspath, renameat2)
 {
 	test_enter(PPME_SYSCALL_RENAMEAT2_E, 0);
-	test_exit_source_target(oldpath, newpath, PPME_SYSCALL_RENAMEAT2_X, 5, res, olddirfd, oldpath, newdirfd, newpath, flags);
+	test_exit_source_target(oldpath, oldpath, newpath, newpath, PPME_SYSCALL_RENAMEAT2_X, 5, res, olddirfd, oldpath, newdirfd, newpath, flags);
 	test_failed_exit(PPME_SYSCALL_RENAMEAT2_X, 5, failed_res, olddirfd, oldpath, newdirfd, newpath, flags);
 }
 
 TEST_F(fspath, link)
 {
 	test_enter(PPME_SYSCALL_LINK_E, 2, oldpath, newpath);
-	test_exit_source_target(newpath, oldpath, PPME_SYSCALL_LINK_X, 1, res);
+	test_exit_source_target(newpath, newpath, oldpath, oldpath, PPME_SYSCALL_LINK_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_LINK_X, 1, failed_res);
 }
 
 TEST_F(fspath, link_relative)
 {
 	test_enter(PPME_SYSCALL_LINK_E, 2, rel_oldpath, rel_newpath);
-	test_exit_source_target_raw(resolved_rel_newpath, rel_newpath,
+	test_exit_source_target(resolved_rel_newpath, rel_newpath,
 				    resolved_rel_oldpath, rel_oldpath,
 				    PPME_SYSCALL_LINK_X, 1, res);
 }
@@ -498,14 +470,14 @@ TEST_F(fspath, link_relative)
 TEST_F(fspath, linkat)
 {
 	test_enter(PPME_SYSCALL_LINKAT_E, 4, olddirfd, oldpath, newdirfd, newpath);
-	test_exit_source_target(newpath, oldpath, PPME_SYSCALL_LINKAT_X, 1, res);
+	test_exit_source_target(newpath, newpath, oldpath, oldpath, PPME_SYSCALL_LINKAT_X, 1, res);
 	test_failed_exit(PPME_SYSCALL_LINKAT_X, 1, failed_res);
 }
 
 TEST_F(fspath, linkat_relative)
 {
 	test_enter(PPME_SYSCALL_LINKAT_E, 4, olddirfd, rel_oldpath, newdirfd, rel_newpath);
-	test_exit_source_target_raw(resolved_rel_newpath, rel_newpath,
+	test_exit_source_target(resolved_rel_newpath, rel_newpath,
 				    resolved_rel_oldpath, rel_oldpath,
 				    PPME_SYSCALL_LINKAT_X, 1, res);
 }
@@ -513,14 +485,14 @@ TEST_F(fspath, linkat_relative)
 TEST_F(fspath, link_2)
 {
 	test_enter(PPME_SYSCALL_LINK_2_E, 0);
-	test_exit_source_target(newpath, oldpath, PPME_SYSCALL_LINK_2_X, 3, res, oldpath, newpath);
+	test_exit_source_target(newpath, newpath, oldpath, oldpath, PPME_SYSCALL_LINK_2_X, 3, res, oldpath, newpath);
 	test_failed_exit(PPME_SYSCALL_LINK_2_X, 3, failed_res, oldpath, newpath);
 }
 
 TEST_F(fspath, link_2_relative)
 {
 	test_enter(PPME_SYSCALL_LINK_2_E, 0);
-	test_exit_source_target_raw(resolved_rel_newpath, rel_newpath,
+	test_exit_source_target(resolved_rel_newpath, rel_newpath,
 				    resolved_rel_oldpath, rel_oldpath,
 				    PPME_SYSCALL_LINK_2_X, 3, res, rel_oldpath, rel_newpath);
 }
@@ -528,14 +500,14 @@ TEST_F(fspath, link_2_relative)
 TEST_F(fspath, linkat_2)
 {
 	test_enter(PPME_SYSCALL_LINKAT_2_E, 0);
-	test_exit_source_target(newpath, oldpath, PPME_SYSCALL_LINKAT_2_X, 6, res, olddirfd, oldpath, newdirfd, newpath, flags);
+	test_exit_source_target(newpath, newpath, oldpath, oldpath, PPME_SYSCALL_LINKAT_2_X, 6, res, olddirfd, oldpath, newdirfd, newpath, flags);
 	test_failed_exit(PPME_SYSCALL_LINKAT_2_X, 6, failed_res, olddirfd, oldpath, newdirfd, newpath, flags);
 }
 
 TEST_F(fspath, linkat_2_relative)
 {
 	test_enter(PPME_SYSCALL_LINKAT_2_E, 0);
-	test_exit_source_target_raw(resolved_rel_newpath, rel_newpath,
+	test_exit_source_target(resolved_rel_newpath, rel_newpath,
 				    resolved_rel_oldpath, rel_oldpath,
 				    PPME_SYSCALL_LINKAT_2_X, 6, res, olddirfd, rel_oldpath, newdirfd, rel_newpath, flags);
 }
@@ -543,14 +515,14 @@ TEST_F(fspath, linkat_2_relative)
 TEST_F(fspath, symlink)
 {
 	test_enter(PPME_SYSCALL_SYMLINK_E, 0);
-	test_exit_source_target(linkpath, targetpath, PPME_SYSCALL_SYMLINK_X, 3, res, targetpath, linkpath);
+	test_exit_source_target(linkpath, linkpath, targetpath, targetpath, PPME_SYSCALL_SYMLINK_X, 3, res, targetpath, linkpath);
 	test_failed_exit(PPME_SYSCALL_SYMLINK_X, 3, failed_res, targetpath, linkpath);
 }
 
 TEST_F(fspath, symlink_relative)
 {
 	test_enter(PPME_SYSCALL_SYMLINK_E, 0);
-	test_exit_source_target_raw(resolved_rel_linkpath, rel_linkpath,
+	test_exit_source_target(resolved_rel_linkpath, rel_linkpath,
 				    resolved_rel_targetpath, rel_targetpath,
 				    PPME_SYSCALL_SYMLINK_X, 3, res, rel_targetpath, rel_linkpath);
 }
@@ -558,14 +530,14 @@ TEST_F(fspath, symlink_relative)
 TEST_F(fspath, symlinkat)
 {
 	test_enter(PPME_SYSCALL_SYMLINKAT_E, 0);
-	test_exit_source_target(linkpath, targetpath, PPME_SYSCALL_SYMLINKAT_X, 4, res, targetpath, linkdirfd, linkpath);
+	test_exit_source_target(linkpath, linkpath, targetpath, targetpath, PPME_SYSCALL_SYMLINKAT_X, 4, res, targetpath, linkdirfd, linkpath);
 	test_failed_exit(PPME_SYSCALL_SYMLINKAT_X, 4, failed_res, targetpath, linkdirfd, linkpath);
 }
 
 TEST_F(fspath, symlinkat_relative)
 {
 	test_enter(PPME_SYSCALL_SYMLINKAT_E, 0);
-	test_exit_source_target_raw(resolved_rel_linkpath, rel_linkpath,
+	test_exit_source_target(resolved_rel_linkpath, rel_linkpath,
 				    resolved_rel_targetpath, rel_targetpath,
 				    PPME_SYSCALL_SYMLINKAT_X, 4, res, rel_targetpath, linkdirfd, rel_linkpath);
 }
@@ -576,28 +548,27 @@ TEST_F(fspath, mount)
 	const char *mounttype = "iso9660";
 
 	test_enter(PPME_SYSCALL_MOUNT_E, 1, flags);
-	test_exit_source_target(devpath, mountpath, PPME_SYSCALL_MOUNT_X, 4, res, devpath, mountpath, mounttype);
+	test_exit_source_target(devpath, devpath, mountpath, mountpath, PPME_SYSCALL_MOUNT_X, 4, res, devpath, mountpath, mounttype);
 	test_failed_exit(PPME_SYSCALL_MOUNT_X, 4, failed_res, devpath, mountpath, mounttype);
 }
 
 TEST_F(fspath, umount)
 {
 	test_enter(PPME_SYSCALL_UMOUNT_E, 1, flags);
-	test_exit_path(mountpath, PPME_SYSCALL_UMOUNT_X, 2, res, mountpath);
+	test_exit_path(mountpath, mountpath, PPME_SYSCALL_UMOUNT_X, 2, res, mountpath);
 	test_failed_exit(PPME_SYSCALL_UMOUNT_X, 2, failed_res, mountpath);
 }
 
 TEST_F(fspath, umount_1)
 {
-
 	test_enter(PPME_SYSCALL_UMOUNT_1_E, 0);
-	test_exit_path(mountpath, PPME_SYSCALL_UMOUNT_1_X, 2, res, mountpath);
+	test_exit_path(mountpath, mountpath, PPME_SYSCALL_UMOUNT_1_X, 2, res, mountpath);
 	test_failed_exit(PPME_SYSCALL_UMOUNT_1_X, 2, failed_res, mountpath);
 }
 
 TEST_F(fspath, umount2)
 {
 	test_enter(PPME_SYSCALL_UMOUNT2_E, 1, flags);
-	test_exit_path(mountpath, PPME_SYSCALL_UMOUNT2_X, 2, res, mountpath);
+	test_exit_path(mountpath, mountpath, PPME_SYSCALL_UMOUNT2_X, 2, res, mountpath);
 	test_failed_exit(PPME_SYSCALL_UMOUNT2_X, 2, failed_res, mountpath);
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`fs.path*` still had some minor bugs in handling path resolution and ensuring no trailing `/` is in the output fields.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): fix some path handling in fs.path
```
