### PR TITLE
new(userspace/libsinsp): check usage of wrong-sized variadic arguments in sinsp tests

### DIFF
--- a/userspace/libsinsp/base64.h
+++ b/userspace/libsinsp/base64.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 class Base64
 {

--- a/userspace/libsinsp/test/events_evt.ut.cpp
+++ b/userspace/libsinsp/test/events_evt.ut.cpp
@@ -41,7 +41,7 @@ TEST_F(sinsp_with_test_input, event_category)
 	ASSERT_EQ(get_field_as_string(evt, "evt.num"), "2");
 
 	/* Check that `EC_TRACEPOINT` category is not considered */
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PROCEXIT_1_E, 4, test_errno, test_errno, 0, 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PROCEXIT_1_E, 4, test_errno, test_errno, (uint8_t)0, (uint8_t)0);
 	ASSERT_EQ(evt->get_category(), EC_PROCESS);
 	ASSERT_EQ(get_field_as_string(evt, "evt.category"), "process");
 	ASSERT_EQ(get_field_as_string(evt, "evt.source"), syscall_source_name);

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -170,7 +170,7 @@ TEST_F(sinsp_with_test_input, creates_fd_generic)
 	sinsp_evt* evt = NULL;
 
 	int64_t fd = 5;
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_E, 3, (uint64_t)-1, NULL, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_E, 3, (uint64_t)-1, 0, (uint8_t)0);
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SIGNALFD_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "signalfd");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "s");
@@ -184,14 +184,14 @@ TEST_F(sinsp_with_test_input, creates_fd_generic)
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "2");
 
 	fd = 6;
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_E, 2, 0, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_E, 2, (uint8_t)0, (uint8_t)0);
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_TIMERFD_CREATE_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "timerfd");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "t");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "6");
 
 	fd = 7;
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_E, 1, 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_E, 1, (uint8_t)0);
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT_X, 1, fd);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "inotify");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "i");
@@ -251,7 +251,7 @@ TEST_F(sinsp_with_test_input, creates_fd_generic)
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "i");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "12");
 
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EVENTFD_E, 2, (uint64_t)0, (uint16_t)45);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EVENTFD_E, 2, (uint64_t)0, (uint32_t)45);
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EVENTFD_X, 1, (int64_t)34);
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "event");
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "e");
@@ -460,7 +460,7 @@ TEST_F(sinsp_with_test_input, eventfd)
 	open_inspector();
 	sinsp_evt* evt = NULL;
 	int64_t res = 21;
-	uint16_t flags = 6;
+	uint32_t flags = 6;
 	uint64_t initval = 0;
 
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EVENTFD_E, 2, initval, flags);

--- a/userspace/libsinsp/test/events_net.ut.cpp
+++ b/userspace/libsinsp/test/events_net.ut.cpp
@@ -376,10 +376,10 @@ TEST_F(sinsp_with_test_input, net_connect_exit_event_fails)
 	/* First connection to populate the fdinfo */
 
 	std::vector<uint8_t> server_sockaddr = test_utils::pack_sockaddr(reinterpret_cast<sockaddr*>(&server));
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, client_fd, scap_const_sized_buffer{server_sockaddr.data(), server_sockaddr.size()}, client_fd);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, client_fd, scap_const_sized_buffer{server_sockaddr.data(), server_sockaddr.size()});
 
 	std::vector<uint8_t> socktuple = test_utils::pack_socktuple(reinterpret_cast<sockaddr*>(&client), reinterpret_cast<sockaddr*>(&server));
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 3, return_value, scap_const_sized_buffer{socktuple.data(), socktuple.size()});
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 3, return_value, scap_const_sized_buffer{socktuple.data(), socktuple.size()}, client_fd);
 
 	fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -261,7 +261,7 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval)
 	{
 		std::string test_context = std::string("creat with filename ") + test_utils::describe_string(enter_filename);
 
-		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 3, NULL, 0);
+		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 2, NULL, 0);
 		evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_X, 5, new_fd, expected_string, 0, 0, (uint64_t) 0);
 
 		ASSERT_NE(evt->get_thread_info(), nullptr) << test_context;

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -74,9 +74,9 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_cmd_str)
 	
 	open_inspector();
 
-	int fd = 1;
+	uint64_t fd = 1;
 
-	sinsp_evt* evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_X, 2, fd, (uint64_t)PPM_BPF_PROG_LOAD);
+	sinsp_evt* evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BPF_2_X, 2, fd, PPM_BPF_PROG_LOAD);
 
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.cmd"), "BPF_PROG_LOAD");
 }

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -168,7 +168,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 
 	// should extract legit values for non-ignored event codes
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", PPM_O_RDWR, 0);
-	auto evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (uint64_t)3, "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t)123);
+	auto evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, (uint64_t)6, (uint64_t)3, "/tmp/the_file", PPM_O_RDWR, 0, 5, (uint64_t)123);
 	ASSERT_EQ(evt->get_source_idx(), syscall_source_idx);
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
@@ -191,7 +191,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 
 	// should extract NULL for ignored event codes
 	// `PPME_SYSCALL_OPEN_BY_HANDLE_AT_X` is an ignored event, see plugin_get_extract_event_types
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, "/tmp/the_file.txt");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, (uint64_t)4, (uint64_t)5, PPM_O_RDWR, "/tmp/the_file.txt");
 	ASSERT_EQ(evt->get_source_idx(), syscall_source_idx);
 	ASSERT_EQ(std::string(evt->get_source_name()), syscall_source_name);
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_BY_HANDLE_AT_X);
@@ -204,7 +204,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	// should extract NULL for unknown event sources
 	const char data[2048] = "hello world";
 	/* There are no added plugins with id `1` */
-	uint64_t unknwon_plugin_id = 1;
+	uint32_t unknwon_plugin_id = 1;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PLUGINEVENT_E, 2, unknwon_plugin_id, scap_const_sized_buffer{&data, strlen(data) + 1});
 	ASSERT_EQ(evt->get_source_idx(), sinsp_no_event_source_idx);
 	ASSERT_EQ(evt->get_source_name(), sinsp_no_event_source_name);
@@ -217,7 +217,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 
 	// should extract NULL for non-compatible event sources
 	/* This source plugin generate events with a source that we cannot extract with our plugin */
-	uint64_t source_plugin_id = 999;
+	uint32_t source_plugin_id = 999;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_PLUGINEVENT_E, 2, source_plugin_id, scap_const_sized_buffer{&data, strlen(data) + 1});
 	ASSERT_EQ(evt->get_source_idx(), 1);
 	ASSERT_EQ(std::string(evt->get_source_name()), std::string("sample"));
@@ -412,7 +412,7 @@ TEST_F(sinsp_with_test_input, plugin_syscall_parse)
 	ASSERT_EQ(get_field_as_string(evt, "sample.tick", pl_flist), "false");
 
 	// should extract NULL for ignored event codes, but should still parse it (because the parsing plugin does not ignore it)
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, 4, 5, PPM_O_RDWR, "/tmp/the_file.txt");
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_X, 4, (uint64_t)4, (uint64_t)5, PPM_O_RDWR, "/tmp/the_file.txt");
 	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
 	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
 	ASSERT_FALSE(field_has_value(evt, "sample.tick", pl_flist));

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -43,7 +43,7 @@ void sinsp_with_test_input::open_inspector(sinsp_mode_t mode) {
 	m_inspector.open_test_input(&m_test_data, mode);
 }
 
-scap_evt* sinsp_with_test_input::add_event(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
+scap_evt* sinsp_with_test_input::_add_event(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
 {
 	va_list args;
 	va_start(args, n);
@@ -65,7 +65,7 @@ sinsp_evt* sinsp_with_test_input::advance_ts_get_event(uint64_t ts)
 }
 
 // adds an event and advances the inspector to the new timestamp
-sinsp_evt* sinsp_with_test_input::add_event_advance_ts(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
+sinsp_evt* sinsp_with_test_input::_add_event_advance_ts(uint64_t ts, uint64_t tid, ppm_event_code event_type, uint32_t n, ...)
 {
 	va_list args;
 	va_start(args, n);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Levearaging c++ variadic templates, ensure that variadic arguments are properly sized (at least for integer-like types, that are the most common mistaken ones).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
