### PR TITLE
refactor(libsinsp): better clarify filtercheck subclass extracting only one value

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -1524,7 +1524,7 @@ bool sinsp_filter_check::extract_nocache(sinsp_evt *evt, OUT std::vector<extract
 {
 	values.clear();
 	extract_value_t val;
-	val.ptr = extract(evt, &val.len, sanitize_strings);
+	val.ptr = extract_single(evt, &val.len, sanitize_strings);
 	if (val.ptr != NULL)
 	{
 		values.push_back(val);
@@ -1533,7 +1533,7 @@ bool sinsp_filter_check::extract_nocache(sinsp_evt *evt, OUT std::vector<extract
 	return false;
 }
 
-uint8_t* sinsp_filter_check::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	return NULL;
 }

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -259,7 +259,7 @@ protected:
 	// multiple values. By default, this returns NULL.
 	// Subclasses are meant to either override this, or the multi-valued extract method.
 	bool extract_nocache(sinsp_evt *evt, OUT std::vector<extract_value_t>& values, bool sanitize_strings = true);
-	virtual uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true);
+	virtual uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true);
 
 	bool compare_rhs(cmpop op, ppm_param_type type, const void* operand1, uint32_t op1_len = 0);
 	bool compare_rhs(cmpop op, ppm_param_type type, std::vector<extract_value_t>& values);

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -169,7 +169,7 @@ int32_t sinsp_filter_check_container::parse_field_name(const char* str, bool all
 }
 
 
-uint8_t* sinsp_filter_check_container::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_container::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_container.h
+++ b/userspace/libsinsp/sinsp_filtercheck_container.h
@@ -61,7 +61,7 @@ public:
 	const std::string& get_argstr() const;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(const std::string& val, size_t basename);

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -609,7 +609,7 @@ Json::Value sinsp_filter_check_event::extract_as_js(sinsp_evt *evt, OUT uint32_t
 	case TYPE_DELTA:
 	case TYPE_DELTA_S:
 	case TYPE_DELTA_NS:
-		return (Json::Value::Int64)*(uint64_t*)extract(evt, len);
+		return (Json::Value::Int64)*(uint64_t*)extract_single(evt, len);
 	case TYPE_COUNT:
 		m_u32val = 1;
 		return m_u32val;
@@ -657,7 +657,7 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt *evt, OUT uint3
 	return NULL;
 }
 
-uint8_t* sinsp_filter_check_event::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	switch(m_field_id)
@@ -1798,7 +1798,7 @@ bool sinsp_filter_check_event::compare_nocache(sinsp_evt *evt)
 		bool sanitize_strings = false;
 		// note: this uses the single-value extract because this filtercheck
 		// class does not support multi-valued extraction
-		uint8_t* extracted_val = extract(evt, &len, sanitize_strings);
+		uint8_t* extracted_val = extract_single(evt, &len, sanitize_strings);
 
 		if(extracted_val == NULL)
 		{

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -96,7 +96,7 @@ public:
 
 protected:
 	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
-	virtual uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	virtual uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	virtual bool compare_nocache(sinsp_evt*) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -195,7 +195,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_evtin::allocate_new()
 	return std::make_unique<sinsp_filter_check_evtin>();
 }
 
-uint8_t* sinsp_filter_check_evtin::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_evtin::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	// do nothing: support to tracers has been dropped
 	*len = 0;

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.h
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.h
@@ -62,7 +62,7 @@ public:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(std::string fldname, std::string val);

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -463,7 +463,7 @@ bool sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT std::vector<extract_valu
 	return sinsp_filter_check::extract(evt, values, sanitize_strings);
 }
 
-uint8_t* sinsp_filter_check_fd::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_fd::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	ASSERT(evt);
@@ -1840,7 +1840,7 @@ bool sinsp_filter_check_fd::compare_nocache(sinsp_evt *evt)
 	bool sanitize_strings = false;
 	// note: this uses the single-value extract because this filtercheck
 	// class does not support multi-valued extraction
-	uint8_t* extracted_val = extract(evt, &len, sanitize_strings);
+	uint8_t* extracted_val = extract_single(evt, &len, sanitize_strings);
 
 	if(extracted_val == NULL)
 	{

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -79,7 +79,7 @@ public:
 	bool extract(sinsp_evt*, OUT std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	bool compare_nocache(sinsp_evt*) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fdlist::allocate_new()
 	return std::make_unique<sinsp_filter_check_fdlist>();
 }
 
-uint8_t* sinsp_filter_check_fdlist::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	ASSERT(evt);

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.h
@@ -39,7 +39,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	std::string m_strval;

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -236,7 +236,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fspath::allocate_new()
 	return ret;
 }
 
-uint8_t* sinsp_filter_check_fspath::extract(sinsp_evt* evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_fspath::extract_single(sinsp_evt* evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	ASSERT(evt);

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -39,7 +39,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	typedef std::map<uint16_t, std::shared_ptr<sinsp_filter_check>> filtercheck_map_t;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -98,7 +98,7 @@ Json::Value sinsp_filter_check_gen_event::extract_as_js(sinsp_evt *evt, OUT uint
 	case TYPE_RELTS:
 	case TYPE_RELTS_S:
 	case TYPE_RELTS_NS:
-		return (Json::Value::Int64)*(uint64_t*)extract(evt, len);
+		return (Json::Value::Int64)*(uint64_t*)extract_single(evt, len);
 	default:
 		return Json::nullValue;
 	}
@@ -106,7 +106,7 @@ Json::Value sinsp_filter_check_gen_event::extract_as_js(sinsp_evt *evt, OUT uint
 	return Json::nullValue;
 }
 
-uint8_t* sinsp_filter_check_gen_event::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 
 	std::shared_ptr<sinsp_plugin> plugin;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.h
@@ -51,7 +51,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_group::allocate_new()
 	return std::make_unique<sinsp_filter_check_group>();
 }
 
-uint8_t* sinsp_filter_check_group::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_group.h
+++ b/userspace/libsinsp/sinsp_filtercheck_group.h
@@ -35,5 +35,5 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
@@ -201,7 +201,7 @@ void sinsp_filter_check_k8s::concatenate_container_labels(const map<std::string,
 	}
 }
 
-uint8_t* sinsp_filter_check_k8s::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_k8s::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.h
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.h
@@ -64,7 +64,7 @@ public:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(const std::string& fldname, const std::string& val);

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
@@ -115,7 +115,7 @@ int32_t sinsp_filter_check_mesos::extract_arg(const string& fldname, const strin
 	return parsed_len;
 }
 
-uint8_t* sinsp_filter_check_mesos::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_mesos::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	// note: all mesos fields are deprecated since removing them from the codebase
 	*len = 0;

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.h
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.h
@@ -46,7 +46,7 @@ public:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(const std::string& fldname, const std::string& val);

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
@@ -53,7 +53,7 @@ int32_t rawstring_check::parse_field_name(const char* str, bool alloc_state, boo
 	return -1;
 }
 
-uint8_t* rawstring_check::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* rawstring_check::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = m_text_len;
 	return (uint8_t*)m_text.c_str();

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.h
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.h
@@ -28,7 +28,7 @@ public:
 
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 	void set_text(std::string text);
 

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -47,7 +47,7 @@ int32_t sinsp_filter_check_reference::parse_field_name(const char* str, bool all
 	return -1;
 }
 
-uint8_t* sinsp_filter_check_reference::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_reference::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = m_len;
 	return m_val;
@@ -332,7 +332,7 @@ char* sinsp_filter_check_reference::tostring_nice(sinsp_evt* evt,
 	uint32_t len;
 	// note: this uses the single-value extract because this filtercheck
 	// class does not support multi-valued extraction
-	uint8_t* rawval = extract(evt, &len);
+	uint8_t* rawval = extract_single(evt, &len);
 
 	if(rawval == NULL)
 	{
@@ -394,7 +394,7 @@ Json::Value sinsp_filter_check_reference::tojson(sinsp_evt* evt,
 	uint32_t len;
 	// note: this uses the single-value extract because this filtercheck
 	// class does not support multi-valued extraction
-	uint8_t* rawval = extract(evt, &len);
+	uint8_t* rawval = extract_single(evt, &len);
 
 	if(rawval == NULL)
 	{

--- a/userspace/libsinsp/sinsp_filtercheck_reference.h
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.h
@@ -34,7 +34,7 @@ public:
 
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 	inline void set_val(ppm_param_type type, filtercheck_field_flags flags,
 		uint8_t* val, int32_t len,

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_syslog::allocate_new()
 	return std::make_unique<sinsp_filter_check_syslog>();
 }
 
-uint8_t* sinsp_filter_check_syslog::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_syslog::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	auto& decoder = m_inspector->get_parser()->get_syslog_decoder();

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.h
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.h
@@ -38,7 +38,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	uint32_t m_storageu32;

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -519,7 +519,7 @@ inline bool should_extract_xid(int64_t xid)
 	return xid >= -1 && xid <= UINT32_MAX;
 }
 
-uint8_t* sinsp_filter_check_thread::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -117,7 +117,7 @@ public:
 	int32_t get_argid() const;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 	bool compare_nocache(sinsp_evt*) override;
 
 private:

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -182,7 +182,7 @@ int32_t sinsp_filter_check_tracer::parse_field_name(const char* str, bool alloc_
 	return res;
 }
 
-uint8_t* sinsp_filter_check_tracer::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_tracer::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	// do nothing: support to tracers has been dropped
 	*len = 0;

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.h
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.h
@@ -54,7 +54,7 @@ public:
 	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int32_t extract_arg(std::string fldname, std::string val, OUT const struct ppm_param_info** parinfo);

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_user::allocate_new()
 	return std::make_unique<sinsp_filter_check_user>();
 }
 
-uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	sinsp_threadinfo* tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_user.h
+++ b/userspace/libsinsp/sinsp_filtercheck_user.h
@@ -39,7 +39,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	int64_t m_s64val;

--- a/userspace/libsinsp/sinsp_filtercheck_utils.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_utils::allocate_new()
 	return std::make_unique<sinsp_filter_check_utils>();
 }
 
-uint8_t* sinsp_filter_check_utils::extract(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
+uint8_t* sinsp_filter_check_utils::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
 	*len = 0;
 	switch(m_field_id)

--- a/userspace/libsinsp/sinsp_filtercheck_utils.h
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.h
@@ -34,7 +34,7 @@ public:
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 
 protected:
-	uint8_t* extract(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
+	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
 	uint64_t m_cnt;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Revieweing and operating with the code area related to filterchecks is becoming more and more confusing due to different methods overridden and having the same name. This PR disambiguates the `extract` protected method responsible of extracting only one value, from the broader `extract` that is part fo the actual public interface.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(libsinsp): better clarify filtercheck subclass extracting only one value
```
