### PR TITLE
fix(cmake): reintroduce -Werror with BUILD_WARNINGS_AS_ERRORS

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -49,7 +49,7 @@ if(NOT MSVC)
 			#   - avoid complaining about the option above `-Wno-format-truncation`
 			set(CMAKE_SUPPRESSED_WARNINGS "${CMAKE_SUPPRESSED_WARNINGS} -Wno-c++20-designator -Wno-c99-designator -Wno-unknown-warning-option")
 		endif()
-		set(FALCOSECURITY_LIBS_COMMON_FLAGS "${FALCOSECURITY_LIBS_COMMON_FLAGS} -Wextra ${CMAKE_SUPPRESSED_WARNINGS}")
+		set(FALCOSECURITY_LIBS_COMMON_FLAGS "${FALCOSECURITY_LIBS_COMMON_FLAGS} -Werror -Wextra ${CMAKE_SUPPRESSED_WARNINGS}")
 	endif()
 
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FALCOSECURITY_LIBS_COMMON_FLAGS}")

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -145,9 +145,9 @@ sinsp_filter_check* sinsp_filter_check_thread::allocate_new()
 	return (sinsp_filter_check*) new sinsp_filter_check_thread();
 }
 
-int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT const struct ppm_param_info** parinfo)
+int32_t sinsp_filter_check_thread::extract_arg(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo)
 {
-	uint32_t parsed_len = 0;
+	std::string::size_type parsed_len = 0;
 
 	//
 	// 'arg' and 'resarg' are handled in a custom way
@@ -160,7 +160,7 @@ int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT c
 	{
 		if(val[fldname.size()] == '[')
 		{
-			parsed_len = (uint32_t)val.find(']');
+			parsed_len = val.find(']');
 			if(parsed_len == std::string::npos)
 			{
 				throw sinsp_exception("the field '" + fldname + "' requires an argument but ']' is not found");
@@ -179,8 +179,8 @@ int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT c
 	{
 		if(val[fldname.size()] == '[')
 		{
-			size_t startpos = fldname.size();
-			parsed_len = (uint32_t)val.find(']', startpos);
+			std::string::size_type startpos = fldname.size();
+			parsed_len = val.find(']', startpos);
 
 			if(parsed_len == std::string::npos)
 			{
@@ -203,7 +203,7 @@ int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT c
 	{
 		if(val[fldname.size()] == '.')
 		{
-			size_t endpos;
+			std::string::size_type endpos;
 			for(endpos = fldname.size() + 1; endpos < val.length(); ++endpos)
 			{
 				if(!isalpha(val[endpos])
@@ -213,7 +213,7 @@ int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT c
 				}
 			}
 
-			parsed_len = (uint32_t)endpos;
+			parsed_len = endpos;
 			m_argname = val.substr(fldname.size() + 1, endpos - fldname.size() - 1);
 		}
 		else
@@ -222,7 +222,7 @@ int32_t sinsp_filter_check_thread::extract_arg(string fldname, string val, OUT c
 		}
 	}
 
-	return parsed_len;
+	return (int32_t)parsed_len;
 }
 
 int32_t sinsp_filter_check_thread::parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -164,7 +164,7 @@ struct g_invalidchar
 	{
 		// Exclude all non-printable characters and control characters while
 		// including a wide range of languages (emojis, cyrillic, chinese etc)
-		return !(isprint((unsigned)c) || (c < 0));
+		return !(isprint((unsigned)c));
 	}
 };
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds `-Werror` to make the `BUILD_WARNINGS_AS_ERRORS` options work again. As you can see, we now attempt to enable that via [CMAKE_COMPILE_WARNING_AS_ERROR](https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html) but that option requires CMake 3.24 and we use 3.13 in CI.

Also, fix resulting warnings.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
