### PR TITLE
fix(userspace/libsinsp): field lists are hidden by mistake

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -141,7 +141,7 @@ public:
 	std::string m_desc; ///< Field class description.
 	int32_t m_nfields = 0; ///< Number of fields in this field group.
 	const filtercheck_field_info* m_fields = nullptr; ///< Array containing m_nfields field descriptions.
-	uint32_t m_flags = FL_HIDDEN;
+	uint32_t m_flags = FL_NONE;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -131,6 +131,7 @@ sinsp_filter_check_event::sinsp_filter_check_event()
 	m_info.m_desc = "Event fields applicable to syscall events. Note that for most events you can access the individual arguments/parameters of each syscall via evt.arg, e.g. evt.arg.filename.";
 	m_info.m_fields = sinsp_filter_check_event_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_event_fields) / sizeof(sinsp_filter_check_event_fields[0]);
+	m_info.m_flags = filter_check_info::FL_NONE;
 	m_u64val = 0;
 	m_converter = std::make_unique<sinsp_filter_check_reference>();
 }

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -69,6 +69,7 @@ sinsp_filter_check_evtin::sinsp_filter_check_evtin()
 	m_info.m_desc = "Fields used if information about distributed tracing is available.";
 	m_info.m_fields = sinsp_filter_check_evtin_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_evtin_fields) / sizeof(sinsp_filter_check_evtin_fields[0]);
+	m_info.m_flags = filter_check_info::FL_HIDDEN;
 }
 
 int32_t sinsp_filter_check_evtin::extract_arg(string fldname, string val)

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -71,6 +71,7 @@ sinsp_filter_check_gen_event::sinsp_filter_check_gen_event()
 	m_info.m_shortdesc = "All event types";
 	m_info.m_desc = "These fields can be used for all event types";
 	m_info.m_fields = sinsp_filter_check_gen_event_fields;
+	m_info.m_flags = filter_check_info::FL_NONE;
 	m_info.m_nfields = sizeof(sinsp_filter_check_gen_event_fields) / sizeof(sinsp_filter_check_gen_event_fields[0]);
 	m_u64val = 0;
 }

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
@@ -30,6 +30,7 @@ static const filtercheck_field_info rawstring_check_fields[] =
 rawstring_check::rawstring_check(string text)
 {
 	m_field = rawstring_check_fields;
+	m_info.m_flags = filter_check_info::FL_HIDDEN;
 	m_field_id = 0;
 	set_text(text);
 }

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -30,7 +30,7 @@ sinsp_filter_check_reference::sinsp_filter_check_reference()
 	m_info.m_desc = "";
 	m_info.m_fields = &m_finfo;
 	m_info.m_nfields = 1;
-	m_info.m_flags = 0;
+	m_info.m_flags = filter_check_info::FL_HIDDEN;
 	m_finfo.m_print_format = PF_DEC;
 	m_field = &m_finfo;
 }

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
@@ -53,6 +53,7 @@ sinsp_filter_check_syslog::sinsp_filter_check_syslog()
 {
 	m_info.m_name = "syslog";
 	m_info.m_desc = "Content of Syslog messages.";
+	m_info.m_flags = filter_check_info::FL_NONE;
 	m_info.m_fields = sinsp_filter_check_syslog_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_syslog_fields) / sizeof(sinsp_filter_check_syslog_fields[0]);
 }

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -135,7 +135,6 @@ sinsp_filter_check_thread::sinsp_filter_check_thread()
 	m_info.m_fields = sinsp_filter_check_thread_fields;
 	m_info.m_nfields = sizeof(sinsp_filter_check_thread_fields) / sizeof(sinsp_filter_check_thread_fields[0]);
 	m_info.m_flags = filter_check_info::FL_NONE;
-
 	m_u64val = 0;
 }
 

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -60,6 +60,7 @@ static const filtercheck_field_info sinsp_filter_check_tracer_fields[] =
 
 sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 {
+	m_info.m_flags = filter_check_info::FL_HIDDEN;
 	m_info.m_name = "span";
 	m_info.m_desc = "Fields used if information about distributed tracing is available.";
 	m_info.m_fields = sinsp_filter_check_tracer_fields;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

In one of the refactor series I took on, it seems like some field classes (`evt.*` and `syslog.*`) have been marked as "hidden", meaning that Falco skips them when printing the list of available fields. This PR solves the problem by making sure that the flags of every filter field class are properly initialized.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): field lists are hidden by mistake
```
