### PR TITLE
fix(pman): missing probe skeleton header file

### DIFF
--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -69,7 +69,8 @@ execute_process(COMMAND ${MODERN_CLANG_EXE} --version
   OUTPUT_VARIABLE CLANG_version_output
   ERROR_VARIABLE CLANG_version_error
   RESULT_VARIABLE CLANG_version_result
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 if(${CLANG_version_result} EQUAL 0)
   if("${CLANG_version_output}" MATCHES "clang version ([^\n]+)\n")
@@ -120,7 +121,8 @@ execute_process(COMMAND sh -c "${MODERN_BPFTOOL_EXE} help 2>&1 | grep -wq 'gen'"
   OUTPUT_VARIABLE BPFTOOL_version_output
   ERROR_VARIABLE BPFTOOL_version_error
   RESULT_VARIABLE BPFTOOL_version_result
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 if(NOT ${BPFTOOL_version_result} EQUAL 0)
     message(WARNING "${MODERN_BPF_LOG_PREFIX} bpftool does not support gen command")
@@ -136,7 +138,9 @@ execute_process(
   OUTPUT_VARIABLE CLANG_SYSTEM_INCLUDES_output
   ERROR_VARIABLE CLANG_SYSTEM_INCLUDES_error
   RESULT_VARIABLE CLANG_SYSTEM_INCLUDES_result
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 if(${CLANG_SYSTEM_INCLUDES_result} EQUAL 0)
   string(REPLACE "\n" " " CLANG_SYSTEM_INCLUDES "${CLANG_SYSTEM_INCLUDES_output}")
   message(STATUS "${MODERN_BPF_LOG_PREFIX} BPF system include flags: ${CLANG_SYSTEM_INCLUDES}")
@@ -157,7 +161,9 @@ execute_process(COMMAND uname -m
   OUTPUT_VARIABLE ARCH_output
   ERROR_VARIABLE ARCH_error
   RESULT_VARIABLE ARCH_result
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 if(${ARCH_result} EQUAL 0)
   set(ARCH ${ARCH_output})
   message(STATUS "${MODERN_BPF_LOG_PREFIX} Target arch: ${ARCH}")
@@ -256,5 +262,4 @@ add_custom_command(
 # Add the skeleton as a custom target
 ########################
 
-set(BPF_SKEL_TARGET ProbeSkeleton)
-add_custom_target(${BPF_SKEL_TARGET} ALL DEPENDS ${BPF_SKEL_FILE})
+add_custom_target(ProbeSkeleton ALL DEPENDS ${BPF_SKEL_FILE})

--- a/userspace/libpman/CMakeLists.txt
+++ b/userspace/libpman/CMakeLists.txt
@@ -49,9 +49,7 @@ PUBLIC
     ${ZLIB_LIB}
 )
 
-if(USE_BUNDLED_MODERN_BPF)
-    add_dependencies(pman ProbeSkeleton)
-endif()
+add_dependencies(pman ProbeSkeleton)
 
 if(USE_BUNDLED_LIBBPF)
     add_dependencies(pman libbpf)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build
/area libpman

**Does this PR require a change in the driver versions?**
No.

**What this PR does / why we need it**:
Fix a build error that occurs under certain conditions.

**Which issue(s) this PR fixes**:
Building `falcosecurity/libs` with `USE_BUNDLED_MODERN_BPF=OFF` (non-default value) removes the dependency between target `pman` and target `ProbeSkeleton`. The problem is that `ProbeSkeleton` generates a header file `bpf_probe.skel.h` that is critically needed by `pman`. The depondency must be preserved regardless of the value of `USE_BUNDLED_MODERN_BPF`.

Fixes #1623

**Special notes for your reviewer**:
Some cleanup in the CMake scripts affected by the fix.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
