### PR TITLE
fix(userspace/libsinsp): solve formatts being cropped with fd.types

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -149,7 +149,7 @@ int32_t sinsp_filter_check_fd::parse_field_name(const char* str, bool alloc_stat
 		if(res == 0)
 		{
 			m_argid = -1;
-			res = (int32_t)val.size();
+			res = (int32_t)(sizeof("fd.types") - 1);
 		}
 
 		return res;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When using the `fd.types` field for output formats, only when using it without `[]` arguments, we currently any character following the field due to a length parsing error. So we have:

- `SAMPLE fd.types=%fd.types` -> `SAMPLE fd.types=(...)`
- `fd.types=%fd.types SAMPLE` -> `fd.types=(...)`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): solve formatts being cropped with fd.types
```
