### PR TITLE
cleanup(userspace/libsinsp): reduce allocations in filtercheck classes

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -64,7 +64,6 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 	bool res = true;
 
 	sinsp_filter_check* chk = nullptr;
-	++m_hits;
 
 	auto size = m_checks.size();
 	for(size_t j = 0; j < size; j++)
@@ -126,10 +125,6 @@ bool sinsp_filter_expression::compare(sinsp_evt *evt)
 		}
 	}
  done:
-	if (res)
-	{
-		m_matched_true++;
-	}
 	return res;
 }
 
@@ -266,16 +261,9 @@ sinsp_filter* sinsp_filter_compiler::compile()
 
 	// create new filter using factory
 	auto new_filter = m_factory->new_filter();
-	auto new_sinsp_filter = dynamic_cast<sinsp_filter*>(new_filter);
-	if (new_sinsp_filter == nullptr)
-	{
-		ASSERT(false);
-		delete new_filter;
-		throw sinsp_exception("filter error: factory did not create a sinsp_filter");
-	}
 
 	// setup compiler state and start compilation
-	m_filter = new_sinsp_filter;
+	m_filter = new_filter;
 	m_last_boolop = BO_NONE;
 	m_expect_values = false;
 	try
@@ -284,14 +272,14 @@ sinsp_filter* sinsp_filter_compiler::compile()
 	}
 	catch (const sinsp_exception& e)
 	{
-		delete new_sinsp_filter;
+		delete new_filter;
 		m_filter = NULL;
 		throw e;
 	}
 
 	// return compiled filter
 	m_filter = NULL;
-	return new_sinsp_filter;
+	return new_filter;
 }
 
 void sinsp_filter_compiler::visit(const libsinsp::filter::ast::and_expr* e)

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <libsinsp/sinsp_filtercheck.h>
 #include <libsinsp/value_parser.h>
 
-#define STR_STORAGE_SIZE	1024
+#define STRPROPERTY_STORAGE_SIZE	1024
 
 #ifndef _GNU_SOURCE
 //
@@ -863,9 +863,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(int8_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_INT16:
@@ -888,9 +888,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(int16_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_INT32:
@@ -913,9 +913,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(int32_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_INT64:
@@ -944,9 +944,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				prfmt = (char*)"%" PRId64;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(int64_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_L4PROTO: // This can be resolved in the future
@@ -970,9 +970,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(uint8_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_PORT: // This can be resolved in the future
@@ -996,9 +996,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(uint16_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_UINT32:
@@ -1021,9 +1021,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(uint32_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_UINT64:
@@ -1052,9 +1052,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 			
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 prfmt, *(uint64_t *)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_CHARBUF:
@@ -1070,8 +1070,8 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			}
 			else
 			{
-				auto copy_len = std::min(len, (uint32_t) STR_STORAGE_SIZE);
-				m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+				auto copy_len = std::min(len, (uint32_t) STRPROPERTY_STORAGE_SIZE);
+				m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 				memcpy(m_getpropertystr_storage.data(), rawval, copy_len);
 				m_getpropertystr_storage.data()[copy_len] = 0;
 				return m_getpropertystr_storage.data();
@@ -1092,9 +1092,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return (char*)"false";
 			}
 		case PT_IPV4ADDR:
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-						STR_STORAGE_SIZE,
+						STRPROPERTY_STORAGE_SIZE,
 						"%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8,
 						rawval[0],
 						rawval[1],
@@ -1110,8 +1110,8 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				strlcpy(address, "<NA>", INET6_ADDRSTRLEN);
 			}
 
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
-			strlcpy(m_getpropertystr_storage.data(), address, STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
+			strlcpy(m_getpropertystr_storage.data(), address, STRPROPERTY_STORAGE_SIZE);
 
 			return m_getpropertystr_storage.data();
 		}
@@ -1130,15 +1130,15 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			}
 
 		case PT_DOUBLE:
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-					 STR_STORAGE_SIZE,
+					 STRPROPERTY_STORAGE_SIZE,
 					 "%.1lf", *(double*)rawval);
 			return m_getpropertystr_storage.data();
 		case PT_IPNET:
-			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 			snprintf(m_getpropertystr_storage.data(),
-				 STR_STORAGE_SIZE,
+				 STRPROPERTY_STORAGE_SIZE,
 				 "<IPNET>");
 			return m_getpropertystr_storage.data();
 		default:
@@ -1167,8 +1167,8 @@ char* sinsp_filter_check::tostring(sinsp_evt* evt)
 			res += rawval_to_string(val.ptr, m_field->m_type, m_field->m_print_format, val.len);
 		}
 		res += ")";
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
-		strlcpy(m_getpropertystr_storage.data(), res.c_str(), STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
+		strlcpy(m_getpropertystr_storage.data(), res.c_str(), STRPROPERTY_STORAGE_SIZE);
 		return m_getpropertystr_storage.data();
 	}
 	return rawval_to_string(m_extracted_values[0].ptr, m_field->m_type, m_field->m_print_format, m_extracted_values[0].len);

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -23,6 +23,8 @@ limitations under the License.
 #include <libsinsp/sinsp_filtercheck.h>
 #include <libsinsp/value_parser.h>
 
+#define STR_STORAGE_SIZE	1024
+
 #ifndef _GNU_SOURCE
 //
 // Fallback implementation of memmem
@@ -861,10 +863,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(int8_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_INT16:
 			if(print_format == PF_OCT)
 			{
@@ -885,10 +888,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(int16_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_INT32:
 			if(print_format == PF_OCT)
 			{
@@ -909,10 +913,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(int32_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_INT64:
 		case PT_PID:
 		case PT_ERRNO:
@@ -939,10 +944,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				prfmt = (char*)"%" PRId64;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(int64_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_L4PROTO: // This can be resolved in the future
 		case PT_UINT8:
 			if(print_format == PF_OCT)
@@ -964,10 +970,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(uint8_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_PORT: // This can be resolved in the future
 		case PT_UINT16:
 			if(print_format == PF_OCT)
@@ -989,10 +996,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(uint16_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_UINT32:
 			if(print_format == PF_OCT)
 			{
@@ -1013,10 +1021,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return NULL;
 			}
 
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(uint32_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_UINT64:
 		case PT_RELTIME:
 		case PT_ABSTIME:
@@ -1042,11 +1051,12 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				ASSERT(false);
 				return NULL;
 			}
-
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 prfmt, *(uint64_t *)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_CHARBUF:
 		case PT_FSPATH:
 		case PT_FSRELPATH:
@@ -1060,10 +1070,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			}
 			else
 			{
-				auto copy_len = std::min(len, (uint32_t) sizeof(m_getpropertystr_storage));
-				memcpy(m_getpropertystr_storage, rawval, copy_len);
-				m_getpropertystr_storage[copy_len] = 0;
-				return m_getpropertystr_storage;
+				auto copy_len = std::min(len, (uint32_t) STR_STORAGE_SIZE);
+				m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+				memcpy(m_getpropertystr_storage.data(), rawval, copy_len);
+				m_getpropertystr_storage.data()[copy_len] = 0;
+				return m_getpropertystr_storage.data();
 			}
 		case PT_SOCKADDR:
 			ASSERT(false);
@@ -1081,14 +1092,15 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				return (char*)"false";
 			}
 		case PT_IPV4ADDR:
-			snprintf(m_getpropertystr_storage,
-						sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+						STR_STORAGE_SIZE,
 						"%" PRIu8 ".%" PRIu8 ".%" PRIu8 ".%" PRIu8,
 						rawval[0],
 						rawval[1],
 						rawval[2],
 						rawval[3]);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_IPV6ADDR:
 		{
 			char address[INET6_ADDRSTRLEN];
@@ -1098,9 +1110,10 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 				strlcpy(address, "<NA>", INET6_ADDRSTRLEN);
 			}
 
-			strlcpy(m_getpropertystr_storage, address, sizeof(m_getpropertystr_storage));
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			strlcpy(m_getpropertystr_storage.data(), address, STR_STORAGE_SIZE);
 
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		}
 	        case PT_IPADDR:
 			if(len == sizeof(struct in_addr))
@@ -1117,15 +1130,17 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 			}
 
 		case PT_DOUBLE:
-			snprintf(m_getpropertystr_storage,
-					 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+					 STR_STORAGE_SIZE,
 					 "%.1lf", *(double*)rawval);
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		case PT_IPNET:
-			snprintf(m_getpropertystr_storage,
-				 sizeof(m_getpropertystr_storage),
+			m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+			snprintf(m_getpropertystr_storage.data(),
+				 STR_STORAGE_SIZE,
 				 "<IPNET>");
-			return m_getpropertystr_storage;
+			return m_getpropertystr_storage.data();
 		default:
 			ASSERT(false);
 			throw sinsp_exception("wrong param type " + std::to_string((long long) ptype));
@@ -1152,8 +1167,9 @@ char* sinsp_filter_check::tostring(sinsp_evt* evt)
 			res += rawval_to_string(val.ptr, m_field->m_type, m_field->m_print_format, val.len);
 		}
 		res += ")";
-		strlcpy(m_getpropertystr_storage, res.c_str(), sizeof(m_getpropertystr_storage));
-		return m_getpropertystr_storage;
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		strlcpy(m_getpropertystr_storage.data(), res.c_str(), STR_STORAGE_SIZE);
+		return m_getpropertystr_storage.data();
 	}
 	return rawval_to_string(m_extracted_values[0].ptr, m_field->m_type, m_field->m_print_format, m_extracted_values[0].len);
 }

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -1550,7 +1550,6 @@ bool sinsp_filter_check::extract(sinsp_evt *evt, OUT std::vector<extract_value_t
 
 bool sinsp_filter_check::compare(sinsp_evt* evt)
 {
-	m_hits++;
 	if(m_cache_metrics != NULL)
 	{
 		m_cache_metrics->m_num_eval++;
@@ -1575,23 +1574,11 @@ bool sinsp_filter_check::compare(sinsp_evt* evt)
 			}
 		}
 
-		if (m_eval_cache_entry->m_res)
-		{
-			m_matched_true++;
-		}
-		m_cached++;
-
 		return m_eval_cache_entry->m_res;
 	}
 	else
 	{
-		auto res = compare_nocache(evt);
-		if (res)
-		{
-			m_matched_true++;
-		}
-
-		return res;
+		return compare_nocache(evt);
 	}
 }
 

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -268,7 +268,7 @@ protected:
 	inline uint8_t* filter_value_p(uint16_t i = 0) { return &m_val_storages[i][0]; }
 	inline std::vector<uint8_t>* filter_value(uint16_t i = 0) { return &m_val_storages[i]; }
 
-	char m_getpropertystr_storage[1024];
+	std::vector<char> m_getpropertystr_storage;
 	std::vector<std::vector<uint8_t>> m_val_storages;
 
 	std::vector<filter_value_t> m_vals;

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -233,9 +233,6 @@ public:
 	check_cache_metrics *m_cache_metrics = nullptr;
 	boolop m_boolop = BO_NONE;
 	cmpop m_cmpop = CO_NONE;
-	size_t m_hits = 0;
-	size_t m_cached = 0;
-	size_t m_matched_true = 0;
 
 	char* rawval_to_string(uint8_t* rawval,
 			       ppm_param_type ptype,
@@ -267,7 +264,6 @@ protected:
 	bool compare_rhs(cmpop op, ppm_param_type type, std::vector<extract_value_t>& values);
 
 	Json::Value rawval_to_json(uint8_t* rawval, ppm_param_type ptype, ppm_print_format print_format, uint32_t len);
-	void string_to_rawval(const char* str, uint32_t len, ppm_param_type ptype);
 
 	inline uint8_t* filter_value_p(uint16_t i = 0) { return &m_val_storages[i][0]; }
 	inline std::vector<uint8_t>* filter_value(uint16_t i = 0) { return &m_val_storages[i]; }

--- a/userspace/libsinsp/sinsp_filtercheck_container.h
+++ b/userspace/libsinsp/sinsp_filtercheck_container.h
@@ -21,8 +21,6 @@ limitations under the License.
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_filtercheck.h>
 
-class sinsp_filter_check_reference;
-
 class sinsp_filter_check_container : public sinsp_filter_check
 {
 public:
@@ -55,12 +53,15 @@ public:
 	};
 
 	sinsp_filter_check_container();
+	virtual ~sinsp_filter_check_container() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 	const std::string& get_argstr() const;
+
+protected:
+	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(const std::string& val, size_t basename);

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -133,24 +133,10 @@ sinsp_filter_check_event::sinsp_filter_check_event()
 	m_info.m_nfields = sizeof(sinsp_filter_check_event_fields) / sizeof(sinsp_filter_check_event_fields[0]);
 	m_u64val = 0;
 	m_converter = new sinsp_filter_check_reference();
-
-	m_storage_size = UESTORAGE_INITIAL_BUFSIZE;
-	m_storage = (char*)malloc(m_storage_size);
-	if(m_storage == NULL)
-	{
-		throw sinsp_exception("memory allocation error in sinsp_filter_check_appevt::sinsp_filter_check_event");
-	}
-
-	m_cargname = NULL;
 }
 
 sinsp_filter_check_event::~sinsp_filter_check_event()
 {
-	if(m_storage != NULL)
-	{
-		free(m_storage);
-	}
-
 	if(m_converter != NULL)
 	{
 		delete m_converter;

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -94,6 +94,19 @@ public:
 	size_t parse_filter_value(const char* str, uint32_t len, uint8_t* storage, uint32_t storage_len) override;
 	const filtercheck_field_info* get_field_info() const override;
 
+protected:
+	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
+	virtual uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	virtual bool compare_nocache(sinsp_evt*) override;
+
+private:
+	void validate_filter_value(const char* str, uint32_t len);
+	int32_t extract_arg(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo);
+	int32_t extract_type(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo);
+	uint8_t* extract_error_count(sinsp_evt *evt, OUT uint32_t* len);
+	uint8_t *extract_abspath(sinsp_evt *evt, OUT uint32_t *len);
+	inline uint8_t* extract_buflen(sinsp_evt *evt, OUT uint32_t* len);
+
 	uint64_t m_u64val;
 	int64_t m_s64val;
 	uint64_t m_tsdelta;
@@ -111,23 +124,6 @@ public:
 	// TYPE_RESARG, that need to do on the fly type customization
 	//
 	filtercheck_field_info m_customfield;
-
-protected:
-	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
-	virtual uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
-	virtual bool compare_nocache(sinsp_evt*) override;
-
-private:
-	void validate_filter_value(const char* str, uint32_t len);
-	int32_t extract_arg(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo);
-	int32_t extract_type(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo);
-	uint8_t* extract_error_count(sinsp_evt *evt, OUT uint32_t* len);
-	uint8_t *extract_abspath(sinsp_evt *evt, OUT uint32_t *len);
-	inline uint8_t* extract_buflen(sinsp_evt *evt, OUT uint32_t* len);
-
 	bool m_is_compare;
-	char* m_storage;
-	uint32_t m_storage_size;
-	const char* m_cargname;
 	sinsp_filter_check_reference* m_converter;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.h
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.h
@@ -19,7 +19,6 @@ limitations under the License.
 #pragma once
 
 #include <libsinsp/sinsp_filtercheck.h>
-#include <libsinsp/sinsp_filtercheck_reference.h>
 
 class sinsp_filter_check_evtin : public sinsp_filter_check
 {
@@ -61,11 +60,13 @@ public:
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
-	std::string m_argname;
-	int32_t m_argid;
+protected:
+	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(std::string fldname, std::string val);
+
+	std::string m_argname;
+	int32_t m_argid;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -71,38 +71,12 @@ public:
 		TYPE_FDTYPES = 43,
 	};
 
-	enum fd_type
-	{
-		FDT_NONE,
-		FDT_FILE,
-		FDT_SOCK,
-		FDT_IPV4_SOCK,
-		FDT_IPV6_SOCK,
-		FDT_UNIX_SOCK,
-		FDT_PIPE,
-		FDT_EVENT,
-		FDT_SIGNALFD,
-		FDT_EVENTPOLL,
-		FDT_INOTIFY,
-		FDT_TIMERFD
-	};
-
 	sinsp_filter_check_fd();
+	virtual ~sinsp_filter_check_fd() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	bool extract(sinsp_evt*, OUT std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
-
-	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo* m_fdinfo;
-	fd_type m_fd_type;
-	std::string m_tstr;
-	uint8_t m_tcstr[2];
-	uint32_t m_tbool;
-	int64_t m_argid;
-
-	/* Used in extract helper to save uint64_t data */
-	uint64_t m_conv_uint64;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
@@ -118,4 +92,14 @@ private:
 	bool compare_net(sinsp_evt *evt);
 	bool compare_port(sinsp_evt *evt);
 	bool compare_domain(sinsp_evt *evt);
+
+	sinsp_threadinfo* m_tinfo;
+	sinsp_fdinfo* m_fdinfo;
+	std::string m_tstr;
+	uint8_t m_tcstr[2];
+	uint32_t m_tbool;
+	int64_t m_argid;
+
+	/* Used in extract helper to save uint64_t data */
+	uint64_t m_conv_uint64;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.h
@@ -34,8 +34,11 @@ public:
 	};
 
 	sinsp_filter_check_fdlist();
+	virtual ~sinsp_filter_check_fdlist() = default;
 
 	sinsp_filter_check* allocate_new() override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -34,8 +34,11 @@ public:
 	};
 
 	sinsp_filter_check_fspath();
+	virtual ~sinsp_filter_check_fspath() = default;
 
 	sinsp_filter_check* allocate_new() override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
@@ -56,7 +59,6 @@ private:
 			    OUT std::vector<extract_value_t>& values,
 			    std::shared_ptr<filtercheck_map_t> map);
 	std::string m_tstr;
-	sinsp_evt m_tmp_evt;
 
 	std::shared_ptr<filtercheck_map_t> m_success_checks;
 	std::shared_ptr<filtercheck_map_t> m_path_checks;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.h
@@ -49,9 +49,9 @@ public:
 	virtual ~sinsp_filter_check_gen_event() = default;
 
 	sinsp_filter_check* allocate_new() override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 protected:
+	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_group.h
+++ b/userspace/libsinsp/sinsp_filtercheck_group.h
@@ -30,10 +30,10 @@ public:
 	};
 
 	sinsp_filter_check_group();
+	virtual ~sinsp_filter_check_group() = default;
 
 	sinsp_filter_check* allocate_new() override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
-	uint32_t m_gid;
-	std::string m_name;
+protected:
+	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.h
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.h
@@ -58,9 +58,12 @@ public:
 	};
 
 	sinsp_filter_check_k8s();
+	virtual ~sinsp_filter_check_k8s() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.h
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.h
@@ -40,15 +40,17 @@ public:
 	};
 
 	sinsp_filter_check_mesos();
+	virtual ~sinsp_filter_check_mesos() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(const std::string& fldname, const std::string& val);
 
 	std::string m_argname;
-	std::string m_tstr;
 };
 

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.h
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.h
@@ -24,6 +24,7 @@ class rawstring_check : public sinsp_filter_check
 {
 public:
 	rawstring_check(std::string text);
+	virtual ~rawstring_check() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
 
+#define STR_STORAGE_SIZE	1024
+
 using namespace std;
 
 sinsp_filter_check_reference::sinsp_filter_check_reference()
@@ -70,51 +72,58 @@ char* sinsp_filter_check_reference::format_bytes(double val, uint32_t str_len, b
 
 	if(val > (1024LL * 1024 * 1024 * 1024 * 1024))
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024 * 1024 * 1024), 'P');
 	}
 	else if(val > (1024LL * 1024 * 1024 * 1024))
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024 * 1024), 'T');
 	}
 	else if(val > (1024LL * 1024 * 1024))
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024), 'G');
 	}
 	else if(val > (1024 * 1024))
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024 * 1024), 'M');
 	}
 	else if(val > 1024)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024), 'K');
 	}
 	else
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					pr_fmt, str_len, val, 0);
 	}
 
-	uint32_t len = (uint32_t)strlen(m_getpropertystr_storage);
+	uint32_t len = (uint32_t)strlen(m_getpropertystr_storage.data());
 
 	if(len > str_len)
 	{
-		memmove(m_getpropertystr_storage,
-			m_getpropertystr_storage + len - str_len,
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		memmove(m_getpropertystr_storage.data(),
+			m_getpropertystr_storage.data() + len - str_len,
 			str_len + 1); // include trailing \0
 	}
 
-	return m_getpropertystr_storage;
+	return m_getpropertystr_storage.data();
 }
 
 //
@@ -128,62 +137,71 @@ char* sinsp_filter_check_reference::format_time(uint64_t val, uint32_t str_len)
 {
 	if(val >= 3600 * ONE_SECOND_IN_NS)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%.2u:%.2u:%.2u", (unsigned int)(val / (3600 * ONE_SECOND_IN_NS)),
 					(unsigned int)((val / (60 * ONE_SECOND_IN_NS)) % 60 ),
 					(unsigned int)((val / ONE_SECOND_IN_NS) % 60));
 	}
 	else if(val >= 60 * ONE_SECOND_IN_NS)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%u:%u", (unsigned int)(val / (60 * ONE_SECOND_IN_NS)), (unsigned int)((val / ONE_SECOND_IN_NS) % 60));
 	}
 	else if(val >= ONE_SECOND_IN_NS)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%u.%02us", (unsigned int)(val / ONE_SECOND_IN_NS), (unsigned int)((val % ONE_SECOND_IN_NS) / 10000000));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 100)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%ums", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000)));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 1000)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%u.%02ums", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000)), (unsigned int)((val % ONE_MILLISECOND_IN_NS) / 10000));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 100000)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%uus", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000000)));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 1000000)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%u.%02uus", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000000)), (unsigned int)((val % ONE_MICROSECOND_IN_NS) / 10));
 	}
 	else
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%uns", (unsigned int)val);
 	}
 
-	uint32_t reslen = (uint32_t)strlen(m_getpropertystr_storage);
+	uint32_t reslen = (uint32_t)strlen(m_getpropertystr_storage.data());
 	if(reslen < str_len)
 	{
 		uint32_t padding_size = str_len - reslen;
 
-		memmove(m_getpropertystr_storage + padding_size,
-			m_getpropertystr_storage,
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		memmove(m_getpropertystr_storage.data() + padding_size,
+			m_getpropertystr_storage.data(),
 			str_len + 1);
 
 		for(uint32_t j = 0; j < padding_size; j++)
@@ -192,7 +210,7 @@ char* sinsp_filter_check_reference::format_time(uint64_t val, uint32_t str_len)
 		}
 	}
 
-	return m_getpropertystr_storage;
+	return m_getpropertystr_storage.data();
 }
 
 char* sinsp_filter_check_reference::print_double(uint8_t* rawval, uint32_t str_len)
@@ -238,10 +256,11 @@ char* sinsp_filter_check_reference::print_double(uint8_t* rawval, uint32_t str_l
 
 	if(m_print_format == PF_ID)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%*lf", str_len, val);
-		return m_getpropertystr_storage;
+		return m_getpropertystr_storage.data();
 	}
 	else
 	{
@@ -293,10 +312,11 @@ char* sinsp_filter_check_reference::print_int(uint8_t* rawval, uint32_t str_len)
 
 	if(m_print_format == PF_ID)
 	{
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%*" PRId64, str_len, val);
-		return m_getpropertystr_storage;
+		return m_getpropertystr_storage.data();
 	}
 	else
 	{
@@ -355,10 +375,11 @@ char* sinsp_filter_check_reference::tostring_nice(sinsp_evt* evt,
 			dval /= m_cnt;
 		}
 
-		snprintf(m_getpropertystr_storage,
-					sizeof(m_getpropertystr_storage),
+		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		snprintf(m_getpropertystr_storage.data(),
+					STR_STORAGE_SIZE,
 					"%*.2lf", str_len, dval);
-		return m_getpropertystr_storage;
+		return m_getpropertystr_storage.data();
 	}
 	else
 	{

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
 
-#define STR_STORAGE_SIZE	1024
+#define STRPROPERTY_STORAGE_SIZE	1024
 
 using namespace std;
 
@@ -72,44 +72,44 @@ char* sinsp_filter_check_reference::format_bytes(double val, uint32_t str_len, b
 
 	if(val > (1024LL * 1024 * 1024 * 1024 * 1024))
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024 * 1024 * 1024), 'P');
 	}
 	else if(val > (1024LL * 1024 * 1024 * 1024))
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024 * 1024), 'T');
 	}
 	else if(val > (1024LL * 1024 * 1024))
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024LL * 1024 * 1024), 'G');
 	}
 	else if(val > (1024 * 1024))
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024 * 1024), 'M');
 	}
 	else if(val > 1024)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len - 1, (val) / (1024), 'K');
 	}
 	else
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					pr_fmt, str_len, val, 0);
 	}
 
@@ -117,7 +117,7 @@ char* sinsp_filter_check_reference::format_bytes(double val, uint32_t str_len, b
 
 	if(len > str_len)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		memmove(m_getpropertystr_storage.data(),
 			m_getpropertystr_storage.data() + len - str_len,
 			str_len + 1); // include trailing \0
@@ -137,60 +137,60 @@ char* sinsp_filter_check_reference::format_time(uint64_t val, uint32_t str_len)
 {
 	if(val >= 3600 * ONE_SECOND_IN_NS)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%.2u:%.2u:%.2u", (unsigned int)(val / (3600 * ONE_SECOND_IN_NS)),
 					(unsigned int)((val / (60 * ONE_SECOND_IN_NS)) % 60 ),
 					(unsigned int)((val / ONE_SECOND_IN_NS) % 60));
 	}
 	else if(val >= 60 * ONE_SECOND_IN_NS)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%u:%u", (unsigned int)(val / (60 * ONE_SECOND_IN_NS)), (unsigned int)((val / ONE_SECOND_IN_NS) % 60));
 	}
 	else if(val >= ONE_SECOND_IN_NS)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%u.%02us", (unsigned int)(val / ONE_SECOND_IN_NS), (unsigned int)((val % ONE_SECOND_IN_NS) / 10000000));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 100)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%ums", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000)));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 1000)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%u.%02ums", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000)), (unsigned int)((val % ONE_MILLISECOND_IN_NS) / 10000));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 100000)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%uus", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000000)));
 	}
 	else if(val >= ONE_SECOND_IN_NS / 1000000)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%u.%02uus", (unsigned int)(val / (ONE_SECOND_IN_NS / 1000000)), (unsigned int)((val % ONE_MICROSECOND_IN_NS) / 10));
 	}
 	else
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%uns", (unsigned int)val);
 	}
 
@@ -199,7 +199,7 @@ char* sinsp_filter_check_reference::format_time(uint64_t val, uint32_t str_len)
 	{
 		uint32_t padding_size = str_len - reslen;
 
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		memmove(m_getpropertystr_storage.data() + padding_size,
 			m_getpropertystr_storage.data(),
 			str_len + 1);
@@ -256,9 +256,9 @@ char* sinsp_filter_check_reference::print_double(uint8_t* rawval, uint32_t str_l
 
 	if(m_print_format == PF_ID)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%*lf", str_len, val);
 		return m_getpropertystr_storage.data();
 	}
@@ -312,9 +312,9 @@ char* sinsp_filter_check_reference::print_int(uint8_t* rawval, uint32_t str_len)
 
 	if(m_print_format == PF_ID)
 	{
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%*" PRId64, str_len, val);
 		return m_getpropertystr_storage.data();
 	}
@@ -375,9 +375,9 @@ char* sinsp_filter_check_reference::tostring_nice(sinsp_evt* evt,
 			dval /= m_cnt;
 		}
 
-		m_getpropertystr_storage.resize(STR_STORAGE_SIZE);
+		m_getpropertystr_storage.resize(STRPROPERTY_STORAGE_SIZE);
 		snprintf(m_getpropertystr_storage.data(),
-					STR_STORAGE_SIZE,
+					STRPROPERTY_STORAGE_SIZE,
 					"%*.2lf", str_len, dval);
 		return m_getpropertystr_storage.data();
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_reference.h
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.h
@@ -30,6 +30,7 @@ public:
 	};
 
 	sinsp_filter_check_reference();
+	virtual ~sinsp_filter_check_reference() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.h
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.h
@@ -33,11 +33,14 @@ public:
 	};
 
 	sinsp_filter_check_syslog();
+	virtual ~sinsp_filter_check_syslog() = default;
 
 	sinsp_filter_check* allocate_new() override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
+private:
 	uint32_t m_storageu32;
 	std::string mstrstorage;
-	std::string m_name;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -137,7 +137,6 @@ sinsp_filter_check_thread::sinsp_filter_check_thread()
 	m_info.m_flags = filter_check_info::FL_NONE;
 
 	m_u64val = 0;
-	m_cursec_ts = 0;
 }
 
 sinsp_filter_check* sinsp_filter_check_thread::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -109,6 +109,7 @@ public:
 	};
 
 	sinsp_filter_check_thread();
+	virtual ~sinsp_filter_check_thread() = default;
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
@@ -138,6 +139,5 @@ private:
 	int64_t m_s64val;
 	double m_dval;
 	std::vector<uint64_t> m_last_proc_switch_times;
-	uint64_t m_cursec_ts;
 	std::unique_ptr<libsinsp::state::dynamic_struct::field_accessor<uint64_t>> m_thread_dyn_field_accessor;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 #include <math.h>
 
 #include <libsinsp/sinsp_filtercheck_tracer.h>
-#include <libsinsp/sinsp_filtercheck_reference.h>
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
 #include <libscap/strl.h>
@@ -65,7 +64,6 @@ sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 	m_info.m_desc = "Fields used if information about distributed tracing is available.";
 	m_info.m_fields = sinsp_filter_check_tracer_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_tracer_fields) / sizeof(sinsp_filter_check_tracer_fields[0]);
-	m_cargname = NULL;
 }
 
 sinsp_filter_check* sinsp_filter_check_tracer::allocate_new()
@@ -104,7 +102,6 @@ int32_t sinsp_filter_check_tracer::extract_arg(string fldname, string val, OUT c
 		}
 
 		m_argname = val.substr(fldname.size() + 1);
-		m_cargname = m_argname.c_str();
 		parsed_len = (uint32_t)(fldname.size() + m_argname.size() + 1);
 		m_argid = TEXT_ARG_ID;
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.h
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.h
@@ -52,6 +52,8 @@ public:
 
 	sinsp_filter_check* allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
@@ -59,5 +61,4 @@ private:
 
 	int32_t m_argid;
 	std::string m_argname;
-	const char* m_cargname;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_user.h
+++ b/userspace/libsinsp/sinsp_filtercheck_user.h
@@ -34,11 +34,13 @@ public:
 	};
 
 	sinsp_filter_check_user();
+	virtual ~sinsp_filter_check_user() = default;
 
 	sinsp_filter_check* allocate_new() override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
-	uint32_t m_uid;
-	std::string m_strval;
+private:
 	int64_t m_s64val;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_utils.h
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.h
@@ -29,8 +29,11 @@ public:
 	};
 
 	sinsp_filter_check_utils();
+	virtual ~sinsp_filter_check_utils() = default;
 
 	sinsp_filter_check* allocate_new() override;
+
+protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:

--- a/userspace/libsinsp/test/plugins/plugin_source.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_source.cpp
@@ -145,7 +145,7 @@ static ss_plugin_rc plugin_next_batch(ss_plugin_t* s, ss_instance_t* i, uint32_t
 
     int32_t encode_res = scap_event_encode_params(scap_sized_buffer{istate->evt, sizeof(istate->evt_buf)},
         nullptr, error, PPME_PLUGINEVENT_E, 2,
-        plugin_get_id(), s_evt_data);
+        plugin_get_id(), scap_sized_buffer{(void*) s_evt_data, strlen(s_evt_data) + 1});
 
     if (encode_res == SCAP_FAILURE)
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This should save us some MBs used at runtime for large rulesets. In general, this cleans-up the filtercheck classes by:
- Having explicit virtual destructors
- Remove unused state variables
- Allocating storage variables only on-demand

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
