### PR TITLE
refactor(userspace/libsinsp): optimize allocations of filter checks

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -586,6 +586,12 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string &errstr)
 			m_fields.push_back(tf);
 		}
 
+		// populate fields info
+		m_fields_info.m_name = name() + string(" (plugin)");
+		m_fields_info.m_fields = &m_fields[0]; // we use a vector so this should be safe
+		m_fields_info.m_nfields = m_fields.size();
+		m_fields_info.m_flags = filter_check_info::FL_NONE;
+
 		// This API is not compulsory for the extraction capability
 		resolve_dylib_compatible_sources("get_extract_event_sources",
 			m_handle->api.get_extract_event_sources, m_extract_event_sources);

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -107,6 +107,7 @@ public:
 		m_handle(handle),
 		m_last_owner_err(),
 		m_scap_source_plugin(),
+		m_fields_info(),
 		m_fields(),
 		m_extract_event_sources(),
 		m_extract_event_codes(),
@@ -184,6 +185,11 @@ public:
 
 	const libsinsp::events::set<ppm_event_code>& extract_event_codes() const;
 
+	inline const filter_check_info* fields_info() const
+	{
+		return &m_fields_info;
+	}
+
 	inline const std::vector<filtercheck_field_info>& fields() const
 	{
 		return m_fields;
@@ -242,6 +248,7 @@ private:
 	scap_source_plugin m_scap_source_plugin;
 
 	/** Field Extraction **/
+	filter_check_info m_fields_info;
 	std::vector<filtercheck_field_info> m_fields;
 	std::unordered_set<std::string> m_extract_event_sources;
 	libsinsp::events::set<ppm_event_code> m_extract_event_codes;

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -32,7 +32,7 @@ limitations under the License.
 /*
  * Operators to compare events
  */
-enum cmpop {
+enum cmpop: uint8_t {
 	CO_NONE = 0,
 	CO_EQ = 1,
 	CO_NE = 2,
@@ -54,7 +54,7 @@ enum cmpop {
 	CO_IGLOB = 18,
 };
 
-enum boolop
+enum boolop: uint8_t
 {
 	BO_NONE = 0,
 	BO_NOT = 1,
@@ -175,7 +175,7 @@ struct filtercheck_field_info
 class filter_check_info
 {
 public:
-	enum flags
+	enum flags: uint8_t
 	{
 		FL_NONE = 0,
 		FL_HIDDEN = (1 << 0),	///< This filter check class won't be shown by fields/filter listings.
@@ -219,7 +219,7 @@ public:
 	//
 	virtual const filter_check_info* get_fields() const
 	{
-		return &m_info;
+		return m_info;
 	}
 
 	//
@@ -357,8 +357,17 @@ protected:
 
 	Json::Value rawval_to_json(uint8_t* rawval, ppm_param_type ptype, ppm_print_format print_format, uint32_t len);
 
-	inline uint8_t* filter_value_p(uint16_t i = 0) { return m_vals[i].first; }
-	inline uint32_t filter_value_len(uint16_t i = 0) { return m_vals[i].second; }
+	inline uint8_t* filter_value_p(uint16_t i = 0)
+	{
+		ASSERT(i < m_vals.size());
+		return m_vals[i].first;
+	}
+
+	inline uint32_t filter_value_len(uint16_t i = 0)
+	{
+		ASSERT(i < m_vals.size());
+		return m_vals[i].second;
+	}
 
 	std::vector<char> m_getpropertystr_storage;
 	std::vector<std::vector<uint8_t>> m_val_storages;
@@ -366,7 +375,7 @@ protected:
 	std::vector<filter_value_t> m_vals;
 
 	const filtercheck_field_info* m_field = nullptr;
-	filter_check_info m_info;
+	const filter_check_info* m_info = nullptr;
 	uint32_t m_field_id = (uint32_t) -1;
 
 private:
@@ -383,10 +392,14 @@ private:
 	std::unique_ptr<filtercheck_field_info> m_transformed_field = nullptr;
 
 	// used for comparing right-hand lists of values
-	std::unordered_set<filter_value_t,
-		g_hash_membuf,
-		g_equal_to_membuf> m_val_storages_members;
-	path_prefix_search m_val_storages_paths;
+	std::unique_ptr<
+		std::unordered_set<filter_value_t,
+			g_hash_membuf,
+			g_equal_to_membuf>> m_val_storages_members;
+	std::unique_ptr<path_prefix_search> m_val_storages_paths;
 	uint32_t m_val_storages_min_size;
 	uint32_t m_val_storages_max_size;
+
+	static constexpr const size_t s_min_filter_value_buf_size = 16;
+	static constexpr const size_t s_max_filter_value_buf_size = 256;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_container.h
+++ b/userspace/libsinsp/sinsp_filtercheck_container.h
@@ -67,8 +67,10 @@ private:
 	int32_t extract_arg(std::string_view val, size_t basename);
 
 	std::string m_tstr;
-	uint32_t m_u32val;
 	int32_t m_argid;
 	std::string m_argstr;
-	int64_t m_s64val;
+	union {
+		uint32_t u32;
+		int64_t s64;
+	} m_val;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -106,11 +106,13 @@ private:
 	uint8_t *extract_abspath(sinsp_evt *evt, OUT uint32_t *len);
 	inline uint8_t* extract_buflen(sinsp_evt *evt, OUT uint32_t* len);
 
-	uint64_t m_u64val;
-	int64_t m_s64val;
+	union {
+		uint16_t u16;
+		uint32_t u32;
+		int64_t s64;
+		uint64_t u64;
+	} m_val;
 	uint64_t m_tsdelta;
-	uint16_t m_u16val;
-	uint32_t m_u32val;
 	std::string m_strstorage;
 	std::string m_argname;
 	int32_t m_argid;

--- a/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_evtin.cpp
@@ -65,11 +65,15 @@ static const filtercheck_field_info sinsp_filter_check_evtin_fields[] =
 
 sinsp_filter_check_evtin::sinsp_filter_check_evtin()
 {
-	m_info.m_name = "evtin";
-	m_info.m_desc = "Fields used if information about distributed tracing is available.";
-	m_info.m_fields = sinsp_filter_check_evtin_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_evtin_fields) / sizeof(sinsp_filter_check_evtin_fields[0]);
-	m_info.m_flags = filter_check_info::FL_HIDDEN;
+	static const filter_check_info s_field_infos = {
+		"evtin",
+		"",
+		"Fields used if information about distributed tracing is available.",
+		sizeof(sinsp_filter_check_evtin_fields) / sizeof(sinsp_filter_check_evtin_fields[0]),
+		sinsp_filter_check_evtin_fields,
+		filter_check_info::FL_HIDDEN,
+	};
+	m_info = &s_field_infos;
 }
 
 int32_t sinsp_filter_check_evtin::extract_arg(string_view fldname, string_view val)
@@ -121,7 +125,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.tags"))
 	{
 		m_field_id = TYPE_TAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.tag", val);
 	}
@@ -129,7 +133,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.args"))
 	{
 		m_field_id = TYPE_ARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.arg", val);
 	}
@@ -137,7 +141,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.p.tags"))
 	{
 		m_field_id = TYPE_P_TAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.p.tag", val);
 	}
@@ -145,7 +149,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.p.args"))
 	{
 		m_field_id = TYPE_P_ARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.p.arg", val);
 	}
@@ -153,7 +157,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.s.tags"))
 	{
 		m_field_id = TYPE_S_TAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.s.tag", val);
 	}
@@ -161,7 +165,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.s.args"))
 	{
 		m_field_id = TYPE_S_ARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.s.arg", val);
 	}
@@ -169,7 +173,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.m.tags"))
 	{
 		m_field_id = TYPE_M_TAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.m.tag", val);
 	}
@@ -177,7 +181,7 @@ int32_t sinsp_filter_check_evtin::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("evtin.span.m.args"))
 	{
 		m_field_id = TYPE_M_ARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("evtin.span.m.arg", val);
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -97,9 +97,10 @@ private:
 	sinsp_fdinfo* m_fdinfo;
 	std::string m_tstr;
 	uint8_t m_tcstr[2];
-	uint32_t m_tbool;
 	int64_t m_argid;
 
-	/* Used in extract helper to save uint64_t data */
-	uint64_t m_conv_uint64;
+	union {
+		uint32_t u32;
+		uint64_t u64;
+	} m_val;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -39,11 +39,15 @@ static const filtercheck_field_info sinsp_filter_check_fdlist_fields[] =
 
 sinsp_filter_check_fdlist::sinsp_filter_check_fdlist()
 {
-	m_info.m_name = "fdlist";
-	m_info.m_desc = "Poll event related fields.";
-	m_info.m_fields = sinsp_filter_check_fdlist_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_fdlist_fields) / sizeof(sinsp_filter_check_fdlist_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"fdlist",
+		"",
+		"Poll event related fields.",
+		sizeof(sinsp_filter_check_fdlist_fields) / sizeof(sinsp_filter_check_fdlist_fields[0]),
+		sinsp_filter_check_fdlist_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_fdlist::allocate_new()
@@ -121,6 +125,7 @@ uint8_t* sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt, OUT uint32_t*
 		{
 			if(fdinfo != NULL)
 			{
+				char m_addrbuff[100];
 				if(fdinfo->m_type == SCAP_FD_IPV4_SOCK)
 				{
 					inet_ntop(AF_INET, &fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, m_addrbuff, sizeof(m_addrbuff));
@@ -142,6 +147,7 @@ uint8_t* sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt, OUT uint32_t*
 		{
 			if(fdinfo != NULL)
 			{
+				char m_addrbuff[100];
 				if(fdinfo->m_type == SCAP_FD_IPV4_SOCK)
 				{
 					inet_ntop(AF_INET, &fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, m_addrbuff, sizeof(m_addrbuff));

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.h
@@ -43,5 +43,4 @@ protected:
 
 private:
 	std::string m_strval;
-	char m_addrbuff[100];
 };

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -44,16 +44,20 @@ sinsp_filter_check_fspath::sinsp_filter_check_fspath()
 	// These will either be populated when calling
 	// create_fspath_checks or copied from another filtercheck
 	// when calling set_fspath_checks().
-	: m_success_checks(new filtercheck_map_t()),
-	  m_path_checks(new filtercheck_map_t()),
-	  m_source_checks(new filtercheck_map_t()),
-	  m_target_checks(new filtercheck_map_t())
+	: m_success_checks(std::make_shared<filtercheck_map_t>()),
+	  m_path_checks(std::make_shared<filtercheck_map_t>()),
+	  m_source_checks(std::make_shared<filtercheck_map_t>()),
+	  m_target_checks(std::make_shared<filtercheck_map_t>())
 {
-	m_info.m_name = "fs.path";
-	m_info.m_desc = "Every syscall that has a filesystem path in its arguments has these fields set with information related to the path arguments. This differs from the fd.* fields as it includes syscalls like unlink, rename, etc. that act directly on filesystem paths as compared to opened file descriptors.";
-	m_info.m_fields = sinsp_filter_check_fspath_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_fspath_fields) / sizeof(sinsp_filter_check_fspath_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"fs.path",
+		"",
+		"Every syscall that has a filesystem path in its arguments has these fields set with information related to the path arguments. This differs from the fd.* fields as it includes syscalls like unlink, rename, etc. that act directly on filesystem paths as compared to opened file descriptors.",
+		sizeof(sinsp_filter_check_fspath_fields) / sizeof(sinsp_filter_check_fspath_fields[0]),
+		sinsp_filter_check_fspath_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
 };
 
 std::shared_ptr<sinsp_filter_check> sinsp_filter_check_fspath::create_event_check(const char *name,

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -67,13 +67,16 @@ static const filtercheck_field_info sinsp_filter_check_gen_event_fields[] =
 
 sinsp_filter_check_gen_event::sinsp_filter_check_gen_event()
 {
-	m_info.m_name = "evt";
-	m_info.m_shortdesc = "All event types";
-	m_info.m_desc = "These fields can be used for all event types";
-	m_info.m_fields = sinsp_filter_check_gen_event_fields;
-	m_info.m_flags = filter_check_info::FL_NONE;
-	m_info.m_nfields = sizeof(sinsp_filter_check_gen_event_fields) / sizeof(sinsp_filter_check_gen_event_fields[0]);
-	m_u64val = 0;
+	static const filter_check_info s_field_infos = {
+		"evt",
+		"All event types",
+		"These fields can be used for all event types",
+		sizeof(sinsp_filter_check_gen_event_fields) / sizeof(sinsp_filter_check_gen_event_fields[0]),
+		sinsp_filter_check_gen_event_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
+	memset(&m_val, 0, sizeof(m_val));
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_gen_event::allocate_new()
@@ -138,26 +141,26 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, OUT uint32
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, true, false);
 		RETURN_EXTRACT_STRING(m_strstorage);
 	case TYPE_RAWTS:
-		m_u64val = evt->get_ts();
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = evt->get_ts();
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_RAWTS_S:
-		m_u64val = evt->get_ts() / ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = evt->get_ts() / ONE_SECOND_IN_NS;
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_RAWTS_NS:
-		m_u64val = evt->get_ts() % ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = evt->get_ts() % ONE_SECOND_IN_NS;
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_RELTS:
-		m_u64val = evt->get_ts() - m_inspector->m_firstevent_ts;
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = evt->get_ts() - m_inspector->m_firstevent_ts;
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_RELTS_S:
-		m_u64val = (evt->get_ts() - m_inspector->m_firstevent_ts) / ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = (evt->get_ts() - m_inspector->m_firstevent_ts) / ONE_SECOND_IN_NS;
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_RELTS_NS:
-		m_u64val = (evt->get_ts() - m_inspector->m_firstevent_ts) % ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = (evt->get_ts() - m_inspector->m_firstevent_ts) % ONE_SECOND_IN_NS;
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_NUMBER:
-		m_u64val = evt->get_num();
-		RETURN_EXTRACT_VAR(m_u64val);
+		m_val.u64 = evt->get_num();
+		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_PLUGINNAME:
 	case TYPE_PLUGININFO:
 		plugin = m_inspector->get_plugin_manager()->plugin_by_evt(evt);
@@ -186,13 +189,13 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, OUT uint32
 	case TYPE_ISASYNC:
 		if (libsinsp::events::is_metaevent((ppm_event_code) evt->get_type()))
 		{
-			m_u32val = 1;
+			m_val.u32 = 1;
 		}
 		else
 		{
-			m_u32val = 0;
+			m_val.u32 = 0;
 		}
-		RETURN_EXTRACT_VAR(m_u32val);
+		RETURN_EXTRACT_VAR(m_val.u32);
 	case TYPE_ASYNCTYPE:
 		if (!libsinsp::events::is_metaevent((ppm_event_code) evt->get_type()))
 		{

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.h
@@ -55,7 +55,9 @@ protected:
 	Json::Value extract_as_js(sinsp_evt*, OUT uint32_t* len) override;
 
 private:
-	uint64_t m_u64val;
-	uint32_t m_u32val;
+	union {
+		uint64_t u64;
+		uint32_t u32;
+	} m_val;
 	std::string m_strstorage;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -40,11 +40,15 @@ static const filtercheck_field_info sinsp_filter_check_group_fields[] =
 
 sinsp_filter_check_group::sinsp_filter_check_group()
 {
-	m_info.m_name = "group";
-	m_info.m_desc = "Information about the user group.";
-	m_info.m_fields = sinsp_filter_check_group_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_group_fields) / sizeof(sinsp_filter_check_group_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"group",
+		"",
+		"Information about the user group.",
+		sizeof(sinsp_filter_check_group_fields) / sizeof(sinsp_filter_check_group_fields[0]),
+		sinsp_filter_check_group_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_group::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_k8s.cpp
@@ -69,11 +69,16 @@ static const filtercheck_field_info sinsp_filter_check_k8s_fields[] =
 
 sinsp_filter_check_k8s::sinsp_filter_check_k8s()
 {
-	m_info.m_name = "k8s";
-	m_info.m_desc = "Kubernetes context about pods and namespace name. These fields are populated with data gathered from the container runtime.";
-	m_info.m_fields = sinsp_filter_check_k8s_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_k8s_fields) / sizeof(sinsp_filter_check_k8s_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"k8s",
+		"",
+		"Kubernetes context about pods and namespace name. These fields are populated with data gathered from the container runtime.",
+		sizeof(sinsp_filter_check_k8s_fields) / sizeof(sinsp_filter_check_k8s_fields[0]),
+		sinsp_filter_check_k8s_fields,
+		filter_check_info::FL_NONE,
+	};
+
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_k8s::allocate_new()
@@ -87,7 +92,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.pod.labels"))
 	{
 		m_field_id = TYPE_K8S_POD_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.pod.label", val);
 	}
@@ -95,7 +100,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.rc.labels"))
 	{
 		m_field_id = TYPE_K8S_RC_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.rc.label", val);
 	}
@@ -103,7 +108,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.rs.labels"))
 	{
 		m_field_id = TYPE_K8S_RS_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.rs.label", val);
 	}
@@ -111,7 +116,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.svc.labels"))
 	{
 		m_field_id = TYPE_K8S_SVC_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.svc.label", val);
 	}
@@ -119,7 +124,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.ns.labels"))
 	{
 		m_field_id = TYPE_K8S_NS_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.ns.label", val);
 	}
@@ -127,7 +132,7 @@ int32_t sinsp_filter_check_k8s::parse_field_name(std::string_view val, bool allo
 		!STR_MATCH("k8s.deployment.labels"))
 	{
 		m_field_id = TYPE_K8S_DEPLOYMENT_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("k8s.deployment.label", val);
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_mesos.cpp
@@ -47,11 +47,15 @@ static const filtercheck_field_info sinsp_filter_check_mesos_fields[] =
 
 sinsp_filter_check_mesos::sinsp_filter_check_mesos()
 {
-	m_info.m_name = "mesos";
-	m_info.m_desc = "Mesos related context.";
-	m_info.m_fields = sinsp_filter_check_mesos_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_mesos_fields) / sizeof(sinsp_filter_check_mesos_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"mesos",
+		"",
+		"Mesos related context.",
+		sizeof(sinsp_filter_check_mesos_fields) / sizeof(sinsp_filter_check_mesos_fields[0]),
+		sinsp_filter_check_mesos_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_mesos::allocate_new()
@@ -65,7 +69,7 @@ int32_t sinsp_filter_check_mesos::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("mesos.task.labels"))
 	{
 		m_field_id = TYPE_MESOS_TASK_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("mesos.task.label", val);
 	}
@@ -73,7 +77,7 @@ int32_t sinsp_filter_check_mesos::parse_field_name(std::string_view val, bool al
 		!STR_MATCH("marathon.app.labels"))
 	{
 		m_field_id = TYPE_MARATHON_APP_LABEL;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		return extract_arg("marathon.app.label", val);
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.cpp
@@ -27,25 +27,26 @@ static const filtercheck_field_info rawstring_check_fields[] =
 	{PT_CHARBUF, EPF_NONE, PF_NA, "NA", "NA", "INTERNAL."},
 };
 
-rawstring_check::rawstring_check(string text)
+rawstring_check::rawstring_check(const string& text)
 {
+	static const filter_check_info s_field_infos = {
+		"",
+		"",
+		"",
+		sizeof(rawstring_check_fields) / sizeof(rawstring_check_fields[0]),
+		rawstring_check_fields,
+		filter_check_info::FL_HIDDEN,
+	};
 	m_field = rawstring_check_fields;
-	m_info.m_flags = filter_check_info::FL_HIDDEN;
-	m_info.m_fields = rawstring_check_fields;
+	m_info = &s_field_infos;
 	m_field_id = 0;
-	set_text(text);
+	m_text = text;
 }
 
 std::unique_ptr<sinsp_filter_check> rawstring_check::allocate_new()
 {
 	ASSERT(false);
 	return nullptr;
-}
-
-void rawstring_check::set_text(string text)
-{
-	m_text_len = (uint32_t)text.size();
-	m_text = text;
 }
 
 int32_t rawstring_check::parse_field_name(std::string_view, bool alloc_state, bool needed_for_filtering)
@@ -56,6 +57,6 @@ int32_t rawstring_check::parse_field_name(std::string_view, bool alloc_state, bo
 
 uint8_t* rawstring_check::extract_single(sinsp_evt *evt, OUT uint32_t* len, bool sanitize_strings)
 {
-	*len = m_text_len;
+	*len = m_text.size();
 	return (uint8_t*)m_text.c_str();
 }

--- a/userspace/libsinsp/sinsp_filtercheck_rawstring.h
+++ b/userspace/libsinsp/sinsp_filtercheck_rawstring.h
@@ -23,19 +23,13 @@ limitations under the License.
 class rawstring_check : public sinsp_filter_check
 {
 public:
-	rawstring_check(std::string text);
+	rawstring_check(const std::string& text);
 	virtual ~rawstring_check() = default;
 
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(std::string_view, bool alloc_state, bool needed_for_filtering) override;
 	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
-	void set_text(std::string text);
-
-	// XXX this is overkill and wasted for most of the fields.
-	// It could be optimized by dynamically allocating the right amount
-	// of memory, but we don't care for the moment since we expect filters
-	// to be pretty small.
+private:
 	std::string m_text;
-	uint32_t m_text_len;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_reference.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.cpp
@@ -26,13 +26,14 @@ using namespace std;
 
 sinsp_filter_check_reference::sinsp_filter_check_reference()
 {
-	m_info.m_name = "<NA>";
-	m_info.m_desc = "";
-	m_info.m_fields = &m_finfo;
-	m_info.m_nfields = 1;
-	m_info.m_flags = filter_check_info::FL_HIDDEN;
+	m_cinfo.m_name = "<NA>";
+	m_cinfo.m_desc = "";
+	m_cinfo.m_fields = &m_finfo;
+	m_cinfo.m_nfields = 1;
+	m_cinfo.m_flags = filter_check_info::FL_HIDDEN;
 	m_finfo.m_print_format = PF_DEC;
 	m_field = &m_finfo;
+	m_info = &m_cinfo;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_reference::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_reference.h
+++ b/userspace/libsinsp/sinsp_filtercheck_reference.h
@@ -59,6 +59,7 @@ private:
 	char* print_int(uint8_t* rawval, uint32_t str_len);
 
 	filtercheck_field_info m_finfo;
+	filter_check_info m_cinfo;
 	uint8_t* m_val;
 	uint32_t m_len;
 	double m_cnt;		// For averages, this stores the entry count

--- a/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_syslog.cpp
@@ -51,11 +51,15 @@ static const filtercheck_field_info sinsp_filter_check_syslog_fields[] =
 
 sinsp_filter_check_syslog::sinsp_filter_check_syslog()
 {
-	m_info.m_name = "syslog";
-	m_info.m_desc = "Content of Syslog messages.";
-	m_info.m_flags = filter_check_info::FL_NONE;
-	m_info.m_fields = sinsp_filter_check_syslog_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_syslog_fields) / sizeof(sinsp_filter_check_syslog_fields[0]);
+	static const filter_check_info s_field_infos = {
+		"syslog",
+		"",
+		"Content of Syslog messages.",
+		sizeof(sinsp_filter_check_syslog_fields) / sizeof(sinsp_filter_check_syslog_fields[0]),
+		sinsp_filter_check_syslog_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_syslog::allocate_new()

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -133,11 +133,13 @@ private:
 
 	int32_t m_argid;
 	std::string m_argname;
-	uint32_t m_tbool;
 	std::string m_tstr;
-	uint64_t m_u64val;
-	int64_t m_s64val;
-	double m_dval;
+	union {
+		uint32_t u32;
+		uint64_t u64;
+		int64_t s64;
+		double d;
+	} m_val;
 	std::vector<uint64_t> m_last_proc_switch_times;
 	std::unique_ptr<libsinsp::state::dynamic_struct::field_accessor<uint64_t>> m_thread_dyn_field_accessor;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_tracer.cpp
@@ -60,11 +60,15 @@ static const filtercheck_field_info sinsp_filter_check_tracer_fields[] =
 
 sinsp_filter_check_tracer::sinsp_filter_check_tracer()
 {
-	m_info.m_flags = filter_check_info::FL_HIDDEN;
-	m_info.m_name = "span";
-	m_info.m_desc = "Fields used if information about distributed tracing is available.";
-	m_info.m_fields = sinsp_filter_check_tracer_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_tracer_fields) / sizeof(sinsp_filter_check_tracer_fields[0]);
+	static const filter_check_info s_field_infos = {
+		"span",
+		"",
+		"Fields used if information about distributed tracing is available.",
+		sizeof(sinsp_filter_check_tracer_fields) / sizeof(sinsp_filter_check_tracer_fields[0]),
+		sinsp_filter_check_tracer_fields,
+		filter_check_info::FL_HIDDEN,
+	};
+	m_info = &s_field_infos;
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_tracer::allocate_new()
@@ -125,7 +129,7 @@ int32_t sinsp_filter_check_tracer::parse_field_name(std::string_view val, bool a
 		!STR_MATCH("span.tags"))
 	{
 		m_field_id = TYPE_TAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.tag", val, NULL);
 	}
@@ -133,7 +137,7 @@ int32_t sinsp_filter_check_tracer::parse_field_name(std::string_view val, bool a
 		!STR_MATCH("span.args"))
 	{
 		m_field_id = TYPE_ARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.arg", val, NULL);
 	}
@@ -141,35 +145,35 @@ int32_t sinsp_filter_check_tracer::parse_field_name(std::string_view val, bool a
 		!STR_MATCH("span.enterargs"))
 	{
 		m_field_id = TYPE_ENTERARG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.enterarg", val, NULL);
 	}
 	else if(STR_MATCH("span.duration.fortag"))
 	{
 		m_field_id = TYPE_TAGDURATION;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.duration.fortag", val, NULL);
 	}
 	else if(STR_MATCH("span.count.fortag"))
 	{
 		m_field_id = TYPE_TAGCOUNT;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.count.fortag", val, NULL);
 	}
 	else if(STR_MATCH("span.childcount.fortag"))
 	{
 		m_field_id = TYPE_TAGCHILDSCOUNT;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.childcount.fortag", val, NULL);
 	}
 	else if(STR_MATCH("span.idtag"))
 	{
 		m_field_id = TYPE_IDTAG;
-		m_field = &m_info.m_fields[m_field_id];
+		m_field = &m_info->m_fields[m_field_id];
 
 		res = extract_arg("span.idtag", val, NULL);
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -44,11 +44,16 @@ static const filtercheck_field_info sinsp_filter_check_user_fields[] =
 
 sinsp_filter_check_user::sinsp_filter_check_user()
 {
-	m_info.m_name = "user";
-	m_info.m_desc = "Information about the user executing the specific event.";
-	m_info.m_fields = sinsp_filter_check_user_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_user_fields) / sizeof(sinsp_filter_check_user_fields[0]);
-	m_info.m_flags = filter_check_info::FL_NONE;
+	static const filter_check_info s_field_infos = {
+		"user",
+		"",
+		"Information about the user executing the specific event.",
+		sizeof(sinsp_filter_check_user_fields) / sizeof(sinsp_filter_check_user_fields[0]),
+		sinsp_filter_check_user_fields,
+		filter_check_info::FL_NONE,
+	};
+	m_info = &s_field_infos;
+	memset(&m_val, 0, sizeof(m_val));
 }
 
 std::unique_ptr<sinsp_filter_check> sinsp_filter_check_user::allocate_new()
@@ -84,8 +89,8 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt *evt, OUT uint32_t* l
 	switch(m_field_id)
 	{
 	case TYPE_UID:
-		m_uid = tinfo->m_user.uid();
-		RETURN_EXTRACT_VAR(m_uid);
+		m_val.u32 = tinfo->m_user.uid();
+		RETURN_EXTRACT_VAR(m_val.u32);
 	case TYPE_NAME:
 		m_strval = tinfo->m_user.name();
 		RETURN_EXTRACT_STRING(m_strval);
@@ -96,12 +101,12 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt *evt, OUT uint32_t* l
 		m_strval = tinfo->m_user.shell();
 		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_LOGINUID:
-		m_s64val = (int64_t)-1;
+		m_val.s64 = (int64_t)-1;
 		if(tinfo->m_loginuser.uid() < UINT32_MAX)
 		{
-			m_s64val = (int64_t)tinfo->m_loginuser.uid();
+			m_val.s64 = (int64_t)tinfo->m_loginuser.uid();
 		}
-		RETURN_EXTRACT_VAR(m_s64val);
+		RETURN_EXTRACT_VAR(m_val.s64);
 	case TYPE_LOGINNAME:
 		m_strval = tinfo->m_loginuser.name();
 		RETURN_EXTRACT_STRING(m_strval);

--- a/userspace/libsinsp/sinsp_filtercheck_user.h
+++ b/userspace/libsinsp/sinsp_filtercheck_user.h
@@ -42,7 +42,9 @@ protected:
 	uint8_t* extract_single(sinsp_evt*, OUT uint32_t* len, bool sanitize_strings = true) override;
 
 private:
-	int64_t m_s64val;
-	uint32_t m_uid;
+	union {
+		uint32_t u32;
+		int64_t s64;
+	} m_val;
 	std::string m_strval;
 };

--- a/userspace/libsinsp/sinsp_filtercheck_utils.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.cpp
@@ -34,11 +34,15 @@ static const filtercheck_field_info sinsp_filter_check_utils_fields[] =
 
 sinsp_filter_check_utils::sinsp_filter_check_utils()
 {
-	m_info.m_name = "util";
-	m_info.m_desc = "";
-	m_info.m_fields = sinsp_filter_check_utils_fields;
-	m_info.m_nfields = sizeof(sinsp_filter_check_utils_fields) / sizeof(sinsp_filter_check_utils_fields[0]);
-	m_info.m_flags = filter_check_info::FL_HIDDEN;
+	static const filter_check_info s_field_infos = {
+		"util",
+		"",
+		"",
+		sizeof(sinsp_filter_check_utils_fields) / sizeof(sinsp_filter_check_utils_fields[0]),
+		sinsp_filter_check_utils_fields,
+		filter_check_info::FL_HIDDEN,
+	};
+	m_info = &s_field_infos;
 	m_cnt = 0;
 }
 

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -62,10 +62,11 @@ public:
 
 	sinsp_filter_check_mock()
 	{
-		m_info.m_name = "test";
-		m_info.m_desc = "";
-		m_info.m_fields = sinsp_filter_check_mock_fields;
-		m_info.m_nfields = sizeof(sinsp_filter_check_mock_fields) / sizeof(sinsp_filter_check_mock_fields[0]);
+		m_finfo.m_name = "test";
+		m_finfo.m_desc = "";
+		m_finfo.m_fields = sinsp_filter_check_mock_fields;
+		m_finfo.m_nfields = sizeof(sinsp_filter_check_mock_fields) / sizeof(sinsp_filter_check_mock_fields[0]);
+		m_info = &m_finfo;
 	}
 	virtual ~sinsp_filter_check_mock() = default;
 
@@ -126,6 +127,7 @@ protected:
 	}
 
 private:
+	filter_check_info m_finfo;
 	std::string m_str_val;
 	uint64_t m_u64_val;
 };

--- a/userspace/libsinsp/value_parser.cpp
+++ b/userspace/libsinsp/value_parser.cpp
@@ -26,6 +26,20 @@ limitations under the License.
 #include <netdb.h>
 #endif
 
+static inline void check_storage_size(
+	const char* str, std::string::size_type storage_len, std::string::size_type used_len)
+{
+	if (used_len > storage_len) {
+		throw sinsp_exception(
+			+ "filter parameter too long (used="
+			+ std::to_string(used_len)
+			+ ", available="
+			+ std::to_string(storage_len)
+			+ "):"
+			+ std::string(str));
+	}
+}
+
 size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len, uint8_t *storage, std::string::size_type max_len, ppm_param_type ptype)
 {
 	size_t parsed_len;
@@ -33,20 +47,24 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 	switch(ptype)
 	{
 		case PT_INT8:
+			check_storage_size(str, max_len, sizeof(int8_t));
 			*(int8_t*)storage = sinsp_numparser::parsed8(str);
 			parsed_len = sizeof(int8_t);
 			break;
 		case PT_INT16:
+			check_storage_size(str, max_len, sizeof(int16_t));
 			*(int16_t*)storage = sinsp_numparser::parsed16(str);
 			parsed_len = sizeof(int16_t);
 			break;
 		case PT_INT32:
+			check_storage_size(str, max_len, sizeof(int32_t));
 			*(int32_t*)storage = sinsp_numparser::parsed32(str);
 			parsed_len = sizeof(int32_t);
 			break;
 		case PT_INT64:
 		case PT_FD:
 		case PT_ERRNO:
+			check_storage_size(str, max_len, sizeof(int64_t));
 			*(int64_t*)storage = sinsp_numparser::parsed64(str);
 			parsed_len = sizeof(int64_t);
 			break;
@@ -54,11 +72,13 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 		case PT_FLAGS8:
 		case PT_UINT8:
 		case PT_ENUMFLAGS8:
+			check_storage_size(str, max_len, sizeof(uint8_t));
 			*(uint8_t*)storage = sinsp_numparser::parseu8(str);
 			parsed_len = sizeof(int8_t);
 			break;
 		case PT_PORT:
 		{
+			check_storage_size(str, max_len, sizeof(uint16_t));
 			std::string in(str);
 
 			if(in.empty())
@@ -93,6 +113,7 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 		case PT_FLAGS16:
 		case PT_UINT16:
 		case PT_ENUMFLAGS16:
+			check_storage_size(str, max_len, sizeof(uint16_t));
 			*(uint16_t*)storage = sinsp_numparser::parseu16(str);
 			parsed_len = sizeof(uint16_t);
 			break;
@@ -100,15 +121,18 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 		case PT_UINT32:
 		case PT_MODE:
 		case PT_ENUMFLAGS32:
+			check_storage_size(str, max_len, sizeof(uint32_t));
 			*(uint32_t*)storage = sinsp_numparser::parseu32(str);
 			parsed_len = sizeof(uint32_t);
 			break;
 		case PT_UINT64:
+			check_storage_size(str, max_len, sizeof(uint64_t));
 			*(uint64_t*)storage = sinsp_numparser::parseu64(str);
 			parsed_len = sizeof(uint64_t);
 			break;
 		case PT_RELTIME:
 		case PT_ABSTIME:
+			check_storage_size(str, max_len, sizeof(uint64_t));
 			*(uint64_t*)storage = sinsp_numparser::parseu64(str);
 			parsed_len = sizeof(uint64_t);
 			break;
@@ -119,10 +143,7 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 		case PT_FSRELPATH:
 			{
 				len = (uint32_t)strlen(str);
-				if(len >= max_len)
-				{
-					throw sinsp_exception("filter parameter too long:" + std::string(str));
-				}
+				check_storage_size(str, max_len, len + 1);
 
 				memcpy(storage, str, len);
 				*(uint8_t*)(&storage[len]) = 0;
@@ -130,6 +151,7 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			}
 			break;
 		case PT_BOOL:
+			check_storage_size(str, max_len, sizeof(uint32_t));
 			parsed_len = sizeof(uint32_t);
 			if(std::string(str) == "true")
 			{
@@ -156,15 +178,17 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			}
 
 			break;
-	        case PT_IPV4ADDR:
+	    case PT_IPV4ADDR:
+			check_storage_size(str, max_len, sizeof(struct in_addr));
 			if(inet_pton(AF_INET, str, storage) != 1)
 			{
 				throw sinsp_exception("unrecognized IPv4 address " + std::string(str));
 			}
 			parsed_len = sizeof(struct in_addr);
 			break;
-	        case PT_IPV6ADDR:
+	    case PT_IPV6ADDR:
 		{
+			check_storage_size(str, max_len, sizeof(ipv6addr));
 			new (storage) ipv6addr(str);
 			parsed_len = sizeof(ipv6addr);
 			break;
@@ -178,10 +202,10 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 			{
 				return string_to_rawval(str, len, storage, max_len, PT_IPV6NET);
 			}
-
 			break;
 		case PT_IPV4NET:
 		{
+			check_storage_size(str, max_len, sizeof(ipv4net));
 			std::stringstream ss(str);
 			std::string ip, mask;
 			ipv4net* net = (ipv4net*)storage;
@@ -221,6 +245,7 @@ size_t sinsp_filter_value_parser::string_to_rawval(const char* str, uint32_t len
 		}
 		case PT_IPV6NET:
 		{
+			check_storage_size(str, max_len, sizeof(ipv6net));
 			new (storage) ipv6net(str);
 			parsed_len = sizeof(ipv6net);
 			break;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

While profiling Falco's memory usage, I figured that features related to sinsp filters (used in Falco rules) allocate memory eagerly in most instances, even when not needed. This PR attempts switching approach so that those components allocate memory lazily (only when needed) and with much less redundancy.

In use cases with many filters allocated (e.g. Falco rules), they can represent a substantial chunk of Falco's memory allocations (the same applies for other projects built on top of the libs and using filters/formatters). From my experiments, I was able to see a 30% memory usage reduction for allocations related to filters when testing this patch on Falco by loading the default stable rules.

Functionally, this changes nothing. The API should also be unchanged, as most of this all happens as internal code in sinsp.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp): optimize allocations of filter checks
```
