### PR TITLE
cleanup(libsinsp): do not rely on null-terminated string_views

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -169,14 +169,14 @@ template<> std::string sinsp_fdinfo_t::tostring_clean()
 	return m_tstr;
 }
 
-template<> void sinsp_fdinfo_t::add_filename_raw(const char* rawpath)
+template<> void sinsp_fdinfo_t::add_filename_raw(std::string_view rawpath)
 {
-	m_name_raw = rawpath;
+	m_name_raw = std::string(rawpath);
 }
 
-template<> void sinsp_fdinfo_t::add_filename(const char* fullpath)
+template<> void sinsp_fdinfo_t::add_filename(std::string_view fullpath)
 {
-	m_name = fullpath;
+	m_name = std::string(fullpath);
 }
 
 template<> bool sinsp_fdinfo_t::set_net_role_by_guessing(sinsp* inspector,

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -369,8 +369,8 @@ public:
 		FLAGS_CONNECTION_FAILED = (1 << 16),
 	};
 
-	void add_filename_raw(const char* rawpath);
-	void add_filename(const char* fullpath);
+	void add_filename_raw(std::string_view rawpath);
+	void add_filename(std::string_view fullpath);
 
 	inline bool is_transaction() const
 	{

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2313,10 +2313,8 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 				* we are not able to recover information about `dirfd` in our `sinsp` state.
 				* Fallback to `<NA>`.
 				*/
-				if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && strncmp(pathname.data(), "<NA>", 5) == 0) ||
-				sdir.compare("<UNKNOWN>") == 0)
+				if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && pathname == "<NA>") || sdir == "<UNKNOWN>")
 				{
-					/* we copy also the string terminator `\0`. */
 					fullpath = "<NA>";
 				}
 				/* (3) In this case we have already obtained the `exepath` and it is `sdir`, we just need
@@ -2618,7 +2616,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			enter_evt_name = enter_evt->get_param(0)->as<std::string_view>();
 			enter_evt_flags = enter_evt->get_param(1)->as<uint32_t>();
 
-			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && enter_evt_name != "<NA>")
 			{
 				name = enter_evt_name;
 
@@ -2652,7 +2650,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			enter_evt_name = enter_evt->get_param(0)->as<std::string_view>();
 			enter_evt_flags = 0;
 
-			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && enter_evt_name != "<NA>")
 			{
 				name = enter_evt_name;
 
@@ -2702,7 +2700,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			enter_evt_flags = enter_evt->get_param(2)->as<uint32_t>();
 			int64_t enter_evt_dirfd = enter_evt->get_param(0)->as<int64_t>();
 
-			if(enter_evt_name.data() != nullptr && strncmp(enter_evt_name.data(), "<NA>", 5) != 0)
+			if(enter_evt_name.data() != nullptr && enter_evt_name != "<NA>")
 			{
 				name = enter_evt_name;
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5310,10 +5310,10 @@ void sinsp_parser::parse_user_evt(sinsp_evt *evt)
 
 	if (evt->m_pevt->type == PPME_USER_ADDED_E)
 	{
-		m_inspector->m_usergroup_manager.add_user(container_id.data(), -1, uid, gid, name.data(), home.data(), shell.data());
+		m_inspector->m_usergroup_manager.add_user(std::string(container_id), -1, uid, gid, name, home, shell);
 	} else
 	{
-		m_inspector->m_usergroup_manager.rm_user(container_id.data(), uid);
+		m_inspector->m_usergroup_manager.rm_user(std::string(container_id), uid);
 	}
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5679,12 +5679,7 @@ void sinsp_parser::parse_pidfd_open_exit(sinsp_evt *evt)
 	{
 		// note: approximating equivalent filename as in:
 		// https://man7.org/linux/man-pages/man2/pidfd_getfd.2.html
-		char fname[SCAP_MAX_PATH_SIZE];
-		snprintf(fname,
-		         sizeof(fname),
-		         "%s/proc/%lld",
-		         scap_get_host_root(),
-		         (long long) pid);
+		std::string fname = std::string(scap_get_host_root()) + "/proc/" + std::to_string(pid);
 		fdi.m_type = scap_fd_type::SCAP_FD_PIDFD;
 		fdi.add_filename(fname);
 		fdi.m_openflags = flags;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2762,8 +2762,8 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 		fdi.m_mount_id = 0;
 		fdi.m_dev = dev;
 		fdi.m_ino = ino;
-		fdi.add_filename_raw(name.data());
-		fdi.add_filename(fullpath.c_str());
+		fdi.add_filename_raw(name);
+		fdi.add_filename(fullpath);
 
 		//
 		// Add the fd to the table.
@@ -5637,7 +5637,7 @@ void sinsp_parser::parse_memfd_create_exit(sinsp_evt *evt, scap_fd_type type)
 	Suppose you create a memfd named libstest resulting in a fd.name libstest while on disk 
 	(e.g. ls -l /proc/$PID/fd/$FD_NUM) it may look like /memfd:libstest (deleted)
 	*/
-	std::string name = std::string(evt->get_param(1)->as<std::string_view>());
+	auto name = evt->get_param(1)->as<std::string_view>();
 	
 	/* flags */
 	flags = evt->get_param(2)->as<uint32_t>();
@@ -5645,7 +5645,7 @@ void sinsp_parser::parse_memfd_create_exit(sinsp_evt *evt, scap_fd_type type)
 	if(fd >= 0)
 	{
 		fdi.m_type = type;
-		fdi.add_filename(name.c_str());
+		fdi.add_filename(name);
 		fdi.m_openflags = flags;
 	}
 

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -45,7 +45,7 @@ public:
 	//
 	// Combine the openat arguments into a full file name
 	//
-	static void parse_dirfd(sinsp_evt *evt, const char* name, int64_t dirfd, OUT std::string* sdir);
+	std::string parse_dirfd(sinsp_evt *evt, std::string_view name, int64_t dirfd);
 
 	void set_track_connection_status(bool enabled);
 	bool get_track_connection_status() { return m_track_connection_status; }

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -214,7 +214,6 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 		{
 			sinsp_evt enter_evt;
 			const sinsp_evt_param *parinfo;
-			std::string sdir;
 
 			if(etype == PPME_SYSCALL_OPENAT_X)
 			{
@@ -235,7 +234,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 			parinfo = etype == PPME_SYSCALL_OPENAT_X ? enter_evt.get_param(0) : evt->get_param(1);
 			int64_t dirfd = parinfo->as<int64_t>();
 
-			sinsp_parser::parse_dirfd(evt, name.data(), dirfd, &sdir);
+			std::string sdir = m_inspector->get_parser()->parse_dirfd(evt, name, dirfd);
 
 			if(fd_nameraw)
 			{

--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -89,7 +89,7 @@ TEST_F(usergroup_manager_test, system_lookup)
 
 	sinsp_usergroup_manager mgr(&m_inspector);
 
-	mgr.add_user(container_id, -1, 0, 0, nullptr, nullptr, nullptr);
+	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
 	auto* user = mgr.get_user(container_id, 0);
 	ASSERT_NE(user, nullptr);
 	ASSERT_EQ(user->uid, 0);
@@ -105,7 +105,7 @@ TEST_F(usergroup_manager_test, system_lookup)
 #endif
 	ASSERT_EQ(std::string(user->shell).empty(), false);
 
-	mgr.add_group(container_id, -1, 0, nullptr);
+	mgr.add_group(container_id, -1, 0, {});
 	auto* group = mgr.get_group(container_id, 0);
 	ASSERT_NE(group, nullptr);
 	ASSERT_EQ(group->gid, 0);
@@ -196,7 +196,7 @@ TEST_F(usergroup_manager_host_root_test, host_root_lookup)
 
 	sinsp_usergroup_manager mgr(&m_inspector);
 
-	mgr.add_user(container_id, -1, 0, 0, nullptr, nullptr, nullptr);
+	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
 	auto* user = mgr.get_user(container_id, 0);
 	ASSERT_NE(user, nullptr);
 	ASSERT_EQ(user->uid, 0);
@@ -205,7 +205,7 @@ TEST_F(usergroup_manager_host_root_test, host_root_lookup)
 	ASSERT_STREQ(user->homedir, "/toor");
 	ASSERT_STREQ(user->shell, "/bin/ash");
 
-	mgr.add_group(container_id, -1, 0, nullptr);
+	mgr.add_group(container_id, -1, 0, {});
 	auto* group = mgr.get_group(container_id, 0);
 	ASSERT_NE(group, nullptr);
 	ASSERT_EQ(group->gid, 0);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -516,7 +516,7 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 	if (!user)
 	{
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
-		user = m_inspector->m_usergroup_manager.add_user(m_container_id, m_pid, uid, m_group.gid, NULL, NULL, NULL, notify);
+		user = m_inspector->m_usergroup_manager.add_user(m_container_id, m_pid, uid, m_group.gid, {}, {}, {}, notify);
 	}
 	if (user)
 	{
@@ -538,7 +538,7 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 	if (!group)
 	{
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
-		group = m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, NULL, notify);
+		group = m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, {}, notify);
 	}
 	if (group)
 	{

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -242,22 +242,18 @@ scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(
 	userinfo_map &map,
 	uint32_t uid,
 	uint32_t gid,
-	const char *name,
-	const char *home,
-	const char *shell)
+	std::string_view name,
+	std::string_view home,
+	std::string_view shell)
 {
-	ASSERT(name);
-	ASSERT(home);
-	ASSERT(shell);
-
 	auto &usr = map[uid];
 	usr.uid = uid;
 	usr.gid = gid;
 	// In case the node is configured to use NIS,
 	// some struct passwd* fields may be set to NULL.
-	strlcpy(usr.name, (name != nullptr) ? name : "<NA>", MAX_CREDENTIALS_STR_LEN);
-	strlcpy(usr.homedir, (home != nullptr) ? home : "<NA>", SCAP_MAX_PATH_SIZE);
-	strlcpy(usr.shell, (shell != nullptr) ? shell : "<NA>", SCAP_MAX_PATH_SIZE);
+	strlcpy(usr.name, (name.data() != nullptr) ? std::string(name).c_str() : "<NA>", MAX_CREDENTIALS_STR_LEN);
+	strlcpy(usr.homedir, (home.data() != nullptr) ? std::string(home).c_str() : "<NA>", SCAP_MAX_PATH_SIZE);
+	strlcpy(usr.shell, (shell.data() != nullptr) ? std::string(shell).c_str() : "<NA>", SCAP_MAX_PATH_SIZE);
 
 	return &usr;
 }
@@ -265,18 +261,16 @@ scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(
 scap_groupinfo *sinsp_usergroup_manager::groupinfo_map_insert(
 	groupinfo_map &map,
 	uint32_t gid,
-	const char *name)
+	std::string_view name)
 {
-	ASSERT(name);
-
 	auto &grp = map[gid];
 	grp.gid = gid;
-	strlcpy(grp.name, (name != nullptr) ? name : "<NA>", MAX_CREDENTIALS_STR_LEN);
+	strlcpy(grp.name, (name.data() != nullptr) ? std::string(name).c_str() : "<NA>", MAX_CREDENTIALS_STR_LEN);
 
 	return &grp;
 }
 
-scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, int64_t pid, uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify)
+scap_userinfo *sinsp_usergroup_manager::add_user(const std::string &container_id, int64_t pid, uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify)
 {
 	if (!m_import_users)
 	{
@@ -289,11 +283,11 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, int
 	if(usr)
 	{
 		// Update user if it was already there
-		if (name)
+		if (name.data() != nullptr)
 		{
-			strlcpy(usr->name, name, MAX_CREDENTIALS_STR_LEN);
-			strlcpy(usr->homedir, home, SCAP_MAX_PATH_SIZE);
-			strlcpy(usr->shell, shell, SCAP_MAX_PATH_SIZE);
+			strlcpy(usr->name, std::string(name).c_str(), MAX_CREDENTIALS_STR_LEN);
+			strlcpy(usr->homedir, std::string(home).c_str(), SCAP_MAX_PATH_SIZE);
+			strlcpy(usr->shell, std::string(shell).c_str(), SCAP_MAX_PATH_SIZE);
 		}
 		return usr;
 	}
@@ -305,13 +299,13 @@ scap_userinfo *sinsp_usergroup_manager::add_user(const string &container_id, int
 	return add_container_user(container_id, pid, uid, notify);
 }
 
-scap_userinfo *sinsp_usergroup_manager::add_host_user(uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify)
+scap_userinfo *sinsp_usergroup_manager::add_host_user(uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify)
 {
 	libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
 			"adding host user: name: %s", name);
 
 	scap_userinfo *retval{nullptr};
-	if (name)
+	if (name.data() != nullptr)
 	{
 		retval = userinfo_map_insert(
 			m_userlist[""],
@@ -411,7 +405,7 @@ bool sinsp_usergroup_manager::rm_user(const string &container_id, uint32_t uid, 
 	return res;
 }
 
-scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, int64_t pid, uint32_t gid, const char *name, bool notify)
+scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, int64_t pid, uint32_t gid, std::string_view name, bool notify)
 {
 	if (!m_import_users)
 	{
@@ -423,9 +417,9 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, i
 	if (gr)
 	{
 		// Update group if it was already there
-		if (name != nullptr)
+		if (name.data() != nullptr)
 		{
-			strlcpy(gr->name, name, MAX_CREDENTIALS_STR_LEN);
+			strlcpy(gr->name, std::string(name).c_str(), MAX_CREDENTIALS_STR_LEN);
 		}
 		return gr;
 	}
@@ -437,13 +431,13 @@ scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, i
 	return add_container_group(container_id, pid, gid, notify);
 }
 
-scap_groupinfo *sinsp_usergroup_manager::add_host_group(uint32_t gid, const char *name, bool notify)
+scap_groupinfo *sinsp_usergroup_manager::add_host_group(uint32_t gid, std::string_view name, bool notify)
 {
 	libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
 			"adding host group: name: %s", name);
 
 	scap_groupinfo *gr = nullptr;
-	if (name)
+	if (name.data())
 	{
 		gr = groupinfo_map_insert(m_grouplist[""], gid, name);
 	}

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -121,8 +121,8 @@ public:
 
 	// Note: pid is an unused parameter when container_id is an empty string
 	// ie: it is only used when adding users/groups from containers.
-	scap_userinfo *add_user(const std::string &container_id, int64_t pid, uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify = false);
-	scap_groupinfo *add_group(const std::string &container_id, int64_t pid, uint32_t gid, const char *name, bool notify = false);
+	scap_userinfo *add_user(const std::string &container_id, int64_t pid, uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify = false);
+	scap_groupinfo *add_group(const std::string &container_id, int64_t pid, uint32_t gid, std::string_view name, bool notify = false);
 
 	bool rm_user(const std::string &container_id, uint32_t uid, bool notify = false);
 	bool rm_group(const std::string &container_id, uint32_t gid, bool notify = false);
@@ -135,10 +135,10 @@ public:
 	bool m_import_users;
 
 private:
-	scap_userinfo *add_host_user(uint32_t uid, uint32_t gid, const char *name, const char *home, const char *shell, bool notify);
+	scap_userinfo *add_host_user(uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify);
 	scap_userinfo *add_container_user(const std::string &container_id, int64_t pid, uint32_t uid, bool notify);
 
-	scap_groupinfo *add_host_group(uint32_t gid, const char *name, bool notify);
+	scap_groupinfo *add_host_group(uint32_t gid, std::string_view name, bool notify);
 	scap_groupinfo *add_container_group(const std::string &container_id, int64_t pid, uint32_t gid, bool notify);
 
 	bool user_to_sinsp_event(const scap_userinfo *user, sinsp_evt* evt, const std::string &container_id, uint16_t ev_type);
@@ -156,13 +156,14 @@ private:
 		userinfo_map &map,
 		uint32_t uid,
 		uint32_t gid,
-		const char *name,
-		const char *home,
-		const char *shell);
+		std::string_view name,
+		std::string_view home,
+		std::string_view shell);
+
 	scap_groupinfo *groupinfo_map_insert(
 		groupinfo_map &map,
 		uint32_t gid,
-		const char *name);
+		std::string_view name);
 
 	std::unordered_map<std::string, userinfo_map> m_userlist;
 	std::unordered_map<std::string, groupinfo_map> m_grouplist;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:


/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

During recent refactors of parameter handling in parsers we introduced `std::string_view`s to handle strings coming from the drivers. However, in subsequent calls that required `const char *` we relied on the fact that those string views had a NUL right after the end. This is technically an oob read (although harmless in this case) and so we just need to handle this properly by using `std::string`s when necessary. We already got rid of a few instances, this PR cleans up the rest of them.

cc @gnosek @fededp

/milestone 0.15.0

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
