### PR TITLE
fix(libsinsp): do not include null terminator in enter event strings

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2161,8 +2161,7 @@ void sinsp_evt::save_enter_event_params(sinsp_evt* enter_evt)
 		param = enter_evt->get_param_by_name(pname);
 		if(param)
 		{
-			std::string val;
-			val.assign((char *) param->m_val, param->m_len);
+			std::string val {param->as<std::string_view>()};
 			m_enter_path_param[pname] = val;
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Sometimes we were saving `std::string`s formatted like `content\0` because we were including the full length of the message. This resulted in the final backslash in paths being added accidentally to `fs.path.*` fields. This fixes it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): prevent extra characters from being added to fs.path.* fields
```
