### PR TITLE
fix(userspace/libsinsp): do not suppress zero ptids

### DIFF
--- a/userspace/libsinsp/sinsp_suppress.cpp
+++ b/userspace/libsinsp/sinsp_suppress.cpp
@@ -145,6 +145,10 @@ int32_t libsinsp::sinsp_suppress::process_event(scap_evt *e, uint16_t devid)
 
 bool libsinsp::sinsp_suppress::is_suppressed_tid(uint64_t tid, uint16_t devid) const
 {
+	if (tid == 0)
+	{
+		return false;
+	}
 	if(devid != UINT16_MAX && cache_slot(devid) == tid)
 	{
 		return true;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The recent process-based event suppression refactor (cc @gnosek) added a new cache slot for better performance. However, given that the cache slots are likely initialized to zero, we can fall into the case in which we consider a zero TID to be suppressed. The issue with that is that if the zero TID is taken from a PTID of an event (execve, clone, etc...), then we also mark as suppressed the child process. We indeed set PTID to zero in our drivers when we can find no parent for a thread, which in this case would cause a whole hierarchy of processes to have their events ignored. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): do not suppress zero ptids
```
