### PR TITLE
fix(sinsp): remove wrong unix parsing logic

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3180,11 +3180,6 @@ void sinsp_parser::parse_connect_enter(sinsp_evt *evt){
         // Add the friendly name to the fd info
         //
         evt->get_fd_info()->m_name = evt->get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
-
-        //
-        // Update the FD with this tuple
-        //
-        evt->get_fd_info()->set_unix_info(packed_data);
 	}
 
     //


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR removes a wrong parsing logic for the connect_e event. Probably this was a wrong copy&paste from the connect_x parser. In the enter event, we don't have the tuple but just the family + path. So the function `set_unix_info` is reading random memory...

```cpp
	inline void set_unix_info(uint8_t* packed_data)
	{
		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_source, packed_data + 1, sizeof(uint64_t));
		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_dest, packed_data + 9, sizeof(uint64_t));
	}
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
