### PR TITLE
wip: new(ci): added a workflow to check release note label.

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -1,0 +1,20 @@
+name: Check release notes
+on:
+  pull_request:
+    types: [milestoned]
+    branches: [master]
+
+jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Try to generate release notes
+        uses: leodido/rn2md@0669e5f3b21492c11c2db43cd6e267566f5880f3
+        with:
+          milestone: ${{ github.event.milestone.title }}
+          output: ./notes.md
+          
+      - name: Print error
+        if: failure()
+        run: |
+          echo "Wrong release note label. Check it out."


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Adds a new workflow that leverages `rn2md` tool to try to generate release notes for the milestone a PR gets attached to. 
If it fails, it means the release note block has an unsupported format, and error is thrown.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
