### PR TITLE
fix(userspace/libsinsp): not report container id as host on failed lookups

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -179,12 +179,11 @@ uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len
 	}
 
 	sinsp_container_info::ptr_t container_info = NULL;
-	bool is_host = true;
+	bool is_host = tinfo->m_container_id.empty() && !tinfo->is_in_pid_namespace();
 
 	if(!tinfo->m_container_id.empty())
 	{
-		is_host = false;
-		container_info = m_inspector->m_container_manager.get_container(tinfo->m_container_id);
+		container_info = m_inspector->m_container_manager.get_container(tinfo->m_container_id);	
 	}
 
 	switch(m_field_id)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

On failed container info lookups, the container ID stored in each thread info can potentially be marked as empty. However, the `container.id` field currently reports empty container IDs as `host` value, thus making impossible to distinguish actual threads running on the host from threads running in containers for which the metadata lookup failed.

This attempts mitigating the issue by also checking that the thread is running outside of a namespace for `container.id`. As such, failed container ID lookups will return an empty string instead of `host`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): not report container id as host on failed lookups
```
