### PR TITLE
chore: limit MIN/MAX macros to plain C

### DIFF
--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -84,11 +84,12 @@ void scap_free_device_table(scap_mountinfo* dev_list);
 //
 // Useful stuff
 //
+#ifndef __cplusplus
 #ifndef MIN
 #define MIN(X,Y) ((X) < (Y)? (X):(Y))
 #define MAX(X,Y) ((X) > (Y)? (X):(Y))
 #endif
-
+#endif
 
 //
 // Driver proc info table sizes


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
No

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
Header file `scap-int.h` has two macros `MIN` and `MAX` for performing the obvious operations. These are never used in C++ code, which has its own function templates `std::min` and `std::max`, and are juts for the benefit of plain C code.
For this reason it would be best to avoid defining them altogether when the header is included in C++ code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The library does not define MIN/MAX macros for C++ code anymore, they are now limited for plain C.
Should client C++ code rely on them it is advised to refactor it for using standard C++ functions std::min and std:max.
```
