### PR TITLE
fix(userspace/libsinsp): revert to old `concatenate_paths` helper funtion for perf reasons

### DIFF
--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -24,6 +24,12 @@ TEST(sinsp_utils_test, concatenate_paths)
 	// Some tests were motivated by this resource:
 	// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap04.html#tag_04_11
 
+	// PLEASE NOTE:
+	// * current impl does not support unicode.
+	// * current impl does not sanitize path1
+	// * current impl expects path1 to end with '/'
+	// * current impl skips path1 altogether if path2 is absolute
+
 	std::string path1, path2, res;
 
 	res = sinsp_utils::concatenate_paths("", "");
@@ -32,12 +38,57 @@ TEST(sinsp_utils_test, concatenate_paths)
 	path1 = "";
 	path2 = "../";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("..", res);
+	EXPECT_EQ("", res);
+
+	path1 = "";
+	path2 = "..";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("", res);
+
+	path1 = "/";
+	path2 = "../";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/", res);
+
+	path1 = "a";
+	path2 = "../";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("a..", res); // since the helper does not add any "/" between path1 and path2, we end up with this.
+
+	path1 = "a/";
+	path2 = "../";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("", res);
+
+	path1 = "";
+	path2 = "/foo";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/foo", res);
+
+	path1 = "foo/";
+	path2 = "..//a";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("a", res); // path2 has been sanitized, plus we moved up a folder because of ".."
+
+	path1 = "/foo/";
+	path2 = "..//a";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/a", res); // path2 has been sanitized, plus we moved up a folder because of ".."
+
+	path1 = "heolo";
+	path2 = "w////////////..//////.////////r.|";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("r.|", res); // since the helper does not add any "/" between path1 and path2, we end up with this.
+
+	path1 = "heolo";
+	path2 = "w/////////////..//"; // heolow/////////////..// > heolow/..// -> /
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("", res); // since the helper does not add any "/" between path1 and path2, we end up with this, ie a folder up from "heolow/"
 
 	path1 = "";
 	path2 = "./";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ(".", res);
+	EXPECT_EQ("", res);
 
 	path1 = "";
 	path2 = "dir/term";
@@ -92,27 +143,28 @@ TEST(sinsp_utils_test, concatenate_paths)
 	path1 = "./app";
 	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("app/custom/term", res);
+	EXPECT_EQ("./appcustom/term", res); // since path1 is not '/' terminated, we expect a string concat without further path fields
 
 	path1 = "/app";
 	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/app/custom/term", res);
+	EXPECT_EQ("/appcustom/term", res); // since path1 is not '/' terminated, we expect a string concat without further path fields
 
 	path1 = "app";
 	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("app/custom/term", res);
+	EXPECT_EQ("appcustom/term", res); // since path1 is not '/' terminated, we expect a string concat without further path fields
 
-	path1 = "app//";
+	path1 = "app/";
 	path2 = "custom/term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("app/custom/term", res);
 
+	// We don't support sanitizing path1
 	path1 = "app/////";
 	path2 = "custom////term";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("app/custom/term", res);
+	EXPECT_EQ("app/////custom/term", res);
 
 	path1 = "/";
 	path2 = "/app/custom/dir/././././../../term/";
@@ -124,6 +176,7 @@ TEST(sinsp_utils_test, concatenate_paths)
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/app", res);
 
+	/* No unicode support
 	path1 = "/root/";
 	path2 = "../😉";
 	res = sinsp_utils::concatenate_paths(path1, path2);
@@ -142,5 +195,5 @@ TEST(sinsp_utils_test, concatenate_paths)
 	path1 = "/root";
 	path2 = "c:/hello/world/";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/root/c:/hello/world", res);
+	EXPECT_EQ("/root/c:/hello/world", res); */
 }

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -95,10 +95,11 @@ public:
 
 	//
 	// Concatenate posix-style path1 and path2 up to max_len in size, normalizing the result.
+	// path1 MUST be '/' terminated and is not sanitized.
 	// If path2 is absolute, the result will be equivalent to path2.
 	// If the result would be too long, the output will contain the string "/PATH_TOO_LONG" instead.
 	//
-	static std::string concatenate_paths(std::string_view path1, std::string_view path2, size_t max_len=SCAP_MAX_PATH_SIZE-1);
+	static std::string concatenate_paths(std::string_view path1, std::string_view path2);
 
 	//
 	// Determines if an IPv6 address is IPv4-mapped


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR embeds a better fix for the issue found in #1530, reverting the new `std::filesystem` implementation (that was great btw, and much better edge cases coverage; see #1533 ) to the old one with some small fixes on top, for perf reasons. We found that the new impl had like a 7.5x slowdown; since it is used in hot paths, we had to revert.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
