### PR TITLE
fix(test/drivers): fix ENOSYS check and test skipping.

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -47,13 +47,13 @@ std::unique_ptr<event_test> get_syscall_event_test()
 // SYSCALL RESULT ASSERTIONS
 /////////////////////////////////
 
-void assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, assertion_operators op, long expected_rc)
+void _assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, assertion_operators op, long expected_rc)
 {
 	bool match = false;
 
 	if (errno == ENOSYS)
 	{
-		GTEST_SKIP() << "Syscall " << syscall_name << " not implemented"  << std::endl;
+		// it is managed upward by assert_syscall_state macro.
 		return;
 	}
 

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -69,6 +69,19 @@ enum direction
  */
 #define TEST_EXECUTABLE_NAME "drivers_test"
 
+/*
+ * Macro that wraps internal _assert_syscall_state,
+ * dealing with ENOSYS syscalls, ie: syscalls that are defined but unimplemented,
+ * skipping the test.
+ */
+#define assert_syscall_state(syscall_state, syscall_name, ...) \
+        do { \
+		errno = 0; \
+		_assert_syscall_state(syscall_state, syscall_name, __VA_ARGS__); \
+                if(errno == ENOSYS) \
+			GTEST_SKIP() << "Syscall " << syscall_name << " not implemented" << std::endl; \
+	} while(0)
+
 /////////////////////////////////
 // SYSCALL RESULT ASSERTIONS
 /////////////////////////////////
@@ -80,13 +93,16 @@ enum direction
  *
  * When you use this method you must check what is the syscall return value!
  *
+ * PLEASE use the assert_syscall_state macro instead, that automatically
+ * deals with unimplemented syscalls errors.
+ *
  * @param syscall_state it could be `SYSCALL_FAILURE` or `SYSCALL_SUCCESS`
  * @param syscall_name the name of the syscall to assert.
  * @param syscall_rc the return code of the syscall to assert.
  * @param op the operation we want to perform in the assertion.
  * @param expected_rc the return code we expect.
  */
-void assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, enum assertion_operators op = EQUAL, long expected_rc = -1);
+void _assert_syscall_state(int syscall_state, const char* syscall_name, long syscall_rc, enum assertion_operators op = EQUAL, long expected_rc = -1);
 
 class event_test
 {

--- a/test/drivers/helpers/file_opener.cpp
+++ b/test/drivers/helpers/file_opener.cpp
@@ -4,7 +4,8 @@
 file_opener::file_opener(const char* filename, int flags, int dirfd)
 {
     m_fd = syscall(__NR_openat, dirfd, filename, flags, 0);
-	assert_syscall_state(SYSCALL_SUCCESS, "openat", m_fd, NOT_EQUAL, -1);
+    // Using the macro that deals with ENOSYS produces a build issue since GTEST_SKIP returns value in a ctor.
+    _assert_syscall_state(SYSCALL_SUCCESS, "openat", m_fd, NOT_EQUAL, -1);
     m_tmpfile_supported = (errno == EOPNOTSUPP);
     if(flags & O_DIRECTORY && strcmp(filename, ".") == 0)
     {

--- a/test/drivers/helpers/file_opener.cpp
+++ b/test/drivers/helpers/file_opener.cpp
@@ -3,6 +3,7 @@
 
 file_opener::file_opener(const char* filename, int flags, int dirfd)
 {
+    errno = 0;
     m_fd = syscall(__NR_openat, dirfd, filename, flags, 0);
     // Using the macro that deals with ENOSYS produces a build issue since GTEST_SKIP returns value in a ctor.
     _assert_syscall_state(SYSCALL_SUCCESS, "openat", m_fd, NOT_EQUAL, -1);

--- a/test/drivers/test_suites/syscall_exit_suite/dup3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/dup3_x.cpp
@@ -17,8 +17,8 @@ TEST(SyscallExit, dup3X)
 	int32_t new_fd = old_fd;
 	uint32_t flags = O_CLOEXEC;
 	int32_t res = syscall(__NR_dup3, old_fd, new_fd, flags);
-	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
 	int64_t errno_value = -errno;
+	assert_syscall_state(SYSCALL_FAILURE, "dup3", res);
 
 	syscall(__NR_close, new_fd);
 	syscall(__NR_close, res);

--- a/test/drivers/test_suites/syscall_exit_suite/newfstatat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/newfstatat_x.cpp
@@ -65,8 +65,8 @@ TEST(SyscallExit, newfstatatX_failure)
 	int flags = AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW;
 
 	int32_t res = syscall(__NR_newfstatat, dirfd, pathname, &buffer, flags);
-	assert_syscall_state(SYSCALL_FAILURE, "newfstatat", res);
 	int64_t errno_value = -errno;
+	assert_syscall_state(SYSCALL_FAILURE, "newfstatat", res);
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We cannot call GTEST_SKIP() in a sub-routine of a test, but only in the test body.
I kept the changes at the bare minumum to avoid touching all of the test cases...i had to introduce a simple macro though.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
