### PR TITLE
fix(ci): do not install headers if drivers are not modified

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -73,7 +73,7 @@ jobs:
           cd src && sudo make install
        
       - name: Install kernel headers (workaround)
-        if: matrix.arch == 'arm64'
+        if: (needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true') && matrix.arch == 'arm64'
         run: |
           sudo apt install -y --no-install-recommends
           sudo mkdir -p /usr/src
@@ -84,7 +84,7 @@ jobs:
           sudo ln -s /usr/src/linux-headers-$(uname -r)/ /lib/modules/$(uname -r)/source
           
       - name: Install kernel headers
-        if: matrix.arch == 'amd64'
+        if: (needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true') && matrix.arch == 'amd64'
         run: |
           sudo apt install -y --no-install-recommends linux-headers-$(uname -r)
           
@@ -150,7 +150,7 @@ jobs:
           cd src && sudo make install
           
       - name: Install kernel headers (workaround) and gcc
-        if: matrix.arch == 'arm64'
+        if: (needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true') && matrix.arch == 'arm64'
         run: |
           sudo apt install -y --no-install-recommends gcc g++
           sudo mkdir -p /usr/src
@@ -161,7 +161,7 @@ jobs:
           sudo ln -s /usr/src/linux-headers-$(uname -r)/ /lib/modules/$(uname -r)/source
           
       - name: Install kernel headers and gcc
-        if: matrix.arch == 'amd64'
+        if: (needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true') && matrix.arch == 'amd64'
         run: |
           sudo apt install -y --no-install-recommends linux-headers-$(uname -r) gcc-multilib g++-multilib
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Honestly not sure if this is the root cause but it seems that CI has difficulties downloading kernel headers, and the `apt update` step is only executed if `needs.paths-filter.outputs.driver_changed == 'true' || needs.paths-filter.outputs.libscap_changed == 'true'`, so it seems right to always run it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
