### PR TITLE
fix(driver): properly pass KBUILD_MODPOST_WARN env variable to configure makefile if set

### DIFF
--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -1,7 +1,7 @@
 MODULE_MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Run the module build.sh (wrapper for make) script with an empty environment, but PATH
-HAS_@CONFIGURE_MODULE@ := $(shell env -i PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
+HAS_@CONFIGURE_MODULE@ := $(shell env -i KBUILD_MODPOST_WARN=$(KBUILD_MODPOST_WARN) PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
 
 ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure] Setting HAS_@CONFIGURE_MODULE@ flag)

--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -1,7 +1,9 @@
 MODULE_MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
-# Run the module build.sh (wrapper for make) script with an empty environment, but PATH
-HAS_@CONFIGURE_MODULE@ := $(shell env -i KBUILD_MODPOST_WARN=$(KBUILD_MODPOST_WARN) PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
+# Run the module build.sh (wrapper for make) script with an empty environment,
+# but pass PATH, KERNELDIR and eventually (if set) CC and KBUILD_MODPOST_WARN.
+# The latter ones are used by driverkit build templates.
+HAS_@CONFIGURE_MODULE@ := $(shell env -i CC=$(CC) KBUILD_MODPOST_WARN=$(KBUILD_MODPOST_WARN) PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
 
 ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure] Setting HAS_@CONFIGURE_MODULE@ flag)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build
/area driver-kmod

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes latest-kernel CI: https://github.com/falcosecurity/libs/actions/runs/8184781555/job/22379860975
Basically, driverkit vanilla builder [exports](https://github.com/falcosecurity/driverkit/blob/master/pkg/driverbuilder/builder/templates/vanilla.sh#L57) `KBUILD_MODPOST_WARN=1` to correctly build. Since #1452 , that env variable was not passed to sub-modules makefiles when configuring driver features, therefore it result in broken CI.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Nothing changes when the var is not set.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
