### PR TITLE
fix(userspace/libsinsp): fix resolved PT_FSPATH and PT_FSRELPATH evt params

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1047,7 +1047,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				else
 				{
 					std::string concatenated_path = sinsp_utils::concatenate_paths(cwd, path);
-					strcpy_sanitized(&m_paramstr_storage[0], concatenated_path.data(), std::min(concatenated_path.size() + 1, m_paramstr_storage.size()));
+					strcpy_sanitized(&m_resolved_paramstr_storage[0], concatenated_path.data(), std::min(concatenated_path.size() + 1, m_resolved_paramstr_storage.size()));
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This fixes a minor bug introduced in https://github.com/falcosecurity/libs/pull/1533 and affecting event params of type `PT_FSPATH` and `PT_FSRELPATH`. The issue involves wrong path resolutions in `sinsp_evt::get_param_as_str` that can cause the returned value to contain the resolved absolute path instead of the relative one even when not desired.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): fix resolved PT_FSPATH and PT_FSRELPATH evt params
```
