### PR TITLE
new(driver/bpf): added bpf configure system similar to the kmod one.

### DIFF
--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -40,7 +40,7 @@ ifeq ($(FIRST_MAKEFILE_DIRNAME)/$(FIRST_MAKEFILE_FILENAME), scripts/Makefile.bui
 # Build phase
 MODULE_MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 MAKEFILE_INC_FILES := $(shell find $(MODULE_MAKEFILE_DIR)/configure -type f -name Makefile.inc)
-$(info [configure] Including $(MAKEFILE_INC_FILES))
+$(info [configure-kmod] Including $(MAKEFILE_INC_FILES))
 include $(MAKEFILE_INC_FILES)
 endif
 endif # $(strip $(MAKEFILE_LIST)),Makefile

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -42,6 +42,10 @@ set(BPF_SOURCES
 	types.h
 )
 
+if(NOT DEFINED DRIVER_BPF_COMPONENT_NAME)
+	set(DRIVER_BPF_COMPONENT_NAME ${DRIVER_COMPONENT_NAME})
+endif()
+
 # Append driver headers too since they are used by bpf headers
 file(GLOB DRIVER_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../*.h)
 list(APPEND BPF_SOURCES ${DRIVER_HEADERS})
@@ -55,6 +59,12 @@ foreach(SOURCE IN LISTS BPF_SOURCES)
 	list(APPEND INSTALL_SET ${CMAKE_CURRENT_BINARY_DIR}/src/${FILENAME})
 endforeach()
 
+install(FILES
+	${INSTALL_SET}
+	DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}/bpf"
+	COMPONENT ${DRIVER_BPF_COMPONENT_NAME}
+)
+
 #
 # Copy all the "configure" modules
 #
@@ -66,20 +76,12 @@ foreach(subdir ${configure_modules})
 		configure_file(configure/Makefile src/configure/${CONFIGURE_MODULE}/Makefile COPYONLY)
 		configure_file(configure/build.sh src/configure/${CONFIGURE_MODULE}/build.sh COPYONLY)
 		configure_file(configure/Makefile.inc.in src/configure/${CONFIGURE_MODULE}/Makefile.inc)
-		list(APPEND INSTALL_SET
+		install(FILES
 				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/build.sh"
 				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/test.c"
 				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/Makefile"
-				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/Makefile.inc")
+				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/Makefile.inc"
+				DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}/bpf/configure/${CONFIGURE_MODULE}"
+				COMPONENT ${DRIVER_BPF_COMPONENT_NAME})
 	endif()
 endforeach()
-
-if(NOT DEFINED DRIVER_BPF_COMPONENT_NAME)
-	set(DRIVER_BPF_COMPONENT_NAME ${DRIVER_COMPONENT_NAME})
-endif()
-
-install(FILES
-	${INSTALL_SET}
-	DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}/bpf"
-	COMPONENT ${DRIVER_BPF_COMPONENT_NAME}
-)

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -55,6 +55,25 @@ foreach(SOURCE IN LISTS BPF_SOURCES)
 	list(APPEND INSTALL_SET ${CMAKE_CURRENT_BINARY_DIR}/src/${FILENAME})
 endforeach()
 
+#
+# Copy all the "configure" modules
+#
+file(GLOB configure_modules "${CMAKE_CURRENT_SOURCE_DIR}/configure/*")
+foreach(subdir ${configure_modules})
+	if(IS_DIRECTORY "${subdir}")
+		file(RELATIVE_PATH CONFIGURE_MODULE "${CMAKE_CURRENT_SOURCE_DIR}/configure" "${subdir}")
+		configure_file(configure/${CONFIGURE_MODULE}/test.c src/configure/${CONFIGURE_MODULE}/test.c COPYONLY)
+		configure_file(configure/Makefile src/configure/${CONFIGURE_MODULE}/Makefile COPYONLY)
+		configure_file(configure/build.sh src/configure/${CONFIGURE_MODULE}/build.sh COPYONLY)
+		configure_file(configure/Makefile.inc.in src/configure/${CONFIGURE_MODULE}/Makefile.inc)
+		list(APPEND INSTALL_SET
+				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/build.sh"
+				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/test.c"
+				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/Makefile"
+				"${CMAKE_CURRENT_BINARY_DIR}/src/configure/${CONFIGURE_MODULE}/Makefile.inc")
+	endif()
+endforeach()
+
 if(NOT DEFINED DRIVER_BPF_COMPONENT_NAME)
 	set(DRIVER_BPF_COMPONENT_NAME ${DRIVER_COMPONENT_NAME})
 endif()

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -13,6 +13,8 @@ always = $(always-y)
 LLC ?= llc
 CLANG ?= clang
 
+ifeq ($(strip $(MAKEFILE_LIST)),Makefile)
+
 KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 # DEBUG = -DBPF_DEBUG
@@ -42,6 +44,23 @@ clean:
 	$(MAKE) -C $(KERNELDIR) M=$$PWD clean
 	@rm -f *~
 
+else
+
+KERNELDIR 	?= $(CURDIR)
+#
+# Get the path of the module sources
+#
+FIRST_MAKEFILE := $(firstword $(MAKEFILE_LIST))
+FIRST_MAKEFILE_FILENAME := $(notdir $(FIRST_MAKEFILE))
+FIRST_MAKEFILE_DIRNAME := $(shell basename $(dir $(FIRST_MAKEFILE)))
+ifeq ($(FIRST_MAKEFILE_DIRNAME)/$(FIRST_MAKEFILE_FILENAME), scripts/Makefile.build)
+# Build phase
+MODULE_MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+MAKEFILE_INC_FILES := $(shell find $(MODULE_MAKEFILE_DIR)/configure -type f -name Makefile.inc)
+$(info [configure-bpf] Including $(MAKEFILE_INC_FILES))
+include $(MAKEFILE_INC_FILES)
+endif
+
 $(obj)/probe.o: $(src)/probe.c \
 		$(src)/bpf_helpers.h \
 		$(src)/filler_helpers.h \
@@ -66,3 +85,5 @@ $(obj)/probe.o: $(src)/probe.c \
 		-Wno-unknown-attributes \
 		-O2 -g -emit-llvm -c $< -o $(patsubst %.o,%.ll,$@)
 	$(LLC) -march=bpf -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
+
+endif # $(strip $(MAKEFILE_LIST)),Makefile

--- a/driver/bpf/configure/Makefile
+++ b/driver/bpf/configure/Makefile
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-only OR MIT
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
+always-y += test.o
+# kept for compatibility with kernels < 5.11
+always = $(always-y)
+
+LLC ?= llc
+CLANG ?= clang
+
+KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+
+# -fmacro-prefix-map is not supported on version of clang older than 10
+# so remove it if necessary.
+IS_CLANG_OLDER_THAN_10 := $(shell expr `$(CLANG) -dumpversion | cut -f1 -d.` \<= 10)
+ifeq ($(IS_CLANG_OLDER_THAN_10), 1)
+	KBUILD_CPPFLAGS := $(filter-out -fmacro-prefix-map=%,$(KBUILD_CPPFLAGS))
+endif
+
+all:
+	$(MAKE) -C $(KERNELDIR) M=$$PWD
+
+clean:
+	$(MAKE) -C $(KERNELDIR) M=$$PWD clean
+	@rm -f *~
+
+$(obj)/test.o: $(src)/test.c
+	$(CLANG) $(LINUXINCLUDE) \
+		$(KBUILD_CPPFLAGS) \
+		$(KBUILD_EXTRA_CPPFLAGS) \
+		-D__KERNEL__ \
+		-D__BPF_TRACING__ \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-address-of-packed-member \
+		-fno-jump-tables \
+		-fno-stack-protector \
+		-Wno-tautological-compare \
+		-Wno-unknown-attributes \
+		-O2 -g -emit-llvm -c $< -o $(patsubst %.o,%.ll,$@)
+	$(LLC) -march=bpf -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)

--- a/driver/bpf/configure/Makefile.inc.in
+++ b/driver/bpf/configure/Makefile.inc.in
@@ -4,10 +4,10 @@ MODULE_MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 HAS_@CONFIGURE_MODULE@ := $(shell env -i PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
 
 ifeq ($(HAS_@CONFIGURE_MODULE@),0)
-$(info [configure-kmod] Setting HAS_@CONFIGURE_MODULE@ flag)
-ccflags-y += -DHAS_@CONFIGURE_MODULE@
+$(info [configure-bpf] Setting HAS_@CONFIGURE_MODULE@ flag)
+KBUILD_CPPFLAGS += -DHAS_@CONFIGURE_MODULE@
 else
 HAS_@CONFIGURE_MODULE@_OUT := $(shell cat $(MODULE_MAKEFILE_DIR)/build.log)
-$(info [configure-kmod] Build output for HAS_@CONFIGURE_MODULE@:)
-$(info [configure-kmod] $(HAS_@CONFIGURE_MODULE@_OUT))
+$(info [configure-bpf] Build output for HAS_@CONFIGURE_MODULE@:)
+$(info [configure-bpf] $(HAS_@CONFIGURE_MODULE@_OUT))
 endif

--- a/driver/bpf/configure/RSS_STAT_ARRAY/test.c
+++ b/driver/bpf/configure/RSS_STAT_ARRAY/test.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+
+Copyright (C) 2023 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+/*
+ * Check that mm_struct's field `rss_stat` is an array.
+ * See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
+ */
+
+#include "../../quirks.h"
+
+#include <uapi/linux/bpf.h>
+
+#include "../../ppm_events_public.h"
+#include "../../bpf_helpers.h"
+#include "../../types.h"
+#include "../../maps.h"
+
+// struct mm_struct declaration
+#include <linux/mm_types.h>
+
+#ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
+#define BPF_PROBE(prefix, event, type)			\
+__bpf_section(TP_NAME #event)				\
+int bpf_##event(struct type *ctx)
+#else
+#define BPF_PROBE(prefix, event, type)			\
+__bpf_section(TP_NAME prefix #event)			\
+int bpf_##event(struct type *ctx)
+#endif
+
+BPF_PROBE("signal/", signal_deliver, signal_deliver_args)
+{
+	long val;
+	struct mm_struct *mm;
+	val = mm->rss_stat[0].count;
+	return 0;
+}
+
+char __license[] __bpf_section("license") = "Dual MIT/GPL";

--- a/driver/bpf/configure/RSS_STAT_ARRAY/test.c
+++ b/driver/bpf/configure/RSS_STAT_ARRAY/test.c
@@ -14,26 +14,11 @@ or GPL2.txt for full copies of the license.
  */
 
 #include "../../quirks.h"
-
-#include <uapi/linux/bpf.h>
-
 #include "../../ppm_events_public.h"
-#include "../../bpf_helpers.h"
 #include "../../types.h"
-#include "../../maps.h"
 
 // struct mm_struct declaration
 #include <linux/mm_types.h>
-
-#ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
-#define BPF_PROBE(prefix, event, type)			\
-__bpf_section(TP_NAME #event)				\
-int bpf_##event(struct type *ctx)
-#else
-#define BPF_PROBE(prefix, event, type)			\
-__bpf_section(TP_NAME prefix #event)			\
-int bpf_##event(struct type *ctx)
-#endif
 
 BPF_PROBE("signal/", signal_deliver, signal_deliver_args)
 {

--- a/driver/bpf/configure/build.sh
+++ b/driver/bpf/configure/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+# This file is dual licensed under either the MIT or GPL 2. See
+# MIT.txt or GPL.txt for full copies of the license.
+#
+
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname ${SCRIPT})
+
+make -C ${SCRIPT_DIR} > ${SCRIPT_DIR}/build.log 2>&1

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -854,11 +854,10 @@ static __always_inline unsigned long bpf_get_mm_counter(struct mm_struct *mm,
 {
 	long val;
 
-	// See 6.2 kernel commit: https://github.com/torvalds/linux/commit/f1a7941243c102a44e8847e3b94ff4ff3ec56f25
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
-	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
-#else
+#ifdef HAS_RSS_STAT_ARRAY
 	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat[member].count);
+#else
+	bpf_probe_read_kernel(&val, sizeof(val), &mm->rss_stat.count[member]);
 #endif
 	if (val < 0)
 		val = 0;

--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -27,16 +27,6 @@ or GPL2.txt for full copies of the license.
 #include "fillers.h"
 #include "builtins.h"
 
-#ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
-#define BPF_PROBE(prefix, event, type)			\
-__bpf_section(TP_NAME #event)				\
-int bpf_##event(struct type *ctx)
-#else
-#define BPF_PROBE(prefix, event, type)			\
-__bpf_section(TP_NAME prefix #event)			\
-int bpf_##event(struct type *ctx)
-#endif
-
 #define __NR_ia32_socketcall 102
 
 BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -25,6 +25,16 @@ or GPL2.txt for full copies of the license.
 #endif
 
 #ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
+#define BPF_PROBE(prefix, event, type)			\
+__bpf_section(TP_NAME #event)				\
+int bpf_##event(struct type *ctx)
+#else
+#define BPF_PROBE(prefix, event, type)			\
+__bpf_section(TP_NAME prefix #event)			\
+int bpf_##event(struct type *ctx)
+#endif
+
+#ifdef BPF_SUPPORTS_RAW_TRACEPOINTS
 struct sys_enter_args {
 	unsigned long regs;
 	unsigned long id;


### PR DESCRIPTION


**What type of PR is this?**

/kind bug
/kind feature

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This is the corrispettive of #1452  for bpf.
Moreover, it also adds a fix for rss_stat becoming an array in kernel 6.2 (this was backported in centos 5.14: https://falcosecurity.github.io/libs/matrix_X64/#centos-514-bpf-probe_build).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

While we could somehow reuse same code used for kmod, i preferred to duplicate it a bit but at the same time making the code driver-dependent since we might have to add very specific/different test cases in the future (imagine if eg: some kernel backported `BPF_FUNC_ktime_get_boot_ns` or if we want to enable `BPF_SUPPORTS_RAW_TRACEPOINTS` by checking that the kernel has backported some features...)
Indeed the very first test case added, ie: checking for `rss_stat` field being an array in `mm_struct` kernel structure, could also be made as a simpler kmod configure module and then its define added to bpf driver too, somehow.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
