### PR TITLE
fix(sinsp): set a null terminator instead of throwing an exception

### DIFF
--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -208,3 +208,15 @@ TEST(sinsp_utils_test, sinsp_split_buf)
 	EXPECT_EQ(split[0], "hello");
 	EXPECT_EQ(split[1], "world");
 }
+
+TEST(sinsp_utils_test, sinsp_split_check_terminator)
+{
+	// check that the null terminator is enforced
+	const char *in = "hello\0worlddd";
+	size_t len = 13;
+	auto split = sinsp_split(in, len, '\0');
+
+	EXPECT_EQ(split.size(), 2);
+	EXPECT_EQ(split[0], "hello");
+	EXPECT_EQ(split[1], "worldd");
+}

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1392,14 +1392,21 @@ std::vector<std::string> sinsp_split(const char *buf, size_t len, char delim)
 		return {};
 	}
 
+	std::string s {buf, len - 1};
+
 	if(buf[len - 1] != '\0')
 	{
+#ifdef _DEBUG
 		throw sinsp_exception("expected a NUL-terminated buffer of size " +	
 							  std::to_string(len) + ", which instead ends with " +
 							  std::to_string(buf[len - 1]));
+#else
+		libsinsp_logger()->format(sinsp_logger::SEV_WARNING, "expected a NUL-terminated buffer of size '%ld' which instead ends with '%c'", len, buf[len - 1]);
+		// enforce the null terminator
+		s.replace(len-1, 1, "\0");
+#endif
 	}
 
-	std::string s {buf, len - 1};
 	return sinsp_split(s, delim);
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

The checks in this PR were probably too strict https://github.com/falcosecurity/libs/pull/1810. Our codebase at the moment is not ready to throw an exception when a vector of strings is not null-terminated. For example, when scanning proc this is something that could still happen, in this PR we fixed a possible case but who knows how many corner cases there are... a more conservative solution is to log a warning and enforce the null terminator in release mode. In debug mode, we keep the exception so it's easier to figure out the root cause with a backtrace.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(sinsp): set a null terminator instead of throwing an exception
```
