### PR TITLE
new(userspace/libsinsp): add building blocks for filter field transformers

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(sinsp
 	dumper.cpp
 	fdinfo.cpp
 	filter.cpp
+	sinsp_filter_transformer.cpp
 	sinsp_filtercheck.cpp
 	sinsp_filtercheck_container.cpp
 	sinsp_filtercheck_event.cpp

--- a/userspace/libsinsp/base64.h
+++ b/userspace/libsinsp/base64.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2024, The Falco Authors
+ *
+ * Originally from Istio, Copyright 2019, Istio Authors
+ * https://raw.githubusercontent.com/istio/proxy/1.18.2/extensions/common/wasm/base64.h
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+class Base64
+{
+public:
+	template<class Out> static inline void encode(const char* input, uint64_t length, bool add_padding, Out& ret);
+
+	template<class Out> static inline bool decodeWithoutPadding(std::string_view input, Out& ret);
+
+private:
+	template<class Out>
+	static inline bool decodeBase(const uint8_t cur_char, uint64_t pos, Out& ret,
+				      const unsigned char* const reverse_lookup_table);
+
+	template<class Out>
+	static inline bool decodeLast(const uint8_t cur_char, uint64_t pos, Out& ret,
+				      const unsigned char* const reverse_lookup_table);
+
+	template<class Out>
+	static inline void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, Out& ret,
+				      const char* const char_table);
+
+	template<class Out>
+	static inline void encodeLast(uint64_t pos, uint8_t last_char, Out& ret, const char* const char_table,
+				      bool add_padding);
+
+	// clang-format off
+    static inline constexpr char CHAR_TABLE[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    static inline constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
+            7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+            64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+            49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64};
+	// clang-format on
+};
+
+template<class Out>
+bool Base64::decodeBase(const uint8_t cur_char, uint64_t pos, Out& ret, const unsigned char* const reverse_lookup_table)
+{
+	const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+	if(c == 64)
+	{
+		// Invalid character
+		return false;
+	}
+
+	switch(pos % 4)
+	{
+	case 0:
+		ret.push_back(c << 2);
+		break;
+	case 1:
+		ret.back() |= c >> 4;
+		ret.push_back(c << 4);
+		break;
+	case 2:
+		ret.back() |= c >> 2;
+		ret.push_back(c << 6);
+		break;
+	case 3:
+		ret.back() |= c;
+		break;
+	}
+	return true;
+}
+
+template<class Out>
+bool Base64::decodeLast(const uint8_t cur_char, uint64_t pos, Out& ret, const unsigned char* const reverse_lookup_table)
+{
+	const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+	if(c == 64)
+	{
+		// Invalid character
+		return false;
+	}
+
+	switch(pos % 4)
+	{
+	case 0:
+		return false;
+	case 1:
+		ret.back() |= c >> 4;
+		return (c & 0b1111) == 0;
+	case 2:
+		ret.back() |= c >> 2;
+		return (c & 0b11) == 0;
+	case 3:
+		ret.back() |= c;
+		break;
+	}
+	return true;
+}
+
+template<class Out>
+void Base64::encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, Out& ret, const char* const char_table)
+{
+	switch(pos % 3)
+	{
+	case 0:
+		ret.push_back(char_table[cur_char >> 2]);
+		next_c = (cur_char & 0x03) << 4;
+		break;
+	case 1:
+		ret.push_back(char_table[next_c | (cur_char >> 4)]);
+		next_c = (cur_char & 0x0f) << 2;
+		break;
+	case 2:
+		ret.push_back(char_table[next_c | (cur_char >> 6)]);
+		ret.push_back(char_table[cur_char & 0x3f]);
+		next_c = 0;
+		break;
+	}
+}
+
+template<class Out>
+void Base64::encodeLast(uint64_t pos, uint8_t last_char, Out& ret, const char* const char_table, bool add_padding)
+{
+	switch(pos % 3)
+	{
+	case 1:
+		ret.push_back(char_table[last_char]);
+		if(add_padding)
+		{
+			ret.push_back('=');
+			ret.push_back('=');
+		}
+		break;
+	case 2:
+		ret.push_back(char_table[last_char]);
+		if(add_padding)
+		{
+			ret.push_back('=');
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+template<class Out> void Base64::encode(const char* input, uint64_t length, bool add_padding, Out& ret)
+{
+	uint64_t output_length = (length + 2) / 3 * 4;
+	ret.clear();
+	ret.reserve(output_length);
+
+	uint64_t pos = 0;
+	uint8_t next_c = 0;
+
+	for(uint64_t i = 0; i < length; ++i)
+	{
+		encodeBase(input[i], pos++, next_c, ret, CHAR_TABLE);
+	}
+
+	encodeLast(pos, next_c, ret, CHAR_TABLE, add_padding);
+}
+
+template<class Out> bool Base64::decodeWithoutPadding(std::string_view input, Out& ret)
+{
+	ret.clear();
+	if(input.empty())
+	{
+		return true;
+	}
+
+	// At most last two chars can be '='.
+	size_t n = input.length();
+	if(input[n - 1] == '=')
+	{
+		n--;
+		if(n > 0 && input[n - 1] == '=')
+		{
+			n--;
+		}
+	}
+	// Last position before "valid" padding character.
+	uint64_t last = n - 1;
+	// Determine output length.
+	size_t max_length = (n + 3) / 4 * 3;
+	if(n % 4 == 3)
+	{
+		max_length -= 1;
+	}
+	if(n % 4 == 2)
+	{
+		max_length -= 2;
+	}
+
+	ret.reserve(max_length);
+	for(uint64_t i = 0; i < last; ++i)
+	{
+		if(!decodeBase(input[i], i, ret, REVERSE_LOOKUP_TABLE))
+		{
+			return false;
+		}
+	}
+
+	if(!decodeLast(input[last], last, ret, REVERSE_LOOKUP_TABLE))
+	{
+		return false;
+	}
+
+	return ret.size() == max_length;
+}

--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <libsinsp/base64.h>
+#include <libsinsp/sinsp_filter_transformer.h>
+#include <cstring>
+
+static void throw_unsupported_err(filter_transformer_type t)
+{
+    throw sinsp_exception("transformer '" + std::to_string(t) + "' is not supported");
+}
+
+static void throw_type_incompatibility_err(ppm_param_type t, const std::string& trname)
+{
+    throw sinsp_exception("field type '" + std::to_string(t) + "' is not supported by '" + trname + "' transformer");
+}
+
+bool sinsp_filter_transformer::string_transformer(std::vector<extract_value_t>& vec, ppm_param_type t, str_transformer_func_t f)
+{
+    m_storage_values.resize(vec.size());
+    for(std::size_t i = 0; i < vec.size(); i++)
+    {
+        storage_t& buf = m_storage_values[i];
+
+        buf.clear();
+        if(vec[i].ptr == nullptr)
+        {
+            continue;
+        }
+
+        // we don't know whether this will come as a string or a byte buf,
+        // so we sanitize by skipping all terminator characters
+        size_t in_len = vec[i].len;
+        while (in_len > 0 && vec[i].ptr[in_len - 1] == '\0')
+        {
+            in_len--;
+        }
+
+        // each function can assume that the input size does NOT include
+        // the terminator character, and should not assume that the string
+        // is null-terminated
+        std::string_view in{(const char*) vec[i].ptr, in_len};
+        if (!f(in, buf))
+        {
+            return false;
+        }
+
+        // we insert a null terminator in case we miss one, just to stay safe
+        if (buf[buf.size() - 1] != '\0')
+        {
+            buf.push_back('\0');
+        }
+
+        vec[i].ptr = (uint8_t*) &buf[0];
+        vec[i].len = buf.size();
+    }
+    return true;
+}
+
+bool sinsp_filter_transformer::transform_type(ppm_param_type& t) const
+{
+    switch(m_type)
+    {
+    case FTR_TOUPPER:
+    {
+        switch(t)
+        {
+        case PT_CHARBUF:
+        case PT_FSPATH:
+        case PT_FSRELPATH:
+            // for TOUPPER, the transformed type is the same as the input type
+            return true;
+        default:
+            return false;
+        }
+    }
+    case FTR_TOLOWER:
+    {
+        switch(t)
+        {
+        case PT_CHARBUF:
+        case PT_FSPATH:
+        case PT_FSRELPATH:
+            // for TOLOWER, the transformed type is the same as the input type
+            return true;
+        default:
+            return false;
+        }
+    }
+    case FTR_BASE64:
+    {
+        switch(t)
+        {
+        case PT_CHARBUF:
+        case PT_BYTEBUF:
+            // for BASE64, the transformed type is the same as the input type
+            return true;
+        default:
+            return false;
+        }
+    }
+    case FTR_STORAGE:
+    {
+        // for STORAGE, the transformed type is the same as the input type
+        return true;
+    }
+    default:
+        throw_unsupported_err(m_type);
+        return false;
+    }
+}
+
+bool sinsp_filter_transformer::transform_values(std::vector<extract_value_t>& vec, ppm_param_type& t)
+{
+    if (!transform_type(t))
+    {
+        throw_type_incompatibility_err(t, filter_transformer_type_str(m_type));
+    }
+
+    switch(m_type)
+    {
+    case FTR_TOUPPER:
+    {
+        return string_transformer(vec, t, [](std::string_view in, storage_t& out) -> bool {
+            for (auto c : in)
+            {
+                out.push_back(toupper(c));
+            }
+            return true;
+        });
+    }
+    case FTR_TOLOWER:
+    {
+        return string_transformer(vec, t, [](std::string_view in, storage_t& out) -> bool {
+            for (auto c : in)
+            {
+                out.push_back(tolower(c));
+            }
+            return true;
+        });
+    }
+    case FTR_BASE64:
+    {
+        return string_transformer(vec, t, [](std::string_view in, storage_t& out) -> bool {            
+            return Base64::decodeWithoutPadding(in, out);
+        });
+    }
+    case FTR_STORAGE:
+    {
+        // note: for STORAGE, the transformed type is the same as the input type
+        m_storage_values.resize(vec.size());
+        for (std::size_t i = 0; i < vec.size(); i++)
+        {
+            storage_t& buf = m_storage_values[i];
+
+            buf.clear();
+            if(vec[i].ptr == nullptr)
+            {
+                continue;
+            }
+
+            // We reserve one extra chat for the null terminator
+            buf.resize(vec[i].len+1);
+            memcpy(&(buf[0]), vec[i].ptr, vec[i].len);
+            // We put the string terminator in any case
+            buf[vec[i].len] = '\0';
+            vec[i].ptr = &(buf[0]);
+            // `vec[i].len` is the same as before
+        }
+        return true;
+    }
+    default:
+        throw_unsupported_err(m_type);
+        return false;
+    }
+}

--- a/userspace/libsinsp/sinsp_filter_transformer.h
+++ b/userspace/libsinsp/sinsp_filter_transformer.h
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <cstdint>
+#include <functional>
+#include <driver/ppm_events_public.h>
+#include <libsinsp/sinsp_exception.h>
+
+struct extract_value_t
+{
+	uint8_t* ptr = nullptr;
+	uint32_t len = 0;
+};
+
+enum filter_transformer_type: uint8_t
+{
+	FTR_TOUPPER = 0,
+	FTR_TOLOWER = 1,
+	FTR_BASE64 = 2,
+	FTR_STORAGE = 3, // This transformer is only used internally
+};
+
+static inline std::string filter_transformer_type_str(filter_transformer_type m)
+{
+	switch(m)
+	{
+	case FTR_TOUPPER:
+		return "toupper";
+	case FTR_TOLOWER:
+		return "tolower";
+	case FTR_BASE64:
+		return "b64";
+	case FTR_STORAGE:
+		return "storage";
+	default:
+		throw sinsp_exception("unknown field transfomer id " + std::to_string(m));
+	}
+}
+
+static inline filter_transformer_type filter_transformer_from_str(const std::string& str)
+{
+	if (str == "tolower")
+	{
+		return filter_transformer_type::FTR_TOLOWER;
+	}
+	if (str == "toupper")
+	{
+		return filter_transformer_type::FTR_TOUPPER;
+	}
+	if (str == "b64")
+	{
+		return filter_transformer_type::FTR_BASE64;
+	}
+	if (str == "storage")
+	{
+		return filter_transformer_type::FTR_STORAGE;
+	}
+	throw sinsp_exception("unknown field transfomer '" + str + "'");
+}
+
+class sinsp_filter_transformer
+{
+public:
+	using storage_t = std::vector<uint8_t>;
+
+	sinsp_filter_transformer(filter_transformer_type t): m_type(t) { };
+
+	bool transform_type(ppm_param_type& t) const;
+
+	bool transform_values(std::vector<extract_value_t>& vals, ppm_param_type& t);
+
+private:
+	using str_transformer_func_t = std::function<bool(std::string_view in, storage_t& out)>;
+
+	bool string_transformer(std::vector<extract_value_t>& vec, ppm_param_type t, str_transformer_func_t mod);
+
+	filter_transformer_type m_type;
+	std::vector<storage_t> m_storage_values;
+};

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <libsinsp/filter_value.h>
 #include <libsinsp/prefix_search.h>
 #include <libsinsp/event.h>
+#include <libsinsp/sinsp_filter_transformer.h>
 
 /*
  * Operators to compare events
@@ -75,11 +76,6 @@ namespace std
 std::string to_string(cmpop);
 std::string to_string(boolop);
 }
-
-struct extract_value_t {
-	uint8_t* ptr = nullptr;
-	uint32_t len = 0;
-};
 
 class check_extraction_cache_entry
 {

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -108,6 +108,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_op_bcontains.ut.cpp
 	filter_op_pmatch.ut.cpp
 	filter_compiler.ut.cpp
+	filter_transformer.ut.cpp
 	user.ut.cpp
 	sinsp_utils.ut.cpp
 	state.ut.cpp

--- a/userspace/libsinsp/test/filter_transformer.ut.cpp
+++ b/userspace/libsinsp/test/filter_transformer.ut.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+#include <libsinsp/utils.h>
+#include <libsinsp/sinsp_filter_transformer.h>
+
+static std::unordered_set<ppm_param_type> all_param_types()
+{
+    std::unordered_set<ppm_param_type> ret;
+    for (auto i = PT_NONE; i < PT_MAX; i = (ppm_param_type) ((size_t) i + 1))
+    {
+        ret.insert(i);
+    }
+    return ret;
+}
+
+static std::string supported_type_msg(ppm_param_type t, bool support_expected)
+{
+    return "expected param type to"
+        + std::string((support_expected ? " " : " not "))
+        + "be supported: "
+        + std::string(param_type_to_string(t));
+}
+
+static extract_value_t const_str_to_extract_value(const char* v)
+{
+    extract_value_t ret;
+    ret.ptr = (uint8_t*) v;
+    ret.len = strlen(v) + 1;
+    return ret;
+}
+
+TEST(sinsp_filter_transformer, toupper)
+{
+    sinsp_filter_transformer tr(filter_transformer_type::FTR_TOUPPER);
+
+    auto all_types = all_param_types();
+
+    auto supported_types = std::unordered_set<ppm_param_type>({
+        PT_CHARBUF, PT_FSPATH, PT_FSRELPATH });
+
+    auto sample_vals = std::vector<extract_value_t>({
+        const_str_to_extract_value("hello"),
+        const_str_to_extract_value("world") });
+
+    // check for unsupported types
+    for (auto t : all_types)
+    {
+        if (supported_types.find(t) == supported_types.end())
+        {
+            auto vals = sample_vals;
+            EXPECT_FALSE(tr.transform_type(t)) << supported_type_msg(t, false);
+            EXPECT_ANY_THROW(tr.transform_values(vals, t)) << supported_type_msg(t, false);
+        }
+    }
+
+    // check for supported types
+    for (auto t : supported_types)
+    {
+        auto original = t;
+        EXPECT_TRUE(tr.transform_type(t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t); // note: toupper is expected not to alter the type
+
+        auto vals = sample_vals;
+        EXPECT_TRUE(tr.transform_values(vals, t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t);
+        EXPECT_EQ(vals.size(), 2);
+        EXPECT_EQ(std::string((const char*) vals[0].ptr), "HELLO");
+        EXPECT_EQ(vals[0].len, sizeof("HELLO"));
+        EXPECT_EQ(std::string((const char*) vals[1].ptr), "WORLD");
+        EXPECT_EQ(vals[1].len, sizeof("WORLD"));
+    }
+}
+
+TEST(sinsp_filter_transformer, tolower)
+{
+    sinsp_filter_transformer tr(filter_transformer_type::FTR_TOLOWER);
+
+    auto all_types = all_param_types();
+
+    auto supported_types = std::unordered_set<ppm_param_type>({
+        PT_CHARBUF, PT_FSPATH, PT_FSRELPATH });
+
+    auto sample_vals = std::vector<extract_value_t>({
+        const_str_to_extract_value("HELLO"),
+        const_str_to_extract_value("WORLD") });
+
+    // check for unsupported types
+    for (auto t : all_types)
+    {
+        if (supported_types.find(t) == supported_types.end())
+        {
+            auto vals = sample_vals;
+            EXPECT_FALSE(tr.transform_type(t)) << supported_type_msg(t, false);
+            EXPECT_ANY_THROW(tr.transform_values(vals, t)) << supported_type_msg(t, false);
+        }
+    }
+
+    // check for supported types
+    for (auto t : supported_types)
+    {
+        auto original = t;
+        EXPECT_TRUE(tr.transform_type(t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t); // note: tolower is expected not to alter the type
+
+        auto vals = sample_vals;
+        EXPECT_TRUE(tr.transform_values(vals, t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t);
+        EXPECT_EQ(vals.size(), 2);
+        EXPECT_EQ(std::string((const char*) vals[0].ptr), "hello");
+        EXPECT_EQ(vals[0].len, sizeof("hello"));
+        EXPECT_EQ(std::string((const char*) vals[1].ptr), "world");
+        EXPECT_EQ(vals[1].len, sizeof("world"));
+    }
+}
+
+TEST(sinsp_filter_transformer, b64)
+{
+    sinsp_filter_transformer tr(filter_transformer_type::FTR_BASE64);
+
+    auto all_types = all_param_types();
+
+    auto supported_types = std::unordered_set<ppm_param_type>({
+        PT_CHARBUF, PT_BYTEBUF });
+
+    auto sample_vals = std::vector<extract_value_t>({
+        const_str_to_extract_value("aGVsbG8="), // 'hello'
+        const_str_to_extract_value("d29ybGQgIQ==") }); // 'world !'
+
+    // check for unsupported types
+    for (auto t : all_types)
+    {
+        if (supported_types.find(t) == supported_types.end())
+        {
+            auto vals = sample_vals;
+            EXPECT_FALSE(tr.transform_type(t)) << supported_type_msg(t, false);
+            EXPECT_ANY_THROW(tr.transform_values(vals, t)) << supported_type_msg(t, false);
+        }
+    }
+
+    // check for supported types
+    for (auto t : supported_types)
+    {
+        auto original = t;
+        EXPECT_TRUE(tr.transform_type(t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t); // note: tolower is expected not to alter the type
+
+        auto vals = sample_vals;
+        EXPECT_TRUE(tr.transform_values(vals, t)) << supported_type_msg(original, true);
+        EXPECT_EQ(original, t);
+        EXPECT_EQ(vals.size(), 2);
+        EXPECT_EQ(std::string((const char*) vals[0].ptr), "hello");
+        EXPECT_EQ(vals[0].len, sizeof("hello"));
+        EXPECT_EQ(std::string((const char*) vals[1].ptr), "world !");
+        EXPECT_EQ(vals[1].len, sizeof("world !"));
+    }
+
+    // check invalid input being rejected
+    {
+        auto t = PT_CHARBUF;
+        auto vals = sample_vals;
+        vals[0].ptr = (uint8_t*) ((const char*) "!!!");
+        vals[0].len = sizeof("!!!");
+        EXPECT_FALSE(tr.transform_values(vals, t));
+        EXPECT_EQ(t, PT_CHARBUF);
+        EXPECT_EQ(vals.size(), 2);
+    }
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

As part of https://github.com/falcosecurity/libs/issues/1789, this PR adds the base constructs through which field transformers will be implemented in the first rollout of the proposed feature. This does not wire any of the new functionalities to the current filter field classes, but rather just adding an implementation to be used in subsequent changes.

This implements the `toupper`, `tolower`, and `b64` operations as defined in the proposal. There will be an opportunity to add more later on through the same building blocks.

Tests have been added for decent coverage about the bare functionality and the type consistency guarantees.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
