### PR TITLE
fix(driver): use configure system to build class_create with a single parameter

### DIFF
--- a/driver/configure/CLASS_CREATE_1/test.c
+++ b/driver/configure/CLASS_CREATE_1/test.c
@@ -1,0 +1,32 @@
+/*
+
+Copyright (C) 2024 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+/*
+ * Check that `class_create` builds with only a single parameter
+ * See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1aaba11da9aa7d7d6b52a74d45b31cac118295a1
+ */
+
+#include <linux/module.h>
+#include <linux/device.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("the Falco authors");
+
+static int class_create_test_init(void)
+{
+	struct class *g_ppm_class = class_create("test");
+	return 0;
+}
+
+static void class_create_test_exit(void)
+{
+}
+
+module_init(class_create_test_init);
+module_exit(class_create_test_exit);

--- a/driver/main.c
+++ b/driver/main.c
@@ -2864,7 +2864,7 @@ int scap_init(void)
 		goto init_module_err;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+#ifndef HAS_CLASS_CREATE_1
 	g_ppm_class = class_create(THIS_MODULE, DRIVER_DEVICE_NAME);
 #else
 	g_ppm_class = class_create(DRIVER_DEVICE_NAME);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Address RHEL 9 backport of class_create signature change introduced in kernel 6.4 git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1aaba11da9aa7d7d6b52a74d45b31cac118295a1

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(driver-kmod): error: too many arguments to function ‘class_create’
```
