### PR TITLE
fix(libscap/gvisor): use consistent new/delete functions for gvisor platform

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -134,8 +134,7 @@ static const struct scap_platform_vtable scap_gvisor_platform_vtable = {
 
 scap_platform* scap_gvisor_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
-	struct scap_gvisor_platform* platform =
-	                 (struct scap_gvisor_platform*)calloc(sizeof(*platform), 1);
+	auto platform = new scap_gvisor_platform();
 	platform->m_generic.m_vtable = &scap_gvisor_platform_vtable;
 
 	init_proclist(&platform->m_generic.m_proclist, proc_callback, proc_callback_context);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:


/area libscap-engine-gvisor

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

It is undefined behavior to allocate memory with `calloc()` and release it with `delete()`. This fixes it. In C++, `new T();` will zero-initialize the allocated memory. Don't believe me? The standard says so and the compiler agrees (below):
<img width="571" alt="Screenshot 2023-12-20 at 15 42 43" src="https://github.com/falcosecurity/libs/assets/35580196/4f263852-c327-4254-9cd5-fbc06a5df3e7">

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
