### PR TITLE
update(userspace/libsinsp)!: support field transformers in filter grammar, ast, parser, and data structures

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include <libsinsp/filter.h>
 #include <libsinsp/filter/parser.h>
 #include <libsinsp/sinsp_filtercheck.h>
+#include <libsinsp/plugin_filtercheck.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_filter_expression implementation
@@ -220,6 +221,8 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 
 std::unique_ptr<sinsp_filter> sinsp_filter_compiler::compile()
 {
+	m_warnings.clear();
+
 	// parse filter string on-the-fly if not pre-parsed AST is provided
 	if (m_flt_ast == NULL)
 	{
@@ -240,7 +243,8 @@ std::unique_ptr<sinsp_filter> sinsp_filter_compiler::compile()
 	// setup compiler state and start compilation
 	m_filter = m_factory->new_filter();
 	m_last_boolop = BO_NONE;
-	m_expect_values = false;
+	m_last_node_field = nullptr;
+	m_last_node_field_is_plugin = false;
 	try
 	{
 		m_flt_ast->accept(this);
@@ -308,11 +312,16 @@ void sinsp_filter_compiler::visit(const libsinsp::filter::ast::not_expr* e)
 void sinsp_filter_compiler::visit(const libsinsp::filter::ast::unary_check_expr* e)
 {
 	m_pos = e->get_pos();
-	std::string field = create_filtercheck_name(e->field, e->arg);
-	auto check = create_filtercheck(field);
+	m_last_node_field = nullptr;
+	m_last_node_field_is_plugin = false;
+	e->left->accept(this);
+	if (!m_last_node_field)
+	{
+		throw sinsp_exception("filter error: missing field in left-hand of unary check");
+	}
+	auto check = std::move(m_last_node_field);
 	check->m_cmpop = str_to_cmpop(e->op);
 	check->m_boolop = m_last_boolop;
-	check->parse_field_name(field, true, true);
 	m_filter->add_check(std::move(check));
 }
 
@@ -338,36 +347,115 @@ static void add_filtercheck_value(sinsp_filter_check* chk, size_t idx, std::stri
 void sinsp_filter_compiler::visit(const libsinsp::filter::ast::binary_check_expr* e)
 {
 	m_pos = e->get_pos();
-	std::string field = create_filtercheck_name(e->field, e->arg);
-	auto check = create_filtercheck(field);
+	m_last_node_field = nullptr;
+	m_last_node_field_is_plugin = false;
+	e->left->accept(this);
+	if (!m_last_node_field)
+	{
+		throw sinsp_exception("filter error: missing field in left-hand of binary check");
+	}
+	
+	auto left_from_plugin = m_last_node_field_is_plugin;
+	auto check = std::move(m_last_node_field);
 	check->m_cmpop = str_to_cmpop(e->op);
 	check->m_boolop = m_last_boolop;
-	check->parse_field_name(field, true, true);
 
-	// Read the the the right-hand values of the filtercheck.
-	// For list-related operators ('in', 'intersects', 'pmatch'), the vector
-	// can be filled with more than 1 value, whereas in all other cases we
-	// expect the vector to only have 1 value. We don't check this here, as
-	// the parser is trusted to apply proper grammar checks on this constraint.
-	m_expect_values = true;
-	e->value->accept(this);
-	m_expect_values = false;
-	for (size_t i = 0; i < m_field_values.size(); i++)
+	// Read the right-hand values of the filtercheck.
+	m_last_node_field_is_plugin = false;
+	e->right->accept(this);
+
+	if (m_last_node_field)
 	{
-		add_filtercheck_value(check.get(), i, m_field_values[i]);
+		// When the lhs is a plugin filter check and the rhs side is again a plugin filter check
+		// we have an issue. Even if the 2 filter checks are different the memory for extracted values is provided by the plugin.
+		// So when we call the second extraction on the rhs filter check the previously extracted value 
+		// for the lhs filter check will be overridden.
+		//
+		// As a workaround we add a custom internal transformer `FTR_STORAGE` to the lhs filter check.
+		// The only goal of this transformer is to copy the memory storage of the extracted values from the plugin to the transformer.
+		// In this way when we have 2 extractions on a plugin filter check, the plugin will hold only the memory of the rhs filter check,
+		// while the storage of the lhs will be kept by the `FTR_STORAGE` transformer.
+		//
+		// The steps are the following:
+		// * check if both the filter checks (lhs and rhs) are plugin filter checks.
+		// * if yes, check if they are associated with the same plugin instance, otherwise, this is not an issue. We use the plugin name
+		//   to understand if the plugin is the same.
+		// * if yes, add the `FTR_STORAGE` transformer to the lhs filter check.
+		auto right_from_plugin = m_last_node_field_is_plugin;
+		if (left_from_plugin && right_from_plugin)
+		{
+			check->add_transformer(filter_transformer_type::FTR_STORAGE);
+		}
+
+		// We found another field as right-hand side of the comparison
+		check->add_filter_value(std::move(m_last_node_field));
+	}
+	else
+	{
+		// We found no field as right-hand side of the comparison, so we
+		// assume to find some constant values.
+		// For list-related operators ('in', 'intersects', 'pmatch'), the vector
+		// can be filled with more than 1 value, whereas in all other cases we
+		// expect the vector to only have 1 value. We don't check this here, as
+		// the parser is trusted to apply proper grammar checks on this constraint.
+		for (size_t i = 0; i < m_field_values.size(); i++)
+		{
+			check_value_and_add_warnings(e->right->get_pos(), m_field_values[i]);
+			add_filtercheck_value(check.get(), i, m_field_values[i]);
+		}
 	}
 	m_filter->add_check(std::move(check));
+}
+
+void sinsp_filter_compiler::visit(const libsinsp::filter::ast::identifier_expr* e)
+{
+	m_pos = e->get_pos();
+	throw sinsp_exception("filter error: unexpected identifier '" + e->identifier + "'");
+}
+
+void sinsp_filter_compiler::check_value_and_add_warnings(
+		const libsinsp::filter::ast::pos_info& pos, const std::string& v)
+{
+	try
+	{
+		// remove all spaces to catch most common errors
+		auto s = v;
+		s.erase(std::remove_if(s.begin(), s.end(), isspace), s.end());
+
+		// check if the string is a valid field
+		if (m_factory->new_filtercheck(s.c_str()) != nullptr)
+		{
+			auto msg = "string '" + v
+				+ "' may be a valid field wrongly interpreted as a string value";
+			m_warnings.push_back({msg, pos});
+		}
+
+		// check if the string may be a valid transformer
+		auto transformers = libsinsp::filter::parser::supported_field_transformers(true);
+		for (const auto& t : transformers)
+		{
+			if (s.size() >= t.size() + 2
+					&& s.compare(0, t.size(), t) == 0
+					&& s[t.size()] == '('
+					&& s.back() == ')')
+			{
+				auto msg = "string '" + v
+					+ "' may be a valid field transformer wrongly interpreted as a string value";
+				m_warnings.push_back({msg, pos});
+			}
+		}
+	}
+	catch (...)
+	{
+		// parsing invalid strings as fields may cause unexpected errors.
+		// we're not interested in any of those, we just want to catch
+		// success cases in order to emit a warning
+	}
 }
 
 void sinsp_filter_compiler::visit(const libsinsp::filter::ast::value_expr* e)
 {
 	m_pos = e->get_pos();
-	if (!m_expect_values)
-	{
-		// this ensures that identifiers, such as Falco macros, are not left
-		// unresolved at filter compilation time
-		throw sinsp_exception("filter error: unexpected identifier '" + e->value + "'");
-	}
 	m_field_values.clear();
 	m_field_values.push_back(e->value);
 }
@@ -375,14 +463,37 @@ void sinsp_filter_compiler::visit(const libsinsp::filter::ast::value_expr* e)
 void sinsp_filter_compiler::visit(const libsinsp::filter::ast::list_expr* e)
 {
 	m_pos = e->get_pos();
-	if (!m_expect_values)
-	{
-		ASSERT(false);
-		// this is not expected, as it should not be allowed by the parser
-		throw sinsp_exception("filter error: unexpected value list");
-	}
-	m_field_values.clear();
 	m_field_values = e->values;
+}
+
+void sinsp_filter_compiler::visit(const libsinsp::filter::ast::field_expr* e)
+{
+	m_pos = e->get_pos();
+	auto field_name = create_filtercheck_name(e->field, e->arg);
+	m_last_node_field = create_filtercheck(field_name);
+	m_last_node_field_is_plugin = dynamic_cast<sinsp_filter_check_plugin*>(m_last_node_field.get()) != nullptr;
+	if (m_last_node_field->parse_field_name(field_name, true, true) == -1)
+	{
+		throw sinsp_exception("filter error: can't parse field expression '" + field_name + "'");
+	}
+}
+
+void sinsp_filter_compiler::visit(const libsinsp::filter::ast::field_transformer_expr* e)
+{
+	m_pos = e->get_pos();
+	m_last_node_field = nullptr;
+	m_last_node_field_is_plugin = false;
+	e->value->accept(this);
+	if (!m_last_node_field)
+	{
+		throw sinsp_exception("filter error: found null child node on '" + e->transformer + "' transformer");
+	}
+
+	// apply transformer, ignoring the "identity one"
+	if (e->transformer != "val")
+	{
+		m_last_node_field->add_transformer(filter_transformer_from_str(e->transformer));
+	}
 }
 
 std::string sinsp_filter_compiler::create_filtercheck_name(const std::string& name, const std::string& arg)

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -188,6 +188,12 @@ class SINSP_PUBLIC sinsp_filter_compiler:
 	private libsinsp::filter::ast::const_expr_visitor
 {
 public:
+	struct message
+	{
+		std::string msg;
+		libsinsp::filter::ast::pos_info pos;
+	};
+	
 	/*!
 		\brief Constructs the compiler
 
@@ -239,27 +245,35 @@ public:
 
 	const libsinsp::filter::ast::pos_info& get_pos() const { return m_pos; }
 
+	const std::vector<message>& get_warnings() const { return m_warnings; }
+
 private:
 	void visit(const libsinsp::filter::ast::and_expr*) override;
 	void visit(const libsinsp::filter::ast::or_expr*) override;
 	void visit(const libsinsp::filter::ast::not_expr*) override;
+	void visit(const libsinsp::filter::ast::identifier_expr*) override;
 	void visit(const libsinsp::filter::ast::value_expr*) override;
 	void visit(const libsinsp::filter::ast::list_expr*) override;
 	void visit(const libsinsp::filter::ast::unary_check_expr*) override;
 	void visit(const libsinsp::filter::ast::binary_check_expr*) override;
+	void visit(const libsinsp::filter::ast::field_expr*) override;
+	void visit(const libsinsp::filter::ast::field_transformer_expr*) override;
 	cmpop str_to_cmpop(std::string_view);
 	std::string create_filtercheck_name(const std::string& name, const std::string& arg);
 	std::unique_ptr<sinsp_filter_check> create_filtercheck(std::string_view field);
+	void check_value_and_add_warnings(const libsinsp::filter::ast::pos_info& pos, const std::string& v);
 
 	libsinsp::filter::ast::pos_info m_pos;
-	bool m_expect_values;
 	boolop m_last_boolop;
+	std::unique_ptr<sinsp_filter_check> m_last_node_field;
+	bool m_last_node_field_is_plugin;
 	std::string m_flt_str;
 	std::unique_ptr<sinsp_filter> m_filter;
 	std::vector<std::string> m_field_values;
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 	const libsinsp::filter::ast::expr* m_flt_ast;
 	std::shared_ptr<sinsp_filter_factory> m_factory;
+	std::vector<message> m_warnings;
 	sinsp_filter_check_list m_default_filterlist;
 };
 

--- a/userspace/libsinsp/filter/ast.cpp
+++ b/userspace/libsinsp/filter/ast.cpp
@@ -57,15 +57,38 @@ void base_expr_visitor::visit(binary_check_expr* e)
 {
     if (!m_should_stop_visit)
     {
+        e->left->accept(this);
+    }
+
+    if (!m_should_stop_visit)
+    {
+        e->right->accept(this);
+    }
+}
+
+void base_expr_visitor::visit(unary_check_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
+        e->left->accept(this);
+    }
+}
+
+void base_expr_visitor::visit(field_transformer_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
         e->value->accept(this);
     }
 }
+
+void base_expr_visitor::visit(identifier_expr* e) { }
 
 void base_expr_visitor::visit(value_expr* e) { }
 
 void base_expr_visitor::visit(list_expr* e) { }
 
-void base_expr_visitor::visit(unary_check_expr* e) { }
+void base_expr_visitor::visit(field_expr* e) { }
 
 void const_base_expr_visitor::visit(const and_expr* e)
 {
@@ -103,128 +126,142 @@ void const_base_expr_visitor::visit(const binary_check_expr* e)
 {
     if (!m_should_stop_visit)
     {
+        e->left->accept(this);
+    }
+    if (!m_should_stop_visit)
+    {
+        e->right->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const unary_check_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
+        e->left->accept(this);
+    }
+}
+
+void const_base_expr_visitor::visit(const field_transformer_expr* e)
+{
+    if (!m_should_stop_visit)
+    {
         e->value->accept(this);
     }
 }
+
+void const_base_expr_visitor::visit(const identifier_expr* e) { }
 
 void const_base_expr_visitor::visit(const value_expr* e) { }
 
 void const_base_expr_visitor::visit(const list_expr* e) { }
 
-void const_base_expr_visitor::visit(const unary_check_expr* e) { }
+void const_base_expr_visitor::visit(const field_expr* e) { }
 
 void string_visitor::visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children)
 {
-	bool first = true;
+    bool first = true;
 
-	m_str += "(";
-
-	for (auto &c : children)
-	{
-		if(!first)
-		{
-			m_str += " ";
-			m_str += op;
-			m_str += " ";
-		}
-		first = false;
-		c->accept(this);
-	}
-	m_str += ")";
+    m_str += "(";
+    for (auto &c : children)
+    {
+        if(!first)
+        {
+            m_str += " ";
+            m_str += op;
+            m_str += " ";
+        }
+        first = false;
+        c->accept(this);
+    }
+    m_str += ")";
 }
 
 void string_visitor::visit(const and_expr* e)
 {
-	visit_logical_op("and", e->children);
+    visit_logical_op("and", e->children);
 }
 
 void string_visitor::visit(const or_expr* e)
 {
-	visit_logical_op("or", e->children);
+    visit_logical_op("or", e->children);
 }
 
 void string_visitor::visit(const not_expr* e)
 {
-	m_str += "not ";
+    m_str += "not ";
+    e->child->accept(this);
+}
 
-	e->child->accept(this);
+void string_visitor::visit(const identifier_expr* e)
+{
+    m_str += e->identifier;
 }
 
 void string_visitor::visit(const value_expr* e)
 {
-	if(escape_next_value)
-	{
-		m_str += libsinsp::filter::escape_str(e->value);
-	}
-	else
-	{
-		m_str += e->value;
-	}
-
-	escape_next_value = false;
+    m_str += libsinsp::filter::escape_str(e->value);
 }
 
 void string_visitor::visit(const list_expr* e)
 {
-	bool first = true;
+    bool first = true;
 
-	m_str += "(";
-
-	for(auto &val : e->values)
-	{
-		if(!first)
-		{
-			m_str += ", ";
-		}
-		first = false;
-		m_str += libsinsp::filter::escape_str(val);
-	}
-
-	m_str += ")";
+    m_str += "(";
+    for(auto &val : e->values)
+    {
+        if(!first)
+        {
+            m_str += ", ";
+        }
+        first = false;
+        m_str += libsinsp::filter::escape_str(val);
+    }
+    m_str += ")";
 }
 void string_visitor::visit(const unary_check_expr* e)
 {
-	m_str += e->field;
-
-	if(e->arg != "")
-	{
-		m_str += "[" + libsinsp::filter::escape_str(e->arg) + "]";
-	}
-
-	m_str += " ";
-	m_str += e->op;
+    e->left->accept(this);
+    m_str += " ";
+    m_str += e->op;
 }
 
 void string_visitor::visit(const binary_check_expr* e)
 {
-	m_str += e->field;
+    e->left->accept(this);
+    m_str += " ";
+    m_str += e->op;
+    m_str += " ";
+    e->right->accept(this);
+}
 
-	if(e->arg != "")
-	{
-	        m_str += "[" + libsinsp::filter::escape_str(e->arg) + "]";
-	}
+void string_visitor::visit(const field_expr* e)
+{
+    m_str += e->field;
+    if(e->arg != "")
+    {
+        m_str += "[" + libsinsp::filter::escape_str(e->arg) + "]";
+    }
+}
 
-	m_str += " ";
-	m_str += e->op;
-	m_str += " ";
-
-	escape_next_value = true;
-
-	e->value->accept(this);
+void string_visitor::visit(const field_transformer_expr* e)
+{
+    m_str += e->transformer;
+    m_str += "(";
+    e->value->accept(this);
+    m_str += ")";
 }
 
 const std::string& string_visitor::as_string()
 {
-	return m_str;
+    return m_str;
 }
 
 std::string libsinsp::filter::ast::as_string(const ast::expr *e)
 {
-	string_visitor sv;
-
-	e->accept(&sv);
-
-	return sv.as_string();
+    string_visitor sv;
+    e->accept(&sv);
+    return sv.as_string();
 }
 
 std::unique_ptr<expr> libsinsp::filter::ast::clone(const expr* e)
@@ -263,13 +300,23 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(const expr* e)
 
         void visit(const binary_check_expr* e) override
         {
-            e->value->accept(this);
-            m_last_node = binary_check_expr::create(e->field, e->arg, e->op, std::move(m_last_node), e->get_pos());
+            e->left->accept(this);
+            auto left = std::move(m_last_node);
+            e->right->accept(this);
+            auto right = std::move(m_last_node);
+            m_last_node = binary_check_expr::create(std::move(left), e->op, std::move(right), e->get_pos());
         }
 
         void visit(const unary_check_expr* e) override
         {
-            m_last_node = unary_check_expr::create(e->field, e->arg, e->op, e->get_pos());
+            e->left->accept(this);
+            auto left = std::move(m_last_node);
+            m_last_node = unary_check_expr::create(std::move(left), e->op, e->get_pos());
+        }
+
+        void visit(const identifier_expr* e) override
+        {
+            m_last_node = identifier_expr::create(e->identifier, e->get_pos());
         }
 
         void visit(const value_expr* e) override
@@ -280,6 +327,18 @@ std::unique_ptr<expr> libsinsp::filter::ast::clone(const expr* e)
         void visit(const list_expr* e) override
         {
             m_last_node = list_expr::create(e->values, e->get_pos());
+        }
+
+        void visit(const field_expr* e) override
+        {
+            m_last_node = field_expr::create(e->field, e->arg, e->get_pos());
+        }
+
+        void visit(const field_transformer_expr* e) override
+        {
+            e->value->accept(this);
+            auto value = std::move(m_last_node);
+            m_last_node = field_transformer_expr::create(e->transformer, std::move(value), e->get_pos());
         }
     } visitor;
 

--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -32,53 +32,54 @@ class expr;
 struct and_expr;
 struct or_expr;
 struct not_expr;
+struct identifier_expr;
 struct value_expr;
 struct list_expr;
 struct unary_check_expr;
 struct binary_check_expr;
+struct field_expr;
+struct field_transformer_expr;
 
 /*!
-	\brief A struct containing info about the position of the parser
-	relatively to the string input. For example, this can either be used
-	to retrieve context information when an exception is thrown.
+    \brief A struct containing info about the position of the parser
+    relatively to the string input. For example, this can either be used
+    to retrieve context information when an exception is thrown.
 */
 struct pos_info
 {
-	pos_info()
-	{
-		reset();
-	}
-	pos_info(uint32_t i, uint32_t l, uint32_t c): idx(i), line(l), col(c) { }
-	pos_info(pos_info&&) = default;
-	pos_info& operator = (pos_info&&) = default;
-	pos_info(const pos_info&) = default;
-	pos_info& operator = (const pos_info&) = default;
-	bool operator ==(const pos_info &b) const
+    pos_info() = default;
+    ~pos_info() = default;
+    pos_info(uint32_t i, uint32_t l, uint32_t c): idx(i), line(l), col(c) { }
+    pos_info(pos_info&&) = default;
+    pos_info& operator = (pos_info&&) = default;
+    pos_info(const pos_info&) = default;
+    pos_info& operator = (const pos_info&) = default;
+    bool operator ==(const pos_info &b) const
     {
         return idx == b.idx && line == b.line && col == b.col;
     }
-	bool operator !=(const pos_info &b) const
+    bool operator !=(const pos_info &b) const
     {
         return idx != b.idx || line != b.line || col != b.col;
     }
 
-	inline void reset()
-	{
-		idx = 0;
-		line = 1;
-		col = 1;
-	}
+    inline void reset()
+    {
+        idx = 0;
+        line = 1;
+        col = 1;
+    }
 
-	inline std::string as_string() const
-	{
-		return "index " + std::to_string(idx)
-			+ ", line " + std::to_string(line)
-			+ ", column " + std::to_string(col);
-	}
+    inline std::string as_string() const
+    {
+        return "index " + std::to_string(idx)
+            + ", line " + std::to_string(line)
+            + ", column " + std::to_string(col);
+    }
 
-	uint32_t idx;
-	uint32_t line;
-	uint32_t col;
+    uint32_t idx = 0;
+    uint32_t line = 1;
+    uint32_t col = 1;
 };
 
 static pos_info s_initial_pos;
@@ -92,10 +93,13 @@ struct SINSP_PUBLIC expr_visitor
     virtual void visit(and_expr*) = 0;
     virtual void visit(or_expr*) = 0;
     virtual void visit(not_expr*) = 0;
+    virtual void visit(identifier_expr*) = 0;
     virtual void visit(value_expr*) = 0;
     virtual void visit(list_expr*) = 0;
     virtual void visit(unary_check_expr*) = 0;
     virtual void visit(binary_check_expr*) = 0;
+    virtual void visit(field_expr*) = 0;
+    virtual void visit(field_transformer_expr*) = 0;
 };
 
 /*!
@@ -107,10 +111,13 @@ struct SINSP_PUBLIC const_expr_visitor
     virtual void visit(const and_expr*) = 0;
     virtual void visit(const or_expr*) = 0;
     virtual void visit(const not_expr*) = 0;
+    virtual void visit(const identifier_expr*) = 0;
     virtual void visit(const value_expr*) = 0;
     virtual void visit(const list_expr*) = 0;
     virtual void visit(const unary_check_expr*) = 0;
     virtual void visit(const binary_check_expr*) = 0;
+    virtual void visit(const field_expr*) = 0;
+    virtual void visit(const field_transformer_expr*) = 0;
 };
 
 /*!
@@ -136,10 +143,13 @@ public:
     virtual void visit(and_expr*) override;
     virtual void visit(or_expr*) override;
     virtual void visit(not_expr*) override;
+    virtual void visit(identifier_expr*) override;
     virtual void visit(value_expr*) override;
     virtual void visit(list_expr*) override;
     virtual void visit(unary_check_expr*) override;
     virtual void visit(binary_check_expr*) override;
+    virtual void visit(field_expr*) override;
+    virtual void visit(field_transformer_expr*) override;
 
 private:
     bool m_should_stop_visit = false;
@@ -165,10 +175,13 @@ public:
     virtual void visit(const and_expr*) override;
     virtual void visit(const or_expr*) override;
     virtual void visit(const not_expr*) override;
+    virtual void visit(const identifier_expr*) override;
     virtual void visit(const value_expr*) override;
     virtual void visit(const list_expr*) override;
     virtual void visit(const unary_check_expr*) override;
     virtual void visit(const binary_check_expr*) override;
+    virtual void visit(const field_expr*) override;
+    virtual void visit(const field_transformer_expr*) override;
 
 private:
     bool m_should_stop_visit = false;
@@ -181,26 +194,25 @@ private:
 struct SINSP_PUBLIC string_visitor: public const_expr_visitor
 {
 public:
-	virtual ~string_visitor() = default;
-	virtual void visit(const and_expr*) override;
-	virtual void visit(const or_expr*) override;
-	virtual void visit(const not_expr*) override;
-	virtual void visit(const value_expr*) override;
-	virtual void visit(const list_expr*) override;
-	virtual void visit(const unary_check_expr*) override;
-	virtual void visit(const binary_check_expr*) override;
+    virtual ~string_visitor() = default;
+    virtual void visit(const and_expr*) override;
+    virtual void visit(const or_expr*) override;
+    virtual void visit(const not_expr*) override;
+    virtual void visit(const identifier_expr*) override;
+    virtual void visit(const value_expr*) override;
+    virtual void visit(const list_expr*) override;
+    virtual void visit(const unary_check_expr*) override;
+    virtual void visit(const binary_check_expr*) override;
+    virtual void visit(const field_expr*) override;
+    virtual void visit(const field_transformer_expr*) override;
 
-	const std::string& as_string();
+    const std::string& as_string();
 
 protected:
 
-	void visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children);
+    void visit_logical_op(const char *op, const std::vector<std::unique_ptr<expr>> &children);
 
-	// If true, the next call to vist(value_expr*) will escape the
-	// value. This occurs for any right hand side of a binary check.
-	bool escape_next_value = false;
-
-	std::string m_str;
+    std::string m_str;
 };
 
 /*!
@@ -224,14 +236,15 @@ private:
 /*!
     \brief Compares two ASTs, returns true if they are deep equal
 */
-inline bool compare(const expr* left, const expr* right)
+static inline bool compare(const expr* left, const expr* right)
 {
     return left->is_equal(right);
 };
 
 struct SINSP_PUBLIC and_expr: expr
 {
-    and_expr() { }
+    and_expr() = default;
+    virtual ~and_expr() = default;
 
     explicit and_expr(std::vector<std::unique_ptr<expr>> &c): children(std::move(c)) { }
 
@@ -267,17 +280,18 @@ struct SINSP_PUBLIC and_expr: expr
     std::vector<std::unique_ptr<expr>> children;
 
     static std::unique_ptr<and_expr> create(std::vector<std::unique_ptr<expr>> &c,
-					    const libsinsp::filter::ast::pos_info &pos = s_initial_pos)
+                        const libsinsp::filter::ast::pos_info &pos = s_initial_pos)
     {
-        std::unique_ptr<and_expr> ret(new and_expr(c));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<and_expr>(c);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC or_expr: expr
 {
-    or_expr() { }
+    or_expr() = default;
+    virtual ~or_expr() = default;
 
     explicit or_expr(std::vector<std::unique_ptr<expr>> &c): children(std::move(c)) { }
 
@@ -313,17 +327,18 @@ struct SINSP_PUBLIC or_expr: expr
     std::vector<std::unique_ptr<expr>> children;
 
     static std::unique_ptr<or_expr> create(std::vector<std::unique_ptr<expr>> &c,
-					   const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+                       const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-        std::unique_ptr<or_expr> ret(new or_expr(c));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<or_expr>(c);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC not_expr: expr
 {
-    not_expr() { }
+    not_expr() = default;
+    virtual ~not_expr() = default;
 
     explicit not_expr(std::unique_ptr<expr> c): child(std::move(c)) { }
 
@@ -346,17 +361,52 @@ struct SINSP_PUBLIC not_expr: expr
     std::unique_ptr<expr> child;
 
     static std::unique_ptr<not_expr> create(std::unique_ptr<expr> c,
-					    const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+                        const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-        std::unique_ptr<not_expr> ret(new not_expr(std::move(c)));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<not_expr>(std::move(c));
+        ret->set_pos(pos);
+        return ret;
+    }
+};
+
+struct SINSP_PUBLIC identifier_expr: expr
+{
+    identifier_expr() = default;
+    virtual ~identifier_expr() = default;
+
+    explicit identifier_expr(const std::string& i): identifier(i) { }
+
+    void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
+    bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const identifier_expr*>(other);
+        return o != nullptr && identifier == o->identifier;
+    }
+
+    std::string identifier;
+
+    static std::unique_ptr<identifier_expr> create(const std::string& i,
+                          const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+    {
+        auto ret = std::make_unique<identifier_expr>(i);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC value_expr: expr
 {
-    value_expr() { }
+    value_expr() = default;
+    virtual ~value_expr() = default;
 
     explicit value_expr(const std::string& v): value(v) { }
 
@@ -379,17 +429,18 @@ struct SINSP_PUBLIC value_expr: expr
     std::string value;
 
     static std::unique_ptr<value_expr> create(const std::string& v,
-					      const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+                          const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-        std::unique_ptr<value_expr> ret(new value_expr(v));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<value_expr>(v);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC list_expr: expr
 {
-    list_expr() { }
+    list_expr() = default;
+    virtual ~list_expr() = default;
 
     explicit list_expr(const std::vector<std::string>& v): values(v) { }
 
@@ -412,22 +463,22 @@ struct SINSP_PUBLIC list_expr: expr
     std::vector<std::string> values;
 
     static std::unique_ptr<list_expr> create(const std::vector<std::string>& v,
-					     const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+                         const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-        std::unique_ptr<list_expr> ret(new list_expr(v));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<list_expr>(v);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC unary_check_expr: expr
 {
-    unary_check_expr() { }
+    unary_check_expr() = default;
+    virtual ~unary_check_expr() = default;
 
     unary_check_expr(
-        const std::string& f,
-        const std::string& a,
-        const std::string& o): field(f), arg(a), op(o) { }
+        std::unique_ptr<expr> l,
+        const std::string& o): left(std::move(l)), op(o) { }
 
     void accept(expr_visitor* v) override
     {
@@ -442,34 +493,32 @@ struct SINSP_PUBLIC unary_check_expr: expr
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const unary_check_expr*>(other);
-        return o != nullptr && field == o->field
-            && arg == o->arg && op == o->op;
+        return o != nullptr && left->is_equal(o->left.get());
     }
 
-    std::string field;
-    std::string arg;
+    std::unique_ptr<expr> left;
     std::string op;
 
-    static std::unique_ptr<unary_check_expr> create(const std::string& f,
-        const std::string& a,
+    static std::unique_ptr<unary_check_expr> create(
+        std::unique_ptr<expr> l,
         const std::string& o,
         const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-	std::unique_ptr<unary_check_expr> ret(new unary_check_expr(f, a, o));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<unary_check_expr>(std::move(l), o);
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 struct SINSP_PUBLIC binary_check_expr: expr
 {
-    binary_check_expr() { }
+    binary_check_expr() = default;
+    virtual ~binary_check_expr() = default;
 
     binary_check_expr(
-        const std::string& f,
-        const std::string& a,
+        std::unique_ptr<expr> l,
         const std::string& o,
-        std::unique_ptr<expr> &v): field(f), arg(a), op(o), value(std::move(v)) { }
+        std::unique_ptr<expr> r): left(std::move(l)), op(o), right(std::move(r)) { }
 
     void accept(expr_visitor* v) override
     {
@@ -484,37 +533,114 @@ struct SINSP_PUBLIC binary_check_expr: expr
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const binary_check_expr*>(other);
-        return o != nullptr && field == o->field
-            && arg == o->arg && op == o->op && value->is_equal(o->value.get());
+        return o != nullptr
+            && left->is_equal(o->left.get())
+            && right->is_equal(o->right.get());
+    }
+
+    std::unique_ptr<expr> left;
+    std::string op;
+    std::unique_ptr<expr> right;
+
+    static std::unique_ptr<binary_check_expr> create(
+        std::unique_ptr<expr> l,
+        const std::string& o,
+        std::unique_ptr<expr> r,
+        const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+    {
+        auto ret = std::make_unique<binary_check_expr>(std::move(l), o, std::move(r));
+        ret->set_pos(pos);
+        return ret;
+    }
+};
+
+struct SINSP_PUBLIC field_expr: expr
+{
+    field_expr() = default;
+    virtual ~field_expr() = default;
+
+    field_expr(
+        const std::string& f,
+        const std::string& a): field(f), arg(a) { }
+
+    void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
+    bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const field_expr*>(other);
+        return o != nullptr && field == o->field && arg == o->arg;
     }
 
     std::string field;
     std::string arg;
-    std::string op;
-    std::unique_ptr<expr> value;
 
-    static std::unique_ptr<binary_check_expr> create(
+    static std::unique_ptr<field_expr> create(
         const std::string& f,
         const std::string& a,
-        const std::string& o,
-        std::unique_ptr<expr> v,
-	const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+        const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
     {
-        std::unique_ptr<binary_check_expr> ret(new binary_check_expr(f, a, o, v));
-	ret->set_pos(pos);
-	return ret;
+        auto ret = std::make_unique<field_expr>(f, a);
+        ret->set_pos(pos);
+        return ret;
+    }
+};
+
+struct SINSP_PUBLIC field_transformer_expr: expr
+{
+    field_transformer_expr() = default;
+    virtual ~field_transformer_expr() = default;
+
+    field_transformer_expr(
+        const std::string& t,
+        std::unique_ptr<expr> v): transformer(t), value(std::move(v)) { }
+
+    void accept(expr_visitor* v) override
+    {
+        v->visit(this);
+    };
+
+    void accept(const_expr_visitor* v) const override
+    {
+        v->visit(this);
+    };
+
+    bool is_equal(const expr* other) const override
+    {
+        auto o = dynamic_cast<const field_transformer_expr*>(other);
+        return o != nullptr && transformer == o->transformer && value->is_equal(o->value.get());
+    }
+
+    std::string transformer;
+    std::unique_ptr<expr> value;
+
+    static std::unique_ptr<field_transformer_expr> create(
+        const std::string& m,
+        std::unique_ptr<expr> v,
+        const libsinsp::filter::ast::pos_info& pos = s_initial_pos)
+    {
+        auto ret = std::make_unique<field_transformer_expr>(m, std::move(v));
+        ret->set_pos(pos);
+        return ret;
     }
 };
 
 /*!
-	\brief Return a string representation of an AST.
-	\return A string representation of an AST.
+    \brief Return a string representation of an AST.
+    \return A string representation of an AST.
 */
 std::string as_string(const ast::expr *e);
 
 /*!
-	\brief Creates a deep clone of a filter AST
-	\return The newly created cloned AST. Comparing the return value
+    \brief Creates a deep clone of a filter AST
+    \return The newly created cloned AST. Comparing the return value
     with the input parameter returns true
 */
 std::unique_ptr<expr> clone(const expr* e);

--- a/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
+++ b/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
@@ -288,3 +288,44 @@ TEST_CODES(filter_ppm_codes, check_properties)
     ASSERT_FILTER_EQ(t, "not (proc.name=cat or fd.type=file)", "not (fd.type=file or proc.name=cat)");
     ASSERT_FILTER_EQ(t, "not proc.name=cat or not fd.type=file", "not fd.type=file or not proc.name=cat");
 }
+
+TEST_CODES(filter_ppm_codes, field_transformers)
+{
+    auto parse = [](const std::string& f) {
+        libsinsp::filter::ast::ppm_event_codes(libsinsp::filter::parser(f).parse().get());
+    };
+    
+    ASSERT_NO_THROW(parse("evt.type = close"));
+    ASSERT_NO_THROW(parse("b64(proc.name) = cat"));
+    ASSERT_NO_THROW(parse("proc.name = b64(fd.name)"));
+    ASSERT_NO_THROW(parse("b64(proc.name) = b64(fd.name)"));
+    ASSERT_NO_THROW(parse("evt.type != close"));
+    ASSERT_NO_THROW(parse("b64(proc.name) != cat"));
+    ASSERT_NO_THROW(parse("proc.name != b64(fd.name)"));
+    ASSERT_NO_THROW(parse("b64(proc.name) != b64(fd.name)"));
+    ASSERT_NO_THROW(parse("not evt.type = close"));
+    ASSERT_NO_THROW(parse("not b64(proc.name) = cat"));
+    ASSERT_NO_THROW(parse("not proc.name = b64(fd.name)"));
+    ASSERT_NO_THROW(parse("not b64(proc.name) = b64(fd.name)"));
+    ASSERT_NO_THROW(parse("not evt.type != close"));
+    ASSERT_NO_THROW(parse("not b64(proc.name) != cat"));
+    ASSERT_NO_THROW(parse("not proc.name != b64(fd.name)"));
+    ASSERT_NO_THROW(parse("not b64(proc.name) != b64(fd.name)"));
+
+    ASSERT_ANY_THROW(parse("b64(evt.type) = close"));
+    ASSERT_ANY_THROW(parse("evt.type = b64(proc.name)"));
+    ASSERT_ANY_THROW(parse("evt.type = val(proc.name)"));
+    ASSERT_ANY_THROW(parse("b64(evt.type) = val(proc.name)"));
+    ASSERT_ANY_THROW(parse("b64(evt.type) != close"));
+    ASSERT_ANY_THROW(parse("evt.type != b64(proc.name)"));
+    ASSERT_ANY_THROW(parse("evt.type != val(proc.name)"));
+    ASSERT_ANY_THROW(parse("b64(evt.type) != val(proc.name)"));
+    ASSERT_ANY_THROW(parse("not b64(evt.type) = close"));
+    ASSERT_ANY_THROW(parse("not evt.type = b64(proc.name)"));
+    ASSERT_ANY_THROW(parse("not evt.type = val(proc.name)"));
+    ASSERT_ANY_THROW(parse("not b64(evt.type) = val(proc.name)"));
+    ASSERT_ANY_THROW(parse("not b64(evt.type) != close"));
+    ASSERT_ANY_THROW(parse("not evt.type != b64(proc.name)"));
+    ASSERT_ANY_THROW(parse("not evt.type != val(proc.name)"));
+    ASSERT_ANY_THROW(parse("not b64(evt.type) != val(proc.name)"));
+}

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -143,6 +143,13 @@ TEST(plugins, broken_async_capability)
 	ASSERT_ANY_THROW(register_plugin_api(inspector.get(), api));
 }
 
+static bool evaluate_filter_str(sinsp* inspector, std::string filter_str, sinsp_evt* evt, filter_check_list& list)
+{
+	sinsp_filter_compiler compiler(std::make_shared<sinsp_filter_factory>(inspector, list), filter_str);
+	auto filter = compiler.compile();
+	return filter->run(evt);
+}
+
 // scenario: a plugin with field extraction capability compatible with the
 // "syscall" event source should be able to extract filter values from
 // regular syscall events produced by any scap engine.
@@ -177,6 +184,29 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract)
 	ASSERT_FALSE(field_has_value(evt, "sample.open_count", pl_flist));
 	ASSERT_FALSE(field_has_value(evt, "sample.evt_count", pl_flist));
 	ASSERT_EQ(get_field_as_string(evt, "sample.tick", pl_flist), "false");
+
+	// Check rhs filter checks support on plugins
+	
+	// Check on strings
+	ASSERT_EQ(get_field_as_string(evt, "sample.proc_name", pl_flist), "init");
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(sample.proc_name = init)", evt, pl_flist));
+	ASSERT_FALSE(evaluate_filter_str(&m_inspector, "(sample.proc_name = sample.proc_name)", evt, pl_flist));
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(sample.proc_name = val(sample.proc_name))", evt, pl_flist));
+	ASSERT_FALSE(evaluate_filter_str(&m_inspector, "(sample.proc_name = val(sample.tick))", evt, pl_flist));
+	ASSERT_FALSE(evaluate_filter_str(&m_inspector, "(sample.proc_name = val(evt.pluginname))", evt, pl_flist));
+	ASSERT_FALSE(evaluate_filter_str(&m_inspector, "(evt.pluginname = val(sample.proc_name))", evt, pl_flist));
+
+	// Check on uin64_t
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(sample.is_open = 1)", evt, pl_flist));
+	ASSERT_THROW(evaluate_filter_str(&m_inspector, "(sample.is_open = sample.is_open)", evt, pl_flist), sinsp_exception);
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(sample.is_open = val(sample.is_open))", evt, pl_flist));
+
+	// Check transformers on plugins filter checks
+	ASSERT_FALSE(evaluate_filter_str(&m_inspector, "(toupper(sample.proc_name) = init)", evt, pl_flist));
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(toupper(sample.proc_name) = INIT)", evt, pl_flist));
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(tolower(toupper(sample.proc_name)) = init)", evt, pl_flist));
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(tolower(toupper(sample.proc_name)) = tolower(toupper(sample.proc_name)))", evt, pl_flist));
+	ASSERT_TRUE(evaluate_filter_str(&m_inspector, "(toupper(sample.proc_name) = toupper(sample.proc_name))", evt, pl_flist));
 
 	// Here `sample.is_open` should be false
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_INOTIFY_INIT1_X, 2, (int64_t)12, (uint16_t)32);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Moving forward with https://github.com/falcosecurity/libs/issues/1789, this PR:
- Updates the grammar of libsinsp filters to support field transformers as documented in https://github.com/falcosecurity/libs/issues/1789
    - Note: as for all the checks, analysis, and tests, this is not expected to be a breaking change. The grammar is backward compatible, and all the newly introduced notations used to be rejected by previous versions of the grammar and its parser
- Refactors the AST definitions used for parsing the filtering grammar to represent field transformers, fields, and also identifiers (this was a disambiguation requirement we had since two years, so we batch all the AST changes we need into a single round)
    - Note: for whoever developed visitors on top of the AST structure known so far, **this may be a code breaking change** with a clear transition path. We'll adapt Falco accordingly in subsequent PRs
- Updates the filter syntax parser to implement the new grammar and produce the new AST structure
- Updates the filter compiler to turn ASTs into the runtime-evaluable tree-like data structure implementing the filters. Support to modifiers has already been added as a building block in https://github.com/falcosecurity/libs/pull/1795
- Tests all over the place for both the grammar/parser (also rejection cases, of course) and the compiler's output
    - Note: I took care of testing Falco on this too, with both our unit tests and regression tests

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/libsinsp)!: support field transformers in filter grammar, ast, parser, and data structures
```
