### PR TITLE
new(scap-open): add stats for syscalls received in userspace

### DIFF
--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -827,7 +827,6 @@ static inline bool engine_uses_bpf()
 	return false;
 }
 
-
 void print_syscalls_stats()
 {
 	// ppm_sc_count will become out of order so we save the code
@@ -842,7 +841,7 @@ void print_syscalls_stats()
 	{
 		for(int j = i + 1; j < PPM_SC_MAX*2; ++j)
 		{
-			/* swapping strings if they are not in the lexicographical order */
+			
 			if(ppm_sc_count[i].counter < ppm_sc_count[j].counter)
 			{
 				tmp = ppm_sc_count[i];
@@ -888,37 +887,33 @@ void print_stats()
 
 	printf("\n----------------------------- STATS ------------------------------\n");
 
-	printf("\n[SCAP-OPEN]: General statistics\n");
-	printf("\nEvents correctly captured (SCAP_SUCCESS): %" PRIu64 "\n", g_nevts);
-	printf("Number of bytes received: %" PRIu64 " bytes\n", g_total_number_of_bytes);
-	if(g_nevts!=0)
-	{
-		printf("Average dimension of events: %" PRIu64 " bytes\n", g_total_number_of_bytes/g_nevts);
-	}
+	/////////////////////
+	// Kernel stats
+	/////////////////////
+
+	printf("\n------------> Kernel stats\n");
 	printf("Seen by driver (kernel side events): %" PRIu64 "\n", n_evts);
-	printf("Time elapsed: %ld s\n", tval_result.tv_sec);
 	if(tval_result.tv_sec != 0)
 	{
-		printf("Rate of userspace events (events/second): %ld\n", g_nevts / tval_result.tv_sec);
 		printf("Rate of kernel side events (events/second): %ld\n", n_evts / tval_result.tv_sec);
 	}
-	printf("Number of timeouts: %ld\n", number_of_timeouts);
-	printf("Number of 'next' calls: %ld\n", number_of_scap_next);
 
-	printf("\n[SCAP-OPEN]: Stats v2.\n");
-	printf("\n[SCAP-OPEN]: %u metrics in total\n", nstats);
+	printf("Stats v2: %u metrics in total\n", nstats);
 	if(engine_uses_bpf())
 	{
-		printf("[SCAP-OPEN]: [1] kernel-side counters\n");
-		printf("[SCAP-OPEN]: [2] libbpf stats (compare to `bpftool prog show` CLI)\n\n");
+		printf("[1] kernel-side counters\n");
 		if (!(engine_flags & ENGINE_FLAG_BPF_STATS_ENABLED))
 		{
-			printf("\n[Notice]: `/proc/sys/kernel/bpf_stats_enabled` not enabled, no `libbpf` stats retrieved.\n\n");
+			printf("[Notice]: `/proc/sys/kernel/bpf_stats_enabled` not enabled, no `libbpf` stats retrieved.\n");
+		}
+		else
+		{
+			printf("[2] libbpf stats (compare to `bpftool prog show` CLI)\n");
 		}
 	}
 	else
 	{
-		printf("[SCAP-OPEN]: [1] kernel-side counters.\n\n");
+		printf("[1] kernel-side counters.\n\n");
 	}
 	if (stats_v2 && nstats > 0)
 	{
@@ -931,10 +926,26 @@ void print_stats()
 		}
 	}
 
-	// Print syscall stats userspace side:
-	printf("\n[SCAP-OPEN]: Syscall stats userspace side.\n\n");
+	/////////////////////
+	// Userspace stats
+	/////////////////////
+
+	printf("\n------------> Userspace stats\n");
+	printf("Number of `SCAP_SUCCESS` (events correctly captured): %" PRIu64 "\n", g_nevts);
+	printf("Number of `SCAP_TIMEOUTS`: %ld\n", number_of_timeouts);
+	printf("Number of `scap_next` calls: %ld\n", number_of_scap_next);
+	printf("Number of bytes received: %" PRIu64 " bytes\n", g_total_number_of_bytes);
+	if(g_nevts!=0)
+	{
+		printf("Average dimension of events: %" PRIu64 " bytes\n", g_total_number_of_bytes/g_nevts);
+	}
+	printf("Time elapsed: %ld s\n", tval_result.tv_sec);
+	if(tval_result.tv_sec != 0)
+	{
+		printf("Rate of userspace events (events/second): %ld\n", g_nevts / tval_result.tv_sec);
+	}
+	printf("Syscall stats (userspace-side):\n");
 	print_syscalls_stats();
-	
 	printf("\n\n------------------------------------------------------------------\n\n");
 	printf("\n[SCAP-OPEN]: Bye!\n");
 }

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -150,10 +150,10 @@ static int simple_set[] = {
 	-1
 };
 
-struct pair_counter{
+typedef struct ppm_sc_counter{
 	uint64_t counter;
 	ppm_sc_code code; /* we need the code also here because at the end we will sort */
-} typedef pair_counter;
+} ppm_sc_counter;
 
 /* Generic global variables. */
 static scap_open_args oargs = {};						    /* scap oargs used in `scap_open`. */
@@ -166,7 +166,7 @@ static char* valptr = NULL; /* pointer used to print the value of event params. 
 static struct timeval tval_start, tval_end, tval_result;
 static unsigned long number_of_timeouts; /* Times in which there were no events in the buffer. */
 static unsigned long number_of_scap_next; /* Times in which the 'scap-next' method is called. */
-static pair_counter ppm_sc_count[PPM_SC_MAX*2] = {0}; /* Number of times a syscall is called. We want the `*2` because we store the enter and the exit count separately */
+static ppm_sc_counter ppm_sc_count[PPM_SC_MAX*2] = {0}; /* Number of times a syscall is called. We want the `*2` because we store the enter and the exit count separately */
 
 /*=============================== PRINT SUPPORTED SYSCALLS ===========================*/
 
@@ -836,7 +836,7 @@ void print_syscalls_stats()
 	}
 
 	// sort them 
-	pair_counter tmp;
+	ppm_sc_counter tmp;
 	for(int i = 0; i < PPM_SC_MAX*2; ++i)
 	{
 		for(int j = i + 1; j < PPM_SC_MAX*2; ++j)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR adds stats for syscalls received in userspace and splits the console output in userspace and kernel side. Let me know if you like it, the new output is something like this:

```
----------------------------- STATS ------------------------------

------------> Kernel stats
Seen by driver (kernel side events): 225250
Rate of kernel side events (events/second): 56312
Stats v2: 18 metrics in total
[1] kernel-side counters
[Notice]: `/proc/sys/kernel/bpf_stats_enabled` not enabled, no `libbpf` stats retrieved.
[1] n_evts: 225250
[1] n_drops_buffer_total: 0
[1] n_drops_buffer_clone_fork_enter: 0
[1] n_drops_buffer_clone_fork_exit: 0
[1] n_drops_buffer_execve_enter: 0
[1] n_drops_buffer_execve_exit: 0
[1] n_drops_buffer_connect_enter: 0
[1] n_drops_buffer_connect_exit: 0
[1] n_drops_buffer_open_enter: 0
[1] n_drops_buffer_open_exit: 0
[1] n_drops_buffer_dir_file_enter: 0
[1] n_drops_buffer_dir_file_exit: 0
[1] n_drops_buffer_other_interest_enter: 0
[1] n_drops_buffer_other_interest_exit: 0
[1] n_drops_buffer_close_exit: 0
[1] n_drops_buffer_proc_exit: 0
[1] n_drops_scratch_map: 0
[1] n_drops: 0

------------> Userspace stats
Number of `SCAP_SUCCESS` (events correctly captured): 225176
Number of `SCAP_TIMEOUTS`: 6541
Number of `scap_next` calls: 231717
Number of bytes received: 12737021 bytes
Average dimension of events: 56 bytes
Time elapsed: 4 s
Rate of userspace events (events/second): 56294
Syscall stats (userspace-side):
- [page_fault_user__enter]: 46481
- [sched_switch__enter]: 27819
- [read__enter]: 20021
- [read__exit]: 20021
- [recvmsg__enter]: 7135
- [recvmsg__exit]: 7135
- [clock_nanosleep__exit]: 6552
- [clock_nanosleep__enter]: 6550
- [futex__exit]: 6322
- [futex__enter]: 6320
- [poll__exit]: 4055
- [poll__enter]: 4054
- [rt_sigprocmask__exit]: 3406
- [rt_sigprocmask__enter]: 3406
- [write__exit]: 3311
- [write__enter]: 3311
- [ioctl__enter]: 2272
- [ioctl__exit]: 2271
- [close__enter]: 2038
- [close__exit]: 2038
- [openat__exit]: 1994
- [openat__enter]: 1994
- [epoll_wait__exit]: 1980
- [epoll_wait__enter]: 1979
- [writev__exit]: 1867
- [writev__enter]: 1867
- [fstat__exit]: 1513
- [fstat__enter]: 1513
- [readlink__enter]: 1484
- [readlink__exit]: 1484
- [pread64__enter]: 1379
- [pread64__exit]: 1379
- [bpf__enter]: 1148
- [bpf__exit]: 1148
- [setitimer__enter]: 1133
- [setitimer__exit]: 1133
...
```


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
