### PR TITLE
fix: Clang warning pessimizing move

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2116,7 +2116,7 @@ bool sinsp_evt::clone_event(sinsp_evt &dest, const sinsp_evt &src)
 	{
 		//m_fdinfo_ref is only used to keep a handle to this
 		// copy of the fdinfo which was copied from the global fdinfo table
-		dest.m_fdinfo_ref = std::move(src.m_fdinfo->clone());
+		dest.m_fdinfo_ref = src.m_fdinfo->clone();
 		dest.m_fdinfo = dest.m_fdinfo_ref.get();
 	}
 	dest.m_fdinfo_name_changed = src.m_fdinfo_name_changed;

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -328,7 +328,7 @@ sinsp_fdinfo* sinsp_fdtable::add(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinf
 			fdinfo->m_flags &= ~sinsp_fdinfo::FLAGS_CLOSE_IN_PROGRESS;
 			fdinfo->m_flags |= sinsp_fdinfo::FLAGS_CLOSE_CANCELED;
 
-			m_table[CANCELED_FD_NUMBER] = std::move(it->second->clone());
+			m_table[CANCELED_FD_NUMBER] = it->second->clone();
 		}
 		else
 		{

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4829,7 +4829,7 @@ void sinsp_parser::parse_fcntl_exit(sinsp_evt *evt)
 		// NOTE: dup2 and dup3 accept an existing FD and in that case they close it.
 		//       For us it's ok to just overwrite it.
 		//
-		evt->m_fdinfo = evt->m_tinfo->add_fd(retval, std::move(evt->m_fdinfo->clone()));
+		evt->m_fdinfo = evt->m_tinfo->add_fd(retval, evt->m_fdinfo->clone());
 	}
 }
 
@@ -5717,5 +5717,5 @@ void sinsp_parser::parse_pidfd_getfd_exit(sinsp_evt *evt)
 	{
 		return;
 	}
-	evt->m_tinfo->add_fd(fd, std::move(targetfd_fdinfo->clone()));
+	evt->m_tinfo->add_fd(fd, targetfd_fdinfo->clone());
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
Fix a recurrent warning with Clang. It complains that an `std::move` on an object that is already an rvalue reference is unneeded and could prevent optimizations to take place, i.e. force a move when direct construction could be used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
