### PR TITLE
refactor(userspace/libsinsp)!: reduce usage of raw pointers

### DIFF
--- a/test/libsinsp_e2e/sys_call_test.cpp
+++ b/test/libsinsp_e2e/sys_call_test.cpp
@@ -999,7 +999,7 @@ TEST_F(sys_call_test32, execve_ia32_emulation)
 	{
 		sinsp_filter_compiler compiler(inspector,
 		                               "evt.type=execve and proc.apid=" + std::to_string(getpid()));
-		is_subprocess_execve.reset(compiler.compile());
+		is_subprocess_execve = compiler.compile();
 	};
 
 	event_filter_t filter = [&](sinsp_evt* evt) { return is_subprocess_execve->run(evt); };

--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -211,7 +211,7 @@ void chiselinfo::set_filter(string filterstr)
 
 	if(filterstr != "")
 	{
-		m_filter = compiler.compile();
+		m_filter = compiler.compile().release();
 	}
 }
 

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -319,9 +319,9 @@ int lua_cbacks::request_field(lua_State *ls)
 		throw sinsp_exception("chisel error");
 	}
 
-	sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(fld,
+	auto chk = s_filterlist.new_filter_check_from_fldname(fld,
 		inspector,
-		false);
+		false).release();
 
 	if(chk == NULL)
 	{

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -710,8 +710,8 @@ int lua_cbacks::get_machine_info(lua_State *ls)
 int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool barebone)
 {
 	uint32_t j;
-	sinsp_filter_compiler* compiler = NULL;
-	sinsp_filter* filter = NULL;
+	std::unique_ptr<sinsp_filter_compiler> compiler;
+	std::unique_ptr<sinsp_filter> filter;
 	sinsp_evt tevt;
 	scap_evt tscapevt;
 
@@ -739,7 +739,7 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		{
 			try
 			{
-				compiler = new sinsp_filter_compiler(ch->m_inspector, filterstr);
+				compiler = std::make_unique<sinsp_filter_compiler>(ch->m_inspector, filterstr);
 				filter = compiler->compile();
 			}
 			catch(const sinsp_exception& e)
@@ -1078,11 +1078,6 @@ int lua_cbacks::get_thread_table_int(lua_State *ls, bool include_fds, bool bareb
 		lua_rawseti(ls,-2, (uint32_t)tinfo.m_tid);
 		return true;
 	});
-
-	if(filter)
-	{
-		delete filter;
-	}
 
 	return 1;
 }

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -157,7 +157,7 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 	if(filter != "")
 	{
 		sinsp_filter_compiler compiler(m_inspector, filter);
-		m_filter = compiler.compile();
+		m_filter = compiler.compile().release();
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/userspace/chisel/chisel_table.cpp
+++ b/userspace/chisel/chisel_table.cpp
@@ -167,9 +167,9 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 
 	for(auto vit : *entries)
 	{
-		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth),
+		auto chk = s_filterlist.new_filter_check_from_fldname(vit.get_field(m_view_depth),
 			m_inspector,
-			false);
+			false).release();
 
 		if(chk == NULL)
 		{
@@ -209,9 +209,9 @@ void chisel_table::configure(vector<chisel_view_column_info>* entries, const str
 	}
 	else
 	{
-		sinsp_filter_check* chk = s_filterlist.new_filter_check_from_fldname("util.cnt",
+		auto chk = s_filterlist.new_filter_check_from_fldname("util.cnt",
 			m_inspector,
-			false);
+			false).release();
 
 		if(chk == NULL)
 		{

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -222,14 +222,6 @@ public:
 		return engine_lookup == container_lookups->second.end();
 	}
 
-	/**
-	* \brief get the list of container engines in the inspector
-	*
-	* @return a pointer to the list of container engines
-	*/
-	std::list<std::shared_ptr<libsinsp::container_engine::container_engine_base>>* get_container_engines() {
-		return &m_container_engines;
-	}
 	uint64_t m_last_flush_time_ns;
 	std::string container_to_json(const sinsp_container_info& container_info);
 

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -222,6 +222,14 @@ public:
 		return engine_lookup == container_lookups->second.end();
 	}
 
+	/**
+	* \brief get the list of container engines in the inspector
+	*
+	* @return a pointer to the list of container engines
+	*/
+	std::list<std::shared_ptr<libsinsp::container_engine::container_engine_base>>* get_container_engines() {
+		return &m_container_engines;
+	}
 	uint64_t m_last_flush_time_ns;
 	std::string container_to_json(const sinsp_container_info& container_info);
 

--- a/userspace/libsinsp/container_engine/container_engine_base.h
+++ b/userspace/libsinsp/container_engine/container_engine_base.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #pragma once
 
+#include <memory>
+
 #include <libsinsp/container_engine/container_cache_interface.h>
 
 class sinsp_threadinfo;

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -150,7 +150,7 @@ const sinsp_container_info::container_mount_info *sinsp_container_info::mount_by
 
 std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspector) const
 {
-	std::shared_ptr<sinsp_threadinfo> tinfo(inspector->build_threadinfo());
+	std::shared_ptr<sinsp_threadinfo> tinfo(inspector->build_threadinfo().release());
 	tinfo->m_tid = -1;
 	tinfo->m_pid = -1;
 	tinfo->m_vtid = -2;

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include <chrono>
 #include <future>
 #include <mutex>
+#include <memory>
 #if !defined(__EMSCRIPTEN__)
 #include "tbb/concurrent_unordered_map.h"
 #endif

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <optional>
 #include <unordered_map>
 #include <string_view>
+#include <memory>
 
 #include <json/json.h>
 

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -164,7 +164,7 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 
 	if(last_nontoken_str_start != j)
 	{
-		sinsp_filter_check * chk = new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
+		auto chk = new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
 		m_tokens.emplace_back(std::make_pair("", chk));
 		m_chks_to_free.emplace_back(chk);
 		m_tokenlens.push_back(0);

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -96,10 +96,10 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 
 			if(last_nontoken_str_start != j)
 			{
-				rawstring_check* newtkn = new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
-				m_tokens.emplace_back(std::make_pair("", newtkn));
+				auto newtkn = std::make_unique<rawstring_check>(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
+				m_tokens.emplace_back(std::make_pair("", newtkn.get()));
 				m_tokenlens.push_back(0);
-				m_chks_to_free.push_back(std::unique_ptr<sinsp_filter_check>(newtkn));
+				m_chks_to_free.push_back(std::move(newtkn));
 			}
 
 			if(j == lfmtlen - 1)
@@ -164,9 +164,9 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 
 	if(last_nontoken_str_start != j)
 	{
-		auto chk = new rawstring_check(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
-		m_tokens.emplace_back(std::make_pair("", chk));
-		m_chks_to_free.emplace_back(chk);
+		auto chk = std::make_unique<rawstring_check>(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
+		m_tokens.emplace_back(std::make_pair("", chk.get()));
+		m_chks_to_free.emplace_back(std::move(chk));
 		m_tokenlens.push_back(0);
 	}
 }

--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -99,7 +99,7 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 				auto newtkn = std::make_unique<rawstring_check>(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
 				m_tokens.emplace_back(std::make_pair("", newtkn.get()));
 				m_tokenlens.push_back(0);
-				m_chks_to_free.push_back(std::move(newtkn));
+				m_checks.push_back(std::move(newtkn));
 			}
 
 			if(j == lfmtlen - 1)
@@ -156,7 +156,7 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 			m_tokens.emplace_back(std::make_pair(std::string(fstart, fsize), chk.get()));
 			m_tokenlens.push_back(toklen);
 
-			m_chks_to_free.push_back(std::move(chk));
+			m_checks.push_back(std::move(chk));
 
 			last_nontoken_str_start = j + 1;
 		}
@@ -166,7 +166,7 @@ void sinsp_evt_formatter::set_format(output_format of, const std::string& fmt)
 	{
 		auto chk = std::make_unique<rawstring_check>(lfmt.substr(last_nontoken_str_start, j - last_nontoken_str_start));
 		m_tokens.emplace_back(std::make_pair("", chk.get()));
-		m_chks_to_free.emplace_back(std::move(chk));
+		m_checks.emplace_back(std::move(chk));
 		m_tokenlens.push_back(0);
 	}
 }

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <map>
 #include <utility>
 #include <string>
+#include <memory>
 #include <json/json.h>
 
 #include <libsinsp/filter_check_list.h>

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -55,7 +55,7 @@ public:
 
 	sinsp_evt_formatter(sinsp* inspector, const std::string& fmt, filter_check_list &available_checks);
 
-	virtual ~sinsp_evt_formatter();
+	virtual ~sinsp_evt_formatter() = default;
 
 	/*!
 	  \brief Resolve all the formatted tokens and return them in a key/value
@@ -119,7 +119,7 @@ private:
 	sinsp* m_inspector;
 	filter_check_list &m_available_checks;
 	bool m_require_all_values;
-	std::vector<sinsp_filter_check*> m_chks_to_free;
+	std::vector<std::unique_ptr<sinsp_filter_check>> m_chks_to_free;
 
 	Json::Value m_root;
 	Json::FastWriter m_writer;

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -120,7 +120,7 @@ private:
 	sinsp* m_inspector;
 	filter_check_list &m_available_checks;
 	bool m_require_all_values;
-	std::vector<std::unique_ptr<sinsp_filter_check>> m_chks_to_free;
+	std::vector<std::unique_ptr<sinsp_filter_check>> m_checks;
 
 	Json::Value m_root;
 	Json::FastWriter m_writer;

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+include(jsoncpp)
+
 add_executable(sinsp-example
 	util.cpp
 	test.cpp
@@ -22,6 +24,7 @@ add_executable(sinsp-example
 
 target_link_libraries(sinsp-example
 	sinsp
+	"${JSONCPP_LIB}"
 )
 
 if (EMSCRIPTEN)

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -531,7 +531,7 @@ sinsp_filter_check *sinsp_filter_factory::new_filtercheck(const char *fldname)
 {
 	return m_available_checks.new_filter_check_from_fldname(fldname,
 								m_inspector,
-								true);
+								true).release();
 }
 
 std::list<sinsp_filter_factory::filter_fieldclass_info> sinsp_filter_factory::get_fields() const

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <set>
 #include <string>
 #include <vector>
+#include <memory>
 
 /** @defgroup filter Filtering events
  * Filtering infrastructure.

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -31,48 +31,39 @@ using namespace std;
 // sinsp_filter_check_list implementation
 ///////////////////////////////////////////////////////////////////////////////
 
-filter_check_list::~filter_check_list()
-{
-	for(auto *chk : m_check_list)
-	{
-		delete chk;
-	}
-}
-
-void filter_check_list::add_filter_check(sinsp_filter_check* filter_check)
+void filter_check_list::add_filter_check(std::unique_ptr<sinsp_filter_check> filter_check)
 {
 	// If a filtercheck already exists with this name and
 	// shortdesc, don't add it--this can occur when plugins are
 	// loaded and set up sinsp_filter_checks to handle plugin
 	// events.
 
-	for(auto *chk : m_check_list)
+	for(const auto& chk : m_check_list)
 	{
 		if(chk->get_fields()->m_name == filter_check->get_fields()->m_name &&
 		   chk->get_fields()->m_shortdesc == filter_check->get_fields()->m_shortdesc)
 		{
-			delete filter_check;
 			return;
 		}
 	}
 
-	m_check_list.push_back(filter_check);
+	m_check_list.push_back(std::move(filter_check));
 }
 
 void filter_check_list::get_all_fields(std::vector<const filter_check_info*>& list) const
 {
-	for(auto *chk : m_check_list)
+	for(const auto& chk : m_check_list)
 	{
 		list.push_back(chk->get_fields());
 	}
 }
 
 /* Craft a new filter check from the field name */
-sinsp_filter_check* filter_check_list::new_filter_check_from_fldname(const std::string& name,
+std::unique_ptr<sinsp_filter_check> filter_check_list::new_filter_check_from_fldname(const std::string& name,
 								     sinsp* inspector,
-								     bool do_exact_check)
+								     bool do_exact_check) const
 {
-	for(auto *chk : m_check_list)
+	for(const auto& chk : m_check_list)
 	{
 		chk->m_inspector = inspector;
 
@@ -88,7 +79,7 @@ sinsp_filter_check* filter_check_list::new_filter_check_from_fldname(const std::
 				}
 			}
 
-			sinsp_filter_check* newchk = chk->allocate_new();
+			auto newchk = chk->allocate_new();
 			newchk->set_inspector(inspector);
 			return newchk;
 		}
@@ -99,7 +90,7 @@ sinsp_filter_check* filter_check_list::new_filter_check_from_fldname(const std::
 	// it's very likely that you've forgotten to add your filter to the list in
 	// the constructor
 	//
-	return NULL;
+	return nullptr;
 }
 
 sinsp_filter_check_list::sinsp_filter_check_list()
@@ -107,19 +98,19 @@ sinsp_filter_check_list::sinsp_filter_check_list()
 	//////////////////////////////////////////////////////////////////////////////
 	// ADD NEW FILTER CHECK CLASSES HERE
 	//////////////////////////////////////////////////////////////////////////////
-	add_filter_check(new sinsp_filter_check_gen_event());
-	add_filter_check(new sinsp_filter_check_event());
-	add_filter_check(new sinsp_filter_check_thread());
-	add_filter_check(new sinsp_filter_check_user());
-	add_filter_check(new sinsp_filter_check_group());
-	add_filter_check(new sinsp_filter_check_container());
-	add_filter_check(new sinsp_filter_check_fd());
-	add_filter_check(new sinsp_filter_check_fspath());
-	add_filter_check(new sinsp_filter_check_syslog());
-	add_filter_check(new sinsp_filter_check_utils());
-	add_filter_check(new sinsp_filter_check_fdlist());
-	add_filter_check(new sinsp_filter_check_k8s());
-	add_filter_check(new sinsp_filter_check_mesos());
-	add_filter_check(new sinsp_filter_check_tracer());
-	add_filter_check(new sinsp_filter_check_evtin());
+	add_filter_check(std::make_unique<sinsp_filter_check_gen_event>());
+	add_filter_check(std::make_unique<sinsp_filter_check_event>());
+	add_filter_check(std::make_unique<sinsp_filter_check_thread>());
+	add_filter_check(std::make_unique<sinsp_filter_check_user>());
+	add_filter_check(std::make_unique<sinsp_filter_check_group>());
+	add_filter_check(std::make_unique<sinsp_filter_check_container>());
+	add_filter_check(std::make_unique<sinsp_filter_check_fd>());
+	add_filter_check(std::make_unique<sinsp_filter_check_fspath>());
+	add_filter_check(std::make_unique<sinsp_filter_check_syslog>());
+	add_filter_check(std::make_unique<sinsp_filter_check_utils>());
+	add_filter_check(std::make_unique<sinsp_filter_check_fdlist>());
+	add_filter_check(std::make_unique<sinsp_filter_check_k8s>());
+	add_filter_check(std::make_unique<sinsp_filter_check_mesos>());
+	add_filter_check(std::make_unique<sinsp_filter_check_tracer>());
+	add_filter_check(std::make_unique<sinsp_filter_check_evtin>());
 }

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <string>
 #include <vector>
+#include <memory>
 
 class sinsp_filter_check;
 class filter_check_info;

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -33,13 +33,14 @@ class filter_check_list
 {
 public:
 	filter_check_list() = default;
-	virtual ~filter_check_list();
-	void add_filter_check(sinsp_filter_check* filter_check);
+	virtual ~filter_check_list() = default;
+
+	void add_filter_check(std::unique_ptr<sinsp_filter_check> filter_check);
 	void get_all_fields(std::vector<const filter_check_info*>&) const;
-	sinsp_filter_check* new_filter_check_from_fldname(const std::string& name, sinsp* inspector, bool do_exact_check);
+	std::unique_ptr<sinsp_filter_check> new_filter_check_from_fldname(const std::string& name, sinsp* inspector, bool do_exact_check) const;
 
 protected:
-	std::vector<sinsp_filter_check*> m_check_list;
+	std::vector<std::unique_ptr<sinsp_filter_check>> m_check_list;
 };
 
 //

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -872,9 +872,9 @@ std::vector<sinsp_plugin::open_param> sinsp_plugin::list_open_params() const
 
 /** Field Extraction CAP **/
 
-sinsp_filter_check* sinsp_plugin::new_filtercheck(std::shared_ptr<sinsp_plugin> plugin)
+std::unique_ptr<sinsp_filter_check> sinsp_plugin::new_filtercheck(std::shared_ptr<sinsp_plugin> plugin)
 {
-	return new sinsp_filter_check_plugin(plugin);
+	return std::make_unique<sinsp_filter_check_plugin>(plugin);
 }
 
 bool sinsp_plugin::extract_fields(sinsp_evt* evt, uint32_t num_fields, ss_plugin_extract_field *fields) const

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -80,7 +80,7 @@ public:
 	 *
 	 * todo(jasondellaluce): make this return a unique_ptr
 	 */
-	static sinsp_filter_check* new_filtercheck(std::shared_ptr<sinsp_plugin> plugin);
+	static std::unique_ptr<sinsp_filter_check> new_filtercheck(std::shared_ptr<sinsp_plugin> plugin);
 
 	/**
 	 * @brief Returns true if the source is compatible with the given set

--- a/userspace/libsinsp/plugin_filtercheck.cpp
+++ b/userspace/libsinsp/plugin_filtercheck.cpp
@@ -128,9 +128,9 @@ int32_t sinsp_filter_check_plugin::parse_field_name(const char* str, bool alloc_
 	return res;
 }
 
-sinsp_filter_check* sinsp_filter_check_plugin::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_plugin::allocate_new()
 {
-	return new sinsp_filter_check_plugin(*this);
+	return std::make_unique<sinsp_filter_check_plugin>(*this);
 }
 
 bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, OUT vector<extract_value_t>& values, bool sanitize_strings)

--- a/userspace/libsinsp/plugin_filtercheck.h
+++ b/userspace/libsinsp/plugin_filtercheck.h
@@ -41,7 +41,7 @@ public:
 
 	virtual ~sinsp_filter_check_plugin() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 	int32_t parse_field_name(
 		const char* str,

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1784,9 +1784,9 @@ std::shared_ptr<const sinsp_stats_v2> sinsp::get_sinsp_stats_v2() const
 	return m_sinsp_stats_v2;
 }
 
-sinsp_filter_check* sinsp::new_generic_filtercheck()
+std::unique_ptr<sinsp_filter_check> sinsp::new_generic_filtercheck()
 {
-	return new sinsp_filter_check_gen_event();
+	return std::make_unique<sinsp_filter_check_gen_event>();
 }
 
 void sinsp::get_capture_stats(scap_stats* stats) const

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -785,11 +785,7 @@ void sinsp::close()
 
 	deinit_state();
 
-	if(m_filter != NULL)
-	{
-		delete m_filter;
-		m_filter = NULL;
-	}
+	m_filter.reset();
 
 	// unset the meta-event callback to all plugins that support it
 	if (!is_capture() && m_mode != SINSP_MODE_NONE)
@@ -1706,7 +1702,7 @@ void sinsp::start_dropping_mode(uint32_t sampling_ratio)
 }
 #endif // _WIN32
 
-void sinsp::set_filter(sinsp_filter* filter)
+void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter)
 {
 	if(m_filter != NULL)
 	{
@@ -1714,7 +1710,7 @@ void sinsp::set_filter(sinsp_filter* filter)
 		throw sinsp_exception("filter can only be set once");
 	}
 
-	m_filter = filter;
+	m_filter = std::move(filter);
 }
 
 void sinsp::set_filter(const std::string& filter)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -84,8 +84,8 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 	m_h = NULL;
 	m_parser = NULL;
 	m_is_dumping = false;
-	m_parser = new sinsp_parser(this);
-	m_thread_manager = new sinsp_thread_manager(this);
+	m_parser = std::make_unique<sinsp_parser>(this);
+	m_thread_manager = std::make_unique<sinsp_thread_manager>(this);
 	m_max_fdtable_size = MAX_FD_TABLE_SIZE;
 	m_containers_purging_scan_time_ns = DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S * ONE_SECOND_IN_NS;
 	m_usergroups_purging_scan_time_ns = DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S * ONE_SECOND_IN_NS;
@@ -130,24 +130,12 @@ sinsp::sinsp(bool static_container, const std::string &static_id, const std::str
 
 	// create state tables registry
 	m_table_registry = std::make_shared<libsinsp::state::table_registry>();
-	m_table_registry->add_table(m_thread_manager);
+	m_table_registry->add_table(m_thread_manager.get());
 }
 
 sinsp::~sinsp()
 {
 	close();
-
-	if(m_parser)
-	{
-		delete m_parser;
-		m_parser = NULL;
-	}
-
-	if(m_thread_manager)
-	{
-		delete m_thread_manager;
-		m_thread_manager = NULL;
-	}
 
 	m_container_manager.cleanup();
 
@@ -1929,11 +1917,6 @@ void sinsp::set_hostname_and_port_resolution_mode(bool enable)
 void sinsp::set_max_evt_output_len(uint32_t len)
 {
 	m_max_evt_output_len = len;
-}
-
-sinsp_parser* sinsp::get_parser()
-{
-	return m_parser;
 }
 
 double sinsp::get_read_progress_file() const

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -441,7 +441,7 @@ public:
 	  \brief Returns a new instance of a filtercheck supporting fields for
 	  a generic event source (e.g. evt.num, evt.time, evt.pluginname...)
 	*/
-	static sinsp_filter_check* new_generic_filtercheck();
+	static std::unique_ptr<sinsp_filter_check> new_generic_filtercheck();
 
 	/*!
 	  \brief Return information about the machine generating the events.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -857,11 +857,14 @@ public:
 		m_get_procs_cpu_from_driver = get_procs_cpu_from_driver;
 	}
 
-	sinsp_parser* get_parser();
+	sinsp_parser* get_parser()
+	{
+		return m_parser.get();
+	}
 
 	inline const sinsp_parser* get_parser() const
 	{
-		return m_parser;
+		return m_parser.get();
 	}
 
 	/*=============================== PPM_SC set related (ppm_sc.cpp) ===============================*/
@@ -1140,7 +1143,7 @@ private:
 	std::vector<int64_t> m_fds_to_remove;
 	uint64_t m_lastevent_ts;
 	// the parsing engine
-	sinsp_parser* m_parser;
+	std::unique_ptr<sinsp_parser> m_parser;
 	// the statistics analysis engine
 	std::unique_ptr<sinsp_dumper> m_dumper;
 	bool m_is_dumping;
@@ -1160,7 +1163,7 @@ private:
 	int32_t m_quantization_interval = -1;
 
 public:
-	sinsp_thread_manager* m_thread_manager;
+	std::unique_ptr<sinsp_thread_manager> m_thread_manager;
 
 	sinsp_container_manager m_container_manager;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -526,10 +526,10 @@ public:
 
 	libsinsp::event_processor* m_external_event_processor;
 
-	inline sinsp_threadinfo* build_threadinfo()
+	inline std::unique_ptr<sinsp_threadinfo> build_threadinfo()
     {
         return m_external_event_processor ? m_external_event_processor->build_threadinfo(this)
-                                          : m_thread_manager->new_threadinfo().release();
+                                          : m_thread_manager->new_threadinfo();
     }
 
 	inline std::unique_ptr<sinsp_fdinfo> build_fdinfo()
@@ -998,7 +998,7 @@ public:
 
 	bool remove_inactive_threads();
 
-	bool add_thread(const sinsp_threadinfo *ptinfo);
+	std::shared_ptr<sinsp_threadinfo> add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo);
 
 	void set_mode(sinsp_mode_t value)
 	{

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -300,7 +300,7 @@ public:
 
 	  \param filter the runtime filter object
 	*/
-	void set_filter(sinsp_filter* filter);
+	void set_filter(std::unique_ptr<sinsp_filter> filter);
 
 	/*!
 	  \brief Return the filter set for this capture.
@@ -1173,7 +1173,7 @@ public:
 	bool m_print_container_data;
 
 	uint64_t m_firstevent_ts;
-	sinsp_filter* m_filter;
+	std::unique_ptr<sinsp_filter> m_filter;
 	std::string m_filterstring;
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -857,7 +857,7 @@ public:
 		m_get_procs_cpu_from_driver = get_procs_cpu_from_driver;
 	}
 
-	sinsp_parser* get_parser()
+	inline sinsp_parser* get_parser()
 	{
 		return m_parser.get();
 	}

--- a/userspace/libsinsp/sinsp_external_processor.h
+++ b/userspace/libsinsp/sinsp_external_processor.h
@@ -52,7 +52,7 @@ public:
 	 * If this is overridden by the event processor, the processor MUST be registered
 	 * before the sinsp object is init-ed
 	 */
-	virtual sinsp_threadinfo* build_threadinfo(sinsp* inspector);
+	virtual std::unique_ptr<sinsp_threadinfo> build_threadinfo(sinsp* inspector);
 
 	/**
 	 * Some event processors allocate different fd info types with extra data.

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <string>
 #include <unordered_set>
+#include <memory>
 #include <json/json.h>
 #include <libscap/scap.h>
 #include <libsinsp/tuples.h>
@@ -163,7 +164,7 @@ public:
 	// Allocate a new check of the same type.
 	// Every filtercheck plugin must implement this.
 	//
-	virtual sinsp_filter_check* allocate_new()
+	virtual std::unique_ptr<sinsp_filter_check> allocate_new()
 	{
 		throw sinsp_exception("can't clone abstract sinsp_filter_check");
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -69,9 +69,9 @@ sinsp_filter_check_container::sinsp_filter_check_container()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_container::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_container::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_container();
+	return std::make_unique<sinsp_filter_check_container>();
 }
 
 int32_t sinsp_filter_check_container::extract_arg(const string &val, size_t basepos)

--- a/userspace/libsinsp/sinsp_filtercheck_container.h
+++ b/userspace/libsinsp/sinsp_filtercheck_container.h
@@ -55,7 +55,7 @@ public:
 	sinsp_filter_check_container();
 	virtual ~sinsp_filter_check_container() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 	const std::string& get_argstr() const;

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -132,15 +132,7 @@ sinsp_filter_check_event::sinsp_filter_check_event()
 	m_info.m_fields = sinsp_filter_check_event_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_event_fields) / sizeof(sinsp_filter_check_event_fields[0]);
 	m_u64val = 0;
-	m_converter = new sinsp_filter_check_reference();
-}
-
-sinsp_filter_check_event::~sinsp_filter_check_event()
-{
-	if(m_converter != NULL)
-	{
-		delete m_converter;
-	}
+	m_converter = std::make_unique<sinsp_filter_check_reference>();
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_event::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -143,9 +143,9 @@ sinsp_filter_check_event::~sinsp_filter_check_event()
 	}
 }
 
-sinsp_filter_check* sinsp_filter_check_event::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_event::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_event();
+	return std::make_unique<sinsp_filter_check_event>();
 }
 
 int32_t sinsp_filter_check_event::extract_arg(string fldname, string val, OUT const ppm_param_info** parinfo)

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -89,7 +89,7 @@ public:
 	sinsp_filter_check_event();
 	virtual ~sinsp_filter_check_event();
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	size_t parse_filter_value(const char* str, uint32_t len, uint8_t* storage, uint32_t storage_len) override;
 	const filtercheck_field_info* get_field_info() const override;

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -87,7 +87,7 @@ public:
 	};
 
 	sinsp_filter_check_event();
-	virtual ~sinsp_filter_check_event();
+	virtual ~sinsp_filter_check_event() = default;
 
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
@@ -125,5 +125,5 @@ private:
 	//
 	filtercheck_field_info m_customfield;
 	bool m_is_compare;
-	sinsp_filter_check_reference* m_converter;
+	std::unique_ptr<sinsp_filter_check_reference> m_converter;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -189,9 +189,9 @@ int32_t sinsp_filter_check_evtin::parse_field_name(const char* str, bool alloc_s
 	return res;
 }
 
-sinsp_filter_check* sinsp_filter_check_evtin::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_evtin::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_evtin();
+	return std::make_unique<sinsp_filter_check_evtin>();
 }
 
 uint8_t* sinsp_filter_check_evtin::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.h
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.h
@@ -58,7 +58,7 @@ public:
 	sinsp_filter_check_evtin();
 	virtual ~sinsp_filter_check_evtin() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -109,9 +109,9 @@ sinsp_filter_check_fd::sinsp_filter_check_fd()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_fd::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fd::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_fd();
+	return std::make_unique<sinsp_filter_check_fd>();
 }
 
 int32_t sinsp_filter_check_fd::extract_arg(string fldname, string val)

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -74,7 +74,7 @@ public:
 	sinsp_filter_check_fd();
 	virtual ~sinsp_filter_check_fd() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	bool extract(sinsp_evt*, OUT std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
 

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -46,9 +46,9 @@ sinsp_filter_check_fdlist::sinsp_filter_check_fdlist()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_fdlist::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fdlist::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_fdlist();
+	return std::make_unique<sinsp_filter_check_fdlist>();
 }
 
 uint8_t* sinsp_filter_check_fdlist::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.h
@@ -36,7 +36,7 @@ public:
 	sinsp_filter_check_fdlist();
 	virtual ~sinsp_filter_check_fdlist() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -219,7 +219,7 @@ void sinsp_filter_check_fspath::set_fspath_checks(std::shared_ptr<filtercheck_ma
 	m_target_checks = target_checks;
 }
 
-sinsp_filter_check* sinsp_filter_check_fspath::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fspath::allocate_new()
 {
 	// If not yet populated, do so now. The maps will be empty
 	// *only* for the initial filtercheck created in
@@ -229,7 +229,7 @@ sinsp_filter_check* sinsp_filter_check_fspath::allocate_new()
 		create_fspath_checks();
 	}
 
-	sinsp_filter_check_fspath* ret = new sinsp_filter_check_fspath();
+	auto ret = std::make_unique<sinsp_filter_check_fspath>();
 
 	ret->set_fspath_checks(m_success_checks, m_path_checks, m_source_checks, m_target_checks);
 

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -36,7 +36,7 @@ public:
 	sinsp_filter_check_fspath();
 	virtual ~sinsp_filter_check_fspath() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -75,9 +75,9 @@ sinsp_filter_check_gen_event::sinsp_filter_check_gen_event()
 	m_u64val = 0;
 }
 
-sinsp_filter_check* sinsp_filter_check_gen_event::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_gen_event::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_gen_event();
+	return std::make_unique<sinsp_filter_check_gen_event>();
 }
 
 Json::Value sinsp_filter_check_gen_event::extract_as_js(sinsp_evt *evt, OUT uint32_t* len)

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.h
@@ -48,7 +48,7 @@ public:
 	sinsp_filter_check_gen_event();
 	virtual ~sinsp_filter_check_gen_event() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -50,9 +50,9 @@ sinsp_filter_check_group::sinsp_filter_check_group()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_group::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_group::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_group();
+	return std::make_unique<sinsp_filter_check_group>();
 }
 
 uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_group.h
+++ b/userspace/libsinsp/sinsp_filtercheck_group.h
@@ -32,7 +32,7 @@ public:
 	sinsp_filter_check_group();
 	virtual ~sinsp_filter_check_group() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
@@ -76,9 +76,9 @@ sinsp_filter_check_k8s::sinsp_filter_check_k8s()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_k8s::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_k8s::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_k8s();
+	return std::make_unique<sinsp_filter_check_k8s>();
 }
 
 int32_t sinsp_filter_check_k8s::parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.h
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.h
@@ -60,7 +60,7 @@ public:
 	sinsp_filter_check_k8s();
 	virtual ~sinsp_filter_check_k8s() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
@@ -54,9 +54,9 @@ sinsp_filter_check_mesos::sinsp_filter_check_mesos()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_mesos::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_mesos::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_mesos();
+	return std::make_unique<sinsp_filter_check_mesos>();
 }
 
 int32_t sinsp_filter_check_mesos::parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.h
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.h
@@ -42,7 +42,7 @@ public:
 	sinsp_filter_check_mesos();
 	virtual ~sinsp_filter_check_mesos() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
@@ -34,10 +34,10 @@ rawstring_check::rawstring_check(string text)
 	set_text(text);
 }
 
-sinsp_filter_check* rawstring_check::allocate_new()
+std::unique_ptr<sinsp_filter_check> rawstring_check::allocate_new()
 {
 	ASSERT(false);
-	return NULL;
+	return nullptr;
 }
 
 void rawstring_check::set_text(string text)

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.h
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.h
@@ -26,7 +26,7 @@ public:
 	rawstring_check(std::string text);
 	virtual ~rawstring_check() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -35,10 +35,10 @@ sinsp_filter_check_reference::sinsp_filter_check_reference()
 	m_field = &m_finfo;
 }
 
-sinsp_filter_check* sinsp_filter_check_reference::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_reference::allocate_new()
 {
 	ASSERT(false);
-	return NULL;
+	return nullptr;
 }
 
 int32_t sinsp_filter_check_reference::parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering)

--- a/userspace/libsinsp/sinsp_filtercheck_reference.h
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.h
@@ -32,7 +32,7 @@ public:
 	sinsp_filter_check_reference();
 	virtual ~sinsp_filter_check_reference() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
@@ -57,9 +57,9 @@ sinsp_filter_check_syslog::sinsp_filter_check_syslog()
 	m_info.m_nfields = sizeof(sinsp_filter_check_syslog_fields) / sizeof(sinsp_filter_check_syslog_fields[0]);
 }
 
-sinsp_filter_check* sinsp_filter_check_syslog::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_syslog::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_syslog();
+	return std::make_unique<sinsp_filter_check_syslog>();
 }
 
 uint8_t* sinsp_filter_check_syslog::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.h
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.h
@@ -35,7 +35,7 @@ public:
 	sinsp_filter_check_syslog();
 	virtual ~sinsp_filter_check_syslog() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -139,9 +139,9 @@ sinsp_filter_check_thread::sinsp_filter_check_thread()
 	m_u64val = 0;
 }
 
-sinsp_filter_check* sinsp_filter_check_thread::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_thread::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_thread();
+	return std::make_unique<sinsp_filter_check_thread>();
 }
 
 int32_t sinsp_filter_check_thread::extract_arg(std::string fldname, std::string val, OUT const ppm_param_info** parinfo)

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -111,7 +111,7 @@ public:
 	sinsp_filter_check_thread();
 	virtual ~sinsp_filter_check_thread() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 	int32_t get_argid() const;

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -66,9 +66,9 @@ sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 	m_info.m_nfields = sizeof(sinsp_filter_check_tracer_fields) / sizeof(sinsp_filter_check_tracer_fields[0]);
 }
 
-sinsp_filter_check* sinsp_filter_check_tracer::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_tracer::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_tracer();
+	return std::make_unique<sinsp_filter_check_tracer>();
 }
 
 int32_t sinsp_filter_check_tracer::extract_arg(string fldname, string val, OUT const ppm_param_info** parinfo)

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.h
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.h
@@ -50,7 +50,7 @@ public:
 	sinsp_filter_check_tracer();
 	virtual ~sinsp_filter_check_tracer() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -59,9 +59,9 @@ sinsp_filter_check_user::sinsp_filter_check_user()
 	m_info.m_flags = filter_check_info::FL_NONE;
 }
 
-sinsp_filter_check* sinsp_filter_check_user::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_user::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_user();
+	return std::make_unique<sinsp_filter_check_user>();
 }
 
 uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_user.h
+++ b/userspace/libsinsp/sinsp_filtercheck_user.h
@@ -36,7 +36,7 @@ public:
 	sinsp_filter_check_user();
 	virtual ~sinsp_filter_check_user() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filtercheck_utils.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.cpp
@@ -42,9 +42,9 @@ sinsp_filter_check_utils::sinsp_filter_check_utils()
 	m_cnt = 0;
 }
 
-sinsp_filter_check* sinsp_filter_check_utils::allocate_new()
+std::unique_ptr<sinsp_filter_check> sinsp_filter_check_utils::allocate_new()
 {
-	return (sinsp_filter_check*) new sinsp_filter_check_utils();
+	return std::make_unique<sinsp_filter_check_utils>();
 }
 
 uint8_t* sinsp_filter_check_utils::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_utils.h
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.h
@@ -31,7 +31,7 @@ public:
 	sinsp_filter_check_utils();
 	virtual ~sinsp_filter_check_utils() = default;
 
-	sinsp_filter_check* allocate_new() override;
+	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
 	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <functional>
 #include <type_traits>
+#include <memory>
 
 namespace libsinsp {
 namespace state {

--- a/userspace/libsinsp/test/eventformatter.ut.cpp
+++ b/userspace/libsinsp/test/eventformatter.ut.cpp
@@ -30,10 +30,10 @@ using namespace std;
 
 TEST(eventformatter, get_field_names)
 {
-	auto inspector = std::make_unique<sinsp>();
+	sinsp inspector;
 	sinsp_filter_check_list filterlist;
 	string output = "this is a sample output %proc.name %fd.type %proc.pid";
-	sinsp_evt_formatter fmt(inspector.get(), output, filterlist);
+	sinsp_evt_formatter fmt(&inspector, output, filterlist);
 	vector<string> output_fields;
 	fmt.get_field_names(output_fields);
 	ASSERT_EQ(output_fields.size(), 3);

--- a/userspace/libsinsp/test/eventformatter.ut.cpp
+++ b/userspace/libsinsp/test/eventformatter.ut.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 #include <string>
 #include <iostream>
@@ -29,15 +30,14 @@ using namespace std;
 
 TEST(eventformatter, get_field_names)
 {
-	auto inspector = new sinsp();
+	auto inspector = std::make_unique<sinsp>();
 	sinsp_filter_check_list filterlist;
 	string output = "this is a sample output %proc.name %fd.type %proc.pid";
-	sinsp_evt_formatter fmt(inspector, output, filterlist);
+	sinsp_evt_formatter fmt(inspector.get(), output, filterlist);
 	vector<string> output_fields;
 	fmt.get_field_names(output_fields);
 	ASSERT_EQ(output_fields.size(), 3);
 	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "proc.name"), output_fields.end());
 	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "fd.type"), output_fields.end());
 	ASSERT_NE(find(output_fields.begin(), output_fields.end(), "proc.pid"), output_fields.end());
-	delete inspector;
 }

--- a/userspace/libsinsp/test/filter_compiler.h
+++ b/userspace/libsinsp/test/filter_compiler.h
@@ -32,12 +32,11 @@ static void filter_compile(sinsp_filter **out, std::string filter)
 		auto f = compiler.compile();
 		if (!out)
 		{
-			delete f;
 			FAIL() << "Unexpected successful compilation for: " << filter;
 		}
 		else
 		{
-			*out = f;
+			*out = f.release();
 		}
 	}
 	catch(const sinsp_exception& e)

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -57,14 +57,14 @@ class mock_compiler_filter_factory: public sinsp_filter_factory
 public:
 	mock_compiler_filter_factory(sinsp *inspector): sinsp_filter_factory(inspector, m_filterlist) {}
 
-	inline sinsp_filter *new_filter() override
+	inline std::unique_ptr<sinsp_filter> new_filter() const override
 	{
-		return new sinsp_filter(m_inspector);
+		return std::make_unique<sinsp_filter>(m_inspector);
 	}
 
-	inline sinsp_filter_check *new_filtercheck(const char *fldname) override
+	inline std::unique_ptr<sinsp_filter_check> new_filtercheck(const char *fldname) const override
 	{
-		return new mock_compiler_filter_check();
+		return std::make_unique<mock_compiler_filter_check>();
 	}
 
 	inline list<sinsp_filter_factory::filter_fieldclass_info> get_fields() const override
@@ -92,7 +92,6 @@ void test_filter_run(bool result, string filter_str)
 		{
 			FAIL() << filter_str << " -> unexpected '" << (result ? "false" : "true") << "' result";
 		}
-		delete filter;
 	}
 	catch(const sinsp_exception& e)
 	{
@@ -109,7 +108,6 @@ void test_filter_compile(
 	try
 	{
 		auto filter = compiler.compile();
-		delete filter;
 		if (expect_fail)
 		{
 			FAIL() << filter_str << " -> expected failure but compilation was successful";

--- a/userspace/libsinsp/test/sinsp_stats.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_stats.ut.cpp
@@ -38,7 +38,7 @@ TEST_F(sinsp_with_test_input, sinsp_stats_v2_resource_utilization)
 	const scap_stats_v2* sinsp_stats_v2_snapshot;
 	auto buffer = m_inspector.get_sinsp_stats_v2_buffer();
     auto sinsp_stats_v2_counters = m_inspector.get_sinsp_stats_v2();
-    sinsp_thread_manager* thread_manager = m_inspector.m_thread_manager;
+    sinsp_thread_manager* thread_manager = m_inspector.m_thread_manager.get();
 	uint32_t flags = 0;
 	sinsp_stats_v2_snapshot = libsinsp::stats::get_sinsp_stats_v2(flags, agent_info, thread_manager, sinsp_stats_v2_counters, buffer, &nstats, &rc);
     ASSERT_EQ(nstats, 0);

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -431,7 +431,6 @@ bool sinsp_with_test_input::field_exists(sinsp_evt* evt, const std::string& fiel
 	if(new_fl != nullptr)
 	{
 		// if we can create a filter check it means that the field exists
-		delete new_fl;
 		return true;
 	}
 	else

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -305,7 +305,7 @@ TEST(thread_manager, table_access)
     static const int s_threadinfo_static_fields_count = 20;
 
     sinsp inspector;
-    auto table = static_cast<libsinsp::state::table<int64_t>*>(inspector.m_thread_manager);
+    auto table = static_cast<libsinsp::state::table<int64_t>*>(inspector.m_thread_manager.get());
     
     // empty table state and info
     ASSERT_EQ(table->name(), "threads");

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -2119,7 +2119,7 @@ threadinfo_map_t::ptr_t sinsp_thread_manager::get_thread_ref(int64_t tid, bool q
         // Done. Add the new thread to the list.
         //
         add_thread(std::move(newti), false);
-		sinsp_proc = find_thread(tid, lookup_only);
+        sinsp_proc = find_thread(tid, lookup_only);
     }
 
     return sinsp_proc;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -785,7 +785,7 @@ public:
 
 	std::unique_ptr<sinsp_fdinfo> new_fdinfo() const;
 
-	bool add_thread(sinsp_threadinfo *threadinfo, bool from_scap_proctable);
+	threadinfo_map_t::ptr_t add_thread(std::unique_ptr<sinsp_threadinfo> threadinfo, bool from_scap_proctable);
 	sinsp_threadinfo* find_new_reaper(sinsp_threadinfo*);
 	void remove_thread(int64_t tid);
 	// Returns true if the table is actually scanned
@@ -887,8 +887,7 @@ public:
 		}
 		entry.release();
 		tinfo->m_tid = key;
-		add_thread(tinfo, false);
-		return get_entry(key);
+		return add_thread(std::unique_ptr<sinsp_threadinfo>(tinfo), false);
 	}
 
 	bool erase_entry(const int64_t& key) override

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -123,7 +123,7 @@ sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	, m_inspector(inspector)
 	, m_host_root(m_inspector->get_host_root())
 #if defined(__linux__) && (defined(HAVE_PWD_H) || defined(HAVE_GRP_H))
-	, m_ns_helper(new libsinsp::procfs_utils::ns_helper(m_host_root))
+	, m_ns_helper(std::make_unique<libsinsp::procfs_utils::ns_helper>(m_host_root))
 #else
 	, m_ns_helper(nullptr)
 #endif
@@ -132,13 +132,6 @@ sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	strlcpy(m_fallback_user.homedir, "<NA>", sizeof(m_fallback_user.homedir));
 	strlcpy(m_fallback_user.shell, "<NA>", sizeof(m_fallback_user.shell));
 	strlcpy(m_fallback_grp.name, "<NA>", sizeof(m_fallback_grp.name));
-}
-
-sinsp_usergroup_manager::~sinsp_usergroup_manager()
-{
-#if defined(__linux__) && (defined(HAVE_PWD_H) || defined(HAVE_GRP_H))
-	delete m_ns_helper;
-#endif
 }
 // clang-format on
 

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <unordered_map>
 #include <string>
+#include <memory>
 #include <libsinsp/container_info.h>
 #include <libsinsp/procfs_utils.h>
 #include <libscap/scap.h>

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -64,7 +64,7 @@ class sinsp_usergroup_manager
 {
 public:
 	explicit sinsp_usergroup_manager(sinsp* inspector);
-	~sinsp_usergroup_manager();
+	~sinsp_usergroup_manager() = default;
 
 	// Do not call subscribe_container_mgr() in capture mode, because
 	// events shall not be sent as they will be loaded from capture file.
@@ -175,7 +175,7 @@ private:
 	scap_groupinfo m_fallback_grp;
 
 	const std::string &m_host_root;
-	libsinsp::procfs_utils::ns_helper *m_ns_helper;
+	std::unique_ptr<libsinsp::procfs_utils::ns_helper> m_ns_helper;
 };
 
 #endif // FALCOSECURITY_LIBS_USER_H


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This has been discussed for a while, and also during one of the past few maintainers call. Basically, the usage of raw pointers is the root of many debugging nightmares and memory-related issues both during the development cycles and at release time.

This PR hunts for all the evident places where a raw pointer could be substituted by a unique_ptr. This has been "optimized" to be as low impact as possible in terms of LOC, so I didn't spend too much time refactoring some legacy code parts like chisels but put extra attention to the core codebase. The most important components involved in the changes are the ones of thread management, filterchecks, filters, formatters, and their factory classes/methods. Overall, most of raw pointers are now gone.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

With this, most of our pointers will be safely managed as unique or shared. However, my opinion is that we may have put too many pointed as shared (with ref count) whereas they could be simpler unique_ptr in many cases. Will look into this if/after this one goes through.

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp)!: reduce usage of raw pointers
```
