### PR TITLE
new(tests): check vdso-vsyscalls involved syscalls on 32/64 bits

### DIFF
--- a/test/drivers/helpers/ia32.c
+++ b/test/drivers/helpers/ia32.c
@@ -5,45 +5,107 @@
  */
 
 #include <unistd.h>
+#include <stdio.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/mman.h>
-#include <linux/net.h>        /* Definition of SYS_* constants */
+#include <linux/net.h> /* Definition of SYS_* constants */
 
 #ifdef __NR_openat2
-#include <linux/openat2.h>  /* Definition of RESOLVE_* constants */
+#include <linux/openat2.h> /* Definition of RESOLVE_* constants */
 #endif
 
-int main() {
+#define TRY_1_ARGS_CALL(x, a1)                                                                                         \
+	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
+	{                                                                                                              \
+		syscall(x, a1);                                                                                        \
+		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
+		return 0;                                                                                              \
+	}
+
+#define TRY_2_ARGS_CALL(x, a1, a2)                                                                                     \
+	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
+	{                                                                                                              \
+		syscall(x, a1, a2);                                                                                    \
+		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
+		return 0;                                                                                              \
+	}
+
+#define TRY_3_ARGS_CALL(x, a1, a2, a3)                                                                                 \
+	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
+	{                                                                                                              \
+		syscall(x, a1, a2, a3);                                                                                \
+		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
+		return 0;                                                                                              \
+	}
+
+int main(int argc, char** argv)
+{
+	// Throw some generic syscalls if we just pass the name of the executable
+	// todo!: we need to convert it to single `if` like the other cases.
+	if(argc == 1)
+	{
 #ifdef __NR_openat2
-	struct open_how how;
-	how.flags = O_RDWR;
-	how.mode = 0;
-	how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
-	syscall(__NR_openat2, 11, "mock_path", &how, sizeof(struct open_how));
+		struct open_how how;
+		how.flags = O_RDWR;
+		how.mode = 0;
+		how.resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS;
+		syscall(__NR_openat2, 11, "mock_path", &how, sizeof(struct open_how));
 #endif
-	syscall(__NR_write, 17, NULL, 1013);
+		syscall(__NR_write, 17, NULL, 1013);
 
-	syscall(__NR_getegid32);
-	syscall(__NR_geteuid32);
+		syscall(__NR_getegid32);
+		syscall(__NR_geteuid32);
 
-	syscall(__NR_umount, "mock_path");
+		syscall(__NR_umount, "mock_path");
 
-	long int p = syscall(__NR_mmap, NULL, 1003520, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	syscall(__NR_munmap, p, 1003520);
-	p = syscall(__NR_mmap2, NULL, 1003520, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-	syscall(__NR_munmap, p, 1003520);
+		long int p =
+			syscall(__NR_mmap, NULL, 1003520, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		syscall(__NR_munmap, p, 1003520);
+		p = syscall(__NR_mmap2, NULL, 1003520, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		syscall(__NR_munmap, p, 1003520);
 
-	unsigned long args[3] = {0};
-	args[0] = AF_INET;
-	args[1] = SOCK_RAW;
-	args[2] = PF_INET;
-	syscall(__NR_socketcall, SYS_SOCKET, args);
-	syscall(__NR_socketcall, SYS_ACCEPT4, args);
-	syscall(__NR_socketcall, SYS_SEND, args);
-	syscall(__NR_socketcall, SYS_ACCEPT, args);
-	syscall(__NR_socketcall, -1, args);
-	return 0;
+		unsigned long args[3] = {0};
+		args[0] = AF_INET;
+		args[1] = SOCK_RAW;
+		args[2] = PF_INET;
+		syscall(__NR_socketcall, SYS_SOCKET, args);
+		syscall(__NR_socketcall, SYS_ACCEPT4, args);
+		syscall(__NR_socketcall, SYS_SEND, args);
+		syscall(__NR_socketcall, SYS_ACCEPT, args);
+		syscall(__NR_socketcall, -1, args);
+		return 0;
+	}
+
+	if(argc != 2)
+	{
+		fprintf(stderr, "we need exactly one single arg\n");
+		return -1;
+	}
+
+#ifdef __NR_write
+	TRY_3_ARGS_CALL(__NR_write, 17, NULL, 1013)
+#endif
+
+#ifdef __NR_clock_gettime
+	TRY_2_ARGS_CALL(__NR_clock_gettime, 0, NULL)
+#endif
+
+#ifdef __NR_getcpu
+	TRY_3_ARGS_CALL(__NR_getcpu, NULL, NULL, NULL)
+#endif
+
+#ifdef __NR_gettimeofday
+	TRY_2_ARGS_CALL(__NR_gettimeofday, NULL, NULL)
+#endif
+
+#ifdef __NR_time
+	TRY_1_ARGS_CALL(__NR_time, NULL)
+#endif
+
+	fprintf(stderr, "not managed syscall: '%s'\n", argv[1]);
+	return -1;
 }

--- a/test/drivers/helpers/ia32.c
+++ b/test/drivers/helpers/ia32.c
@@ -18,26 +18,10 @@
 #include <linux/openat2.h> /* Definition of RESOLVE_* constants */
 #endif
 
-#define TRY_1_ARGS_CALL(x, a1)                                                                                         \
+#define TRY_SYSCALL(x, ...)                                                                                            \
 	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
 	{                                                                                                              \
-		syscall(x, a1);                                                                                        \
-		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
-		return 0;                                                                                              \
-	}
-
-#define TRY_2_ARGS_CALL(x, a1, a2)                                                                                     \
-	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
-	{                                                                                                              \
-		syscall(x, a1, a2);                                                                                    \
-		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
-		return 0;                                                                                              \
-	}
-
-#define TRY_3_ARGS_CALL(x, a1, a2, a3)                                                                                 \
-	if(strncmp(#x, argv[1], sizeof(#x)) == 0)                                                                      \
-	{                                                                                                              \
-		syscall(x, a1, a2, a3);                                                                                \
+		syscall(x, ##__VA_ARGS__);                                                                             \
 		printf("--> Test_ia32 called '%s'\n", #x);                                                             \
 		return 0;                                                                                              \
 	}
@@ -87,23 +71,23 @@ int main(int argc, char** argv)
 	}
 
 #ifdef __NR_write
-	TRY_3_ARGS_CALL(__NR_write, 17, NULL, 1013)
+	TRY_SYSCALL(__NR_write, 17, NULL, 1013)
 #endif
 
 #ifdef __NR_clock_gettime
-	TRY_2_ARGS_CALL(__NR_clock_gettime, 0, NULL)
+	TRY_SYSCALL(__NR_clock_gettime, 0, NULL)
 #endif
 
 #ifdef __NR_getcpu
-	TRY_3_ARGS_CALL(__NR_getcpu, NULL, NULL, NULL)
+	TRY_SYSCALL(__NR_getcpu, NULL, NULL, NULL)
 #endif
 
 #ifdef __NR_gettimeofday
-	TRY_2_ARGS_CALL(__NR_gettimeofday, NULL, NULL)
+	TRY_SYSCALL(__NR_gettimeofday, NULL, NULL)
 #endif
 
 #ifdef __NR_time
-	TRY_1_ARGS_CALL(__NR_time, NULL)
+	TRY_SYSCALL(__NR_time, NULL)
 #endif
 
 	fprintf(stderr, "not managed syscall: '%s'\n", argv[1]);

--- a/test/drivers/test_suites/actions_suite/ia32.cpp.in
+++ b/test/drivers/test_suites/actions_suite/ia32.cpp.in
@@ -29,7 +29,8 @@ TEST(Actions, ia32)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -42,78 +43,78 @@ TEST(Actions, ia32)
 	/* Retrieve events in order. */
 #ifdef __NR_openat2
 	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_OPENAT2_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_OPENAT2_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_OPENAT2_X);
 #endif
 	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_WRITE_E);
 	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_WRITE_X);
 
-  // getegid32 and geteuid32 are ia32 only syscalls and are translated to getegid and geteuid x86_64 syscalls
+	// getegid32 and geteuid32 are ia32 only syscalls and are translated to getegid and geteuid x86_64 syscalls
 	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEGID_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEGID_X);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEUID_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEUID_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEGID_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEUID_E);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_GETEUID_X);
 
-  // umount is ia32 only and is translated to x86_64 umount2
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_UMOUNT2_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_UMOUNT2_X);
+	// umount is ia32 only and is translated to x86_64 umount2
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_UMOUNT2_E);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_UMOUNT2_X);
 
 	// mmap2 is translated to x86_64 mmap
 	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_X);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_X);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_X);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_E);
-  evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_E);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_E);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MMAP_X);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_E);
+	evt_test->assert_event_presence(ret_pid, PPME_SYSCALL_MUNMAP_X);
 	evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SOCKET_E);
 	evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SOCKET_X);
 	evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT4_6_E);
 	evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT4_6_X);
 
-  /*
-   * Special cases: socketcalls whose SYS_foo code is defined but the syscall is not.
-   * See socketcall_to_syscall.h comment.
-   */
+	/*
+	 * Special cases: socketcalls whose SYS_foo code is defined but the syscall is not.
+	 * See socketcall_to_syscall.h comment.
+	 */
 	if(evt_test->is_modern_bpf_engine())
 	{
-	    /*
-       * ModernBPF jump table is syscalls-indexed;
-       * Since SYS_SEND exists but __NR_send does not on x86_64,
-       * convert_network_syscalls() returns -1 and we don't push anything to consumers.
-       */
-    	evt_test->assert_event_absence(ret_pid, PPME_SOCKET_SEND_E);
-    	evt_test->assert_event_absence(ret_pid, PPME_SOCKET_SEND_X);
+		/*
+		 * ModernBPF jump table is syscalls-indexed;
+		 * Since SYS_SEND exists but __NR_send does not on x86_64,
+		 * convert_network_syscalls() returns -1 and we don't push anything to consumers.
+		 */
+		evt_test->assert_event_absence(ret_pid, PPME_SOCKET_SEND_E);
+		evt_test->assert_event_absence(ret_pid, PPME_SOCKET_SEND_X);
 
-    	/*
-    	 * Same as above
-    	 */
-    	evt_test->assert_event_absence(ret_pid, PPME_SOCKET_ACCEPT4_6_E);
-    	evt_test->assert_event_absence(ret_pid, PPME_SOCKET_ACCEPT4_6_X);
+		/*
+		 * Same as above
+		 */
+		evt_test->assert_event_absence(ret_pid, PPME_SOCKET_ACCEPT4_6_E);
+		evt_test->assert_event_absence(ret_pid, PPME_SOCKET_ACCEPT4_6_X);
 	}
 	else
 	{
-	  /*
-	   * Kmod and old bpf jump table is events-indexed.
-	   * We are able to fallback at sending the events.
-	   */
-    evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SEND_E);
-    evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SEND_X);
+		/*
+		 * Kmod and old bpf jump table is events-indexed.
+		 * We are able to fallback at sending the events.
+		 */
+		evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SEND_E);
+		evt_test->assert_event_presence(ret_pid, PPME_SOCKET_SEND_X);
 
-    /*
-     * Same as above
-     */
-    evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT_5_E);
-    evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT_5_X);
+		/*
+		 * Same as above
+		 */
+		evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT_5_E);
+		evt_test->assert_event_presence(ret_pid, PPME_SOCKET_ACCEPT_5_X);
 	}
-  /*
-   * Last event sent by the script is a socketcall with non existing SYS_ code.
-   * We don't expect any event generated.
-   */
-  // We cannot assert PPME_GENERIC_E since 'exit_group' syscall is sent when program exits,
-  // and it is mapped to a generic enter event.
-  // evt_test->assert_event_absence(ret_pid, PPME_GENERIC_E);
-  evt_test->assert_event_absence(ret_pid, PPME_GENERIC_X);
+	/*
+	 * Last event sent by the script is a socketcall with non existing SYS_ code.
+	 * We don't expect any event generated.
+	 */
+	// We cannot assert PPME_GENERIC_E since 'exit_group' syscall is sent when program exits,
+	// and it is mapped to a generic enter event.
+	// evt_test->assert_event_absence(ret_pid, PPME_GENERIC_E);
+	evt_test->assert_event_absence(ret_pid, PPME_GENERIC_X);
 }
 
 #ifdef __NR_execve
@@ -137,7 +138,8 @@ TEST(Actions, ia32_execve_compat)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -148,7 +150,7 @@ TEST(Actions, ia32_execve_compat)
 	evt_test->disable_capture();
 
 	/* We search for a child event. */
-  evt_test->assert_event_presence(ret_pid);
+	evt_test->assert_event_presence(ret_pid);
 }
 #endif
 
@@ -171,7 +173,8 @@ TEST(Actions, ia32_openat2_x)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -186,36 +189,36 @@ TEST(Actions, ia32_openat2_x)
 
 	if(HasFatalFailure())
 	{
-  	return;
-  }
+		return;
+	}
 
-  evt_test->parse_event();
-  evt_test->assert_header();
+	evt_test->parse_event();
+	evt_test->assert_header();
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  /* Parameter 1: fd (type: PT_FD) */
-  // can't assert return code; sometime is -EBADF, sometime -ENOTDIR
-  //evt_test->assert_numeric_param(1, (int64_t)-EBADF);
+	/* Parameter 1: fd (type: PT_FD) */
+	// can't assert return code; sometime is -EBADF, sometime -ENOTDIR
+	// evt_test->assert_numeric_param(1, (int64_t)-EBADF);
 
-  /* Parameter 2: dirfd (type: PT_FD) */
-  evt_test->assert_numeric_param(2, (int64_t)11);
+	/* Parameter 2: dirfd (type: PT_FD) */
+	evt_test->assert_numeric_param(2, (int64_t)11);
 
-  /* Parameter 3: name (type: PT_FSPATH) */
-  evt_test->assert_charbuf_param(3, "mock_path");
+	/* Parameter 3: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(3, "mock_path");
 
-  /* Parameter 4: flags (type: PT_FLAGS32) */
-  evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR);
+	/* Parameter 4: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(4, (uint32_t)PPM_O_RDWR);
 
-  /* Parameter 5: mode (type: PT_UINT32) */
-  evt_test->assert_numeric_param(5, (uint32_t)0);
+	/* Parameter 5: mode (type: PT_UINT32) */
+	evt_test->assert_numeric_param(5, (uint32_t)0);
 
-  /* Parameter 6: resolve (type: PT_FLAGS32) */
-  evt_test->assert_numeric_param(6, (uint32_t)PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
+	/* Parameter 6: resolve (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(6, (uint32_t)PPM_RESOLVE_BENEATH | PPM_RESOLVE_NO_MAGICLINKS);
 
- 	/*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
- 	evt_test->assert_num_params_pushed(8);
+	evt_test->assert_num_params_pushed(8);
 }
 #endif
 
@@ -230,15 +233,16 @@ TEST(Actions, ia32_write_e)
 	pid_t ret_pid = syscall(__NR_fork);
 	if(ret_pid == 0)
 	{
-		char* const argv[] = {NULL};
-		char* const envp[] = {NULL};
-		execve("${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
+		const char* argv[] = {"ia32", "__NR_write", NULL};
+		const char* envp[] = {NULL};
+		syscall(__NR_execve, "${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
 		exit(EXIT_FAILURE);
 	}
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -253,23 +257,23 @@ TEST(Actions, ia32_write_e)
 
 	if(HasFatalFailure())
 	{
-  	return;
-  }
+		return;
+	}
 
-  evt_test->parse_event();
-  evt_test->assert_header();
+	evt_test->parse_event();
+	evt_test->assert_header();
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 	/* Parameter 1: fd (type: PT_FD) */
-  evt_test->assert_numeric_param(1, (int64_t)17);
+	evt_test->assert_numeric_param(1, (int64_t)17);
 
-  /* Parameter 2: size (type: PT_UINT32)*/
-  evt_test->assert_numeric_param(2, (uint32_t)1013);
+	/* Parameter 2: size (type: PT_UINT32)*/
+	evt_test->assert_numeric_param(2, (uint32_t)1013);
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  evt_test->assert_num_params_pushed(2);
+	evt_test->assert_num_params_pushed(2);
 }
 #endif
 
@@ -292,7 +296,8 @@ TEST(Actions, ia32_socket_e)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -307,26 +312,26 @@ TEST(Actions, ia32_socket_e)
 
 	if(HasFatalFailure())
 	{
-  	return;
-  }
+		return;
+	}
 
-  evt_test->parse_event();
-  evt_test->assert_header();
+	evt_test->parse_event();
+	evt_test->assert_header();
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  /* Parameter 1: domain (type: PT_ENUMFLAGS32) */
-  evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_INET);
+	/* Parameter 1: domain (type: PT_ENUMFLAGS32) */
+	evt_test->assert_numeric_param(1, (uint32_t)PPM_AF_INET);
 
-  /* Parameter 2: type (type: PT_UINT32) */
-  evt_test->assert_numeric_param(2, (uint32_t)SOCK_RAW);
+	/* Parameter 2: type (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (uint32_t)SOCK_RAW);
 
-  /* Parameter 3: proto (type: PT_UINT32) */
-  evt_test->assert_numeric_param(3, (uint32_t)PF_INET);
+	/* Parameter 3: proto (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)PF_INET);
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  evt_test->assert_num_params_pushed(3);
+	evt_test->assert_num_params_pushed(3);
 }
 #endif
 
@@ -349,7 +354,8 @@ TEST(Actions, ia32_umount_e)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -364,20 +370,20 @@ TEST(Actions, ia32_umount_e)
 
 	if(HasFatalFailure())
 	{
-  	return;
-  }
+		return;
+	}
 
-  evt_test->parse_event();
-  evt_test->assert_header();
+	evt_test->parse_event();
+	evt_test->assert_header();
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  /* Parameter 1: flags (type: PT_FLAGS32) */
-  evt_test->assert_numeric_param(1, 0);
+	/* Parameter 1: flags (type: PT_FLAGS32) */
+	evt_test->assert_numeric_param(1, 0);
 
- 	/*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
- 	evt_test->assert_num_params_pushed(1);
+	evt_test->assert_num_params_pushed(1);
 }
 
 TEST(Actions, ia32_umount_x)
@@ -398,7 +404,8 @@ TEST(Actions, ia32_umount_x)
 	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
 	int status = 0;
 	int options = 0;
-	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL, -1);
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
 
 	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
 	{
@@ -413,23 +420,235 @@ TEST(Actions, ia32_umount_x)
 
 	if(HasFatalFailure())
 	{
-  	return;
-  }
+		return;
+	}
 
-  evt_test->parse_event();
-  evt_test->assert_header();
+	evt_test->parse_event();
+	evt_test->assert_header();
 
-  /*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
-  /* Parameter 1: fd (type: PT_ERRNO) */
-  evt_test->assert_numeric_param(1, (int64_t)-ENOENT);
+	/* Parameter 1: fd (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)-ENOENT);
 
-  /* Parameter 2: name (type: PT_FSPATH) */
-  evt_test->assert_charbuf_param(2, "mock_path");
+	/* Parameter 2: name (type: PT_FSPATH) */
+	evt_test->assert_charbuf_param(2, "mock_path");
 
- 	/*=============================== ASSERT PARAMETERS  ===========================*/
+	/*=============================== ASSERT PARAMETERS  ===========================*/
 
- 	evt_test->assert_num_params_pushed(2);
+	evt_test->assert_num_params_pushed(2);
+}
+#endif
+
+#ifdef __NR_clock_gettime
+TEST(Actions, ia32_clock_gettime)
+{
+	auto evt_test = get_syscall_event_test(__NR_clock_gettime, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		const char* argv[] = {"ia32", "__NR_clock_gettime", NULL};
+		const char* envp[] = {NULL};
+		syscall(__NR_execve, "${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
+		exit(EXIT_FAILURE);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(ret_pid, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_CLOCK_GETTIME);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif
+
+#ifdef __NR_getcpu
+TEST(Actions, ia32_getcpu)
+{
+	auto evt_test = get_syscall_event_test(__NR_getcpu, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		const char* argv[] = {"ia32", "__NR_getcpu", NULL};
+		const char* envp[] = {NULL};
+		syscall(__NR_execve, "${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
+		exit(EXIT_FAILURE);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(ret_pid, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_GETCPU);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif
+
+#ifdef __NR_gettimeofday
+TEST(Actions, ia32_gettimeofday)
+{
+	auto evt_test = get_syscall_event_test(__NR_gettimeofday, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		const char* argv[] = {"ia32", "__NR_gettimeofday", NULL};
+		const char* envp[] = {NULL};
+		syscall(__NR_execve, "${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
+		exit(EXIT_FAILURE);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(ret_pid, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_GETTIMEOFDAY);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif
+
+#ifdef __NR_time
+TEST(Actions, ia32_time)
+{
+	auto evt_test = get_syscall_event_test(__NR_time, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+	pid_t ret_pid = syscall(__NR_fork);
+	if(ret_pid == 0)
+	{
+		const char* argv[] = {"ia32", "__NR_time", NULL};
+		const char* envp[] = {NULL};
+		syscall(__NR_execve, "${CMAKE_CURRENT_BINARY_DIR}/ia32", argv, envp);
+		exit(EXIT_FAILURE);
+	}
+	assert_syscall_state(SYSCALL_SUCCESS, "fork", ret_pid, NOT_EQUAL, -1);
+	int status = 0;
+	int options = 0;
+	assert_syscall_state(SYSCALL_SUCCESS, "wait4", syscall(__NR_wait4, ret_pid, &status, options, NULL), NOT_EQUAL,
+			     -1);
+
+	if(__WEXITSTATUS(status) == EXIT_FAILURE || __WIFSIGNALED(status) != 0)
+	{
+		FAIL() << "Fork failed..." << std::endl;
+	}
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(ret_pid, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_TIME);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
 }
 #endif
 

--- a/test/drivers/test_suites/syscall_exit_suite/clock_gettime_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clock_gettime_x.cpp
@@ -1,0 +1,41 @@
+
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_clock_gettime
+TEST(SyscallExit, clock_gettime_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_clock_gettime, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	syscall(__NR_clock_gettime, 0, NULL);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_CLOCK_GETTIME);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/getcpu_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/getcpu_x.cpp
@@ -1,0 +1,41 @@
+
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_getcpu
+TEST(SyscallExit, getcpu_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_getcpu, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	syscall(__NR_getcpu, NULL, NULL, NULL);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_GETCPU);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/gettimeofday_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/gettimeofday_x.cpp
@@ -1,0 +1,41 @@
+
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_gettimeofday
+TEST(SyscallExit, gettimeofday_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_gettimeofday, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	syscall(__NR_gettimeofday, NULL, NULL);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_GETTIMEOFDAY);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif

--- a/test/drivers/test_suites/syscall_exit_suite/time_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/time_x.cpp
@@ -1,0 +1,41 @@
+
+#include "../../event_class/event_class.h"
+
+#ifdef __NR_time
+TEST(SyscallExit, time_X)
+{
+	auto evt_test = get_syscall_event_test(__NR_time, EXIT_EVENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	syscall(__NR_time, NULL);
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	/* Disable the capture: no more events from now. */
+	evt_test->disable_capture();
+
+	/* Retrieve events in order. */
+	evt_test->assert_event_presence(CURRENT_PID, PPME_GENERIC_X);
+
+	if(HasFatalFailure())
+	{
+		return;
+	}
+
+	evt_test->parse_event();
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: ID (type: PT_SYSCALLID) */
+	/* This is the PPM_SC code obtained from the syscall id. */
+	evt_test->assert_numeric_param(1, (uint16_t)PPM_SC_TIME);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(1);
+}
+#endif


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Here i'm trying to reproduce this issue https://github.com/falcosecurity/falco/issues/3181 related to VSYSCALL addresses. 

```
[17285552.983963] BUG: unable to handle page fault for address: ffffffffff6000c7
```

The idea is to check if an unmanaged page fault is triggered when we use one of these syscalls. Syscalls involved in the vsyscall-vdso logic are the following:
*  __NR_clock_gettime
* __NR_getcpu
* __NR_gettimeofday
* __NR_time

Unfortunately, I didn't reproduce the issue but these tests are still valuable IMO.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
