### PR TITLE
build: Improve scap_engine_noop dependency

### DIFF
--- a/userspace/libscap/engine/bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/bpf/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_bpf scap_bpf.c attached_prog.c)
 add_dependencies(scap_engine_bpf libelf zlib)
 target_link_libraries(scap_engine_bpf

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -47,7 +47,6 @@ limitations under the License.
 #include "compat/misc.h"
 #include "compat/bpf.h"
 #include "strl.h"
-#include "noop.h"
 #include "strerror.h"
 
 static const char * const bpf_kernel_counters_stats_names[] = {
@@ -1636,18 +1635,18 @@ int32_t scap_bpf_load(
 	{
 		return scap_errprintf(handle->m_lasterr, 0, "mismatch, processors online after the 'for' loop: %d, '_SC_NPROCESSORS_ONLN' before the 'for' loop: %d", online_idx, devset->m_ndevs);
 	}
-	
+
 	// Check that no CPUs were hotplugged during the for loop
 	uint32_t final_ndevs = sysconf(_SC_NPROCESSORS_ONLN);
 	if(final_ndevs == -1)
 	{
 		return scap_errprintf(handle->m_lasterr, errno, "cannot obtain the number of online CPUs from '_SC_NPROCESSORS_ONLN' to check against the previous value");
 	}
-	if (online_idx != final_ndevs) 
+	if (online_idx != final_ndevs)
 	{
 		return scap_errprintf(handle->m_lasterr, 0, "mismatch, processors online after the 'for' loop: %d, '_SC_NPROCESSORS_ONLN' after the 'for' loop: %d", online_idx, final_ndevs);
 	}
-	
+
 
 	if(set_default_settings(handle) != SCAP_SUCCESS)
 	{
@@ -1773,7 +1772,7 @@ const struct scap_stats_v2* scap_bpf_get_stats_v2(struct scap_engine_handle engi
 	 * Hopefully someone upstreams such capabilities to libbpf one day :)
 	 * Meanwhile, we can simulate perf comparisons between future LSM hooks and sys enter and exit tracepoints
 	 * via leveraging syscall selection mechanisms `handle->curr_sc_set`.
-	 * 
+	 *
 	 * Please note that libbpf stats are available only on kernels >= 5.1, they could be backported but
 	 * it's possible that in some of our supported kernels they won't be available.
 	 */
@@ -1803,7 +1802,7 @@ const struct scap_stats_v2* scap_bpf_get_stats_v2(struct scap_engine_handle engi
 				}
 				stats[offset].type = STATS_VALUE_TYPE_U64;
 				stats[offset].flags = PPM_SCAP_STATS_LIBBPF_STATS;
-				/* The possibility to specify a name for a BPF program was introduced in kernel 4.15 
+				/* The possibility to specify a name for a BPF program was introduced in kernel 4.15
 				 * https://github.com/torvalds/linux/commit/cb4d2b3f03d8eed90be3a194e5b54b734ec4bbe9
 				 * So it's possible that in some of our supported kernels `info.name` will be "".
 				 */

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 
 message(STATUS "Build modern BPF engine")
 option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)
@@ -52,7 +52,11 @@ add_library(scap_engine_modern_bpf
 	scap_modern_bpf.c
 )
 
-add_dependencies(scap_engine_modern_bpf pman)
-target_link_libraries(scap_engine_modern_bpf PRIVATE pman scap_engine_util scap_engine_noop)
+target_link_libraries(scap_engine_modern_bpf
+PRIVATE
+    pman
+    scap_engine_util
+    scap_engine_noop
+)
 
 set_scap_target_properties(scap_engine_modern_bpf)

--- a/userspace/libscap/engine/nodriver/CMakeLists.txt
+++ b/userspace/libscap/engine/nodriver/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_nodriver nodriver.c)
 target_link_libraries(scap_engine_nodriver PRIVATE scap_engine_noop)
 set_scap_target_properties(scap_engine_nodriver)

--- a/userspace/libscap/engine/noop/CMakeLists.txt
+++ b/userspace/libscap/engine/noop/CMakeLists.txt
@@ -16,4 +16,5 @@
 #
 include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_noop STATIC noop.c)
+target_include_directories(scap_engine_noop PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(scap_engine_noop uthash)

--- a/userspace/libscap/engine/savefile/CMakeLists.txt
+++ b/userspace/libscap/engine/savefile/CMakeLists.txt
@@ -14,15 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 
 # Since we have circular dependencies between libscap and the savefile engine,
 # make this library always static (directly linked into libscap)
-add_library(scap_engine_savefile
-    STATIC
+add_library(scap_engine_savefile STATIC
     scap_savefile.c
     scap_reader_gzfile.c
-    scap_reader_buffered.c)
+    scap_reader_buffered.c
+)
 
 add_dependencies(scap_engine_savefile zlib)
-target_link_libraries(scap_engine_savefile PRIVATE scap_engine_noop scap_platform_util ${ZLIB_LIB})
+target_link_libraries(scap_engine_savefile
+PRIVATE
+    scap_engine_noop
+    scap_platform_util
+    ${ZLIB_LIB}
+)

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -38,7 +38,7 @@ struct iovec {
 #include "scap_savefile.h"
 #include "savefile_platform.h"
 #include "scap_reader.h"
-#include "../noop/noop.h"
+#include "noop.h"
 
 #include "strl.h"
 

--- a/userspace/libscap/engine/source_plugin/CMakeLists.txt
+++ b/userspace/libscap/engine/source_plugin/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_source_plugin source_plugin.c)
 target_link_libraries(scap_engine_source_plugin PRIVATE scap_engine_noop)
 

--- a/userspace/libscap/engine/test_input/CMakeLists.txt
+++ b/userspace/libscap/engine/test_input/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include_directories(${LIBSCAP_INCLUDE_DIRS})
 add_library(scap_engine_test_input test_input.c test_input_platform.c)
 target_link_libraries(scap_engine_test_input PRIVATE scap_engine_noop scap_platform_util)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build
/area libscap-engine-noop

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
Automates the include path seen by libraries that depend on library `scap_engine_noop`. Rather than repeating the path in each library the target `scap_engine_noop` brings now this property with itself.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
