### PR TITLE
fix(userspace/libsinsp): make sure simple sinsp wrapper methods are inlined

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1398,21 +1398,6 @@ uint64_t sinsp::get_num_events() const
 	}
 }
 
-threadinfo_map_t::ptr_t sinsp::get_thread_ref(int64_t tid, bool query_os_if_not_found, bool lookup_only, bool main_thread)
-{
-	return m_thread_manager->get_thread_ref(tid, query_os_if_not_found, lookup_only, main_thread);
-}
-
-std::shared_ptr<sinsp_threadinfo> sinsp::add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo)
-{
-	return m_thread_manager->add_thread(std::move(ptinfo), false);
-}
-
-void sinsp::remove_thread(int64_t tid)
-{
-	m_thread_manager->remove_thread(tid);
-}
-
 bool sinsp::suppress_events_comm(const std::string &comm)
 {
 	m_suppress.suppress_comm(comm);
@@ -1750,16 +1735,6 @@ const scap_machine_info* sinsp::get_machine_info() const
 const scap_agent_info* sinsp::get_agent_info() const
 {
 	return m_agent_info;
-}
-
-std::shared_ptr<sinsp_stats_v2> sinsp::get_sinsp_stats_v2()
-{
-	return m_sinsp_stats_v2;
-}
-
-std::shared_ptr<const sinsp_stats_v2> sinsp::get_sinsp_stats_v2() const
-{
-	return m_sinsp_stats_v2;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp::new_generic_filtercheck()
@@ -2207,15 +2182,5 @@ bool sinsp::get_track_connection_status() const
 void sinsp::set_track_connection_status(bool enabled)
 {
 	m_parser->set_track_connection_status(enabled);
-}
-
-uint64_t sinsp::get_new_ts() const
-{
-	// m_lastevent_ts = 0 at startup when containers are
-	// being created as a part of the initial process
-	// scan.
-	return (m_lastevent_ts == 0)
-			? sinsp_utils::get_current_time_ns()
-			: m_lastevent_ts;
 }
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -474,8 +474,15 @@ public:
 	  \brief Return sinsp stats v2 containing continually updated counters around thread and fd state tables.
 
 	*/
-	std::shared_ptr<sinsp_stats_v2> get_sinsp_stats_v2();
-	std::shared_ptr<const sinsp_stats_v2> get_sinsp_stats_v2() const;
+	inline std::shared_ptr<sinsp_stats_v2> get_sinsp_stats_v2()
+	{
+		return m_sinsp_stats_v2;
+	}
+
+	inline std::shared_ptr<const sinsp_stats_v2> get_sinsp_stats_v2() const
+	{
+		return m_sinsp_stats_v2;
+	}
 
 	/*!
 	  \brief Look up a thread given its tid and return its information,
@@ -496,7 +503,10 @@ public:
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-	threadinfo_map_t::ptr_t get_thread_ref(int64_t tid, bool query_os_if_not_found = false, bool lookup_only = true, bool main_thread = false);
+	inline threadinfo_map_t::ptr_t get_thread_ref(int64_t tid, bool query_os_if_not_found = false, bool lookup_only = true, bool main_thread = false)
+	{
+		return m_thread_manager->get_thread_ref(tid, query_os_if_not_found, lookup_only, main_thread);
+	}
 
 	/*!
 	  \brief Fill the given structure with statistics about the currently
@@ -1003,18 +1013,32 @@ public:
 	 * \return The current time in nanoseconds if the last event timestamp is 0,
 	 * otherwise, the last event timestamp.
 	 */
-	uint64_t get_new_ts() const;
+	inline uint64_t get_new_ts() const
+	{
+		// m_lastevent_ts = 0 at startup when containers are
+		// being created as a part of the initial process
+		// scan.
+		return (m_lastevent_ts == 0)
+				? sinsp_utils::get_current_time_ns()
+				: m_lastevent_ts;
+	}
 
 	bool remove_inactive_threads();
 
-	std::shared_ptr<sinsp_threadinfo> add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo);
+	inline std::shared_ptr<sinsp_threadinfo> add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo)
+	{
+		return m_thread_manager->add_thread(std::move(ptinfo), false);
+	}
 
 	void set_mode(sinsp_mode_t value)
 	{
 		m_mode = value;
 	}
 
-	void remove_thread(int64_t tid);
+	inline void remove_thread(int64_t tid)
+	{
+		m_thread_manager->remove_thread(tid);
+	}
 
 	inline const struct scap_platform* get_scap_platform() const
 	{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR attempts improving performance in the hot path by inlining few methods that are simple wrappers of the `sinsp` class to other subclasses, which are currently not inlined if not in the `sinsp.cpp` compilation unit. By profiling with valgrind, I discovered that few operations involving shared_ptrs (e.g. statsv2, add_thread, ...) have an additional useless CPU cost when not inlined.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
