### PR TITLE
fix(libscap): fix memleak by freeing proclist info upon platform close

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -76,6 +76,7 @@ void scap_free_userlist(scap_userlist* uhandle);
 int32_t scap_proc_fill_pidns_start_ts(char* error, struct scap_threadinfo* tinfo, const char* procdirname);
 
 bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_entries, char* error);
+void scap_free_proclist_info(struct ppm_proclist_info *proclist);
 
 void scap_free_device_table(scap_mountinfo* dev_list);
 

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -50,6 +50,12 @@ static int32_t scap_generic_close_platform(struct scap_platform* platform)
 		platform->m_proclist.m_proclist = NULL;
 	}
 
+	if(platform->m_driver_procinfo != NULL)
+	{
+		scap_free_proclist_info(platform->m_driver_procinfo);
+		platform->m_driver_procinfo = NULL;
+	}
+
 	return SCAP_SUCCESS;
 }
 

--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -211,3 +211,8 @@ bool scap_alloc_proclist_info(struct ppm_proclist_info **proclist_p, uint32_t n_
 
 	return true;
 }
+
+void scap_free_proclist_info(struct ppm_proclist_info *proclist)
+{
+	free(proclist);
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

There appears to be a potential memory leak happening when we allocate proclist info in `m_driver_procinfo` because it seems like we never free that variable: https://github.com/falcosecurity/libs/blob/3d5d2d3d4534c23e1bb69b72bddca9406e917ff2/userspace/libscap/scap_platform_api.c#L148

Add a function to do it and call on platform close.

cc @gnosek , I am not entirely sure this is the right thing to do with the platform design

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libscap): fix m_driver_procinfo memleak on inspector close
```
