### PR TITLE
fix(gvisor): fix duplicated command names

### DIFF
--- a/userspace/libscap/engine/gvisor/parsers.cpp
+++ b/userspace/libscap/engine/gvisor/parsers.cpp
@@ -115,7 +115,9 @@ static parse_result parse_container_start(uint32_t id, scap_const_sized_buffer p
 	}
 
 	std::string args;
-	for(int j = 0; j < gvisor_evt.args_size(); j++) {
+
+	// skip argv[0]
+	for(int j = 1; j < gvisor_evt.args_size(); j++) {
 		args += gvisor_evt.args(j);
 		args.push_back('\0');
 	}
@@ -291,7 +293,9 @@ static parse_result parse_execve(uint32_t id, scap_const_sized_buffer proto, sca
 	if(gvisor_evt.has_exit())
 	{
 		std::string args;
-		for(int j = 0; j < gvisor_evt.argv_size(); j++) {
+
+		// skip argv[0]
+		for(int j = 1; j < gvisor_evt.argv_size(); j++) {
 			args += gvisor_evt.argv(j);
 			args.push_back('\0');
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libscap-engine-gvisor

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Sometimes gVisor events would show duplicated command name (e.g. `cat cat` instead of `cat`). This fixes it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(gvisor): fix duplicated command names
```
