### PR TITLE
update(libsinsp): double thread_table_absolute_max_size

### DIFF
--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -889,7 +889,9 @@ VISIBILITY_PRIVATE
 	int64_t m_last_tid;
 	std::weak_ptr<sinsp_threadinfo> m_last_tinfo;
 	uint64_t m_last_flush_time_ns;
-	const uint32_t m_thread_table_absolute_max_size = 131072;
+	// Increased legacy default of 131072 in January 2024 to prevent
+	// possible drops due to full threadtable on more modern servers
+	const uint32_t m_thread_table_absolute_max_size = 262144;
 	uint32_t m_max_thread_table_size;
 	int32_t m_n_proc_lookups = 0;
 	uint64_t m_n_proc_lookups_duration_ns = 0;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Deployed the new libsinsp state metrics and for the first time we have visibility into drops due to a full threadtable (note this metric was never exposed before not even via the old libsinsp stats). It turns out that the legacy default absolute max value does not seem to cut it anymore on more modern infrastructure. 

Went ahead and deployed this patch to production and like a miracle no more drops at all even on busy clusters. Looked at CPU and memory metrics and it seems safe. I observed metrics for over a week. By the way the state engine is healthy in many regards, I just observed some puzzling correlation between store events actions and higher memory usage. However, higher memory usage seems not related to the plain number of threads we store. Let me open a dedicated issue to discuss this further no not digress too much here.

Of course we could expose the absolute max threadtable size as config, not sure however if it is needed given we already have so many configs.

In summary, again global memory on a very large fleet did not change after increasing this value, this is why I would like to say that it seems safe with some level of confidence. Needless to say how much we gain from no drops due to a full threadtable.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
