### PR TITLE
cleanup(libsinsp): fix warnings on e2e tests

### DIFF
--- a/test/libsinsp_e2e/vtidcollision.c
+++ b/test/libsinsp_e2e/vtidcollision.c
@@ -16,6 +16,7 @@ limitations under the License.
 
 */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
@@ -26,7 +27,6 @@ limitations under the License.
 
 #include <sys/eventfd.h>
 #include <sys/wait.h>
-#define _GNU_SOURCE
 #include <linux/sched.h>
 
 /**

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4151,8 +4151,9 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt)
 				parinfo = evt->get_param(4);
 				if(parinfo->m_len > sizeof(cmsghdr))
 				{
-					cmsghdr *cmsg = (cmsghdr *)parinfo->m_val;
-					if(cmsg->cmsg_type == SCM_RIGHTS)
+					cmsghdr cmsg;
+					memcpy(&cmsg, parinfo->m_val, sizeof(cmsghdr));
+					if(cmsg.cmsg_type == SCM_RIGHTS)
 					{
 						char error[SCAP_LASTERR_SIZE];
 						scap_threadinfo scap_tinfo {};


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This is necessary to add sanitizers and warnings enabled for our new e2e tests

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
