### PR TITLE
cleanup(libscap): fix unaligned memory reads

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -811,8 +811,8 @@ static int32_t scap_read_iflist(scap_reader_t* r, uint32_t block_length, uint32_
 
 		if(block_type != IL_BLOCK_TYPE_V2)
 		{
-			iftype = *(uint16_t *)pif;
-			ifnamlen = *(uint16_t *)(pif + 2);
+			memcpy(&iftype, pif, sizeof(iftype));
+			memcpy(&ifnamlen, pif + 2, sizeof(ifnamlen));
 
 			if(iftype == SCAP_II_IPV4)
 			{
@@ -833,16 +833,16 @@ static int32_t scap_read_iflist(scap_reader_t* r, uint32_t block_length, uint32_
 			else
 			{
 				snprintf(error, SCAP_LASTERR_SIZE, "trace file has corrupted interface list(1)");
-				ASSERT(false);
 				res = SCAP_FAILURE;
 				goto scap_read_iflist_error;
 			}
 		}
 		else
 		{
-			entrysize = *(uint32_t *)pif + sizeof(uint32_t);
-			iftype = *(uint16_t *)(pif + 4);
-			ifnamlen = *(uint16_t *)(pif + 4 + 2);
+			memcpy(&entrysize, pif, sizeof(entrysize));
+			entrysize += sizeof(uint32_t);
+			memcpy(&iftype, pif + 4, sizeof(iftype));
+			memcpy(&ifnamlen, pif + 4 + 2, sizeof(ifnamlen));
 		}
 
 		if(toread < entrysize)
@@ -865,7 +865,6 @@ static int32_t scap_read_iflist(scap_reader_t* r, uint32_t block_length, uint32_
 		}
 		else
 		{
-			ASSERT(false);
 			snprintf(error, SCAP_LASTERR_SIZE, "unknown interface type %d", (int)iftype);
 			res = SCAP_FAILURE;
 			goto scap_read_iflist_error;
@@ -942,13 +941,13 @@ static int32_t scap_read_iflist(scap_reader_t* r, uint32_t block_length, uint32_
 
 		if(block_type == IL_BLOCK_TYPE_V2)
 		{
-			entrysize = *(uint32_t *)pif;
+			memcpy(&entrysize, pif, sizeof(entrysize));
 			totreadsize += sizeof(uint32_t);
 			pif += sizeof(uint32_t);
 		}
 
-		iftype = *(uint16_t *)pif;
-		ifnamlen = *(uint16_t *)(pif + 2);
+		memcpy(&iftype, pif, sizeof(iftype));
+		memcpy(&ifnamlen, pif + 2, sizeof(ifnamlen));
 
 		if(ifnamlen >= SCAP_MAX_PATH_SIZE)
 		{
@@ -1956,7 +1955,7 @@ static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_
 
 		if(bh.block_type == EVF_BLOCK_TYPE || bh.block_type == EVF_BLOCK_TYPE_V2 || bh.block_type == EVF_BLOCK_TYPE_V2_LARGE)
 		{
-			*pflags = *(uint32_t *)(handle->m_reader_evt_buf + sizeof(uint16_t));
+			memcpy(pflags, handle->m_reader_evt_buf + sizeof(uint16_t), sizeof(uint32_t));
 			*pevent = (struct ppm_evt_hdr *)(handle->m_reader_evt_buf + sizeof(uint16_t) + sizeof(uint32_t));
 		}
 		else


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Next step in this effort: https://github.com/falcosecurity/libs/issues/1470 this brings unit/integration to 0 warnings, e2e are next.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
