### PR TITLE
fix(driver): CC variable for debian

### DIFF
--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -3,7 +3,7 @@ MODULE_MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 # Run the module build.sh (wrapper for make) script with an empty environment,
 # but pass PATH, KERNELDIR and eventually (if set) CC and KBUILD_MODPOST_WARN.
 # The latter ones are used by driverkit build templates.
-HAS_@CONFIGURE_MODULE@ := $(shell env -i CC=$(CC) KBUILD_MODPOST_WARN=$(KBUILD_MODPOST_WARN) PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
+HAS_@CONFIGURE_MODULE@ := $(shell env -i CC="$(CC)" KBUILD_MODPOST_WARN="$(KBUILD_MODPOST_WARN)" PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
 
 ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure-kmod] Setting HAS_@CONFIGURE_MODULE@ flag)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> /area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
In Debian 12 we happen to have `CC= gcc-12`, so we have to wrap it in quotes when setting it to the configure system env

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
