### PR TITLE
cleanup: Modernize C++ struct/enum/union declarations

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -22,7 +22,7 @@ static_assert(sizeof(cgroup_prefix_array) / sizeof(*cgroup_prefix_array) == CGRO
 #define VALUE_NOT_CORRECT ">>>>> value of the param is not correct. Param id = "
 #define VALUE_NOT_ZERO ">>>>> value of the param must not be zero. Param id = "
 
-extern const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
+extern const syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
 
 /////////////////////////////////
 // RETRIEVE EVENT CLASS
@@ -47,7 +47,7 @@ std::unique_ptr<event_test> get_syscall_event_test()
 // SYSCALL RESULT ASSERTIONS
 /////////////////////////////////
 
-void assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, enum assertion_operators op, long expected_rc)
+void assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, assertion_operators op, long expected_rc)
 {
 	bool match = false;
 
@@ -255,9 +255,9 @@ void event_test::clear_ring_buffers()
 	}
 }
 
-struct ppm_evt_hdr* event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
+ppm_evt_hdr* event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
 {
-	struct ppm_evt_hdr* hdr = NULL;
+	ppm_evt_hdr* hdr = NULL;
 	uint16_t attempts = 0;
 	int32_t res = 0;
 	uint32_t flags = 0;
@@ -282,9 +282,9 @@ struct ppm_evt_hdr* event_test::get_event_from_ringbuffer(uint16_t* cpu_id)
 void event_test::parse_event()
 {
 	uint8_t nparams = m_event_header->nparams;
-	uint16_t* lens16 = (uint16_t*)((char*)m_event_header + sizeof(struct ppm_evt_hdr));
+	uint16_t* lens16 = (uint16_t*)((char*)m_event_header + sizeof(ppm_evt_hdr));
 	char* valptr = (char*)lens16 + nparams * sizeof(uint16_t);
-	uint32_t total_len = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
+	uint32_t total_len = sizeof(ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	struct param par;
 
 	/* Insert a dummy param just to use index starting from 1 insted of 0. */
@@ -327,7 +327,7 @@ void event_test::server_reuse_address_port(int32_t socketfd)
 	assert_syscall_state(SYSCALL_SUCCESS, "setsockopt (server port)", syscall(__NR_setsockopt, socketfd, SOL_SOCKET, SO_REUSEPORT, &option_value, sizeof(option_value)), NOT_EQUAL, -1);
 }
 
-void event_test::client_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
+void event_test::client_fill_sockaddr_in(sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin_family = AF_INET;
@@ -335,7 +335,7 @@ void event_test::client_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t i
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET, ipv4_string, &(sockaddr->sin_addr)), NOT_EQUAL, -1);
 }
 
-void event_test::server_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
+void event_test::server_fill_sockaddr_in(sockaddr_in* sockaddr, int32_t ipv4_port, const char* ipv4_string)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin_family = AF_INET;
@@ -343,7 +343,7 @@ void event_test::server_fill_sockaddr_in(struct sockaddr_in* sockaddr, int32_t i
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET, ipv4_string, &(sockaddr->sin_addr)), NOT_EQUAL, -1);
 }
 
-void event_test::client_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
+void event_test::client_fill_sockaddr_in6(sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
@@ -351,7 +351,7 @@ void event_test::client_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (client)", inet_pton(AF_INET6, ipv6_string, &(sockaddr->sin6_addr)), NOT_EQUAL, -1);
 }
 
-void event_test::server_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
+void event_test::server_fill_sockaddr_in6(sockaddr_in6* sockaddr, int32_t ipv6_port, const char* ipv6_string)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sin6_family = AF_INET6;
@@ -359,7 +359,7 @@ void event_test::server_fill_sockaddr_in6(struct sockaddr_in6* sockaddr, int32_t
 	assert_syscall_state(SYSCALL_SUCCESS, "inet_pton (server)", inet_pton(AF_INET6, ipv6_string, &(sockaddr->sin6_addr)), NOT_EQUAL, -1);
 }
 
-void event_test::client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path)
+void event_test::client_fill_sockaddr_un(sockaddr_un* sockaddr, const char* unix_path)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sun_family = AF_UNIX;
@@ -367,7 +367,7 @@ void event_test::client_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	strlcpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH);
 }
 
-void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const char* unix_path)
+void event_test::server_fill_sockaddr_un(sockaddr_un* sockaddr, const char* unix_path)
 {
 	memset(sockaddr, 0, sizeof(*sockaddr));
 	sockaddr->sun_family = AF_UNIX;
@@ -375,7 +375,7 @@ void event_test::server_fill_sockaddr_un(struct sockaddr_un* sockaddr, const cha
 	strlcpy(sockaddr->sun_path, unix_path, MAX_SUN_PATH);
 }
 
-void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr, int32_t port_client, int32_t port_server)
+void event_test::connect_ipv4_client_to_server(int32_t* client_socket, sockaddr_in* client_sockaddr, int32_t* server_socket, sockaddr_in* server_sockaddr, int32_t port_client, int32_t port_server)
 {
 	/* Create the server socket. */
 	*server_socket = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -386,7 +386,7 @@ void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct so
 	server_fill_sockaddr_in(server_sockaddr, port_server);
 
 	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
 
 	/* The server now is ready, we need to create at least one connection from the client. */
@@ -399,11 +399,11 @@ void event_test::connect_ipv4_client_to_server(int32_t* client_socket, struct so
 	client_fill_sockaddr_in(client_sockaddr, port_client);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 }
 
-void event_test::connect_ipv4_udp_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr, int32_t port_client, int32_t port_server)
+void event_test::connect_ipv4_udp_client_to_server(int32_t* client_socket, sockaddr_in* client_sockaddr, int32_t* server_socket, sockaddr_in* server_sockaddr, int32_t port_client, int32_t port_server)
 {
 	/* Create the server socket. */
 	*server_socket = syscall(__NR_socket, AF_INET, SOCK_DGRAM, 0);
@@ -414,7 +414,7 @@ void event_test::connect_ipv4_udp_client_to_server(int32_t* client_socket, struc
 	server_fill_sockaddr_in(server_sockaddr, port_server);
 
 	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 
 	/* The server now is ready, we need to create at least one connection from the client. */
 
@@ -426,10 +426,10 @@ void event_test::connect_ipv4_udp_client_to_server(int32_t* client_socket, struc
 	client_fill_sockaddr_in(client_sockaddr, port_client);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
 }
 
-void event_test::connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr)
+void event_test::connect_ipv6_client_to_server(int32_t* client_socket, sockaddr_in6* client_sockaddr, int32_t* server_socket, sockaddr_in6* server_sockaddr)
 {
 	/* Create the server socket. */
 	*server_socket = syscall(__NR_socket, AF_INET6, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -440,7 +440,7 @@ void event_test::connect_ipv6_client_to_server(int32_t* client_socket, struct so
 	server_fill_sockaddr_in6(server_sockaddr);
 
 	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
 
 	/* The server now is ready, we need to create at least one connection from the client. */
@@ -453,11 +453,11 @@ void event_test::connect_ipv6_client_to_server(int32_t* client_socket, struct so
 	client_fill_sockaddr_in6(client_sockaddr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 }
 
-void event_test::connect_unix_client_to_server(int32_t* client_socket, struct sockaddr_un* client_sockaddr, int32_t* server_socket, struct sockaddr_un* server_sockaddr)
+void event_test::connect_unix_client_to_server(int32_t* client_socket, sockaddr_un* client_sockaddr, int32_t* server_socket, sockaddr_un* server_sockaddr)
 {
 	/* Create the server socket. */
 	*server_socket = syscall(__NR_socket, AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -467,7 +467,7 @@ void event_test::connect_unix_client_to_server(int32_t* client_socket, struct so
 	server_fill_sockaddr_un(server_sockaddr);
 
 	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, *server_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 	assert_syscall_state(SYSCALL_SUCCESS, "listen (server)", syscall(__NR_listen, *server_socket, QUEUE_LENGTH), NOT_EQUAL, -1);
 
 	/* The server now is ready, we need to create at least one connection from the client. */
@@ -479,8 +479,8 @@ void event_test::connect_unix_client_to_server(int32_t* client_socket, struct so
 	client_fill_sockaddr_un(client_sockaddr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (struct sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (struct sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, *client_socket, (sockaddr*)client_sockaddr, sizeof(*client_sockaddr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, *client_socket, (sockaddr*)server_sockaddr, sizeof(*server_sockaddr)), NOT_EQUAL, -1);
 }
 
 /////////////////////////////////
@@ -533,7 +533,7 @@ void event_test::assert_only_param_len(int param_num, uint16_t expected_size)
 }
 
 template<typename T>
-void event_test::assert_numeric_param(int param_num, T param, enum assertion_operators op)
+void event_test::assert_numeric_param(int param_num, T param, assertion_operators op)
 {
 	assert_param_boundaries(param_num);
 	assert_param_len(sizeof(T));
@@ -562,14 +562,14 @@ void event_test::assert_numeric_param(int param_num, T param, enum assertion_ope
 	}
 }
 
-template void event_test::assert_numeric_param<uint8_t>(int, uint8_t, enum assertion_operators);
-template void event_test::assert_numeric_param<uint16_t>(int, uint16_t, enum assertion_operators);
-template void event_test::assert_numeric_param<uint32_t>(int, uint32_t, enum assertion_operators);
-template void event_test::assert_numeric_param<uint64_t>(int, uint64_t, enum assertion_operators);
-template void event_test::assert_numeric_param<int8_t>(int, int8_t, enum assertion_operators);
-template void event_test::assert_numeric_param<int16_t>(int, int16_t, enum assertion_operators);
-template void event_test::assert_numeric_param<int32_t>(int, int32_t, enum assertion_operators);
-template void event_test::assert_numeric_param<int64_t>(int, int64_t, enum assertion_operators);
+template void event_test::assert_numeric_param<uint8_t>(int, uint8_t, assertion_operators);
+template void event_test::assert_numeric_param<uint16_t>(int, uint16_t, assertion_operators);
+template void event_test::assert_numeric_param<uint32_t>(int, uint32_t, assertion_operators);
+template void event_test::assert_numeric_param<uint64_t>(int, uint64_t, assertion_operators);
+template void event_test::assert_numeric_param<int8_t>(int, int8_t, assertion_operators);
+template void event_test::assert_numeric_param<int16_t>(int, int16_t, assertion_operators);
+template void event_test::assert_numeric_param<int32_t>(int, int32_t, assertion_operators);
+template void event_test::assert_numeric_param<int64_t>(int, int64_t, assertion_operators);
 
 void event_test::assert_charbuf_param(int param_num, const char* param)
 {
@@ -878,7 +878,7 @@ void event_test::assert_address_family(uint8_t desired_family, int starting_inde
 	ASSERT_EQ(family, desired_family) << VALUE_NOT_CORRECT << m_current_param << std::endl;
 }
 
-void event_test::assert_ipv4_string(const char* desired_ipv4, int starting_index, enum direction dir)
+void event_test::assert_ipv4_string(const char* desired_ipv4, int starting_index, direction dir)
 {
 	char ipv4_string[ADDRESS_LENGTH];
 	if(inet_ntop(AF_INET, (uint8_t*)(m_event_params[m_current_param].valptr + starting_index), ipv4_string, ADDRESS_LENGTH) == NULL)
@@ -896,7 +896,7 @@ void event_test::assert_ipv4_string(const char* desired_ipv4, int starting_index
 	}
 }
 
-void event_test::assert_port_string(const char* desired_port, int starting_index, enum direction dir)
+void event_test::assert_port_string(const char* desired_port, int starting_index, direction dir)
 {
 	uint16_t port = *(uint16_t*)(m_event_params[m_current_param].valptr + starting_index);
 	const char* port_string = std::to_string(port).c_str();
@@ -911,7 +911,7 @@ void event_test::assert_port_string(const char* desired_port, int starting_index
 	}
 }
 
-void event_test::assert_ipv6_string(const char* desired_ipv6, int starting_index, enum direction dir)
+void event_test::assert_ipv6_string(const char* desired_ipv6, int starting_index, direction dir)
 {
 	char ipv6_string[ADDRESS_LENGTH];
 	if(inet_ntop(AF_INET6, (uint32_t*)(m_event_params[m_current_param].valptr + starting_index), ipv6_string, ADDRESS_LENGTH) == NULL)

--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -20,7 +20,7 @@
 #define KMOD_NAME "scap"
 
 scap_t* event_test::s_scap_handle = NULL;
-static enum falcosecurity_log_severity severity_level = FALCOSECURITY_LOG_SEV_WARNING;
+static falcosecurity_log_severity severity_level = FALCOSECURITY_LOG_SEV_WARNING;
 
 int remove_kmod()
 {
@@ -79,7 +79,7 @@ int insert_kmod(const std::string& kmod_path)
 	return EXIT_SUCCESS;
 }
 
-void abort_if_already_configured(const struct scap_vtable* vtable)
+void abort_if_already_configured(const scap_vtable* vtable)
 {
 	if(vtable != nullptr)
 	{
@@ -88,7 +88,7 @@ void abort_if_already_configured(const struct scap_vtable* vtable)
 	}
 }
 
-void test_open_log_fn(const char* component, const char* msg, const enum falcosecurity_log_severity sev)
+void test_open_log_fn(const char* component, const char* msg, falcosecurity_log_severity sev)
 {
 	if(sev <= severity_level)
 	{
@@ -143,11 +143,11 @@ int open_engine(int argc, char** argv)
 		{0, 0, 0, 0}};
 
 	// They should live until we call 'scap_open'
-	struct scap_modern_bpf_engine_params modern_bpf_params = {0};
-	struct scap_bpf_engine_params bpf_params = {0};
-	struct scap_kmod_engine_params kmod_params = {0};
+	scap_modern_bpf_engine_params modern_bpf_params = {0};
+	scap_bpf_engine_params bpf_params = {0};
+	scap_kmod_engine_params kmod_params = {0};
 	int ret = 0;
-	const struct scap_vtable* vtable = nullptr;
+	const scap_vtable* vtable = nullptr;
 	scap_open_args oargs = {};
 	oargs.log_fn = test_open_log_fn;
 	unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
@@ -279,7 +279,7 @@ int open_engine(int argc, char** argv)
 					std::cerr << "Invalid logging level. Valid range is '" << std::to_string(FALCOSECURITY_LOG_SEV_FATAL) <<"' <= lev <= '" << std::to_string(FALCOSECURITY_LOG_SEV_TRACE) << "'" << std::endl;
 					return EXIT_FAILURE;
 				}
-				severity_level = (enum falcosecurity_log_severity)level;
+				severity_level = (falcosecurity_log_severity)level;
 			}
 			break;
 

--- a/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
+++ b/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
@@ -21,7 +21,7 @@ TEST(Actions, dynamic_snaplen_negative_fd)
 	const unsigned data_len = DEFAULT_SNAPLEN * 2;
 	char buf[data_len] = "HTTP/\0";
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -103,7 +103,7 @@ TEST(Actions, dynamic_snaplen_no_socket)
 	const unsigned data_len = DEFAULT_SNAPLEN * 2;
 	char buf[data_len] = "HTTP/\0";
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -180,8 +180,8 @@ TEST(Actions, dynamic_snaplen_HTTP)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -189,14 +189,14 @@ TEST(Actions, dynamic_snaplen_HTTP)
 	char buf[data_len] = "HTTP/\0";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -265,8 +265,8 @@ TEST(Actions, dynamic_snaplen_partial_HTTP_OPT)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -275,14 +275,14 @@ TEST(Actions, dynamic_snaplen_partial_HTTP_OPT)
 	char buf[data_len] = "OP\0";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -351,8 +351,8 @@ TEST(Actions, dynamic_snaplen_HTTP_TRACE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -360,14 +360,14 @@ TEST(Actions, dynamic_snaplen_HTTP_TRACE)
 	char buf[data_len] = "TRACE\0";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -436,8 +436,8 @@ TEST(Actions, dynamic_snaplen_MYSQL)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
 
 	/* Send a message to the server */
@@ -447,14 +447,14 @@ TEST(Actions, dynamic_snaplen_MYSQL)
 	buf[3] = 3;
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -523,8 +523,8 @@ TEST(Actions, dynamic_snaplen_not_MYSQL)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
 
 	/* Send a message to the server */
@@ -532,14 +532,14 @@ TEST(Actions, dynamic_snaplen_not_MYSQL)
 	char buf[data_len] = "1111\0";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -608,8 +608,8 @@ TEST(Actions, dynamic_snaplen_POSTGRES)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
 
 	/* Send a message to the server */
@@ -619,14 +619,14 @@ TEST(Actions, dynamic_snaplen_POSTGRES)
 	buf[1] = 0;
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -695,8 +695,8 @@ TEST(Actions, dynamic_snaplen_not_POSTGRES)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
 
 	/* Send a message to the server */
@@ -704,14 +704,14 @@ TEST(Actions, dynamic_snaplen_not_POSTGRES)
 	char buf[data_len] = "00\0";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -780,8 +780,8 @@ TEST(Actions, dynamic_snaplen_MONGO)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -790,14 +790,14 @@ TEST(Actions, dynamic_snaplen_MONGO)
 	*(int32_t *)(&buf[12]) = 0x01; // this 1 and it's ok
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -866,8 +866,8 @@ TEST(Actions, dynamic_snaplen_not_MONGO)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -876,14 +876,14 @@ TEST(Actions, dynamic_snaplen_not_MONGO)
 	*(int32_t *)(&buf[12]) = 0x07;
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -955,8 +955,8 @@ TEST(Actions, dynamic_snaplen_fullcapture_port_range)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -964,14 +964,14 @@ TEST(Actions, dynamic_snaplen_fullcapture_port_range)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -1048,8 +1048,8 @@ TEST(Actions, dynamic_snaplen_statsd_port)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1057,14 +1057,14 @@ TEST(Actions, dynamic_snaplen_statsd_port)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}
@@ -1141,8 +1141,8 @@ TEST(Actions, dynamic_snaplen_no_statsd_port)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1150,14 +1150,14 @@ TEST(Actions, dynamic_snaplen_no_statsd_port)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
 	if(ret_pid == 0)
 	{
 		/* In this way in the father we know if the call was successful or not. */
-		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
+		if(syscall(__NR_sendto, client_socket_fd, buf, data_len, sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)) == -1)
 		{
 			exit(EXIT_FAILURE);
 		}

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
@@ -22,7 +22,7 @@ TEST(GenericTracepoints, sched_proc_exec)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -164,7 +164,7 @@ TEST(GenericTracepoints, sched_proc_exec_success_memfd)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
@@ -19,7 +19,7 @@ TEST(GenericTracepoints, sched_proc_exit_no_children)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -108,7 +108,7 @@ TEST(GenericTracepoints, sched_proc_exit_prctl_subreaper)
 	pid_t p2_t1 = 61030;
 	pid_t p3_t1 = 61050;
 
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -122,14 +122,14 @@ TEST(GenericTracepoints, sched_proc_exit_prctl_subreaper)
 			exit(EXIT_FAILURE);
 		}
 
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 1;
 		cl_args_child.exit_signal = SIGCHLD;
 		pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
 		if(p2_t1_pid == 0)
 		{
-			struct clone_args cl_args_child = {0};
+			clone_args cl_args_child = {0};
 			cl_args_child.set_tid = (uint64_t)&p3_t1;
 			cl_args_child.set_tid_size = 1;
 			cl_args_child.exit_signal = SIGCHLD;
@@ -225,7 +225,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper)
 	pid_t p3_t1[2] = {3, 59026};
 
 	/* p1_t1 is in the new namespace */
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 2;
 	cl_args_parent.flags = CLONE_NEWPID;
@@ -234,14 +234,14 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper)
 
 	if(p1_t1_pid == 0)
 	{
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 2;
 		cl_args_child.exit_signal = SIGCHLD;
 		pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
 		if(p2_t1_pid == 0)
 		{
-			struct clone_args cl_args_child = {0};
+			clone_args cl_args_child = {0};
 			cl_args_child.set_tid = (uint64_t)&p3_t1;
 			cl_args_child.set_tid_size = 2;
 			cl_args_child.exit_signal = SIGCHLD;
@@ -337,7 +337,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 	pid_t p2_t1[2] = {2, 59025};
 
 	/* p1_t1 is in the new namespace */
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 2;
 	cl_args_parent.flags = CLONE_NEWPID;
@@ -346,7 +346,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 
 	if(p1_t1_pid == 0)
 	{
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 2;
 		cl_args_parent.exit_signal = SIGCHLD;
@@ -407,7 +407,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 static int child_func(void* arg)
 {
 	pid_t p2_t1 = 57006;
-	struct clone_args cl_args_child = {0};
+	clone_args cl_args_child = {0};
 	cl_args_child.set_tid = (uint64_t)&p2_t1;
 	cl_args_child.set_tid_size = 1;
 	pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
@@ -459,7 +459,7 @@ TEST(GenericTracepoints, sched_proc_exit_reaper_in_the_same_group)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	evt_test->disable_capture();
-	
+
 	evt_test->assert_event_presence(p1_t2_tid);
 
 	if(HasFatalFailure())

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_fork.cpp
@@ -25,7 +25,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -125,7 +125,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_create_child_with_2_threads
 	pid_t p1_t1 = 61001;
 	pid_t p1_t2 = 61004;
 
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -135,7 +135,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_create_child_with_2_threads
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 1;
 		/* CLONE_PARENT has no additional effects if we are spawning a thread
@@ -226,7 +226,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_clone_parent_flag)
 	pid_t p1_t1 = 61024;
 	pid_t p2_t1 = 60128;
 
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -234,7 +234,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_clone_parent_flag)
 
 	if(ret_pid == 0)
 	{
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 1;
 		cl_args_child.flags = CLONE_PARENT;
@@ -330,7 +330,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_new_namespace_from_ch
 
 	/* Here we create a child process in a new namespace. */
 	pid_t p1_t1[2] = {1, 61032};
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -415,7 +415,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_new_namespace_create_
 	/* Please note that a process can have the same pid number in different namespaces */
 	pid_t p1_t2[2] = {61036, 61036};
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -425,7 +425,7 @@ TEST(GenericTracepoints, sched_proc_fork_case_clone3_child_new_namespace_create_
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 2;
 		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK;

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
@@ -16,7 +16,7 @@ TEST(GenericTracepoints, sched_switch)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_enter_suite/accept4_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/accept4_e.cpp
@@ -11,7 +11,7 @@ TEST(SyscallEnter, accept4E)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "accept4", syscall(__NR_accept4, mock_fd, addr, addrlen, flags));

--- a/test/drivers/test_suites/syscall_enter_suite/accept_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/accept_e.cpp
@@ -11,7 +11,7 @@ TEST(SyscallEnter, acceptE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, addr, addrlen));
 

--- a/test/drivers/test_suites/syscall_enter_suite/bind_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/bind_e.cpp
@@ -10,7 +10,7 @@ TEST(SyscallEnter, bindE)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t addrlen = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, mock_fd, addr, addrlen));
 

--- a/test/drivers/test_suites/syscall_enter_suite/bpf_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/bpf_e.cpp
@@ -20,7 +20,7 @@ TEST(SyscallEnter, bpfE)
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_enter_suite/clone3_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/clone3_e.cpp
@@ -13,7 +13,7 @@ TEST(SyscallEnter, clone3E)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* flags are invalid so the syscall will fail. */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = (unsigned long)-1;
 	assert_syscall_state(SYSCALL_FAILURE, "clone3", syscall(__NR_clone3, &cl_args, sizeof(cl_args)));
 

--- a/test/drivers/test_suites/syscall_enter_suite/connect_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/connect_e.cpp
@@ -11,9 +11,9 @@ TEST(SyscallEnter, connectE_INET)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -62,9 +62,9 @@ TEST(SyscallEnter, connectE_INET6)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr_in6 server_addr;
+	sockaddr_in6 server_addr;
 	evt_test->server_fill_sockaddr_in6(&server_addr);
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -116,9 +116,9 @@ TEST(SyscallEnter, connectE_UNIX)
 	 * the maximum length (`MAX_SUN_PATH`).
 	 */
 	int32_t mock_fd = -1;
-	struct sockaddr_un server_addr;
+	sockaddr_un server_addr;
 	evt_test->server_fill_sockaddr_un(&server_addr);
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -178,9 +178,9 @@ TEST(SyscallEnter, connectE_UNIX_max_path)
 	 */
 
 	int32_t mock_fd = -1;
-	struct sockaddr_un server_addr;
+	sockaddr_un server_addr;
 	evt_test->server_fill_sockaddr_un(&server_addr, UNIX_LONG_PATH);
-	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -232,7 +232,7 @@ TEST(SyscallEnter, connectE_null_sockaddr)
 	 * The invalid socket fd, in this case, is negative so the `sockaddr` param will be empty.
 	 */
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t addrlen = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, addr, addrlen));
 

--- a/test/drivers/test_suites/syscall_enter_suite/ioctl_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/ioctl_e.cpp
@@ -23,7 +23,7 @@ TEST(SyscallEnter, ioctlE)
 	/* Here we need to call the `ioctl` from a child because the main process throws lots of
 	 * `ioctl` to manage the kmod.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_enter_suite/ptrace_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/ptrace_e.cpp
@@ -12,7 +12,7 @@ TEST(SyscallEnter, ptraceE)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	enum __ptrace_request request = PTRACE_PEEKSIGINFO;
+	__ptrace_request request = PTRACE_PEEKSIGINFO;
 	pid_t pid = -1;
 	void* addr = NULL;
 	void* data = NULL;

--- a/test/drivers/test_suites/syscall_enter_suite/recvfrom_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/recvfrom_e.cpp
@@ -14,7 +14,7 @@ TEST(SyscallEnter, recvfromE)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t flags = 0;
-	struct sockaddr *src_addr = NULL;
+	sockaddr* src_addr = NULL;
 	socklen_t *addrlen = NULL;
 	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_recvfrom, mock_fd, received_data, received_data_len, flags, src_addr, addrlen));
 

--- a/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -12,8 +12,8 @@ TEST(SyscallEnter, sendmsgE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -21,7 +21,7 @@ TEST(SyscallEnter, sendmsgE)
 	struct iovec iov[3];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";

--- a/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -12,14 +12,14 @@ TEST(SyscallEnter, sendtoE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_shutdown, server_socket_fd, 2);

--- a/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
@@ -20,7 +20,7 @@ TEST(SyscallEnter, socketE)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socketcall_e.cpp
@@ -26,7 +26,7 @@ TEST(SyscallEnter, socketcall_socketE)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -136,7 +136,7 @@ TEST(SyscallEnter, socketcall_connectE)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 	unsigned long args[3] = {0};
 	args[0] = mock_fd;
@@ -345,7 +345,7 @@ TEST(SyscallEnter, socketcall_acceptE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 
 	unsigned long args[3] = {0};
@@ -409,7 +409,7 @@ TEST(SyscallEnter, socketcall_accept4E)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 
@@ -507,7 +507,7 @@ TEST(SyscallEnter, socketcall_recvfromE)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t flags = 0;
-	struct sockaddr *src_addr = NULL;
+	sockaddr* src_addr = NULL;
 	socklen_t *addrlen = NULL;
 
 	unsigned long args[6] = {0};
@@ -617,8 +617,8 @@ TEST(SyscallEnter, socketcall_sendtoE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -685,8 +685,8 @@ TEST(SyscallEnter, socketcall_sendmsgE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -694,7 +694,7 @@ TEST(SyscallEnter, socketcall_sendmsgE)
 	struct iovec iov[3];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr *)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
@@ -1185,7 +1185,7 @@ TEST(SyscallEnter, socketcall_null_pointer)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	evt_test->assert_num_params_pushed(2);	
+	evt_test->assert_num_params_pushed(2);
 }
 
 TEST(SyscallEnter, socketcall_null_pointer_and_wrong_code_socketcall_interesting)

--- a/test/drivers/test_suites/syscall_exit_suite/accept4_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/accept4_x.cpp
@@ -14,12 +14,12 @@ TEST(SyscallExit, accept4X_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
@@ -83,12 +83,12 @@ TEST(SyscallExit, accept4X_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in6 client_addr = {0};
-	struct sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {0};
+	sockaddr_in6 server_addr = {0};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
@@ -158,7 +158,7 @@ TEST(SyscallExit, accept4X_UNIX)
 	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 	int connected_socket_fd = syscall(__NR_accept4, server_socket_fd, addr, addrlen, flags);
@@ -224,7 +224,7 @@ TEST(SyscallExit, accept4X_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "accept4", syscall(__NR_accept4, mock_fd, addr, addrlen, flags));

--- a/test/drivers/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/accept_x.cpp
@@ -12,8 +12,8 @@ TEST(SyscallExit, acceptX_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -78,8 +78,8 @@ TEST(SyscallExit, acceptX_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in6 client_addr = {0};
-	struct sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {0};
+	sockaddr_in6 server_addr = {0};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -213,7 +213,7 @@ TEST(SyscallExit, acceptX_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	assert_syscall_state(SYSCALL_FAILURE, "accept", syscall(__NR_accept, mock_fd, addr, addrlen));
 	int64_t errno_value = -errno;

--- a/test/drivers/test_suites/syscall_exit_suite/bind_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/bind_x.cpp
@@ -16,10 +16,10 @@ TEST(SyscallExit, bindX_INET)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
 	evt_test->server_reuse_address_port(server_socket_fd);
 
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, server_socket_fd);
@@ -64,10 +64,10 @@ TEST(SyscallExit, bindX_INET6)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
 	evt_test->server_reuse_address_port(server_socket_fd);
 
-	struct sockaddr_in6 server_addr;
+	sockaddr_in6 server_addr;
 	evt_test->server_fill_sockaddr_in6(&server_addr);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, server_socket_fd);
@@ -115,7 +115,7 @@ TEST(SyscallExit, bindX_UNIX)
 	struct sockaddr_un server_addr;
 	evt_test->server_fill_sockaddr_un(&server_addr);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind", syscall(__NR_bind, server_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, server_socket_fd);
@@ -159,7 +159,7 @@ TEST(SyscallExit, bindX_failure)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t addrlen = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "bind", syscall(__NR_bind, mock_fd, addr, addrlen));
 	int64_t errno_value = -errno;

--- a/test/drivers/test_suites/syscall_exit_suite/bpf_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/bpf_x.cpp
@@ -21,7 +21,7 @@ TEST(SyscallExit, bpfX_invalid_cmd)
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -91,13 +91,13 @@ TEST(SyscallExit, bpfX_MAP_CREATE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t cmd = 1;
-	union bpf_attr *attr = NULL; 
-	
+	union bpf_attr *attr = NULL;
+
 
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -125,7 +125,7 @@ TEST(SyscallExit, bpfX_MAP_CREATE)
 	{
 		FAIL() << "The bpf call is successful while it should fail..." << std::endl;
 	}
-	
+
 	int64_t errno_value = -EINVAL;
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -26,7 +26,7 @@ TEST(SyscallExit, clone3X_father)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -153,7 +153,7 @@ TEST(SyscallExit, clone3X_child)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -265,7 +265,7 @@ TEST(SyscallExit, clone3X_create_child_with_2_threads)
 	pid_t p1_t1 = 61001;
 	pid_t p1_t2 = 61004;
 
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -275,7 +275,7 @@ TEST(SyscallExit, clone3X_create_child_with_2_threads)
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 1;
 		/* CLONE_PARENT has no additional effects if we are spawning a thread
@@ -370,7 +370,7 @@ TEST(SyscallExit, clone3X_child_clone_parent_flag)
 	pid_t p1_t1 = 61024;
 	pid_t p2_t1 = 60128;
 
-	struct clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {0};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -378,7 +378,7 @@ TEST(SyscallExit, clone3X_child_clone_parent_flag)
 
 	if(ret_pid == 0)
 	{
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 1;
 		cl_args_child.flags = CLONE_PARENT;
@@ -477,7 +477,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_child)
 	/* Here we create a child process in a new namespace. */
 	pid_t p1_t1[2] = {1, 61032};
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -560,7 +560,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_caller)
 	/* Here we create a child process in a new namespace. */
 	pid_t p1_t1[2] = {1, 61032};
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -642,7 +642,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_create_thread)
 	/* Please note that a process can have the same pid number in different namespaces */
 	pid_t p1_t2[2] = {61036, 61036};
 
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -652,7 +652,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_create_thread)
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		struct clone_args cl_args_child = {0};
+		clone_args cl_args_child = {0};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 2;
 		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK;

--- a/test/drivers/test_suites/syscall_exit_suite/connect_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/connect_x.cpp
@@ -17,18 +17,18 @@ TEST(SyscallExit, connectX_INET)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
 	evt_test->client_reuse_address_port(client_socket_fd);
 
-	struct sockaddr_in client_addr;
+	sockaddr_in client_addr;
 	evt_test->client_fill_sockaddr_in(&client_addr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
 	/* Now we associate the client socket with the server address. */
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
 	/* With `SOCK_DGRAM` the `connect` will not perform a connection this is why the syscall doesn't fail. */
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, client_socket_fd);
@@ -77,17 +77,17 @@ TEST(SyscallExit, connectX_INET6)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
 	evt_test->client_reuse_address_port(client_socket_fd);
 
-	struct sockaddr_in6 client_addr;
+	sockaddr_in6 client_addr;
 	evt_test->client_fill_sockaddr_in6(&client_addr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
-	struct sockaddr_in6 server_addr;
+	sockaddr_in6 server_addr;
 	evt_test->server_fill_sockaddr_in6(&server_addr);
 
 	/* Now we associate the client socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, client_socket_fd);
@@ -140,7 +140,7 @@ TEST(SyscallExit, connectX_UNIX)
 	evt_test->client_fill_sockaddr_un(&client_addr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
 	/* We need to create a server socket. */
 	int32_t server_socket_fd = syscall(__NR_socket, AF_UNIX, SOCK_DGRAM, 0);
@@ -149,9 +149,9 @@ TEST(SyscallExit, connectX_UNIX)
 	struct sockaddr_un server_addr;
 	evt_test->server_fill_sockaddr_un(&server_addr);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "connect (client)", syscall(__NR_connect, client_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Cleaning phase */
 	syscall(__NR_close, client_socket_fd);
@@ -201,7 +201,7 @@ TEST(SyscallExit, connectX_failure)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	const struct sockaddr *addr = NULL;
+	const sockaddr* addr = NULL;
 	socklen_t addrlen = 0;
 	assert_syscall_state(SYSCALL_FAILURE, "connect", syscall(__NR_connect, mock_fd, addr, addrlen));
 	int64_t errno_value = -errno;
@@ -249,17 +249,17 @@ TEST(SyscallExit, connectX_failure_ECONNREFUSED)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
 	evt_test->client_reuse_address_port(client_socket_fd);
 
-	struct sockaddr_in client_addr;
+	sockaddr_in client_addr;
 	evt_test->client_fill_sockaddr_in(&client_addr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
 	/* We try to reach this server that doesn't exist */
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
-	assert_syscall_state(SYSCALL_FAILURE, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect (client)", syscall(__NR_connect, client_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -313,26 +313,26 @@ TEST(SyscallExit, connectX_failure_EINPROGRESS)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
 	evt_test->client_reuse_address_port(client_socket_fd);
 
-	struct sockaddr_in client_addr;
+	sockaddr_in client_addr;
 	evt_test->client_fill_sockaddr_in(&client_addr);
 
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
 	int32_t server_socket_fd = syscall(__NR_socket, AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (server)", server_socket_fd, NOT_EQUAL, -1);
 	evt_test->server_reuse_address_port(server_socket_fd);
 
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
 	/* Now we bind the server socket with the server address. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (server)", syscall(__NR_bind, server_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)), NOT_EQUAL, -1);
 
 	/* Here we don't call listen so the connection from the client should be
 	 * in progress.
 	 */
 
-	assert_syscall_state(SYSCALL_FAILURE, "connect (client)", syscall(__NR_connect, client_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)));
+	assert_syscall_state(SYSCALL_FAILURE, "connect (client)", syscall(__NR_connect, client_socket_fd, (sockaddr*)&server_addr, sizeof(server_addr)));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -178,7 +178,7 @@ TEST(SyscallExit, execveX_success)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -361,7 +361,7 @@ TEST(SyscallExit, execveX_not_upperlayer)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -558,7 +558,7 @@ TEST(SyscallExit, execveX_upperlayer_success)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -717,7 +717,7 @@ TEST(SyscallExit, execveX_success_memfd)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -818,7 +818,7 @@ TEST(SyscallExit, execveX_symlink)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -185,7 +185,7 @@ TEST(SyscallExit, execveatX_correct_exit)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -311,7 +311,7 @@ TEST(SyscallExit, execveatX_execve_exit)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -462,7 +462,7 @@ TEST(SyscallExit, execveatX_success_memfd)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_exit_suite/ioctl_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/ioctl_x.cpp
@@ -23,7 +23,7 @@ TEST(SyscallExit, ioctlX)
 	/* Here we need to call the `ioctl` from a child because the main process throws lots of
 	 * `ioctl` to manage the kmod.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/prctl_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/prctl_x.cpp
@@ -133,7 +133,7 @@ TEST(SyscallExit, prctlX_set_child_subreaper)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -209,7 +209,7 @@ TEST(SyscallExit, prctlX_set_name)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.exit_signal = SIGCHLD;
 
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/ptrace_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/ptrace_x.cpp
@@ -14,7 +14,7 @@ TEST(SyscallExit, ptraceX_failure)
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	enum __ptrace_request request = PTRACE_PEEKSIGINFO;
+	__ptrace_request request = PTRACE_PEEKSIGINFO;
 	pid_t pid = -1;
 	void* addr = NULL;
 	void* data = NULL;

--- a/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -14,14 +14,14 @@ TEST(SyscallExit, recvfromX_tcp_connection_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -31,10 +31,10 @@ TEST(SyscallExit, recvfromX_tcp_connection_no_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	struct sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {0};
 	socklen_t addrlen = sizeof(src_addr);
 
-	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (struct sockaddr *)&src_addr, &addrlen);
+	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (sockaddr*)&src_addr, &addrlen);
 	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
 
 	/* Cleaning phase */
@@ -87,14 +87,14 @@ TEST(SyscallExit, recvfromX_tcp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -104,10 +104,10 @@ TEST(SyscallExit, recvfromX_tcp_connection_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	struct sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {0};
 	socklen_t addrlen = sizeof(src_addr);
 
-	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (struct sockaddr *)&src_addr, &addrlen);
+	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (sockaddr*)&src_addr, &addrlen);
 	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
 
 	/* Cleaning phase */
@@ -160,14 +160,14 @@ TEST(SyscallExit, recvfromX_tcp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -178,7 +178,7 @@ TEST(SyscallExit, recvfromX_tcp_connection_NULL_sockaddr)
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
 
-	/// TODO: if we use `struct sockaddr_in* src_addr = NULL` kernel module and old bpf are not able to get correct data.
+	/// TODO: if we use `sockaddr_in* src_addr = NULL` kernel module and old bpf are not able to get correct data.
 	/// There is a check on the sockaddr pointer if it is NULL we return an empty tuple. We need to fix it.
 	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, NULL, 0);
 	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
@@ -242,25 +242,25 @@ TEST(SyscallExit, recvfromX_udp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags,
-				     (struct sockaddr *)&server_addr, sizeof(server_addr));
+				     (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	struct sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {0};
 	socklen_t addrlen = sizeof(src_addr);
 
 	int64_t received_bytes = syscall(__NR_recvfrom, server_socket_fd, received_data, received_data_len,
-					 recvfrom_flags, (struct sockaddr *)&src_addr, &addrlen);
+					 recvfrom_flags, (sockaddr*)&src_addr, &addrlen);
 	assert_syscall_state(SYSCALL_SUCCESS, "recvfrom (server)", received_bytes, NOT_EQUAL, -1);
 
 	/* Cleaning phase */
@@ -323,15 +323,15 @@ TEST(SyscallExit, recvfromX_udp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
 	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags,
-				     (struct sockaddr *)&server_addr, sizeof(server_addr));
+				     (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	char received_data[MAX_RECV_BUF_SIZE];
@@ -404,7 +404,7 @@ TEST(SyscallExit, recvfromX_fail)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t flags = 0;
-	struct sockaddr *src_addr = NULL;
+	sockaddr* src_addr = NULL;
 	socklen_t *addrlen = NULL;
 	assert_syscall_state(SYSCALL_FAILURE, "recvfrom", syscall(__NR_recvfrom, mock_fd, received_data, received_data_len, flags, src_addr, addrlen));
 	int64_t errno_value = -errno;

--- a/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -14,14 +14,14 @@ TEST(SyscallExit, recvmsgX_tcp_connection_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -32,7 +32,7 @@ TEST(SyscallExit, recvmsgX_tcp_connection_no_snaplen)
 	struct iovec iov[2];
 	memset(&recv_msg, 0, sizeof(recv_msg));
 	memset(iov, 0, sizeof(iov));
-	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_name = (sockaddr*)&client_addr;
 	recv_msg.msg_namelen = sizeof(client_addr);
 	char data_1[MAX_RECV_BUF_SIZE];
 	char data_2[MAX_RECV_BUF_SIZE];
@@ -115,14 +115,14 @@ TEST(SyscallExit, recvmsgX_tcp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -133,7 +133,7 @@ TEST(SyscallExit, recvmsgX_tcp_connection_snaplen)
 	struct iovec iov[2];
 	memset(&recv_msg, 0, sizeof(recv_msg));
 	memset(iov, 0, sizeof(iov));
-	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_name = (sockaddr*)&client_addr;
 	recv_msg.msg_namelen = sizeof(client_addr);
 	char data_1[MAX_RECV_BUF_SIZE];
 	char data_2[MAX_RECV_BUF_SIZE];
@@ -213,14 +213,14 @@ TEST(SyscallExit, recvmsgX_tcp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -311,21 +311,21 @@ TEST(SyscallExit, recvmsgX_udp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	struct msghdr recv_msg;
 	struct iovec iov[2];
 	memset(&recv_msg, 0, sizeof(recv_msg));
 	memset(iov, 0, sizeof(iov));
-	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_name = (sockaddr*)&client_addr;
 	recv_msg.msg_namelen = sizeof(client_addr);
 	char data_1[MAX_RECV_BUF_SIZE];
 	char data_2[MAX_RECV_BUF_SIZE];
@@ -405,14 +405,14 @@ TEST(SyscallExit, recvmsgX_udp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	struct msghdr recv_msg;
@@ -557,7 +557,7 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 	struct cmsghdr *cmsg;
 	char cmsg_buf[CMSG_SPACE(sizeof(int))];
 	struct iovec iov = {
-		.iov_base = (void *)FULL_MESSAGE, 
+		.iov_base = (void *)FULL_MESSAGE,
 		.iov_len = FULL_MESSAGE_LEN,
 	};
 
@@ -643,7 +643,7 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 	evt_test->parse_event();
 
 	evt_test->assert_header();
-	
+
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_ERRNO) */
@@ -656,7 +656,7 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 	evt_test->assert_bytebuf_param(3, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/* Parameter 5: msg_control (type: PT_BYTEBUF) */
-	evt_test->assert_bytebuf_param(5, (const char *)cmsg, msg_controllen);	
+	evt_test->assert_bytebuf_param(5, (const char *)cmsg, msg_controllen);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -17,8 +17,8 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -26,7 +26,7 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 	struct iovec iov[2];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
@@ -86,8 +86,8 @@ TEST(SyscallExit, sendmsgX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -95,7 +95,7 @@ TEST(SyscallExit, sendmsgX_snaplen)
 	struct iovec iov[3];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr*)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";

--- a/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -17,14 +17,14 @@ TEST(SyscallExit, sendtoX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* Cleaning phase */
@@ -72,14 +72,14 @@ TEST(SyscallExit, sendtoX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr*)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* Cleaning phase */

--- a/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
@@ -20,7 +20,7 @@ TEST(SyscallExit, socketX)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -26,7 +26,7 @@ TEST(SyscallExit, socketcall_socketX)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	struct clone_args cl_args = {0};
+	clone_args cl_args = {0};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -96,7 +96,7 @@ TEST(SyscallExit, socketcall_bindX)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket", server_socket_fd, NOT_EQUAL, -1);
 	evt_test->server_reuse_address_port(server_socket_fd);
 
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
 	unsigned long args[3] = {0};
@@ -149,14 +149,14 @@ TEST(SyscallExit, socketcall_connectX)
 	assert_syscall_state(SYSCALL_SUCCESS, "socket (client)", client_socket_fd, NOT_EQUAL, -1);
 	evt_test->client_reuse_address_port(client_socket_fd);
 
-	struct sockaddr_in client_addr;
+	sockaddr_in client_addr;
 	evt_test->client_fill_sockaddr_in(&client_addr);
 
 	/* We need to bind the client socket with an address otherwise we cannot assert against it. */
-	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (struct sockaddr *)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "bind (client)", syscall(__NR_bind, client_socket_fd, (sockaddr*)&client_addr, sizeof(client_addr)), NOT_EQUAL, -1);
 
 	/* Now we associate the client socket with the server address. */
-	struct sockaddr_in server_addr;
+	sockaddr_in server_addr;
 	evt_test->server_fill_sockaddr_in(&server_addr);
 
 	/* With `SOCK_DGRAM` the `connect` will not perform a connection this is why the syscall doesn't fail. */
@@ -365,8 +365,8 @@ TEST(SyscallExit, socketcall_acceptX_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -448,8 +448,8 @@ TEST(SyscallExit, socketcall_acceptX_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in6 client_addr = {0};
-	struct sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {0};
+	sockaddr_in6 server_addr = {0};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -617,7 +617,7 @@ TEST(SyscallExit, socketcall_acceptX_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 
 	unsigned long args[3] = {0};
@@ -678,12 +678,12 @@ TEST(SyscallExit, socketcall_accept4X_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 
@@ -753,12 +753,12 @@ TEST(SyscallExit, socketcall_accept4X_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in6 client_addr = {0};
-	struct sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {0};
+	sockaddr_in6 server_addr = {0};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 
@@ -834,7 +834,7 @@ TEST(SyscallExit, socketcall_accept4X_UNIX)
 	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 
@@ -906,7 +906,7 @@ TEST(SyscallExit, socketcall_accept4X_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int32_t mock_fd = -1;
-	struct sockaddr *addr = NULL;
+	sockaddr* addr = NULL;
 	socklen_t *addrlen = NULL;
 	int flags = 0;
 
@@ -1014,14 +1014,14 @@ TEST(SyscallExit, socketcall_recvfromX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -1031,9 +1031,9 @@ TEST(SyscallExit, socketcall_recvfromX_no_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	/// TODO: if we use `struct sockaddr_in* src_addr = NULL` kernel module and old bpf are not able to get correct data.
+	/// TODO: if we use `sockaddr_in* src_addr = NULL` kernel module and old bpf are not able to get correct data.
 	/// Fixing them means changing how we retrieve network data, so it would be quite a big change.
-	struct sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {0};
 	socklen_t addrlen = sizeof(src_addr);
 
 	unsigned long args[6] = {0};
@@ -1097,14 +1097,14 @@ TEST(SyscallExit, socketcall_recvfromX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -1114,7 +1114,7 @@ TEST(SyscallExit, socketcall_recvfromX_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	struct sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {0};
 	socklen_t addrlen = sizeof(src_addr);
 
 	unsigned long args[6] = {0};
@@ -1181,7 +1181,7 @@ TEST(SyscallExit, socketcall_recvfromX_fail)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t flags = 0;
-	struct sockaddr *src_addr = NULL;
+	sockaddr* src_addr = NULL;
 	socklen_t *addrlen = NULL;
 
 	unsigned long args[6] = {0};
@@ -1370,8 +1370,8 @@ TEST(SyscallExit, socketcall_sendtoX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1433,8 +1433,8 @@ TEST(SyscallExit, socketcall_sendtoX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1498,7 +1498,7 @@ TEST(SyscallExit, socketcall_sendtoX_fail)
 	char sent_data[DEFAULT_SNAPLEN / 2] = "some-data";
 	size_t len = DEFAULT_SNAPLEN / 2;
 	uint32_t sendto_flags = 0;
-	struct sockaddr *dest_addr = NULL;
+	sockaddr* dest_addr = NULL;
 	socklen_t addrlen = 0;
 
 	unsigned long args[6] = {0};
@@ -1551,7 +1551,7 @@ TEST(SyscallExit, socketcall_sendtoX_empty)
 	char *sent_data = NULL;
 	size_t len = 0;
 	uint32_t sendto_flags = 0;
-	struct sockaddr *dest_addr = NULL;
+	sockaddr* dest_addr = NULL;
 	socklen_t addrlen = 0;
 
 	unsigned long args[6] = {0};
@@ -1611,8 +1611,8 @@ TEST(SyscallExit, socketcall_sendmsgX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1620,7 +1620,7 @@ TEST(SyscallExit, socketcall_sendmsgX_no_snaplen)
 	struct iovec iov[2];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr *)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
@@ -1684,8 +1684,8 @@ TEST(SyscallExit, socketcall_sendmsgX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1693,7 +1693,7 @@ TEST(SyscallExit, socketcall_sendmsgX_snaplen)
 	struct iovec iov[3];
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
-	send_msg.msg_name = (struct sockaddr *)&server_addr;
+	send_msg.msg_name = (sockaddr*)&server_addr;
 	send_msg.msg_namelen = sizeof(server_addr);
 	char sent_data_1[FIRST_MESSAGE_LEN] = "hey! there is a first message here.";
 	char sent_data_2[SECOND_MESSAGE_LEN] = "hey! there is a second message here.";
@@ -1942,14 +1942,14 @@ TEST(SyscallExit, socketcall_recvmsgX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[NO_SNAPLEN_MESSAGE_LEN] = NO_SNAPLEN_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -1960,7 +1960,7 @@ TEST(SyscallExit, socketcall_recvmsgX_no_snaplen)
 	struct iovec iov[2];
 	memset(&recv_msg, 0, sizeof(recv_msg));
 	memset(iov, 0, sizeof(iov));
-	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_name = (sockaddr*)&client_addr;
 	recv_msg.msg_namelen = sizeof(client_addr);
 	char data_1[MAX_RECV_BUF_SIZE];
 	char data_2[MAX_RECV_BUF_SIZE];
@@ -2048,14 +2048,14 @@ TEST(SyscallExit, socketcall_recvmsgX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_in client_addr = {0};
-	struct sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {0};
+	sockaddr_in server_addr = {0};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
 	char sent_data[FULL_MESSAGE_LEN] = FULL_MESSAGE;
 	uint32_t sendto_flags = 0;
-	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	int64_t sent_bytes = syscall(__NR_sendto, client_socket_fd, sent_data, sizeof(sent_data), sendto_flags, (sockaddr*)&server_addr, sizeof(server_addr));
 	assert_syscall_state(SYSCALL_SUCCESS, "sendto (client)", sent_bytes, NOT_EQUAL, -1);
 
 	/* The server accepts the connection and receives the message */
@@ -2066,7 +2066,7 @@ TEST(SyscallExit, socketcall_recvmsgX_snaplen)
 	struct iovec iov[2];
 	memset(&recv_msg, 0, sizeof(recv_msg));
 	memset(iov, 0, sizeof(iov));
-	recv_msg.msg_name = (struct sockaddr *)&client_addr;
+	recv_msg.msg_name = (sockaddr*)&client_addr;
 	recv_msg.msg_namelen = sizeof(client_addr);
 	char data_1[MAX_RECV_BUF_SIZE];
 	char data_2[MAX_RECV_BUF_SIZE];

--- a/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
+++ b/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
@@ -75,7 +75,7 @@ TEST(gvisor_parsers, parse_execve_e)
 
     EXPECT_EQ(res.scap_events.size(), 1);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 1);
     EXPECT_STREQ(static_cast<const char*>(decoded_params[0].buf), "/usr/bin/ls");
@@ -159,7 +159,7 @@ TEST(gvisor_parsers, parse_execve_x)
 
     EXPECT_EQ(res.scap_events.size(), 1);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 27);
     EXPECT_STREQ(static_cast<const char*>(decoded_params[1].buf), "/usr/bin/ls"); // exe
@@ -191,7 +191,7 @@ TEST(gvisor_parsers, parse_fork_e)
 
     EXPECT_EQ(res.scap_events[0]->type, PPME_SYSCALL_FORK_20_E);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 0);
 }
@@ -222,7 +222,7 @@ TEST(gvisor_parsers, parse_fork_x)
 
     EXPECT_EQ(res.scap_events.size(), 1);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 21);
     EXPECT_STREQ(static_cast<const char*>(decoded_params[1].buf), "ls"); // exe
@@ -253,7 +253,7 @@ TEST(gvisor_parsers, parse_clone_e)
 
     EXPECT_EQ(res.scap_events[0]->type, PPME_SYSCALL_CLONE_20_E);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 0);
 }
@@ -283,7 +283,7 @@ TEST(gvisor_parsers, parse_clone_x)
 
     EXPECT_EQ(res.scap_events.size(), 1);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 21);
     EXPECT_STREQ(static_cast<const char*>(decoded_params[1].buf), "ls"); // exe
@@ -320,7 +320,7 @@ TEST(gvisor_parsers, parse_socketpair_e)
 
     EXPECT_EQ(res.scap_events[0]->type, PPME_SOCKET_SOCKETPAIR_E);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 3);
 
@@ -366,7 +366,7 @@ TEST(gvisor_parsers, parse_socketpair_x)
 
     EXPECT_EQ(res.scap_events[0]->type, PPME_SOCKET_SOCKETPAIR_X);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
     EXPECT_EQ(n, 5);
 

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -6,9 +6,9 @@
 #include <syscall.h>
 #include <helpers/engines.h>
 
-static enum falcosecurity_log_severity severity_level = FALCOSECURITY_LOG_SEV_WARNING;
+static falcosecurity_log_severity severity_level = FALCOSECURITY_LOG_SEV_WARNING;
 
-static void test_open_log_fn(const char* component, const char* msg, const enum falcosecurity_log_severity sev)
+static void test_open_log_fn(const char* component, const char* msg, falcosecurity_log_severity sev)
 {
 	if(sev <= severity_level)
 	{
@@ -240,10 +240,10 @@ TEST(modern_bpf, double_scap_stats_call)
 	ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS);
 	ASSERT_GT(stats.n_evts, 0);
 
-	/* Double call */	
+	/* Double call */
 	ASSERT_EQ(scap_get_stats(h, &stats), SCAP_SUCCESS);
 	ASSERT_GT(stats.n_evts, 0);
-	
+
 	ASSERT_EQ(scap_stop_capture(h), SCAP_SUCCESS);
 	scap_close(h);
 }

--- a/test/libscap/test_suites/userspace/scap_event.cpp
+++ b/test/libscap/test_suites/userspace/scap_event.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include <scap.h>
 #include <gtest/gtest.h>
 
-// fills the buffer with ASCII data to catch bugs 
+// fills the buffer with ASCII data to catch bugs
 static void fill_buffer(scap_sized_buffer buf)
 {
     char *cbuf = static_cast<char*>(buf.buf);
@@ -44,7 +44,7 @@ static void fill_buffer(scap_sized_buffer buf)
 // This function behaves exactly like scap_event_encode_params but it will allocate the event and return it by setting the event pointer.
 static int32_t scap_event_generate(scap_evt **event, char *error, ppm_event_code event_type, uint32_t n, ...)
 {
-    struct scap_sized_buffer event_buf = {NULL, 0};
+    scap_sized_buffer event_buf = {NULL, 0};
     size_t event_size;
     va_list args;
     va_start(args, n);
@@ -93,7 +93,7 @@ TEST(scap_event, empty_clone)
 
     EXPECT_EQ(evt->nparams, 0);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
     EXPECT_EQ(n, 0);
 }
@@ -109,7 +109,7 @@ TEST(scap_event, int_args)
 
     EXPECT_EQ(evt->nparams, 2);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
     EXPECT_EQ(n, 2);
     EXPECT_EQ(decoded_params[0].size, sizeof(uint64_t));
@@ -135,7 +135,7 @@ TEST(scap_event, empty_buffers)
 
     EXPECT_EQ(evt->nparams, 2);
 
-    struct scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
+    scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
     uint32_t n = scap_event_decode_params(evt.get(), decoded_params);
     EXPECT_EQ(n, 2);
     EXPECT_EQ(decoded_params[0].size, sizeof(uint64_t));

--- a/test/libscap/test_suites/userspace/scap_ppm_sc.cpp
+++ b/test/libscap/test_suites/userspace/scap_ppm_sc.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include <sys/syscall.h>
 
-extern const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
+extern const syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
 
 TEST(scap_ppm_sc, scap_get_modifies_state_ppm_sc)
 {
@@ -98,7 +98,7 @@ TEST(scap_ppm_sc, scap_get_events_from_ppm_sc)
 		ASSERT_EQ(scap_get_events_from_ppm_sc(ppm_sc_array, events_array), SCAP_SUCCESS);
 		for(int sys_id = 0; sys_id < SYSCALL_TABLE_SIZE; sys_id++)
 		{
-			struct syscall_evt_pair pair = g_syscall_table[sys_id];
+			syscall_evt_pair pair = g_syscall_table[sys_id];
 			if(pair.ppm_sc == ppm_sc)
 			{
 				ASSERT_TRUE(events_array[pair.enter_event_type]) << "ppm_sc: " << scap_get_ppm_sc_name((ppm_sc_code)pair.ppm_sc) << " (" << pair.ppm_sc << ") should be associated with event: " << pair.enter_event_type << std::endl;
@@ -143,7 +143,7 @@ TEST(scap_ppm_sc, scap_get_ppm_sc_from_events)
 		ASSERT_EQ(scap_get_ppm_sc_from_events(events_array, ppm_sc_array), SCAP_SUCCESS);
 		for(int sys_id = 0; sys_id < SYSCALL_TABLE_SIZE; sys_id++)
 		{
-			struct syscall_evt_pair pair = g_syscall_table[sys_id];
+			syscall_evt_pair pair = g_syscall_table[sys_id];
 			if(pair.enter_event_type == evt_id || pair.exit_event_type == evt_id)
 			{
 				ASSERT_TRUE(ppm_sc_array[pair.ppm_sc]) << "event: " << scap_get_event_info_table()[evt_id].name << " (" << evt_id << ") should be associated with ppm_sc: " << pair.ppm_sc << std::endl;

--- a/test/libscap/test_suites/userspace/syscall_table.cpp
+++ b/test/libscap/test_suites/userspace/syscall_table.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include <scap.h>
 #include <gtest/gtest.h>
 
-extern const struct syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
+extern const syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
 
 /* Each syscall_id should have its own PPM_SC, note that this should be true also for generic syscalls
  * only the event type is generic, the PPM_SC code is defined! This test is architecture dependent!

--- a/userspace/chisel/chisel.h
+++ b/userspace/chisel/chisel.h
@@ -43,11 +43,11 @@ typedef struct lua_State lua_State;
 /*!
   \brief This is the class that compiles and runs filters.
 */
-typedef struct chiseldir_info
+struct chiseldir_info
 {
 	bool m_need_to_resolve;
 	std::string m_dir;
-}chiseldir_info;
+};
 
 class chiselarg_desc
 {

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -1477,7 +1477,7 @@ int lua_cbacks::udp_send(lua_State *ls)
 	string message(lua_tostring(ls, 1));
 
 	if(sendto(ch->m_udp_socket, message.c_str(), message.size(), 0,
-		(struct sockaddr *)&ch->m_serveraddr, sizeof(ch->m_serveraddr)) < 0)
+		(sockaddr*)&ch->m_serveraddr, sizeof(ch->m_serveraddr)) < 0)
 	{
 		string err = "udp_send error: cannot send the buffer: ";
 		fprintf(stderr, "%s\n", err.c_str());

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -33,7 +33,7 @@ static sinsp_filter_check_list s_filterlist;
 //
 //
 // Table sorter functor
-typedef struct table_row_cmp
+struct table_row_cmp
 {
 	bool operator()(const chisel_sample_row& src, const chisel_sample_row& dst)
 	{
@@ -72,7 +72,7 @@ typedef struct table_row_cmp
 	uint32_t m_colid;
 	ppm_param_type m_type;
 	bool m_ascending;
-}table_row_cmp;
+};
 
 chisel_table::chisel_table(sinsp* inspector, tabletype type, uint64_t refresh_interval_ns,
 	chisel_table::output_type output_type, uint32_t json_first_row, uint32_t json_last_row)

--- a/userspace/chisel/chisel_table.h
+++ b/userspace/chisel/chisel_table.h
@@ -23,7 +23,7 @@ limitations under the License.
 #define CHISEL_TABLE_DEFAULT_REFRESH_INTERVAL_NS 1000000000
 #define CHISEL_TABLE_BUFFER_ENTRY_SIZE 16384
 
-typedef enum chisel_table_action
+enum chisel_table_action
 {
 	STA_NONE,
 	STA_PARENT_HANDLE,
@@ -38,7 +38,7 @@ typedef enum chisel_table_action
 	STA_SPECTRO,
 	STA_SPECTRO_FILE,
 	STA_DESTROY_CHILD,
-} chisel_table_action;
+};
 
 class chisel_table_field
 {

--- a/userspace/chisel/chisel_viewinfo.cpp
+++ b/userspace/chisel/chisel_viewinfo.cpp
@@ -323,13 +323,13 @@ void chisel_view_manager::add(chisel_view_info* vinfo)
 	m_views.push_back(*vinfo);
 }
 
-typedef struct view_cmp
+struct view_cmp
 {
 	bool operator()(const chisel_view_info& src, const chisel_view_info& dst)
 	{
 		return src.m_name < dst.m_name;
 	}
-}table_row_cmp;
+};
 
 void chisel_view_manager::sort_views()
 {

--- a/userspace/chisel/chisel_viewinfo.h
+++ b/userspace/chisel/chisel_viewinfo.h
@@ -25,7 +25,7 @@ limitations under the License.
 //
 // Aggregation type for table fields
 //
-typedef enum chisel_field_aggregation
+enum chisel_field_aggregation
 {
 	A_NONE,
 	A_SUM,
@@ -33,7 +33,7 @@ typedef enum chisel_field_aggregation
 	A_TIME_AVG,
 	A_MIN,
 	A_MAX,
-} chisel_field_aggregation;
+};
 
 //
 // chisel_view_column_info flags

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -45,7 +45,7 @@ namespace scap_gvisor {
 extern "C"{
 #endif
 
-static int32_t scap_gvisor_init_platform(struct scap_platform* platform, char* lasterr, struct scap_engine_handle engine, struct scap_open_args* oargs)
+static int32_t scap_gvisor_init_platform(scap_platform* platform, char* lasterr, scap_engine_handle engine, struct scap_open_args* oargs)
 {
 	auto gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(platform);
 	auto params = reinterpret_cast<scap_gvisor_engine_params *>(oargs->engine_params);
@@ -63,7 +63,7 @@ static int32_t get_fdinfos(void* ctx, const scap_threadinfo *tinfo, uint64_t *n,
 	return gv->get_fdinfos(tinfo, n, fdinfos);
 }
 
-static int32_t scap_gvisor_refresh_proc_table(struct scap_platform* platform, struct scap_proclist* proclist)
+static int32_t scap_gvisor_refresh_proc_table(scap_platform* platform, struct scap_proclist* proclist)
 {
 	auto gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(platform);
 	scap_gvisor::platform *gv = gvisor_platform->m_platform.get();
@@ -85,23 +85,23 @@ static int32_t scap_gvisor_refresh_proc_table(struct scap_platform* platform, st
 	return scap_proc_scan_vtable(gvisor_platform->m_lasterr, proclist, n, tinfos, gv, get_fdinfos);
 }
 
-static int32_t scap_gvisor_close_platform(struct scap_platform* platform)
+static int32_t scap_gvisor_close_platform(scap_platform* platform)
 {
 	return SCAP_SUCCESS;
 }
 
-static void scap_gvisor_free_platform(struct scap_platform* platform)
+static void scap_gvisor_free_platform(scap_platform* platform)
 {
 	auto gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(platform);
 	delete gvisor_platform;
 }
 
-bool scap_gvisor_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t tid, const char* comm)
+bool scap_gvisor_is_thread_alive(scap_platform* platform, int64_t pid, int64_t tid, const char* comm)
 {
 	return true; // TODO we actually need a real implementation
 }
 
-static int32_t gvisor_get_threadlist(struct scap_platform* platform, struct ppm_proclist_info **procinfo_p, char *lasterr)
+static int32_t gvisor_get_threadlist(scap_platform* platform, ppm_proclist_info** procinfo_p, char *lasterr)
 {
 	if(*procinfo_p == NULL)
 	{
@@ -117,7 +117,7 @@ static int32_t gvisor_get_threadlist(struct scap_platform* platform, struct ppm_
 	return SCAP_SUCCESS;
 }
 
-static const struct scap_platform_vtable scap_gvisor_platform_vtable = {
+static const scap_platform_vtable scap_gvisor_platform_vtable = {
 	.init_platform = scap_gvisor_init_platform,
 	.refresh_addr_list = NULL,
 	.get_device_by_mount_id = NULL,
@@ -154,57 +154,57 @@ static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout, params->gvisor_platform);
 }
 
-static void gvisor_free_handle(struct scap_engine_handle engine)
+static void gvisor_free_handle(scap_engine_handle engine)
 {
 	delete engine.m_handle;
 }
 
-static int32_t gvisor_start_capture(struct scap_engine_handle engine)
+static int32_t gvisor_start_capture(scap_engine_handle engine)
 {
 	return engine.m_handle->start_capture();
 }
 
-static int32_t gvisor_close(struct scap_engine_handle engine)
+static int32_t gvisor_close(scap_engine_handle engine)
 {
 	return engine.m_handle->close();
 }
 
-static int32_t gvisor_stop_capture(struct scap_engine_handle engine)
+static int32_t gvisor_stop_capture(scap_engine_handle engine)
 {
 	return engine.m_handle->stop_capture();
 }
 
-static int32_t gvisor_next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
+static int32_t gvisor_next(scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
 	return engine.m_handle->next(pevent, pdevid, pflags);
 }
 
-static int32_t gvisor_configure(struct scap_engine_handle engine, enum scap_setting setting, unsigned long arg1, unsigned long arg2)
+static int32_t gvisor_configure(scap_engine_handle engine, scap_setting setting, unsigned long arg1, unsigned long arg2)
 {
 	return SCAP_SUCCESS;
 }
 
-static int32_t gvisor_get_stats(struct scap_engine_handle engine, scap_stats* stats)
+static int32_t gvisor_get_stats(scap_engine_handle engine, scap_stats* stats)
 {
 	return engine.m_handle->get_stats(stats);
 }
 
-static const struct scap_stats_v2* gvisor_get_stats_v2(struct scap_engine_handle engine, uint32_t flags, uint32_t* nstats, int32_t* rc)
+static const struct scap_stats_v2* gvisor_get_stats_v2(scap_engine_handle engine, uint32_t flags, uint32_t* nstats, int32_t* rc)
 {
 	return engine.m_handle->get_stats_v2(flags, nstats, rc);
 }
 
-static int32_t gvisor_get_n_tracepoint_hit(struct scap_engine_handle engine, long* ret)
+static int32_t gvisor_get_n_tracepoint_hit(scap_engine_handle engine, long* ret)
 {
 	return SCAP_NOT_SUPPORTED;
 }
 
-static uint32_t gvisor_get_n_devs(struct scap_engine_handle engine)
+static uint32_t gvisor_get_n_devs(scap_engine_handle engine)
 {
 	return 0;
 }
 
-static uint64_t gvisor_get_max_buf_used(struct scap_engine_handle engine)
+static uint64_t gvisor_get_max_buf_used(scap_engine_handle engine)
 {
 	return 0;
 }

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -497,7 +497,7 @@ int32_t engine::process_message_from_fd(int fd)
 		{
 			snprintf(m_lasterr, SCAP_LASTERR_SIZE,"Cannot realloc gvisor buffer to %zu", parse_result.size);
 			return SCAP_FAILURE;
-		};
+		}
 		parse_result = parsers::parse_gvisor_proto(id, gvisor_msg, m_sandbox_data[fd].m_buf);
 	}
 

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -282,7 +282,7 @@ bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, 
 	scapevt->type = PPME_CONTAINER_JSON_2_E;
 	scapevt->nparams = 1;
 
-	uint32_t* lens = (uint32_t*)((char *)scapevt + sizeof(struct ppm_evt_hdr));
+	uint32_t* lens = (uint32_t*)((char *)scapevt + sizeof(ppm_evt_hdr));
 	char* valptr = (char*)lens + sizeof(uint32_t);
 
 	*lens = (uint32_t)json.length() + 1;
@@ -711,4 +711,3 @@ void sinsp_container_manager::set_container_labels_max_len(uint32_t max_label_le
 {
 	sinsp_container_info::m_container_label_max_length = max_label_len;
 }
-

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -85,8 +85,8 @@ inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string 
 {
 	dns_info dinfo;
 
-	struct addrinfo hints, *result, *rp;
-	memset(&hints, 0, sizeof(struct addrinfo));
+	addrinfo hints, *result, *rp;
+	memset(&hints, 0, sizeof(addrinfo));
 
 	// Allow IPv4 or IPv6, all socket types, all protocols
 	hints.ai_family = AF_UNSPEC;
@@ -98,12 +98,12 @@ inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string 
 		{
 			if(rp->ai_family == AF_INET)
 			{
-				dinfo.m_v4_addrs.insert(((struct sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
+				dinfo.m_v4_addrs.insert(((sockaddr_in*)rp->ai_addr)->sin_addr.s_addr);
 			}
 			else // AF_INET6
 			{
 				ipv6addr v6;
-				memcpy(v6.m_b, ((struct sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
+				memcpy(v6.m_b, ((sockaddr_in6*)rp->ai_addr)->sin6_addr.s6_addr, sizeof(ipv6addr));
 				dinfo.m_v6_addrs.insert(v6);
 			}
 		}

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -239,7 +239,7 @@ const char *sinsp_evt::get_param_name(uint32_t id)
 	return m_info->params[id].name;
 }
 
-const struct ppm_param_info* sinsp_evt::get_param_info(uint32_t id)
+const ppm_param_info* sinsp_evt::get_param_info(uint32_t id)
 {
 	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0)
 	{
@@ -875,8 +875,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 		memcpy(&dyn_idx, param->m_val, sizeof(uint8_t));
 
 		if(dyn_idx < param_info->ninfo) {
-			const struct ppm_param_info* dyn_params =
-				(const struct ppm_param_info*)param_info->info;
+			auto dyn_params = (const ppm_param_info*)param_info->info;
 
 			dyn_param = sinsp_evt_param(param->m_evt, param->m_idx,
 				param->m_val + sizeof(uint8_t), param->m_len - sizeof(uint8_t));
@@ -1426,7 +1425,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				     m_paramstr_storage.size(),
 				     "%" PRIu32, val);
 
-			const struct ppm_name_value *flags = (const struct ppm_name_value *)m_info->params[id].info;
+			auto flags = (const ppm_name_value*)m_info->params[id].info;
 			const bool exact_match = param_info->type == PT_ENUMFLAGS8 || param_info->type == PT_ENUMFLAGS16 || param_info->type == PT_ENUMFLAGS32;
 			const char *separator = "";
 			uint32_t initial_val = val;
@@ -1488,7 +1487,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					m_paramstr_storage.size(),
 					prfmt, val);
 
-			const struct ppm_name_value *mode = (const struct ppm_name_value *)m_info->params[id].info;
+			auto mode = (const ppm_name_value*)m_info->params[id].info;
 			const char *separator = "";
 			uint32_t initial_val = val;
 			uint32_t j = 0;
@@ -2181,7 +2180,7 @@ std::optional<std::reference_wrapper<const std::string>> sinsp_evt::get_enter_ev
 
 void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const
 {
-	const struct ppm_param_info* parinfo = get_info();
+	const ppm_param_info* parinfo = get_info();
 
 	std::stringstream ss;
 	ss << "could not parse param " << m_idx << " (" << parinfo->name << ") for event "
@@ -2191,7 +2190,7 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const
 	throw sinsp_exception(ss.str());
 }
 
-const struct ppm_param_info* sinsp_evt_param::get_info() const
+const ppm_param_info* sinsp_evt_param::get_info() const
 {
 	return &(m_evt->get_info()->params[m_idx]);
 }

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -36,8 +36,8 @@ limitations under the License.
 #include "settings.h"
 #include "sinsp_exception.h"
 
-typedef class sinsp sinsp;
-typedef class sinsp_threadinfo sinsp_threadinfo;
+class sinsp;
+class sinsp_threadinfo;
 class sinsp_evt;
 
 namespace test_helpers {
@@ -45,11 +45,10 @@ namespace test_helpers {
 	class sinsp_mock;
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // Event arguments
 ///////////////////////////////////////////////////////////////////////////////
-typedef enum filtercheck_field_flags
+enum filtercheck_field_flags
 {
 	EPF_NONE              = 0,
 	EPF_FILTER_ONLY       = 1 << 0, ///< this field can only be used as a filter.
@@ -63,12 +62,12 @@ typedef enum filtercheck_field_flags
 	EPF_ARG_INDEX         = 1 << 8, ///< this field accepts numeric arguments.
 	EPF_ARG_KEY           = 1 << 9, ///< this field accepts string arguments.
 	EPF_DEPRECATED        = 1 << 10,///< this field is deprecated.
-}filtercheck_field_flags;
+};
 
 /*!
   \brief Information about a filter/formatting field.
 */
-typedef struct filtercheck_field_info
+struct filtercheck_field_info
 {
 	ppm_param_type m_type; ///< Field type.
 	uint32_t m_flags;  ///< Field flags.
@@ -76,7 +75,7 @@ typedef struct filtercheck_field_info
 	char m_name[64];  ///< Field name.
 	char m_display[64];  ///< Field display name (short description). May be empty.
 	char m_description[1024];  ///< Field description.
-}filtercheck_field_info;
+};
 
 /** @defgroup event Event manipulation
  * Classes to manipulate events, extract their content and convert them into strings.

--- a/userspace/libsinsp/events/sinsp_events.cpp
+++ b/userspace/libsinsp/events/sinsp_events.cpp
@@ -17,49 +17,49 @@ bool libsinsp::events::is_generic(ppm_event_code event_type)
 bool libsinsp::events::is_unused_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
+	ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
 	return (flags & EF_UNUSED);
 }
 
 bool libsinsp::events::is_skip_parse_reset_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
+	ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
 	return (flags & EF_SKIPPARSERESET);
 }
 
 bool libsinsp::events::is_old_version_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
+	ppm_event_flags flags = scap_get_event_info_table()[event_type].flags;
 	return (flags & EF_OLD_VERSION);
 }
 
 bool libsinsp::events::is_syscall_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
+	ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	return (category & EC_SYSCALL);
 }
 
 bool libsinsp::events::is_tracepoint_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
+	ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	return (category & EC_TRACEPOINT);
 }
 
 bool libsinsp::events::is_metaevent(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
+	ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	return (category & EC_METAEVENT);
 }
 
 bool libsinsp::events::is_unknown_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
+	ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	/* Please note this is not an `&` but an `==` if one event has
 	 * the `EC_UNKNOWN` category, it must have only this category!
 	 */
@@ -69,7 +69,7 @@ bool libsinsp::events::is_unknown_event(ppm_event_code event_type)
 bool libsinsp::events::is_plugin_event(ppm_event_code event_type)
 {
 	ASSERT(event_type < PPM_EVENT_MAX);
-	enum ppm_event_category category = scap_get_event_info_table()[event_type].category;
+	ppm_event_category category = scap_get_event_info_table()[event_type].category;
 	return (category & EC_PLUGIN);
 }
 

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -57,14 +57,14 @@ limitations under the License.
  *  @{
  */
 
-typedef union _sinsp_sockinfo
+union sinsp_sockinfo
 {
 	ipv4tuple m_ipv4info; ///< The tuple if this an IPv4 socket.
 	ipv6tuple m_ipv6info; ///< The tuple if this an IPv6 socket.
 	ipv4serverinfo m_ipv4serverinfo;  ///< Information about an IPv4 server socket.
 	ipv6serverinfo m_ipv6serverinfo; ///< Information about an IPv6 server socket.
 	unix_tuple m_unixinfo; ///< The tuple if this a unix socket.
-}sinsp_sockinfo;
+};
 
 /*!
   \brief File Descriptor information class.

--- a/userspace/libsinsp/gen_filter.h
+++ b/userspace/libsinsp/gen_filter.h
@@ -97,10 +97,10 @@ public:
 
 };
 
-typedef struct extract_value {
+struct extract_value_t {
 	uint8_t* ptr;
 	uint32_t len;
-} extract_value_t;
+};
 
 class gen_event_filter_check
 {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -434,7 +434,7 @@ void sinsp_parser::process_event(sinsp_evt *evt)
 		break;
 	case PPME_SYSCALL_PRCTL_X:
 		parse_prctl_exit_event(evt);
-		break;		
+		break;
 	default:
 		break;
 	}
@@ -967,10 +967,10 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	 */
 
 	/*=============================== ENRICH/CREATE ESSENTIAL CALLER STATE ===========================*/
-	
+
 	/* Let's see if we have some info regarding the caller */
 	auto caller_tinfo = m_inspector->get_thread_ref(caller_tid, true);
-	
+
 	/* This happens only if we reach the max entries in our table otherwise we should obtain a new fresh empty
 	 * thread info to populate even if we are not able to recover any information!
 	 * If `caller_tinfo == nullptr` we return, we won't have enough space for the child in the table!
@@ -985,7 +985,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	/* We have an invalid thread:
 	 * 1. The process is dead and we are not able to find it in /proc.
 	 * 2. We have done too much /proc scan and we cannot recover it.
-	 */	
+	 */
 	if(caller_tinfo->is_invalid())
 	{
 		/* In case of invalid thread we enrich it with fresh info and we obtain a sort of valid thread info */
@@ -1017,7 +1017,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		case PPME_SYSCALL_CLONE3_X:
 			caller_tinfo->m_vtid = evt->get_param(18)->as<int64_t>();
 
-			caller_tinfo->m_vpid = evt->get_param(19)->as<int64_t>();		
+			caller_tinfo->m_vpid = evt->get_param(19)->as<int64_t>();
 			break;
 		default:
 			ASSERT(false);
@@ -1072,10 +1072,10 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	 * Please note: if only the child is running into a container
 	 * (so when the child is the init process of the new namespace)
 	 * this flag is not set
-	 * 
+	 *
 	 * PPM_CL_CLONE_NEWPID is true when:
 	 * - the child is the init process of a new namespace
-	 * 
+	 *
 	 * PPM_CL_CLONE_PARENT is set by `runc:[0:PARENT]` when it creates
 	 * the first process in the new pid namespace. In new sinsp versions
 	 * `PPM_CL_CHILD_IN_PIDNS` is enough but in old scap-files where we don't have
@@ -1083,13 +1083,13 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	 * is set since we don't know if the new child is in a pid namespace or not.
 	 * Moreover when `PPM_CL_CLONE_PARENT` is set `PPM_CL_CLONE_NEWPID` cannot
 	 * be set according to the clone manual.
-	 * 
+	 *
 	 * When `caller_tid != caller_tinfo->m_vtid` is true we are for
 	 * sure in a container, and so is the child.
 	 * This is not a strict requirement (leave it here for compatibility with old
 	 * scap-files)
 	 */
-	if(flags & PPM_CL_CHILD_IN_PIDNS || 
+	if(flags & PPM_CL_CHILD_IN_PIDNS ||
 		flags & PPM_CL_CLONE_NEWPID ||
 		flags & PPM_CL_CLONE_PARENT ||
 		caller_tid != caller_tinfo->m_vtid)
@@ -1200,7 +1200,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	{
 		/* pid */
 		child_tinfo->m_pid = caller_tinfo->m_pid;
-		
+
 		/* ptid */
 		/* The parent is the parent of the calling process */
 		child_tinfo->m_ptid = caller_tinfo->m_ptid;
@@ -1212,7 +1212,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		 */
 		child_tinfo->m_flags |= PPM_CL_CLONE_FILES;
 
-		/* If we are a new thread we keep the same lastexec time of the main thread 
+		/* If we are a new thread we keep the same lastexec time of the main thread
 		 * If the caller is invalid we are re-initializing this value to 0 again.
 		 */
 		child_tinfo->m_lastexec_ts = caller_tinfo->m_lastexec_ts;
@@ -1224,9 +1224,9 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 
 	/* vtid */
 	child_tinfo->m_vtid = child_tinfo->m_tid;
-	
+
 	/* vpid */
-	child_tinfo->m_vpid = child_tinfo->m_pid;	
+	child_tinfo->m_vpid = child_tinfo->m_pid;
 
 	/* exe */
 	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
@@ -1256,7 +1256,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	default:
 		ASSERT(false);
 	}
-	
+
 	/* fdlimit */
 	child_tinfo->m_fdlimit = evt->get_param(7)->as<int64_t>();
 
@@ -1924,7 +1924,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	if(evt->get_num_params() > 20)
 	{
 		/* If we are in container! */
-		if(child_tinfo->m_flags & PPM_CL_CHILD_IN_PIDNS || 
+		if(child_tinfo->m_flags & PPM_CL_CHILD_IN_PIDNS ||
 			child_tinfo->m_flags & PPM_CL_CLONE_NEWPID ||
 			child_tinfo->m_tid != child_tinfo->m_vtid)
 		{
@@ -1994,9 +1994,9 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 {
 	int64_t childtid = evt->get_param(0)->as<int64_t>();
 	/* Please note that if the child is in a namespace different from the init one
-	 * we should never use this `childtid` otherwise we will use a thread id referred to 
+	 * we should never use this `childtid` otherwise we will use a thread id referred to
 	 * an internal namespace and not to the init one!
-	 */	
+	 */
 	if(childtid < 0)
 	{
 		//
@@ -2049,7 +2049,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 		return;
 	}
 
-	/* In some corner cases an execve is thrown by a secondary thread when 
+	/* In some corner cases an execve is thrown by a secondary thread when
 	 * the main thread is already dead. In these cases the secondary thread
 	 * will become a main thread (it will change its tid) and here we will have
 	 * an execve exit event called by a main thread that is dead.
@@ -2231,7 +2231,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 		evt->m_tinfo->m_exepath = parinfo->m_val;
 	}
 	else
-	{	
+	{
 		/* ONLY VALID FOR OLD SCAP-FILES:
 		 * In older event versions we can only rely on our userspace reconstruction
 		 */
@@ -2481,7 +2481,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	 * execve, then all threads other than the thread group
 	 * leader are terminated, and the new program is executed in
 	 * the thread group leader.
-	 * 
+	 *
 	 * if `evt->m_tinfo->m_tginfo->get_thread_count() > 1` it means
 	 * we still have some not leader threads in the group.
 	 */
@@ -3748,7 +3748,7 @@ void sinsp_parser::parse_thread_exit(sinsp_evt *evt)
 	}
 
 	/* [Mark thread as dead]
-	 * We mark the thread as dead here and we will remove it 
+	 * We mark the thread as dead here and we will remove it
 	 * from the table during remove_thread().
 	 * Please note that the `!evt->m_tinfo->is_dead()` shouldn't be
 	 * necessary at all since here we shouldn't receive dead threads.
@@ -3760,7 +3760,7 @@ void sinsp_parser::parse_thread_exit(sinsp_evt *evt)
 	}
 	evt->m_tinfo->set_dead();
 
-	/* [Store the tid to remove] 
+	/* [Store the tid to remove]
 	 * We set the current tid to remove. We don't remove it here so we can parse the event
 	 */
 	m_inspector->m_tid_to_remove = evt->get_tid();
@@ -4159,16 +4159,16 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 
 			//
 			// Check if recvmsg contains ancillary data. If so, we check for SCM_RIGHTS,
-			// which is used to pass FDs between processes, and update the sinsp state 
+			// which is used to pass FDs between processes, and update the sinsp state
 			// accordingly via procfs scan.
 			//
 #ifndef _WIN32
 			if(etype == PPME_SOCKET_RECVMSG_X && evt->get_num_params() >= 5)
 			{
 				parinfo = evt->get_param(4);
-				if(parinfo->m_len > sizeof(struct cmsghdr))
+				if(parinfo->m_len > sizeof(cmsghdr))
 				{
-					struct cmsghdr *cmsg = (struct cmsghdr *)parinfo->m_val;
+					cmsghdr *cmsg = (cmsghdr *)parinfo->m_val;
 					if(cmsg->cmsg_type == SCM_RIGHTS)
 					{
 						char error[SCAP_LASTERR_SIZE];
@@ -4189,7 +4189,7 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 				}
 			}
 #endif
-		
+
 		}
 		else
 		{
@@ -5631,14 +5631,14 @@ void sinsp_parser::parse_memfd_create_exit(sinsp_evt *evt, scap_fd_type type)
 	/* ret (fd) */
 	ASSERT(evt->get_param_info(0)->type == PT_FD);
 	fd = evt->get_param(0)->as<int64_t>();
-	
+
 	/* name */
 	/*
-	Suppose you create a memfd named libstest resulting in a fd.name libstest while on disk 
+	Suppose you create a memfd named libstest resulting in a fd.name libstest while on disk
 	(e.g. ls -l /proc/$PID/fd/$FD_NUM) it may look like /memfd:libstest (deleted)
 	*/
 	auto name = evt->get_param(1)->as<std::string_view>();
-	
+
 	/* flags */
 	flags = evt->get_param(2)->as<uint32_t>();
 
@@ -5671,7 +5671,7 @@ void sinsp_parser::parse_pidfd_open_exit(sinsp_evt *evt)
 	/* pid (fd) */
 	ASSERT(evt->get_param_info(1)->type == PT_PID);
 	pid = evt->get_param(1)->as<int64_t>();
-	
+
 	/* flags */
 	flags = evt->get_param(2)->as<uint32_t>();
 
@@ -5726,7 +5726,7 @@ void sinsp_parser::parse_pidfd_getfd_exit(sinsp_evt *evt)
 	{
 		return;
 	}
-	
+
 	auto targetfd_fdinfo = pidfd_tinfo->get_fd(targetfd);
 	if (targetfd_fdinfo == nullptr)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -338,7 +338,7 @@ void sinsp::set_import_users(bool import_users)
 
 /*=============================== OPEN METHODS ===============================*/
 
-void sinsp::open_common(scap_open_args* oargs, const struct scap_vtable* vtable, struct scap_platform* platform,
+void sinsp::open_common(scap_open_args* oargs, const scap_vtable* vtable, scap_platform* platform,
 			sinsp_mode_t mode)
 {
 	libsinsp_logger()->log("Trying to open the right engine!");
@@ -466,14 +466,14 @@ void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, const libsinsp::eve
 	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
 
 	/* Engine-specific args. */
-	struct scap_kmod_engine_params params;
+	scap_kmod_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 	if(platform)
 	{
-		auto linux_plat = (struct scap_linux_platform*)platform;
+		auto linux_plat = (scap_linux_platform*)platform;
 		linux_plat->m_linux_vtable = &scap_kmod_linux_vtable;
 	}
 
@@ -498,12 +498,12 @@ void sinsp::open_bpf(const std::string& bpf_path, unsigned long driver_buffer_by
 	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
 
 	/* Engine-specific args. */
-	struct scap_bpf_engine_params params;
+	scap_bpf_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.bpf_probe = bpf_path.data();
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 	open_common(&oargs, &scap_bpf_engine, platform, SINSP_MODE_LIVE);
 #else
 	throw sinsp_exception("BPF engine is not supported in this build");
@@ -514,12 +514,12 @@ void sinsp::open_nodriver(bool full_proc_scan)
 {
 #ifdef HAS_ENGINE_NODRIVER
 	scap_open_args oargs {};
-	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 	if(platform)
 	{
 		if(!full_proc_scan)
 		{
-			auto linux_plat = (struct scap_linux_platform*)platform;
+			auto linux_plat = (scap_linux_platform*)platform;
 			linux_plat->m_fd_lookup_limit = SCAP_NODRIVER_MAX_FD_LOOKUP;
 			linux_plat->m_minimal_scan = true;
 		}
@@ -539,7 +539,7 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 {
 #ifdef HAS_ENGINE_SAVEFILE
 	scap_open_args oargs {};
-	struct scap_savefile_engine_params params;
+	scap_savefile_engine_params params;
 
 	m_input_filename = filename;
 	m_input_fd = fd; /* default is 0. */
@@ -573,7 +573,7 @@ void sinsp::open_savefile(const std::string& filename, int fd)
 	params.fbuffer_size = 0;
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform = scap_savefile_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_savefile_alloc_platform(::on_new_entry_from_proc, this);
 	params.platform = platform;
 	open_common(&oargs, &scap_savefile_engine, platform, SINSP_MODE_CAPTURE);
 #else
@@ -585,13 +585,13 @@ void sinsp::open_plugin(const std::string& plugin_name, const std::string& plugi
 {
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
 	scap_open_args oargs {};
-	struct scap_source_plugin_engine_params params;
+	scap_source_plugin_engine_params params;
 	set_input_plugin(plugin_name, plugin_open_params);
 	params.input_plugin = &m_input_plugin->as_scap_source();
 	params.input_plugin_params = (char*)m_input_plugin_open_params.c_str();
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform;
+	scap_platform* platform;
 	switch(mode)
 	{
 		case SINSP_MODE_PLUGIN:
@@ -618,13 +618,13 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	}
 
 	scap_open_args oargs {};
-	struct scap_gvisor_engine_params params;
+	scap_gvisor_engine_params params;
 	params.gvisor_root_path = root_path.c_str();
 	params.gvisor_config_path = config_path.c_str();
 	params.no_events = no_events;
 	params.gvisor_epoll_timeout = epoll_timeout;
 
-	struct scap_platform* platform = scap_gvisor_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_gvisor_alloc_platform(::on_new_entry_from_proc, this);
 	params.gvisor_platform = reinterpret_cast<scap_gvisor_platform*>(platform);
 
 	oargs.engine_params = &params;
@@ -646,13 +646,13 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim, uint16_t cpus
 	fill_ppm_sc_of_interest(&oargs, ppm_sc_of_interest);
 
 	/* Engine-specific args. */
-	struct scap_modern_bpf_engine_params params;
+	scap_modern_bpf_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.cpus_for_each_buffer = cpus_for_each_buffer;
 	params.allocate_online_only = online_only;
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
+	scap_platform* platform = scap_linux_alloc_platform(::on_new_entry_from_proc, this);
 	open_common(&oargs, &scap_modern_bpf_engine, platform, SINSP_MODE_LIVE);
 #else
 	throw sinsp_exception("MODERN_BPF engine is not supported in this build");
@@ -663,11 +663,11 @@ void sinsp::open_test_input(scap_test_input_data* data, sinsp_mode_t mode)
 {
 #ifdef HAS_ENGINE_TEST_INPUT
 	scap_open_args oargs {};
-	struct scap_test_input_engine_params params;
+	scap_test_input_engine_params params;
 	params.test_input_data = data;
 	oargs.engine_params = &params;
 
-	struct scap_platform* platform;
+	scap_platform* platform;
 	switch(mode)
 	{
 	case SINSP_MODE_TEST:
@@ -1133,7 +1133,7 @@ void sinsp::get_procs_cpu_from_driver(uint64_t ts)
 		// create scap event
 		uint32_t evlen = sizeof(scap_evt) + 2 * sizeof(uint16_t) + 2 * sizeof(uint64_t);
 		auto piscapevt_buf = std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>>(new uint8_t[evlen]);
-		uint16_t* evt_lens = (uint16_t*) (piscapevt_buf.get() + sizeof(struct ppm_evt_hdr));
+		uint16_t* evt_lens = (uint16_t*) (piscapevt_buf.get() + sizeof(ppm_evt_hdr));
 		auto piscapevt = (scap_evt*) piscapevt_buf.get();
 		piscapevt->len = evlen;
 		piscapevt->type = PPME_PROCINFO_E;
@@ -1900,10 +1900,10 @@ void sinsp::print_capture_stats(sinsp_logger::severity sev) const
 		stats.n_drops_bug);
 }
 
-const struct scap_stats_v2* sinsp::get_capture_stats_v2(uint32_t flags, uint32_t* nstats, int32_t* rc) const
+const scap_stats_v2* sinsp::get_capture_stats_v2(uint32_t flags, uint32_t* nstats, int32_t* rc) const
 {
 	/* On purpose ignoring failures to not interrupt in case of stats retrieval failure. */
-	const struct scap_stats_v2* stats_v2 = scap_get_stats_v2(m_h, flags, nstats, rc);
+	const scap_stats_v2* stats_v2 = scap_get_stats_v2(m_h, flags, nstats, rc);
 	if (!stats_v2)
 	{
 		*nstats = 0;
@@ -2304,7 +2304,7 @@ uint64_t sinsp::get_new_ts() const
 			: m_lastevent_ts;
 }
 
-struct scap_platform* sinsp::get_scap_platform()
+scap_platform* sinsp::get_scap_platform()
 {
 	return m_platform;
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -151,7 +151,7 @@ public:
 /*!
   \brief Sinsp possible modes
 */
-typedef enum
+enum sinsp_mode_t
 {
 	/*!
 		 * Default value that mostly exists so that sinsp can have a valid value
@@ -180,7 +180,7 @@ typedef enum
 		 * Do not attempt to query the underlying system.
 	 */
 	SINSP_MODE_TEST,
-} sinsp_mode_t;
+};
 
 /** @defgroup inspector Main library
  @{
@@ -205,7 +205,6 @@ public:
 		  const std::string &static_image = "");
 
 	virtual ~sinsp() override;
-
 
 	/* Wrappers to open a specific engine. */
 	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const libsinsp::events::set<ppm_sc_code> &ppm_sc_of_interest = {});

--- a/userspace/libsinsp/sinsp_cgroup.cpp
+++ b/userspace/libsinsp/sinsp_cgroup.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<std::string> sinsp_cgroup::lookup_cgroup_dir(const std::string &
 void sinsp_cgroup::lookup_cgroups(sinsp_threadinfo& tinfo)
 {
 	std::string procdirname = m_root + "/proc/" + std::to_string(tinfo.m_tid) + '/';
-	struct scap_cgroup_set thread_cgroups = {};
+	scap_cgroup_set thread_cgroups = {};
 	char error[SCAP_LASTERR_SIZE];
 
 	int ret = scap_cgroup_get_thread(&m_scap_cgroup, procdirname.c_str(), &thread_cgroups, error);

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -162,7 +162,7 @@ sinsp_filter_check* sinsp_filter_check_event::allocate_new()
 	return (sinsp_filter_check*) new sinsp_filter_check_event();
 }
 
-int32_t sinsp_filter_check_event::extract_arg(string fldname, string val, OUT const struct ppm_param_info** parinfo)
+int32_t sinsp_filter_check_event::extract_arg(string fldname, string val, OUT const ppm_param_info** parinfo)
 {
 	uint32_t parsed_len = 0;
 
@@ -197,7 +197,7 @@ int32_t sinsp_filter_check_event::extract_arg(string fldname, string val, OUT co
 			throw sinsp_exception("wrong syntax for evt.around");
 		}
 
-		const struct ppm_param_info* pi =
+		const ppm_param_info* pi =
 			sinsp_utils::find_longest_matching_evt_param(val.substr(fldname.size() + 1));
 
 		if(pi == NULL)
@@ -222,7 +222,7 @@ int32_t sinsp_filter_check_event::extract_arg(string fldname, string val, OUT co
 	return parsed_len;
 }
 
-int32_t sinsp_filter_check_event::extract_type(string fldname, string val, OUT const struct ppm_param_info** parinfo)
+int32_t sinsp_filter_check_event::extract_type(string fldname, string val, OUT const ppm_param_info** parinfo)
 {
 	uint32_t parsed_len = 0;
 
@@ -360,7 +360,7 @@ void sinsp_filter_check_event::validate_filter_value(const char* str, uint32_t l
 	if(m_field_id == TYPE_TYPE)
 	{
 		sinsp_evttables* einfo = m_inspector->get_event_info_tables();
-		const struct ppm_event_info* etable = einfo->m_event_info;
+		const ppm_event_info* etable = einfo->m_event_info;
 		string stype(str, len);
 
 		for(uint32_t j = 0; j < PPM_EVENT_MAX; j++)

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -89,7 +89,7 @@ int32_t sinsp_filter_check_evtin::extract_arg(string fldname, string val)
 	}
 	else if(val[fldname.size()] == '.')
 	{
-		const struct ppm_param_info* pi =
+		const ppm_param_info* pi =
 			sinsp_utils::find_longest_matching_evt_param(val.substr(fldname.size() + 1));
 
 		if(pi == NULL)

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -145,7 +145,7 @@ sinsp_filter_check* sinsp_filter_check_thread::allocate_new()
 	return (sinsp_filter_check*) new sinsp_filter_check_thread();
 }
 
-int32_t sinsp_filter_check_thread::extract_arg(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo)
+int32_t sinsp_filter_check_thread::extract_arg(std::string fldname, std::string val, OUT const ppm_param_info** parinfo)
 {
 	std::string::size_type parsed_len = 0;
 

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -73,7 +73,7 @@ sinsp_filter_check* sinsp_filter_check_tracer::allocate_new()
 	return (sinsp_filter_check*) new sinsp_filter_check_tracer();
 }
 
-int32_t sinsp_filter_check_tracer::extract_arg(string fldname, string val, OUT const struct ppm_param_info** parinfo)
+int32_t sinsp_filter_check_tracer::extract_arg(string fldname, string val, OUT const ppm_param_info** parinfo)
 {
 	uint32_t parsed_len = 0;
 

--- a/userspace/libsinsp/sinsp_suppress.cpp
+++ b/userspace/libsinsp/sinsp_suppress.cpp
@@ -68,7 +68,7 @@ int32_t libsinsp::sinsp_suppress::process_event(scap_evt *e, uint16_t devid)
 		const char *comm = nullptr;
 		uint64_t *ptid = nullptr;
 
-		auto *lens = (uint16_t *)((char *)e + sizeof(struct ppm_evt_hdr));
+		auto *lens = (uint16_t *)((char *)e + sizeof(ppm_evt_hdr));
 		char *valptr = (char *)lens + e->nparams * sizeof(uint16_t);
 
 		ASSERT(e->nparams >= 14);

--- a/userspace/libsinsp/stats.h
+++ b/userspace/libsinsp/stats.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include <scap_machine_info.h>
 #include "threadinfo.h"
 
-typedef struct sinsp_stats_v2
+struct sinsp_stats_v2
 {
 	uint64_t m_n_noncached_fd_lookups;
 	uint64_t m_n_cached_fd_lookups;
@@ -40,9 +40,10 @@ typedef struct sinsp_stats_v2
 	uint32_t m_n_drops_full_threadtable;
 	uint32_t m_n_missing_container_images;
 	uint32_t m_n_containers;
-}sinsp_stats_v2;
+};
 
-typedef enum sinsp_stats_v2_resource_utilization {
+enum sinsp_stats_v2_resource_utilization
+{
 	SINSP_RESOURCE_UTILIZATION_CPU_PERC = 0, ///< Current CPU usage, `ps` like, unit: percentage of one CPU.
 	SINSP_RESOURCE_UTILIZATION_MEMORY_RSS, ///< Current RSS (Resident Set Size), unit: kb.
 	SINSP_RESOURCE_UTILIZATION_MEMORY_VSZ, ///< Current VSZ (Virtual Memory Size), unit: kb.
@@ -72,7 +73,7 @@ typedef enum sinsp_stats_v2_resource_utilization {
 	SINSP_STATS_V2_N_MISSING_CONTAINER_IMAGES, ///<  Number of cached containers (cgroups) without container info such as image, hijacked sinsp_container_manager::remove_inactive_containers() -> every flush snapshot update, unit: count.
 	SINSP_STATS_V2_N_CONTAINERS, ///<  Number of containers (cgroups) currently cached by sinsp_container_manager, hijacked sinsp_container_manager::remove_inactive_containers() -> every flush snapshot update, unit: count.
 	SINSP_MAX_STATS_V2
-}sinsp_stats_v2_resource_utilization;
+};
 
 #ifdef __linux__
 namespace libsinsp {

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -53,7 +53,7 @@ TEST(sinsp_thread_manager, thread_group_manager)
 TEST(sinsp_thread_manager, create_thread_dependencies_null_pointer)
 {
 	sinsp m_inspector;
-	struct scap_test_input_data data;
+	scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
@@ -68,7 +68,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_null_pointer)
 TEST(sinsp_thread_manager, create_thread_dependencies_invalid_tinfo)
 {
 	sinsp m_inspector;
-	struct scap_test_input_data data;
+	scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
@@ -86,7 +86,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_invalid_tinfo)
 TEST(sinsp_thread_manager, create_thread_dependencies_tginfo_already_there)
 {
 	sinsp m_inspector;
-	struct scap_test_input_data data;
+	scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
@@ -107,7 +107,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_tginfo_already_there)
 TEST(sinsp_thread_manager, create_thread_dependencies_new_tginfo)
 {
 	sinsp m_inspector;
-	struct scap_test_input_data data;
+	scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
@@ -128,7 +128,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_new_tginfo)
 TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo)
 {
 	sinsp m_inspector;
-	struct scap_test_input_data data;
+	scap_test_input_data data;
 	data.event_count = 0;
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -116,7 +116,7 @@ TEST_F(sinsp_with_test_input, bytebuf_empty_param)
 	int64_t test_errno = 0;
 
 	/* `PPME_SYSCALL_PWRITE_X` is a simple event that uses a `PT_BYTEBUF` */
-	struct scap_const_sized_buffer bytebuf_param;
+	scap_const_sized_buffer bytebuf_param;
 	bytebuf_param.buf = NULL;
 	bytebuf_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_PWRITE_X, 2, test_errno, bytebuf_param);
@@ -138,7 +138,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	int64_t fd = 0;
 
 	/* `PPME_SOCKET_CONNECT_E` is a simple event that uses a `PT_SOCKADDR` */
-	struct scap_const_sized_buffer sockaddr_param;
+	scap_const_sized_buffer sockaddr_param;
 	sockaddr_param.buf = NULL;
 	sockaddr_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, fd, sockaddr_param);
@@ -146,7 +146,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	ASSERT_EQ(param->m_len, 0);
 
 	/* `PPME_SOCKET_CONNECT_X` is a simple event that uses a `PT_SOCKTUPLE` */
-	struct scap_const_sized_buffer socktuple_param;
+	scap_const_sized_buffer socktuple_param;
 	socktuple_param.buf = NULL;
 	socktuple_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 3, fd, socktuple_param, fd);
@@ -154,7 +154,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param)
 	ASSERT_EQ(param->m_len, 0);
 
 	/* `PPME_SYSCALL_POLL_X` is a simple event that uses a `PT_FDLIST` */
-	struct scap_const_sized_buffer fdlist_param;
+	scap_const_sized_buffer fdlist_param;
 	fdlist_param.buf = NULL;
 	fdlist_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_POLL_X, 2, fd, fdlist_param);
@@ -286,7 +286,7 @@ TEST_F(sinsp_with_test_input, execve_invalid_path_entry)
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_E, 1, "<NA>");
 
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "/bin/test-exe", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "test-exe", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	ASSERT_EQ(get_field_as_string(evt, "proc.name"), "test-exe");

--- a/userspace/libsinsp/test/events_proc.ut.cpp
+++ b/userspace/libsinsp/test/events_proc.ut.cpp
@@ -48,7 +48,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", PPM_EXVAT_AT_EMPTY_PATH);
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the file pointed by the `dirfd` since `execveat` is called with
@@ -88,7 +88,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "file", 0);
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the directory pointed by the `dirfd` + the pathname
@@ -130,7 +130,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", 0);
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be `<NA>`, sinsp should recognize that the `pathname`
@@ -162,7 +162,7 @@ TEST_F(sinsp_with_test_input, execveat_absolute_path)
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, invalid_dirfd, "/tmp/file", (uint32_t) 0);
 
 	/* Please note the exit event for an `execveat` is an `execve` if the syscall succeeds. */
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVE_19_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the absolute file path that we passed in the
@@ -198,7 +198,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag_s390)
 	 */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", PPM_EXVAT_AT_EMPTY_PATH);
 
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the file pointed by the `dirfd` since `execveat` is called with
@@ -234,7 +234,7 @@ TEST_F(sinsp_with_test_input, execveat_relative_path_s390)
 	 */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "file", 0);
 
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the directory pointed by the `dirfd` + the pathname
@@ -264,7 +264,7 @@ TEST_F(sinsp_with_test_input, execveat_absolute_path_s390)
 	uint64_t invalid_dirfd = 0;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, invalid_dirfd, "/tmp/s390/file", 0);
 
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be the absolute file path that we passed in the
@@ -300,7 +300,7 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path_s390)
 	 */
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, "<NA>", 0);
 
-	struct scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
+	scap_const_sized_buffer empty_bytebuf = {nullptr, 0};
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_X, 23, (int64_t) 0, "<NA>", empty_bytebuf, (uint64_t) 1, (uint64_t) 1, (uint64_t) 1, "<NA>", (uint64_t) 0, (uint64_t) 0, (uint64_t) 0, 0, 0, 0, "<NA>", empty_bytebuf, empty_bytebuf, 0, (uint64_t) 0, 0, 0, (uint64_t) 0, (uint64_t) 0, (uint64_t) 0);
 
 	/* The `exepath` should be `<NA>`, sinsp should recognize that the `pathname`
@@ -336,13 +336,13 @@ TEST_F(sinsp_with_test_input, spawn_process)
 
 	/* Parent clone exit event */
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, parent_pid, parent_tid, null_pid, "", fdlimit, pgft_maj, pgft_min, 12088, 7208, 0, "init", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, parent_pid, parent_tid);
-	
+
 	/* Child clone exit event */
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_X, 20, 0, "bash", empty_bytebuf, child_pid, child_tid, parent_tid, "", fdlimit, pgft_maj, pgft_min, 12088, 3764, 0, "init", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID, 1000, 1000, child_pid, child_tid);
 
 	/* Execve enter event */
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
-	
+
 	/* Execve exit event */
 	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 27, (int64_t) 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", fdlimit, pgft_maj, pgft_min, (uint32_t) 29612, (uint32_t) 4, (uint32_t) 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, (int32_t) 34818, parent_pid, loginuid, (int32_t) PPM_EXE_WRITABLE, parent_pid, parent_pid, parent_pid, exe_ino, ctime, mtime, euid);
 
@@ -550,7 +550,7 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 
 	/* Execve enter event */
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_E, 1, "/bin/test-exe");
-	
+
 	/* Execve exit event */
 	evt = add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_EXECVE_19_X, 20, (int64_t) 0, "/bin/test-exe", scap_const_sized_buffer{argsv.data(), argsv.size()}, child_tid, child_pid, parent_tid, "", (uint64_t) 1024, (uint64_t) 0, (uint64_t) 28, (uint32_t) 29612, (uint32_t) 4, (uint32_t) 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, scap_const_sized_buffer{envv.data(), envv.size()}, (uint32_t) 34818, parent_pid, (int32_t) 1000, (uint32_t) 1);
 
@@ -564,7 +564,7 @@ TEST_F(sinsp_with_test_input, pid_over_32bit)
 	// spawn a child process to verify ppid/apid
 	add_event_advance_ts(increasing_ts(), child_tid, PPME_SYSCALL_CLONE_20_E, 0);
 
-	/* Child clone exit event 
+	/* Child clone exit event
 	 * Please note that now we are calling the child exit event before the parent one.
 	 */
 	add_event_advance_ts(increasing_ts(), child2_tid, PPME_SYSCALL_CLONE_20_X, 20, (int64_t) 0, "/bin/test-exe", empty_bytebuf, child2_pid, child2_tid, child_tid, "", fdlimit, pgft_maj, pgft_min, (uint32_t) 12088, (uint32_t) 3764, (uint32_t) 0, "test-exe", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, (uint32_t) (PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID), (uint32_t) 1000, (uint32_t) 1000, child2_vpid, child2_vtid);

--- a/userspace/libsinsp/test/plugins/plugin_extract.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_extract.cpp
@@ -30,13 +30,13 @@ limitations under the License.
  * - Is compatible with the "sample" event source only
  * - Extracts a simple field containing the string inside the events' payload
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
     std::string strstorage;
     const char* strptr;
     std::vector<uint16_t> event_types;
-} plugin_state;
+};
 
 static const char* plugin_get_required_api_version()
 {

--- a/userspace/libsinsp/test/plugins/plugin_source.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_source.cpp
@@ -29,19 +29,19 @@ static constexpr const char* s_evt_data = "hello world";
 /**
  * Example of plugin implementing only the event sourcing capability, which:
  * - Implements a specific event source "sample"
- * - Sources plugin events containing a sample string 
+ * - Sources plugin events containing a sample string
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
-} plugin_state;
+};
 
-typedef struct instance_state
+struct instance_state
 {
     uint64_t count;
     uint8_t evt_buf[2048];
     ss_plugin_event* evt;
-} instance_state;
+};
 
 static const char* plugin_get_required_api_version()
 {

--- a/userspace/libsinsp/test/plugins/syscall_async.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_async.cpp
@@ -32,7 +32,7 @@ limitations under the License.
  * - Defines only one async event name
  * - Sends an async event periodically given the configured time period
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
     uint64_t async_period;
@@ -41,7 +41,7 @@ typedef struct plugin_state
     std::atomic<bool> async_thread_run;
     uint8_t async_evt_buf[2048];
     ss_plugin_event* async_evt;
-} plugin_state;
+};
 
 static const char* plugin_get_required_api_version()
 {

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -32,7 +32,7 @@ limitations under the License.
  * - Optionally accesses a field defined at runtime by another plugin on the thread table
  * - Optionally accesses a table defined at runtime by another plugin
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
     uint64_t u64storage;
@@ -43,7 +43,7 @@ typedef struct plugin_state
     ss_plugin_table_field_t* thread_opencount_field;
     ss_plugin_table_t* evtcount_table;
     ss_plugin_table_field_t* evtcount_count_field;
-} plugin_state;
+};
 
 static inline bool evt_type_is_open(uint16_t type)
 {

--- a/userspace/libsinsp/test/plugins/syscall_parse.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_parse.cpp
@@ -33,14 +33,14 @@ limitations under the License.
  * - Owns and defines a new table that has one entry for each event type,
  *   with a field representing a counter for all events of that type across all threads.
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
     ss_plugin_table_t* thread_table;
     ss_plugin_table_field_t* thread_opencount_field;
     sample_table::ptr_t event_count_table;
     ss_plugin_table_field_t* event_count_table_count_field;
-} plugin_state;
+};
 
 static inline bool evt_type_is_open(uint16_t type)
 {

--- a/userspace/libsinsp/test/plugins/syscall_source.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_source.cpp
@@ -27,19 +27,19 @@ limitations under the License.
 /**
  * Example of plugin implementing only the event sourcing capability, which:
  * - Does not implement a specific event source, thus can create any syscall event
- * - Sources events of type PPME_SYSCALL_OPEN_X 
+ * - Sources events of type PPME_SYSCALL_OPEN_X
  */
-typedef struct plugin_state
+struct plugin_state
 {
     std::string lasterr;
-} plugin_state;
+};
 
-typedef struct instance_state
+struct instance_state
 {
     uint64_t count;
     uint8_t evt_buf[2048];
     ss_plugin_event* evt;
-} instance_state;
+};
 
 static const char* plugin_get_required_api_version()
 {

--- a/userspace/libsinsp/test/plugins/tables.cpp
+++ b/userspace/libsinsp/test/plugins/tables.cpp
@@ -28,7 +28,7 @@ limitations under the License.
  * Example of plugin that accesses the thread table and that exposes its own
  * sta table. The goal is to test all the methods of the table API.
  */
-typedef struct plugin_state
+struct plugin_state
 {
 	std::string lasterr;
 	ss_plugin_table_t* thread_table;
@@ -37,7 +37,7 @@ typedef struct plugin_state
 	ss_plugin_table_field_t* thread_dynamic_field_str;
 	sample_table::ptr_t internal_table;
 	ss_plugin_table_field_t* internal_dynamic_field;
-} plugin_state;
+};
 
 static const char* plugin_get_required_api_version()
 {
@@ -416,7 +416,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 			exit(1);
 		}
 	}
-	
+
 	// loop over all threads, we expect to only find two (init, and our new one)
 	step++;
 	{

--- a/userspace/libsinsp/test/test_utils.cpp
+++ b/userspace/libsinsp/test/test_utils.cpp
@@ -42,9 +42,9 @@ limitations under the License.
 namespace test_utils {
 
 #if !defined(_WIN32)
-struct sockaddr_in fill_sockaddr_in(int32_t ipv4_port, const char* ipv4_string)
+sockaddr_in fill_sockaddr_in(int32_t ipv4_port, const char* ipv4_string)
 {
-	struct sockaddr_in sockaddr;
+	sockaddr_in sockaddr;
 	memset(&sockaddr, 0, sizeof(sockaddr));
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons(ipv4_port);
@@ -52,9 +52,9 @@ struct sockaddr_in fill_sockaddr_in(int32_t ipv4_port, const char* ipv4_string)
 	return sockaddr;
 }
 
-struct sockaddr_in6 fill_sockaddr_in6(int32_t ipv6_port, const char* ipv6_string)
+sockaddr_in6 fill_sockaddr_in6(int32_t ipv6_port, const char* ipv6_string)
 {
-	struct sockaddr_in6 sockaddr;
+	sockaddr_in6 sockaddr;
 	memset(&sockaddr, 0, sizeof(sockaddr));
 	sockaddr.sin6_family = AF_INET6;
 	sockaddr.sin6_port = htons(ipv6_port);

--- a/userspace/libsinsp/thread_group_info.h
+++ b/userspace/libsinsp/thread_group_info.h
@@ -31,7 +31,7 @@ class sinsp_threadinfo;
 #define DEFAULT_DEAD_THREADS_THRESHOLD 11
 
 /* New struct that keep information regarding the thread group */
-typedef struct thread_group_info
+struct thread_group_info
 {
 public:
 	thread_group_info(int64_t group_pid, bool reaper, std::weak_ptr<sinsp_threadinfo> current_thread):
@@ -116,4 +116,4 @@ private:
 	uint64_t m_alive_count;
 	std::list<std::weak_ptr<sinsp_threadinfo>> m_threads;
 	bool m_reaper;
-} thread_group_info;
+};

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -43,14 +43,14 @@ struct iovec {
 class sinsp_delays_info;
 class blprogram;
 
-typedef struct erase_fd_params
+struct erase_fd_params
 {
 	bool m_remove_from_table;
 	int64_t m_fd;
 	sinsp_threadinfo* m_tinfo;
 	sinsp_fdinfo_t* m_fdinfo;
 	uint64_t m_ts;
-}erase_fd_params;
+};
 
 /** @defgroup state State management
  *  @{
@@ -67,15 +67,13 @@ typedef struct erase_fd_params
   \note sinsp_threadinfo is also used to keep process state. For the sinsp
    library, a process is just a thread with TID=PID.
 */
-class SINSP_PUBLIC sinsp_threadinfo: public libsinsp::state::table_entry
+class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry
 {
-
 public:
 	sinsp_threadinfo(
 		sinsp *inspector = nullptr,
 		std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> dyn_fields = nullptr);
 	virtual ~sinsp_threadinfo();
-
 
 	/*!
 	  \brief Return the name of the process containing this thread, e.g. "top".

--- a/userspace/libsinsp/tuples.h
+++ b/userspace/libsinsp/tuples.h
@@ -26,29 +26,29 @@ limitations under the License.
  */
 
 /*!
-	\brief An IPv4 tuple. 
+	\brief An IPv4 tuple.
 */
-typedef union _ipv4tuple
+union ipv4tuple
 {
-	struct 
+	struct
 	{
-		uint32_t m_sip; ///< Source (i.e. client) address. 
+		uint32_t m_sip; ///< Source (i.e. client) address.
 		uint32_t m_dip; ///< Destination (i.e. server) address.
 		uint16_t m_sport; ///< Source (i.e. client) port.
 		uint16_t m_dport; ///< Destination (i.e. server) port.
 		uint8_t m_l4proto; ///< Layer 4 protocol (e.g. TCP, UDP...).
-	}m_fields;
+	} m_fields;
 	uint8_t m_all[13]; ///< The fields as a raw array ob bytes. Used for hashing.
-}ipv4tuple;
+};
 
 /*!
 	\brief An IPv4 network.
 */
-typedef struct ipv4net
+struct ipv4net
 {
 	uint32_t m_ip; ///< IP addr
 	uint32_t m_netmask; ///< Subnet mask
-}ipv4net;
+};
 
 struct ipv6addr
 {
@@ -77,9 +77,9 @@ public:
 };
 
 /*!
-	\brief An IPv6 tuple. 
+	\brief An IPv6 tuple.
 */
-typedef union _ipv6tuple
+union ipv6tuple
 {
 	struct {
 
@@ -90,32 +90,32 @@ typedef union _ipv6tuple
 		uint8_t m_l4proto; ///< Layer 4 protocol (e.g. TCP, UDP...)
 	} m_fields;
 	uint8_t m_all[37]; ///< The fields as a raw array ob bytes. Used for hashing.
-} ipv6tuple;
+};
 
 /*!
-	\brief An IPv4 server address. 
+	\brief An IPv4 server address.
 */
-typedef struct ipv4serverinfo
+struct ipv4serverinfo
 {
 	uint32_t m_ip; ///< address
 	uint16_t m_port; ///< port
 	uint8_t m_l4proto; ///< IP protocol
-} ipv4serverinfo;
+};
 
 /*!
-	\brief An IPv6 server address. 
+	\brief An IPv6 server address.
 */
-typedef struct ipv6serverinfo
+struct ipv6serverinfo
 {
 	ipv6addr m_ip;  ///< address
 	uint16_t m_port;  ///< port
 	uint8_t m_l4proto;  ///< IP protocol
-} ipv6serverinfo;
+};
 
 /*!
-	\brief A unix socket tuple. 
+	\brief A unix socket tuple.
 */
-typedef union _unix_tuple
+union unix_tuple
 {
 	struct
 	{
@@ -123,6 +123,6 @@ typedef union _unix_tuple
 		uint64_t m_dest;  ///< destination OS pointer.
 	} m_fields;
 	uint8_t m_all[16]; ///< The fields as a raw array ob bytes. Used for hashing.
-} unix_tuple;
+};
 
 /*@}*/

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -595,7 +595,7 @@ bool sinsp_usergroup_manager::user_to_sinsp_event(const scap_userinfo *user, sin
 	scapevt->type = ev_type;
 	scapevt->nparams = 6;
 
-	auto* lens = (uint16_t*)((char *)scapevt + sizeof(struct ppm_evt_hdr));
+	auto* lens = (uint16_t*)((char *)scapevt + sizeof(ppm_evt_hdr));
 	char* valptr = (char*)lens + scapevt->nparams * sizeof(uint16_t);
 
 	lens[0] = sizeof(uint32_t);
@@ -645,7 +645,7 @@ bool sinsp_usergroup_manager::group_to_sinsp_event(const scap_groupinfo *group, 
 	scapevt->type = ev_type;
 	scapevt->nparams = 3;
 
-	auto* lens = (uint16_t*)((char *)scapevt + sizeof(struct ppm_evt_hdr));
+	auto* lens = (uint16_t*)((char *)scapevt + sizeof(ppm_evt_hdr));
 	char* valptr = (char*)lens + scapevt->nparams * sizeof(uint16_t);
 
 	lens[0] = sizeof(uint32_t);

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -663,10 +663,10 @@ bool sinsp_utils::is_ipv4_mapped_ipv6(uint8_t* paddr)
 	}
 }
 
-const struct ppm_param_info* sinsp_utils::find_longest_matching_evt_param(std::string name)
+const ppm_param_info* sinsp_utils::find_longest_matching_evt_param(std::string name)
 {
 	uint32_t maxlen = 0;
-	const struct ppm_param_info* res = nullptr;
+	const ppm_param_info* res = nullptr;
 	const auto name_len = name.size();
 
 	for(uint32_t j = 0; j < PPM_EVENT_MAX; j++)
@@ -1171,7 +1171,7 @@ std::string ipv6serveraddr_to_string(ipv6serverinfo* addr, bool resolve)
 	return std::string(buf);
 }
 
-std::string ipv6tuple_to_string(_ipv6tuple* tuple, bool resolve)
+std::string ipv6tuple_to_string(ipv6tuple* tuple, bool resolve)
 {
 	char source_address[INET6_ADDRSTRLEN];
 	if(NULL == inet_ntop(AF_INET6, tuple->m_fields.m_sip.m_b, source_address, 100))
@@ -1779,7 +1779,7 @@ unsigned int read_num_possible_cpus(void)
 ///////////////////////////////////////////////////////////////////////////////
 // Log helper
 ///////////////////////////////////////////////////////////////////////////////
-void sinsp_scap_log_fn(const char* component, const char* msg, const enum falcosecurity_log_severity sev)
+void sinsp_scap_log_fn(const char* component, const char* msg, falcosecurity_log_severity sev)
 {
 	std::string prefix = (component == NULL) ? "" : std::string(component) + ": ";
 	libsinsp_logger()->log(prefix + msg, (sinsp_logger::severity)sev);

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -39,7 +39,7 @@ limitations under the License.
 #endif
 
 class sinsp_evttables;
-typedef union _sinsp_sockinfo sinsp_sockinfo;
+union sinsp_sockinfo;
 class filter_check_info;
 
 extern sinsp_evttables g_infotables;


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
From the `falcosecurity/libs` project's coding guidelines:

> Also we think that defining the struct as a typedef makes forward declarations
clunky and find using the C++ style when declaring our structs makes our
lives easier.
> ```c++
>    //
>    // Us human parsers find this confusing.
>    //
>    typedef struct _my_struct
>    {
>      u_int16	m_field;
>    } my_struct,
>    *p_my_struct;
>
>    //
>    // This is easier!
>    //
>    struct my_struct {
>      u_int16	m_field;
>    };
>```

This PR changes `struct`/`union`/`enum` definitions to follow just that.
Also, it changes declarations of objects of struct/union/enum type as to remove the `struct`/`union`/`enum` in the C++ code as user-defined types are "first-class citizens" in C++ and don't need a special, longer, syntax. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The changes are very many, but consider that they are all instances of the same change. For instance `struct sinsp_chisel* ch;` becomes `sinsp_chisel* ch;`. Apart the mechanical change, there is no difficult logic to be reviewed in this PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
