### PR TITLE
refactor: smart pointer usage

### DIFF
--- a/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/fork_x.cpp
@@ -132,9 +132,9 @@ TEST(SyscallExit, forkX_father)
 
 TEST(SyscallExit, forkX_child)
 {
-	auto evt_test = new event_test(__NR_fork, EXIT_EVENT);
+	event_test evt_test(__NR_fork, EXIT_EVENT);
 
-	evt_test->enable_capture();
+	evt_test.enable_capture();
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
@@ -166,7 +166,7 @@ TEST(SyscallExit, forkX_child)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->disable_capture();
+	evt_test.disable_capture();
 
 	/* In some architectures we are not able to catch the `clone exit child
 	 * event` from the `sys_exit` tracepoint. This is because there is no
@@ -174,61 +174,61 @@ TEST(SyscallExit, forkX_child)
 	 * info in `driver/feature_gates.h`.
 	 */
 #ifdef CAPTURE_SCHED_PROC_FORK
-	evt_test->assert_event_absence(ret_pid);
+	evt_test.assert_event_absence(ret_pid);
 #else
-	evt_test->assert_event_presence(ret_pid);
+	evt_test.assert_event_presence(ret_pid);
 
 	if(HasFatalFailure())
 	{
 		return;
 	}
 
-	evt_test->parse_event();
+	evt_test.parse_event();
 
-	evt_test->assert_header();
+	evt_test.assert_header();
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_PID)*/
-	evt_test->assert_numeric_param(1, (int64_t)0);
+	evt_test.assert_numeric_param(1, (int64_t)0);
 
 	/* Parameter 2: exe (type: PT_CHARBUF) */
 #ifndef __powerpc64__ // Page fault
-	evt_test->assert_charbuf_param(2, info.args[0]);
+	evt_test.assert_charbuf_param(2, info.args[0]);
 
 	/* Parameter 3: args (type: PT_CHARBUFARRAY) */
 	/* Starting from `1` because the first is `exe`. */
-	evt_test->assert_charbuf_array_param(3, &info.args[1]);
+	evt_test.assert_charbuf_array_param(3, &info.args[1]);
 #endif
 	/* Parameter 4: tid (type: PT_PID) */
-	evt_test->assert_numeric_param(4, (int64_t)ret_pid);
+	evt_test.assert_numeric_param(4, (int64_t)ret_pid);
 
 	/* Parameter 5: pid (type: PT_PID) */
 	/* We are the main thread of the process so it's equal to `tid`. */
-	evt_test->assert_numeric_param(5, (int64_t)ret_pid);
+	evt_test.assert_numeric_param(5, (int64_t)ret_pid);
 
 	/* Parameter 6: ptid (type: PT_PID) */
-	evt_test->assert_numeric_param(6, (int64_t)::getpid());
+	evt_test.assert_numeric_param(6, (int64_t)::getpid());
 
 	/* Parameter 7: cwd (type: PT_CHARBUF) */
 	/* leave the current working directory empty like in the old probe. */
-	evt_test->assert_empty_param(7);
+	evt_test.assert_empty_param(7);
 
 	/* Parameter 14: comm (type: PT_CHARBUF) */
-	evt_test->assert_charbuf_param(14, TEST_EXECUTABLE_NAME);
+	evt_test.assert_charbuf_param(14, TEST_EXECUTABLE_NAME);
 
 	/* Parameter 15: cgroups (type: PT_CHARBUFARRAY) */
-	evt_test->assert_cgroup_param(15);
+	evt_test.assert_cgroup_param(15);
 
 	/* Parameter 16: flags (type: PT_FLAGS32) */
-	evt_test->assert_numeric_param(16, (uint32_t)0);
+	evt_test.assert_numeric_param(16, (uint32_t)0);
 
 	/* Parameter 21: pid_namespace init task start_time monotonic time in ns (type: PT_UINT64) */
-	evt_test->assert_numeric_param(21, (uint64_t)0, GREATER_EQUAL);
+	evt_test.assert_numeric_param(21, (uint64_t)0, GREATER_EQUAL);
 
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-	evt_test->assert_num_params_pushed(21);
+	evt_test.assert_num_params_pushed(21);
 
 #endif
 }

--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -191,12 +191,12 @@ bool podman::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 {
 	std::string container_id, api_sock;
 
-	if(m_api_sock_can_exist == nullptr)
+	if(!m_api_sock_can_exist.has_value())
 	{
-		m_api_sock_can_exist.reset(new bool(can_api_sock_exist()));
+		m_api_sock_can_exist = can_api_sock_exist();
 	}
 
-	if(! (*(m_api_sock_can_exist.get())))
+	if(!m_api_sock_can_exist.value())
 	{
 		return false;
 	}

--- a/userspace/libsinsp/container_engine/docker/podman.h
+++ b/userspace/libsinsp/container_engine/docker/podman.h
@@ -2,6 +2,8 @@
 
 #include <libsinsp/container_engine/docker/base.h>
 
+#include <optional>
+
 namespace libsinsp {
 namespace container_engine {
 
@@ -16,7 +18,7 @@ private:
 
 	// true if any file matching any possible api socket pattern
 	// exists. Is set at the first call to resolve()
-	std::unique_ptr<bool> m_api_sock_can_exist;
+	std::optional<bool> m_api_sock_can_exist;
 
 	// Return true if any possible api socket pattern exists.
 	bool can_api_sock_exist();

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -120,9 +120,7 @@ public:
 
 	virtual std::unique_ptr<sinsp_fdinfo> clone() const
 	{
-		auto ret = std::make_unique<sinsp_fdinfo>();
-		*(ret.get()) = *this;
-		return ret;
+		return std::make_unique<sinsp_fdinfo>(*this);
 	}
 
 	/*!
@@ -462,7 +460,7 @@ public:
 	{
 		for(auto it = m_table.begin(); it != m_table.end(); ++it)
 		{
-			if (!callback(it->first, *(it->second.get())))
+			if (!callback(it->first, *it->second))
 			{
 				return false;
 			}
@@ -474,7 +472,7 @@ public:
 	{
 		for(auto it = m_table.begin(); it != m_table.end(); ++it)
 		{
-			if (!callback(it->first, *(it->second.get())))
+			if (!callback(it->first, *it->second))
 			{
 				return false;
 			}

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -192,30 +192,25 @@ void sinsp_filter::add_check(std::unique_ptr<sinsp_filter_check> chk)
 sinsp_filter_compiler::sinsp_filter_compiler(
 		sinsp* inspector,
 		const std::string& fltstr)
+	: m_flt_str(fltstr),
+	  m_factory(std::make_shared<sinsp_filter_factory>(inspector, m_default_filterlist))
 {
-	m_factory.reset(new sinsp_filter_factory(inspector, m_default_filterlist));
-	m_filter = NULL;
-	m_flt_str = fltstr;
-	m_flt_ast = NULL;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
 		std::shared_ptr<sinsp_filter_factory> factory,
 		const std::string& fltstr)
+	: m_flt_str(fltstr),
+	  m_factory(factory)
 {
-	m_factory = factory;
-	m_filter = NULL;
-	m_flt_str = fltstr;
-	m_flt_ast = NULL;
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
 		std::shared_ptr<sinsp_filter_factory> factory,
 		const libsinsp::filter::ast::expr* fltast)
+	: m_flt_ast(fltast),
+	  m_factory(factory)
 {
-	m_factory = factory;
-	m_filter = NULL;
-	m_flt_ast = fltast;
 }
 
 std::unique_ptr<sinsp_filter> sinsp_filter_compiler::compile()

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -258,7 +258,7 @@ private:
 	std::unique_ptr<sinsp_filter> m_filter;
 	std::vector<std::string> m_field_values;
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
-	const libsinsp::filter::ast::expr* m_flt_ast;
+	const libsinsp::filter::ast::expr* m_flt_ast = nullptr;
 	std::shared_ptr<sinsp_filter_factory> m_factory;
 	sinsp_filter_check_list m_default_filterlist;
 };

--- a/userspace/libsinsp/mpsc_priority_queue.h
+++ b/userspace/libsinsp/mpsc_priority_queue.h
@@ -111,7 +111,7 @@ public:
 			// we just checked.
 			elm_ptr top = m_queue_top.load();
 			auto should_pop = pred(*top);
-			
+
 			// we must not pop the element
 			if (!should_pop)
 			{
@@ -166,8 +166,8 @@ private:
 			// gives the same result when inverting the operands, then we can
 			// assume them being equal.
 			Cmp c{};
-			auto res = c(*elm.get(), *r.elm.get());
-			if (res == c(*r.elm.get(), *elm.get()))
+			auto res = c(*elm, *r.elm);
+			if (res == c(*r.elm, *elm))
 			{
 				// if elements have the same priority, order them by
 				// temporal order of arrival in the queue by using an atomic

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -396,7 +396,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val, bool a
 		if(alloc_state)
 		{
 			auto acc = m_inspector->m_thread_manager->dynamic_fields()->add_field<uint64_t>("_tmp_sinsp_filter_thread_totexectime");
-			m_thread_dyn_field_accessor.reset(new libsinsp::state::dynamic_struct::field_accessor<uint64_t>(acc.new_accessor<uint64_t>()));
+			m_thread_dyn_field_accessor =
+				std::make_unique<libsinsp::state::dynamic_struct::field_accessor<uint64_t>>(acc.new_accessor<uint64_t>());
 		}
 
 		return sinsp_filter_check::parse_field_name(val, alloc_state, needed_for_filtering);
@@ -414,7 +415,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val, bool a
 		if(alloc_state)
 		{
 			auto acc = m_inspector->m_thread_manager->dynamic_fields()->add_field<uint64_t>("_tmp_sinsp_filter_thread_cpu");
-			m_thread_dyn_field_accessor.reset(new libsinsp::state::dynamic_struct::field_accessor<uint64_t>(acc.new_accessor<uint64_t>()));
+			m_thread_dyn_field_accessor =
+				std::make_unique<libsinsp::state::dynamic_struct::field_accessor<uint64_t>>(acc.new_accessor<uint64_t>());
 		}
 
 		return sinsp_filter_check::parse_field_name(val, alloc_state, needed_for_filtering);
@@ -486,7 +488,7 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 		tcpu = user + system;
 
 		uint64_t last_t_tot_cpu = 0;
-		tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get(), last_t_tot_cpu);
+		tinfo->get_dynamic_field(*m_thread_dyn_field_accessor, last_t_tot_cpu);
 		if(last_t_tot_cpu != 0)
 		{
 			uint64_t deltaval = tcpu - last_t_tot_cpu;
@@ -501,7 +503,7 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt *evt, OUT uint3
 			m_dval = 0;
 		}
 
-		tinfo->set_dynamic_field(*m_thread_dyn_field_accessor.get(), tcpu);
+		tinfo->set_dynamic_field(*m_thread_dyn_field_accessor, tcpu);
 
 		RETURN_EXTRACT_VAR(m_dval);
 	}
@@ -978,9 +980,9 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, OUT uint32_t*
 			if(tinfo != NULL)
 			{
 				uint64_t ptot = 0;
-				tinfo->get_dynamic_field(*m_thread_dyn_field_accessor.get(), ptot);
+				tinfo->get_dynamic_field(*m_thread_dyn_field_accessor, ptot);
 				m_u64val += ptot;
-				tinfo->set_dynamic_field(*m_thread_dyn_field_accessor.get(), m_u64val);
+				tinfo->set_dynamic_field(*m_thread_dyn_field_accessor, m_u64val);
 				RETURN_EXTRACT_VAR(m_u64val);
 			}
 			else

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -83,8 +83,7 @@ public:
 void test_filter_run(bool result, string filter_str)
 {
 	sinsp inspector;
-	std::shared_ptr<sinsp_filter_factory> factory;
-	factory.reset(new mock_compiler_filter_factory(&inspector));
+	auto factory = std::make_shared<mock_compiler_filter_factory>(&inspector);
 	sinsp_filter_compiler compiler(factory, filter_str);
 	try
 	{

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -131,17 +131,16 @@ private:
 };
 
 // Note the we create a filter check without values on purpose.
-static std::unique_ptr<sinsp_filter_check> create_filtercheck_from_field(sinsp* inspector, std::string field,
+static std::unique_ptr<sinsp_filter_check> create_filtercheck_from_field(sinsp* inspector, std::string_view field,
 									 enum cmpop op = CO_EQ)
 {
 	sinsp_filter_check_list filter_list;
 	filter_list.add_filter_check(std::make_unique<sinsp_filter_check_mock>());
-	std::unique_ptr<sinsp_filter_factory> factory;
-	factory.reset(new sinsp_filter_factory(inspector, filter_list));
-	auto check = factory->new_filtercheck(field.c_str());
+	sinsp_filter_factory factory(inspector, filter_list);
+	auto check = factory.new_filtercheck(field);
 	check->m_cmpop = op;
 	check->m_boolop = BO_NONE;
-	check->parse_field_name(field.c_str(), true, true);
+	check->parse_field_name(field, true, true);
 	return check;
 }
 

--- a/userspace/libsinsp/test/helpers/scoped_pipe.cpp
+++ b/userspace/libsinsp/test/helpers/scoped_pipe.cpp
@@ -30,7 +30,7 @@ limitations under the License.
 
 using namespace test_helpers;
 
-scoped_pipe::scoped_pipe() : m_read_end(), m_write_end()
+scoped_pipe::scoped_pipe()
 {
 	int fds[2] = {};
 
@@ -43,18 +43,18 @@ scoped_pipe::scoped_pipe() : m_read_end(), m_write_end()
 		throw std::runtime_error(out.str());
 	}
 
-	m_read_end.reset(new scoped_file_descriptor(fds[0]));
-	m_write_end.reset(new scoped_file_descriptor(fds[1]));
+	m_read_end = std::make_unique<scoped_file_descriptor>(fds[0]);
+	m_write_end = std::make_unique<scoped_file_descriptor>(fds[1]);
 }
 
 scoped_file_descriptor& scoped_pipe::read_end()
 {
-	return *m_read_end.get();
+	return *m_read_end;
 }
 
 scoped_file_descriptor& scoped_pipe::write_end()
 {
-	return *m_write_end.get();
+	return *m_write_end;
 }
 
 void scoped_pipe::close()

--- a/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
+++ b/userspace/libsinsp/test/mpsc_priority_queue.ut.cpp
@@ -36,7 +36,7 @@ TEST(mpsc_priority_queue, order_consistency)
             return std::greater_equal<int>{}(l.v, r.v);
         }
     };
-    
+
     using val_t = std::unique_ptr<val>;
 
     mpsc_priority_queue<val_t, val_less> q;
@@ -98,14 +98,14 @@ TEST(mpsc_priority_queue, single_concurrent_producer)
         {
             continue;
         }
-        
+
         if (!q.try_pop(v))
         {
             failed++;
             continue;
         }
 
-        failed += (*v.get() != i) ? 1 : 0;
+        failed += (*v != i) ? 1 : 0;
         i++;
     }
 
@@ -167,7 +167,7 @@ TEST(mpsc_priority_queue, multi_concurrent_producers)
             failed++;
         }
 
-        last_val = *v.get();
+        last_val = *v;
         i++;
     }
 

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -206,7 +206,7 @@ TEST(dynamic_struct, defs_and_access)
     s.set_dynamic_field(acc_str, std::string("hello"));
     s.get_dynamic_field(acc_str, tmpstr);
     ASSERT_EQ(tmpstr, std::string("hello"));
-    
+
     s.set_dynamic_field(acc_str, std::string(""));
     const char* ctmpstr = "sample";
     s.get_dynamic_field(acc_str, ctmpstr);
@@ -251,7 +251,7 @@ TEST(table_registry, defs_and_access)
         {
             for (const auto& e : m_entries)
             {
-                if (!pred(*e.second.get()))
+                if (!pred(*e.second))
                 {
                     return false;
                 }
@@ -306,7 +306,7 @@ TEST(thread_manager, table_access)
 
     sinsp inspector;
     auto table = static_cast<libsinsp::state::table<int64_t>*>(inspector.m_thread_manager.get());
-    
+
     // empty table state and info
     ASSERT_EQ(table->name(), "threads");
     ASSERT_EQ(table->key_info(), libsinsp::state::typeinfo::of<int64_t>());

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -272,7 +272,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi)
 		{
 			newfdi->m_flags |= sinsp_fdinfo::FLAGS_SOCKET_CONNECTED;
 		}
-		m_inspector->get_ifaddr_list().update_fd(*(newfdi.get()));
+		m_inspector->get_ifaddr_list().update_fd(*newfdi);
 		newfdi->m_name = ipv4tuple_to_string(&newfdi->m_sockinfo.m_ipv4info, m_inspector->is_hostname_and_port_resolution_enabled());
 		break;
 	case SCAP_FD_IPV4_SERVSOCK:
@@ -306,7 +306,7 @@ void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo *fdi)
 			{
 				newfdi->m_flags |= sinsp_fdinfo::FLAGS_SOCKET_CONNECTED;
 			}
-			m_inspector->get_ifaddr_list().update_fd((*(newfdi.get())));
+			m_inspector->get_ifaddr_list().update_fd(*newfdi);
 			newfdi->m_name = ipv4tuple_to_string(&newfdi->m_sockinfo.m_ipv4info, m_inspector->is_hostname_and_port_resolution_enabled());
 		}
 		else

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -685,7 +685,7 @@ public:
 	{
 		return m_lastevent_type;
 	}
-	
+
 	inline void set_lastevent_type(uint16_t v)
 	{
 		m_lastevent_type = v;
@@ -695,7 +695,7 @@ public:
 	{
 		return m_lastevent_cpuid;
 	}
-	
+
 	inline void set_lastevent_cpuid(uint16_t v)
 	{
 		m_lastevent_cpuid = v;
@@ -817,7 +817,7 @@ public:
 	{
 		for (const auto& it : m_threads)
 		{
-			if (!callback(*it.second.get()))
+			if (!callback(*it.second))
 			{
 				return false;
 			}
@@ -829,7 +829,7 @@ public:
 	{
 		for (auto& it : m_threads)
 		{
-			if (!callback(*it.second.get()))
+			if (!callback(*it.second))
 			{
 				return false;
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
No specific area. This is a general cleanup refactoring.

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
There are some usages of smart pointers that can be simplified a but and, occasionally, made more efficient.

1. Use the overloaded dereference operator directly on the smart pointer without invoking `get()`, i.e. prefer `*ptr` rather than `*(ptr.get())`.
2. Create objects stored in smart pointers with `make_unique` or `make_shared` rather than using `new`. For `shared_ptr`s this has the performance advantage of storing the pointer's control block with the object itself, improving memory locality, beneficial for cache reasons, and using a single allocation call.
3. Prefer using automatic objects - i.e. stored on the stack - than heap allocated ones. This effectively removes the usage of the smart pointer.
4. One instance of `unique_ptr<bool>` has been replaced with `std::optional<bool>` as it seems to make more sense in the context.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
