### PR TITLE
cleanup(libsinsp): remove some more misaligned accesses

### DIFF
--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -269,8 +269,8 @@ public:
 
 	inline void set_unix_info(uint8_t* packed_data)
 	{
-		m_sockinfo.m_unixinfo.m_fields.m_source = *(uint64_t *)(packed_data + 1);
-		m_sockinfo.m_unixinfo.m_fields.m_dest = *(uint64_t *)(packed_data + 9);
+		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_source, packed_data + 1, sizeof(uint64_t));
+		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_dest, packed_data + 9, sizeof(uint64_t));
 	}
 
 	/*!

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -634,9 +634,7 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint3
 
 	if(pi != NULL)
 	{
-		ASSERT(pi->m_len == sizeof(uint64_t));
-
-		int64_t res = *(int64_t*)pi->m_val;
+		int64_t res = pi->as<int64_t>();
 		if(res < 0)
 		{
 			m_u32val = 1;
@@ -654,9 +652,7 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint3
 
 		if(pi != NULL)
 		{
-			ASSERT(pi->m_len == sizeof(uint64_t));
-
-			int64_t res = *(int64_t*)pi->m_val;
+			int64_t res = pi->as<int64_t>();
 			if(res < 0)
 			{
 				m_u32val = 1;
@@ -1202,9 +1198,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 
 			if(pi != NULL)
 			{
-				ASSERT(pi->m_len == sizeof(int64_t));
-
-				int64_t res = *(int64_t*)pi->m_val;
+				int64_t res = pi->as<int64_t>();
 
 				if(res >= 0)
 				{
@@ -1232,7 +1226,7 @@ uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bo
 					pi = evt->get_param_by_name("fd");
 					if (pi)
 					{
-						int64_t res = *(int64_t*)pi->m_val;
+						int64_t res = pi->as<int64_t>();
 
 						if(res >= 0)
 						{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

As usual, the more test coverage we get the easier it is to catch these instances.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
