### PR TITLE
fix: Allow builds with newer gRPC versions

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -216,6 +216,12 @@ function(prepare_cri_grpc api_version)
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 	)
 	add_dependencies(cri_${api_version} grpc)
+	target_link_libraries(cri_${api_version}
+	PRIVATE
+		${GPR_LIB}
+		${GRPC_LIB}
+		${GRPCPP_LIB}
+	)
 endfunction()
 
 if (NOT EMSCRIPTEN)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
This fixes a problem with a broken build when building the project with `USE_BUNDLED_GRPC=OFF` and using more recent gRPC versions.
It could also be a starting point for a future change to upgrade gRPC.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
