### PR TITLE
fix(modern): try to address a page fault caused by `bpf_probe_read_kernel`

### DIFF
--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -11,6 +11,14 @@
 
 /* This header should include different definitions according to different architectures.*/
 
+#ifndef likely
+# define likely(X)		__builtin_expect(!!(X), 1)
+#endif
+
+#ifndef unlikely
+# define unlikely(X)		__builtin_expect(!!(X), 0)
+#endif
+
 /*
  * Per process flags
  */

--- a/driver/modern_bpf/helpers/base/common.h
+++ b/driver/modern_bpf/helpers/base/common.h
@@ -16,31 +16,6 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 
-/*=============================== LIBBPF MISSING TRACING DEFINITION ===========================*/
-
-/* Look at bpf/bpf_tracing.h, this definition is similar
- * to the others `PT_REGS_PARAM...`
- */
-
-#ifndef PT_REGS_PARM6_CORE_SYSCALL
-
-#if defined(bpf_target_x86)
-#define __PT_PARM6_REG r9
-#elif defined(bpf_target_arm64)
-#define __PT_PARM6_REG regs[5]
-#elif defined(bpf_target_s390)
-#define __PT_PARM6_REG gprs[7]
-#elif defined(bpf_target_powerpc)
-#define __PT_PARM6_REG gpr[8]
-#endif
-
-#define PT_REGS_PARM6_CORE(x) BPF_CORE_READ(__PT_REGS_CAST(x), __PT_PARM6_REG)
-#define PT_REGS_PARM6_CORE_SYSCALL(x) PT_REGS_PARM6_CORE(x)
-
-#endif
-
-/*=============================== LIBBPF MISSING TRACING DEFINITION ===========================*/
-
 /*=============================== DEBUG MACRO ===========================*/
 
 /* For more info about this macro look at https://nakryiko.com/posts/bpf-tips-printk/

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -62,6 +62,11 @@ static __always_inline uint16_t maps__get_statsd_port()
 	return g_settings.statsd_port;
 }
 
+static __always_inline int32_t maps__get_scap_pid()
+{
+	return g_settings.scap_pid;
+}
+
 /*=============================== SETTINGS ===========================*/
 
 /*=============================== KERNEL CONFIGS ===========================*/
@@ -74,6 +79,16 @@ static __always_inline bool maps__get_is_dropping()
 static __always_inline void maps__set_is_dropping(bool value)
 {
 	is_dropping = value;
+}
+
+static __always_inline void* maps__get_socket_file_ops()
+{
+	return socket_file_ops;
+}
+
+static __always_inline void maps__set_socket_file_ops(void* value)
+{
+	socket_file_ops = value;
 }
 
 /*=============================== KERNEL CONFIGS ===========================*/

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -62,9 +62,9 @@ static __always_inline uint16_t maps__get_statsd_port()
 	return g_settings.statsd_port;
 }
 
-static __always_inline int32_t maps__get_scap_pid()
+static __always_inline int32_t maps__get_scap_tid()
 {
-	return g_settings.scap_pid;
+	return g_settings.scap_tid;
 }
 
 /*=============================== SETTINGS ===========================*/

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -153,7 +153,7 @@ static __always_inline void ringbuf__rewrite_header_for_calibration(struct ringb
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)ringbuf->data;
 	/* we set this to 0 to recognize this calibration event */
 	hdr->nparams = 0;
-	/* we cannot send the tid seen by the init namespace we need to send the pid seen by the current pid namespace
+	/* we cannot send the tid seen by the init namespace we need to send the tid seen by the current pid namespace
 	 * to be compliant with what scap expects.
 	 */
 	hdr->tid = vtid;

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -148,6 +148,17 @@ static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *r
 	ringbuf->lengths_pos = sizeof(struct ppm_evt_hdr);
 }
 
+static __always_inline void ringbuf__rewrite_header_for_calibration(struct ringbuf_struct *ringbuf, pid_t vtid)
+{
+	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)ringbuf->data;
+	/* we set this to 0 to recognize this calibration event */
+	hdr->nparams = 0;
+	/* we cannot send the tid seen by the init namespace we need to send the pid seen by the current pid namespace
+	 * to be compliant with what scap expects.
+	 */
+	hdr->tid = vtid;
+}
+
 /////////////////////////////////
 // SUBMIT EVENT IN THE RINGBUF
 ////////////////////////////////

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -92,6 +92,11 @@ __weak struct capture_settings g_settings;
  */
 __weak bool is_dropping;
 
+/**
+ * @brief Pointer we use to understand if we are operating on a socket.
+ */
+__weak void *socket_file_ops = NULL;		   
+
 /*=============================== BPF GLOBAL VARIABLES ===============================*/
 
 /*=============================== BPF_MAP_TYPE_PROG_ARRAY ===============================*/

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/accept.bpf.c
@@ -86,15 +86,17 @@ int BPF_PROG(accept_x,
 		 * new one.
 		 */
 		int32_t sockfd = (int32_t)args[0];
-		struct file *file = NULL;
-		file = extract__file_struct_from_fd(sockfd);
-		struct socket *socket = BPF_CORE_READ(file, private_data);
-		struct sock *sk = BPF_CORE_READ(socket, sk);
-		BPF_CORE_READ_INTO(&queuelen, sk, sk_ack_backlog);
-		BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
-		if(queuelen && queuemax)
+		struct file *file = extract__file_struct_from_fd(sockfd);
+		struct socket *socket = get_sock_from_file(file);
+		if(socket != NULL)
 		{
-			queuepct = (uint8_t)((uint64_t)queuelen * 100 / queuemax);
+			struct sock *sk = BPF_CORE_READ(socket, sk);
+			BPF_CORE_READ_INTO(&queuelen, sk, sk_ack_backlog);
+			BPF_CORE_READ_INTO(&queuemax, sk, sk_max_ack_backlog);
+			if(queuelen && queuemax)
+			{
+				queuepct = (uint8_t)((uint64_t)queuelen * 100 / queuemax);
+			}
 		}
 	}
 	else

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -73,6 +73,29 @@ int BPF_PROG(socket_x,
 	/* Parameter 1: res (type: PT_ERRNO)*/
 	ringbuf__store_s64(&ringbuf, ret);
 
+	/* Just called once by our scap process */
+	if(ret >= 0 && maps__get_socket_file_ops() == NULL)
+	{
+		struct task_struct *task = get_current_task();
+		/* Please note that in `g_settings.scap_pid` scap will put its virtual pid
+		 * if it is running inside a container. If we want to extract the same information
+		 * in the kernel we need to extract the virtual pid of the task.
+		 */
+		pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
+		/* it means that scap is performing the calibration */
+		if(vpid == maps__get_scap_pid())
+		{
+			struct file *f = extract__file_struct_from_fd(ret);
+			if(f)
+			{
+				struct file_operations *f_op = (struct file_operations *)BPF_CORE_READ(f, f_op);
+				maps__set_socket_file_ops((void*)f_op);
+				/* we need to rewrite the event header */
+				ringbuf__rewrite_header_for_calibration(&ringbuf, vpid);
+			}
+		}
+	}
+
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	ringbuf__submit_event(&ringbuf);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -77,13 +77,13 @@ int BPF_PROG(socket_x,
 	if(ret >= 0 && maps__get_socket_file_ops() == NULL)
 	{
 		struct task_struct *task = get_current_task();
-		/* Please note that in `g_settings.scap_pid` scap will put its virtual pid
+		/* Please note that in `g_settings.scap_tid` scap will put its virtual tid
 		 * if it is running inside a container. If we want to extract the same information
-		 * in the kernel we need to extract the virtual pid of the task.
+		 * in the kernel we need to extract the virtual tid of the task.
 		 */
-		pid_t vpid = extract__task_xid_vnr(task, PIDTYPE_TGID);
+		pid_t vtid = extract__task_xid_vnr(task, PIDTYPE_PID);
 		/* it means that scap is performing the calibration */
-		if(vpid == maps__get_scap_pid())
+		if(vtid == maps__get_scap_tid())
 		{
 			struct file *f = extract__file_struct_from_fd(ret);
 			if(f)
@@ -91,7 +91,7 @@ int BPF_PROG(socket_x,
 				struct file_operations *f_op = (struct file_operations *)BPF_CORE_READ(f, f_op);
 				maps__set_socket_file_ops((void*)f_op);
 				/* we need to rewrite the event header */
-				ringbuf__rewrite_header_for_calibration(&ringbuf, vpid);
+				ringbuf__rewrite_header_for_calibration(&ringbuf, vtid);
 			}
 		}
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -91,10 +91,13 @@ int BPF_PROG(socketpair_x,
 
 		/* Get source and peer. */
 		struct file *file = extract__file_struct_from_fd((int32_t)fds[0]);
-		struct socket *socket = BPF_CORE_READ(file, private_data);
-		BPF_CORE_READ_INTO(&source, socket, sk);
-		struct unix_sock *us = (struct unix_sock *)source;
-		BPF_CORE_READ_INTO(&peer, us, peer);
+		struct socket *socket = get_sock_from_file(file);
+		if(socket != NULL)
+		{
+			BPF_CORE_READ_INTO(&source, socket, sk);
+			struct unix_sock *us = (struct unix_sock *)source;
+			BPF_CORE_READ_INTO(&peer, us, peer);
+		}
 	}
 
 	/* Parameter 2: fd1 (type: PT_FD) */

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -33,6 +33,7 @@ struct capture_settings
 	uint16_t fullcapture_port_range_start; /* first interesting port */
 	uint16_t fullcapture_port_range_end;   /* last interesting port */
 	uint16_t statsd_port;		       /* port for statsd metrics */
+	int32_t scap_pid;		       /* pid of the scap process */
 };
 
 /**

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -33,7 +33,7 @@ struct capture_settings
 	uint16_t fullcapture_port_range_start; /* first interesting port */
 	uint16_t fullcapture_port_range_end;   /* last interesting port */
 	uint16_t statsd_port;		       /* port for statsd metrics */
-	int32_t scap_pid;		       /* pid of the scap process */
+	int32_t scap_tid;		       /* tid of the scap process */
 };
 
 /**

--- a/driver/syscall_compat.h
+++ b/driver/syscall_compat.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#if defined(__x86_64__) || defined(__EMSCRIPTEN__)
+#include "syscall_compat_x86_64.h"
+#elif defined(__aarch64__)
+#include "syscall_compat_aarch64.h"
+#elif defined(__s390x__)
+#include "syscall_compat_s390x.h"
+#elif defined(__powerpc__)
+#include "syscall_compat_ppc64le.h"
+#elif defined(__riscv)
+#include "syscall_compat_riscv64.h"
+#elif defined(__loongarch__)
+#include "syscall_compat_loongarch64.h"
+#endif /* __x86_64__ */

--- a/driver/syscall_table64.c
+++ b/driver/syscall_table64.c
@@ -18,19 +18,7 @@ or GPL2.txt for full copies of the license.
  * even if the driver won't be able to send all syscalls.
  */
 #if defined(__GNUC__)
-#if defined(__x86_64__) || defined(__EMSCRIPTEN__)
-#include "syscall_compat_x86_64.h"
-#elif defined(__aarch64__)
-#include "syscall_compat_aarch64.h"
-#elif defined(__s390x__)
-#include "syscall_compat_s390x.h"
-#elif defined(__powerpc__)
-#include "syscall_compat_ppc64le.h"
-#elif defined(__riscv)
-#include "syscall_compat_riscv64.h"
-#elif defined(__loongarch__)
-#include "syscall_compat_loongarch64.h"
-#endif /* __x86_64__ */
+#include "syscall_compat.h"
 #elif defined(_MSC_VER) || defined(__EMSCRIPTEN__)
 // these are Linux syscall numbers and obviously meaningless for Windows/macOS
 // but we need *some* definition so that we have a mapping for scap_ppm_sc.c

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -374,11 +374,11 @@ extern "C"
 	void pman_set_statsd_port(uint16_t statsd_port);
 
 	/**
-	 * @brief Set scap pid for socket calibration logic.
+	 * @brief Set scap tid for socket calibration logic.
 	 *
-	 * @param scap_pid port number.
+	 * @param scap_tid
 	 */
-	void pman_set_scap_pid(int32_t scap_pid);
+	void pman_set_scap_tid(int32_t scap_tid);
 
 	/**
 	 * @brief Get API version to check it a runtime.

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -374,6 +374,13 @@ extern "C"
 	void pman_set_statsd_port(uint16_t statsd_port);
 
 	/**
+	 * @brief Set scap pid for socket calibration logic.
+	 *
+	 * @param scap_pid port number.
+	 */
+	void pman_set_scap_pid(int32_t scap_pid);
+
+	/**
 	 * @brief Get API version to check it a runtime.
 	 *
 	 * @return API version

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -105,6 +105,11 @@ void pman_set_statsd_port(uint16_t statsd_port)
 	g_state.skel->bss->g_settings.statsd_port = statsd_port;
 }
 
+void pman_set_scap_pid(int32_t scap_pid)
+{
+	g_state.skel->bss->g_settings.scap_pid = scap_pid;
+}
+
 void pman_mark_single_64bit_syscall(int intersting_syscall_id, bool interesting)
 {
 	g_state.skel->bss->g_64bit_interesting_syscalls_table[intersting_syscall_id] = interesting;

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -105,9 +105,9 @@ void pman_set_statsd_port(uint16_t statsd_port)
 	g_state.skel->bss->g_settings.statsd_port = statsd_port;
 }
 
-void pman_set_scap_pid(int32_t scap_pid)
+void pman_set_scap_tid(int32_t scap_tid)
 {
-	g_state.skel->bss->g_settings.scap_pid = scap_pid;
+	g_state.skel->bss->g_settings.scap_tid = scap_tid;
 }
 
 void pman_mark_single_64bit_syscall(int intersting_syscall_id, bool interesting)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We recently saw some issues with modern_ebpf driver -> https://github.com/falcosecurity/falco/issues/3181.
Analyzing the call trace it seems the issue is related to the `accept4_x` filler.

```
[17285553.068504] Call Trace:
[17285553.074274]  <TASK>
[17285553.079218]  ? show_regs.cold.14+0x1a/0x1f
[17285553.084320]  ? __die_body+0x1f/0x70
[17285553.089309]  ? __die+0x2a/0x35
[17285553.094284]  ? _end+0x7b5da0c7/0x0
[17285553.099340]  ? page_fault_oops+0xaf/0x270
[17285553.104379]  ? bpf_probe_read_kernel+0x1d/0x50
[17285553.109575]  ? bpf_ringbuf_submit+0x10/0x20
[17285553.115044]  ? bpf_prog_182d4293644cc965_pf_kernel+0x549/0x558
[17285553.121418]  ? _end+0x7b5da0c7/0x0
[17285553.127468]  ? do_user_addr_fault+0x30b/0x590
[17285553.132943]  ? _end+0x7b5da0c7/0x0
[17285553.138381]  ? exc_page_fault+0x6f/0x160
[17285553.143782]  ? asm_exc_page_fault+0x27/0x30
[17285553.149265]  ? _end+0x7b5da0c7/0x0
[17285553.154742]  ? copy_from_kernel_nofault+0x6d/0x120
[17285553.160220]  bpf_probe_read_kernel+0x1d/0x50
[17285553.166254]  bpf_prog_3a9838b3cf5001f5_accept4_x+0x2e6/0x1589
[17285553.172566]  ? bpf_probe_read_kernel+0x1d/0x50
[17285553.178263]  ? bpf_prog_c5b1b737d5cb01c5_sys_exit+0x28f/0x50c
[17285553.184115]  bpf_trace_run2+0x54/0xd0
[17285553.189977]  __bpf_trace_sys_exit+0x9/0x10
[17285553.195917]  syscall_exit_to_user_mode_prepare+0x171/0x1d0
[17285553.202015]  syscall_exit_to_user_mode+0xd/0x40
[17285553.207926]  do_syscall_64+0x46/0x90
[17285553.214281]  entry_SYSCALL_64_after_hwframe+0x63/0xcd
```
We can see that the culprit is `bpf_probe_read_kernel` helper... but we are in ebpf so a page fault should never happen...
Indeed it turns out there is a bug on x86 machines when trying to use `copy_from_kernel_nofault()` to read vsyscall page
through a bpf program -> https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=32019c659ec

And looking at the address that causes the page fault, we can notice that this is a `VSYSCALL` address

```
[17285552.983963] BUG: unable to handle page fault for address: ffffffffff6000c7
```

The question now is, why are we reading from a vsyscall address? We are inside an `accept4` this doesn't make so much sense...
My guess here is that due to some race conditions, we can read a random address from `extract__file_struct_from_fd` and then we try to cast this address to a socket and do some `bpf_probe_read_kernel`. 

All the code added in this PR is an extra safe check that we already have in the legacy ebpf probe. We initially avoided it in the modern probe as a performance optimization because without this "vsyscall address" bug the probe should never cause an unhandled page fault at runtime... Unfortunately, this bug is fixed only in kernel version >= 6.8 so we need a workaround to handle this situation.

This check indeed introduces a little bit of overhead but it's also true that should guarantee more reliable information since we explicitly check that we are a socket before performing some extra `bpf_probe_read_kernel`, so in any case, these changes can be seen as an improvement in consistency.

Please note that this is just an assumption, the call trace seems to be compatible with this analysis but the page fault could still be there... in that case, we should apply more strict checks on our `bpf_probe_read_kernel` checking that the address is different from a `VSYSCALL` address. 

**Which issue(s) this PR fixes**:

ref https://github.com/falcosecurity/falco/issues/3181

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
