### PR TITLE
fix(gvisor): handle arbitrary sandbox IDs

### DIFF
--- a/test/libscap/test_suites/engines/gvisor/gvisor_platform.cpp
+++ b/test/libscap/test_suites/engines/gvisor/gvisor_platform.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+#include "scap.h"
+#include "engine/gvisor/gvisor.h"
+
+TEST(gvisor_platform, generate_sandbox_id)
+{
+	char lasterr[SCAP_LASTERR_SIZE];
+
+	scap_gvisor::platform p(lasterr, "/the/root/path");
+	uint32_t id;
+
+	std::set<uint32_t> seen_ids;
+	uint32_t insertions = 0;
+
+	// insert sandboxes
+	id = p.get_numeric_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff817");
+	EXPECT_NE(id, 0);
+	seen_ids.insert(id);
+	EXPECT_EQ(seen_ids.size(), ++insertions);
+
+	uint32_t id_18 = p.get_numeric_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff818");
+	EXPECT_NE(id_18, 0);
+	seen_ids.insert(id_18);
+	EXPECT_EQ(seen_ids.size(), ++insertions);
+
+	id = p.get_numeric_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff819");
+	EXPECT_NE(id, 0);
+	seen_ids.insert(id);
+	EXPECT_EQ(seen_ids.size(), ++insertions);
+
+	id = p.get_numeric_sandbox_id("hello");
+	EXPECT_NE(id, 0);
+	seen_ids.insert(id);
+	EXPECT_EQ(seen_ids.size(), ++insertions);
+
+	id = p.get_numeric_sandbox_id("A");
+	EXPECT_NE(id, 0);
+	seen_ids.insert(id);
+	EXPECT_EQ(seen_ids.size(), ++insertions);
+
+	// retrieve ID
+	id = p.get_numeric_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff818");
+	EXPECT_NE(id, 0);
+	EXPECT_EQ(id_18, id);
+
+	// release and retrieve
+	p.release_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff818");
+	id = p.get_numeric_sandbox_id("8d966e94e52551866762589eecdd9d44a9d9f87f27cd85af4cf45b7d3d2ff820");
+	EXPECT_NE(id, 0);
+}

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -151,8 +151,7 @@ static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	scap_gvisor_platform *gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(params->gvisor_platform);
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout, gvisor_platform);
+	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout, params->gvisor_platform);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -151,7 +151,8 @@ static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout);
+	scap_gvisor_platform *gvisor_platform = reinterpret_cast<struct scap_gvisor_platform*>(params->gvisor_platform);
+	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout, gvisor_platform);
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -37,9 +37,9 @@ namespace scap_gvisor {
 #pragma pack(push, 1)
 struct header
 {
-	uint16_t header_size;
-	uint16_t message_type;
-	uint32_t dropped_count;
+    uint16_t header_size;
+    uint16_t message_type;
+    uint32_t dropped_count;
 };
 #pragma pack(pop)
 
@@ -47,13 +47,13 @@ namespace parsers {
 
 struct parse_result {
     // the scap status of the operation
-	uint32_t status = 0;
+    uint32_t status = 0;
     // description of the error in case of failure
-	std::string error;
+    std::string error;
     // the total encoded event(s) size
-	size_t size = 0;
+    size_t size = 0;
     // pointers to each encoded event within the supplied output buffer
-	std::vector<scap_evt*> scap_events;
+    std::vector<scap_evt*> scap_events;
     // number of events dropped by gVisor
     uint32_t dropped_count = 0;
 };
@@ -131,14 +131,14 @@ namespace runsc
 // contains entries to store per-sandbox data and buffers to use to write events in
 class sandbox_entry {
 public:
-	sandbox_entry();
+    sandbox_entry();
     ~sandbox_entry();
 
     int32_t expand_buffer(size_t size);
 
     scap_sized_buffer m_buf;
     uint64_t m_last_dropped_count;
-	bool m_closing;
+    bool m_closing;
     uint32_t m_id;
     std::string m_container_id;
 };
@@ -146,27 +146,27 @@ public:
 class platform
 {
 public:
-	platform(char *lasterr, std::string &&root_path) :
-		m_lasterr(lasterr),
-		m_root_path(std::move(root_path)) {}
+    platform(char *lasterr, std::string &&root_path) :
+        m_lasterr(lasterr),
+        m_root_path(std::move(root_path)) {}
 
-	uint32_t get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos);
-	uint32_t get_fdinfos(const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos);
+    uint32_t get_threadinfos(uint64_t *n, const scap_threadinfo **tinfos);
+    uint32_t get_fdinfos(const scap_threadinfo *tinfo, uint64_t *n, const scap_fdinfo **fdinfos);
 
     // obtains a unique ID for each active sandbox
     uint32_t get_numeric_sandbox_id(std::string container_id);
     void release_sandbox_id(std::string container_id);
 
 private:
-	// the following two maps store and manage memory for thread information requested
-	// when get_threadinfos() is called. They are only updated upon get_threadinfos()
-	std::vector<scap_threadinfo> m_threadinfos_threads;
-	std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
+    // the following two maps store and manage memory for thread information requested
+    // when get_threadinfos() is called. They are only updated upon get_threadinfos()
+    std::vector<scap_threadinfo> m_threadinfos_threads;
+    std::unordered_map<uint64_t, std::vector<scap_fdinfo>> m_threadinfos_fds;
 
     std::unordered_map<std::string, uint32_t> m_sandbox_ids;
 
-	char* m_lasterr;
-	std::string m_root_path;
+    char* m_lasterr;
+    std::string m_root_path;
 };
 
 class engine {

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -30,7 +30,7 @@ extern "C"
 
 		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 		int gvisor_epoll_timeout;	///< When using gvisor, the timeout to wait for a new event
-		struct scap_platform *gvisor_platform; ///< The gvisor engine and platform have a bit of shared state
+		struct scap_gvisor_platform *gvisor_platform; ///< The gvisor engine and platform have a bit of shared state
 	};
 
 	struct scap_platform;

--- a/userspace/libscap/engine/gvisor/gvisor_public.h
+++ b/userspace/libscap/engine/gvisor/gvisor_public.h
@@ -30,6 +30,7 @@ extern "C"
 
 		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 		int gvisor_epoll_timeout;	///< When using gvisor, the timeout to wait for a new event
+		struct scap_platform *gvisor_platform; ///< The gvisor engine and platform have a bit of shared state
 	};
 
 	struct scap_platform;

--- a/userspace/libscap/engine/gvisor/parsers.h
+++ b/userspace/libscap/engine/gvisor/parsers.h
@@ -21,79 +21,108 @@ limitations under the License.
 
 #include "gvisor.h"
 #include "pkg/sentry/seccheck/points/syscall.pb.h"
+#include "pkg/sentry/seccheck/points/sentry.pb.h"
+#include "pkg/sentry/seccheck/points/container.pb.h"
 
 namespace scap_gvisor {
 
 namespace parsers {
 
-typedef std::function<parse_result(const char *proto, size_t proto_size, scap_sized_buffer scap_buf)> parser;
+struct event_parser {
+	std::function<parse_result(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf)> parse_msg;
+	std::function<std::string(scap_const_sized_buffer proto)> parse_container_id;
+};
 
-static parse_result parse_container_start(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_sentry_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_sentry_task_exit(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_generic_syscall(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_open(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_close(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_read(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_connect(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_execve(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_socket(const char *proto, size_t proto_size, scap_sized_buffer event_buf);
-static parse_result parse_chdir(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_setid(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_setresid(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_prlimit64(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_pipe(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_fcntl(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_dup(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_signalfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_chroot(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_eventfd(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_clone(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_bind(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_accept(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_timerfd_create(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_fork(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_inotify_init(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_socketpair(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
-static parse_result parse_write(const char *proto, size_t proto_size, scap_sized_buffer scap_buf);
+template<class T>
+static std::string container_id_from_context(scap_const_sized_buffer proto)
+{
+	T gvisor_evt;
+	if(!gvisor_evt.ParseFromArray(proto.buf, proto.size))
+	{
+		return "";
+	}
+
+    auto& context_data = gvisor_evt.context_data();
+    return context_data.container_id();
+}
+
+static std::string container_id_from_container_start(scap_const_sized_buffer proto)
+{
+	gvisor::container::Start gvisor_evt;
+	if(!gvisor_evt.ParseFromArray(proto.buf, proto.size))
+	{
+		return "";
+	}
+
+	return gvisor_evt.id();
+}
+
+static parse_result parse_container_start(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_sentry_clone(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_sentry_task_exit(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_generic_syscall(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_open(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_close(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_read(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_connect(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_execve(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_socket(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_chdir(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_setid(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_setresid(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_prlimit64(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_pipe(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_fcntl(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_dup(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_signalfd(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_chroot(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_eventfd(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_clone(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_bind(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_accept(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_timerfd_create(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_fork(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_inotify_init(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_socketpair(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
+static parse_result parse_write(uint32_t id, scap_const_sized_buffer proto, scap_sized_buffer scap_buf);
 
 // List of parsers. Indexes are based on MessageType enum values
-std::vector<parser> dispatchers = {
-	nullptr, 				// MESSAGE_UNKNOWN
-	parse_container_start,
-	parse_sentry_clone, 
-	nullptr,                                // MESSAGE_SENTRY_EXEC
-	nullptr,                                // MESSAGE_SENTRY_EXIT_NOTIFY_PARENT
-	parse_sentry_task_exit,
-	parse_generic_syscall,
-	parse_open,
-	parse_close,
-	parse_read,
-	parse_connect,
-	parse_execve,
-	parse_socket,
-	parse_chdir,
-	parse_setid,
-	parse_setresid,
-	parse_prlimit64,
-  	parse_pipe,
-  	parse_fcntl,
-  	parse_dup,
-   	parse_signalfd,
-  	parse_chroot,
-  	parse_eventfd,
-  	parse_clone,
-  	parse_bind,
-  	parse_accept,
-  	parse_timerfd_create,
-	nullptr,				// MESSAGE_SYSCALL_TIMERFD_SETTIME
-	nullptr,				// MESSAGE_SYSCALL_TIMERFD_GETTIME
-  	parse_fork,
-  	parse_inotify_init,
-	nullptr,				// MESSAGE_SYSCALL_INOTIFY_ADD_WATCH
-	nullptr,				// MESSAGE_SYSCALL_INOTIFY_RM_WATCH
-	parse_socketpair,
-	parse_write,
+std::vector<event_parser> dispatchers = {
+	{nullptr, nullptr}, 				// MESSAGE_UNKNOWN
+	{parse_container_start, container_id_from_container_start},
+	{parse_sentry_clone, container_id_from_context<gvisor::sentry::CloneInfo>},
+	{nullptr, nullptr},                                // MESSAGE_SENTRY_EXEC
+	{nullptr, nullptr},                                // MESSAGE_SENTRY_EXIT_NOTIFY_PARENT
+	{parse_sentry_task_exit, container_id_from_context<gvisor::sentry::TaskExit>},
+	{parse_generic_syscall, container_id_from_context<gvisor::syscall::Syscall>},
+	{parse_open, container_id_from_context<gvisor::syscall::Open>},
+	{parse_close, container_id_from_context<gvisor::syscall::Close>},
+	{parse_read, container_id_from_context<gvisor::syscall::Read>},
+	{parse_connect, container_id_from_context<gvisor::syscall::Connect>},
+	{parse_execve, container_id_from_context<gvisor::syscall::Execve>},
+	{parse_socket, container_id_from_context<gvisor::syscall::Socket>},
+	{parse_chdir, container_id_from_context<gvisor::syscall::Chdir>},
+	{parse_setid, container_id_from_context<gvisor::syscall::Setid>},
+	{parse_setresid, container_id_from_context<gvisor::syscall::Setresid>},
+	{parse_prlimit64, container_id_from_context<gvisor::syscall::Prlimit>},
+  	{parse_pipe, container_id_from_context<gvisor::syscall::Pipe>},
+  	{parse_fcntl, container_id_from_context<gvisor::syscall::Fcntl>},
+  	{parse_dup, container_id_from_context<gvisor::syscall::Dup>},
+   	{parse_signalfd, container_id_from_context<gvisor::syscall::Signalfd>},
+  	{parse_chroot, container_id_from_context<gvisor::syscall::Chroot>},
+  	{parse_eventfd, container_id_from_context<gvisor::syscall::Eventfd>},
+  	{parse_clone, container_id_from_context<gvisor::syscall::Clone>},
+  	{parse_bind, container_id_from_context<gvisor::syscall::Bind>},
+  	{parse_accept, container_id_from_context<gvisor::syscall::Accept>},
+  	{parse_timerfd_create, container_id_from_context<gvisor::syscall::TimerfdCreate>},
+	{nullptr, nullptr},				// MESSAGE_SYSCALL_TIMERFD_SETTIME
+	{nullptr, nullptr},				// MESSAGE_SYSCALL_TIMERFD_GETTIME
+  	{parse_fork, container_id_from_context<gvisor::syscall::Fork>},
+  	{parse_inotify_init, container_id_from_context<gvisor::syscall::Eventfd>},
+	{nullptr, nullptr},				// MESSAGE_SYSCALL_INOTIFY_ADD_WATCH
+	{nullptr, nullptr},				// MESSAGE_SYSCALL_INOTIFY_RM_WATCH
+	{parse_socketpair, container_id_from_context<gvisor::syscall::SocketPair>},
+	{parse_write, container_id_from_context<gvisor::syscall::Write>}
 };
 
 } // namespace parsers

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -96,14 +96,19 @@ bool scap_is_thread_alive(struct scap_platform* platform, int64_t pid, int64_t t
 
 int32_t scap_getpid_global(struct scap_platform* platform, int64_t* pid)
 {
-	if (platform && platform->m_vtable->get_global_pid)
+	if (platform == NULL)
 	{
-		char lasterr[SCAP_LASTERR_SIZE];
-		return platform->m_vtable->get_global_pid(platform, pid, lasterr);
+		ASSERT(false);
+		return SCAP_FAILURE;
 	}
 
-	ASSERT(false);
-	return SCAP_FAILURE;
+	if (platform->m_vtable->get_global_pid == NULL)
+	{
+		return SCAP_NOT_SUPPORTED;
+	}
+
+	char lasterr[SCAP_LASTERR_SIZE];
+	return platform->m_vtable->get_global_pid(platform, pid, lasterr);
 }
 
 const scap_machine_info* scap_get_machine_info(struct scap_platform* platform)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -645,7 +645,7 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	params.gvisor_epoll_timeout = epoll_timeout;
 
 	struct scap_platform* platform = scap_gvisor_alloc_platform(::on_new_entry_from_proc, this);
-	params.gvisor_platform = platform;
+	params.gvisor_platform = reinterpret_cast<scap_gvisor_platform*>(platform);
 
 	oargs.engine_params = &params;
 	

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -643,9 +643,12 @@ void sinsp::open_gvisor(const std::string& config_path, const std::string& root_
 	params.gvisor_config_path = config_path.c_str();
 	params.no_events = no_events;
 	params.gvisor_epoll_timeout = epoll_timeout;
-	oargs.engine_params = &params;
 
 	struct scap_platform* platform = scap_gvisor_alloc_platform(::on_new_entry_from_proc, this);
+	params.gvisor_platform = platform;
+
+	oargs.engine_params = &params;
+	
 	open_common(&oargs, &scap_gvisor_engine, platform, SINSP_MODE_LIVE);
 
 	set_get_procs_cpu_from_driver(false);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap-engine-gvisor

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No.

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In the gvisor engine we handle the sandbox ID by generating a numeric value to represent it and using it in the pid/tid fields to distinguish between containers. This was initially extracted from the string itself if it was written in hex (like it is normally in containerd, docker, ...) but it is not a reliable way because it does not handle arbitrary strings or collisions.

This PR fixes it by implementing the following:
- A function in the platform that generates unique ID for each active sandbox, maintaining a 1:1 mapping with the string ID
- A function in the parsers that can extract the container ID as a string
- State tracking in the gvisor engine to associate numeric IDs to sandbox fds

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1602

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(gvisor): handle arbitrary sandbox IDs
```
