### PR TITLE
cleanup(userspace/libsinsp): remove and rearrange legacy definitions

### DIFF
--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -130,9 +130,7 @@ const static struct luaL_Reg ll_tool [] =
 	{"udp_setpeername", &lua_cbacks::udp_setpeername},
 	{"udp_send", &lua_cbacks::udp_send},
 	{"get_read_progress", &lua_cbacks::get_read_progress},
-#ifdef HAS_ANALYZER
 	{"push_metric", &lua_cbacks::push_metric},
-#endif
 	{NULL,NULL}
 };
 

--- a/userspace/chisel/chisel.h
+++ b/userspace/chisel/chisel.h
@@ -86,6 +86,21 @@ public:
 	chisel_view_info m_viewinfo;
 };
 
+class chisel_metric
+{
+public:
+	void reset()
+	{
+		m_name = "";
+		m_value = 0;
+		m_tags.clear();
+	}
+
+	std::string m_name;
+	double m_value = 0;
+	std::map<std::string, std::string> m_tags;
+};
+
 class chiselinfo
 {
 public:

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -23,9 +23,6 @@ limitations under the License.
 #include <chisel/chisel_api.h>
 #include <libsinsp/filter.h>
 #include <libsinsp/filterchecks.h>
-#ifdef HAS_ANALYZER
-#include "analyzer.h"
-#endif
 
 #define HAS_LUA_CHISELS
 
@@ -1504,11 +1501,9 @@ int lua_cbacks::get_read_progress(lua_State *ls)
 	return 1;
 }
 
-#ifdef HAS_ANALYZER
 int lua_cbacks::push_metric(lua_State *ls)
 {
-	statsd_metric metric;
-	metric.m_type = statsd_metric::type_t::GAUGE;
+	chisel_metric metric;
 
 	lua_getglobal(ls, "sichisel");
 
@@ -1579,5 +1574,5 @@ int lua_cbacks::push_metric(lua_State *ls)
 	return 0;
 }
 
-#endif // HAS_ANALYZER
+
 #endif // HAS_LUA_CHISELS

--- a/userspace/chisel/chisel_api.h
+++ b/userspace/chisel/chisel_api.h
@@ -63,9 +63,7 @@ public:
 	static int udp_setpeername(lua_State *ls);
 	static int udp_send(lua_State *ls);
 	static int get_read_progress(lua_State *ls);
-#ifdef HAS_ANALYZER
 	static int push_metric(lua_State *ls);
-#endif
 private:
 	static int get_thread_table_int(lua_State *ls, bool include_fds, bool barebone);
 };

--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -6,8 +6,7 @@
  * sinsp in order to start receiving appropriate callbacks.
  */
 
-// Required until the chisel_api dependency on the analyzer can be removed
-class statsd_metric;
+class chisel_metric;
 class sinsp;
 class threadinfo;
 
@@ -40,9 +39,9 @@ public:
 	virtual void process_event(sinsp_evt* evt, event_return rc) = 0;
 
 	/**
-	 * Required until the chisel_api dependency on the analyzer can be removed
+	 * Handles a metric pushed by a chisel
 	 */
-	virtual void add_chisel_metric(statsd_metric* metric) = 0;
+	virtual void add_chisel_metric(chisel_metric* metric) = 0;
 
 	/**
 	 * Some event processors allocate different thread types with extra data.

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3188,12 +3188,10 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
         //
         evt->m_fdinfo->m_name = evt->get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
 
-#ifndef HAS_ANALYZER
         //
         // Update the FD with this tuple
         //
         evt->m_fdinfo->set_unix_info(packed_data);
-#endif
 	}
 
     //
@@ -3283,12 +3281,10 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt *evt, uint8_t *packe
         //
         evt->m_fdinfo->m_name = evt->get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
 
-#ifndef HAS_ANALYZER
         //
         // Update the FD with this tuple
         //
         evt->m_fdinfo->set_unix_info(packed_data);
-#endif
     }
 
     if(evt->m_fdinfo->is_role_none())

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -40,10 +40,6 @@ limitations under the License.
 #include <libscap/strl.h>
 #include <libsinsp/plugin_manager.h>
 #include <libsinsp/sinsp_observer.h>
-
-#ifdef SIMULATE_DROP_MODE
-bool should_drop(sinsp_evt *evt);
-#endif
 #include <libsinsp/sinsp_int.h>
 
 #if !defined(MINIMAL_BUILD) && !defined(__EMSCRIPTEN__)

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -17,17 +17,12 @@ limitations under the License.
 */
 
 #pragma once
+
 //
 // Memory storage size for an entry in the event storage LIFO.
 // Events bigger than SP_EVT_BUF_SIZE won't be be stored in the LIFO.
 //
 #define SP_EVT_BUF_SIZE 4096
-
-//
-// Controls if assertions break execution or if they are just printed to the
-// log
-//
-#define ASSERT_TO_LOG
 
 //
 // Max size that the FD table of a process can reach
@@ -48,11 +43,6 @@ limitations under the License.
 // Default snaplen
 //
 #define DEFAULT_SNAPLEN 80
-
-//
-// Maximum user event buffer size
-//
-#define MAX_USER_EVT_BUFFER 65536
 
 //
 // The time after which a clone should be considered stale

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -99,7 +99,6 @@ limitations under the License.
 #include <libsinsp/sinsp_suppress.h>
 class sinsp_partial_transaction;
 class sinsp_parser;
-class sinsp_analyzer;
 class sinsp_filter;
 class cycle_writer;
 class sinsp_plugin;
@@ -1102,11 +1101,6 @@ public:
 	// How to render the data buffers
 	//
 	sinsp_evt::param_fmt m_buffer_format;
-
-	//
-	// Some dropping infrastructure
-	//
-	bool m_isdropping;
 
 	// A queue of pending internal state events:
 	// * 	container events. Written from async

--- a/userspace/libsinsp/test/external_processor.ut.cpp
+++ b/userspace/libsinsp/test/external_processor.ut.cpp
@@ -25,7 +25,7 @@ class sinsp_external_processor_dummy : public event_processor
 {
 	void on_capture_start() override {}
 	void process_event(sinsp_evt* evt, event_return rc) override {}
-	void add_chisel_metric(statsd_metric* metric) override {}
+	void add_chisel_metric(chisel_metric* metric) override {}
 };
 
 TEST(sinsp, external_event_processor_initialization)

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2080,16 +2080,12 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
                 }
             }
 
-#ifdef HAS_ANALYZER
             uint64_t ts = sinsp_utils::get_current_time_ns();
-#endif
             if(scap_proc_get(m_inspector->get_scap_platform(), tid, &scap_proc, scan_sockets) == SCAP_SUCCESS)
-	    {
-		have_scap_proc = true;
-	    }
-#ifdef HAS_ANALYZER
+            {
+                have_scap_proc = true;
+            }
             m_n_proc_lookups_duration_ns += sinsp_utils::get_current_time_ns() - ts;
-#endif
         }
 
         if(have_scap_proc)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This makes some steps in the direction of removing or rearranging legacy definitions and ifdefs around libsinsp. Most of the things touched here are unused, and thus removed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
