### PR TITLE
fix(userspace/libsinsp/test): avoid deadlocks in mpsc queue tests

### DIFF
--- a/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
+++ b/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
@@ -119,8 +119,8 @@ TEST(mpsc_priority_queue, single_concurrent_producer)
 TEST(mpsc_priority_queue, multi_concurrent_producers)
 {
     using val_t = std::unique_ptr<int>;
-    const constexpr int64_t timeout_secs = 10;
-    const constexpr int num_values = 1000;
+    const constexpr int64_t timeout_secs = 30;
+    const constexpr int num_values = 100;
     const constexpr int num_producers = 10;
     const constexpr int num_total_elems = num_values * num_producers;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

Nah

**What this PR does / why we need it**:

We're experiencing deadlocks on the concurrent tests on the MPSC priority queue, so far only on aarch64 in our CI. This may either reveal a thread-safety issue in the queue's implementation, or may just be pathological due to the scheduler being unpredictable -- the queue can order elements already pushed, but can't know if an higher-priority event is not yet pushed due to its producer being sleepy. This PR solves the issue by making the test fail with a timeout, and provides more in-depth messages about the failure. Also, the exit condition of the loop was still faulty in case of out-of-order elements, so this should also be cleared now.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```