### PR TITLE
fix(driver/bpf): not sending all arguments on execve fail

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1941,6 +1941,14 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 		}
 
 		len = bpf_probe_read_user_str(&data->buf[off & SCRATCH_SIZE_HALF], SCRATCH_SIZE_HALF, arg);
+
+		// set trailing \0 if the arg is empty
+		if(len == 0)
+		{
+			data->buf[off & SCRATCH_SIZE_HALF] = 0;
+			len = 1;
+		}
+		
 		if (len == -EFAULT)
 			return PPM_FAILURE_INVALID_USER_MEMORY;
 
@@ -2346,6 +2354,7 @@ FILLER(proc_startupdate, true)
 		}
 	} else if (data->state->tail_ctx.evt_type == PPME_SYSCALL_EXECVE_19_X ||
 	           data->state->tail_ctx.evt_type == PPME_SYSCALL_EXECVEAT_X ) {
+
 		unsigned long val;
 		char **argv;
 

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -389,10 +389,19 @@ static __always_inline void auxmap__store_execve_args(struct auxiliary_map *auxm
 		{
 			break;
 		}
-		arg_len = push__charbuf(auxmap->data, &auxmap->payload_pos, charbuf_pointer, MAX_PROC_ARG_ENV, USER);
-		if(!arg_len)
+
+		if(!charbuf_pointer)
 		{
 			break;
+		}
+
+		arg_len = push__charbuf(auxmap->data, &auxmap->payload_pos, charbuf_pointer, MAX_PROC_ARG_ENV, USER);
+		
+		// push trailing \0 if the arg is empty
+		if(arg_len == 0)
+		{
+			push__u8(auxmap->data, &auxmap->payload_pos, 0);
+			arg_len = 1;
 		}
 		total_len += arg_len;
 	}

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -879,4 +879,159 @@ TEST(SyscallExit, execveX_symlink)
 	evt_test->assert_num_params_pushed(28);
 }
 #endif
+
+TEST(SyscallExit, execveX_failure_empty_arg)
+{
+	auto evt_test = get_syscall_event_test(__NR_execve, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Get all the info from proc. */
+	struct proc_info info = {};
+	pid_t pid = ::getpid();
+	if(!get_proc_info(pid, &info))
+	{
+		FAIL() << "Unable to get all the info from proc" << std::endl;
+	}
+
+	/*
+	 * Get the process capabilities.
+	 */
+	/* On kernels >= 5.8 the suggested version should be `_LINUX_CAPABILITY_VERSION_3` */
+	struct __user_cap_header_struct header = {};
+	struct __user_cap_data_struct data[_LINUX_CAPABILITY_U32S_3];
+	cap_user_header_t hdrp = &header;
+	cap_user_data_t datap = data;
+
+	/* Prepare the header. */
+	header.pid = 0; /* `0` means the pid of the actual process. */
+	header.version = _LINUX_CAPABILITY_VERSION_3;
+	assert_syscall_state(SYSCALL_SUCCESS, "capget", syscall(__NR_capget, hdrp, datap), EQUAL, 0);
+
+	/*
+	 * Call the `execve`
+	 */
+	char pathname[] = "//**null-file-path**//";
+	const char *newargv[] = {pathname, "first_argv", "second_argv", "", "fourth_argv", NULL};
+	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", "", "0_ARGUMENT=no", NULL};
+	assert_syscall_state(SYSCALL_FAILURE, "execve", syscall(__NR_execve, pathname, newargv, newenviron));
+	int64_t errno_value = -errno;
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO)*/
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: exe (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(2, pathname);
+
+	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
+	/* Starting from `1` because the first is `exe`. */
+	evt_test->assert_charbuf_array_param(3, &newargv[1]);
+
+	/* Parameter 4: tid (type: PT_PID) */
+	evt_test->assert_numeric_param(4, (int64_t)pid);
+
+	/* Parameter 5: pid (type: PT_PID) */
+	/* We are the main thread of the process so it's equal to `tid`. */
+	evt_test->assert_numeric_param(5, (int64_t)pid);
+
+	/* Parameter 6: ptid (type: PT_PID) */
+	evt_test->assert_numeric_param(6, (int64_t)info.ppid);
+
+	/* Parameter 7: cwd (type: PT_CHARBUF) */
+	/* leave the current working directory empty like in the old probe. */
+	evt_test->assert_empty_param(7);
+
+	/* Parameter 8: fdlimit (type: PT_UINT64) */
+	evt_test->assert_numeric_param(8, (uint64_t)info.file_rlimit.rlim_cur);
+
+	/* Parameter 9: pgft_maj (type: PT_UINT64) */
+	/* Right now we can't find a precise value to perform the assertion. */
+	evt_test->assert_numeric_param(9, (uint64_t)0, GREATER_EQUAL);
+
+	/* Parameter 10: pgft_min (type: PT_UINT64) */
+	/* Right now we can't find a precise value to perform the assertion. */
+	evt_test->assert_numeric_param(10, (uint64_t)0, GREATER_EQUAL);
+
+	/* Parameter 11: vm_size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(11, (uint32_t)0, GREATER_EQUAL);
+
+	/* Parameter 12: vm_rss (type: PT_UINT32) */
+	evt_test->assert_numeric_param(12, (uint32_t)0, GREATER_EQUAL);
+
+	/* Parameter 13: vm_swap (type: PT_UINT32) */
+	evt_test->assert_numeric_param(13, (uint32_t)0, GREATER_EQUAL);
+
+	/* Parameter 14: comm (type: PT_CHARBUF) */
+	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);
+
+	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
+	evt_test->assert_cgroup_param(15);
+
+	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
+	evt_test->assert_charbuf_array_param(16, &newenviron[0]);
+
+	/* Parameter 17: tty (type: PT_UINT32) */
+	evt_test->assert_numeric_param(17, (uint32_t)info.tty);
+
+	/* Parameter 18: pgid (type: PT_PID) */
+	evt_test->assert_numeric_param(18, (int64_t)info.pgid);
+
+	/* Parameter 19: loginuid (type: PT_UID) */
+	evt_test->assert_numeric_param(19, (uint32_t)info.loginuid);
+
+	/* PPM_EXE_WRITABLE is set when the user that executed a process can also write to the executable
+	 * file that is used to spawn it or is its owner or otherwise capable.
+	 */
+	evt_test->assert_numeric_param(20, (uint32_t)PPM_EXE_WRITABLE);
+
+	/* Parameter 21: cap_inheritable (type: PT_UINT64) */
+	evt_test->assert_numeric_param(21, (uint64_t)capabilities_to_scap(((unsigned long)data[1].inheritable << 32) | data[0].inheritable));
+
+	/* Parameter 22: cap_permitted (type: PT_UINT64) */
+	evt_test->assert_numeric_param(22, (uint64_t)capabilities_to_scap(((unsigned long)data[1].permitted << 32) | data[0].permitted));
+
+	/* Parameter 23: cap_effective (type: PT_UINT64) */
+	evt_test->assert_numeric_param(23, (uint64_t)capabilities_to_scap(((unsigned long)data[1].effective << 32) | data[0].effective));
+
+	/* Parameter 24: exe_file ino (type: PT_UINT64) */
+	evt_test->assert_numeric_param(24, (uint64_t)1, GREATER_EQUAL);
+
+	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+
+	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */
+	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+
+	/* Parameter 27: euid (type: PT_UID) */
+	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);
+
+	/* Parameter 28: trusted_exepath (type: PT_FSPATH) */
+	/* Here we don't call the execve so the result should be the full path to the drivers test executable */
+	evt_test->assert_charbuf_param(28, info.exepath);
+
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(28);
+}
+
 #endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

When `execve` fails we get the arguments (or environment variables) from the systems call arguments instead of trying to get them from the kernel.
However, when one of the arguments is empty, the BPF driver doesn't send it to userspace, or even worse, doesn't send the following ones.
Example:
```
const char* argv[] = {"/non/existent", "arg0", "arg1", "", "arg3", NULL};
const char* envp[] = {"env0", "env1", "", "env3", NULL};
execve(argv[0], argv, envp);
```
Expected args: `arg0.arg1..arg3.`
Actual args (BPF): `arg0.arg1.arg3.`
Actual args (modern BPF): `arg0.arg1.` 

As you can see, in the case of BPF the empty argument is skipped.
In the case of modern BPF the empty argument and the following ones are skipped.

This PR fixes this issue.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver/bpf): not sending entire arguments array on execve fail
```
