### PR TITLE
fix(userspace/libsinsp): make sure fd table's tid is set

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -235,6 +235,7 @@ scap_l4_proto sinsp_fdinfo::get_l4proto() const
 ///////////////////////////////////////////////////////////////////////////////
 sinsp_fdtable::sinsp_fdtable(sinsp* inspector)
 {
+	m_tid = 0;
 	m_inspector = inspector;
 	reset_cache();
 }
@@ -414,7 +415,7 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo* fdi, uint64_t fd)
 		return;
 	}
 
-	if(fdi->is_file() && fdi->m_dev == 0 && fdi->m_mount_id != 0)
+	if(m_tid != 0 && m_tid != (uint64_t)-1 && fdi->is_file() && fdi->m_dev == 0 && fdi->m_mount_id != 0)
 	{
 		char procdir[SCAP_MAX_PATH_SIZE];
 		snprintf(procdir, sizeof(procdir), "%s/proc/%ld/", scap_get_host_root(), m_tid);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1157,6 +1157,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 			if(fd_table_ptr != NULL)
 			{
 				child_tinfo->get_fdtable().clear();
+				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
 				fd_table_ptr->const_loop([&child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
 					/* Track down that those are cloned fds */
 					auto newinfo = info.clone();
@@ -1749,7 +1750,8 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 			if(fd_table_ptr != NULL)
 			{
 				child_tinfo->get_fdtable().clear();
-				fd_table_ptr->loop([&child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
+				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
+				fd_table_ptr->const_loop([&child_tinfo](int64_t fd, const sinsp_fdinfo& info) {
 					/* Track down that those are cloned fds.
 					* This flag `FLAGS_IS_CLONED` seems to be never used...
 					*/


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This fixes a recently-introduced issue where we could invoke `lookup_device` with an invalid thread ID, either uninitialized or simply not set to the proper value. This causes both performance issues and file descriptor info consistency problems.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
