### PR TITLE
fix(userspace/libsinsp): podman support during scap files replay

### DIFF
--- a/userspace/libsinsp/container_engine/docker/podman.cpp
+++ b/userspace/libsinsp/container_engine/docker/podman.cpp
@@ -163,8 +163,14 @@ int detect_podman(const sinsp_threadinfo *tinfo, std::string &container_id)
 }
 }
 
-bool podman::can_api_sock_exist()
+bool podman::can_api_sock_exist(sinsp *inspector)
 {
+	// Short-circuit: always enable podman when running from a capture file.
+	if (inspector->is_capture())
+	{
+		return true;
+	}
+
 	glob_t gl;
 	int rc;
 	int glob_flags = 0;
@@ -193,7 +199,7 @@ bool podman::resolve(sinsp_threadinfo *tinfo, bool query_os_for_missing_info)
 
 	if(!m_api_sock_can_exist.has_value())
 	{
-		m_api_sock_can_exist = can_api_sock_exist();
+		m_api_sock_can_exist = can_api_sock_exist(tinfo->m_inspector);
 	}
 
 	if(!m_api_sock_can_exist.value())

--- a/userspace/libsinsp/container_engine/docker/podman.h
+++ b/userspace/libsinsp/container_engine/docker/podman.h
@@ -21,7 +21,7 @@ private:
 	std::optional<bool> m_api_sock_can_exist;
 
 	// Return true if any possible api socket pattern exists.
-	bool can_api_sock_exist();
+	static bool can_api_sock_exist(sinsp *inspector);
 
 	// Return whether or not any possible api socket exists. (The actual socket is
 	// implement container_engine_base

--- a/userspace/libsinsp/sinsp_filtercheck_container.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_container.cpp
@@ -343,6 +343,9 @@ uint8_t* sinsp_filter_check_container::extract_single(sinsp_evt *evt, OUT uint32
 			case sinsp_container_type::CT_BPM:
 				m_tstr = "bpm";
 				break;
+			case sinsp_container_type::CT_PODMAN:
+				m_tstr = "podman";
+				break;
 			default:
 				ASSERT(false);
 				break;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

This PR fixes podman support while replaying scap files; moreover, it fixes a small bug in `container.type` filtercheck.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): podman support during scap files replay
```
