### PR TITLE
clenup(userspace/libsinsp)!: remove unused filter compiler flag

### DIFF
--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -743,7 +743,7 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		{
 			try
 			{
-				compiler = new sinsp_filter_compiler(ch->m_inspector, filterstr, true);
+				compiler = new sinsp_filter_compiler(ch->m_inspector, filterstr);
 				filter = compiler->compile();
 			}
 			catch(const sinsp_exception& e)

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -60,15 +60,13 @@ public:
 		\param inspector Pointer to the inspector instance that will generate
 		the events to be filtered
 		\param fltstr The filter string to compile
-		\param ttable_only For internal use only
 
 		\note This is not the primary constructor, and is only maintained for
 		backward compatibility
 	*/
 	sinsp_filter_compiler(
 		sinsp* inspector,
-		const std::string& fltstr,
-		bool ttable_only=false);
+		const std::string& fltstr);
 
 	/*!
 		\brief Constructs the compiler
@@ -76,12 +74,10 @@ public:
 		\param factory Pointer to a filter factory to be used to build
 		the filtercheck tree
 		\param fltstr The filter string to compile
-		\param ttable_only For internal use only
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<gen_event_filter_factory> factory,
-		const std::string& fltstr,
-		bool ttable_only=false);
+		const std::string& fltstr);
 
 	/*!
 		\brief Constructs the compiler
@@ -90,12 +86,10 @@ public:
 		the filtercheck tree
 		\param fltast AST of a parsed filter, used to build the filtercheck
 		tree
-		\param ttable_only For internal use only
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<gen_event_filter_factory> factory,
-		const libsinsp::filter::ast::expr* fltast,
-		bool ttable_only=false);
+		const libsinsp::filter::ast::expr* fltast);
 
 	/*!
 		\brief Builds a filtercheck tree and bundles it in sinsp_filter
@@ -117,13 +111,11 @@ private:
 	void visit(const libsinsp::filter::ast::list_expr*) override;
 	void visit(const libsinsp::filter::ast::unary_check_expr*) override;
 	void visit(const libsinsp::filter::ast::binary_check_expr*) override;
-	void check_ttable_only(std::string& field, gen_event_filter_check *check);
 	cmpop str_to_cmpop(const std::string& str);
 	std::string create_filtercheck_name(const std::string& name, const std::string& arg);
 	gen_event_filter_check* create_filtercheck(std::string& field);
 
 	libsinsp::filter::ast::pos_info m_pos;
-	bool m_ttable_only;
 	bool m_expect_values;
 	boolop m_last_boolop;
 	std::string m_flt_str;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -117,8 +117,7 @@ public:
 	enum flags
 	{
 		FL_NONE =   0,
-		FL_WORKS_ON_THREAD_TABLE = (1 << 0),	///< This filter check class supports filtering incomplete events that contain only valid thread info and FD info.
-		FL_HIDDEN = (1 << 1),	///< This filter check class won't be shown by fields/filter listings.
+		FL_HIDDEN = (1 << 0),	///< This filter check class won't be shown by fields/filter listings.
 	};
 
 	filter_check_info()

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -66,7 +66,7 @@ sinsp_filter_check_container::sinsp_filter_check_container()
 	m_info.m_desc = "Container information. If the event is not happening inside a container, both id and name will be set to 'host'.";
 	m_info.m_fields = sinsp_filter_check_container_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_container_fields) / sizeof(sinsp_filter_check_container_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_container::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -106,7 +106,7 @@ sinsp_filter_check_fd::sinsp_filter_check_fd()
 	m_info.m_desc = "Every syscall that has a file descriptor in its arguments has these fields set with information related to the file.";
 	m_info.m_fields = sinsp_filter_check_fd_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_fd_fields) / sizeof(sinsp_filter_check_fd_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_fd::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -43,7 +43,7 @@ sinsp_filter_check_fdlist::sinsp_filter_check_fdlist()
 	m_info.m_desc = "Poll event related fields.";
 	m_info.m_fields = sinsp_filter_check_fdlist_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_fdlist_fields) / sizeof(sinsp_filter_check_fdlist_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_fdlist::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -53,7 +53,7 @@ sinsp_filter_check_fspath::sinsp_filter_check_fspath()
 	m_info.m_desc = "Every syscall that has a filesystem path in its arguments has these fields set with information related to the path arguments. This differs from the fd.* fields as it includes syscalls like unlink, rename, etc. that act directly on filesystem paths as compared to opened file descriptors.";
 	m_info.m_fields = sinsp_filter_check_fspath_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_fspath_fields) / sizeof(sinsp_filter_check_fspath_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 };
 
 std::shared_ptr<sinsp_filter_check> sinsp_filter_check_fspath::create_event_check(const char *name,

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -47,7 +47,7 @@ sinsp_filter_check_group::sinsp_filter_check_group()
 	m_info.m_desc = "Information about the user group.";
 	m_info.m_fields = sinsp_filter_check_group_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_group_fields) / sizeof(sinsp_filter_check_group_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_group::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
@@ -73,7 +73,7 @@ sinsp_filter_check_k8s::sinsp_filter_check_k8s()
 	m_info.m_desc = "Kubernetes related context. When configured to fetch from the API server, all fields are available. Otherwise, only the `k8s.pod.*` and `k8s.ns.name` fields are populated with data gathered from the container runtime.";
 	m_info.m_fields = sinsp_filter_check_k8s_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_k8s_fields) / sizeof(sinsp_filter_check_k8s_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_k8s::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
@@ -51,7 +51,7 @@ sinsp_filter_check_mesos::sinsp_filter_check_mesos()
 	m_info.m_desc = "Mesos related context.";
 	m_info.m_fields = sinsp_filter_check_mesos_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_mesos_fields) / sizeof(sinsp_filter_check_mesos_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_mesos::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -134,7 +134,7 @@ sinsp_filter_check_thread::sinsp_filter_check_thread()
 	m_info.m_desc = "Additional information about the process and thread executing the syscall event.";
 	m_info.m_fields = sinsp_filter_check_thread_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_thread_fields) / sizeof(sinsp_filter_check_thread_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 
 	m_u64val = 0;
 	m_cursec_ts = 0;

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -56,7 +56,7 @@ sinsp_filter_check_user::sinsp_filter_check_user()
 	m_info.m_desc = "Information about the user executing the specific event.";
 	m_info.m_fields = sinsp_filter_check_user_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_user_fields) / sizeof(sinsp_filter_check_user_fields[0]);
-	m_info.m_flags = filter_check_info::FL_WORKS_ON_THREAD_TABLE;
+	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
 sinsp_filter_check* sinsp_filter_check_user::allocate_new()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This removes a quite old flag on filterchecks that was in place only for use cases related to chisels, which now bring little to no value.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
clenup(userspace/libsinsp)!: remove unused filter compiler flag
```
