### PR TITLE
refactor: Add some const-correctness

### DIFF
--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -51,20 +51,20 @@ typedef struct table_row_cmp
 		if(src.m_values[m_colid].m_cnt > 1 ||
 			dst.m_values[m_colid].m_cnt > 1)
 		{
-			return flt_compare_avg(op, m_type, 
-				src.m_values[m_colid].m_val, 
-				dst.m_values[m_colid].m_val, 
-				src.m_values[m_colid].m_len, 
+			return flt_compare_avg(op, m_type,
+				src.m_values[m_colid].m_val,
+				dst.m_values[m_colid].m_val,
+				src.m_values[m_colid].m_len,
 				dst.m_values[m_colid].m_len,
-				src.m_values[m_colid].m_cnt, 
+				src.m_values[m_colid].m_cnt,
 				dst.m_values[m_colid].m_cnt);
 		}
 		else
 		{
-			return flt_compare(op, m_type, 
-				src.m_values[m_colid].m_val, 
-				dst.m_values[m_colid].m_val, 
-				src.m_values[m_colid].m_len, 
+			return flt_compare(op, m_type,
+				src.m_values[m_colid].m_val,
+				dst.m_values[m_colid].m_val,
+				src.m_values[m_colid].m_len,
 				dst.m_values[m_colid].m_len);
 		}
 	}
@@ -74,7 +74,7 @@ typedef struct table_row_cmp
 	bool m_ascending;
 }table_row_cmp;
 
-chisel_table::chisel_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns, 
+chisel_table::chisel_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns,
 	chisel_table::output_type output_type, uint32_t json_first_row, uint32_t json_last_row)
 {
 	m_inspector = inspector;
@@ -133,11 +133,11 @@ chisel_table::~chisel_table()
 	{
 		delete m_filter;
 	}
-	
+
 	delete m_printer;
 }
 
-void chisel_table::configure(vector<chisel_view_column_info>* entries, const string& filter, 
+void chisel_table::configure(vector<chisel_view_column_info>* entries, const string& filter,
 	bool use_defaults, uint32_t view_depth)
 {
 	m_use_defaults = use_defaults;
@@ -167,7 +167,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 
 	for(auto vit : *entries)
 	{
-		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth), 
+		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth),
 			m_inspector,
 			false);
 
@@ -209,7 +209,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 	}
 	else
 	{
-		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname("util.cnt", 
+		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname("util.cnt",
 			m_inspector,
 			false);
 
@@ -252,7 +252,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 	m_vals_array_sz = m_premerge_vals_array_sz;
 
 	//////////////////////////////////////////////////////////////////////////////////////
-	// If a merge has been specified, configure it 
+	// If a merge has been specified, configure it
 	//////////////////////////////////////////////////////////////////////////////////////
 	uint32_t n_gby_keys = 0;
 
@@ -348,7 +348,7 @@ void chisel_table::add_row(bool merging)
 {
 	uint32_t j;
 
-	chisel_table_field key(m_fld_pointers[0].m_val, 
+	chisel_table_field key(m_fld_pointers[0].m_val,
 		m_fld_pointers[0].m_len,
 		m_fld_pointers[0].m_cnt);
 
@@ -549,13 +549,13 @@ void chisel_table::process_proctable(sinsp_evt* evt)
 }
 
 void chisel_table::flush(sinsp_evt* evt)
-{	
+{
 	if(!m_paused)
 	{
 		if(m_next_flush_time_ns != 0)
 		{
 			//
-			// Time to emit the sample! 
+			// Time to emit the sample!
 			// Add the proctable as a sample at the end of the second
 			//
 			process_proctable(evt);
@@ -581,7 +581,7 @@ void chisel_table::flush(sinsp_evt* evt)
 			if(m_type == chisel_table::TT_TABLE)
 			{
 				//
-				// Switch the data storage so that the current one is still usable by the 
+				// Switch the data storage so that the current one is still usable by the
 				// consumers of the table.
 				//
 				switch_buffers();
@@ -619,13 +619,13 @@ void chisel_table::print_raw(vector<chisel_sample_row>* sample_data, uint64_t ti
 			check_wrapper* extractor = m_extractors->at(j + 1);
 			uint64_t td = 0;
 
-			if(extractor->m_aggregation == A_TIME_AVG || 
+			if(extractor->m_aggregation == A_TIME_AVG ||
 				extractor->m_merge_aggregation == A_TIME_AVG)
 			{
 				td = time_delta;
 			}
 
-			m_printer->set_val(m_types->at(j + 1), 
+			m_printer->set_val(m_types->at(j + 1),
 				EPF_NONE,
 				it->m_values[j].m_val,
 				it->m_values[j].m_len,
@@ -673,19 +673,19 @@ void chisel_table::print_json(vector<chisel_sample_row>* sample_data, uint64_t t
 		Json::Value root;
 		Json::Value jd;
 		auto row = sample_data->at(k);
-		
+
 		for(uint32_t j = 0; j < m_n_fields - 1; j++)
 		{
 			check_wrapper* extractor = m_extractors->at(j + 1);
 			uint64_t td = 0;
 
-			if(extractor->m_aggregation == A_TIME_AVG || 
+			if(extractor->m_aggregation == A_TIME_AVG ||
 				extractor->m_merge_aggregation == A_TIME_AVG)
 			{
 				td = time_delta;
 			}
 
-			m_printer->set_val(m_types->at(j + 1), 
+			m_printer->set_val(m_types->at(j + 1),
 				EPF_NONE,
 				row.m_values[j].m_val,
 				row.m_values[j].m_len,
@@ -749,13 +749,13 @@ void chisel_table::filter_sample()
 			        type == PT_IPV6ADDR ||
 				type == PT_UID || type == PT_GID)
 			{
-				m_printer->set_val(type, 
+				m_printer->set_val(type,
 					EPF_NONE,
-					it.m_values[j].m_val, 
+					it.m_values[j].m_val,
 					it.m_values[j].m_len,
 					it.m_values[j].m_cnt,
 					legend->at(j + 1).m_print_format);
-					
+
 				string strval = m_printer->tostring_nice(NULL, 0, 0);
 
 				if(strval.find(m_freetext_filter) != string::npos)
@@ -976,7 +976,7 @@ void chisel_table::set_sorting_col(uint32_t col)
 	m_sorting_col = col - 1;
 }
 
-uint32_t chisel_table::get_sorting_col()
+uint32_t chisel_table::get_sorting_col() const
 {
 	return (uint32_t)m_sorting_col + 1;
 }
@@ -990,7 +990,7 @@ void chisel_table::create_sample()
 		chisel_sample_row row;
 
 		//
-		// If merging is on, perform the merge and switch to the merged table 
+		// If merging is on, perform the merge and switch to the merged table
 		//
 		if(m_do_merging)
 		{
@@ -1058,7 +1058,7 @@ void chisel_table::add_fields_sum(ppm_param_type type, chisel_table_field *dst, 
 {
 	uint8_t* operand1 = dst->m_val;
 	uint8_t* operand2 = src->m_val;
-	
+
 	switch(type)
 	{
 	case PT_INT8:
@@ -1102,7 +1102,7 @@ void chisel_table::add_fields_sum_of_avg(ppm_param_type type, chisel_table_field
 	uint8_t* operand2 = src->m_val;
 	uint32_t cnt1 = dst->m_cnt;
 	uint32_t cnt2 = src->m_cnt;
-	
+
 	switch(type)
 	{
 	case PT_INT8:
@@ -1374,10 +1374,10 @@ void chisel_table::add_fields(uint32_t dst_id, chisel_table_field* src, uint32_t
 		return;
 	case A_AVG:
 		dst->m_cnt += src->m_cnt;
-		add_fields_sum(type, dst, src);		
+		add_fields_sum(type, dst, src);
 		return;
 	case A_MAX:
-		add_fields_max(type, dst, src);		
+		add_fields_max(type, dst, src);
 		return;
 	case A_MIN:
 		if(src->m_cnt != 0)
@@ -1399,7 +1399,7 @@ void chisel_table::add_fields(uint32_t dst_id, chisel_table_field* src, uint32_t
 	}
 }
 
-uint32_t chisel_table::get_field_len(uint32_t id)
+uint32_t chisel_table::get_field_len(uint32_t id) const
 {
 	ppm_param_type type;
 	chisel_table_field *fld;
@@ -1560,7 +1560,7 @@ pair<filtercheck_field_info*, string> chisel_table::get_row_key_name_and_val(uin
 
 		m_printer->set_val(types->at(0),
 			EPF_NONE,
-			m_sample_data->at(rownum).m_key.m_val, 
+			m_sample_data->at(rownum).m_key.m_val,
 			m_sample_data->at(rownum).m_key.m_len,
 			m_sample_data->at(rownum).m_key.m_cnt,
 			legend->at(0).m_print_format);
@@ -1581,7 +1581,7 @@ chisel_table_field* chisel_table::get_row_key(uint32_t rownum)
 	return &m_sample_data->at(rownum).m_key;
 }
 
-int32_t chisel_table::get_row_from_key(chisel_table_field* key)
+int32_t chisel_table::get_row_from_key(chisel_table_field* key) const
 {
 	uint32_t j;
 

--- a/userspace/chisel/chisel_table.h
+++ b/userspace/chisel/chisel_table.h
@@ -76,7 +76,7 @@ public:
 	uint32_t m_cnt;		// For averages, this stores the entry count
 	uint8_t* m_val;
 
-	friend class curses_table;	
+	friend class curses_table;
 };
 
 #define STF_STORAGE_BUFSIZE 512
@@ -138,7 +138,7 @@ struct chisel_table_field_hasher
 		  h = h * 101 + (unsigned) *s++;
 	  }
 
-	  return h;  
+	  return h;
   }
 };
 
@@ -222,7 +222,7 @@ public:
 
 class chisel_table
 {
-public:	
+public:
 	enum tabletype
 	{
 		TT_NONE = 0,
@@ -230,7 +230,7 @@ public:
 		TT_LIST,
 	};
 
-	enum output_type 
+	enum output_type
 	{
 		OT_CURSES,
 		OT_RAW,
@@ -253,13 +253,13 @@ public:
 		{
 			delete m_check;
 		}
-	
+
 		sinsp_filter_check* m_check;
 		chisel_field_aggregation m_aggregation;
 		chisel_field_aggregation m_merge_aggregation;
 	};
 
-	chisel_table(sinsp* inspector, tabletype type, 
+	chisel_table(sinsp* inspector, tabletype type,
 		uint64_t refresh_interval_ns, chisel_table::output_type output_type,
 		uint32_t json_first_row, uint32_t json_last_row);
 	~chisel_table();
@@ -285,16 +285,16 @@ public:
 		}
 	}
 	void set_sorting_col(uint32_t col);
-	uint32_t get_sorting_col();
+	uint32_t get_sorting_col() const;
 	std::pair<filtercheck_field_info*, std::string> get_row_key_name_and_val(uint32_t rownum, bool force);
 	chisel_table_field* get_row_key(uint32_t rownum);
-	int32_t get_row_from_key(chisel_table_field* key);
+	int32_t get_row_from_key(chisel_table_field* key) const;
 	void set_paused(bool paused);
 	void set_freetext_filter(std::string filter)
 	{
 		m_freetext_filter = filter;
 	}
-	tabletype get_type()
+	tabletype get_type() const
 	{
 		return m_type;
 	}
@@ -303,11 +303,11 @@ public:
 		m_refresh_interval_ns = newinterval_ns;
 	}
 	void clear();
-	bool is_merging()
+	bool is_merging() const
 	{
 		return m_do_merging;
 	}
-	bool is_sorting_ascending()
+	bool is_sorting_ascending() const
 	{
 		return m_is_sorting_ascending;
 	}
@@ -330,7 +330,7 @@ private:
 	inline void add_fields_min(ppm_param_type type, chisel_table_field* dst, chisel_table_field* src);
 	inline void add_fields(uint32_t dst_id, chisel_table_field* src, uint32_t aggr);
 	void process_proctable(sinsp_evt* evt);
-	inline uint32_t get_field_len(uint32_t id);
+	inline uint32_t get_field_len(uint32_t id) const;
 	inline uint8_t* get_default_val(filtercheck_field_info* fld);
 	void create_sample();
 	void switch_buffers();
@@ -385,6 +385,6 @@ private:
 	uint32_t m_json_first_row;
 	uint32_t m_json_last_row;
 
-	friend class curses_table;	
+	friend class curses_table;
 	friend class sinsp_cursesui;
 };

--- a/userspace/chisel/chisel_viewinfo.cpp
+++ b/userspace/chisel/chisel_viewinfo.cpp
@@ -287,7 +287,7 @@ chisel_view_column_info* chisel_view_info::get_key()
 	return NULL;
 }
 
-string chisel_view_info::get_filter(uint32_t depth)
+string chisel_view_info::get_filter(uint32_t depth) const
 {
 	if(m_filter.find("%depth+1") != string::npos)
 	{

--- a/userspace/chisel/chisel_viewinfo.h
+++ b/userspace/chisel/chisel_viewinfo.h
@@ -150,7 +150,7 @@ public:
 
 	void get_col_names_and_sizes(OUT std::vector<std::string>* colnames, OUT std::vector<int32_t>* colsizes);
 	chisel_view_column_info* get_key();
-	std::string get_filter(uint32_t depth);
+	std::string get_filter(uint32_t depth) const;
 	viewtype get_type()
 	{
 		return m_type;
@@ -205,11 +205,15 @@ public:
 	std::vector<chisel_view_info>* get_views();
 	uint32_t get_selected_view();
 	void set_selected_view(std::string viewid);
-	size_t size()
+	size_t size() const
 	{
 		return m_views.size();
 	}
 	chisel_view_info* at(uint32_t viewnum)
+	{
+		return &m_views[viewnum];
+	}
+	const chisel_view_info* at(uint32_t viewnum) const
 	{
 		return &m_views[viewnum];
 	}

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -181,8 +181,8 @@ public:
 
     int32_t next(scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags);
 
-    uint32_t get_vxid(uint64_t pid);
-    int32_t get_stats(scap_stats *stats);
+    uint32_t get_vxid(uint64_t pid) const;
+    int32_t get_stats(scap_stats *stats) const;
     const struct scap_stats_v2* get_stats_v2(uint32_t flags, uint32_t* nstats, int32_t* rc);
 private:
     int32_t process_message_from_fd(int fd);

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -135,7 +135,7 @@ int32_t engine::init(std::string config_path, std::string root_path, bool no_eve
 	m_platform = platform;
 
 	m_trace_session_path = config_path;
-	
+
 	std::ifstream config_file(config_path);
 	if (config_file.fail())
 	{
@@ -266,7 +266,7 @@ static bool handshake(int client)
 	{
 		return false;
 	}
-	
+
 	return true;
 }
 
@@ -324,7 +324,7 @@ int32_t engine::start_capture()
 	m_accept_thread.detach();
 
 	m_capture_started = true;
-	
+
 	for(const auto& sandbox : existing_sandboxes)
 	{
 		// Since they were already running, we need to force the creation
@@ -398,18 +398,18 @@ int32_t engine::stop_capture()
 			snprintf(m_lasterr, SCAP_LASTERR_SIZE, "Cannot delete session for sandbox %s", sandbox.c_str());
 			return SCAP_FAILURE;
 		}
-	}	
+	}
 
 	m_capture_started = false;
     return SCAP_SUCCESS;
 }
 
-uint32_t engine::get_vxid(uint64_t xid)
+uint32_t engine::get_vxid(uint64_t xid) const
 {
 	return parsers::get_vxid(xid);
 }
 
-int32_t engine::get_stats(scap_stats *stats)
+int32_t engine::get_stats(scap_stats *stats) const
 {
 	stats->n_drops = m_gvisor_stats.n_drops_parsing + m_gvisor_stats.n_drops_gvisor;
 	stats->n_drops_bug = m_gvisor_stats.n_drops_parsing;
@@ -418,7 +418,7 @@ int32_t engine::get_stats(scap_stats *stats)
 	return SCAP_SUCCESS;
 }
 
-const struct scap_stats_v2* engine::get_stats_v2(uint32_t flags, uint32_t* nstats, int32_t* rc)
+const scap_stats_v2* engine::get_stats_v2(uint32_t flags, uint32_t* nstats, int32_t* rc)
 {
 	*nstats = scap_gvisor::stats::MAX_GVISOR_COUNTERS_STATS;
 	scap_stats_v2* stats = engine::m_stats;
@@ -499,7 +499,7 @@ int32_t engine::process_message_from_fd(int fd)
 			return SCAP_FAILURE;
 		};
 		parse_result = parsers::parse_gvisor_proto(id, gvisor_msg, m_sandbox_data[fd].m_buf);
-	} 
+	}
 
 	if(parse_result.status == SCAP_NOT_SUPPORTED)
 	{
@@ -546,7 +546,7 @@ int32_t engine::next(scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags)
 
 	// at this moment, there are no events in any of the buffers we allocated
 	// for each sandbox: this is the right place to close fds and deallocate
-	// buffers safely for all the sandboxes that are no longer connected. 
+	// buffers safely for all the sandboxes that are no longer connected.
 
 	for(auto it = m_sandbox_data.begin(); it != m_sandbox_data.end(); )
 	{

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -67,7 +67,7 @@ public:
 		m_max_refresh_timeout = ns;
 	};
 
-	size_t size()
+	size_t size() const
 	{
 #if defined(HAS_CAPTURE) && !defined(CYGWING_AGENT) && !defined(_WIN32) && !defined(__EMSCRIPTEN__)
 		return m_cache.size();

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -133,7 +133,7 @@ event_direction sinsp_evt::get_direction() const
 	return (event_direction)(m_pevt->type & PPME_DIRECTION_FLAG);
 }
 
-int64_t sinsp_evt::get_tid()
+int64_t sinsp_evt::get_tid() const
 {
 	return m_pevt->tid;
 }
@@ -143,7 +143,7 @@ void sinsp_evt::set_iosize(uint32_t size)
 	m_iosize = size;
 }
 
-uint32_t sinsp_evt::get_iosize()
+uint32_t sinsp_evt::get_iosize() const
 {
 	return m_iosize;
 }
@@ -164,7 +164,7 @@ sinsp_threadinfo* sinsp_evt::get_thread_info(bool query_os_if_not_found)
 	return m_inspector->get_thread_ref(m_pevt->tid, query_os_if_not_found, false).get();
 }
 
-int64_t sinsp_evt::get_fd_num()
+int64_t sinsp_evt::get_fd_num() const
 {
 	if(m_fdinfo)
 	{
@@ -252,7 +252,7 @@ const struct ppm_param_info* sinsp_evt::get_param_info(uint32_t id)
 	return &(m_info->params[id]);
 }
 
-uint32_t binary_buffer_to_hex_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_hex_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k;
@@ -346,7 +346,7 @@ uint32_t binary_buffer_to_hex_string(char *dst, const char *src, uint32_t dstlen
 	}
 }
 
-uint32_t binary_buffer_to_asciionly_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_asciionly_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k = 0;
@@ -403,7 +403,7 @@ uint32_t binary_buffer_to_asciionly_string(char *dst, const char *src, uint32_t 
 	return k;
 }
 
-uint32_t binary_buffer_to_string_dots(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_string_dots(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t j;
 	uint32_t k = 0;
@@ -446,7 +446,7 @@ uint32_t binary_buffer_to_string_dots(char *dst, const char *src, uint32_t dstle
 	return k;
 }
 
-uint32_t binary_buffer_to_base64_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_base64_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	//
 	// base64 encoder, malloc-free version of:
@@ -493,7 +493,7 @@ uint32_t binary_buffer_to_base64_string(char *dst, const char *src, uint32_t dst
 	return enc_dstlen;
 }
 
-uint32_t binary_buffer_to_json_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_json_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t k = 0;
 	switch(fmt)
@@ -514,7 +514,7 @@ uint32_t binary_buffer_to_json_string(char *dst, const char *src, uint32_t dstle
 	return k;
 }
 
-uint32_t binary_buffer_to_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
+static uint32_t binary_buffer_to_string(char *dst, const char *src, uint32_t dstlen, uint32_t srclen, sinsp_evt::param_fmt fmt)
 {
 	uint32_t k = 0;
 
@@ -557,7 +557,7 @@ uint32_t binary_buffer_to_string(char *dst, const char *src, uint32_t dstlen, ui
 	return k;
 }
 
-uint32_t strcpy_sanitized(char *dest, const char *src, uint32_t dstsize)
+static uint32_t strcpy_sanitized(char *dest, const char *src, uint32_t dstsize)
 {
 	volatile char* tmp = (volatile char *)dest;
 	uint32_t j = 0;
@@ -1877,7 +1877,7 @@ const char* sinsp_evt::get_param_value_str(const char* name, OUT const char** re
 	return NULL;
 }
 
-void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
+void sinsp_evt::get_category(OUT sinsp_evt::category* cat) const
 {
 	/* We always search the category inside the event table */
 	cat->m_category = get_category();
@@ -1946,12 +1946,12 @@ void sinsp_evt::get_category(OUT sinsp_evt::category* cat)
 	}
 }
 
-bool sinsp_evt::is_filtered_out()
+bool sinsp_evt::is_filtered_out() const
 {
 	return m_filtered_out;
 }
 
-scap_dump_flags sinsp_evt::get_dump_flags(OUT bool* should_drop)
+scap_dump_flags sinsp_evt::get_dump_flags(OUT bool* should_drop) const
 {
 	uint32_t dflags = SCAP_DF_NONE;
 	*should_drop = false;
@@ -2167,18 +2167,16 @@ void sinsp_evt::save_enter_event_params(sinsp_evt* enter_evt)
 	}
 }
 
-std::optional<std::reference_wrapper<std::string>> sinsp_evt::get_enter_evt_param(const std::string& param)
+std::optional<std::reference_wrapper<const std::string>> sinsp_evt::get_enter_evt_param(const std::string& param) const
 {
-	std::optional<std::reference_wrapper<std::string>> ret;
-
 	auto it = m_enter_path_param.find(param);
 
 	if(it != m_enter_path_param.end())
 	{
-		ret = it->second;
+		return it->second;
 	}
 
-	return ret;
+	return std::nullopt;
 }
 
 void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -342,10 +342,10 @@ public:
 		 *   - `EC_TRACEPOINT
 		 *   - `EC_PLUGIN`
 		 *   - `EC_METAEVENT`
-		 * 
+		 *
 		 * 2. The lowest bits represent the syscall category
 		 * to which the specific event belongs.
-		 * 
+		 *
 		 * This function removes the highest bits, so we consider only the syscall category.
 		 */
 		const int bitmask = EC_SYSCALL - 1;
@@ -355,7 +355,7 @@ public:
 	/*!
 	  \brief Get the ID of the thread that generated the event.
 	*/
-	int64_t get_tid();
+	int64_t get_tid() const;
 
 	/*!
 	  \brief Return the information about the thread that generated the event.
@@ -371,7 +371,7 @@ public:
 
 	  \note For events that are not I/O related, get_fd_info() returns NULL.
 	*/
-	inline sinsp_fdinfo_t* get_fd_info()
+	inline sinsp_fdinfo_t* get_fd_info() const
 	{
 		return m_fdinfo;
 	}
@@ -391,7 +391,7 @@ public:
 
 	  \note For events that are not I/O related, get_fd_num() returns sinsp_evt::INVALID_FD_NUM.
 	*/
-	int64_t get_fd_num();
+	int64_t get_fd_num() const;
 
 	/*!
 	  \brief Return the number of parameters that this event has.
@@ -443,13 +443,13 @@ public:
 	  \brief Return the event's category, based on the event type and the FD on
 	   which the event operates.
 	*/
-	void get_category(OUT sinsp_evt::category* cat);
+	void get_category(OUT sinsp_evt::category* cat) const;
 
 	/*!
 	  \brief Return true if the event has been rejected by the filtering system.
 	*/
-	bool is_filtered_out();
-	scap_dump_flags get_dump_flags(OUT bool* should_drop);
+	bool is_filtered_out() const;
+	scap_dump_flags get_dump_flags(OUT bool* should_drop) const;
 
 	// todo(jasondellaluce): this is deprecated and will need to be removed
 	inline uint16_t get_source() const override
@@ -495,9 +495,9 @@ private:
 #endif
 
 	void set_iosize(uint32_t size);
-	uint32_t get_iosize();
+	uint32_t get_iosize() const;
 
-	std::string get_base_dir(uint32_t id, sinsp_threadinfo *tinfo);
+	std::string get_base_dir(uint32_t id, sinsp_threadinfo*);
 
 	const char* get_param_as_str(uint32_t id, OUT const char** resolved_str, param_fmt fmt = PF_NORMAL);
 
@@ -581,43 +581,43 @@ private:
 		/* We need the event info to overwrite some parameters if necessary. */
 		const struct ppm_event_info* event_info = &m_event_info_table[m_pevt->type];
 		int param_type = 0;
-		
+
 		for(j = 0; j < nparams; j++)
 		{
 			/* Here we need to manage a particular case:
-			* 
+			*
 			*    - PT_CHARBUF
 			*    - PT_FSRELPATH
 			*    - PT_BYTEBUF
 			*    - PT_BYTEBUF
-			* 
+			*
 			* In the past these params could be `<NA>` or `(NULL)` or empty.
 			* Now they can be only empty! The ideal solution would be:
 			* 	params[i].buf = NULL;
 			*	params[i].size = 0;
-			* 
+			*
 			* The problem is that userspace is not
 			* able to manage `NULL` pointers... but it manages `<NA>` so we
 			* convert all these cases to `<NA>` when they are empty!
-			* 
+			*
 			* If we read scap-files we could face `(NULL)` params, so also in
 			* this case we convert them to `<NA>`.
-			* 
+			*
 			* To be honest there could be another corner case, but right now
 			* we don't have to manage it:
-			*    
+			*
 			*    - PT_SOCKADDR
 			*    - PT_SOCKTUPLE
 			*    - PT_FDLIST
-			* 
+			*
 			* Could be empty, so we will have:
 			* 	params[i].buf = "pointer to the next param";
 			*	params[i].size = 0;
-			* 
+			*
 			* However, as we said in the previous case, the ideal outcome would be:
 			* 	params[i].buf = NULL;
 			*	params[i].size = 0;
-			* 
+			*
 			* The difference with the previous case is that the userspace can manage
 			* these params when they have `params[i].size == 0`, so we don't have
 			* to use the `<NA>` workaround! We could also introduce the `NULL` and so
@@ -627,7 +627,7 @@ private:
 			* step we would keep them as they are.
 			*/
 			param_type = event_info->params[j].type;
-			
+
 			if((param_type == PT_CHARBUF ||
 				param_type == PT_FSRELPATH ||
 				param_type == PT_FSPATH)
@@ -651,12 +651,12 @@ private:
 	int render_fd_json(Json::Value *ret, int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
 	inline uint32_t get_dump_flags() const { return m_dump_flags; }
 	static bool clone_event(sinsp_evt& dest, const sinsp_evt& src);
-	int32_t get_errorcode() { return m_errorcode; }
+	int32_t get_errorcode() const { return m_errorcode; }
 
 	// Save important values from the provided enter event. They
 	// are accessible from get_enter_evt_param().
 	void save_enter_event_params(sinsp_evt* enter_evt);
-	std::optional<std::reference_wrapper<std::string>> get_enter_evt_param(const std::string& param);
+	std::optional<std::reference_wrapper<const std::string>> get_enter_evt_param(const std::string& param) const;
 
 VISIBILITY_PRIVATE
 	enum flags

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -62,7 +62,7 @@ template<> std::string* sinsp_fdinfo_t::tostring()
 	return &m_name;
 }
 
-template<> char sinsp_fdinfo_t::get_typechar()
+template<> char sinsp_fdinfo_t::get_typechar() const
 {
 	switch(m_type)
 	{
@@ -115,58 +115,58 @@ template<> char sinsp_fdinfo_t::get_typechar()
 	}
 }
 
-template<> char* sinsp_fdinfo_t::get_typestring() const
+template<> const char* sinsp_fdinfo_t::get_typestring() const
 {
 	switch(m_type)
 	{
 	case SCAP_FD_FILE_V2:
 	case SCAP_FD_FILE:
-		return (char*)"file";
+		return "file";
 	case SCAP_FD_DIRECTORY:
-		return (char*)"directory";
+		return "directory";
 	case SCAP_FD_IPV4_SOCK:
 	case SCAP_FD_IPV4_SERVSOCK:
-		return (char*)"ipv4";
+		return "ipv4";
 	case SCAP_FD_IPV6_SOCK:
 	case SCAP_FD_IPV6_SERVSOCK:
-		return (char*)"ipv6";
+		return "ipv6";
 	case SCAP_FD_UNIX_SOCK:
-		return (char*)"unix";
+		return "unix";
 	case SCAP_FD_FIFO:
-		return (char*)"pipe";
+		return "pipe";
 	case SCAP_FD_EVENT:
-		return (char*)"event";
+		return "event";
 	case SCAP_FD_SIGNALFD:
-		return (char*)"signalfd";
+		return "signalfd";
 	case SCAP_FD_EVENTPOLL:
-		return (char*)"eventpoll";
+		return "eventpoll";
 	case SCAP_FD_INOTIFY:
-		return (char*)"inotify";
+		return "inotify";
 	case SCAP_FD_TIMERFD:
-		return (char*)"timerfd";
+		return "timerfd";
 	case SCAP_FD_NETLINK:
-		return (char*)"netlink";
+		return "netlink";
 	case SCAP_FD_BPF:
-		return (char*)"bpf";
+		return "bpf";
 	case SCAP_FD_USERFAULTFD:
-		return (char*)"userfaultfd";
+		return "userfaultfd";
 	case SCAP_FD_IOURING:
-		return (char*)"io_uring";
+		return "io_uring";
 	case SCAP_FD_MEMFD:
-		return (char*)"memfd";	
+		return "memfd";
 	case SCAP_FD_PIDFD:
-		return (char*)"pidfd";
+		return "pidfd";
 	default:
-		return (char*)"<NA>";
+		return "<NA>";
 	}
 }
 
-template<> std::string sinsp_fdinfo_t::tostring_clean()
+template<> std::string sinsp_fdinfo_t::tostring_clean() const
 {
-	std::string m_tstr = m_name;
-	sanitize_string(m_tstr);
+	std::string tstr = m_name;
+	sanitize_string(tstr);
 
-	return m_tstr;
+	return tstr;
 }
 
 template<> void sinsp_fdinfo_t::add_filename_raw(const char* rawpath)
@@ -222,7 +222,7 @@ wildass_guess:
 	return true;
 }
 
-template<> scap_l4_proto sinsp_fdinfo_t::get_l4proto()
+template<> scap_l4_proto sinsp_fdinfo_t::get_l4proto() const
 {
 	scap_fd_type evt_type = m_type;
 
@@ -433,7 +433,7 @@ void sinsp_fdtable::clear()
 	m_table.clear();
 }
 
-size_t sinsp_fdtable::size()
+size_t sinsp_fdtable::size() const
 {
 	return m_table.size();
 }

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -52,7 +52,7 @@ limitations under the License.
 #define CHAR_FD_MEMFD			'm'
 #define CHAR_FD_PIDFD			'P'
 
-/** @defgroup state State management 
+/** @defgroup state State management
  * A collection of classes to query process and FD state.
  *  @{
  */
@@ -72,7 +72,7 @@ typedef union _sinsp_sockinfo
   manipulate FDs and retrieve FD information.
 
   \note As a library user, you won't need to construct thread objects. Rather,
-   you get them by calling \ref sinsp_evt::get_fd_info or 
+   you get them by calling \ref sinsp_evt::get_fd_info or
    \ref sinsp_threadinfo::get_fd.
 */
 template<class T>
@@ -80,7 +80,7 @@ class SINSP_PUBLIC sinsp_fdinfo
 {
 public:
 	sinsp_fdinfo();
-	sinsp_fdinfo (const sinsp_fdinfo &other) 
+	sinsp_fdinfo (const sinsp_fdinfo &other)
 	{
 		copy(other, false);
 	}
@@ -105,7 +105,7 @@ public:
 	inline void copy(const sinsp_fdinfo &other, bool free_state)
 	{
 		m_type = other.m_type;
-		m_openflags = other.m_openflags;	
+		m_openflags = other.m_openflags;
 		m_sockinfo = other.m_sockinfo;
 		m_name = other.m_name;
 		m_name_raw = other.m_name_raw;
@@ -115,7 +115,7 @@ public:
 		m_mount_id = other.m_mount_id;
 		m_ino = other.m_ino;
 		m_pid = other.m_pid;
-		
+
 		if(free_state)
 		{
 			if(m_usrstate != NULL)
@@ -139,19 +139,19 @@ public:
 
 	  Refer to the CHAR_FD_* defines in this fdinfo.h.
 	*/
-	char get_typechar();
+	char get_typechar() const;
 
 	/*!
 	  \brief Return an ASCII string that identifies the FD type.
 
 	  Can be on of 'file', 'directory', ipv4', 'ipv6', 'unix', 'pipe', 'event', 'signalfd', 'eventpoll', 'inotify', 'signalfd'.
 	*/
-	char* get_typestring() const;
+	const char* get_typestring() const;
 
 	/*!
 	  \brief Return the fd name, after removing unprintable or invalid characters from it.
 	*/
-	std::string tostring_clean();
+	std::string tostring_clean() const;
 
 	/*!
 	  \brief Return true if this is a log device.
@@ -233,7 +233,7 @@ public:
 		return m_type == SCAP_FD_PIDFD;
 	}
 
-	uint16_t get_serverport()
+	uint16_t get_serverport() const
 	{
 		if(m_type == SCAP_FD_IPV4_SOCK)
 		{
@@ -285,12 +285,12 @@ public:
 	/*!
 	  \brief If this is a socket, returns the IP protocol. Otherwise, return SCAP_FD_UNKNOWN.
 	*/
-	scap_l4_proto get_l4proto();
+	scap_l4_proto get_l4proto() const;
 
 	/*!
 	  \brief Return true if this FD is a socket server
 	*/
-	inline bool is_role_server()
+	inline bool is_role_server() const
 	{
 		return (m_flags & FLAGS_ROLE_SERVER) == FLAGS_ROLE_SERVER;
 	}
@@ -298,7 +298,7 @@ public:
 	/*!
 	  \brief Return true if this FD is a socket client
 	*/
-	inline bool is_role_client()
+	inline bool is_role_client() const
 	{
 		return (m_flags & FLAGS_ROLE_CLIENT) == FLAGS_ROLE_CLIENT;
 	}
@@ -306,34 +306,34 @@ public:
 	/*!
 	  \brief Return true if this FD is neither a client nor a server
 	*/
-	inline bool is_role_none()
+	inline bool is_role_none() const
 	{
 		return (m_flags & (FLAGS_ROLE_CLIENT | FLAGS_ROLE_SERVER)) == 0;
 	}
 
-	inline bool is_socket_connected()
+	inline bool is_socket_connected() const
 	{
 		return (m_flags & FLAGS_SOCKET_CONNECTED) == FLAGS_SOCKET_CONNECTED;
 	}
 
-	inline bool is_socket_pending()
+	inline bool is_socket_pending() const
 	{
 		return (m_flags & FLAGS_CONNECTION_PENDING) == FLAGS_CONNECTION_PENDING;
 	}
 
-	inline bool is_socket_failed()
+	inline bool is_socket_failed() const
 	{
 		return (m_flags & FLAGS_CONNECTION_FAILED) == FLAGS_CONNECTION_FAILED;
 	}
 
-	inline bool is_cloned()
+	inline bool is_cloned() const
 	{
 		return (m_flags & FLAGS_IS_CLONED) == FLAGS_IS_CLONED;
 	}
 
 	scap_fd_type m_type; ///< The fd type, e.g. file, directory, IPv4 socket...
 	uint32_t m_openflags; ///< If this FD is a file, the flags that were used when opening it. See the PPM_O_* definitions in driver/ppm_events_public.h.
-	
+
 	/*!
 	  \brief Socket-specific state.
 	  This is uninitialized (zero) for non-socket FDs.
@@ -374,7 +374,7 @@ public:
 
 	inline bool is_transaction() const
 	{
-		return (m_usrstate != NULL); 
+		return (m_usrstate != NULL);
 	}
 
 	T* get_usrstate()
@@ -382,6 +382,10 @@ public:
 		return m_usrstate;
 	}
 
+	const T* get_usrstate() const
+	{
+		return m_usrstate;
+	}
 
 	inline void set_role_server()
 	{
@@ -393,8 +397,8 @@ public:
 		m_flags |= FLAGS_ROLE_CLIENT;
 	}
 
-	bool set_net_role_by_guessing(sinsp* inspector, 
-		sinsp_threadinfo* ptinfo, 
+	bool set_net_role_by_guessing(sinsp* inspector,
+		sinsp_threadinfo* ptinfo,
 		sinsp_fdinfo_t* pfdinfo,
 		bool incoming);
 
@@ -403,17 +407,17 @@ public:
 		m_flags = FLAGS_NONE;
 	}
 
-	inline void set_socketpipe()
+	inline void set_socketpipe() const
 	{
 		m_flags |= FLAGS_IS_SOCKET_PIPE;
 	}
 
-	inline bool is_socketpipe()
+	inline bool is_socketpipe() const
 	{
-		return (m_flags & FLAGS_IS_SOCKET_PIPE) == FLAGS_IS_SOCKET_PIPE; 
+		return (m_flags & FLAGS_IS_SOCKET_PIPE) == FLAGS_IS_SOCKET_PIPE;
 	}
 
-	inline bool has_no_role()
+	inline bool has_no_role() const
 	{
 		return !is_role_client() && !is_role_server();
 	}
@@ -440,19 +444,19 @@ public:
 		m_flags &= ~FLAGS_IN_BASELINE_OTHER;
 	}
 
-	inline bool is_inpipeline_r()
+	inline bool is_inpipeline_r() const
 	{
-		return (m_flags & FLAGS_IN_BASELINE_R) == FLAGS_IN_BASELINE_R; 
+		return (m_flags & FLAGS_IN_BASELINE_R) == FLAGS_IN_BASELINE_R;
 	}
 
-	inline bool is_inpipeline_rw()
+	inline bool is_inpipeline_rw() const
 	{
-		return (m_flags & FLAGS_IN_BASELINE_RW) == FLAGS_IN_BASELINE_RW; 
+		return (m_flags & FLAGS_IN_BASELINE_RW) == FLAGS_IN_BASELINE_RW;
 	}
 
-	inline bool is_inpipeline_other()
+	inline bool is_inpipeline_other() const
 	{
-		return (m_flags & FLAGS_IN_BASELINE_OTHER) == FLAGS_IN_BASELINE_OTHER; 
+		return (m_flags & FLAGS_IN_BASELINE_OTHER) == FLAGS_IN_BASELINE_OTHER;
 	}
 
 	inline void set_socket_connected()
@@ -497,7 +501,7 @@ public:
 	sinsp_fdtable(sinsp* inspector);
 
 	sinsp_fdinfo_t* find(int64_t fd);
-	
+
 	// If the key is already present, overwrite the existing value and return false.
 	sinsp_fdinfo_t* add(int64_t fd, sinsp_fdinfo_t* fdinfo);
 
@@ -518,7 +522,7 @@ public:
 	// If the key is present, returns true, otherwise returns false.
 	void erase(int64_t fd);
 	void clear();
-	size_t size();
+	size_t size() const;
 	void reset_cache();
 
 	sinsp* m_inspector;

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -398,7 +398,7 @@ gen_event_filter_check *sinsp_filter_factory::new_filtercheck(const char *fldnam
 								true);
 }
 
-std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory::get_fields()
+std::list<gen_event_filter_factory::filter_fieldclass_info> sinsp_filter_factory::get_fields() const
 {
 	std::vector<const filter_check_info*> fc_plugins;
 	m_available_checks.get_all_fields(fc_plugins);

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -148,7 +148,7 @@ public:
 
 	gen_event_filter* new_filter() override;
 	gen_event_filter_check* new_filtercheck(const char* fldname) override;
-	std::list<gen_event_filter_factory::filter_fieldclass_info> get_fields() override;
+	std::list<gen_event_filter_factory::filter_fieldclass_info> get_fields() const override;
 
 	// Convienence method to convert a vector of
 	// filter_check_infos into a list of

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -59,7 +59,7 @@ void filter_check_list::add_filter_check(sinsp_filter_check* filter_check)
 	m_check_list.push_back(filter_check);
 }
 
-void filter_check_list::get_all_fields(std::vector<const filter_check_info*>& list)
+void filter_check_list::get_all_fields(std::vector<const filter_check_info*>& list) const
 {
 	for(auto *chk : m_check_list)
 	{
@@ -123,4 +123,3 @@ sinsp_filter_check_list::sinsp_filter_check_list()
 	add_filter_check(new sinsp_filter_check_tracer());
 	add_filter_check(new sinsp_filter_check_evtin());
 }
-

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -35,7 +35,7 @@ public:
 	filter_check_list() = default;
 	virtual ~filter_check_list();
 	void add_filter_check(sinsp_filter_check* filter_check);
-	void get_all_fields(std::vector<const filter_check_info*>& list);
+	void get_all_fields(std::vector<const filter_check_info*>&) const;
 	sinsp_filter_check* new_filter_check_from_fldname(const std::string& name, sinsp* inspector, bool do_exact_check);
 
 protected:
@@ -50,4 +50,3 @@ public:
 	sinsp_filter_check_list();
 	virtual ~sinsp_filter_check_list() = default;
 };
-

--- a/userspace/libsinsp/gen_filter.cpp
+++ b/userspace/libsinsp/gen_filter.cpp
@@ -173,26 +173,24 @@ bool gen_event_filter_expression::extract(gen_event *evt, std::vector<extract_va
 	return false;
 }
 
-int32_t gen_event_filter_expression::get_expr_boolop()
+int32_t gen_event_filter_expression::get_expr_boolop() const
 {
-	std::vector<gen_event_filter_check*>* cks = &(m_checks);
-
-	if(cks->size() <= 1)
+	if(m_checks.size() <= 1)
 	{
 		return m_boolop;
 	}
 
 	// Reset bit 0 to remove irrelevant not
-	boolop b0 = (boolop)((uint32_t)(cks->at(1)->m_boolop) & (uint32_t)~1);
+	boolop b0 = (boolop)((uint32_t)(m_checks.at(1)->m_boolop) & (uint32_t)~1);
 
-	if(cks->size() <= 2)
+	if(m_checks.size() <= 2)
 	{
 		return b0;
 	}
 
-	for(uint32_t l = 2; l < cks->size(); l++)
+	for(uint32_t l = 2; l < m_checks.size(); l++)
 	{
-		if((boolop)((uint32_t)(cks->at(l)->m_boolop) & (uint32_t)~1) != b0)
+		if((boolop)((uint32_t)(m_checks.at(l)->m_boolop) & (uint32_t)~1) != b0)
 		{
 			return -1;
 		}
@@ -252,13 +250,13 @@ void gen_event_filter::add_check(gen_event_filter_check* chk)
 	m_curexpr->add_check((gen_event_filter_check *) chk);
 }
 
-bool gen_event_filter_factory::filter_field_info::is_skippable()
+bool gen_event_filter_factory::filter_field_info::is_skippable() const
 {
 	// Skip fields with the EPF_TABLE_ONLY flag.
 	return (tags.find("EPF_TABLE_ONLY") != tags.end());
 }
 
-bool gen_event_filter_factory::filter_field_info::is_deprecated()
+bool gen_event_filter_factory::filter_field_info::is_deprecated() const
 {
 	// Skip fields with the EPF_DEPRECATED flag.
 	return (tags.find("EPF_DEPRECATED") != tags.end());
@@ -442,4 +440,3 @@ std::string gen_event_filter_factory::filter_fieldclass_info::as_string(bool ver
 
 	return os.str();
 }
-

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -115,9 +115,9 @@ public:
 	size_t m_matched_true = 0;
 
 	virtual int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) = 0;
-	virtual void add_filter_value(const char* str, uint32_t len, uint32_t i = 0 ) = 0;
-	virtual bool compare(gen_event *evt) = 0;
-	virtual bool extract(gen_event *evt, std::vector<extract_value_t>& values, bool sanitize_strings = true) = 0;
+	virtual void add_filter_value(const char* str, uint32_t len, uint32_t i = 0) = 0;
+	virtual bool compare(gen_event*) = 0;
+	virtual bool extract(gen_event*, std::vector<extract_value_t>& values, bool sanitize_strings = true) = 0;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -157,13 +157,11 @@ public:
 	// This method returns the expression operator (BO_AND/BO_OR/BO_NONE) if the
 	// expression is consistent. It returns -1 if the expression is not consistent.
 	//
-	int32_t get_expr_boolop();
+	int32_t get_expr_boolop() const;
 
 	gen_event_filter_expression* m_parent;
 	std::vector<gen_event_filter_check*> m_checks;
 };
-
-
 
 class gen_event_filter
 {
@@ -215,8 +213,8 @@ public:
 		// etc
 		std::set<std::string> tags;
 
-		bool is_skippable();
-		bool is_deprecated();
+		bool is_skippable() const;
+		bool is_deprecated() const;
 	};
 
 	// Describes a group of filtercheck fields ("ka")
@@ -264,7 +262,7 @@ public:
 	virtual gen_event_filter_check *new_filtercheck(const char *fldname) = 0;
 
 	// Return the set of fields supported by this factory
-	virtual std::list<filter_fieldclass_info> get_fields() = 0;
+	virtual std::list<filter_fieldclass_info> get_fields() const = 0;
 };
 
 class gen_event_formatter
@@ -295,7 +293,6 @@ public:
 
 	virtual output_format get_output_format() = 0;
 };
-
 
 class gen_event_formatter_factory
 {

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -195,10 +195,8 @@ void sinsp_network_interfaces::update_fd(sinsp_fdinfo_t *fd)
 	}
 }
 
-bool sinsp_network_interfaces::is_ipv4addr_in_subnet(uint32_t addr)
+bool sinsp_network_interfaces::is_ipv4addr_in_subnet(uint32_t addr) const
 {
-	std::vector<sinsp_ipv4_ifinfo>::iterator it;
-
 	//
 	// Accept everything that comes from private internets:
 	// - 10.0.0.0/8
@@ -214,9 +212,9 @@ bool sinsp_network_interfaces::is_ipv4addr_in_subnet(uint32_t addr)
 	}
 
 	// try to find an interface for the same subnet
-	for(it = m_ipv4_interfaces.begin(); it != m_ipv4_interfaces.end(); it++)
+	for(auto& el : m_ipv4_interfaces)
 	{
-		if((it->m_addr & it->m_netmask) == (addr & it->m_netmask))
+		if((el.m_addr & el.m_netmask) == (addr & el.m_netmask))
 		{
 			return true;
 		}

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -76,7 +76,7 @@ public:
 	void import_interfaces(scap_addrlist* paddrlist);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 	void update_fd(sinsp_fdinfo_t *fd);
-	bool is_ipv4addr_in_subnet(uint32_t addr);
+	bool is_ipv4addr_in_subnet(uint32_t addr) const;
 	bool is_ipv4addr_in_local_machine(uint32_t addr, sinsp_threadinfo* tinfo) const;
 	void import_ipv6_interface(const sinsp_ipv6_ifinfo& ifinfo);
 	bool is_ipv6addr_in_local_machine(ipv6addr &addr, sinsp_threadinfo* tinfo) const;

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -48,7 +48,7 @@ public:
 	static void parse_dirfd(sinsp_evt *evt, const char* name, int64_t dirfd, OUT std::string* sdir);
 
 	void set_track_connection_status(bool enabled);
-	bool get_track_connection_status() { return m_track_connection_status; }
+	bool get_track_connection_status() const { return m_track_connection_status; }
 
 	inline sinsp_syslog_decoder& get_syslog_decoder()
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -691,7 +691,7 @@ void sinsp::open_test_input(scap_test_input_data* data, sinsp_mode_t mode)
 
 /*=============================== Engine related ===============================*/
 
-bool sinsp::check_current_engine(const std::string& engine_name)
+bool sinsp::check_current_engine(const std::string& engine_name) const
 {
 	return scap_check_current_engine(m_h, engine_name.data());
 }
@@ -1823,7 +1823,17 @@ scap_stats_v2* sinsp::get_sinsp_stats_v2_buffer()
 	return m_sinsp_stats_v2_buffer;
 }
 
+const scap_stats_v2* sinsp::get_sinsp_stats_v2_buffer() const
+{
+	return m_sinsp_stats_v2_buffer;
+}
+
 std::shared_ptr<sinsp_stats_v2> sinsp::get_sinsp_stats_v2()
+{
+	return m_sinsp_stats_v2;
+}
+
+std::shared_ptr<const sinsp_stats_v2> sinsp::get_sinsp_stats_v2() const
 {
 	return m_sinsp_stats_v2;
 }
@@ -1982,18 +1992,6 @@ void sinsp::set_max_evt_output_len(uint32_t len)
 sinsp_parser* sinsp::get_parser()
 {
 	return m_parser;
-}
-
-bool sinsp::setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress)
-{
-	m_compress = compress;
-
-	if(rollover_mb != 0 || duration_seconds != 0 || file_limit != 0 || event_limit != 0)
-	{
-		m_write_cycling = true;
-	}
-
-	return m_cycle_writer->setup(base_file_name, rollover_mb, duration_seconds, file_limit, event_limit);
 }
 
 double sinsp::get_read_progress_file() const

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -255,7 +255,7 @@ public:
 	/*!
 	  \brief Get the maximum number of bytes currently in use by any CPU buffer
      */
-	uint64_t max_buf_used();
+	uint64_t max_buf_used() const;
 
 	/*!
 	  \brief Get the number of events that have been captured and processed
@@ -263,7 +263,7 @@ public:
 
 	  \return the number of captured events.
 	*/
-	uint64_t get_num_events();
+	uint64_t get_num_events() const;
 
 	/*!
 	  \brief Set the capture snaplen, i.e. the maximum size an event
@@ -350,7 +350,7 @@ public:
 	  \return the filter previously set with \ref set_filter(), or an empty
 	   string if no filter has been set yet.
 	*/
-	const std::string get_filter();
+	std::string get_filter() const;
 
 	/*!
 	  \brief Return the AST (wrapped in a shared pointer) for the filter set for this capture.
@@ -431,7 +431,7 @@ public:
 	*/
 	static sinsp_filter_check* new_generic_filtercheck();
 
-	bool has_metrics();
+	bool has_metrics() const;
 
 	/*!
 	  \brief Return information about the machine generating the events.
@@ -440,14 +440,14 @@ public:
 	   info is stored in the trace files. In that case, the returned
 	   machine info is the one of the machine where the capture happened.
 	*/
-	const scap_machine_info* get_machine_info();
+	const scap_machine_info* get_machine_info() const;
 
 	/*!
 	  \brief Return information about the agent based on start up conditions.
 
 	  \note not for use in scap files.
 	*/
-	const scap_agent_info* get_agent_info();
+	const scap_agent_info* get_agent_info() const;
 
 	/*!
 	  \brief Return sinsp stats v2 static size buffer w/ scap_stats_v2 schema.
@@ -541,7 +541,7 @@ public:
 	/*!
 	  \brief get last library error.
 	*/
-	std::string getlasterr()
+	std::string getlasterr() const
 	{
 		return m_lasterr;
 	}
@@ -551,7 +551,7 @@ public:
 
 	  \return Pointer to the interface list manager.
 	*/
-	const sinsp_network_interfaces& get_ifaddr_list();
+	const sinsp_network_interfaces& get_ifaddr_list() const;
 
 	/*!
 	  \brief Set the format used to render event data
@@ -563,12 +563,12 @@ public:
 	  \brief Get the format used to render event data
 	   buffer arguments.
 	*/
-	sinsp_evt::param_fmt get_buffer_format();
+	sinsp_evt::param_fmt get_buffer_format() const;
 
 	/*!
 	  \brief Returns true if the current capture is happening from a scap file
 	*/
-	inline bool is_capture()
+	inline bool is_capture() const
 	{
 		return m_mode == SINSP_MODE_CAPTURE;
 	}
@@ -576,7 +576,7 @@ public:
 	/*!
 	  \brief Returns true if the current capture is offline
 	*/
-	inline bool is_offline()
+	inline bool is_offline() const
 	{
 		return is_capture() || m_mode == SINSP_MODE_TEST;
 	}
@@ -584,7 +584,7 @@ public:
 	/*!
 	  \brief Returns true if the current capture is live
 	*/
-	inline bool is_live()
+	inline bool is_live() const
 	{
 		return m_mode == SINSP_MODE_LIVE;
 	}
@@ -592,7 +592,7 @@ public:
 	/*!
 	  \brief Returns true if the kernel module is not loaded
 	*/
-	inline bool is_nodriver()
+	inline bool is_nodriver() const
 	{
 		return m_mode == SINSP_MODE_NODRIVER;
 	}
@@ -600,7 +600,7 @@ public:
 	/*!
 	  \brief Returns true if the current capture has a plugin producing events.
 	*/
-	inline bool is_plugin()
+	inline bool is_plugin() const
 	{
 		return m_mode == SINSP_MODE_PLUGIN && m_input_plugin != nullptr;
 	}
@@ -608,7 +608,7 @@ public:
 	/*!
 	  \brief Returns true if the current capture has a plugin producing syscall events.
 	*/
-	inline bool is_syscall_plugin()
+	inline bool is_syscall_plugin() const
 	{
 		return is_plugin() && m_input_plugin->id() == 0;
 	}
@@ -734,7 +734,7 @@ public:
 	/*!
 	  \brief Returns true if the debug mode is enabled.
 	*/
-	inline bool is_debug_enabled()
+	inline bool is_debug_enabled() const
 	{
 		return m_isdebug_enabled;
 	}
@@ -750,7 +750,7 @@ public:
 	/*!
 	  \brief Returns true if the command line argument is set to show container information.
 	*/
-	inline bool is_print_container_data()
+	inline bool is_print_container_data() const
 	{
 		return m_print_container_data;
 	}
@@ -759,7 +759,7 @@ public:
 	  \brief If this is an offline capture, return the name of the file that is
 	   being read, otherwise return an empty string.
 	*/
-	std::string get_input_filename()
+	std::string get_input_filename() const
 	{
 		return m_input_filename;
 	}
@@ -768,14 +768,14 @@ public:
 	  \brief When reading events from a trace file or a plugin, this function
 	   returns the read progress as a number between 0 and 100.
 	*/
-	double get_read_progress();
+	double get_read_progress() const;
 
 	/*!
 	  \brief When reading events from a trace file or a plugin, this function
 	   returns the read progress as a number and as a string, giving the plugins
 	   flexibility on the format.
 	*/
-	double get_read_progress_with_str(OUT std::string* progress_str);
+	double get_read_progress_with_str(OUT std::string* progress_str) const;
 
 	/*!
 	  \brief Make the amount of data gathered for a syscall to be
@@ -826,7 +826,7 @@ public:
 
 	/**
 	 * @brief Check if the current engine is the one passed as parameter.
-	 * 
+	 *
 	 * @param engine_name engine that we want to check.
 	 * @return true if the passed engine is the active one otherwise false.
 	 */
@@ -837,7 +837,7 @@ public:
 	bool setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 
-	uint64_t get_bytes_read()
+	uint64_t get_bytes_read() const
 	{
 		return scap_ftell(m_h);
 	}
@@ -846,7 +846,7 @@ public:
 		scap_refresh_proc_table(get_scap_platform());
 	}
 
-	std::vector<long> get_n_tracepoint_hit();
+	std::vector<long> get_n_tracepoint_hit() const;
 
 	static unsigned num_possible_cpus();
 
@@ -861,7 +861,7 @@ public:
 
 	bool suppress_events_tid(int64_t tid);
 
-	bool check_suppressed(int64_t tid);
+	bool check_suppressed(int64_t tid) const;
 
 	void set_docker_socket_path(std::string socket_path);
 	void set_query_docker_image_info(bool query_image_info);
@@ -924,16 +924,16 @@ public:
 	void set_observer(sinsp_observer* observer) { m_observer = observer; }
 	sinsp_observer* get_observer() const { return m_observer; }
 
-	bool get_track_connection_status();
+	bool get_track_connection_status() const;
 	void set_track_connection_status(bool enabled);
 
 	/**
 	 * \brief Get a new timestamp.
-	 * 
+	 *
 	 * \return The current time in nanoseconds if the last event timestamp is 0,
 	 * otherwise, the last event timestamp.
 	 */
-	uint64_t get_new_ts();
+	uint64_t get_new_ts() const;
 
 VISIBILITY_PROTECTED
 	bool add_thread(const sinsp_threadinfo *ptinfo);
@@ -955,7 +955,7 @@ private:
 	void init();
 	void deinit_state();
 	void consume_initialstate_events();
-	bool is_initialstate_event(scap_evt* pevent);
+	bool is_initialstate_event(scap_evt* pevent) const;
 	void import_ifaddr_list();
 	void import_user_list();
 	void remove_thread(int64_t tid);
@@ -987,8 +987,8 @@ private:
 		       m_increased_snaplen_port_range.range_end > 0;
 	}
 
-	double get_read_progress_file();
-	void get_read_progress_plugin(OUT double* nres, std::string* sres);
+	double get_read_progress_file() const;
+	void get_read_progress_plugin(OUT double* nres, std::string* sres) const;
 
 	void get_procs_cpu_from_driver(uint64_t ts);
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -455,6 +455,7 @@ public:
 	  \note sinsp stats may be refactored near-term.
 	*/
 	scap_stats_v2* get_sinsp_stats_v2_buffer();
+	const scap_stats_v2* get_sinsp_stats_v2_buffer() const;
 
 	/*!
 	  \brief Return sinsp stats v2 containing continually updated counters around thread and fd state tables.
@@ -462,6 +463,7 @@ public:
 	  \note sinsp stats may be refactored near-term.
 	*/
 	std::shared_ptr<sinsp_stats_v2> get_sinsp_stats_v2();
+	std::shared_ptr<const sinsp_stats_v2> get_sinsp_stats_v2() const;
 
 	/*!
 	  \brief Look up a thread given its tid and return its information,
@@ -830,11 +832,10 @@ public:
 	 * @param engine_name engine that we want to check.
 	 * @return true if the passed engine is the active one otherwise false.
 	 */
-	bool check_current_engine(const std::string& engine_name);
+	bool check_current_engine(const std::string& engine_name) const;
 
 	/*=============================== Engine related ===============================*/
 
-	bool setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 
 	uint64_t get_bytes_read() const

--- a/userspace/libsinsp/sinsp_cycledumper.cpp
+++ b/userspace/libsinsp/sinsp_cycledumper.cpp
@@ -213,7 +213,7 @@ void sinsp_cycledumper::next_file()
 	m_file_index++;
 }
 
-bool sinsp_cycledumper::is_new_file_needed(sinsp_evt* evt) const
+bool sinsp_cycledumper::is_new_file_needed(sinsp_evt* evt)
 {
 	m_event_count++;
 

--- a/userspace/libsinsp/sinsp_cycledumper.cpp
+++ b/userspace/libsinsp/sinsp_cycledumper.cpp
@@ -213,7 +213,7 @@ void sinsp_cycledumper::next_file()
 	m_file_index++;
 }
 
-bool sinsp_cycledumper::is_new_file_needed(sinsp_evt* evt)
+bool sinsp_cycledumper::is_new_file_needed(sinsp_evt* evt) const
 {
 	m_event_count++;
 

--- a/userspace/libsinsp/sinsp_cycledumper.h
+++ b/userspace/libsinsp/sinsp_cycledumper.h
@@ -87,7 +87,7 @@ private:
     at the current time. The reason for the return code is written to
     m_last_reason.
     */
-    bool is_new_file_needed(sinsp_evt* evt);
+    bool is_new_file_needed(sinsp_evt*) const;
 
     /*!
     \brief Setups the new current filename.

--- a/userspace/libsinsp/sinsp_cycledumper.h
+++ b/userspace/libsinsp/sinsp_cycledumper.h
@@ -87,7 +87,7 @@ private:
     at the current time. The reason for the return code is written to
     m_last_reason.
     */
-    bool is_new_file_needed(sinsp_evt*) const;
+    bool is_new_file_needed(sinsp_evt* evt);
 
     /*!
     \brief Setups the new current filename.

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -1221,7 +1221,7 @@ size_t sinsp_filter_check::parse_filter_value(const char* str, uint32_t len, uin
 	return parsed_len;
 }
 
-const filtercheck_field_info* sinsp_filter_check::get_field_info()
+const filtercheck_field_info* sinsp_filter_check::get_field_info() const
 {
 	return &m_info.m_fields[m_field_id];
 }
@@ -1490,7 +1490,7 @@ bool sinsp_filter_check::extract_cached(sinsp_evt *evt, OUT std::vector<extract_
 	}
 }
 
-bool sinsp_filter_check::compare(gen_event *evt)
+bool sinsp_filter_check::compare(gen_event* evt)
 {
 	m_hits++;
 	if(m_cache_metrics != NULL)
@@ -1537,7 +1537,7 @@ bool sinsp_filter_check::compare(gen_event *evt)
 	}
 }
 
-bool sinsp_filter_check::compare(sinsp_evt *evt)
+bool sinsp_filter_check::compare(sinsp_evt* evt)
 {
 	m_extracted_values.clear();
 	if(!extract_cached(evt, m_extracted_values, false))

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -111,7 +111,7 @@ public:
 	//
 	// Return the info about the field that this instance contains
 	//
-	virtual const filtercheck_field_info* get_field_info();
+	virtual const filtercheck_field_info* get_field_info() const;
 
 	//
 	// Return true if this filtercheck can have an argument,

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -107,7 +107,7 @@ int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t base
 	return end+1;
 }
 
-const std::string &sinsp_filter_check_container::get_argstr()
+const std::string &sinsp_filter_check_container::get_argstr() const
 {
 	return m_argstr;
 }

--- a/userspace/libsinsp/sinsp_filtercheck_container.h
+++ b/userspace/libsinsp/sinsp_filtercheck_container.h
@@ -60,7 +60,7 @@ public:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
-	const std::string& get_argstr();
+	const std::string& get_argstr() const;
 
 private:
 	int32_t extract_arg(const std::string& val, size_t basename);

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -410,7 +410,7 @@ void sinsp_filter_check_event::validate_filter_value(const char* str, uint32_t l
 	}
 }
 
-const filtercheck_field_info* sinsp_filter_check_event::get_field_info()
+const filtercheck_field_info* sinsp_filter_check_event::get_field_info() const
 {
 	if(m_field_id == TYPE_ARGRAW)
 	{

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -92,7 +92,7 @@ public:
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	size_t parse_filter_value(const char* str, uint32_t len, uint8_t* storage, uint32_t storage_len) override;
-	const filtercheck_field_info* get_field_info() override;
+	const filtercheck_field_info* get_field_info() const override;
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
 	bool compare(sinsp_evt*) override;

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -436,13 +436,13 @@ bool sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT std::vector<extract_valu
 		// All of the pointers come from the fd_typesting() function so
 		// we shouldn't have the situation of two distinct pointers to
 		// the same string literal and we can just compare based on pointer
-		std::unordered_set<char*> fd_types;
+		std::unordered_set<const char*> fd_types;
 
 		// Iterate over the list of open file descriptors and add all
 		// unique file descriptor types to the vector for comparison
 		auto fd_type_gather = [&fd_types, &values](uint64_t, const sinsp_fdinfo_t& fdinfo)
 		{
-			char* type = fdinfo.get_typestring();
+			const char* type = fdinfo.get_typestring();
 
 			if (fd_types.emplace(type).second)
 			{

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -248,7 +248,7 @@ uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, b
 		return NULL;
 	}
 
-	std::optional<std::reference_wrapper<std::string>> enter_param;
+	std::optional<std::reference_wrapper<const std::string>> enter_param;
 	std::vector<extract_value_t> extract_values;
 
 	switch(m_field_id)

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -572,7 +572,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			}
 
 			// This can occur when the session leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual session id, as 
+			// is running in a pid namespace and we only have the virtual session id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same session id and
 			// declare it to be the session leader.
@@ -614,7 +614,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			}
 
 			// This can occur when the session leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual session id, as 
+			// is running in a pid namespace and we only have the virtual session id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same session id and
 			// declare it to be the session leader.
@@ -654,9 +654,9 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 					RETURN_EXTRACT_STRING(m_tstr);
 				}
 			}
-			
+
 			// This can occur when the session leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual session id, as 
+			// is running in a pid namespace and we only have the virtual session id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same session id and
 			// declare it to be the session leader.
@@ -697,7 +697,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 				}
 			}
 			// This can occur when the process group leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual process group id, as 
+			// is running in a pid namespace and we only have the virtual process group id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same process group id and
 			// declare it to be the process group leader.
@@ -738,7 +738,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 				}
 			}
 			// This can occur when the process group leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual process group id, as 
+			// is running in a pid namespace and we only have the virtual process group id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same process group id and
 			// declare it to be the process group leader.
@@ -781,7 +781,7 @@ uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, b
 			}
 
 			// This can occur when the process group leader process has exited or if the process
-			// is running in a pid namespace and we only have the virtual process group id, as 
+			// is running in a pid namespace and we only have the virtual process group id, as
 			// seen from its pid namespace.
 			// Find the highest ancestor process that has the same process group id and
 			// declare it to be the process group leader.
@@ -1983,7 +1983,7 @@ bool sinsp_filter_check_thread::compare(sinsp_evt *evt)
 	return sinsp_filter_check::compare(evt);
 }
 
-int32_t sinsp_filter_check_thread::get_argid()
+int32_t sinsp_filter_check_thread::get_argid() const
 {
 	return m_argid;
 }

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -114,7 +114,7 @@ public:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	bool compare(sinsp_evt*) override;
 
-	int32_t get_argid();
+	int32_t get_argid() const;
 
 private:
 	uint64_t extract_exectime(sinsp_evt *evt);

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 // A mock filtercheck that returns always true or false depending on
 // the passed-in field name. The operation is ignored.
-class mock_compiler_filter_check: public gen_event_filter_check
+class mock_compiler_filter_check : public gen_event_filter_check
 {
 public:
 	inline int32_t parse_field_name(const char* str, bool a, bool n) override
@@ -16,7 +16,7 @@ public:
 		return 0;
 	}
 
-	inline bool compare(gen_event *evt) override
+	inline bool compare(gen_event*) override
 	{
 		if (m_name == "c.true")
 		{
@@ -38,7 +38,7 @@ public:
 	}
 
 	inline void add_filter_value(const char* str, uint32_t l, uint32_t i) override
-	{ 
+	{
 		m_value = string(str, l);
 	}
 
@@ -67,7 +67,7 @@ public:
 		return new mock_compiler_filter_check();
 	}
 
-	inline list<gen_event_filter_factory::filter_fieldclass_info> get_fields() override
+	inline list<gen_event_filter_factory::filter_fieldclass_info> get_fields() const override
 	{
 		return m_list;
 	}
@@ -101,7 +101,7 @@ void test_filter_run(bool result, string filter_str)
 }
 
 void test_filter_compile(
-		std::shared_ptr<gen_event_filter_factory> factory, 
+		std::shared_ptr<gen_event_filter_factory> factory,
 		string filter_str,
 		bool expect_fail=false)
 {

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -342,8 +342,8 @@ public:
 			m_avail_list.pop_front();
 		}
 	}
-	void push(OBJ* newentry)
 
+	void push(OBJ* newentry)
 	{
 		m_avail_list.push_front(newentry);
 	}
@@ -359,7 +359,7 @@ public:
 		return head;
 	}
 
-	bool empty()
+	bool empty() const
 	{
 		return m_avail_list.empty();
 	}
@@ -387,7 +387,7 @@ private:
 template<typename T>
 int ci_find_substr(const T& str1, const T& str2, const std::locale& loc = std::locale())
 {
-	typename T::const_iterator it = std::search(str1.begin(), str1.end(),
+	auto it = std::search(str1.begin(), str1.end(),
 		str2.begin(), str2.end(), ci_equal<typename T::value_type>(loc) );
 	if(it != str1.end()) { return it - str1.begin(); }
 	return -1;


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
> /area API-version
> /area build
> /area CI
> /area driver-kmod
> /area driver-bpf
> /area driver-modern-bpf
> /area libscap-engine-bpf
> /area libscap-engine-gvisor
> /area libscap-engine-kmod
> /area libscap-engine-modern-bpf
> /area libscap-engine-nodriver
> /area libscap-engine-noop
> /area libscap-engine-source-plugin
> /area libscap-engine-savefile
> /area libscap
> /area libpman
> /area libsinsp
> /area tests
> /area proposals

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
This PR adds `const` to a number of class member functions, when applicable, to allow to use them on const objects. Functions of classes that call these functions on their data members are prevented from declaring their functions const, even they are logically so, because of the missing const.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
