### PR TITLE
fix: Some warnings when compiling with GCC 14

### DIFF
--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2092,7 +2092,7 @@ static const struct scap_platform_vtable scap_savefile_platform_vtable = {
 
 struct scap_platform *scap_savefile_alloc_platform(proc_entry_callback proc_callback, void *proc_callback_context)
 {
-	struct scap_savefile_platform *platform = calloc(sizeof(*platform), 1);
+	struct scap_savefile_platform *platform = calloc(1, sizeof(*platform));
 
 	if(platform == NULL)
 	{

--- a/userspace/libscap/engine/test_input/test_input_platform.c
+++ b/userspace/libscap/engine/test_input/test_input_platform.c
@@ -85,7 +85,7 @@ static const struct scap_platform_vtable scap_test_input_platform = {
 
 struct scap_platform* scap_test_input_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
-	struct scap_test_input_platform* platform = calloc(sizeof(*platform), 1);
+	struct scap_test_input_platform* platform = calloc(1, sizeof(*platform));
 
 	if(platform == NULL)
 	{

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -123,7 +123,7 @@ static const struct scap_platform_vtable scap_linux_platform_vtable = {
 
 struct scap_platform* scap_linux_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
-	struct scap_linux_platform* platform = calloc(sizeof(*platform), 1);
+	struct scap_linux_platform* platform = calloc(1, sizeof(*platform));
 
 	if(platform == NULL)
 	{

--- a/userspace/libscap/ringbuffer/devset.c
+++ b/userspace/libscap/ringbuffer/devset.c
@@ -29,7 +29,7 @@ int32_t devset_init(struct scap_device_set *devset, size_t num_devs, char *laste
 {
 	devset->m_ndevs = num_devs;
 
-	devset->m_devs = (scap_device*) calloc(sizeof(scap_device), devset->m_ndevs);
+	devset->m_devs = (scap_device*) calloc(devset->m_ndevs, sizeof(scap_device));
 	if(!devset->m_devs)
 	{
 		strlcpy(lasterr, "error allocating the device handles", SCAP_LASTERR_SIZE);

--- a/userspace/libscap/scap_platform.c
+++ b/userspace/libscap/scap_platform.c
@@ -72,7 +72,7 @@ struct scap_platform_vtable scap_generic_platform_vtable = {
 
 struct scap_platform* scap_generic_alloc_platform(proc_entry_callback proc_callback, void* proc_callback_context)
 {
-	struct scap_platform* platform = calloc(sizeof(*platform), 1);
+	struct scap_platform* platform = calloc(1, sizeof(*platform));
 
 	if(platform == NULL)
 	{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
I tried building the library with gcc 14 and a few warnings came up. In a scenario where warnings are treated as errors this would be a blocker. The warnings are a tad picky as they lament that fuction `calloc` is being used with the element size first and the number of elements after, when it should be the opposite. Regardless of the check being extra meticulous, the fix is easy and prepares the code for future compiler upgrades.

```c++
    calloc(sizeof(int), N); // raises the warning
    calloc(N, sizeof(int)); // ok
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
