### PR TITLE
fix(libsinsp): modify switch case

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1103,7 +1103,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 	break;
 	case PT_SOCKADDR:
 		sockfamily = param->m_val[0];
-		if(sockfamily == AF_UNIX)
+		if(sockfamily == PPM_AF_UNIX)
 		{
 			ASSERT(param->m_len > 1);
 
@@ -1247,7 +1247,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				        m_paramstr_storage.size(),
 				        "INVALID IPv6");
 		}
-		else if(sockfamily == AF_UNIX)
+		else if(sockfamily == PPM_AF_UNIX)
 		{
 			ASSERT(param->m_len > 17);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area libsinsp


**Does this PR require a change in the driver versions?**

I am not sure about this.

**What this PR does / why we need it**:

@dwindsor @incertum 
Noticed this while working on another issue. Shouldn't this be using the PPM socket type like the rest of the socket types in this "if/else if" case statement. You can see we are using PPM_AF_INET6 & PPM_AF_INET, so why are we not using the PPM_AF_UNIX def?

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--a
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
