### PR TITLE
cleanup(libsinsp): add CT_UNKNOWN as container_type zero value

### DIFF
--- a/userspace/libsinsp/container_engine/sinsp_container_type.h
+++ b/userspace/libsinsp/container_engine/sinsp_container_type.h
@@ -32,4 +32,7 @@ enum sinsp_container_type
 	CT_BPM = 9,
 	CT_STATIC = 10,
 	CT_PODMAN = 11,
+
+	// Default value, may be changed if necessary
+	CT_UNKNOWN = 0xffff
 };

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -256,6 +256,7 @@ public:
 	};
 
 	sinsp_container_info(sinsp_container_lookup &&lookup = sinsp_container_lookup()):
+		m_type(CT_UNKNOWN),
 		m_container_ip(0),
 		m_privileged(false),
 		m_memory_limit(0),


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Part of https://github.com/falcosecurity/libs/issues/1470 , fixes an issue identified in https://github.com/falcosecurity/libs/pull/1685 . This fixes the uninitialized `m_type` member in `container_info` when the default constructor is used.

This is a simple patch but could be potentially catastrophic so that's why it needs a bit more thought for the review.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
