### PR TITLE
fix(userspace/libsinsp): properly use `strlen` instead of `sizeof` when assigning user/group string infos

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -523,9 +523,9 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_user.set_name(user->name, sizeof(user->name));
-			m_user.set_homedir(user->homedir, sizeof(user->homedir));
-			m_user.set_shell(user->shell, sizeof(user->shell));
+			m_user.set_name(user->name, strlen(user->name));
+			m_user.set_homedir(user->homedir, strlen(user->homedir));
+			m_user.set_shell(user->shell, strlen(user->shell));
 		}
 	}
 	else
@@ -551,7 +551,7 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_group.set_name(group->name, sizeof(group->name));
+			m_group.set_name(group->name, strlen(group->name));
 		}
 	}
 	else
@@ -574,9 +574,9 @@ void sinsp_threadinfo::set_loginuser(uint32_t loginuid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_loginuser.set_name(login_user->name, sizeof(login_user->name));
-			m_loginuser.set_homedir(login_user->homedir, sizeof(login_user->homedir));
-			m_loginuser.set_shell(login_user->shell, sizeof(login_user->shell));
+			m_loginuser.set_name(login_user->name, strlen(login_user->name));
+			m_loginuser.set_homedir(login_user->homedir, strlen(login_user->homedir));
+			m_loginuser.set_shell(login_user->shell, strlen(login_user->shell));
 		}
 	}
 	else

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -523,9 +523,9 @@ void sinsp_threadinfo::set_user(uint32_t uid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_user.set_name(user->name, strlen(user->name));
-			m_user.set_homedir(user->homedir, strlen(user->homedir));
-			m_user.set_shell(user->shell, strlen(user->shell));
+			m_user.set_name(user->name, strnlen(user->name, MAX_CREDENTIALS_STR_LEN));
+			m_user.set_homedir(user->homedir, strnlen(user->homedir, MAX_CREDENTIALS_STR_LEN));
+			m_user.set_shell(user->shell, strnlen(user->shell, MAX_CREDENTIALS_STR_LEN));
 		}
 	}
 	else
@@ -551,7 +551,7 @@ void sinsp_threadinfo::set_group(uint32_t gid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_group.set_name(group->name, strlen(group->name));
+			m_group.set_name(group->name, strnlen(group->name, MAX_CREDENTIALS_STR_LEN));
 		}
 	}
 	else
@@ -574,9 +574,9 @@ void sinsp_threadinfo::set_loginuser(uint32_t loginuid)
 
 		if (m_inspector->is_user_details_enabled())
 		{
-			m_loginuser.set_name(login_user->name, strlen(login_user->name));
-			m_loginuser.set_homedir(login_user->homedir, strlen(login_user->homedir));
-			m_loginuser.set_shell(login_user->shell, strlen(login_user->shell));
+			m_loginuser.set_name(login_user->name, strnlen(login_user->name, MAX_CREDENTIALS_STR_LEN));
+			m_loginuser.set_homedir(login_user->homedir, strnlen(login_user->homedir, MAX_CREDENTIALS_STR_LEN));
+			m_loginuser.set_shell(login_user->shell, strnlen(login_user->shell, MAX_CREDENTIALS_STR_LEN));
 		}
 	}
 	else


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Small fixup on top of https://github.com/falcosecurity/libs/pull/1765.
cc @erthalion 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
