### PR TITLE
fix(driver/kmod): always send fds to userspace in poll/ppoll syscall exit

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -3294,7 +3294,6 @@ static int poll_parse_fds(struct event_filler_arguments *args, bool enter_event)
 	char *targetbuf;
 	unsigned long val;
 	unsigned long nfds;
-	unsigned long fds_count;
 	uint32_t j;
 	uint32_t pos;
 	uint16_t flags;
@@ -3336,30 +3335,21 @@ static int poll_parse_fds(struct event_filler_arguments *args, bool enter_event)
 
 	pos = 2;
 	targetbuf = args->str_storage + nfds * sizeof(struct pollfd);
-	fds_count = 0;
 
 	/* Copy each fd into the temporary buffer */
 	for (j = 0; j < nfds; j++) {
 		if (enter_event) {
 			flags = poll_events_to_scap(fds[j].events);
 		} else {
-			/*
-			 * If it's an exit event, we copy only the fds that
-			 * returned something
-			 */
-			if (!fds[j].revents)
-				continue;
-
 			flags = poll_events_to_scap(fds[j].revents);
 		}
 
 		*(int64_t *)(targetbuf + pos) = (int64_t)fds[j].fd;
 		*(int16_t *)(targetbuf + pos + 8) = flags;
 		pos += 10;
-		++fds_count;
 	}
 
-	*(uint16_t *)(targetbuf) = (uint16_t)fds_count;
+	*(uint16_t *)(targetbuf) = (uint16_t)nfds;
 
 	return val_to_ring(args, (uint64_t)(unsigned long)targetbuf, pos, false, 0);
 }

--- a/driver/ppm_flag_helpers.h
+++ b/driver/ppm_flag_helpers.h
@@ -25,6 +25,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/capability.h>
 #include <linux/eventpoll.h>
 #include <linux/prctl.h>
+#include <linux/splice.h>
 #ifdef __NR_finit_module
 #include <uapi/linux/module.h>
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/poll_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/poll_x.cpp
@@ -63,17 +63,7 @@ TEST(SyscallExit, pollX_success)
 	evt_test->assert_numeric_param(1, (int64_t)0);
 
 	/* Parameter 2: fds (type: PT_FDLIST) */
-	if(evt_test->is_kmod_engine())
-	{
-		/* The logic in the kmod is slightly different: we collect data only if `revents != 0`
-		 * https://github.com/falcosecurity/libs/blob/master/driver/ppm_fillers.c#L3322-L3326
-		 */
-		evt_test->assert_fd_list(2, NULL, 0);
-	}
-	else
-	{
-		evt_test->assert_fd_list(2, (struct fd_poll *)&expected, 2);
-	}
+	evt_test->assert_fd_list(2, (struct fd_poll *)&expected, 2);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/process_vm_readv_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/process_vm_readv_x.cpp
@@ -14,7 +14,7 @@ TEST(SyscallExit, process_vm_readvX_failure)
 	iovec iov[] = {{buf, 16}};
 	int32_t iovcnt = 7;
 
-	size_t res = syscall(__NR_process_vm_readv, getpid(), iov, iovcnt, iov, iovcnt, 0);
+	size_t res = syscall(__NR_process_vm_readv, getpid(), iov, iovcnt, iov, iovcnt, 1);
 	assert_syscall_state(SYSCALL_FAILURE, "process_vm_readv", res, EQUAL, -1);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This uniforms the kmod driver's behavior to that of bpf and mbpf drivers in `poll/ppoll` syscall

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
