### PR TITLE
fix(engine/savefile): fix crash when reading proclist from scap

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -924,7 +924,11 @@ void sinsp::on_new_entry_from_proc(void* context,
 
 		if(!sinsp_tinfo)
 		{
-			ASSERT(tinfo != NULL);
+			if (tinfo == NULL)
+			{
+				// we have an fd but no associated tinfo, skip it
+				return;
+			}
 
 			auto newti = build_threadinfo();
 			newti->init(tinfo);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area libscap-engine-savefile

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In https://github.com/falcosecurity/libs/pull/1471 we have removed the null check for the process entry callback replacing it with a default callback. However, the savefile engine was not calling that function but only using the regular callback instead which is routed to sinsp. The two work differently and the regular one is unable to handle missing proc entries when parsing fds (yes the callback for fds and procs is the same) leading to crashes while reading scap files. This patch restores the use of the default callback during scap read.

Meanwhile, in https://github.com/falcosecurity/libs/pull/1472 we have removed reading from the scap proc table at sinsp startup which makes some sense since the scap proc table was no longer written due to the fact that we were not using the default callback, but once we started using it again we need to reintroduce it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
