### PR TITLE
fix(driver): avoid sending a NULL tuple in `recvfrom` syscall

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -84,8 +84,8 @@ int BPF_PROG(recvfrom_x,
 		}
 
 		/* Collect parameters at the beginning to manage socketcalls */
-		unsigned long args[2];
-		extract__network_args(args, 2, regs);
+		unsigned long args[5];
+		extract__network_args(args, 5, regs);
 
 		/* Parameter 2: data (type: PT_BYTEBUF) */
 		unsigned long received_data_pointer = args[1];
@@ -93,7 +93,8 @@ int BPF_PROG(recvfrom_x,
 
 		/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
 		uint32_t socket_fd = (uint32_t)args[0];
-		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND, NULL);
+		struct sockaddr *usrsockaddr = (struct sockaddr *)args[4];
+		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND, usrsockaddr);
 	}
 	else
 	{

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -204,10 +204,6 @@ inline int sock_getname(struct socket* sock, struct sockaddr* sock_address, int 
 
 		sin->sin_family = AF_INET;
 		if (peer) {
-			if (!inet->inet_dport ||
-			    ((1 << sk->sk_state) & (TCPF_CLOSE | TCPF_SYN_SENT))) {
-				return -ENOTCONN;
-			}
 			sin->sin_port = inet->inet_dport;
 			sin->sin_addr.s_addr = inet->inet_daddr;
 		} else {
@@ -228,10 +224,6 @@ inline int sock_getname(struct socket* sock, struct sockaddr* sock_address, int 
 
 		sin->sin6_family = AF_INET6;
 		if (peer) {
-			if ((!inet->inet_dport) ||
-			    ((1 << sk->sk_state) & (TCPF_CLOSE | TCPF_SYN_SENT))) {
-				return -ENOTCONN;
-			}
 			sin->sin6_port = inet->inet_dport;
 			sin->sin6_addr = sk->sk_v6_daddr;
 		} else {

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -2544,6 +2544,17 @@ int f_sys_recvfrom_x(struct event_filler_arguments *args)
 					targetbuf,
 					STR_STORAGE_SIZE);
 			}
+		} else {
+			/*
+			* Get socket endpoint information from fd if the user-provided *sockaddr is NULL
+			*/
+			size = fd_to_socktuple(fd,
+				NULL,
+				0,
+				false,
+				true,
+				targetbuf,
+				STR_STORAGE_SIZE);
 		}
 	}
 

--- a/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -215,17 +215,8 @@ TEST(SyscallExit, recvfromX_tcp_connection_NULL_sockaddr)
 	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
-	if(evt_test->is_modern_bpf_engine())
-	{
-		/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
-		evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
-	}
-	else
-	{
-		evt_test->assert_empty_param(3);
-		evt_test->assert_num_params_pushed(3);
-		GTEST_SKIP() << "[RECVFROM_X]: we send an empty tuple, but we can fix this case" << std::endl;
-	}
+	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
@@ -293,20 +284,9 @@ TEST(SyscallExit, recvfromX_udp_connection_snaplen)
 	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
-	if(!evt_test->is_modern_bpf_engine())
-	{
-		/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
-		evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
-	}
-	else
-	{
-		/* In UDP connections we cannot extract the tuple from kernel structs we always need to use the userspace struct
-		 * Right now the modern probe doesn't support this behavior we need to fix it
-		 */
-		evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_EMPTY, IPV4_SERVER, IPV4_PORT_EMPTY_STRING, IPV4_PORT_SERVER_STRING);
-		evt_test->assert_num_params_pushed(3);
-		GTEST_SKIP() << "[RECVFROM_X]: we send a tuple without the source, but we can fix this case" << std::endl;
-	}
+	/* The server performs a 'recvmsg` so the server is the final destination of the packet while the client is the src. */
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_CLIENT, IPV4_SERVER, IPV4_PORT_CLIENT_STRING, IPV4_PORT_SERVER_STRING);
+
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
@@ -372,19 +352,11 @@ TEST(SyscallExit, recvfromX_udp_connection_NULL_sockaddr)
 	evt_test->assert_bytebuf_param(2, FULL_MESSAGE, DEFAULT_SNAPLEN);
 
 	/* Parameter 3: tuple (type: PT_SOCKTUPLE) */
-	if(!evt_test->is_modern_bpf_engine())
-	{
-		evt_test->assert_empty_param(3);
-		GTEST_SKIP() << "[RECVFROM_X]: we send an empty tuple, but we can at least send the dest ip and source" << std::endl;
-	}
-	else
-	{
-		/* This is the correct behavior because if the userspace struct is empty
-		 * we cannot extract the source ip and port, unless we directly read the packet
-		 * headers!
-		 */
-		evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_EMPTY, IPV4_SERVER, IPV4_PORT_EMPTY_STRING, IPV4_PORT_SERVER_STRING);
-	}
+	/* If the userspace struct is empty
+	* we cannot extract the source ip and port, unless we directly read the packet
+	* headers!
+	*/
+	evt_test->assert_tuple_inet_param(3, PPM_AF_INET, IPV4_EMPTY, IPV4_SERVER, IPV4_PORT_EMPTY_STRING, IPV4_PORT_SERVER_STRING);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
The kernel module and the old bpf probe send a NULL tuple to userspace when `recvfrom` is called with a null `sockaddr` pointer.
This PR fixes this behavior by getting the tuple info from the socket file descriptor itself.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): avoid sending a NULL tuple in `recvfrom` syscall
```
