### PR TITLE
refactor(userspace/libsinsp)!: file descriptor tables for better OOP design and extensibility

### DIFF
--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -788,22 +788,22 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		{
 			bool match = false;
 
-			for(auto fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
-			{
+			fdtable->loop([&](int64_t fd, sinsp_fdinfo& fdi) {
 				tevt.m_tinfo = &tinfo;
-				tevt.m_fdinfo = fdit->second.get();
+				tevt.m_fdinfo = &fdi;
 				tscapevt.tid = tinfo.m_tid;
 				int64_t tlefd = tevt.m_tinfo->m_lastevent_fd;
-				tevt.m_tinfo->m_lastevent_fd = fdit->first;
+				tevt.m_tinfo->m_lastevent_fd = fd;
 
 				if(filter->run(&tevt))
 				{
 					match = true;
-					break;
+					return false; // break out of the loop
 				}
 
 				tevt.m_tinfo->m_lastevent_fd = tlefd;
-			}
+				return true;
+			});
 
 			if(!match)
 			{
@@ -912,19 +912,19 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 
 		if(include_fds)
 		{
-			for(auto fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
-			{
+			fdtable->loop([&](int64_t fd, sinsp_fdinfo& fdi) {
 				tevt.m_tinfo = &tinfo;
-				tevt.m_fdinfo = fdit->second.get();
+				tevt.m_fdinfo = &fdi;
 				tscapevt.tid = tinfo.m_tid;
 				int64_t tlefd = tevt.m_tinfo->m_lastevent_fd;
-				tevt.m_tinfo->m_lastevent_fd = fdit->first;
+				tevt.m_tinfo->m_lastevent_fd = fd;
 
 				if(filter != NULL)
 				{
 					if(filter->run(&tevt) == false)
 					{
-						continue;
+						// continue the loop to next iteration
+						return true;
 					}
 				}
 
@@ -934,14 +934,14 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 				if(!barebone)
 				{
 					lua_pushliteral(ls, "name");
-					lua_pushstring(ls, fdit->second->tostring_clean().c_str());
+					lua_pushstring(ls, fdi.tostring_clean().c_str());
 					lua_settable(ls, -3);
 					lua_pushliteral(ls, "type");
-					lua_pushstring(ls, fdit->second->get_typestring());
+					lua_pushstring(ls, fdi.get_typestring());
 					lua_settable(ls, -3);
 				}
 
-				scap_fd_type evt_type = fdit->second->m_type;
+				scap_fd_type evt_type = fdi.m_type;
 				if(evt_type == SCAP_FD_IPV4_SOCK || evt_type == SCAP_FD_IPV4_SERVSOCK ||
 				   evt_type == SCAP_FD_IPV6_SOCK || evt_type == SCAP_FD_IPV6_SERVSOCK)
 				{
@@ -956,38 +956,38 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 					{
 						include_client = true;
 						af = AF_INET;
-						cip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4info.m_fields.m_sip);
-						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4info.m_fields.m_dip);
-						cport = fdit->second->m_sockinfo.m_ipv4info.m_fields.m_sport;
-						sport = fdit->second->m_sockinfo.m_ipv4info.m_fields.m_dport;
-						is_server = fdit->second->is_role_server();
+						cip = (uint8_t*)&(fdi.m_sockinfo.m_ipv4info.m_fields.m_sip);
+						sip = (uint8_t*)&(fdi.m_sockinfo.m_ipv4info.m_fields.m_dip);
+						cport = fdi.m_sockinfo.m_ipv4info.m_fields.m_sport;
+						sport = fdi.m_sockinfo.m_ipv4info.m_fields.m_dport;
+						is_server = fdi.is_role_server();
 					}
 					else if (evt_type == SCAP_FD_IPV4_SERVSOCK)
 					{
 						include_client = false;
 						af = AF_INET;
 						cip = NULL;
-						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4serverinfo.m_ip);
-						sport = fdit->second->m_sockinfo.m_ipv4serverinfo.m_port;
+						sip = (uint8_t*)&(fdi.m_sockinfo.m_ipv4serverinfo.m_ip);
+						sport = fdi.m_sockinfo.m_ipv4serverinfo.m_port;
 						is_server = true;
 					}
 					else if (evt_type == SCAP_FD_IPV6_SOCK)
 					{
 						include_client = true;
 						af = AF_INET6;
-						cip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6info.m_fields.m_sip);
-						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6info.m_fields.m_dip);
-						cport = fdit->second->m_sockinfo.m_ipv6info.m_fields.m_sport;
-						sport = fdit->second->m_sockinfo.m_ipv6info.m_fields.m_dport;
-						is_server = fdit->second->is_role_server();
+						cip = (uint8_t*)&(fdi.m_sockinfo.m_ipv6info.m_fields.m_sip);
+						sip = (uint8_t*)&(fdi.m_sockinfo.m_ipv6info.m_fields.m_dip);
+						cport = fdi.m_sockinfo.m_ipv6info.m_fields.m_sport;
+						sport = fdi.m_sockinfo.m_ipv6info.m_fields.m_dport;
+						is_server = fdi.is_role_server();
 					}
 					else
 					{
 						include_client = false;
 						af = AF_INET6;
 						cip = NULL;
-						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6serverinfo.m_ip);
-						sport = fdit->second->m_sockinfo.m_ipv6serverinfo.m_port;
+						sip = (uint8_t*)&(fdi.m_sockinfo.m_ipv6serverinfo.m_ip);
+						sport = fdi.m_sockinfo.m_ipv6serverinfo.m_port;
 						is_server = true;
 					}
 
@@ -1038,7 +1038,7 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 
 					// l4proto
 					const char* l4ps;
-					scap_l4_proto l4p = fdit->second->get_l4proto();
+					scap_l4_proto l4p = fdi.get_l4proto();
 
 					switch(l4p)
 					{
@@ -1068,8 +1068,9 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 				// is_server
 				string l4proto;
 
-				lua_rawseti(ls,-2, (uint32_t)fdit->first);
-			}
+				lua_rawseti(ls,-2, (uint32_t)fd);
+				return true;
+			});
 		}
 
 

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -712,7 +712,6 @@ int lua_cbacks::get_machine_info(lua_State *ls)
 
 int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool barebone)
 {
-	unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
 	uint32_t j;
 	sinsp_filter_compiler* compiler = NULL;
 	sinsp_filter* filter = NULL;
@@ -789,10 +788,10 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		{
 			bool match = false;
 
-			for(fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
+			for(auto fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
 			{
 				tevt.m_tinfo = &tinfo;
-				tevt.m_fdinfo = &(fdit->second);
+				tevt.m_fdinfo = fdit->second.get();
 				tscapevt.tid = tinfo.m_tid;
 				int64_t tlefd = tevt.m_tinfo->m_lastevent_fd;
 				tevt.m_tinfo->m_lastevent_fd = fdit->first;
@@ -913,10 +912,10 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 
 		if(include_fds)
 		{
-			for(fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
+			for(auto fdit = fdtable->m_table.begin(); fdit != fdtable->m_table.end(); ++fdit)
 			{
 				tevt.m_tinfo = &tinfo;
-				tevt.m_fdinfo = &(fdit->second);
+				tevt.m_fdinfo = fdit->second.get();
 				tscapevt.tid = tinfo.m_tid;
 				int64_t tlefd = tevt.m_tinfo->m_lastevent_fd;
 				tevt.m_tinfo->m_lastevent_fd = fdit->first;
@@ -935,14 +934,14 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 				if(!barebone)
 				{
 					lua_pushliteral(ls, "name");
-					lua_pushstring(ls, fdit->second.tostring_clean().c_str());
+					lua_pushstring(ls, fdit->second->tostring_clean().c_str());
 					lua_settable(ls, -3);
 					lua_pushliteral(ls, "type");
-					lua_pushstring(ls, fdit->second.get_typestring());
+					lua_pushstring(ls, fdit->second->get_typestring());
 					lua_settable(ls, -3);
 				}
 
-				scap_fd_type evt_type = fdit->second.m_type;
+				scap_fd_type evt_type = fdit->second->m_type;
 				if(evt_type == SCAP_FD_IPV4_SOCK || evt_type == SCAP_FD_IPV4_SERVSOCK ||
 				   evt_type == SCAP_FD_IPV6_SOCK || evt_type == SCAP_FD_IPV6_SERVSOCK)
 				{
@@ -957,38 +956,38 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 					{
 						include_client = true;
 						af = AF_INET;
-						cip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv4info.m_fields.m_sip);
-						sip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv4info.m_fields.m_dip);
-						cport = fdit->second.m_sockinfo.m_ipv4info.m_fields.m_sport;
-						sport = fdit->second.m_sockinfo.m_ipv4info.m_fields.m_dport;
-						is_server = fdit->second.is_role_server();
+						cip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4info.m_fields.m_sip);
+						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4info.m_fields.m_dip);
+						cport = fdit->second->m_sockinfo.m_ipv4info.m_fields.m_sport;
+						sport = fdit->second->m_sockinfo.m_ipv4info.m_fields.m_dport;
+						is_server = fdit->second->is_role_server();
 					}
 					else if (evt_type == SCAP_FD_IPV4_SERVSOCK)
 					{
 						include_client = false;
 						af = AF_INET;
 						cip = NULL;
-						sip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv4serverinfo.m_ip);
-						sport = fdit->second.m_sockinfo.m_ipv4serverinfo.m_port;
+						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv4serverinfo.m_ip);
+						sport = fdit->second->m_sockinfo.m_ipv4serverinfo.m_port;
 						is_server = true;
 					}
 					else if (evt_type == SCAP_FD_IPV6_SOCK)
 					{
 						include_client = true;
 						af = AF_INET6;
-						cip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv6info.m_fields.m_sip);
-						sip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv6info.m_fields.m_dip);
-						cport = fdit->second.m_sockinfo.m_ipv6info.m_fields.m_sport;
-						sport = fdit->second.m_sockinfo.m_ipv6info.m_fields.m_dport;
-						is_server = fdit->second.is_role_server();
+						cip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6info.m_fields.m_sip);
+						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6info.m_fields.m_dip);
+						cport = fdit->second->m_sockinfo.m_ipv6info.m_fields.m_sport;
+						sport = fdit->second->m_sockinfo.m_ipv6info.m_fields.m_dport;
+						is_server = fdit->second->is_role_server();
 					}
 					else
 					{
 						include_client = false;
 						af = AF_INET6;
 						cip = NULL;
-						sip = (uint8_t*)&(fdit->second.m_sockinfo.m_ipv6serverinfo.m_ip);
-						sport = fdit->second.m_sockinfo.m_ipv6serverinfo.m_port;
+						sip = (uint8_t*)&(fdit->second->m_sockinfo.m_ipv6serverinfo.m_ip);
+						sport = fdit->second->m_sockinfo.m_ipv6serverinfo.m_port;
 						is_server = true;
 					}
 
@@ -1039,7 +1038,7 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 
 					// l4proto
 					const char* l4ps;
-					scap_l4_proto l4p = fdit->second.get_l4proto();
+					scap_l4_proto l4p = fdit->second->get_l4proto();
 
 					switch(l4p)
 					{
@@ -1114,7 +1113,6 @@ int lua_cbacks::get_thread_table_barebone_nofds(lua_State *ls)
 int lua_cbacks::get_container_table(lua_State *ls)
 {
 #ifndef _WIN32
-	unordered_map<int64_t, sinsp_fdinfo_t>::iterator fdit;
 	uint32_t j;
 	sinsp_evt tevt;
 

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -529,6 +529,7 @@ void chisel_table::process_proctable(sinsp_evt* evt)
 	tevt.m_cpuid = 0;
 	tevt.m_evtnum = 0;
 	tevt.m_pevt = &tscapevt;
+	tevt.m_fdinfo_ref.reset();
 	tevt.m_fdinfo = NULL;
 
 	threadtable->loop([&] (sinsp_threadinfo& tinfo) {

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -602,7 +602,7 @@ int sinsp_evt::render_fd_json(Json::Value *ret, int64_t fd, const char** resolve
 
 	if(fd >= 0)
 	{
-		sinsp_fdinfo_t *fdinfo = tinfo->get_fd(fd);
+		sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
 		if(fdinfo)
 		{
 			char tch = fdinfo->get_typechar();
@@ -695,7 +695,7 @@ char* sinsp_evt::render_fd(int64_t fd, const char** resolved_str, sinsp_evt::par
 
 	if(fd >= 0)
 	{
-		sinsp_fdinfo_t *fdinfo = tinfo->get_fd(fd);
+		sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
 		if(fdinfo)
 		{
 			char tch = fdinfo->get_typechar();
@@ -1295,7 +1295,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 				int64_t fd = 0;
 				memcpy(&fd, param->m_val + pos, sizeof(uint64_t));
 
-				sinsp_fdinfo_t *fdinfo = tinfo->get_fd(fd);
+				sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
 				if(fdinfo)
 				{
 					tch = fdinfo->get_typechar();
@@ -2111,11 +2111,12 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 
 	// fd info
 	dest.m_fdinfo = nullptr;
+	dest.m_fdinfo_ref.reset();
 	if (src.m_fdinfo != nullptr)
 	{
 		//m_fdinfo_ref is only used to keep a handle to this
 		// copy of the fdinfo which was copied from the global fdinfo table
-		dest.m_fdinfo_ref.reset(new sinsp_fdinfo_t(*src.m_fdinfo));
+		dest.m_fdinfo_ref = std::move(src.m_fdinfo->clone());
 		dest.m_fdinfo = dest.m_fdinfo_ref.get();
 	}
 	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include <libsinsp/gen_filter.h>
 #include <libsinsp/settings.h>
 #include <libsinsp/sinsp_exception.h>
+#include <libsinsp/fdinfo.h>
 
 class sinsp;
 class sinsp_threadinfo;
@@ -370,7 +371,7 @@ public:
 
 	  \note For events that are not I/O related, get_fd_info() returns NULL.
 	*/
-	inline sinsp_fdinfo_t* get_fd_info() const
+	inline sinsp_fdinfo* get_fd_info() const
 	{
 		return m_fdinfo;
 	}
@@ -507,6 +508,7 @@ private:
 		m_flags = EF_NONE;
 		m_info = &(m_event_info_table[m_pevt->type]);
 		m_fdinfo = NULL;
+		m_fdinfo_ref.reset();
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_poriginal_evt = NULL;
@@ -519,6 +521,7 @@ private:
 		m_tinfo_ref.reset();
 		m_tinfo = NULL;
 		m_fdinfo = NULL;
+		m_fdinfo_ref.reset();
 		m_fdinfo_name_changed = false;
 	}
 	inline void init(uint8_t* evdata, uint16_t cpuid)
@@ -528,6 +531,7 @@ private:
 		m_info = &(m_event_info_table[m_pevt->type]);
 		m_tinfo_ref.reset();
 		m_tinfo = NULL;
+		m_fdinfo_ref.reset();
 		m_fdinfo = NULL;
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
@@ -539,12 +543,13 @@ private:
 	inline void init(scap_evt *scap_event,
 			 ppm_event_info * ppm_event,
 			 sinsp_threadinfo *threadinfo,
-			 sinsp_fdinfo_t *fdinfo)
+			 sinsp_fdinfo *fdinfo)
 	{
 		m_pevt = scap_event;
 		m_info = ppm_event;
 		m_tinfo_ref.reset(); // we don't own the threadinfo so don't try to manage its lifetime
 		m_tinfo = threadinfo;
+		m_tinfo_ref.reset();
 		m_fdinfo = fdinfo;
 		m_source_idx = sinsp_no_event_source_idx;
 		m_source_name = sinsp_no_event_source_name;
@@ -684,7 +689,7 @@ VISIBILITY_PRIVATE
 	// it should either be null, or point to the same place as m_tinfo
 	std::shared_ptr<sinsp_threadinfo> m_tinfo_ref;
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo_t* m_fdinfo;
+	sinsp_fdinfo* m_fdinfo;
 
 	// If true, then the associated fdinfo changed names as a part
 	// of parsing this event.
@@ -696,7 +701,7 @@ VISIBILITY_PRIVATE
 	bool m_filtered_out;
 	const struct ppm_event_info* m_event_info_table;
 
-	std::shared_ptr<sinsp_fdinfo_t> m_fdinfo_ref;
+	std::shared_ptr<sinsp_fdinfo> m_fdinfo_ref;
 	// For some exit events, the "path" argument from the
 	// corresponding enter event is stored here.
 	std::unordered_map<std::string, std::string> m_enter_path_param;

--- a/userspace/libsinsp/ifinfo.cpp
+++ b/userspace/libsinsp/ifinfo.cpp
@@ -102,21 +102,21 @@ uint32_t sinsp_network_interfaces::infer_ipv4_address(uint32_t destination_addre
 	return 0;
 }
 
-void sinsp_network_interfaces::update_fd(sinsp_fdinfo_t *fd)
+void sinsp_network_interfaces::update_fd(sinsp_fdinfo& fd)
 {
-	ipv4tuple *pipv4info = &(fd->m_sockinfo.m_ipv4info);
-	ipv6tuple *pipv6info = &(fd->m_sockinfo.m_ipv6info);
+	ipv4tuple *pipv4info = &(fd.m_sockinfo.m_ipv4info);
+	ipv6tuple *pipv6info = &(fd.m_sockinfo.m_ipv6info);
 
 	//
 	// only handle ipv4/ipv6 udp sockets
 	//
-	if(fd->m_type != SCAP_FD_IPV4_SOCK &&
-	   fd->m_type != SCAP_FD_IPV6_SOCK)
+	if(fd.m_type != SCAP_FD_IPV4_SOCK &&
+	   fd.m_type != SCAP_FD_IPV6_SOCK)
 	{
 		return;
 	}
 
-	if(fd->m_type == SCAP_FD_IPV4_SOCK)
+	if(fd.m_type == SCAP_FD_IPV4_SOCK)
 	{
 
 		if(0 != pipv4info->m_fields.m_sip && 0 != pipv4info->m_fields.m_dip)
@@ -154,7 +154,7 @@ void sinsp_network_interfaces::update_fd(sinsp_fdinfo_t *fd)
 			pipv4info->m_fields.m_dip = newaddr;
 		}
 	}
-	else if(fd->m_type == SCAP_FD_IPV6_SOCK)
+	else if(fd.m_type == SCAP_FD_IPV6_SOCK)
 	{
 
 		if(ipv6addr::empty_address != pipv6info->m_fields.m_sip &&

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <libsinsp/settings.h>
 #include <libsinsp/sinsp_public.h>
 #include <libsinsp/tuples.h>
+#include <libsinsp/fdinfo.h>
 
 #include <string>
 #include <vector>
@@ -75,7 +76,7 @@ public:
 
 	void import_interfaces(scap_addrlist* paddrlist);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
-	void update_fd(sinsp_fdinfo_t *fd);
+	void update_fd(sinsp_fdinfo& fd);
 	bool is_ipv4addr_in_subnet(uint32_t addr) const;
 	bool is_ipv4addr_in_local_machine(uint32_t addr, sinsp_threadinfo* tinfo) const;
 	void import_ipv6_interface(const sinsp_ipv6_ifinfo& ifinfo);

--- a/userspace/libsinsp/ifinfo_test.cpp
+++ b/userspace/libsinsp/ifinfo_test.cpp
@@ -81,7 +81,7 @@ TEST(sinsp_network_interfaces, fd_is_of_wrong_type)
 	sinsp_fdinfo fd;
 	fd.m_type = SCAP_FD_UNKNOWN;
 	sinsp_network_interfaces interfaces;
-	interfaces.update_fd(&fd);
+	interfaces.update_fd(fd);
 }
 
 TEST(sinsp_network_interfaces, socket_is_of_wrong_type)
@@ -90,7 +90,7 @@ TEST(sinsp_network_interfaces, socket_is_of_wrong_type)
 	fd.m_type = SCAP_FD_IPV4_SOCK;
 	fd.m_info.m_ipv4info.m_fields.m_l4proto = SCAP_L4_TCP;
 	sinsp_network_interfaces interfaces;
-	interfaces.update_fd(&fd);
+	interfaces.update_fd(fd);
 }
 
 TEST(sinsp_network_interfaces, sip_and_dip_are_not_zero)
@@ -101,7 +101,7 @@ TEST(sinsp_network_interfaces, sip_and_dip_are_not_zero)
 	fd.m_info.m_ipv4info.m_fields.m_sip = 1;
 	fd.m_info.m_ipv4info.m_fields.m_dip = 1;
 	sinsp_network_interfaces interfaces;
-	interfaces.update_fd(&fd);
+	interfaces.update_fd(fd);
 }
 
 TEST(sinsp_network_interfaces, infer_finds_exact_match)

--- a/userspace/libsinsp/include/sinsp_external_processor.h
+++ b/userspace/libsinsp/include/sinsp_external_processor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 /**
  * This api defines a relationship between libsinsp and an external event processor.
  * Such external processors should derive from event_processor and register themselves with
@@ -52,6 +54,15 @@ public:
 	 * before the sinsp object is init-ed
 	 */
 	virtual sinsp_threadinfo* build_threadinfo(sinsp* inspector);
+
+	/**
+	 * Some event processors allocate different fd info types with extra data.
+	 *
+	 * This allows the processor to override the fd info builder. Note that
+	 * If this is overridden by the event processor, the processor MUST be registered
+	 * before the sinsp object is init-ed
+	 */
+	virtual std::unique_ptr<sinsp_fdinfo> build_fdinfo(sinsp* inspector);
 };
 
 }  // namespace libsinsp

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1163,16 +1163,13 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 			if(fd_table_ptr != NULL)
 			{
 				child_tinfo->m_fdtable.clear();
-				fd_table_ptr->loop([child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
-					child_tinfo->m_fdtable.add(fd, std::move(info.clone()));
+				fd_table_ptr->const_loop([child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
+					/* Track down that those are cloned fds */
+					auto newinfo = info.clone();
+					newinfo->set_is_cloned();
+					child_tinfo->m_fdtable.add(fd, std::move(newinfo));
 					return true;
 				});
-
-				/* Track down that those are cloned fds */
-				for(auto fdit = child_tinfo->m_fdtable.m_table.begin(); fdit != child_tinfo->m_fdtable.m_table.end(); ++fdit)
-				{
-					fdit->second->set_is_cloned();
-				}
 
 				/* It's important to reset the cache of the child thread, to prevent it from
 				* referring to an element in the parent's table.
@@ -1764,18 +1761,14 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 			{
 				child_tinfo->m_fdtable.clear();
 				fd_table_ptr->loop([child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
-					child_tinfo->m_fdtable.add(fd, std::move(info.clone()));
+					/* Track down that those are cloned fds.
+					* This flag `FLAGS_IS_CLONED` seems to be never used...
+					*/
+					auto newinfo = info.clone();
+					newinfo->set_is_cloned();
+					child_tinfo->m_fdtable.add(fd, std::move(newinfo));
 					return true;
 				});
-
-				/* Track down that those are cloned fds.
-				 * This flag `FLAGS_IS_CLONED` seems to be never used...
-				 */
-				for(auto fdit = child_tinfo->m_fdtable.m_table.begin();
-				    fdit != child_tinfo->m_fdtable.m_table.end(); ++fdit)
-				{
-					fdit->second->set_is_cloned();
-				}
 
 				/* It's important to reset the cache of the child thread, to prevent it from
 				 * referring to an element in the parent's table.

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -22,6 +22,8 @@ limitations under the License.
 #pragma once
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_syslog.h>
+#include <libsinsp/fdinfo.h>
+#include <memory>
 
 class sinsp_parser
 {
@@ -118,7 +120,7 @@ private:
 	void parse_capset_exit(sinsp_evt *evt);
 	void parse_unshare_setns_exit(sinsp_evt *evt);
 
-	inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo,
+	inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo* fdinfo,
 		uint32_t tsip, uint16_t tsport, uint32_t tdip, uint16_t tdport, bool overwrite_dest=true);
 	inline void fill_client_socket_info(sinsp_evt* evt, uint8_t* packed_data, bool overwrite_dest);
 	inline void add_socket(sinsp_evt* evt, int64_t fd, uint32_t domain, uint32_t type, uint32_t protocol);
@@ -128,12 +130,12 @@ private:
 	bool update_fd(sinsp_evt *evt, const sinsp_evt_param* parinfo);
 
 	// Next 4 return false if the update didn't happen because the tuple is identical to the given address
-	bool set_ipv4_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
-	bool set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
-	bool set_ipv6_addresses_and_ports(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
-	bool set_unix_info(sinsp_fdinfo_t* fdinfo, uint8_t* packed_data);
+	bool set_ipv4_addresses_and_ports(sinsp_fdinfo* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
+	bool set_ipv4_mapped_ipv6_addresses_and_ports(sinsp_fdinfo* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
+	bool set_ipv6_addresses_and_ports(sinsp_fdinfo* fdinfo, uint8_t* packed_data, bool overwrite_dest=true);
+	bool set_unix_info(sinsp_fdinfo* fdinfo, uint8_t* packed_data);
 
-	void swap_addresses(sinsp_fdinfo_t* fdinfo);
+	void swap_addresses(sinsp_fdinfo* fdinfo);
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
 

--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -64,12 +64,3 @@ limitations under the License.
 //
 #define DEFAULT_INCREASE_SNAPLEN_PORT_RANGE {0, 0}
 
-//
-// FD class customized with the storage we need
-//
-#ifdef HAS_ANALYZER
-#include "analyzer_settings.h"
-#else
-template<class T> class sinsp_fdinfo;
-typedef sinsp_fdinfo<int> sinsp_fdinfo_t;
-#endif // HAS_ANALYZER

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -945,6 +945,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 				tevt.m_evtnum = 0;
 				tevt.m_inspector = this;
 				tevt.m_tinfo = sinsp_tinfo.get();
+				tevt.m_fdinfo_ref.reset();
 				tevt.m_fdinfo = NULL;
 				sinsp_tinfo->m_lastevent_fd = -1;
 				sinsp_tinfo->m_lastevent_data = NULL;
@@ -980,8 +981,7 @@ void sinsp::on_new_entry_from_proc(void* context,
 			}
 		}
 
-		sinsp_fdinfo_t sinsp_fdinfo;
-		sinsp_tinfo->add_fd_from_scap(fdinfo, &sinsp_fdinfo);
+		sinsp_tinfo->add_fd_from_scap(fdinfo);
 	}
 }
 
@@ -2192,6 +2192,12 @@ sinsp_threadinfo*
 libsinsp::event_processor::build_threadinfo(sinsp* inspector)
 {
 	return new sinsp_threadinfo(inspector);
+}
+
+std::unique_ptr<sinsp_fdinfo>
+libsinsp::event_processor::build_fdinfo(sinsp* inspector)
+{
+	return std::make_unique<sinsp_fdinfo>();
 }
 
 void sinsp::handle_async_event(std::unique_ptr<sinsp_evt> evt)

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -509,10 +509,16 @@ public:
 
 	libsinsp::event_processor* m_external_event_processor;
 
-	sinsp_threadinfo* build_threadinfo()
+	inline sinsp_threadinfo* build_threadinfo()
     {
         return m_external_event_processor ? m_external_event_processor->build_threadinfo(this)
                                           : m_thread_manager->new_threadinfo().release();
+    }
+
+	inline std::unique_ptr<sinsp_fdinfo> build_fdinfo()
+    {
+        return m_external_event_processor ? m_external_event_processor->build_fdinfo(this)
+                                          : m_thread_manager->new_fdinfo();
     }
 
 	/*!

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1406,7 +1406,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 			ppm_event_flags eflags = evt->get_info_flags();
 			if(eflags & EF_WRITES_TO_FD)
 			{
-				sinsp_fdinfo_t* fdinfo = evt->m_fdinfo;
+				sinsp_fdinfo* fdinfo = evt->m_fdinfo;
 
 				if(fdinfo != NULL && fdinfo->is_syslog())
 				{
@@ -1423,7 +1423,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		return extract_error_count(evt, len);
 	case TYPE_COUNT_ERROR_FILE:
 		{
-			sinsp_fdinfo_t* fdinfo = evt->m_fdinfo;
+			sinsp_fdinfo* fdinfo = evt->m_fdinfo;
 
 			if(fdinfo != NULL)
 			{
@@ -1453,7 +1453,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		}
 	case TYPE_COUNT_ERROR_NET:
 		{
-			sinsp_fdinfo_t* fdinfo = evt->m_fdinfo;
+			sinsp_fdinfo* fdinfo = evt->m_fdinfo;
 
 			if(fdinfo != NULL)
 			{
@@ -1496,7 +1496,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 		}
 	case TYPE_COUNT_ERROR_OTHER:
 		{
-			sinsp_fdinfo_t* fdinfo = evt->m_fdinfo;
+			sinsp_fdinfo* fdinfo = evt->m_fdinfo;
 
 			if(fdinfo != NULL)
 			{

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -439,7 +439,7 @@ bool sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT std::vector<extract_valu
 
 		// Iterate over the list of open file descriptors and add all
 		// unique file descriptor types to the vector for comparison
-		auto fd_type_gather = [&fd_types, &values](uint64_t, const sinsp_fdinfo_t& fdinfo)
+		auto fd_type_gather = [&fd_types, &values](uint64_t, const sinsp_fdinfo& fdinfo)
 		{
 			const char* type = fdinfo.get_typestring();
 

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -96,7 +96,7 @@ public:
 	bool compare(sinsp_evt*) override;
 
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo_t* m_fdinfo;
+	sinsp_fdinfo* m_fdinfo;
 	fd_type m_fd_type;
 	std::string m_tstr;
 	uint8_t m_tcstr[2];

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -89,7 +89,7 @@ uint8_t* sinsp_filter_check_fdlist::extract(sinsp_evt *evt, OUT uint32_t* len, b
 		bool add_comma = true;
 		int64_t fd = *(int64_t *)(payload + pos);
 
-		sinsp_fdinfo_t *fdinfo = tinfo ? tinfo->get_fd(fd) : NULL;
+		sinsp_fdinfo *fdinfo = tinfo ? tinfo->get_fd(fd) : NULL;
 
 		switch(m_field_id)
 		{

--- a/userspace/libsinsp/sinsp_observer.h
+++ b/userspace/libsinsp/sinsp_observer.h
@@ -25,11 +25,11 @@ class sinsp_observer
 public:
 	virtual ~sinsp_observer() {}
 
-	virtual void on_read(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
-	virtual void on_write(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo_t* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
+	virtual void on_read(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
+	virtual void on_write(sinsp_evt* evt, int64_t tid, int64_t fd, sinsp_fdinfo* fdinfo, const char *data, uint32_t original_len, uint32_t len) = 0;
 	virtual void on_sendfile(sinsp_evt* evt, int64_t fdin, uint32_t len) = 0;
 	virtual void on_connect(sinsp_evt* evt, uint8_t* packed_data) = 0;
-	virtual void on_accept(sinsp_evt* evt, int64_t newfd, uint8_t* packed_data, sinsp_fdinfo_t* new_fdinfo) = 0;
+	virtual void on_accept(sinsp_evt* evt, int64_t newfd, uint8_t* packed_data, sinsp_fdinfo* new_fdinfo) = 0;
 	virtual void on_file_open(sinsp_evt* evt, const std::string& fullpath, uint32_t flags) = 0;
 	virtual void on_error(sinsp_evt* evt) = 0;
 	virtual void on_erase_fd(erase_fd_params* params) = 0;

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -280,7 +280,7 @@ TEST_F(sinsp_with_test_input, umount)
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.res"), std::to_string(res));
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), name);
 
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_EQ(fdinfo, nullptr);
 }
 
@@ -301,7 +301,7 @@ TEST_F(sinsp_with_test_input, umount2)
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.res"), std::to_string(res));
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), name);
 
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_EQ(fdinfo, nullptr);
 }
 
@@ -333,7 +333,7 @@ TEST_F(sinsp_with_test_input, pipe)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check the `openflags` field of the fdinfo2, it should be 0 since pipe has no flags */
-	sinsp_fdinfo_t* fdinfo2 = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
 	ASSERT_NE(fdinfo2, nullptr);
 	ASSERT_EQ(fdinfo2->m_openflags, 0);
 	ASSERT_FD_GETTERS_NOT_FILE(fdinfo2)
@@ -341,7 +341,7 @@ TEST_F(sinsp_with_test_input, pipe)
 	/* Now we get the first file descriptor (`3`) and we assert some fields directly through the `fdinfo` pointer. */
 
 	ASSERT_NE(evt->get_thread_info(), nullptr);
-	sinsp_fdinfo_t* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
+	sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
 	ASSERT_NE(fdinfo1, nullptr);
 	ASSERT_STREQ(fdinfo1->get_typestring(), "pipe");
 	ASSERT_EQ(fdinfo1->get_typechar(), 'p');
@@ -380,14 +380,14 @@ TEST_F(sinsp_with_test_input, pipe2)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check the `openflags` field of the fdinfo2, it should be 17 since pipe2 has flags field */
-	sinsp_fdinfo_t* fdinfo2 = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
 	ASSERT_NE(fdinfo2, nullptr);
 	ASSERT_EQ(fdinfo2->m_openflags, flags);
 	ASSERT_FD_GETTERS_NOT_FILE(fdinfo2)
 
 	/* Now we get the first file descriptor (`3`) and we assert some fields directly through the `fdinfo` pointer. */
 	ASSERT_NE(evt->get_thread_info(), nullptr);
-	sinsp_fdinfo_t* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
+	sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
 	ASSERT_NE(fdinfo1, nullptr);
 	ASSERT_STREQ(fdinfo1->get_typestring(), "pipe");
 	ASSERT_EQ(fdinfo1->get_typechar(), 'p');
@@ -416,7 +416,7 @@ TEST_F(sinsp_with_test_input, inotify_init)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "inotify");
 	ASSERT_EQ(fdinfo->get_typechar(), 'i');
@@ -445,7 +445,7 @@ TEST_F(sinsp_with_test_input, inotify_init1)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "inotify");
 	ASSERT_EQ(fdinfo->get_typechar(), 'i');
@@ -474,7 +474,7 @@ TEST_F(sinsp_with_test_input, eventfd)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "event");
 	ASSERT_EQ(fdinfo->get_typechar(), 'e');
@@ -504,7 +504,7 @@ TEST_F(sinsp_with_test_input, eventfd2)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "event");
 	ASSERT_EQ(fdinfo->get_typechar(), 'e');
@@ -534,7 +534,7 @@ TEST_F(sinsp_with_test_input, signalfd)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "signalfd");
 	ASSERT_EQ(fdinfo->get_typechar(), 's');
@@ -564,7 +564,7 @@ TEST_F(sinsp_with_test_input, signalfd4)
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo_t* fdinfo = evt->get_fd_info();
+	sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "signalfd");
 	ASSERT_EQ(fdinfo->get_typechar(), 's');

--- a/userspace/libsinsp/test/events_net.ut.cpp
+++ b/userspace/libsinsp/test/events_net.ut.cpp
@@ -48,7 +48,7 @@ TEST_F(sinsp_with_test_input, net_socket)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 
 	int64_t client_fd = 9;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, (uint32_t) PPM_AF_INET, (uint32_t) SOCK_STREAM,  (uint32_t) 0);
@@ -82,7 +82,7 @@ TEST_F(sinsp_with_test_input, net_ipv4_connect)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	sinsp_threadinfo* tinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 	int64_t client_fd = 7;
@@ -166,7 +166,7 @@ TEST_F(sinsp_with_test_input, net_ipv4_connect_with_intermediate_event)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	int64_t client_fd = 8;
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, (uint32_t) PPM_AF_INET, (uint32_t) SOCK_STREAM, (uint32_t) 0);
@@ -263,7 +263,7 @@ TEST_F(sinsp_with_test_input, net_bind_listen_accept_ipv4)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 
 	int64_t server_fd = 3;
@@ -377,7 +377,7 @@ TEST_F(sinsp_with_test_input, net_connect_exit_event_fails)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 	int64_t client_fd = 7;
 
@@ -450,7 +450,7 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_empty)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 	int64_t client_fd = 7;
 
@@ -520,7 +520,7 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_missing)
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 	int64_t client_fd = 7;
 
@@ -578,7 +578,7 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_missing_wo_fd_param_exi
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo_t* fdinfo = NULL;
+	sinsp_fdinfo* fdinfo = NULL;
 	int64_t client_fd = 7;
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, (uint32_t) PPM_AF_INET, (uint32_t) SOCK_DGRAM, (uint32_t) 0);

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -288,7 +288,7 @@ public:
 
 	  \return True if all callback invoations returned true, false if not
 	*/
-	bool loop_fds(sinsp_fdtable::fdtable_visitor_t visitor);
+	bool loop_fds(sinsp_fdtable::fdtable_const_visitor_t visitor);
 
 	/*!
 	  \brief Return true if this thread is bound to the given server port.

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -48,7 +48,7 @@ struct erase_fd_params
 	bool m_remove_from_table;
 	int64_t m_fd;
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo_t* m_fdinfo;
+	sinsp_fdinfo* m_fdinfo;
 	uint64_t m_ts;
 };
 
@@ -258,7 +258,7 @@ public:
 	  \return Pointer to the FD information, or NULL if the given FD doesn't
 	   exist
 	*/
-	inline sinsp_fdinfo_t* get_fd(int64_t fd)
+	inline sinsp_fdinfo* get_fd(int64_t fd)
 	{
 		if(fd < 0)
 		{
@@ -269,7 +269,7 @@ public:
 
 		if(fdt)
 		{
-			sinsp_fdinfo_t *fdinfo = fdt->find(fd);
+			sinsp_fdinfo *fdinfo = fdt->find(fd);
 			if(fdinfo)
 			{
 				// Its current name is now its old
@@ -559,8 +559,8 @@ VISIBILITY_PRIVATE
 	// return true if, based on the current inspector filter, this thread should be kept
 	void init(scap_threadinfo* pi);
 	void fix_sockets_coming_from_proc();
-	sinsp_fdinfo_t* add_fd(int64_t fd, sinsp_fdinfo_t *fdinfo);
-	void add_fd_from_scap(scap_fdinfo *fdinfo, OUT sinsp_fdinfo_t *res);
+	sinsp_fdinfo* add_fd(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
+	void add_fd_from_scap(scap_fdinfo *fdinfo);
 	void remove_fd(int64_t fd);
 	void set_cwd(std::string_view cwd);
 	sinsp_threadinfo* get_cwd_root();
@@ -723,6 +723,9 @@ public:
 	void clear();
 
 	std::unique_ptr<sinsp_threadinfo> new_threadinfo() const;
+
+	std::unique_ptr<sinsp_fdinfo> new_fdinfo() const;
+
 	bool add_thread(sinsp_threadinfo *threadinfo, bool from_scap_proctable);
 	sinsp_threadinfo* find_new_reaper(sinsp_threadinfo*);
 	void remove_thread(int64_t tid);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR attempts refactoring the data structures related to file descriptor tables on the following points:

- Most methods on fd infos could be const or inlined by currently aren't. Furthermore, some methods are currently unused and are now cleaned up
- The `sinsp_fdinfo` class has fields and methods definitions mixed with no clarity about their order and visibility (what's public and what's not?). The class has been cleanup up with reasonable ordering
- `sinsp_fdinfo` is currently a template for no good reason, if not the possibility of extending the class with a "sidecar" delegated object. This suboptimal for type safety and pollutes our headers for very little value, whereas the same can simply be attained through inheritance following well-known OOP principles. This also caused defining the type twice (as `sinsp_fdinfo_t` too), of which unification led to most of the LOC changes of this PR
- The file descriptor tables are currently accessed in their internals from many parts, mostly just with the purpose of looping through their elements, even though we have functional accessors for that. We now uniform that for accessing fds only through loop API
- File descriptor infos are allocated by value instead that by pointer (e.g. which we instead do for thread infos), effectively preventing practitioners and non-falco clients from extending the fd infos, and making allocation a bit puzzling in certain situations. For example, shifting to a pointer-based allocation uncovered a subtle issue in caching fd table queries but that used to work "by mistake"
- Unlike thread infos, there was no factory method for building thread infos, and allocation of new ones was scattered in many points. This is a first step that will allow exposing those tables in the state API accessible by plugins in the future
- Fd infos have been passed as raw pointers without no criteria about who's the memory owner. For example, the simple `add_fd` path drove me crazy in some paths understanding who owned memory. I've now switched to unique pointers wherever possible. More will come later, but this is a starter.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp)!: file descriptor tables for better OOP design and extensibility
```
