### PR TITLE
chore(cmake): allow user to override GIT_COMMIT from cmake.

### DIFF
--- a/cmake/modules/compute_versions.cmake
+++ b/cmake/modules/compute_versions.cmake
@@ -32,6 +32,8 @@ macro(compute_versions api_version_path schema_version_path)
     message(STATUS "Driver schema version ${PPM_SCHEMA_CURRENT_VERSION_MAJOR}.${PPM_SCHEMA_CURRENT_VERSION_MINOR}.${PPM_SCHEMA_CURRENT_VERSION_PATCH}")
 
     # GIT COMMIT
-    execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE GIT_COMMIT ERROR_QUIET WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    if(NOT DEFINED GIT_COMMIT)
+        execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE GIT_COMMIT ERROR_QUIET WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
     string(STRIP "${GIT_COMMIT}" GIT_COMMIT)
 endmacro()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Discovered during the development of https://github.com/falcosecurity/driverkit/pull/302; basically we don't allow the user to override `GIT_COMMIT`; but since we support `DRIVER_VERSION` explicitly set by user, i think we should let user also override the commit.
See the driverkit PR workaround: https://github.com/falcosecurity/driverkit/pull/302/files#diff-16a66a3bc20a8ec693f64ed821148f71efa386a7e942444444eb591512bf129bR51

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
