### PR TITLE
cleanup(libsinsp): scap_evt cleanups

### DIFF
--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -235,7 +235,7 @@ public:
 
 
 private:
-	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo);
+	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo, char* scap_err);
 	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
 	std::list<std::shared_ptr<libsinsp::container_engine::container_engine_base>> m_container_engines;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3037,8 +3037,10 @@ void sinsp_parser::parse_bind_exit(sinsp_evt *evt)
 	//
 	if(family == PPM_AF_INET)
 	{
-		uint32_t ip = *(uint32_t *)(packed_data + 1);
-		uint16_t port = *(uint16_t *)(packed_data + 5);
+		uint32_t ip;
+		uint16_t port;
+		memcpy(&ip, packed_data + 1, sizeof(ip));
+		memcpy(&port, packed_data + 5, sizeof(port));
 		if(port > 0)
 		{
 			evt->get_fd_info()->m_type = SCAP_FD_IPV4_SERVSOCK;
@@ -3846,10 +3848,10 @@ bool sinsp_parser::set_ipv6_addresses_and_ports(sinsp_fdinfo* fdinfo, uint8_t* p
 	uint16_t tsport, tdport;
 
 	memcpy((uint8_t *) tsip.m_b, packed_data + 1, sizeof(tsip.m_b));
-	tsport = *(uint16_t *)(packed_data + 17);
+	memcpy(&tsport, packed_data + 17, sizeof(tsport));
 
 	memcpy((uint8_t *) tdip.m_b, packed_data + 19, sizeof(tdip.m_b));
-	tdport = *(uint16_t *)(packed_data + 35);
+	memcpy(&tdport, packed_data + 35, sizeof(tdport));
 
 	if(fdinfo->m_type == SCAP_FD_IPV6_SOCK)
 	{


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

* `container_to_sinsp_event` was never returning false or error, now it has a reason to (issues during serialization)
* some network args were copied in the old way

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
