### PR TITLE
refactor(userspace/libsinsp): make tid collision a property of the observer

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1436,7 +1436,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	/* If there's a listener, invoke it */
 	if(m_inspector->get_observer())
 	{
-		m_inspector->get_observer()->on_clone(evt, child_tinfo);
+		m_inspector->get_observer()->on_clone(evt, child_tinfo, tid_collision);
 	}
 
 	/* If we had to erase a previous entry for this tid and rebalance the table,
@@ -1446,9 +1446,6 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	if(tid_collision != -1)
 	{
 		reset(evt);
-#ifdef HAS_ANALYZER
-		m_inspector->m_tid_collisions.push_back(tid_collision);
-#endif
 		DBG_SINSP_INFO("tid collision for %" PRIu64 "(%s)",
 		               tid_collision,
 		               child_tinfo->m_comm.c_str());
@@ -1961,7 +1958,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	//
 	if(m_inspector->get_observer())
 	{
-		m_inspector->get_observer()->on_clone(evt, child_tinfo);
+		m_inspector->get_observer()->on_clone(evt, child_tinfo, tid_collision);
 	}
 
 	/* If we had to erase a previous entry for this tid and rebalance the table,
@@ -1972,9 +1969,6 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	if(tid_collision != -1)
 	{
 		reset(evt);
-#ifdef HAS_ANALYZER
-		m_inspector->m_tid_collisions.push_back(tid_collision);
-#endif
 		/* Right now we have collisions only on the clone() caller */
 		DBG_SINSP_INFO("tid collision for %" PRIu64 "(%s)", tid_collision, child_tinfo->m_comm.c_str());
 	}

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1062,8 +1062,6 @@ public:
 	std::string m_filterstring;
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 
-	std::vector<uint64_t> m_tid_collisions;
-
 	//
 	// Saved snaplen
 	//

--- a/userspace/libsinsp/sinsp_observer.h
+++ b/userspace/libsinsp/sinsp_observer.h
@@ -35,7 +35,7 @@ public:
 	virtual void on_erase_fd(erase_fd_params* params) = 0;
 	virtual void on_socket_shutdown(sinsp_evt *evt) = 0;
 	virtual void on_execve(sinsp_evt* evt) = 0;
-	virtual void on_clone(sinsp_evt* evt, sinsp_threadinfo* newtinfo) = 0;
+	virtual void on_clone(sinsp_evt* evt, sinsp_threadinfo* newtinfo, int64_t tid_collision) = 0;
 	virtual void on_bind(sinsp_evt* evt) = 0;
 	virtual bool on_resolve_container(sinsp_container_manager* manager, sinsp_threadinfo* tinfo, bool query_os_for_missing_info) = 0;
 	virtual void on_socket_status_changed(sinsp_evt *evt) = 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We don't make much use of the list of colliding TIDs, and most importantly we don't clean them up although they are rare). Since we have the observer pattern implemented around the interested code area, this refactors the internal code so that tid collisions are passed to observers instead than storing them in the inspector.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
