### PR TITLE
Add new cgroup layout for podman

### DIFF
--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -37,6 +37,7 @@ std::string podman::m_user_api_sock_pattern = "/run/user/*/podman/podman.sock";
 namespace {
 constexpr const cgroup_layout ROOT_PODMAN_CGROUP_LAYOUT[] = {
 	{"/libpod-", ".scope"}, // podman
+	{"/libpod-", ".scope/container"}, // podman
 	{"/libpod-", ""}, // non-systemd podman, e.g. on alpine
 	{nullptr,    nullptr}
 };


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

I'm finding podman cgroup names that are suffixed with `/container`, and because we don't handle this layout pattern, processes in podman containers are being seen as running on the host. This is seen when investigating SCAP files. This patch adds this layout to the list. For example here's some output from `systemd-cgls`:

```
├─machine.slice
│ ├─libpod-conmon-a2bc7b153f034b17f358cde43a7f8c7475147e8a0d1b2573c26473244ec44ce4.scope
│ │ └─45338 /usr/bin/conmon --api-version 1 -c a2bc7b153f034b17f358cde43a7f8c7475147e8a0d1b2573c26473244ec44ce4 -u a2bc7b153f034b17f358cde43a7f8c7475147e8a0d1b2573c26473244ec44ce4 -r /usr/bi>
│ └─libpod-a2bc7b153f034b17f358cde43a7f8c7475147e8a0d1b2573c26473244ec44ce4.scope
│   └─container
│     ├─45341 nginx: master process nginx -g daemon off;
│     ├─45366 nginx: worker process
│     ├─45367 nginx: worker process
│     ├─45368 nginx: worker process
│     └─45369 nginx: worker process
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
