### PR TITLE
fix(driver): fix build of kmod on linux 6.10.

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1649,8 +1649,10 @@ static inline int drop_nostate_event(ppm_event_code event_type,
 		if (close_fd < 0 || close_fd >= fdt->max_fds ||
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 4, 0))
 		    !FD_ISSET(close_fd, fdt->open_fds)
-#else
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0))
 		    !fd_is_open(close_fd, fdt)
+#else
+		    !test_bit(close_fd, fdt->open_fds)
 #endif
 			) {
 			drop = true;

--- a/driver/main.c
+++ b/driver/main.c
@@ -1652,6 +1652,8 @@ static inline int drop_nostate_event(ppm_event_code event_type,
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0))
 		    !fd_is_open(close_fd, fdt)
 #else
+  	            // fd_is_open() was made file-local:
+  		    // https://github.com/torvalds/linux/commit/c4aab26253cd1f302279b8d6b5b66ccf1b120520
 		    !test_bit(close_fd, fdt->open_fds)
 #endif
 			) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod


**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

https://github.com/torvalds/linux/commit/c4aab26253cd1f302279b8d6b5b66ccf1b120520, included in linux 6.10-rc1, moved `fd_is_open` away from an header we can include.
Therefore the proposed patch is to implement ourself the one-liner.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Keeping it as `wip` until linux 6.10 is nearly released.
I'll use this PR for tests if more changes are needed.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): fix build of kmod on linux 6.10.
```
