### PR TITLE
feat(libsinsp/container_info): change default / init lookup state to `FAILED`

### DIFF
--- a/userspace/libsinsp/container_engine/bpm.cpp
+++ b/userspace/libsinsp/container_engine/bpm.cpp
@@ -61,6 +61,7 @@ bool bpm::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if(container_cache().should_lookup(container_info.m_id, CT_BPM))
 	{
 		container_info.m_name = container_info.m_id;
+		container_info.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		container_cache().add_container(std::make_shared<sinsp_container_info>(container_info), tinfo);
 		container_cache().notify_new_container(container_info, tinfo);
 	}

--- a/userspace/libsinsp/container_engine/docker/base.cpp
+++ b/userspace/libsinsp/container_engine/docker/base.cpp
@@ -33,6 +33,7 @@ docker_base::resolve_impl(sinsp_threadinfo *tinfo, const docker_lookup_request& 
 			auto container = sinsp_container_info();
 			container.m_type = request.container_type;
 			container.m_id = request.container_id;
+			container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 			cache->notify_new_container(container, tinfo);
 			return true;
 		}

--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -85,6 +85,7 @@ bool libvirt_lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_inf
 	if(container_cache().should_lookup(container.m_id, CT_LIBVIRT_LXC))
 	{
 		container.m_name = container.m_id;
+		container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}

--- a/userspace/libsinsp/container_engine/lxc.cpp
+++ b/userspace/libsinsp/container_engine/lxc.cpp
@@ -64,6 +64,7 @@ bool lxc::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 	if (container_cache().should_lookup(container.m_id, CT_LXC))
 	{
 		container.m_name = container.m_id;
+		container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}

--- a/userspace/libsinsp/container_engine/mesos.cpp
+++ b/userspace/libsinsp/container_engine/mesos.cpp
@@ -62,6 +62,7 @@ bool libsinsp::container_engine::mesos::resolve(sinsp_threadinfo* tinfo, bool qu
 	if(container_cache().should_lookup(container.m_id, CT_MESOS))
 	{
 		container.m_name = container.m_id;
+		container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		container_cache().add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		container_cache().notify_new_container(container, tinfo);
 	}

--- a/userspace/libsinsp/container_engine/rkt.cpp
+++ b/userspace/libsinsp/container_engine/rkt.cpp
@@ -188,6 +188,7 @@ bool rkt::rkt::resolve(sinsp_threadinfo* tinfo, bool query_os_for_missing_info)
 
 	if (have_rkt)
 	{
+		container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 		cache->add_container(std::make_shared<sinsp_container_info>(container), tinfo);
 		cache->notify_new_container(container, tinfo);
 		return true;

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -55,7 +55,7 @@ public:
 	sinsp_container_lookup(short max_retry = 3, short max_delay_ms = 500):
 		m_max_retry(max_retry),
 		m_max_delay_ms(max_delay_ms),
-		m_state(state::SUCCESSFUL),
+		m_state(state::FAILED),
 		m_retry(0)
 	{
 		assert(max_retry >= 0);
@@ -132,7 +132,7 @@ public:
 private:
 	short m_max_retry;
 	short m_max_delay_ms;
-	state m_state = state::SUCCESSFUL;
+	state m_state = state::FAILED;
 	short m_retry;
 };
 

--- a/userspace/libsinsp/test/container_engine/container_parser_cri_containerd.ut.cpp
+++ b/userspace/libsinsp/test/container_engine/container_parser_cri_containerd.ut.cpp
@@ -647,6 +647,7 @@ TEST_F(sinsp_with_test_input, container_parser_cri_containerd)
 		"blkio=/k8s.io/3ad7b26ded6d8e7b23da7d48fe889434573036c27ae5a74837233de441c3601e",
 		"memory=/k8s.io/3ad7b26ded6d8e7b23da7d48fe889434573036c27ae5a74837233de441c3601e"};
 	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	std::string container_json = m_inspector.m_container_manager.container_to_json(container);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, (uint64_t)1, (uint64_t)1, (uint64_t)0, "", (uint64_t)0, (uint64_t)0, (uint64_t)0, (uint32_t)12088, (uint32_t)7208, (uint32_t)0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, (uint32_t)(PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID | PPM_CL_CLONE_NEWPID | PPM_CL_CHILD_IN_PIDNS), (uint32_t)1000, (uint32_t)1000, (uint64_t)parent_tid, (uint64_t)parent_pid);
@@ -782,6 +783,7 @@ TEST_F(sinsp_with_test_input, container_parser_cri_containerd_sandbox_container)
 		"blkio=/k8s.io/63060edc2d3aa803ab559f2393776b151f99fc5b05035b21db66b3b62246ad6a",
 		"memory=/k8s.io/63060edc2d3aa803ab559f2393776b151f99fc5b05035b21db66b3b62246ad6a"};
 	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	std::string container_json = m_inspector.m_container_manager.container_to_json(container);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, (uint64_t)1, (uint64_t)1, (uint64_t)0, "", (uint64_t)0, (uint64_t)0, (uint64_t)0, (uint32_t)12088, (uint32_t)7208, (uint32_t)0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, (uint32_t)(PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID | PPM_CL_CLONE_NEWPID | PPM_CL_CHILD_IN_PIDNS), (uint32_t)1000, (uint32_t)1000, (uint64_t)parent_tid, (uint64_t)parent_pid);

--- a/userspace/libsinsp/test/container_engine/container_parser_cri_crio.ut.cpp
+++ b/userspace/libsinsp/test/container_engine/container_parser_cri_crio.ut.cpp
@@ -643,6 +643,7 @@ TEST_F(sinsp_with_test_input, container_parser_cri_crio)
 		"pids=/pod_123.slice/pod_123-456.slice/crio-49ecc282021562c567a8159ef424a06cdd8637efdca5953de9794eafe29adcad.scope",
 		"misc=/pod_123.slice/pod_123-456.slice/crio-49ecc282021562c567a8159ef424a06cdd8637efdca5953de9794eafe29adcad.scope"};
 	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	std::string container_json = m_inspector.m_container_manager.container_to_json(container);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, (uint64_t)1, (uint64_t)1, (uint64_t)0, "", (uint64_t)0, (uint64_t)0, (uint64_t)0, (uint32_t)12088, (uint32_t)7208, (uint32_t)0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, (uint32_t)(PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID | PPM_CL_CLONE_NEWPID | PPM_CL_CHILD_IN_PIDNS), (uint32_t)1000, (uint32_t)1000, (uint64_t)parent_tid, (uint64_t)parent_pid);
@@ -745,6 +746,7 @@ TEST_F(sinsp_with_test_input, container_parser_cri_crio_sandbox_container)
 		"pids=/pod_123.slice/pod_123-456.slice/crio-1f04600dc6949359da68eee5fe7c4069706a567c07d1ef89fe3bbfdeac7a6dca.scope",
 		"misc=/pod_123.slice/pod_123-456.slice/crio-1f04600dc6949359da68eee5fe7c4069706a567c07d1ef89fe3bbfdeac7a6dca.scope"};
 	std::string cgroupsv = test_utils::to_null_delimited(cgroups);
+	container.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
 	std::string container_json = m_inspector.m_container_manager.container_to_json(container);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_E, 0);
 	add_event_advance_ts(increasing_ts(), parent_tid, PPME_SYSCALL_CLONE_20_X, 20, child_tid, "bash", empty_bytebuf, (uint64_t)1, (uint64_t)1, (uint64_t)0, "", (uint64_t)0, (uint64_t)0, (uint64_t)0, (uint32_t)12088, (uint32_t)7208, (uint32_t)0, "bash", scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()}, (uint32_t)(PPM_CL_CLONE_CHILD_CLEARTID | PPM_CL_CLONE_CHILD_SETTID | PPM_CL_CLONE_NEWPID | PPM_CL_CHILD_IN_PIDNS), (uint32_t)1000, (uint32_t)1000, (uint64_t)parent_tid, (uint64_t)parent_pid);

--- a/userspace/libsinsp/test/events_plugin.ut.cpp
+++ b/userspace/libsinsp/test/events_plugin.ut.cpp
@@ -131,8 +131,13 @@ TEST_F(sinsp_with_test_input, event_sources)
 	ASSERT_FALSE(field_has_value(evt, "evt.asynctype"));
 
 	// metaevents have the "syscall" event source
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_CONTAINER_JSON_E, 1, "{\"value\": 1}");
-	ASSERT_EQ(evt->get_type(), PPME_CONTAINER_JSON_E);
+	std::shared_ptr<sinsp_container_info> container = std::make_shared<sinsp_container_info>();
+	container->m_type = CT_CONTAINERD;
+	container->m_id = "3ad7b26ded6d";
+	container->set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
+	std::string container_json = m_inspector.m_container_manager.container_to_json(*container);
+	evt = add_event_advance_ts(increasing_ts(), -1, PPME_CONTAINER_JSON_2_E, 1, container_json.c_str());
+	ASSERT_EQ(evt->get_type(), PPME_CONTAINER_JSON_2_E);
 	ASSERT_EQ(evt->get_source_idx(), syscall_source_idx);
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
 	ASSERT_EQ(get_field_as_string(evt, "evt.source"), syscall_source_name);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

While working on https://github.com/falcosecurity/libs/pull/1595 it became evident that the init state is set wrongly. Curious if something breaks, if it does we likely will have found more improvement areas in regards to the container engine in general. 

Opened it again against the libs repo directly to allow for easier testing.

CC @therealbobo @leogr @deepskyblue86 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
