### PR TITLE
refactor(userspace/libsinsp): improve performance of endswith filter operator

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -213,7 +213,7 @@ bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 	case CO_BSTARTSWITH:
 		throw sinsp_exception("'bstartswith' not supported for string filters");
 	case CO_ENDSWITH:
-		return (sinsp_utils::endswith(operand1, operand2));
+		return (sinsp_utils::endswith(operand1, operand2, strlen(operand1), strlen(operand2)));
 	case CO_GLOB:
 		return sinsp_utils::glob_match(operand2, operand1);
 	case CO_IGLOB:

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1432,26 +1432,6 @@ std::string replace(const std::string& str, const std::string& search, const std
 	return s;
 }
 
-
-bool sinsp_utils::endswith(const std::string& str, const std::string& ending)
-{
-	if (ending.size() <= str.size())
-	{
-		return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
-	}
-	return false;
-}
-
-
-bool sinsp_utils::endswith(const char *str, const char *ending, uint32_t lstr, uint32_t lend)
-{
-	if (lstr >= lend)
-	{
-		return (0 == memcmp(ending, str + (lstr - lend), lend));
-	}
-	return 0;
-}
-
 bool sinsp_utils::startswith(const std::string& s, const std::string& prefix)
 {
 	if(prefix.empty())

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <list>
 #include <locale>
 #include <set>
@@ -80,8 +81,23 @@ public:
 	//
 	// Check if string ends with another
 	//
-	static bool endswith(const std::string& str, const std::string& ending);
-	static bool endswith(const char *str, const char *ending, uint32_t lstr, uint32_t lend);
+	static inline bool endswith(const std::string& str, const std::string& ending)
+	{
+		if (ending.size() <= str.size())
+		{
+			return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
+		}
+		return false;
+	}
+
+	static inline bool endswith(const char *str, const char *ending, uint32_t lstr, uint32_t lend)
+	{
+		if (lstr >= lend)
+		{
+			return (0 == memcmp(ending, str + (lstr - lend), lend));
+		}
+		return 0;
+	}
 
 	//
 	// Check if string starts with another


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Doing some benchmarks, I noticed that the `endswith` operator is usually one of the least performing one we support because the current implementation may involve occasional allocation and string copies due to a `const char*` to `const std::string&` conversion. If used extensively in a filter or in Falco rules, that can have noticeable performance and memory impact.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.16.0

I think this should be something to consider for the upcoming release, as quite minimal but useful. Will let the release managers decide.

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp): improve performance of endswith filter operator
```
