### PR TITLE
fix(userspace/libsinsp): fixed possible buffer overflow in `sinsp_plugin::get_metrics`

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <inttypes.h>
 #include <string.h>
+#include <memory>
 #include <vector>
 #include <set>
 #include <sstream>
@@ -939,11 +940,7 @@ std::vector<metrics_v2> sinsp_plugin::get_metrics() const
 		metrics_v2 metric;
 		
 		//copy plugin name
-		int s = strlcpy(metric.name, m_name.c_str(), METRIC_NAME_MAX);
-		//copy dot
-		strlcpy(metric.name + s, ".", METRIC_NAME_MAX);
-		//copy metric name
-		strlcpy(metric.name + s + 1, plugin_metric->name, METRIC_NAME_MAX);
+		snprintf(metric.name, METRIC_NAME_MAX, "%s.%s", m_name.c_str(), plugin_metric->name);
 
 		metric.flags = METRICS_V2_PLUGINS;
 		metric.unit = METRIC_VALUE_UNIT_COUNT;
@@ -1083,7 +1080,7 @@ ss_plugin_rc sinsp_plugin::handle_plugin_async_event(ss_plugin_owner_t *o, const
 
 	try
 	{
-		auto evt = std::unique_ptr<sinsp_evt>(new sinsp_evt());
+		auto evt = std::make_unique<sinsp_evt>();
 		ASSERT(evt->get_scap_evt_storage() == nullptr);
 		evt->set_scap_evt_storage(new char[e->len]);
 		memcpy(evt->get_scap_evt_storage(), e, e->len);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR fixes a possible source of buffer overflow in the recently-added `sinsp_plugin::get_metrics` API (https://github.com/falcosecurity/libs/pull/1828).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Output on master:
```
[ RUN      ] sinsp_with_test_input.plugin_metrics
*** buffer overflow detected ***: terminated
Annullato (core dump creato)
```

Full trace (courtesy of valgrind massif (?)):
```
[ RUN      ] sinsp_with_test_input.plugin_metrics
*** buffer overflow detected ***: terminated
==311913== 
==311913== Process terminating with default action of signal 6 (SIGABRT)
==311913==    at 0x5215B1C: __pthread_kill_implementation (pthread_kill.c:44)
==311913==    by 0x5215B1C: __pthread_kill_internal (pthread_kill.c:78)
==311913==    by 0x5215B1C: pthread_kill@@GLIBC_2.34 (pthread_kill.c:89)
==311913==    by 0x51BC26D: raise (raise.c:26)
==311913==    by 0x519F8FE: abort (abort.c:79)
==311913==    by 0x51A07B5: __libc_message_impl.cold (libc_fatal.c:132)
==311913==    by 0x52ADC18: __fortify_fail (fortify_fail.c:24)
==311913==    by 0x52AD5D3: __chk_fail (chk_fail.c:28)
==311913==    by 0x52AF018: __strlcpy_chk (strlcpy_chk.c:28)
==311913==    by 0x7312C2: strlcpy (string_fortified.h:156)
==311913==    by 0x7312C2: sinsp_plugin::get_metrics() const (plugin.cpp:944)
==311913==    by 0x72B1EB: libs::metrics::libs_metrics_collector::snapshot() (metrics_collector.cpp:468)
==311913==    by 0x46F515: sinsp_with_test_input_plugin_metrics_Test::TestBody() (plugins.ut.cpp:909)
==311913==    by 0x8B6DEE: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x89EB15: testing::Test::Run() (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x89ECD4: testing::TestInfo::Run() (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x89EEBE: testing::TestSuite::Run() (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x8ACD2B: testing::internal::UnitTestImpl::RunAllTests() (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x8B74C6: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x89F0B7: testing::UnitTest::Run() (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913==    by 0x2C0143: main (in /home/federico/Work/libs/build/libsinsp/test/unit-test-libsinsp)
==311913== 
Annullato (core dump creato)
```


**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): fixed possible buffer overflow in sinsp_plugin::get_metrics
```


/milestone 0.17.1
