### PR TITLE
fix(userspace/libsinsp/test): put a bound to threat table max size test

### DIFF
--- a/userspace/libsinsp/test/thread_table.ut.cpp
+++ b/userspace/libsinsp/test/thread_table.ut.cpp
@@ -430,6 +430,8 @@ TEST_F(sinsp_with_test_input, THRD_TABLE_reparenting_in_the_default_tree)
 
 TEST_F(sinsp_with_test_input, THRD_TABLE_max_table_size)
 {
+	m_inspector.m_thread_manager->set_max_thread_table_size(10000);
+
 	add_default_init_thread();
 	open_inspector();
 
@@ -440,7 +442,7 @@ TEST_F(sinsp_with_test_input, THRD_TABLE_max_table_size)
 	/* Here we want to check that creating a number of threads grater
 	 * than m_max_thread_table_size doesn't cause a crash.
 	 */
-	for(uint32_t i = 1; i < (m_inspector.m_thread_manager->m_max_thread_table_size + 10000); i++)
+	for(uint32_t i = 1; i < (m_inspector.m_thread_manager->m_max_thread_table_size + 1000); i++)
 	{
 		/* we change only the tid */
 		generate_clone_x_event(0, pid + i, pid, INIT_TID, PPM_CL_CLONE_THREAD);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The `sinsp_with_test_input.THRD_TABLE_max_table_size` took a while to execute locally and also made my machine crash, which didn't make much sense to me. Looking closer, the max thread table size is a quite large number and it has also been increased. I changed this to set a fixed size for the sake of the test, still with a reasonably-high number so that it keeps being valuable.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
