### PR TITLE
fix(driver/configure): properly pass `CC` variable as make argument.

### DIFF
--- a/driver/configure/build.sh
+++ b/driver/configure/build.sh
@@ -10,4 +10,4 @@
 SCRIPT=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname ${SCRIPT})
 
-make -C ${SCRIPT_DIR} > ${SCRIPT_DIR}/build.log 2>&1
+make CC="${CC}" -C ${SCRIPT_DIR} > ${SCRIPT_DIR}/build.log 2>&1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Some distros (namely ubuntu and debian as far as i know) do not accept `CC` being passed from env.
Instead, they want it to be passed as `make` argument.
Make sure to pass it both way in the configure modules for kmod (`CC` is already passed as env, therefore we just add it to `make` argument too !)

**Which issue(s) this PR fixes**:

`falco-driver-loader` building of drivers on ubuntu.

Fixes #

**Special notes for your reviewer**:

I already saw something similar on driverkit a couple of months ago: https://github.com/falcosecurity/driverkit/pull/322#issuecomment-1983940164

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
