### PR TITLE
fix(plugin_api): wrong metric type enums

### DIFF
--- a/userspace/libsinsp/metrics_collector.cpp
+++ b/userspace/libsinsp/metrics_collector.cpp
@@ -457,19 +457,6 @@ void libs_metrics_collector::snapshot()
 		return;
 	}
 
-	/*
-	* plugins metrics
-	*/
-
-	if(m_metrics_flags & METRICS_V2_PLUGINS)
-	{
-		for (auto& p : m_inspector->get_plugin_manager()->plugins())
-		{
-			std::vector<metrics_v2> plugin_metrics = p->get_metrics();
-			m_metrics.insert(m_metrics.end(), plugin_metrics.begin(), plugin_metrics.end());
-		}
-	}
-
 	/* 
 	 * libscap metrics 
 	 */
@@ -781,6 +768,19 @@ void libs_metrics_collector::snapshot()
 			{
 				m_metrics.emplace_back(sinsp_stats_v2_collectors[i]());
 			}
+		}
+	}
+
+	/*
+	* plugins metrics
+	*/
+
+	if(m_metrics_flags & METRICS_V2_PLUGINS)
+	{
+		for (auto& p : m_inspector->get_plugin_manager()->plugins())
+		{
+			std::vector<metrics_v2> plugin_metrics = p->get_metrics();
+			m_metrics.insert(m_metrics.end(), plugin_metrics.begin(), plugin_metrics.end());
 		}
 	}
 }

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -30,7 +30,7 @@ extern "C" {
 //
 // todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
-#define PLUGIN_API_VERSION_MINOR 5
+#define PLUGIN_API_VERSION_MINOR 6
 #define PLUGIN_API_VERSION_PATCH 0
 
 //

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -136,6 +136,7 @@ plugin_handle_t* plugin_load(const char* path, char* err)
     SYM_RESOLVE(ret, get_async_events);
     SYM_RESOLVE(ret, set_async_event_handler);
     SYM_RESOLVE(ret, set_config);
+    SYM_RESOLVE(ret, get_metrics);
     return ret;
 }
 

--- a/userspace/plugin/plugin_types.h
+++ b/userspace/plugin/plugin_types.h
@@ -298,13 +298,13 @@ typedef enum ss_plugin_log_severity
 // Types supported by the by the metric values
 typedef enum ss_plugin_metric_value_type
 {
-	SS_PLUGIN_METRIC_VALUE_TYPE_U32 = 1,
-	SS_PLUGIN_METRIC_VALUE_TYPE_S32 = 2,
-	SS_PLUGIN_METRIC_VALUE_TYPE_U64 = 3,
-	SS_PLUGIN_METRIC_VALUE_TYPE_S64 = 4,
-	SS_PLUGIN_METRIC_VALUE_TYPE_D = 5,
-	SS_PLUGIN_METRIC_VALUE_TYPE_F = 6,
-	SS_PLUGIN_METRIC_VALUE_TYPE_I = 7,
+	SS_PLUGIN_METRIC_VALUE_TYPE_U32 = 0,
+	SS_PLUGIN_METRIC_VALUE_TYPE_S32 = 1,
+	SS_PLUGIN_METRIC_VALUE_TYPE_U64 = 2,
+	SS_PLUGIN_METRIC_VALUE_TYPE_S64 = 3,
+	SS_PLUGIN_METRIC_VALUE_TYPE_D = 4,
+	SS_PLUGIN_METRIC_VALUE_TYPE_F = 5,
+	SS_PLUGIN_METRIC_VALUE_TYPE_I = 6,
 } ss_plugin_metric_value_type;
 
 // Data representation of metric values
@@ -322,8 +322,8 @@ typedef union ss_plugin_metric_value
 // Metric types
 typedef enum ss_plugin_metric_type
 {
-	SS_PLUGIN_METRIC_TYPE_MONOTONIC = 1,
-	SS_PLUGIN_METRIC_TYPE_NON_MONOTONIC = 2,
+	SS_PLUGIN_METRIC_TYPE_MONOTONIC = 0,
+	SS_PLUGIN_METRIC_TYPE_NON_MONOTONIC = 1,
 } ss_plugin_metric_type;
 
 //


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Fixes wrong metric type enums, which are used to convert plugin metrics to libsinsp metrics.
It also resolves `get_metrics` symbol in plugins. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(plugin_api): wrong metrics type enums
```
