### PR TITLE
refactor: unique_ptr to arrays

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -584,8 +584,7 @@ public:
 		m_errorcode = errorcode;
 	}
 
-	static std::unique_ptr<sinsp_evt> from_scap_evt(
-		std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>> scap_event)
+	static std::unique_ptr<sinsp_evt> from_scap_evt(std::unique_ptr<uint8_t[]> scap_event)
 	{
 		auto ret = std::make_unique<sinsp_evt>();
 		auto evdata = scap_event.release();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1089,7 +1089,7 @@ void sinsp::get_procs_cpu_from_driver(uint64_t ts)
 		}
 
 		uint32_t evlen = sizeof(scap_evt) + 2 * sizeof(uint16_t) + 2 * sizeof(uint64_t);
-		auto piscapevt_buf = std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>>(new uint8_t[evlen]);
+		auto piscapevt_buf = std::unique_ptr<uint8_t[]>(new uint8_t[evlen]);
 		auto piscapevt = (scap_evt*) piscapevt_buf.get();
 		piscapevt->tid = pi->pid;
 		piscapevt->ts = ts;


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area libsinsp

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
This is a little simplification in defining a `unique_ptr` to an array. For example:
```c++
std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>> buffer;
```
Can be written more easily as this.
```c++
std::unique_ptr<uint8_t[]> buffer;
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
refactor: Function sinsp_evt::from_scap_evt takes a slightly different parameter.

This function in file libsinsp/event.h:

    static std::unique_ptr<sinsp_evt> from_scap_evt(
		std::unique_ptr<uint8_t, std::default_delete<uint8_t[]>> scap_event)

Becomes this.

    static std::unique_ptr<sinsp_evt> from_scap_evt(std::unique_ptr<uint8_t[]> scap_event)

BREAKING CHANGE: Callers of this function should adapt the passed-in parameter type accordingly.
```
