### PR TITLE
cleanup(libsinsp): cleanup unaligned access in plugin framework+tests

### DIFF
--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -331,7 +331,10 @@ int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf, siz
 	len = len + sizeof(uint32_t);
 #endif
 
-	*event_size = len;
+	if (event_size != NULL)
+	{
+		*event_size = len;
+	}
 
 	// we were not able to write the event to the buffer
 	if (!scap_buffer_can_fit(event_buf, len))

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/stat.h>
@@ -2222,7 +2223,7 @@ void sinsp::handle_plugin_async_event(const sinsp_plugin& p, std::unique_ptr<sin
 
 		// write plugin ID and timestamp in the event and kick it in the queue
 		auto plid = (uint32_t*)((uint8_t*) evt->get_scap_evt() + sizeof(scap_evt) + 4+4+4);
-		*plid = cur_plugin_id;
+		memcpy(plid, &cur_plugin_id, sizeof(cur_plugin_id));
 		handle_async_event(std::move(evt));
 	}
 }

--- a/userspace/libsinsp/test/plugins/plugin_source.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_source.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <sstream>
 
 #include <driver/ppm_events_public.h>
+#include <scap.h>
 
 #include "test_plugins.h"
 
@@ -139,27 +140,21 @@ static ss_plugin_rc plugin_next_batch(ss_plugin_t* s, ss_instance_t* i, uint32_t
 
     *nevts = 1;
     *evts = &istate->evt;
-    istate->evt->type = PPME_PLUGINEVENT_E;
+
+    char error[SCAP_LASTERR_SIZE];
+
+    int32_t encode_res = scap_event_encode_params(scap_sized_buffer{istate->evt, sizeof(istate->evt_buf)},
+        nullptr, error, PPME_PLUGINEVENT_E, 2,
+        plugin_get_id(), s_evt_data);
+
+    if (encode_res == SCAP_FAILURE)
+    {
+        return SS_PLUGIN_FAILURE;
+    }
+
     istate->evt->tid = -1;
     istate->evt->ts = UINT64_MAX;
-    istate->evt->len = sizeof(ss_plugin_event);
-    istate->evt->nparams = 2;
 
-    uint8_t* parambuf = &istate->evt_buf[0] + sizeof(ss_plugin_event);
-
-    // lenghts
-    *((uint32_t*) parambuf) = sizeof(uint32_t);
-    parambuf += sizeof(uint32_t);
-    *((uint32_t*) parambuf) = strlen(s_evt_data) + 1;
-    parambuf += sizeof(uint32_t);
-
-    // params
-    *((uint32_t*) parambuf) = plugin_get_id();
-    parambuf += sizeof(uint32_t);
-    strcpy((char*) parambuf, s_evt_data);
-    parambuf += strlen(s_evt_data) + 1;
-
-    istate->evt->len += parambuf - (&istate->evt_buf[0] + sizeof(ss_plugin_event));
     istate->count--;
     return SS_PLUGIN_SUCCESS;
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This is part of this effort: https://github.com/falcosecurity/libs/issues/1470

This current PR deals with plugins, note that it introduces a dependency from the plugin tests to the scap library in order to use the `scap_event_encode_params` function which allows the test classes to easily create events without misaligned reads or writes.

It looks like the sinsp test suite is are currently at 7 errors with UBSan.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
