### PR TITLE
fix(tests): add missing bools to sinsp threadinfo

### DIFF
--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -313,9 +313,10 @@ scap_threadinfo sinsp_with_test_input::create_threadinfo(
 	uint64_t cap_permitted, uint64_t cap_inheritable, uint64_t cap_effective,
 	uint32_t vmsize_kb, uint32_t vmrss_kb, uint32_t vmswap_kb, uint64_t pfmajor, uint64_t pfminor,
 	const std::vector<std::string>& cgroups, const std::string& root,
-	int filtered_out, uint32_t tty, uint32_t loginuid)
+	int filtered_out, uint32_t tty, uint32_t loginuid, bool exe_upper_layer, bool exe_from_memfd)
 {
-	scap_threadinfo tinfo;
+	scap_threadinfo tinfo = {};
+
 	tinfo.tid = tid;
 	tinfo.pid = pid;
 	tinfo.ptid = ptid;
@@ -340,6 +341,8 @@ scap_threadinfo sinsp_with_test_input::create_threadinfo(
 	tinfo.clone_ts = clone_ts;
 	tinfo.tty = tty;
 	tinfo.loginuid = loginuid;
+	tinfo.exe_upper_layer = exe_upper_layer;
+	tinfo.exe_from_memfd = exe_from_memfd;
 
 	std::string argsv;
 	if (!args.empty())

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -84,7 +84,7 @@ protected:
 		uint64_t cap_permitted = 0x1ffffffffff, uint64_t cap_inheritable = 0, uint64_t cap_effective = 0x1ffffffffff,
 		uint32_t vmsize_kb = 10000, uint32_t vmrss_kb = 100, uint32_t vmswap_kb = 0, uint64_t pfmajor = 222, uint64_t pfminor = 22,
 		const std::vector<std::string>& cgroups = {}, const std::string& root = "/",
-		int filtered_out = 0, uint32_t tty = 0, uint32_t loginuid = UINT32_MAX);
+		int filtered_out = 0, uint32_t tty = 0, uint32_t loginuid = UINT32_MAX, bool exe_upper_layer = false, bool exe_from_memfd = false);
 
 	void add_default_init_thread();
 	void add_simple_thread(int64_t tid, int64_t pid, int64_t ptid, const std::string& comm = "random");


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

UBSan has located uninitialized reads in tests for `bool exe_upper_layer`, `bool exe_from_memfd`. In fact, those were not set upon threadinfo creation. To try and be a bit "future proof" we are now default-initializing the entire structure before writing to it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
