### PR TITLE
fix(build): replace {0} zero-init with {}

### DIFF
--- a/test/drivers/helpers/file_opener.cpp
+++ b/test/drivers/helpers/file_opener.cpp
@@ -38,17 +38,17 @@ void file_opener::close()
     }
 }
 
-const bool file_opener::is_tmpfile_supported() const
+ bool file_opener::is_tmpfile_supported() const
 {
     return m_tmpfile_supported;
 }
 
-const int file_opener::get_fd() const
+ int file_opener::get_fd() const
 {
     return m_fd;
 }
 
-const int file_opener::get_flags() const
+ int file_opener::get_flags() const
 {
     return m_flags;
 }

--- a/test/drivers/helpers/file_opener.h
+++ b/test/drivers/helpers/file_opener.h
@@ -16,9 +16,9 @@ public:
     ~file_opener();
 
     void close();
-    const bool is_tmpfile_supported() const;
-    const int get_fd() const;
-    const int get_flags() const;
+    bool is_tmpfile_supported() const;
+    int get_fd() const;
+    int get_flags() const;
     const char* get_pathname() const;
 
 private:

--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -143,9 +143,9 @@ int open_engine(int argc, char** argv)
 		{0, 0, 0, 0}};
 
 	// They should live until we call 'scap_open'
-	scap_modern_bpf_engine_params modern_bpf_params = {0};
-	scap_bpf_engine_params bpf_params = {0};
-	scap_kmod_engine_params kmod_params = {0};
+	scap_modern_bpf_engine_params modern_bpf_params = {};
+	scap_bpf_engine_params bpf_params = {};
+	scap_kmod_engine_params kmod_params = {};
 	int ret = 0;
 	const scap_vtable* vtable = nullptr;
 	scap_open_args oargs = {};

--- a/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
+++ b/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
@@ -21,7 +21,7 @@ TEST(Actions, dynamic_snaplen_negative_fd)
 	const unsigned data_len = DEFAULT_SNAPLEN * 2;
 	char buf[data_len] = "HTTP/\0";
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -103,7 +103,7 @@ TEST(Actions, dynamic_snaplen_no_socket)
 	const unsigned data_len = DEFAULT_SNAPLEN * 2;
 	char buf[data_len] = "HTTP/\0";
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -180,8 +180,8 @@ TEST(Actions, dynamic_snaplen_HTTP)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -189,7 +189,7 @@ TEST(Actions, dynamic_snaplen_HTTP)
 	char buf[data_len] = "HTTP/\0";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -265,8 +265,8 @@ TEST(Actions, dynamic_snaplen_partial_HTTP_OPT)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -275,7 +275,7 @@ TEST(Actions, dynamic_snaplen_partial_HTTP_OPT)
 	char buf[data_len] = "OP\0";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -351,8 +351,8 @@ TEST(Actions, dynamic_snaplen_HTTP_TRACE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -360,7 +360,7 @@ TEST(Actions, dynamic_snaplen_HTTP_TRACE)
 	char buf[data_len] = "TRACE\0";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -436,8 +436,8 @@ TEST(Actions, dynamic_snaplen_MYSQL)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
 
 	/* Send a message to the server */
@@ -447,7 +447,7 @@ TEST(Actions, dynamic_snaplen_MYSQL)
 	buf[3] = 3;
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -523,8 +523,8 @@ TEST(Actions, dynamic_snaplen_not_MYSQL)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_MYSQL);
 
 	/* Send a message to the server */
@@ -532,7 +532,7 @@ TEST(Actions, dynamic_snaplen_not_MYSQL)
 	char buf[data_len] = "1111\0";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -608,8 +608,8 @@ TEST(Actions, dynamic_snaplen_POSTGRES)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
 
 	/* Send a message to the server */
@@ -619,7 +619,7 @@ TEST(Actions, dynamic_snaplen_POSTGRES)
 	buf[1] = 0;
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -695,8 +695,8 @@ TEST(Actions, dynamic_snaplen_not_POSTGRES)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr, PPM_PORT_POSTGRES);
 
 	/* Send a message to the server */
@@ -704,7 +704,7 @@ TEST(Actions, dynamic_snaplen_not_POSTGRES)
 	char buf[data_len] = "00\0";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -780,8 +780,8 @@ TEST(Actions, dynamic_snaplen_MONGO)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -790,7 +790,7 @@ TEST(Actions, dynamic_snaplen_MONGO)
 	*(int32_t *)(&buf[12]) = 0x01; // this 1 and it's ok
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -866,8 +866,8 @@ TEST(Actions, dynamic_snaplen_not_MONGO)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -876,7 +876,7 @@ TEST(Actions, dynamic_snaplen_not_MONGO)
 	*(int32_t *)(&buf[12]) = 0x07;
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -955,8 +955,8 @@ TEST(Actions, dynamic_snaplen_fullcapture_port_range)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -964,7 +964,7 @@ TEST(Actions, dynamic_snaplen_fullcapture_port_range)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -1048,8 +1048,8 @@ TEST(Actions, dynamic_snaplen_statsd_port)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1057,7 +1057,7 @@ TEST(Actions, dynamic_snaplen_statsd_port)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -1141,8 +1141,8 @@ TEST(Actions, dynamic_snaplen_no_statsd_port)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -1150,7 +1150,7 @@ TEST(Actions, dynamic_snaplen_no_statsd_port)
 	char buf[data_len] = "simple message";
 	uint32_t sendto_flags = 0;
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exit.cpp
@@ -19,7 +19,7 @@ TEST(GenericTracepoints, sched_proc_exit_no_children)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -108,7 +108,7 @@ TEST(GenericTracepoints, sched_proc_exit_prctl_subreaper)
 	pid_t p2_t1 = 61030;
 	pid_t p3_t1 = 61050;
 
-	clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -122,14 +122,13 @@ TEST(GenericTracepoints, sched_proc_exit_prctl_subreaper)
 			exit(EXIT_FAILURE);
 		}
 
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 1;
 		cl_args_child.exit_signal = SIGCHLD;
 		pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
 		if(p2_t1_pid == 0)
 		{
-			clone_args cl_args_child = {0};
 			cl_args_child.set_tid = (uint64_t)&p3_t1;
 			cl_args_child.set_tid_size = 1;
 			cl_args_child.exit_signal = SIGCHLD;
@@ -225,7 +224,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper)
 	pid_t p3_t1[2] = {3, 59026};
 
 	/* p1_t1 is in the new namespace */
-	clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 2;
 	cl_args_parent.flags = CLONE_NEWPID;
@@ -234,14 +233,13 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper)
 
 	if(p1_t1_pid == 0)
 	{
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 2;
 		cl_args_child.exit_signal = SIGCHLD;
 		pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));
 		if(p2_t1_pid == 0)
 		{
-			clone_args cl_args_child = {0};
 			cl_args_child.set_tid = (uint64_t)&p3_t1;
 			cl_args_child.set_tid_size = 2;
 			cl_args_child.exit_signal = SIGCHLD;
@@ -337,7 +335,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 	pid_t p2_t1[2] = {2, 59025};
 
 	/* p1_t1 is in the new namespace */
-	clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 2;
 	cl_args_parent.flags = CLONE_NEWPID;
@@ -346,7 +344,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 
 	if(p1_t1_pid == 0)
 	{
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 2;
 		cl_args_parent.exit_signal = SIGCHLD;
@@ -407,7 +405,7 @@ TEST(GenericTracepoints, sched_proc_exit_child_namespace_reaper_die)
 static int child_func(void* arg)
 {
 	pid_t p2_t1 = 57006;
-	clone_args cl_args_child = {0};
+	clone_args cl_args_child = {};
 	cl_args_child.set_tid = (uint64_t)&p2_t1;
 	cl_args_child.set_tid_size = 1;
 	pid_t p2_t1_pid = syscall(__NR_clone3, &cl_args_child, sizeof(cl_args_child));

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_switch.cpp
@@ -16,7 +16,7 @@ TEST(GenericTracepoints, sched_switch)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_enter_suite/bpf_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/bpf_e.cpp
@@ -20,7 +20,7 @@ TEST(SyscallEnter, bpfE)
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_enter_suite/clone3_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/clone3_e.cpp
@@ -13,7 +13,7 @@ TEST(SyscallEnter, clone3E)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* flags are invalid so the syscall will fail. */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = (unsigned long)-1;
 	assert_syscall_state(SYSCALL_FAILURE, "clone3", syscall(__NR_clone3, &cl_args, sizeof(cl_args)));
 

--- a/test/drivers/test_suites/syscall_enter_suite/fstat_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/fstat_e.cpp
@@ -11,7 +11,7 @@ TEST(SyscallEnter, fstatE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int f_desc = -1;
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "fstat", syscall(__NR_fstat, f_desc, &statbuf));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_enter_suite/ioctl_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/ioctl_e.cpp
@@ -23,7 +23,7 @@ TEST(SyscallEnter, ioctlE)
 	/* Here we need to call the `ioctl` from a child because the main process throws lots of
 	 * `ioctl` to manage the kmod.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_enter_suite/lstat_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/lstat_e.cpp
@@ -11,7 +11,7 @@ TEST(SyscallEnter, lstatE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	char pathname[] = "//**null-file-path**//";
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "lstat", syscall(__NR_lstat, pathname, &statbuf));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_enter_suite/poll_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/poll_e.cpp
@@ -174,12 +174,12 @@ TEST(SyscallEnter, pollE_truncated)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* We push more than MAX_FDS structs. We should obtain only `MAX_FDS` structs */
-	struct pollfd fds[MAX_FDS + 1] = {0};
+	struct pollfd fds[MAX_FDS + 1] = {};
 	nfds_t nfds = MAX_FDS + 1;
 	int timeout = 0;
 
 	/* We expect only `MAX_FDS` structs */
-	struct fd_poll expected[MAX_FDS] = {0};
+	struct fd_poll expected[MAX_FDS] = {};
 
 	assert_syscall_state(SYSCALL_SUCCESS, "poll", syscall(__NR_poll, fds, nfds, timeout), NOT_EQUAL, -1);
 

--- a/test/drivers/test_suites/syscall_enter_suite/ppoll_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/ppoll_e.cpp
@@ -68,7 +68,7 @@ TEST(SyscallEnter, ppollE_valid_pointers)
 	 * tested it with `poll` syscall.
 	 */
 	struct pollfd* fds = NULL;
-	struct timespec timestamp = {0};
+	struct timespec timestamp = {};
 	timestamp.tv_sec = 2;
 	timestamp.tv_nsec = 250;
 	sigset_t sigmask;

--- a/test/drivers/test_suites/syscall_enter_suite/quotactl_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/quotactl_e.cpp
@@ -15,7 +15,7 @@ TEST(SyscallEnter, quotactlE)
 	int cmd = QCMD(Q_SYNC, USRQUOTA);
 	const char* special = "/dev//*null";
 	int id = 1;
-	struct if_dqblk addr = {0};
+	struct if_dqblk addr = {};
 	assert_syscall_state(SYSCALL_FAILURE, "quotactl", syscall(__NR_quotactl, cmd, special, id, &addr));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -12,8 +12,8 @@ TEST(SyscallEnter, sendmsgE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -86,8 +86,8 @@ TEST(SyscallEnter, sendmsgE_udp)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */

--- a/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -12,8 +12,8 @@ TEST(SyscallEnter, sendtoE)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -69,8 +69,8 @@ TEST(SyscallEnter, sendtoE_udp)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */

--- a/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/socket_e.cpp
@@ -20,7 +20,7 @@ TEST(SyscallEnter, socketE)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_enter_suite/stat_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/stat_e.cpp
@@ -11,7 +11,7 @@ TEST(SyscallEnter, statE)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	char pathname[] = "//**null-file-path**//";
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "stat", syscall(__NR_stat, pathname, &statbuf));
 
 	/*=============================== TRIGGER SYSCALL ===========================*/

--- a/test/drivers/test_suites/syscall_exit_suite/accept4_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/accept4_x.cpp
@@ -14,8 +14,8 @@ TEST(SyscallExit, accept4X_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -83,8 +83,8 @@ TEST(SyscallExit, accept4X_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in6 client_addr = {0};
-	sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {};
+	sockaddr_in6 server_addr = {};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -153,8 +153,8 @@ TEST(SyscallExit, accept4X_UNIX)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_un client_addr = {0};
-	struct sockaddr_un server_addr = {0};
+	struct sockaddr_un client_addr = {};
+	struct sockaddr_un server_addr = {};
 	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */

--- a/test/drivers/test_suites/syscall_exit_suite/accept_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/accept_x.cpp
@@ -12,8 +12,8 @@ TEST(SyscallExit, acceptX_INET)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -78,8 +78,8 @@ TEST(SyscallExit, acceptX_INET6)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in6 client_addr = {0};
-	sockaddr_in6 server_addr = {0};
+	sockaddr_in6 client_addr = {};
+	sockaddr_in6 server_addr = {};
 	evt_test->connect_ipv6_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */
@@ -145,8 +145,8 @@ TEST(SyscallExit, acceptX_UNIX)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_un client_addr = {0};
-	struct sockaddr_un server_addr = {0};
+	struct sockaddr_un client_addr = {};
+	struct sockaddr_un server_addr = {};
 	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* We don't want to get any info about the connected socket so `addr` and `addrlen` are NULL. */

--- a/test/drivers/test_suites/syscall_exit_suite/bpf_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/bpf_x.cpp
@@ -21,7 +21,7 @@ TEST(SyscallExit, bpfX_invalid_cmd)
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -97,7 +97,7 @@ TEST(SyscallExit, bpfX_MAP_CREATE)
 	/* Here we need to call the `bpf` from a child because the main process throws lots of
 	 * `bpf` syscalls to manage the bpf drivers.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_exit_suite/capset_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/capset_x.cpp
@@ -19,7 +19,7 @@ TEST(SyscallExit, capsetX)
 	 */
 
 	/* On kernels >= 5.8 the suggested version should be `_LINUX_CAPABILITY_VERSION_3` */
-	struct __user_cap_header_struct header = {0};
+	struct __user_cap_header_struct header = {};
 	struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
 	cap_user_header_t hdrp = &header;
 	cap_user_data_t datap = data;

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -16,7 +16,7 @@ TEST(SyscallExit, clone3X_father)
 	/* We scan proc before the BPF event is caught so we have
 	 * to use `GREATER_EQUAL` in the assertions.
 	 */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -26,7 +26,7 @@ TEST(SyscallExit, clone3X_father)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -143,7 +143,7 @@ TEST(SyscallExit, clone3X_child)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Here we scan the parent just to obtain some info for the child */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -153,7 +153,7 @@ TEST(SyscallExit, clone3X_child)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -265,7 +265,7 @@ TEST(SyscallExit, clone3X_create_child_with_2_threads)
 	pid_t p1_t1 = 61001;
 	pid_t p1_t2 = 61004;
 
-	clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -275,7 +275,7 @@ TEST(SyscallExit, clone3X_create_child_with_2_threads)
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 1;
 		/* CLONE_PARENT has no additional effects if we are spawning a thread
@@ -370,7 +370,7 @@ TEST(SyscallExit, clone3X_child_clone_parent_flag)
 	pid_t p1_t1 = 61024;
 	pid_t p2_t1 = 60128;
 
-	clone_args cl_args_parent = {0};
+	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
 	cl_args_parent.set_tid_size = 1;
 	cl_args_parent.exit_signal = SIGCHLD;
@@ -378,7 +378,7 @@ TEST(SyscallExit, clone3X_child_clone_parent_flag)
 
 	if(ret_pid == 0)
 	{
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p2_t1;
 		cl_args_child.set_tid_size = 1;
 		cl_args_child.flags = CLONE_PARENT;
@@ -477,7 +477,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_child)
 	/* Here we create a child process in a new namespace. */
 	pid_t p1_t1[2] = {1, 61032};
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -560,7 +560,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_caller)
 	/* Here we create a child process in a new namespace. */
 	pid_t p1_t1[2] = {1, 61032};
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -642,7 +642,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_create_thread)
 	/* Please note that a process can have the same pid number in different namespaces */
 	pid_t p1_t2[2] = {61036, 61036};
 
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;
 	cl_args.set_tid_size = 2;
 	cl_args.flags = CLONE_NEWPID;
@@ -652,7 +652,7 @@ TEST(SyscallExit, clone3X_child_new_namespace_create_thread)
 	if(ret_pid == 0)
 	{
 		/* Spawn a new thread */
-		clone_args cl_args_child = {0};
+		clone_args cl_args_child = {};
 		cl_args_child.set_tid = (uint64_t)&p1_t2;
 		cl_args_child.set_tid_size = 2;
 		cl_args_child.flags = CLONE_THREAD | CLONE_SIGHAND | CLONE_VM | CLONE_VFORK;

--- a/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone_x.cpp
@@ -14,7 +14,7 @@ TEST(SyscallExit, cloneX_father)
 	/* We scan proc before the BPF event is caught so we have
 	 * to use `GREATER_EQUAL` in the assertions.
 	 */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -24,7 +24,7 @@ TEST(SyscallExit, cloneX_father)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	unsigned long clone_flags = CLONE_FILES | SIGCHLD;
+	unsigned long test_clone_flags = CLONE_FILES | SIGCHLD;
 	unsigned long newsp = 0;
 	int parent_tid = 0;
 	int child_tid = 0;
@@ -59,11 +59,11 @@ TEST(SyscallExit, cloneX_father)
 	 *
 	 */
 #ifdef __s390x__
-	ret_pid = syscall(__NR_clone, newsp, clone_flags, &parent_tid, &child_tid, tls);
+	ret_pid = syscall(__NR_clone, newsp, test_clone_flags, &parent_tid, &child_tid, tls);
 #elif defined(__aarch64__) || defined(__riscv)
-	ret_pid = syscall(__NR_clone, clone_flags, newsp, &parent_tid, tls, &child_tid);
+	ret_pid = syscall(__NR_clone, test_clone_flags, newsp, &parent_tid, tls, &child_tid);
 #else
-	ret_pid = syscall(__NR_clone, clone_flags, newsp, &parent_tid, &child_tid, tls);
+	ret_pid = syscall(__NR_clone, test_clone_flags, newsp, &parent_tid, &child_tid, tls);
 #endif
 
 	if(ret_pid == 0)
@@ -178,7 +178,7 @@ TEST(SyscallExit, cloneX_child)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Here we scan the parent just to obtain some info for the child */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -188,7 +188,7 @@ TEST(SyscallExit, cloneX_child)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates. We use `CLONE_FILES` just to test the flags.
 	 */
-	unsigned long clone_flags = CLONE_FILES | SIGCHLD;
+	unsigned long test_clone_flags = CLONE_FILES | SIGCHLD;
 	int parent_tid = 0;
 	unsigned long newsp = 0;
 	int child_tid = 0;
@@ -196,11 +196,11 @@ TEST(SyscallExit, cloneX_child)
 	pid_t ret_pid = 0;
 
 #ifdef __s390x__
-	ret_pid = syscall(__NR_clone, newsp, clone_flags, &parent_tid, &child_tid, tls);
+	ret_pid = syscall(__NR_clone, newsp, test_clone_flags, &parent_tid, &child_tid, tls);
 #elif defined(__aarch64__) || defined(__riscv)
-	ret_pid = syscall(__NR_clone, clone_flags, newsp, &parent_tid, tls, &child_tid);
+	ret_pid = syscall(__NR_clone, test_clone_flags, newsp, &parent_tid, tls, &child_tid);
 #else
-	ret_pid = syscall(__NR_clone, clone_flags, newsp, &parent_tid, &child_tid, tls);
+	ret_pid = syscall(__NR_clone, test_clone_flags, newsp, &parent_tid, &child_tid, tls);
 #endif
 
 	if(ret_pid == 0)

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -16,7 +16,7 @@ TEST(SyscallExit, execveX_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Get all the info from proc. */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -27,7 +27,7 @@ TEST(SyscallExit, execveX_failure)
 	 * Get the process capabilities.
 	 */
 	/* On kernels >= 5.8 the suggested version should be `_LINUX_CAPABILITY_VERSION_3` */
-	struct __user_cap_header_struct header = {0};
+	struct __user_cap_header_struct header = {};
 	struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
 	cap_user_header_t hdrp = &header;
 	cap_user_data_t datap = data;
@@ -178,7 +178,7 @@ TEST(SyscallExit, execveX_success)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -361,7 +361,7 @@ TEST(SyscallExit, execveX_not_upperlayer)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -558,7 +558,7 @@ TEST(SyscallExit, execveX_upperlayer_success)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -717,7 +717,7 @@ TEST(SyscallExit, execveX_success_memfd)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -818,7 +818,7 @@ TEST(SyscallExit, execveX_symlink)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -15,7 +15,7 @@ TEST(SyscallExit, execveatX_failure)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Get all the info from proc. */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -27,7 +27,7 @@ TEST(SyscallExit, execveatX_failure)
 	 */
 
 	/* On kernels >= 5.8 the suggested version should be `_LINUX_CAPABILITY_VERSION_3` */
-	struct __user_cap_header_struct header = {0};
+	struct __user_cap_header_struct header = {};
 	struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
 	cap_user_header_t hdrp = &header;
 	cap_user_data_t datap = data;
@@ -185,7 +185,7 @@ TEST(SyscallExit, execveatX_correct_exit)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -311,7 +311,7 @@ TEST(SyscallExit, execveatX_execve_exit)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 
@@ -462,7 +462,7 @@ TEST(SyscallExit, execveatX_success_memfd)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
 

--- a/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
@@ -14,7 +14,7 @@ TEST(SyscallExit, forkX_father)
 	/* We scan proc before the BPF event is caught so we have
 	 * to use `GREATER_EQUAL` in the assertions.
 	 */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{
@@ -139,7 +139,7 @@ TEST(SyscallExit, forkX_child)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Here we scan the parent just to obtain some info for the child */
-	struct proc_info info = {0};
+	struct proc_info info = {};
 	pid_t pid = ::getpid();
 	if(!get_proc_info(pid, &info))
 	{

--- a/test/drivers/test_suites/syscall_exit_suite/fstat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fstat_x.cpp
@@ -10,7 +10,7 @@ TEST(SyscallExit, fstatX)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	int f_desc = -1;
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "fstat", syscall(__NR_fstat, f_desc, &statbuf));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/getrlimit_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/getrlimit_x.cpp
@@ -13,7 +13,7 @@ TEST(SyscallExit, getrlimitX_success)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int resource = RLIMIT_NPROC;
-	struct rlimit rlim = {0};
+	struct rlimit rlim = {};
 	assert_syscall_state(SYSCALL_SUCCESS, "getrlimit", syscall(__NR_getrlimit, resource, &rlim), NOT_EQUAL, -1);
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
@@ -56,7 +56,7 @@ TEST(SyscallExit, getrlimitX_wrong_resource)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int resource = -1;
-	struct rlimit rlim = {0};
+	struct rlimit rlim = {};
 	assert_syscall_state(SYSCALL_FAILURE, "getrlimit", syscall(__NR_getrlimit, resource, &rlim));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/getsockopt_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/getsockopt_x.cpp
@@ -85,7 +85,7 @@ TEST(SyscallExit, getsockoptX_SO_RCVTIMEO)
 	int32_t mock_fd = -1;
 	int32_t level = SOL_SOCKET;
 	int32_t option_name = SO_RCVTIMEO;
-	struct timeval option_value = {0};
+	struct timeval option_value = {};
 	option_value.tv_sec = 5;
 	option_value.tv_usec = 10;
 	socklen_t option_len = sizeof(struct timeval);

--- a/test/drivers/test_suites/syscall_exit_suite/io_uring_setup_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/io_uring_setup_x.cpp
@@ -18,7 +18,7 @@ TEST(SyscallExit, io_uring_setupX)
 	uint32_t expected_features = 0;
 	uint32_t expected_flags = (uint32_t)-1;
 	uint32_t entries = 4;
-	struct io_uring_params params = {0};
+	struct io_uring_params params = {};
 	params.sq_entries = 5;
 	params.cq_entries = 6;
 	params.flags = (uint32_t)-1;

--- a/test/drivers/test_suites/syscall_exit_suite/ioctl_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/ioctl_x.cpp
@@ -23,7 +23,7 @@ TEST(SyscallExit, ioctlX)
 	/* Here we need to call the `ioctl` from a child because the main process throws lots of
 	 * `ioctl` to manage the kmod.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/lstat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/lstat_x.cpp
@@ -10,7 +10,7 @@ TEST(SyscallExit, lstatX)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	char pathname[] = "//**null-file-path**//";
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "lstat", syscall(__NR_lstat, pathname, &statbuf));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/prctl_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/prctl_x.cpp
@@ -133,7 +133,7 @@ TEST(SyscallExit, prctlX_set_child_subreaper)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));
@@ -209,7 +209,7 @@ TEST(SyscallExit, prctlX_set_name)
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.exit_signal = SIGCHLD;
 
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/quotactl_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/quotactl_x.cpp
@@ -15,7 +15,7 @@ TEST(SyscallExit, quotactlX)
 	int cmd = QCMD(Q_SYNC, USRQUOTA);
 	const char* special = "/dev//*null";
 	int id = 1;
-	struct if_dqblk addr = {0};
+	struct if_dqblk addr = {};
 	assert_syscall_state(SYSCALL_FAILURE, "quotactl", syscall(__NR_quotactl, cmd, special, id, &addr));
 	int64_t errno_value = -errno;
 

--- a/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -14,8 +14,8 @@ TEST(SyscallExit, recvfromX_tcp_connection_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -31,7 +31,7 @@ TEST(SyscallExit, recvfromX_tcp_connection_no_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {};
 	socklen_t addrlen = sizeof(src_addr);
 
 	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (sockaddr*)&src_addr, &addrlen);
@@ -87,8 +87,8 @@ TEST(SyscallExit, recvfromX_tcp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -104,7 +104,7 @@ TEST(SyscallExit, recvfromX_tcp_connection_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {};
 	socklen_t addrlen = sizeof(src_addr);
 
 	int64_t received_bytes = syscall(__NR_recvfrom, connected_socket_fd, received_data, received_data_len, recvfrom_flags, (sockaddr*)&src_addr, &addrlen);
@@ -160,8 +160,8 @@ TEST(SyscallExit, recvfromX_tcp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -242,8 +242,8 @@ TEST(SyscallExit, recvfromX_udp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -256,7 +256,7 @@ TEST(SyscallExit, recvfromX_udp_connection_snaplen)
 	char received_data[MAX_RECV_BUF_SIZE];
 	socklen_t received_data_len = MAX_RECV_BUF_SIZE;
 	uint32_t recvfrom_flags = 0;
-	sockaddr_in src_addr = {0};
+	sockaddr_in src_addr = {};
 	socklen_t addrlen = sizeof(src_addr);
 
 	int64_t received_bytes = syscall(__NR_recvfrom, server_socket_fd, received_data, received_data_len,
@@ -323,8 +323,8 @@ TEST(SyscallExit, recvfromX_udp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */

--- a/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -14,8 +14,8 @@ TEST(SyscallExit, recvmsgX_tcp_connection_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -115,8 +115,8 @@ TEST(SyscallExit, recvmsgX_tcp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -213,8 +213,8 @@ TEST(SyscallExit, recvmsgX_tcp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -311,8 +311,8 @@ TEST(SyscallExit, recvmsgX_udp_connection_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -405,8 +405,8 @@ TEST(SyscallExit, recvmsgX_udp_connection_NULL_sockaddr)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_udp_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -549,11 +549,10 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	struct sockaddr_un client_addr = {0};
-	struct sockaddr_un server_addr = {0};
+	struct sockaddr_un client_addr = {};
+	struct sockaddr_un server_addr = {};
 	evt_test->connect_unix_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 	int64_t received_bytes, sent_bytes, msg_controllen;
-	struct msghdr msg;
 	struct cmsghdr *cmsg;
 	char cmsg_buf[CMSG_SPACE(sizeof(int))];
 	struct iovec iov = {
@@ -571,12 +570,11 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 	{
 		/* Create a socket. It is used to pass it to the child process, just for test purposes */
 		int sock = socket(AF_UNIX, SOCK_STREAM, 0);
-		msg = {
-			.msg_iov = &iov,
-			.msg_iovlen = 1,
-			.msg_control = cmsg_buf,
-			.msg_controllen = sizeof(cmsg_buf)
-		};
+		msghdr msg = {};
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+		msg.msg_control = cmsg_buf;
+		msg.msg_controllen = sizeof(cmsg_buf);
 		msg_controllen = msg.msg_controllen;
 
 		cmsg = CMSG_FIRSTHDR(&msg);
@@ -597,20 +595,17 @@ TEST(SyscallExit, recvmsg_ancillary_data)
 	} else
 	{
 		char buf[FULL_MESSAGE_LEN];
-		struct iovec iov = {
+		iov = {
 			iov.iov_base = (void *)buf,
 			iov.iov_len = sizeof(buf)
 		};
 
-		struct msghdr msg = {
-			.msg_iov = &iov,
-			.msg_iovlen = 1,
-			.msg_control = cmsg_buf,
-			.msg_controllen = sizeof(cmsg_buf)
-		};
-
+		msghdr msg = {};
 		msg.msg_iov = &iov;
 		msg.msg_iovlen = 1;
+		msg.msg_control = cmsg_buf;
+		msg.msg_controllen = sizeof(cmsg_buf);
+
 		iov.iov_base = (void *)buf;
 		iov.iov_len = sizeof(buf);
 

--- a/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/semop_x.cpp
@@ -82,7 +82,7 @@ TEST(SyscallExit, semopX_wrong_nops)
 	int semid = syscall(__NR_semget, key, 1, 0666 | IPC_CREAT);
 	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
 
-	struct sembuf sops = {0};
+	struct sembuf sops = {};
 	sops.sem_num = 0;
 	sops.sem_op = 3;
 	sops.sem_flg = SEM_UNDO;
@@ -155,7 +155,7 @@ TEST(SyscallExit, semopX_1_operation)
 	int semid = syscall(__NR_semget, key, 1, 0666 | IPC_CREAT);
 	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
 
-	struct sembuf sops = {0};
+	struct sembuf sops = {};
 	sops.sem_num = 0;
 	sops.sem_op = 3;
 	sops.sem_flg = SEM_UNDO;
@@ -226,7 +226,7 @@ TEST(SyscallExit, semopX_2_operation)
 	int semid = syscall(__NR_semget, key, 2, 0666 | IPC_CREAT);
 	assert_syscall_state(SYSCALL_SUCCESS, "semget", semid, NOT_EQUAL, -1);
 
-	struct sembuf sops[2] = {0};
+	struct sembuf sops[2] = {};
 	sops[0].sem_num = 0;
 	sops[0].sem_op = 3;
 	sops[0].sem_flg = SEM_UNDO;

--- a/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -17,8 +17,8 @@ TEST(SyscallExit, sendmsgX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -86,8 +86,8 @@ TEST(SyscallExit, sendmsgX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -157,8 +157,8 @@ TEST(SyscallExit, sendmsgX_fail)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct msghdr send_msg = {0};
-	struct iovec iov[1] = {0};
+	struct msghdr send_msg = {};
+	struct iovec iov[1] = {};
 	memset(&send_msg, 0, sizeof(send_msg));
 	memset(iov, 0, sizeof(iov));
 	char sent_data_1[DEFAULT_SNAPLEN / 2] = "some-data";
@@ -225,7 +225,7 @@ TEST(SyscallExit, sendmsgX_null_iovec)
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
 	int32_t mock_fd = -1;
-	struct msghdr send_msg = {0};
+	struct msghdr send_msg = {};
 	memset(&send_msg, 0, sizeof(send_msg));
 	send_msg.msg_iov = NULL;
 	/* here we pass a wrong `iovlen` to check the behavior */

--- a/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -17,8 +17,8 @@ TEST(SyscallExit, sendtoX_no_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */
@@ -72,8 +72,8 @@ TEST(SyscallExit, sendtoX_snaplen)
 
 	int32_t client_socket_fd = 0;
 	int32_t server_socket_fd = 0;
-	sockaddr_in client_addr = {0};
-	sockaddr_in server_addr = {0};
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
 	evt_test->connect_ipv4_client_to_server(&client_socket_fd, &client_addr, &server_socket_fd, &server_addr);
 
 	/* Send a message to the server */

--- a/test/drivers/test_suites/syscall_exit_suite/setsockopt_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/setsockopt_x.cpp
@@ -74,7 +74,7 @@ TEST(SyscallExit, setsockoptX_SO_RCVTIMEO)
 	int32_t mock_fd = -1;
 	int32_t level = SOL_SOCKET;
 	int32_t option_name = SO_RCVTIMEO;
-	struct timeval option_value = {0};
+	struct timeval option_value = {};
 	option_value.tv_sec = 5;
 	option_value.tv_usec = 10;
 	socklen_t option_len = sizeof(struct timeval);

--- a/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socket_x.cpp
@@ -20,7 +20,7 @@ TEST(SyscallExit, socketX)
 	/* Here we need to call the `socket` from a child because the main process throws a `socket`
 	 * syscall to calibrate the socket file options if we are using the bpf probe.
 	 */
-	clone_args cl_args = {0};
+	clone_args cl_args = {};
 	cl_args.flags = CLONE_FILES;
 	cl_args.exit_signal = SIGCHLD;
 	pid_t ret_pid = syscall(__NR_clone3, &cl_args, sizeof(cl_args));

--- a/test/drivers/test_suites/syscall_exit_suite/stat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/stat_x.cpp
@@ -10,7 +10,7 @@ TEST(SyscallExit, statX)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	char pathname[] = "//**null-file-path**//";
-	struct stat statbuf = { 0 };
+	struct stat statbuf = {};
 	assert_syscall_state(SYSCALL_FAILURE, "stat", syscall(__NR_stat, pathname, &statbuf));
 	int64_t errno_value = -errno;
 


### PR DESCRIPTION
Apparently my compiler (gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0) does not like initializing structs with {0} at all.

Honestly, I'm not convinced this is valid C++ either, though I'm pretty sure it is valid C. E.g. this page:
https://en.cppreference.com/w/cpp/language/zero_initialization does not mention {0} as a valid way to zero-initialize a struct.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Not sure how it works for everybody else, but I'm getting tons of build errors for struct initialization that does seem off.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
