### PR TITLE
chore(userspace): properly set `perf_event_attr` size field.

### DIFF
--- a/userspace/libscap/engine/bpf/attached_prog.c
+++ b/userspace/libscap/engine/bpf/attached_prog.c
@@ -84,6 +84,7 @@ static int __attach_tp(struct bpf_attached_prog* prog, char* last_err)
 	attr.sample_period = 1;
 	attr.wakeup_events = 1;
 	attr.config = id;
+	attr.size = sizeof(struct perf_event_attr);
 
 	efd = syscall(__NR_perf_event_open, &attr, -1, 0, -1, 0);
 	if(efd < 0)

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1556,6 +1556,7 @@ int32_t scap_bpf_load(
 			.sample_type = PERF_SAMPLE_RAW,
 			.type = PERF_TYPE_SOFTWARE,
 			.config = PERF_COUNT_SW_BPF_OUTPUT,
+			.size =  sizeof(struct perf_event_attr),
 		};
 		int pmu_fd = 0;
 		int ret = 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Per `perf_event_open` man page:
```
 size   The size of the perf_event_attr structure for
              forward/backward compatibility.  Set this using
              sizeof(struct perf_event_attr) to allow the kernel to see
              the struct size at the time of compilation.

              The related define PERF_ATTR_SIZE_VER0 is set to 64; this
              was the size of the first published struct.
              PERF_ATTR_SIZE_VER1 is 72, corresponding to the addition
              of breakpoints in Linux 2.6.33.  PERF_ATTR_SIZE_VER2 is 80
              corresponding to the addition of branch sampling in Linux
              3.4.  PERF_ATTR_SIZE_VER3 is 96 corresponding to the
              addition of sample_regs_user and sample_stack_user in
              Linux 3.7.  PERF_ATTR_SIZE_VER4 is 104 corresponding to
              the addition of sample_regs_intr in Linux 3.19.
              PERF_ATTR_SIZE_VER5 is 112 corresponding to the addition
              of aux_watermark in Linux 4.1.
```
Set `perf_event_attr` `size` field consequently.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
