### PR TITLE
cleanup(libsinsp): throw exception for invalid parsed string vectors

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include <libsinsp/settings.h>
 #include <libsinsp/sinsp_exception.h>
 #include <libsinsp/fdinfo.h>
+#include <libsinsp/utils.h>
 
 class sinsp;
 class sinsp_threadinfo;
@@ -148,6 +149,12 @@ inline std::string_view get_event_param_as<std::string_view>(const sinsp_evt_par
 	}
 
 	return {param.m_val, string_len};
+}
+
+template<>
+inline std::vector<std::string> get_event_param_as<std::vector<std::string>>(const sinsp_evt_param& param)
+{
+	return sinsp_split(param.m_val, static_cast<size_t>(param.m_len), '\0');
 }
 
 /*!

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -940,7 +940,6 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt *enter_evt, sinsp_evt *exit_ev
 
 void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 {
-	const sinsp_evt_param* parinfo = nullptr;
 	uint16_t etype = evt->get_type();
 	int64_t caller_tid = evt->get_tid();
 
@@ -1229,8 +1228,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
 
 	/* args */
-	parinfo = evt->get_param(2);
-	child_tinfo->set_args(parinfo->m_val, parinfo->m_len);
+	child_tinfo->set_args(evt->get_param(2)->as<std::vector<std::string>>());
 
 	/* comm */
 	switch(etype)
@@ -1354,8 +1352,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		case PPME_SYSCALL_VFORK_20_X:
 		case PPME_SYSCALL_CLONE_20_X:
 		case PPME_SYSCALL_CLONE3_X:
-			parinfo = evt->get_param(14);
-			child_tinfo->set_cgroups(parinfo->m_val, parinfo->m_len);
+			child_tinfo->set_cgroups(evt->get_param(14)->as<std::vector<std::string>>());
 			m_inspector->m_container_manager.resolve_container(child_tinfo.get(), m_inspector->is_live() || m_inspector->is_syscall_plugin());
 			break;
 	}
@@ -1411,8 +1408,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 		caller_tinfo->m_comm = child_tinfo->m_comm;
 
 		/* args */
-		parinfo = evt->get_param(2);
-		caller_tinfo->set_args(parinfo->m_val, parinfo->m_len);
+		caller_tinfo->set_args(evt->get_param(2)->as<std::vector<std::string>>());
 	}
 
 	/*=============================== CREATE CHILD ===========================*/
@@ -1459,7 +1455,6 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 
 void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 {
-	const sinsp_evt_param *parinfo = nullptr;
 	uint16_t etype = evt->get_type();
 	int64_t child_tid = evt->get_tid();
 
@@ -1688,8 +1683,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	}
 
 	/* args */
-	parinfo = evt->get_param(2);
-	child_tinfo->set_args(parinfo->m_val, parinfo->m_len);
+	child_tinfo->set_args(evt->get_param(2)->as<std::vector<std::string>>());
 
 	if(valid_lookup_thread)
 	{
@@ -1799,8 +1793,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 			lookup_tinfo->m_comm = child_tinfo->m_comm;
 
 			/* args */
-			parinfo = evt->get_param(2);
-			lookup_tinfo->set_args(parinfo->m_val, parinfo->m_len);
+			lookup_tinfo->set_args(evt->get_param(2)->as<std::vector<std::string>>());
 		}
 	}
 
@@ -1904,8 +1897,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		parinfo = evt->get_param(14);
-		child_tinfo->set_cgroups(parinfo->m_val, parinfo->m_len);
+		child_tinfo->set_cgroups(evt->get_param(14)->as<std::vector<std::string>>());
 		m_inspector->m_container_manager.resolve_container(child_tinfo.get(), m_inspector->is_live());
 		break;
 	}
@@ -2080,8 +2072,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	}
 
 	// Get the command arguments
-	parinfo = evt->get_param(2);
-	evt->get_tinfo()->set_args(parinfo->m_val, parinfo->m_len);
+	evt->get_tinfo()->set_args(evt->get_param(2)->as<std::vector<std::string>>());
 
 	// Get the pid
 	evt->get_tinfo()->m_pid = evt->get_param(4)->as<uint64_t>();
@@ -2168,8 +2159,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 		//
 		// Set cgroups and heuristically detect container id
 		//
-		parinfo = evt->get_param(14);
-		evt->get_tinfo()->set_cgroups(parinfo->m_val, parinfo->m_len);
+		evt->get_tinfo()->set_cgroups(evt->get_param(14)->as<std::vector<std::string>>());
 
 		//
 		// Resync container status after an execve, we need to do it

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -197,3 +197,14 @@ TEST(sinsp_utils_test, concatenate_paths)
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/root/c:/hello/world", res); */
 }
+
+TEST(sinsp_utils_test, sinsp_split_buf)
+{
+	const char *in = "hello\0world\0";
+	size_t len = 12;
+	auto split = sinsp_split(in, len, '\0');
+
+	EXPECT_EQ(split.size(), 2);
+	EXPECT_EQ(split[0], "hello");
+	EXPECT_EQ(split[1], "world");
+}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -638,8 +638,10 @@ public:
 	void remove_fd(int64_t fd);
 	void update_cwd(std::string_view cwd);
 	void set_args(const char* args, size_t len);
+	void set_args(std::vector<std::string> args);
 	void set_env(const char* env, size_t len);
 	void set_cgroups(const char* cgroups, size_t len);
+	void set_cgroups(std::vector<std::string> cgroups);
 	bool is_lastevent_data_valid() const;
 	inline void set_lastevent_data_validity(bool isvalid)
 	{

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1385,6 +1385,24 @@ std::vector<std::string> sinsp_split(const std::string &s, char delim)
 	return res;
 }
 
+std::vector<std::string> sinsp_split(const char *buf, size_t len, char delim)
+{
+	if(len == 0)
+	{
+		return {};
+	}
+
+	if(buf[len - 1] != '\0')
+	{
+		throw sinsp_exception("expected a NUL-terminated buffer of size " +	
+							  std::to_string(len) + ", which instead ends with " +
+							  std::to_string(buf[len - 1]));
+	}
+
+	std::string s {buf, len - 1};
+	return sinsp_split(s, delim);
+}
+
 //
 // trim from start
 //

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cstring>
 #include <list>
 #include <locale>
@@ -257,6 +258,7 @@ const char* print_format_to_string(ppm_print_format fmt);
 // String helpers
 ///////////////////////////////////////////////////////////////////////////////
 std::vector<std::string> sinsp_split(const std::string& s, char delim);
+std::vector<std::string> sinsp_split(const char *buf, size_t len, char delim);
 
 template<typename It>
 std::string sinsp_join(It begin, It end, char delim)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

After https://github.com/falcosecurity/libs/pull/1800 we want to make sure that what we receive from the drivers is actually what we expect. So, I've changed the way we parse those kind of parameters to check for the NUL terminator, and added a shorthand helper to convert the parameter from buffer to vector.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
