### PR TITLE
[WIP] cleanup(sinsp)!: enforce some runtime checks and remove an extra space from `evt.args`

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -683,11 +683,18 @@ static __always_inline void auxmap__store_socktuple_param(struct auxiliary_map *
 		}
 
 		unsigned long start_reading_point;
-		/* We have to skip the two bytes of socket family. */
 		char first_path_byte = *(char *)path;
 		if(first_path_byte == '\0')
 		{
-			/* This is an abstract socket address, we need to skip the initial `\0`. */
+			/* Please note exceptions in the `sun_path`:
+			 * Taken from: https://man7.org/linux/man-pages/man7/unix.7.html
+			 *
+			 * An `abstract socket address` is distinguished (from a
+			 * pathname socket) by the fact that sun_path[0] is a null byte
+			 * ('\0').
+			 * 
+			 * So in this case, we need to skip the initial `\0`.
+			 */
 			start_reading_point = (unsigned long)path + 1;
 		}
 		else

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1827,6 +1827,27 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	return &m_paramstr_storage[0];
 }
 
+void sinsp_evt::check_param_name_exists(const std::string &name)
+{
+	for(uint32_t i = 0; i < get_num_params(); i++)
+	{
+		if(name.compare(get_param_name(i)) == 0)
+		{
+			return;
+		}
+	}
+
+	throw sinsp_exception("Event '" + std::string(this->get_name()) + "' has no parameters called '" + name +"'. Double check the documentation.");
+}
+
+void sinsp_evt::check_param_id_exists(int32_t id)
+{
+	if(id >= (int32_t)this->get_num_params())
+	{
+		throw sinsp_exception("Event '" + std::string(this->get_name()) + "' has '" + std::to_string(this->get_num_params()) +"' parameters, so '" + std::to_string(id) +"' cannot be used as an index. Only indexes '< " + std::to_string(this->get_num_params())+ "' are allowed.");
+	}
+}
+
 std::string sinsp_evt::get_param_value_str(const std::string &name, bool resolved)
 {
 	for(uint32_t i = 0; i < get_num_params(); i++)

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -440,6 +440,24 @@ public:
 	std::string get_param_value_str(const std::string& name, bool resolved = true);
 
 	/*!
+	  \brief Check if a parameter is exposed by an event.
+	  Throw an exception in case the parameter doesn't exist.
+	  todo! This check should be done when loading rules not at runtime.
+
+	  \param name The parameter name.
+	 */
+	void check_param_name_exists(const std::string &name);
+
+	/*!
+	  \brief Check if a parameter id is exposed by an event.
+	  Throw an exception in case the parameter doesn't exist.
+	  todo! This check should be done when loading rules not at runtime.
+
+	  \param id The parameter id.
+	 */
+	void check_param_id_exists(int32_t id);
+
+	/*!
 	  \brief Return the event's category, based on the event type and the FD on
 	   which the event operates.
 	*/

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1076,6 +1076,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 	case TYPE_CPU:
 		RETURN_EXTRACT_VAR(evt->m_cpuid);
 	case TYPE_ARGRAW:
+		evt->check_param_name_exists(m_argname);
 		return extract_argraw(evt, len, m_arginfo->name);
 		break;
 	case TYPE_ARGSTR:
@@ -1087,15 +1088,12 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			if(m_argid != -1)
 			{
-				if(m_argid >= (int32_t)evt->get_num_params())
-				{
-					return NULL;
-				}
-
+				evt->check_param_id_exists(m_argid);
 				argstr = evt->get_param_as_str(m_argid, &resolved_argstr, m_inspector->get_buffer_format());
 			}
 			else
 			{
+				evt->check_param_name_exists(m_argname);
 				argstr = evt->get_param_value_str(m_argname.c_str(), &resolved_argstr, m_inspector->get_buffer_format());
 			}
 

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1159,6 +1159,10 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 				}
 			}
 
+			if(!m_strstorage.empty())
+			{
+				m_strstorage.pop_back();
+			}
 			RETURN_EXTRACT_STRING(m_strstorage);
 		}
 		break;

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -96,3 +96,39 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_check_evt_arg)
 	// All the args of an event
 	ASSERT_EQ(get_field_as_string(evt, "evt.args"), "res=3 target=sym linkpath=/new/sym");
 }
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_check_evt_arg_uid)
+{
+	add_default_init_thread();
+	open_inspector();
+
+	uint32_t user_id = 5;
+	std::string container_id = "";
+	auto evt = add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_SETUID_E, 1, user_id);
+	ASSERT_EQ(get_field_as_string(evt, "evt.type"), "setuid");
+
+	// The rawarg provides the field directly from the table.
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.uid"), std::to_string(user_id));
+
+	// The `evt.arg.uid` tries to find a user in the user table, in this
+	// case the user table is empty.
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[0]"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "evt.args"), "uid=5(<NA>)");
+
+	// we are adding a user on the host so the `pid` parameter is not considered
+	ASSERT_TRUE(m_inspector.m_usergroup_manager.add_user(container_id, 0, user_id, 6, "test", "/test", "/bin/test"));
+
+	// Now we should have the necessary info
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "test");
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[0]"), "test");
+	ASSERT_EQ(get_field_as_string(evt, "evt.args"), "uid=5(test)");
+
+	// We remove the user, and the fields should be empty again
+	m_inspector.m_usergroup_manager.rm_user(container_id, user_id);
+	ASSERT_FALSE(m_inspector.m_usergroup_manager.get_user(container_id, user_id));
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[0]"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "evt.args"), "uid=5(<NA>)");
+}

--- a/userspace/libsinsp/test/parsers/parse_connect.cpp
+++ b/userspace/libsinsp/test/parsers/parse_connect.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include <test/sinsp_with_test_input.h>
+#include <test/test_utils.h>
+
+// Note:
+// 1. We don't save the type of the unix socket: datagram or stream
+// 2. Do we want to keep the tuple in this way `9c758d0f->9c758d0a /tmp/stream.sock`?
+TEST_F(sinsp_with_test_input, CONNECT_parse_unix_socket)
+{
+	add_default_init_thread();
+	open_inspector();
+
+	int64_t return_value = 0;
+	int64_t client_fd = 9;
+
+	// We need the enter event because we store it and we use it in the exit one.
+	// We only store it, we don't create a fdinfo, if the enter event is missing
+	// we don't parse the exit one.
+	auto evt = add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SOCKET_SOCKET_E, 3, (uint32_t)PPM_AF_UNIX,
+					(uint32_t)SOCK_STREAM, (uint32_t)0);
+	auto fdinfo = evt->get_fd_info();
+	ASSERT_FALSE(fdinfo);
+
+	evt = add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SOCKET_SOCKET_X, 1, client_fd);
+
+	/* FDINFO associated with the event */
+	fdinfo = evt->get_fd_info();
+	ASSERT_TRUE(fdinfo);
+	ASSERT_TRUE(fdinfo->is_unix_socket());
+	// todo! do we want this? In the end a unix socket could be of type datagram or stream
+	ASSERT_EQ(fdinfo->get_l4proto(), scap_l4_proto::SCAP_L4_NA);
+	ASSERT_TRUE(fdinfo->is_role_none());
+	ASSERT_FALSE(fdinfo->is_socket_connected());
+	// The socket syscall doesn't populate the name of the socket
+	ASSERT_EQ(fdinfo->m_name, "");
+
+	/* FDINFO associated with the thread */
+	auto init_tinfo = m_inspector.get_thread_ref(INIT_TID, false).get();
+	ASSERT_TRUE(init_tinfo);
+	fdinfo = init_tinfo->get_fd(client_fd);
+	ASSERT_TRUE(fdinfo);
+	ASSERT_TRUE(fdinfo->is_unix_socket());
+	ASSERT_EQ(fdinfo->get_l4proto(), scap_l4_proto::SCAP_L4_NA);
+	ASSERT_TRUE(fdinfo->is_role_none());
+	ASSERT_FALSE(fdinfo->is_socket_connected());
+	ASSERT_EQ(fdinfo->m_name, "");
+
+	// We don't need the enter event!
+	std::vector<uint8_t> socktuple = test_utils::pack_unix_socktuple(0x9c758d0f, 0x9c758d0a, "/tmp/stream.sock");
+	evt = add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SOCKET_CONNECT_X, 3, return_value,
+				   scap_const_sized_buffer{socktuple.data(), socktuple.size()}, client_fd);
+
+	/* FDINFO associated with the event */
+	fdinfo = evt->get_fd_info();
+	ASSERT_TRUE(fdinfo);
+	ASSERT_TRUE(fdinfo->is_unix_socket());
+	ASSERT_EQ(fdinfo->get_l4proto(), scap_l4_proto::SCAP_L4_NA);
+	ASSERT_TRUE(fdinfo->is_role_client());
+	ASSERT_TRUE(fdinfo->is_socket_connected());
+	// Note: `9c758d0f` is the kernel pointer to the socket that performs the connection.
+	// `9c758d0a` is the kernel pointer to the socket that receives the connection.
+	ASSERT_EQ(fdinfo->m_name, "9c758d0f->9c758d0a /tmp/stream.sock");
+	// we don't have code to populate this `m_name_raw` for sockets.
+	ASSERT_EQ(fdinfo->m_name_raw, "");
+
+	/* FDINFO associated with the thread */
+	fdinfo = init_tinfo->get_fd(client_fd);
+	ASSERT_TRUE(fdinfo);
+	ASSERT_TRUE(fdinfo->is_unix_socket());
+	ASSERT_EQ(fdinfo->get_l4proto(), scap_l4_proto::SCAP_L4_NA);
+	ASSERT_TRUE(fdinfo->is_role_client());
+	ASSERT_TRUE(fdinfo->is_socket_connected());
+	ASSERT_EQ(fdinfo->m_name, "9c758d0f->9c758d0a /tmp/stream.sock");
+	ASSERT_EQ(fdinfo->m_name_raw, "");
+}

--- a/userspace/libsinsp/test/test_utils.cpp
+++ b/userspace/libsinsp/test/test_utils.cpp
@@ -20,17 +20,6 @@ limitations under the License.
 
 #include <cstring>
 
-#if defined(__linux__)
-#include <linux/un.h>
-#else
-#if !defined(_WIN32)
-#include <sys/un.h>
-# endif //_WIN32
-#ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX 108
-#endif
-#endif
-
 #if !defined(_WIN32)
 #include <arpa/inet.h>
 #endif //_WIN32
@@ -38,6 +27,7 @@ limitations under the License.
 
 #include "ppm_events_public.h"
 #include "userspace_flag_helpers.h"
+#include "strl.h"
 
 namespace test_utils {
 
@@ -59,6 +49,15 @@ struct sockaddr_in6 fill_sockaddr_in6(int32_t ipv6_port, const char* ipv6_string
 	sockaddr.sin6_family = AF_INET6;
 	sockaddr.sin6_port = htons(ipv6_port);
 	inet_pton(AF_INET6, ipv6_string, &(sockaddr.sin6_addr));
+	return sockaddr;
+}
+
+struct sockaddr_un fill_sockaddr_un(const char* unix_path)
+{
+	struct sockaddr_un sockaddr;
+	memset(&sockaddr, 0, sizeof(sockaddr));
+	sockaddr.sun_family = AF_UNIX;
+	strlcpy(sockaddr.sun_path, unix_path, UNIX_PATH_MAX);
 	return sockaddr;
 }
 #endif //_WIN32
@@ -260,6 +259,31 @@ std::vector<uint8_t> pack_socktuple(sockaddr *src, sockaddr *dest)
 	res.insert(res.end(), src_addr.begin(), src_addr.end());
 	res.insert(res.end(), dest_addr.begin(), dest_addr.end());
 
+	return res;
+}
+
+std::vector<uint8_t> pack_unix_socktuple(uint64_t scr_pointer, uint64_t dst_pointer, std::string unix_path)
+{
+	std::vector<uint8_t> res;
+
+	// Assert family.
+	res.push_back(PPM_AF_UNIX);
+
+	// Scr pointer 
+	for (size_t i = 0; i < sizeof(scr_pointer); ++i)
+	{
+    	res.push_back(scr_pointer & 0xFF);
+    	scr_pointer >>= 8;
+	}
+
+	// Dest pointer 
+	for (size_t i = 0; i < sizeof(dst_pointer); ++i)
+	{
+    	res.push_back(dst_pointer & 0xFF);
+    	dst_pointer >>= 8;
+	}
+
+	res.insert(res.end(), unix_path.begin(), unix_path.end());
 	return res;
 }
 #endif //_WIN32 __EMSCRIPTEN__

--- a/userspace/libsinsp/test/test_utils.h
+++ b/userspace/libsinsp/test/test_utils.h
@@ -27,6 +27,17 @@ limitations under the License.
 #endif //_WIN32
 #include <event_stats.h>
 
+#if defined(__linux__)
+#include <linux/un.h>
+#else
+#if !defined(_WIN32)
+#include <sys/un.h>
+# endif //_WIN32
+#ifndef UNIX_PATH_MAX
+#define UNIX_PATH_MAX 108
+#endif
+#endif
+
 #define ASSERT_NAMES_EQ(a, b)                                                                                \
 	{                                                                                                        \
 		auto a1 = a;                                                                                         \
@@ -92,8 +103,10 @@ std::set<T> unordered_set_to_ordered(std::unordered_set<T> unordered_set);
 #if !defined(_WIN32)
 struct sockaddr_in fill_sockaddr_in(int32_t ipv4_port, const char* ipv4_string);
 struct sockaddr_in6 fill_sockaddr_in6(int32_t ipv6_port, const char* ipv6_string);
+struct sockaddr_un fill_sockaddr_un(const char* unix_path);
 std::vector<uint8_t> pack_sockaddr(sockaddr *sa);
 std::vector<uint8_t> pack_socktuple(sockaddr *src, sockaddr *dest);
+std::vector<uint8_t> pack_unix_socktuple(uint64_t scr_pointer, uint64_t dst_pointer, std::string unix_path);
 #endif //_WIN32
 
 void print_bytes(uint8_t *buf, size_t size);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR does the followings:
* add a test for UNIX sockets in sinsp
* add some tests for `evt.arg/evt.rawarg/avt.args` fields
* enforce some runtime checks `check_param_name_exists`/`check_param_id_exists` on `evt.arg` this should prevent our users from using non-existent fields with `evt.arg.*` . I noticed it in one of our default rules `Non sudo setuid`, see it here https://github.com/falcosecurity/libs/issues/1630. we use `exe_flags=%evt.arg.flags` when the event is `setuid` but `setuid` doesn't have a `flags` arg. Please note this is a BREAKING CHANGE since now some broken rules will stop Falco at runtime... it would be amazing to stop it when parsing the filter-checks names but at the moment we don't have any event information at that point so we need to do that during extraction :/ BTW there is room for improvements in the future

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cleanup(sinsp)!: enforce some runtime checks and remove an extra space from `evt.args`
```
