### PR TITLE
fix(userspace/libsinsp): consistent thread info filtering while dumping

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -974,7 +974,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 		{
 			if(m_filter != nullptr && is_capture())
 			{
-				scap_evt tscapevt;
+				scap_evt tscapevt = {};
 				tscapevt.tid = tid;
 				tscapevt.ts = 0;
 				tscapevt.type = PPME_SYSCALL_READ_X;
@@ -982,7 +982,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 				tscapevt.nparams = 0;
 
 				auto tinfo = find_thread(tid, true);
-				sinsp_evt tevt;
+				sinsp_evt tevt = {};
 				tevt.m_pevt = &tscapevt;
 				tevt.m_inspector = this;
 				tevt.m_info = &(g_infotables.m_event_info[PPME_SYSCALL_READ_X]);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -974,8 +974,26 @@ void sinsp::on_new_entry_from_proc(void* context,
 		{
 			if(m_filter != nullptr && is_capture())
 			{
-				// we'll run the filter when we see the fds and possibly clear the filtered_out flag
-				newti->m_filtered_out = true;
+				scap_evt tscapevt;
+				tscapevt.tid = tid;
+				tscapevt.ts = 0;
+				tscapevt.type = PPME_SYSCALL_READ_X;
+				tscapevt.len = 0;
+				tscapevt.nparams = 0;
+
+				auto tinfo = find_thread(tid, true);
+				sinsp_evt tevt;
+				tevt.m_pevt = &tscapevt;
+				tevt.m_inspector = this;
+				tevt.m_info = &(g_infotables.m_event_info[PPME_SYSCALL_READ_X]);
+				tevt.m_cpuid = 0;
+				tevt.m_evtnum = 0;
+				tevt.m_tinfo = tinfo.get();
+				tevt.m_fdinfo = NULL;
+				tinfo->m_lastevent_fd = -1;
+				tinfo->m_lastevent_data = NULL;
+
+				tinfo->m_filtered_out = !m_filter->run(&tevt);
 			}
 
 			// we shouldn't see any fds yet

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -144,6 +144,7 @@ void sinsp_threadinfo::init()
 	m_exe_ino_mtime = 0;
 	m_exe_ino_ctime_duration_clone_ts = 0;
 	m_exe_ino_ctime_duration_pidns_start = 0;
+	m_filtered_out = false;
 
 	memset(&m_user, 0, sizeof(scap_userinfo));
 	memset(&m_group, 0, sizeof(scap_groupinfo));


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This attempts amending few issues introduced in https://github.com/falcosecurity/libs/pull/1472 (cc @gnosek for visibility). The bug prevents thread infos to be correctly dumped in captures.

The issue consists in initializing `m_filtered_out` to `true` for each thread infos upon creation from proc scanning, and then eventually turning it to `false` at the first file descriptor passing the configured filter. The goal is to avoid dumping a thread info if it's not needed given a provided filter.

The issue with the current state of things is:
- Lack of initialization of `m_filtered_out` at construction or init time. Since the value is not set in all code paths, we may end up with a corrupted boolean and cause undefined behavior on wether dumping or not a given thread info
- The logic of considering "all threads as non-essential up until we find a fd passing the filter" is broken in two cases: 1) when a thread has no fds open, and 2) when a thread is not a process/group leader (in which case no file descriptor will ever be added to). In both cases, thread infos can end up being marked as "filtered" and not being dumped in captures, which results in missing data.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): consistent thread info filtering while dumping
```
