### PR TITLE
Split user info

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1430,9 +1430,9 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	/* Refresh user / loginuser / group */
 	if(new_child->m_container_id.empty() == false)
 	{
-		new_child->set_user(new_child->m_user.uid);
-		new_child->set_loginuser(new_child->m_loginuser.uid);
-		new_child->set_group(new_child->m_group.gid);
+		new_child->set_user(new_child->m_user.uid());
+		new_child->set_loginuser(new_child->m_loginuser.uid());
+		new_child->set_group(new_child->m_group.gid());
 	}
 
 	/* If there's a listener, invoke it */
@@ -1950,9 +1950,9 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	/* Refresh user / loginuser / group */
 	if(new_child->m_container_id.empty() == false)
 	{
-		new_child->set_user(new_child->m_user.uid);
-		new_child->set_loginuser(new_child->m_loginuser.uid);
-		new_child->set_group(new_child->m_group.gid);
+		new_child->set_user(new_child->m_user.uid());
+		new_child->set_loginuser(new_child->m_loginuser.uid());
+		new_child->set_group(new_child->m_group.gid());
 	}
 
 	//
@@ -2411,7 +2411,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	// Get uid
 	if(evt->get_num_params() > 26)
 	{
-		evt->get_tinfo()->m_user.uid = evt->get_param(26)->as<uint32_t>();
+		evt->get_tinfo()->m_user.set_uid(evt->get_param(26)->as<uint32_t>());
 	}
 
 	//
@@ -2453,9 +2453,9 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	//
 	if(container_id != evt->get_tinfo()->m_container_id)
 	{
-		evt->get_tinfo()->set_user(evt->get_tinfo()->m_user.uid);
-		evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuser.uid);
-		evt->get_tinfo()->set_group(evt->get_tinfo()->m_group.gid);
+		evt->get_tinfo()->set_user(evt->get_tinfo()->m_user.uid());
+		evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuser.uid());
+		evt->get_tinfo()->set_group(evt->get_tinfo()->m_group.gid());
 	}
 
 	//
@@ -5464,9 +5464,9 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt)
 		//
 		if(container_id != evt->get_tinfo()->m_container_id)
 		{
-			evt->get_tinfo()->set_user(evt->get_tinfo()->m_user.uid);
-			evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuser.uid);
-			evt->get_tinfo()->set_group(evt->get_tinfo()->m_group.gid);
+			evt->get_tinfo()->set_user(evt->get_tinfo()->m_user.uid());
+			evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuser.uid());
+			evt->get_tinfo()->set_group(evt->get_tinfo()->m_group.gid());
 		}
 	}
 }

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -302,9 +302,10 @@ void sinsp::init()
 	m_inited = true;
 }
 
-void sinsp::set_import_users(bool import_users)
+void sinsp::set_import_users(bool import_users, bool user_details)
 {
 	m_usergroup_manager.m_import_users = import_users;
+	m_usergroup_manager.m_user_details_enabled = user_details;
 }
 
 /*=============================== OPEN METHODS ===============================*/

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -261,12 +261,18 @@ public:
 	  creating them can increase the startup time. Moreover, they contain
 	  information that could be privacy sensitive.
 
-	  \note default behavior is import_users=true.
+	  \param user_details if set to false, no extended user information will be
+	  stored in sinsp_threadinfo, only user id/group id will be available. By
+	  default thread information is enriched with the full set of user
+	  information, i.e. name, homedir, shell, group name. The parameter
+	  controls this behavior, an can be used to reduce memory footprint.
+
+	  \note default behavior is import_users=true, user_details=true
 
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-	void set_import_users(bool import_users);
+	void set_import_users(bool import_users, bool user_details = true);
 
 	/*!
 	  \brief temporarily pauses event capture.
@@ -781,6 +787,14 @@ public:
 	inline bool is_debug_enabled() const
 	{
 		return m_isdebug_enabled;
+	}
+
+	/*!
+	  \brief Returns true if extended user information is collected.
+	*/
+	inline bool is_user_details_enabled()
+	{
+		return m_usergroup_manager.m_user_details_enabled;
 	}
 
 	/*!

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -27,12 +27,9 @@ using namespace std;
         return (uint8_t*) &(x);     \
 } while(0)
 
-#define RETURN_EXTRACT_CSTR(x) do {             \
-        if((x))                                 \
-        {                                       \
-                *len = strlen((char *) ((x)));  \
-        }                                       \
-        return (uint8_t*) ((x));                \
+#define RETURN_EXTRACT_STRING(x) do {  \
+        *len = (x).size();             \
+        return (uint8_t*) (x).c_str(); \
 } while(0)
 
 static const filtercheck_field_info sinsp_filter_check_group_fields[] =
@@ -68,9 +65,11 @@ uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt *evt, OUT uint32_t* 
 	switch(m_field_id)
 	{
 	case TYPE_GID:
-		RETURN_EXTRACT_VAR(tinfo->m_group.gid);
+		m_gid = tinfo->m_group.gid();
+		RETURN_EXTRACT_VAR(m_gid);
 	case TYPE_NAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_group.name);
+		m_name = tinfo->m_group.name();
+		RETURN_EXTRACT_STRING(m_name);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/sinsp_filtercheck_group.h
+++ b/userspace/libsinsp/sinsp_filtercheck_group.h
@@ -36,4 +36,9 @@ public:
 
 protected:
 	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+
+private:
+	uint32_t m_gid;
+	std::string m_name;
+
 };

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -32,14 +32,6 @@ using namespace std;
         return (uint8_t*) (x).c_str(); \
 } while(0)
 
-#define RETURN_EXTRACT_CSTR(x) do {             \
-        if((x))                                 \
-        {                                       \
-                *len = strlen((char *) ((x)));  \
-        }                                       \
-        return (uint8_t*) ((x));                \
-} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_user_fields[] =
 {
 	{PT_UINT32, EPF_NONE, PF_ID, "user.uid", "User ID", "user ID."},
@@ -92,22 +84,27 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt *evt, OUT uint32_t* l
 	switch(m_field_id)
 	{
 	case TYPE_UID:
-		RETURN_EXTRACT_VAR(tinfo->m_user.uid);
+		m_uid = tinfo->m_user.uid();
+		RETURN_EXTRACT_VAR(m_uid);
 	case TYPE_NAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.name);
+		m_strval = tinfo->m_user.name();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_HOMEDIR:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.homedir);
+		m_strval = tinfo->m_user.homedir();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_SHELL:
-		RETURN_EXTRACT_CSTR(tinfo->m_user.shell);
+		m_strval = tinfo->m_user.shell();
+		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_LOGINUID:
 		m_s64val = (int64_t)-1;
-		if(tinfo->m_loginuser.uid < UINT32_MAX)
+		if(tinfo->m_loginuser.uid() < UINT32_MAX)
 		{
-			m_s64val = (int64_t)tinfo->m_loginuser.uid;
+			m_s64val = (int64_t)tinfo->m_loginuser.uid();
 		}
 		RETURN_EXTRACT_VAR(m_s64val);
 	case TYPE_LOGINNAME:
-		RETURN_EXTRACT_CSTR(tinfo->m_loginuser.name);
+		m_strval = tinfo->m_loginuser.name();
+		RETURN_EXTRACT_STRING(m_strval);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/sinsp_filtercheck_user.h
+++ b/userspace/libsinsp/sinsp_filtercheck_user.h
@@ -43,4 +43,6 @@ protected:
 
 private:
 	int64_t m_s64val;
+	uint32_t m_uid;
+	std::string m_strval;
 };

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -65,6 +65,78 @@ struct erase_fd_params
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry
 {
 public:
+	class sinsp_userinfo
+	{
+	public:
+		sinsp_userinfo() {
+			m_uid = 0xffffffff;
+			m_gid = 0xffffffff;
+		}
+		uint32_t uid() const { return m_uid; }
+		uint32_t gid() const { return m_gid; }
+		std::string name() const {
+			if (m_name.empty())
+			{
+				return (m_uid == 0) ? "root" : "<NA>";
+			}
+			else
+			{
+				return m_name;
+			}
+		};
+		std::string homedir() const {
+			if (m_homedir.empty())
+			{
+				return (m_uid == 0) ? "/root" : "<NA>";
+			}
+			else
+			{
+				return m_homedir;
+			}
+		};
+		std::string shell() const { return m_shell.empty() ? "<NA>" : m_shell; };
+
+		void set_uid(uint32_t uid) { m_uid = uid; };
+		void set_gid(uint32_t gid) { m_gid = gid; };
+		void set_name(char *name, size_t length) { m_name.assign(name, length); };
+		void set_homedir(char *homedir, size_t length) { m_homedir.assign(homedir, length); };
+		void set_shell(char *shell, size_t length) { m_shell.assign(shell, length); };
+
+	private:
+		uint32_t m_uid; ///< User ID
+		uint32_t m_gid; ///< Group ID
+		std::string m_name; ///< Username
+		std::string m_homedir; ///< Home directory
+		std::string m_shell; ///< Shell program
+	};
+
+
+	class sinsp_groupinfo
+	{
+	public:
+		sinsp_groupinfo() {
+			m_gid = 0xffffffff;
+		}
+		uint32_t gid() const { return m_gid; };
+		std::string name() const {
+			if (m_name.empty())
+			{
+				return (m_gid == 0) ? "root" : "<NA>";
+			}
+			else
+			{
+				return m_name;
+			}
+		};
+
+		void set_gid(uint32_t gid) { m_gid = gid; };
+		void set_name(char *name, size_t length) { m_name.assign(name, length); };
+	private:
+		uint32_t m_gid; ///< Group ID
+		std::string m_name; ///< Group name
+	};
+
+
 	sinsp_threadinfo(
 		sinsp *inspector = nullptr,
 		std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> dyn_fields = nullptr);
@@ -431,9 +503,9 @@ public:
 	std::string m_container_id; ///< heuristic-based container id
 	uint32_t m_flags; ///< The thread flags. See the PPM_CL_* declarations in ppm_events_public.h.
 	int64_t m_fdlimit;  ///< The maximum number of FDs this thread can open
-	scap_userinfo m_user; ///< user infos
-	scap_userinfo m_loginuser; ///< loginuser infos (auid)
-	scap_groupinfo m_group; ///< group infos
+	sinsp_userinfo m_user; ///< user infos
+	sinsp_userinfo m_loginuser; ///< loginuser infos (auid)
+	sinsp_groupinfo m_group; ///< group infos
 	uint64_t m_cap_permitted; ///< permitted capabilities
 	uint64_t m_cap_effective; ///< effective capabilities
 	uint64_t m_cap_inheritable; ///< inheritable capabilities

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -119,6 +119,7 @@ using namespace std;
 // clang-format off
 sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	: m_import_users(true)
+	, m_user_details_enabled(true)
 	, m_last_flush_time_ns(0)
 	, m_inspector(inspector)
 	, m_host_root(m_inspector->get_host_root())

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -135,6 +135,8 @@ public:
 	//
 	bool m_import_users;
 
+	bool m_user_details_enabled;
+
 private:
 	scap_userinfo *add_host_user(uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify);
 	scap_userinfo *add_container_user(const std::string &container_id, int64_t pid, uint32_t uid, bool notify);


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

`sinsp_threadinfo` contains two fields with `user` and `login_user`
information. Since those fields are of `scap_userinfo` type and statically
allocated, they take a lot of space:

```
	scap_userinfo              m_user;               /*   368  2312 */
	scap_userinfo              m_loginuser;          /*  2680  2312 */
```

which is 4624 bytes out of 5728 for the whole sinsp_threadinfo:

```
	/* size: 5728, cachelines: 90, members: 64 */
```

Most of this memory is coming from the fields `name`
(`MAX_CREDENTIALS_STR_LEN`), `homedir` and `shell` (both `SCAP_MAX_PATH_SIZE`).
For a process-heavy workload this can mean a lot of memory taken for
these purposes, as in the example below (max possible threadinfo cache size):

![mem](https://github.com/falcosecurity/libs/assets/634032/6d54f9c8-ab0b-4a14-8f12-95837886bdb0)

The memory usage breakdown shows that most of it goes to manage
`sinsp_threadinfo` (where `_M_allocate_node` is a part of threadinfo allocation
process, e.g. in `get_thread_ref`):

```
73.4  43.0%  43.0%     73.5  43.1% std::__detail::_Hashtable_alloc::_M_allocate_node
37.2  21.8%  64.8%     37.2  21.8% sinsp_parser::reserve_event_buffer
30.7  18.0%  82.8%    109.9  64.4% sinsp_thread_manager::new_threadinfo
```

To make memory management more flexible, split `m_user`/`m_loginuser` into
two set of fields:
* one containing uid/gid, which are ubiquitous and generally used
everywhere
* one for the rest of heavy details, which are needed less often

The new user_details structure is not supposed to use separately from
sinsp_threadinfo, thus it's defined inside the class. Allow to configure
whether to use the full or slim version of threadinfo via compile time
configuration.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
