### PR TITLE
fix(userspace): remove some wrong asserts

### DIFF
--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -582,7 +582,6 @@ int32_t scap_fd_read_netlink_sockets_from_proc_fs(const char* filename, scap_fdi
 	f = fopen(filename, "r");
 	if(NULL == f)
 	{
-		ASSERT(false);
 		return scap_errprintf(error, errno, "Could not open netlink sockets file %s", filename);
 	}
 	while(NULL != fgets(line, sizeof(line), f))
@@ -736,7 +735,6 @@ int32_t scap_fd_read_ipv4_sockets_from_proc_fs(const char *dir, int l4proto, sca
 	f = fopen(dir, "r");
 	if(NULL == f)
 	{
-		ASSERT(false);
 		free(scan_buf);
 		return scap_errprintf(error, errno, "Could not open ipv4 sockets dir %s", dir);
 	}
@@ -921,7 +919,6 @@ int32_t scap_fd_read_ipv6_sockets_from_proc_fs(char *dir, int l4proto, scap_fdin
 
 	if(NULL == f)
 	{
-		ASSERT(false);
 		free(scan_buf);
 		return scap_errprintf(error, errno, "Could not open ipv6 sockets dir %s", dir);
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4780,7 +4780,6 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt *evt)
 				 */
 				if(ptinfo == nullptr || ptinfo->is_invalid())
 				{
-					ASSERT(false);
 					return;
 				}
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -691,7 +691,6 @@ const std::vector<std::string>& sinsp_threadinfo::get_env()
 		{
 			// it should never happen but provide a safe fallback just in case
 			// except during sinsp::scap_open() (see sinsp::get_thread()).
-			ASSERT(false);
 			return m_env;
 		}
 	}
@@ -936,7 +935,6 @@ void sinsp_threadinfo::update_cwd(std::string_view cwd)
 
 	if (tinfo == nullptr)
 	{
-		ASSERT(false);
 		return;
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

I was able to hit all these assertions in a reliable way using Falco + stress-ng... so something like

```bash
sudo ./userspace/falco/falco -c ../falco.yaml -r ../rules/falco_rules.yaml -o engine.kind=modern_ebpf 
```
+ on another terminal

```bash
stress-ng --exec 4
```

In case of many drops these situation can happen so we shouldn't use assertions

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
