### PR TITLE
fix(libsinsp_e2e): disable flaky sys_call_test.forking_clone_fs e2e test

### DIFF
--- a/.github/workflows/e2e_ci.yml
+++ b/.github/workflows/e2e_ci.yml
@@ -167,7 +167,7 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1
         run: |
           cd build/test/libsinsp_e2e/
-          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.forking_clone_fs
+          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }}
 
         # the actuated arm64 workers doesn't have the CONFIG_QFMT_V2 flag
         # which is needed for the quotactl_ok test (cmd=QQUOTA_ON + id=QFMT_VFS_V0).
@@ -177,4 +177,4 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1
         run: |
           cd build/test/libsinsp_e2e/
-          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.quotactl_ok:sys_call_test.forking_clone_fs
+          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.quotactl_ok

--- a/.github/workflows/e2e_ci.yml
+++ b/.github/workflows/e2e_ci.yml
@@ -167,7 +167,7 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1
         run: |
           cd build/test/libsinsp_e2e/
-          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }}
+          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.forking_clone_fs
 
         # the actuated arm64 workers doesn't have the CONFIG_QFMT_V2 flag
         # which is needed for the quotactl_ok test (cmd=QQUOTA_ON + id=QFMT_VFS_V0).
@@ -177,4 +177,4 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1
         run: |
           cd build/test/libsinsp_e2e/
-          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.quotactl_ok
+          sudo -E ./libsinsp_e2e_tests ${{ matrix.driver.option }} --gtest_filter=-sys_call_test.quotactl_ok:sys_call_test.forking_clone_fs

--- a/test/libsinsp_e2e/forking.cpp
+++ b/test/libsinsp_e2e/forking.cpp
@@ -341,7 +341,18 @@ static int clone_callback_1(void* arg)
 	return 0;
 }
 
-TEST_F(sys_call_test, forking_clone_fs)
+/*
+ * The `sys_call_test.forking_clone_fs` e2e test makes the assuption
+ * that, if a children closes a file descriptor, the parent trying
+ * to close the same file descriptor will get an error. This seems
+ * not to be always the case. As the man says `It is probably unwise
+ * to close file descriptors while they may be in use by system calls
+ * in other threads in the same process.  Since a file descriptor may
+ * be reused, there are some obscure race conditions that may cause
+ * unintended side effects.` Given that we'll disable it upon further
+ * investigation.
+ */
+TEST_F(sys_call_test, DISABLED_forking_clone_fs)
 {
 	int callnum = 0;
 	char bcwd[1024];


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The `sys_call_test.forking_clone_fs` e2e test makes the assuption that, if a children closes a file descriptor, the parent trying to close the same file descriptor will get an error. This seems not to be always the case. As the man says `It is probably unwise to close file descriptors while they may be in use by system calls in other threads in the same process.  Since a file descriptor may be reused, there are some obscure race conditions that may cause unintended side effects.` Given that we'll disable it upon further investigation.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
