### PR TITLE
fix(driver): fix potential deadlock

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1391,15 +1391,23 @@ cgroups_error:
 			{
 				/* Support exe_writable */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
-				exe_writable |= (file_permission(exe_file, MAY_WRITE) == 0);
+				exe_writable |= (file_permission(exe_file, MAY_WRITE | MAY_NOT_BLOCK) == 0);
 				exe_writable |= inode_owner_or_capable(file_mnt_idmap(exe_file), file_inode(exe_file));
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
-				exe_writable |= (inode_permission(current_user_ns(), file_inode(exe_file), MAY_WRITE) == 0);
+				exe_writable |= (inode_permission(current_user_ns(), file_inode(exe_file), MAY_WRITE | MAY_NOT_BLOCK) == 0);
 				exe_writable |= inode_owner_or_capable(current_user_ns(), file_inode(exe_file));
-#else
-				exe_writable |= (inode_permission(file_inode(exe_file), MAY_WRITE) == 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 1, 0)
+				exe_writable |= (inode_permission(file_inode(exe_file), MAY_WRITE | MAY_NOT_BLOCK) == 0);
 				exe_writable |= inode_owner_or_capable(file_inode(exe_file));
 #endif
+				/*
+				 * Kernels < 3.1.0 doesn't support the exe_writable flags due to the MAY_NOT_BLOCK not being
+				 * available. This limitation is related to the fact that this function (f_sched_prog_exec)
+				 * is in a RCU critical section: this means that this function (and its callee) MUST NOT
+				 * call functions that can yield the processor (e.g. inode_permission that deep down in its
+				 * call stack calls a down_read()). This is addressed after the Kernel 3.1.0 where the
+				 * MAY_OT_BLOCK flag is introduced and avoids the processor to being yield.
+				 */
 
 				/* Support exe_upper_layer */
 				exe_upper_layer = ppm_is_upper_layer(exe_file);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Kernels < 3.1.0 doesn't support the `exe_writable` flags due to the `MAY_NOT_BLOCK` not being available. This limitation is related to the fact that the `f_sched_prog_exec` function is in a RCU critical section: this means that this function (and its callee) MUST NOT call functions that can yield the processor (e.g. `inode_permission` that deep down in its call stack calls a down_read()). This is addressed after the Kernel 3.1.0 where the MAY_OT_BLOCK flag is introduced and avoids the processor to being yield.

Given all of that does make sense to avoid filling the `exe_writable` flag in Kernels <3.1.0.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
The `exe_writable` is not being filled with the correct value with kernels <3.1.0
```
