### PR TITLE
fix(drivers): add always a null terminator after `args` and `envs`

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1929,6 +1929,13 @@ static __always_inline int bpf_accumulate_argv_or_env(struct filler_data *data,
 	*args_len = 0;
 	off = data->state->tail_ctx.curoff;
 
+	if(argv == NULL)
+	{
+		// we need to put a `\0` otherwise we could read junk data
+		data->buf[off & SCRATCH_SIZE_HALF] = '\0';
+		return PPM_SUCCESS;
+	}
+
 	#pragma unroll
 	for (j = 0; j < FAILED_ARGS_ENV_ITEMS_MAX; ++j) {
 		arg = _READ_USER(argv[j]);

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -396,25 +396,18 @@ static __always_inline void auxmap__store_execve_args(struct auxiliary_map *auxm
 		}
 
 		arg_len = push__charbuf(auxmap->data, &auxmap->payload_pos, charbuf_pointer, MAX_PROC_ARG_ENV, USER);
-		
-		// push trailing \0 if the arg is empty
-		if(arg_len == 0)
-		{
-			push__u8(auxmap->data, &auxmap->payload_pos, 0);
-			arg_len = 1;
-		}
 		total_len += arg_len;
+
+		/* the sum of all env variables lengths should be `<= MAX_PROC_ARG_ENV` */
+		if(total_len >= MAX_PROC_ARG_ENV)
+		{
+			total_len = MAX_PROC_ARG_ENV;
+			break;
+		}
 	}
-	/* the sum of all env variables lengths should be `<= MAX_PROC_ARG_ENV` */
-	if(total_len >= MAX_PROC_ARG_ENV)
-	{
-		total_len = MAX_PROC_ARG_ENV;
-	}
-	else
-	{
-		total_len = total_len & (MAX_PROC_ARG_ENV - 1);
-	}
+
 	auxmap->payload_pos = initial_payload_pos + total_len;
+	push__previous_character(auxmap->data, &auxmap->payload_pos, '\0');
 	push__param_len(auxmap->data, &auxmap->lengths_pos, total_len);
 }
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -64,8 +64,6 @@ int BPF_PROG(sched_p_fork,
 	READ_TASK_FIELD_INTO(&arg_start_pointer, child, mm, arg_start);
 	READ_TASK_FIELD_INTO(&arg_end_pointer, child, mm, arg_end);
 
-	unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 	/* Parameter 2: exe (type: PT_CHARBUF) */
 	/* We need to extract the len of `exe` arg so we can understand
 	 * the overall length of the remaining args.
@@ -73,12 +71,9 @@ int BPF_PROG(sched_p_fork,
 	uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-	/* Here we read the whole array starting from the pointer to the first
-	 * element. We could also read the array element per element but
-	 * since we know the total len we read it as a `bytebuf`.
-	 * The `\0` after every argument is preserved.
-	 */
-	auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+	unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+	auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 
 	/* Parameter 4: tid (type: PT_PID) */
 	/* this is called `tid` but it is the `pid`. */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone.bpf.c
@@ -86,21 +86,13 @@ int BPF_PROG(clone_x,
 		READ_TASK_FIELD_INTO(&arg_start_pointer, task, mm, arg_start);
 		READ_TASK_FIELD_INTO(&arg_end_pointer, task, mm, arg_end);
 
-		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* We need to extract the len of `exe` arg so we can understand
-		 * the overall length of the remaining args.
-		 */
 		uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		/* Here we read all the array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+		auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/clone3.bpf.c
@@ -86,21 +86,13 @@ int BPF_PROG(clone3_x,
 		READ_TASK_FIELD_INTO(&arg_start_pointer, task, mm, arg_start);
 		READ_TASK_FIELD_INTO(&arg_end_pointer, task, mm, arg_end);
 
-		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* We need to extract the len of `exe` arg so we can understand
-		 * the overall length of the remaining args.
-		 */
 		uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		/* Here we read all the array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+		auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -87,36 +87,24 @@ int BPF_PROG(execve_x,
 		READ_TASK_FIELD_INTO(&arg_start_pointer, task, mm, arg_start);
 		READ_TASK_FIELD_INTO(&arg_end_pointer, task, mm, arg_end);
 
-		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* We need to extract the len of `exe` arg so we can undestand
+		/* We need to extract the len of `exe` arg so we can understand
 		 * the overall length of the remaining args.
 		 */
 		uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		/* Here we read the whole array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+		auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 	}
 	else
 	{
-		/* This is a charbuf pointer array.
-		 * Every element of `argv` array is a pointer to a charbuf.
-		 * Here the first pointer points to `exe` param while all
-		 * the others point to the different args.
-		 */
 		unsigned long argv = extract__syscall_argument(regs, 1);
 
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		auxmap__store_execve_exe(auxmap, (char **)argv);
-
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		auxmap__store_execve_args(auxmap, (char **)argv, 1);
+		auxmap__store_exe_args_failure(auxmap, (char **)argv);
 	}
 
 	/* Parameter 4: tid (type: PT_PID) */
@@ -209,21 +197,15 @@ int BPF_PROG(t1_execve_x,
 		READ_TASK_FIELD_INTO(&env_start_pointer, task, mm, env_start);
 		READ_TASK_FIELD_INTO(&env_end_pointer, task, mm, env_end);
 
-		unsigned long total_env_len = env_end_pointer - env_start_pointer;
-
 		/* Parameter 16: env (type: PT_CHARBUFARRAY) */
-		/* Here we read all the array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, env_start_pointer, total_env_len & (MAX_PROC_ARG_ENV - 1), USER);
+		auxmap__store_charbufarray_as_bytebuf(auxmap, env_start_pointer, env_end_pointer - env_start_pointer,
+						      MAX_PROC_ARG_ENV);
 	}
 	else
 	{
 		/* Parameter 16: env (type: PT_CHARBUFARRAY) */
 		unsigned long envp = extract__syscall_argument(regs, 2);
-		auxmap__store_execve_args(auxmap, (char **)envp, 0);
+		auxmap__store_env_failure(auxmap, (char **)envp);
 	}
 
 	/* Parameter 17: tty (type: PT_INT32) */

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/fork.bpf.c
@@ -88,21 +88,13 @@ int BPF_PROG(fork_x,
 		READ_TASK_FIELD_INTO(&arg_start_pointer, task, mm, arg_start);
 		READ_TASK_FIELD_INTO(&arg_end_pointer, task, mm, arg_end);
 
-		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* We need to extract the len of `exe` arg so we can undestand
-		 * the overall length of the remaining args.
-		 */
 		uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		/* Here we read all the array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+		auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 	}
 	else
 	{

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/vfork.bpf.c
@@ -88,21 +88,13 @@ int BPF_PROG(vfork_x,
 		READ_TASK_FIELD_INTO(&arg_start_pointer, task, mm, arg_start);
 		READ_TASK_FIELD_INTO(&arg_end_pointer, task, mm, arg_end);
 
-		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
-
 		/* Parameter 2: exe (type: PT_CHARBUF) */
-		/* We need to extract the len of `exe` arg so we can undestand
-		 * the overall length of the remaining args.
-		 */
 		uint16_t exe_arg_len = auxmap__store_charbuf_param(auxmap, arg_start_pointer, MAX_PROC_EXE, USER);
 
 		/* Parameter 3: args (type: PT_CHARBUFARRAY) */
-		/* Here we read all the array starting from the pointer to the first
-		 * element. We could also read the array element per element but
-		 * since we know the total len we read it as a `bytebuf`.
-		 * The `\0` after every argument are preserved.
-		 */
-		auxmap__store_bytebuf_param(auxmap, arg_start_pointer + exe_arg_len, (total_args_len - exe_arg_len) & (MAX_PROC_ARG_ENV - 1), USER);
+		unsigned long total_args_len = arg_end_pointer - arg_start_pointer;
+		auxmap__store_charbufarray_as_bytebuf(auxmap, arg_start_pointer + exe_arg_len,
+						      total_args_len - exe_arg_len, MAX_PROC_ARG_ENV - exe_arg_len);
 	}
 	else
 	{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -731,7 +731,7 @@ int accumulate_argv_or_env(const void __user * argv,
 {
 	int len = 0;
 	int ret = 0;
-	const char __user *p;
+	const char __user * p = NULL;
 
 	for (;;) {
 
@@ -768,7 +768,14 @@ int accumulate_argv_or_env(const void __user * argv,
 		argv += sizeof(argv);
 	}
 
-	str_storage[len-1] = '\0';
+	if(len>0)
+	{
+		str_storage[len-1] = '\0';
+	}
+	else
+	{
+		str_storage[0] = '\0';
+	}
 	return len;
 }
 
@@ -779,7 +786,7 @@ int compat_accumulate_argv_or_env(compat_uptr_t argv,
 {
 	int len = 0;
 	int ret = 0;
-	const char __user *p;
+	const char __user *p = NULL;
 	for (;;) {
 		compat_uptr_t compat_p = 0;
 
@@ -816,7 +823,14 @@ int compat_accumulate_argv_or_env(compat_uptr_t argv,
 		argv += sizeof(argv);
 	}
 
-	str_storage[len-1] = '\0';
+	if(len>0)
+	{
+		str_storage[len-1] = '\0';
+	}
+	else
+	{
+		str_storage[0] = '\0';
+	}
 	return len;
 }
 #endif

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -20,6 +20,7 @@ static_assert(sizeof(cgroup_prefix_array) / sizeof(*cgroup_prefix_array) == CGRO
 
 /* Messages. */
 #define VALUE_NOT_CORRECT ">>>>> value of the param is not correct. Param id = "
+#define LEN_NOT_CORRECT ">>>>> len of the param is not correct. Param id = "
 #define VALUE_NOT_ZERO ">>>>> value of the param must not be zero. Param id = "
 
 extern const syscall_evt_pair g_syscall_table[SYSCALL_TABLE_SIZE];
@@ -592,6 +593,7 @@ void event_test::assert_charbuf_array_param(int param_num, const char** param)
 			break;
 		}
 		/* We can use `STREQ` because every `charbuf` is `\0` terminated. */
+		ASSERT_EQ(strlen(m_event_params[m_current_param].valptr + total_len), strlen(param[index]))  << LEN_NOT_CORRECT << m_current_param << std::endl;
 		ASSERT_STREQ(m_event_params[m_current_param].valptr + total_len, param[index]) << VALUE_NOT_CORRECT << m_current_param << std::endl;
 		total_len += strlen(param[index]) + 1;
 	}

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
@@ -14,10 +14,18 @@ TEST(GenericTracepoints, sched_proc_exec)
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Prepare the execve args */
-	const char *pathname = "/usr/bin/echo";
-	const char *comm = "echo";
-	const char *argv[] = {pathname, "[OUTPUT] GenericTracepoints.sched_proc_exec test", NULL};
-	const char *envp[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", NULL};
+	const char *pathname = "/usr/bin/true";
+	const char *comm = "true";
+
+	std::string too_long_arg (4096, 'x');
+	const char *newargv[] = {pathname, "", "first_argv", "", too_long_arg.c_str(), "second_argv", NULL};
+	std::string truncated_too_long_arg (4096 - (strlen(pathname)+1) - (strlen("first_argv")+1) - 2*(strlen("")+1) - 1, 'x');
+	const char *expected_newargv[] = {pathname, "", "first_argv", "", truncated_too_long_arg.c_str(), NULL};
+
+	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", too_long_arg.c_str(), "2_ARGUMENT=no", NULL};
+	std::string truncated_too_long_env (4096 - (strlen("IN_TEST=yes")+1) - (strlen("3_ARGUMENT=yes")+1) - 1, 'x');
+	const char *expected_newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", truncated_too_long_env.c_str(), NULL};
+
 
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
 	 * when the child terminates.
@@ -28,7 +36,7 @@ TEST(GenericTracepoints, sched_proc_exec)
 
 	if(ret_pid == 0)
 	{
-		syscall(__NR_execve, pathname, argv, envp);
+		syscall(__NR_execve, pathname, newargv, newenviron);
 		exit(EXIT_FAILURE);
 	}
 
@@ -72,7 +80,7 @@ TEST(GenericTracepoints, sched_proc_exec)
 
 	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	/* Starting from `1` because the first is `exe`. */
-	evt_test->assert_charbuf_array_param(3, &argv[1]);
+	evt_test->assert_charbuf_array_param(3, &expected_newargv[1]);
 
 	/* Parameter 4: tid (type: PT_PID) */
 	evt_test->assert_numeric_param(4, (int64_t)ret_pid);
@@ -92,7 +100,7 @@ TEST(GenericTracepoints, sched_proc_exec)
 	evt_test->assert_charbuf_param(14, comm);
 
 	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
-	evt_test->assert_charbuf_array_param(16, &envp[0]);
+	evt_test->assert_charbuf_array_param(16, &expected_newenviron[0]);
 
 	/* PPM_EXE_WRITABLE is set when the user that executed a process can also write to the executable
 	 * file that is used to spawn it or is its owner or otherwise capable.

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -913,7 +913,7 @@ TEST(SyscallExit, execveX_failure_empty_arg)
 	/*
 	 * Call the `execve`
 	 */
-	char pathname[] = "//**null-file-path**//";
+	char pathname[] = "";
 	const char *newargv[] = {pathname, "first_argv", "second_argv", "", "fourth_argv", NULL};
 	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", "", "0_ARGUMENT=no", NULL};
 	assert_syscall_state(SYSCALL_FAILURE, "execve", syscall(__NR_execve, pathname, newargv, newenviron));

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -42,8 +42,15 @@ TEST(SyscallExit, execveatX_failure)
 	 */
 	int dirfd = AT_FDCWD;
 	char pathname[] = "//**null-file-path**//";
-	const char *newargv[] = {pathname, "first_argv", "second_argv", NULL};
-	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", NULL};
+	std::string too_long_arg (4096, 'x');
+	const char *newargv[] = {pathname, "", "first_argv", "", too_long_arg.c_str(), "second_argv", NULL};
+	std::string truncated_too_long_arg (4096 - (strlen(pathname)+1) - (strlen("first_argv")+1) - 2*(strlen("")+1) - 1, 'x');
+	const char *expected_newargv[] = {pathname, "", "first_argv", "", truncated_too_long_arg.c_str(), NULL};
+
+	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", too_long_arg.c_str(), "2_ARGUMENT=no", NULL};
+	std::string truncated_too_long_env (4096 - (strlen("IN_TEST=yes")+1) - (strlen("3_ARGUMENT=yes")+1) - 1, 'x');
+	const char *expected_newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", truncated_too_long_env.c_str(), NULL};
+	
 	int flags = AT_SYMLINK_NOFOLLOW;
 	assert_syscall_state(SYSCALL_FAILURE, "execveat", syscall(__NR_execveat, dirfd, pathname, newargv, newenviron, flags));
 	int64_t errno_value = -errno;
@@ -73,7 +80,7 @@ TEST(SyscallExit, execveatX_failure)
 
 	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	/* Starting from `1` because the first is `exe`. */
-	evt_test->assert_charbuf_array_param(3, &newargv[1]);
+	evt_test->assert_charbuf_array_param(3, &expected_newargv[1]);
 
 	/* Parameter 4: tid (type: PT_PID) */
 	evt_test->assert_numeric_param(4, (int64_t)pid);
@@ -116,7 +123,7 @@ TEST(SyscallExit, execveatX_failure)
 	evt_test->assert_cgroup_param(15);
 
 	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
-	evt_test->assert_charbuf_array_param(16, &newenviron[0]);
+	evt_test->assert_charbuf_array_param(16, &expected_newenviron[0]);
 
 	/* Parameter 17: tty (type: PT_UINT32) */
 	evt_test->assert_numeric_param(17, (uint32_t)info.tty);
@@ -177,9 +184,12 @@ TEST(SyscallExit, execveatX_correct_exit)
 
 	/* Prepare the execve args */
 	int dirfd = 0;
-	const char *pathname = "/usr/bin/echo";
-	const char *argv[] = {pathname, "[OUTPUT] SyscallExit.execveatX_success test", NULL};
-	const char *envp[] = {"IN_TEST=yes", "3_ARGUMENT=yes", "2_ARGUMENT=no", NULL};
+	const char *pathname = "/usr/bin/test";
+
+	std::string too_long_arg (4096, 'x');
+	const char *newargv[] = {pathname, "", "first_argv", "", too_long_arg.c_str(), "second_argv", NULL};
+	const char *newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", too_long_arg.c_str(), "2_ARGUMENT=no", NULL};
+
 	int flags = 0;
 
 	/* We need to use `SIGCHLD` otherwise the parent won't receive any signal
@@ -191,7 +201,7 @@ TEST(SyscallExit, execveatX_correct_exit)
 
 	if(ret_pid == 0)
 	{
-		syscall(__NR_execveat, dirfd, pathname, argv, envp, flags);
+		syscall(__NR_execveat, dirfd, pathname, newargv, newenviron, flags);
 		exit(EXIT_FAILURE);
 	}
 
@@ -226,7 +236,7 @@ TEST(SyscallExit, execveatX_correct_exit)
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	const char *comm = "echo";
+	const char *comm = "test";
 
 	/* Please note here we cannot assert all the params, we check only the possible ones. */
 
@@ -238,7 +248,9 @@ TEST(SyscallExit, execveatX_correct_exit)
 
 	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	/* Starting from `1` because the first is `exe`. */
-	evt_test->assert_charbuf_array_param(3, &argv[1]);
+	std::string truncated_too_long_arg (4096 - (strlen(pathname)+1) - (strlen("first_argv")+1) - 2*(strlen("")+1) - 1, 'x');
+	const char *expected_newargv[] = {pathname, "", "first_argv", "", truncated_too_long_arg.c_str(), NULL};
+	evt_test->assert_charbuf_array_param(3, &expected_newargv[1]);
 
 	/* Parameter 4: tid (type: PT_PID) */
 	evt_test->assert_numeric_param(4, (int64_t)ret_pid);
@@ -261,7 +273,9 @@ TEST(SyscallExit, execveatX_correct_exit)
 	evt_test->assert_cgroup_param(15);
 
 	/* Parameter 16: env (type: PT_CHARBUFARRAY) */
-	evt_test->assert_charbuf_array_param(16, &envp[0]);
+	std::string truncated_too_long_env (4096 - (strlen("IN_TEST=yes")+1) - (strlen("3_ARGUMENT=yes")+1) - 1, 'x');
+	const char *expected_newenviron[] = {"IN_TEST=yes", "3_ARGUMENT=yes", truncated_too_long_env.c_str(), NULL};	
+	evt_test->assert_charbuf_array_param(16, &expected_newenviron[0]);
 
 	/* PPM_EXE_WRITABLE is set when the user that executed a process can also write to the executable
 	 * file that is used to spawn it or is its owner or otherwise capable.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:


This PR contains multiple fixes:
* modern_bpf: related to this https://github.com/falcosecurity/libs/issues/866. Since `bpf_probe_read_user_str` returns `0` in case of an empty string we now add manually a null terminator directly in `push__charbuf`, in this case we can handle empty strings in just one place. Partially reverting this https://github.com/falcosecurity/libs/pull/1760.
* modern_bpf: handle correctly `args` and `envs` greater than the limit (`4096`). Before this fix, in the case of `args`>= 4096, they were truncated without adding a `\0` at the end. This causes issues when handling these params in userspace. Now even in case of partial reads we always terminate the args with a final `\0`.
* kmod: solve the same issue of the modern with the null terminator
* kmod: fix an issue with `accumulate_argv_or_env`. Before this fix, in case of page faults or other errors, the entire event was dropped, now in case of errors we send partial args null-terminated.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(drivers): add always a null terminator after `args` and `envs`
```
