### PR TITLE
fix(userspace/libsinsp): properly set successful lookup state when parsing old container json events

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -5125,6 +5125,11 @@ void sinsp_parser::parse_container_json_evt(sinsp_evt *evt)
 				container_info->set_lookup_status(sinsp_container_lookup::state::FAILED);
 			}
 		}
+		else
+		{
+			// Fallback at successful state
+			container_info->set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);
+		}
 
 		const Json::Value& created_time = container["created_time"];
 		if(check_int64_json_is_convertible(created_time, "created_time"))


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR fixups a small bug indirectly caused by the changes in https://github.com/falcosecurity/libs/pull/1707.
Default at successful lookup state when `lookup_state` is not part of the container json event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Falco CI uses very very old container events in scap files (prior to https://github.com/falcosecurity/libs/commit/58a546a1b5b435caf94dadcefeea4f78363bdcbd changes) thus one event was expected but not received becase it had no `lookup_state` field.
See https://github.com/falcosecurity/falco/actions/runs/8802240019?pr=3177:
>   TestFalco_Legacy_ContainerPrivileged
{"deadline":180000000000,"level":"info","msg":"running falco with runner","time":"2024-04-24T08:33:14Z"}
{"cmd":"/usr/bin/falco -c /etc/falco/falco.yaml -o json_output=true -r falco_rules.yaml -o engine.kind=replay -o engine.replay.capture_file=container-privileged.scap -A -o json_include_output_property=false -o json_include_tags_property=false -o log_level=debug -o log_stderr=true -o log_syslog=false -o stdout_output.enabled=true","level":"debug","msg":"executing command","time":"2024-04-24T08:33:14Z"}
    legacy_test.go:2526: 
        	Error Trace:	/home/runner/work/_actions/falcosecurity/testing/main/legacy_test.go:2526
        	Error:      	Not equal: 
        	            	expected: 3
        	            	actual  : 2
        	Test:       	TestFalco_Legacy_ContainerPrivileged

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
