### PR TITLE
fix(userspace/libsinsp): remove wrong ASSERTs

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -802,7 +802,6 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo)
 	// Ensure the index points to an actual FD
 	if (dir_param_info->type != PT_FD)
 	{
-		ASSERT(dir_param_info->type == PT_FD);
 		return cwd;
 	}
 

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -374,7 +374,6 @@ bool sinsp_fdtable::erase(int64_t fd)
 		// call that created this fd. The assertion will detect it, while in release mode we just
 		// keep going.
 		//
-		ASSERT(false);
 		if (m_inspector != nullptr && m_inspector->get_sinsp_stats_v2())
 		{
 			m_inspector->get_sinsp_stats_v2()->m_n_failed_fd_lookups++;

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -310,7 +310,6 @@ size_t sinsp_logger::decode_severity(const std::string &str, severity& sev)
 void sinsp_logger::reset()
 {
 	m_callback = nullptr;
-	m_flags = OT_NONE;
 	m_sev = SEV_INFO;
 	if(m_file)
 	{
@@ -318,6 +317,7 @@ void sinsp_logger::reset()
 		fclose(m_file);
 		m_file = nullptr;
 	}
+	m_flags = OT_NONE;
 }
 
 sinsp_logger* libsinsp_logger()

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -1520,7 +1520,6 @@ bool sinsp_filter_check::compare_rhs(cmpop op, ppm_param_type type, std::vector<
 				}
 				return false;
 			default:
-				ASSERT(false);
 				throw sinsp_exception("list filter '"
 					+ std::string(m_info.m_fields[m_field_id].m_name)
 					+ "' only supports operators 'exists', 'in' and 'intersects'");


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When running the unit tests with a debug build, I found a bunch of ASSERTs that trigger systematically and that prevent the tests from running properly, so this PR attempts cleaning up a bit those cases.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.17.0

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
