### PR TITLE
fix(plugins): make list_fields return a const pointer

### DIFF
--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -734,7 +734,7 @@ struct sinsp_table_wrapper
 	const sinsp_plugin* m_table_plugin_owner;
 	ss_plugin_table_input* m_table_plugin_input;
 
-	static ss_plugin_table_fieldinfo* list_fields(ss_plugin_table_t* _t, uint32_t* nfields)
+	static const ss_plugin_table_fieldinfo* list_fields(ss_plugin_table_t* _t, uint32_t* nfields)
 	{
 		auto t = static_cast<sinsp_table_wrapper*>(_t);
 	
@@ -1231,7 +1231,7 @@ ss_plugin_rc sinsp_table_wrapper::write_entry_field(ss_plugin_table_t* _t, ss_pl
 // For sinsp-defined tables, the ss_plugin_table_input is a wrapper around
 // the libsinsp::state::table interface. For plugin-defined tables, the
 // ss_plugin_table_input is provided by the table-owner plugin itself.
-static ss_plugin_table_fieldinfo* dispatch_list_fields(ss_plugin_table_t *_t, uint32_t *nfields)
+static const ss_plugin_table_fieldinfo* dispatch_list_fields(ss_plugin_table_t *_t, uint32_t *nfields)
 {
 	auto t = static_cast<ss_plugin_table_input*>(_t);
 	return t->fields_ext->list_table_fields(t->table, nfields);

--- a/userspace/libsinsp/test/plugins/sample_table.h
+++ b/userspace/libsinsp/test/plugins/sample_table.h
@@ -74,7 +74,7 @@ public:
         return t->entries.size();
     }
 
-    static ss_plugin_table_fieldinfo* list_fields(ss_plugin_table_t* _t, uint32_t* nfields)
+    static const ss_plugin_table_fieldinfo* list_fields(ss_plugin_table_t* _t, uint32_t* nfields)
     {
         auto t = static_cast<sample_table*>(_t);
         *nfields = (uint32_t) t->fields.size();

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -31,7 +31,7 @@ extern "C" {
 // todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
 #define PLUGIN_API_VERSION_MINOR 4
-#define PLUGIN_API_VERSION_PATCH 0
+#define PLUGIN_API_VERSION_PATCH 1
 
 //
 // Just some not so smart defines to retrieve plugin api version as string
@@ -51,7 +51,7 @@ extern "C" {
 // give this name to the associated *_ext struct.
 typedef struct
 {
-	ss_plugin_table_fieldinfo* (*list_table_fields)(ss_plugin_table_t* t, uint32_t* nfields);
+	const ss_plugin_table_fieldinfo* (*list_table_fields)(ss_plugin_table_t* t, uint32_t* nfields);
 	ss_plugin_table_field_t* (*get_table_field)(ss_plugin_table_t* t, const char* name, ss_plugin_state_type data_type);
 	ss_plugin_table_field_t* (*add_table_field)(ss_plugin_table_t* t, const char* name, ss_plugin_state_type data_type);
 } ss_plugin_table_fields_vtable;
@@ -66,7 +66,7 @@ typedef struct
 	// available in the entries of the table. nfields will be filled with the number
 	// of elements of the returned array. The array's memory is owned by the
 	// tables's owner. Returns NULL in case of error.
-	ss_plugin_table_fieldinfo* (*list_table_fields)(ss_plugin_table_t* t, uint32_t* nfields);
+	const ss_plugin_table_fieldinfo* (*list_table_fields)(ss_plugin_table_t* t, uint32_t* nfields);
 	//
 	// Returns an opaque pointer representing an accessor to a data field
 	// present in all entries of the table, given its name and type.


### PR DESCRIPTION
The fields returned by a plugin can be a static string and the plugin framework doesn't have any business in modifying it so let's make it const (to avoid a copy for plugins that can return a static string).
    
Note: I only bump the plugin API version by 0.0.1 since the changes in this PR do not affect binary compatibility in any way.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Making the field list `const` isn't strictly necessary (I can always make a writable copy for the plugin framework to have its fun) but apparently we do not modify it anywhere (and tbh I find it hard to come up with a reason to do so), so it seems we can avoid the copy and still be safe.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
