### PR TITLE
new(ci): add a test-drivers-ppc64le workflow.

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -196,8 +196,6 @@ jobs:
           command_timeout: 60m
           script: |
             sudo dnf install -y bpftool ca-certificates cmake make automake gcc gcc-c++ kernel-devel clang git pkg-config autoconf automake libbpf-devel
-            temp_fld=$(mktemp -d)
-            pushd $temp_fld
             git clone -b $GIT_BRANCH $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git libs
             cd libs
             mkdir -p build
@@ -209,8 +207,6 @@ jobs:
             rc_bpf=$?
             sudo ./test/drivers/drivers_test -k
             rc_kmod=$?
-            popd
-            rm -rf $temp_fld
             exit $(($rc_modern + $rc_bpf +$rc_kmod))
         
   build-drivers-s390x:

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -193,6 +193,7 @@ jobs:
           key: ${{ secrets.PPC64LE_KEY }}
           port: ${{ secrets.PPC64LE_PORT }}
           envs: GIT_BRANCH,GITHUB_REPOSITORY,GITHUB_SERVER_URL
+          command_timeout: 60m
           script: |
             sudo dnf install -y bpftool ca-certificates cmake make automake gcc gcc-c++ kernel-devel clang git pkg-config autoconf automake libbpf-devel
             temp_fld=$(mktemp -d)

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -175,17 +175,44 @@ jobs:
         run: |
           cd build
           sudo ./test/drivers/drivers_test -k
-
-  build-drivers-s390x-ppc64le:
-    name: build-drivers-${{ matrix.arch }} 😁 (system_deps)
+          
+  test-drivers-ppc64le:
+    name: test-drivers-ppc64le 😁 (system_deps,custom node)
     runs-on: ubuntu-22.04
     needs: paths-filter
-    strategy:
-      matrix:
-        arch: [s390x, ppc64le]
-      fail-fast: false
-    env:
-      PLATFORM: ${{ matrix.arch == 'ppc64le' && 'powerpc64le' || 's390x' }}
+    steps:
+      - name: Extract branch name
+        run: echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+
+      - name: Build and test drivers on ppc64le node via ssh
+        if: needs.paths-filter.outputs.driver_needs_rebuild
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PPC64LE_HOST }}
+          username: ${{ secrets.PPC64LE_USERNAME }}
+          key: ${{ secrets.PPC64LE_KEY }}
+          port: ${{ secrets.PPC64LE_PORT }}
+          envs: GIT_BRANCH,GITHUB_REPOSITORY,GITHUB_SERVER_URL
+          script_stop: true
+          script: |
+            sudo dnf install -y bpftool ca-certificates cmake make automake gcc gcc-c++ kernel-devel clang git pkg-config autoconf automake libbpf-devel
+            temp_fld=$(mktemp -d)
+            pushd $temp_fld
+            git clone -b $GIT_BRANCH $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git libs
+            cd libs
+            mkdir -p build
+            cd build && cmake -DUSE_BUNDLED_DEPS=ON -DENABLE_DRIVERS_TESTS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_BPF=True -DBUILD_LIBSCAP_GVISOR=OFF ../
+            make drivers_test driver bpf -j6
+            sudo ./test/drivers/drivers_test -m
+            sudo ./test/drivers/drivers_test -b
+            sudo ./test/drivers/drivers_test -k
+            popd
+            rm -rf $temp_fld
+        
+  build-drivers-s390x:
+    name: build-drivers-s390x 😁 (system_deps)
+    runs-on: ubuntu-22.04
+    needs: paths-filter
     steps:
       - name: Checkout Libs ⤵️
         if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
@@ -194,10 +221,10 @@ jobs:
           fetch-depth: 0
 
       - uses: uraimo/run-on-arch-action@4ed76f16f09d12e83abd8a49e1ac1e5bf08784d4 # v2.5.1
-        name: Run ${{ matrix.arch }} build 🏗️
+        name: Run s390x build 🏗️
         if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
         with:
-          arch: ${{ matrix.arch }}
+          arch: s390x
           distro: ubuntu22.04
           githubToken: ${{ github.token }}
 
@@ -210,15 +237,15 @@ jobs:
             cd ../../
             git clone https://github.com/libbpf/libbpf.git --branch v1.3.0 --single-branch
             cd libbpf/src && BUILD_STATIC_ONLY=y DESTDIR=/ make install
-            ln -s /usr/lib64/libbpf.a /usr/lib/${{env.PLATFORM}}-linux-gnu/
+            ln -s /usr/lib64/libbpf.a /usr/lib/s390x-linux-gnu/
           # Please note: we cannot inject the BPF probe inside QEMU, so right now, we only build it
           run: |
             git config --global --add safe.directory $GITHUB_WORKSPACE
             .github/install-deps.sh
             mkdir -p build
-            cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=OFF -DMODERN_PROBE_INCLUDE="-I/usr/include/${{env.PLATFORM}}-linux-gnu" -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DENABLE_DRIVERS_TESTS=On -DCREATE_TEST_TARGETS=On -DBUILD_LIBSCAP_GVISOR=OFF ../
+            cd build && cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=OFF -DMODERN_PROBE_INCLUDE="-I/usr/include/s390x-linux-gnu" -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DENABLE_DRIVERS_TESTS=On -DCREATE_TEST_TARGETS=On -DBUILD_LIBSCAP_GVISOR=OFF ../
             KERNELDIR=/lib/modules/$(ls /lib/modules)/build make driver bpf drivers_test -j6
-
+  
   build-modern-bpf-skeleton:
     needs: paths-filter
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -204,10 +204,14 @@ jobs:
             cd build && cmake -DUSE_BUNDLED_DEPS=ON -DENABLE_DRIVERS_TESTS=ON -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON -DBUILD_BPF=True -DBUILD_LIBSCAP_GVISOR=OFF ../
             make drivers_test driver bpf -j6
             sudo ./test/drivers/drivers_test -m
+            rc_modern=$?
             sudo ./test/drivers/drivers_test -b
+            rc_bpf=$?
             sudo ./test/drivers/drivers_test -k
+            rc_kmod=$?
             popd
             rm -rf $temp_fld
+            exit $(($rc_modern + $rc_bpf +$rc_kmod))
         
   build-drivers-s390x:
     name: build-drivers-s390x 😁 (system_deps)

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -193,7 +193,6 @@ jobs:
           key: ${{ secrets.PPC64LE_KEY }}
           port: ${{ secrets.PPC64LE_PORT }}
           envs: GIT_BRANCH,GITHUB_REPOSITORY,GITHUB_SERVER_URL
-          script_stop: true
           script: |
             sudo dnf install -y bpftool ca-certificates cmake make automake gcc gcc-c++ kernel-devel clang git pkg-config autoconf automake libbpf-devel
             temp_fld=$(mktemp -d)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Our drivers officially support the following architectures:
 | **aarch64** | >= [3.16](https://github.com/torvalds/linux/commit/055b1212d141f1f398fca548f8147787c0b6253f) | >= 4.17                                                                                     | >= 5.8            | _STABLE_ |
 | **s390x**   | >= 2.6                                                                                       | >= [5.5](https://github.com/torvalds/linux/commit/6ae08ae3dea)                              | >= 5.8            | _EXPERIMENTAL_ |
 | **riscv64** | >= [5.0](https://github.com/torvalds/linux/commit/5aeb1b36cedd3a1dfdbfe368629fed52dee34103)  | N/A                                                                                         | N/A               | _EXPERIMENTAL_ |
-| **ppc64le** | >= 2.6                                                                                       | >= [5.1](https://github.com/torvalds/linux/commit/ed1cd6deb013a11959d17a94e35ce159197632da) | >= 5.8               | _EXPERIMENTAL_ |
+| **ppc64le** | >= 2.6                                                                                       | >= [5.1](https://github.com/torvalds/linux/commit/ed1cd6deb013a11959d17a94e35ce159197632da) | >= 5.8               | _STABLE_ |
 
 
 To access up-to-date status reports on Falco drivers kernel testing, please visit this [page](https://falcosecurity.github.io/libs/). It provides a list of supported syscalls as well as the [report](https://falcosecurity.github.io/libs/report/).

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2600,9 +2600,12 @@ FILLER(proc_startupdate_3, true)
 			flags = bpf_syscall_get_argument(data, 0);
 			if (bpf_probe_read_user(&cl_args, sizeof(struct clone_args), (void *)flags)) 
 			{
-				return PPM_FAILURE_INVALID_USER_MEMORY;
+				flags = 0;
 			}
-			flags = cl_args.flags;
+			else
+			{
+				flags = cl_args.flags;
+			}
 #else
 		flags = 0;
 #endif

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1207,9 +1207,12 @@ cgroups_error:
 			res = ppm_copy_from_user(&cl_args, (void *)val, sizeof(struct clone_args));
 			if (unlikely(res != 0))
 			{
-				return PPM_FAILURE_INVALID_USER_MEMORY;
+				val = 0;
 			}
-			val = cl_args.flags;
+			else
+			{
+				val = cl_args.flags;
+			}
 #else
 			val = 0;
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Adds a ppc64le drivers_test CI.
It leverages https://github.com/appleboy/ssh-action since ppc64le is currently unsupported by github actions self-hosted runner: https://github.com/actions/runner/issues/2365 (https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#architectures).

There are of course some security implications: we are giving ssh access to our ppc64le node to a gha, that, while being of course open source, can be victim of attacks.
While i can see that this is quite a big issue, we:
* only use this node to test the build of drivers
* we do not generate any artifact on the node

Given the above, i think it might be a good solution until gha self-hosted runners support ppc64le natively.

cc @LucaGuerra 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

~~This is still wip; still have to add proper secrets to the libs repo.~~

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
