### PR TITLE
fix: class definitions with duplicate names

### DIFF
--- a/userspace/libsinsp/test/plugins/plugin_extract.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_extract.cpp
@@ -25,6 +25,8 @@ limitations under the License.
 
 #include "test_plugins.h"
 
+namespace {
+
 /**
  * Example of plugin implementing only the field extraction capability, which:
  * - Is compatible with the "sample" event source only
@@ -40,32 +42,32 @@ struct plugin_state
     ss_plugin_log_fn_t log;
 };
 
-static const char* plugin_get_required_api_version()
+const char* plugin_get_required_api_version()
 {
     return PLUGIN_API_VERSION_STR;
 }
 
-static const char* plugin_get_version()
+const char* plugin_get_version()
 {
     return "0.1.0";
 }
 
-static const char* plugin_get_name()
+const char* plugin_get_name()
 {
     return "sample_plugin_extract";
 }
 
-static const char* plugin_get_description()
+const char* plugin_get_description()
 {
     return "some desc";
 }
 
-static const char* plugin_get_contact()
+const char* plugin_get_contact()
 {
     return "some contact";
 }
 
-static const char* plugin_get_fields()
+const char* plugin_get_fields()
 {
     return
     "[" \
@@ -73,14 +75,14 @@ static const char* plugin_get_fields()
     "]";
 }
 
-static const char* plugin_get_extract_event_sources()
+const char* plugin_get_extract_event_sources()
 {
     return "[\"sample\"]";
 }
 
-static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t* s)
+uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     if (!ps->event_types.empty())
     {
         *num_types = (uint32_t) ps->event_types.size();
@@ -92,9 +94,9 @@ static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t
     return types;
 }
 
-static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
-    plugin_state *ret = new plugin_state();
+    auto ret = new plugin_state();
 
     //save logger and owner in the state
     ret->log = in->log_fn;
@@ -128,22 +130,22 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
     return ret;
 }
 
-static void plugin_destroy(ss_plugin_t* s)
+void plugin_destroy(ss_plugin_t* s)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     ps->log(ps->owner, NULL, "destroying plugin...", SS_PLUGIN_LOG_SEV_INFO);
 
-    delete ((plugin_state *) s);
+    delete ps;
 }
 
-static const char* plugin_get_last_error(ss_plugin_t* s)
+const char* plugin_get_last_error(ss_plugin_t* s)
 {
     return ((plugin_state *) s)->lasterr.c_str();
 }
 
-static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_field_extract_input* in)
+ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_field_extract_input* in)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     for (uint32_t i = 0; i < in->num_fields; i++)
     {
         switch(in->fields[i].field_id)
@@ -162,13 +164,15 @@ static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_
     return SS_PLUGIN_SUCCESS;
 }
 
-static ss_plugin_rc plugin_set_config(ss_plugin_t *s, const ss_plugin_set_config_input* i)
+ss_plugin_rc plugin_set_config(ss_plugin_t *s, const ss_plugin_set_config_input* i)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     ps->log(ps->owner, NULL, "new config!", SS_PLUGIN_LOG_SEV_INFO);
 
     return SS_PLUGIN_SUCCESS;
 }
+
+} // anonymous namespace
 
 void get_plugin_api_sample_plugin_extract(plugin_api& out)
 {

--- a/userspace/libsinsp/test/plugins/plugin_source.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_source.cpp
@@ -25,6 +25,8 @@ limitations under the License.
 
 #include "test_plugins.h"
 
+namespace {
+
 static constexpr const char* s_evt_data = "hello world";
 
 /**
@@ -46,49 +48,49 @@ struct instance_state
     ss_plugin_event* evt;
 };
 
-static const char* plugin_get_required_api_version()
+const char* plugin_get_required_api_version()
 {
     return PLUGIN_API_VERSION_STR;
 }
 
-static const char* plugin_get_version()
+const char* plugin_get_version()
 {
     return "0.1.0";
 }
 
-static const char* plugin_get_name()
+const char* plugin_get_name()
 {
     return "sample_plugin_source";
 }
 
-static const char* plugin_get_description()
+const char* plugin_get_description()
 {
     return "some desc";
 }
 
-static const char* plugin_get_contact()
+const char* plugin_get_contact()
 {
     return "some contact";
 }
 
-static uint32_t plugin_get_id()
+uint32_t plugin_get_id()
 {
 	return 999;
 }
 
-static const char* plugin_get_event_source()
+const char* plugin_get_event_source()
 {
 	return "sample";
 }
 
-static const char* plugin_get_last_error(ss_plugin_t* s)
+const char* plugin_get_last_error(ss_plugin_t* s)
 {
     return ((plugin_state *) s)->lasterr.c_str();
 }
 
-static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
-    plugin_state *ret = new plugin_state();
+    auto ret = new plugin_state();
 
     //save logger and owner in the state
     ret->log = in->log_fn;
@@ -100,17 +102,17 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
     return ret;
 }
 
-static void plugin_destroy(ss_plugin_t* s)
+void plugin_destroy(ss_plugin_t* s)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     ps->log(ps->owner, NULL, "destroying plugin...", SS_PLUGIN_LOG_SEV_INFO);
-    
-    delete ((plugin_state *) s);
+
+    delete ps;
 }
 
-static ss_instance_t* plugin_open(ss_plugin_t* s, const char* params, ss_plugin_rc* rc)
+ss_instance_t* plugin_open(ss_plugin_t* s, const char* params, ss_plugin_rc* rc)
 {
-    instance_state *ret = new instance_state();
+    auto ret = new instance_state();
     ret->evt = (ss_plugin_event*) &ret->evt_buf;
     ret->count = 10000;
     auto count = atoi(params);
@@ -123,12 +125,12 @@ static ss_instance_t* plugin_open(ss_plugin_t* s, const char* params, ss_plugin_
     return ret;
 }
 
-static void plugin_close(ss_plugin_t* s, ss_instance_t* i)
+void plugin_close(ss_plugin_t* s, ss_instance_t* i)
 {
     delete ((instance_state *) i);
 }
 
-static ss_plugin_rc plugin_next_batch(ss_plugin_t* s, ss_instance_t* i, uint32_t *nevts, ss_plugin_event ***evts)
+ss_plugin_rc plugin_next_batch(ss_plugin_t* s, ss_instance_t* i, uint32_t *nevts, ss_plugin_event ***evts)
 {
     instance_state *istate = (instance_state *) i;
 
@@ -158,6 +160,8 @@ static ss_plugin_rc plugin_next_batch(ss_plugin_t* s, ss_instance_t* i, uint32_t
     istate->count--;
     return SS_PLUGIN_SUCCESS;
 }
+
+} // anonymous namespace
 
 void get_plugin_api_sample_plugin_source(plugin_api& out)
 {

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -24,6 +24,8 @@ limitations under the License.
 
 #include "test_plugins.h"
 
+namespace {
+
 /**
  * Example of plugin implementing only the field extraction capability, which:
  * - Is compatible with the "syscall" event source only
@@ -47,7 +49,7 @@ struct plugin_state
     ss_plugin_log_fn_t log;
 };
 
-static inline bool evt_type_is_open(uint16_t type)
+inline bool evt_type_is_open(uint16_t type)
 {
     return type == PPME_SYSCALL_OPEN_E
         || type == PPME_SYSCALL_OPEN_X
@@ -62,37 +64,37 @@ static inline bool evt_type_is_open(uint16_t type)
     ;
 }
 
-static inline const char* get_async_event_name(const ss_plugin_event* e)
+inline const char* get_async_event_name(const ss_plugin_event* e)
 {
     return (const char*) ((uint8_t*) e + sizeof(ss_plugin_event) + 4+4+4+4);
 }
 
-static const char* plugin_get_required_api_version()
+const char* plugin_get_required_api_version()
 {
     return PLUGIN_API_VERSION_STR;
 }
 
-static const char* plugin_get_version()
+const char* plugin_get_version()
 {
     return "0.1.0";
 }
 
-static const char* plugin_get_name()
+const char* plugin_get_name()
 {
     return "sample_syscall_extract";
 }
 
-static const char* plugin_get_description()
+const char* plugin_get_description()
 {
     return "some desc";
 }
 
-static const char* plugin_get_contact()
+const char* plugin_get_contact()
 {
     return "some contact";
 }
 
-static const char* plugin_get_fields()
+const char* plugin_get_fields()
 {
 	return R"(
 [
@@ -124,12 +126,12 @@ static const char* plugin_get_fields()
 ])";
 }
 
-static const char* plugin_get_extract_event_sources()
+const char* plugin_get_extract_event_sources()
 {
     return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t* s)
+uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
     static uint16_t types[] = {
         PPME_SYSCALL_OPEN_E,
@@ -152,10 +154,10 @@ static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t
     return &types[0];
 }
 
-static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
     *rc = SS_PLUGIN_SUCCESS;
-    plugin_state *ret = new plugin_state();
+    auto ret = new plugin_state();
 
     //save logger and owner in the state
     ret->log = in->log_fn;
@@ -230,26 +232,26 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
     return ret;
 }
 
-static void plugin_destroy(ss_plugin_t* s)
+void plugin_destroy(ss_plugin_t* s)
 {
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     ps->log(ps->owner, NULL, "destroying plugin...", SS_PLUGIN_LOG_SEV_INFO);
 
-    delete ((plugin_state *) s);
+    delete ps;
 }
 
-static const char* plugin_get_last_error(ss_plugin_t* s)
+const char* plugin_get_last_error(ss_plugin_t* s)
 {
     return ((plugin_state *) s)->lasterr.c_str();
 }
 
-static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_field_extract_input* in)
+ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_field_extract_input* in)
 {
     ss_plugin_rc rc;
     ss_plugin_state_data tmp;
     ss_plugin_table_entry_t* thread = NULL;
     ss_plugin_table_entry_t* evtcount = NULL;
-    plugin_state *ps = (plugin_state *) s;
+    auto ps = reinterpret_cast<plugin_state*>(s);
     for (uint32_t i = 0; i < in->num_fields; i++)
     {
         switch(in->fields[i].field_id)
@@ -379,6 +381,8 @@ static ss_plugin_rc plugin_extract_fields(ss_plugin_t *s, const ss_plugin_event_
     }
     return SS_PLUGIN_SUCCESS;
 }
+
+} // anonymous namespace
 
 void get_plugin_api_sample_syscall_extract(plugin_api& out)
 {

--- a/userspace/libsinsp/test/plugins/syscall_subtables_array.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_subtables_array.cpp
@@ -24,6 +24,8 @@ limitations under the License.
 #include <driver/ppm_events_public.h>
 #include "test_plugins.h"
 
+namespace {
+
 struct plugin_state
 {
 	std::string lasterr;
@@ -35,47 +37,47 @@ struct plugin_state
 	uint8_t step = 0;
 };
 
-static const char* plugin_get_required_api_version()
+const char* plugin_get_required_api_version()
 {
 	return PLUGIN_API_VERSION_STR;
 }
 
-static const char* plugin_get_version()
+const char* plugin_get_version()
 {
 	return "0.1.0";
 }
 
-static const char* plugin_get_name()
+const char* plugin_get_name()
 {
 	return "sample_subtables_array";
 }
 
-static const char* plugin_get_description()
+const char* plugin_get_description()
 {
 	return "some desc";
 }
 
-static const char* plugin_get_contact()
+const char* plugin_get_contact()
 {
 	return "some contact";
 }
 
-static const char* plugin_get_parse_event_sources()
+const char* plugin_get_parse_event_sources()
 {
 	return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
+uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
     static uint16_t types[] = { PPME_SYSCALL_OPEN_E };
     *num_types = sizeof(types) / sizeof(uint16_t);
     return &types[0];
 }
 
-static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
 	*rc = SS_PLUGIN_SUCCESS;
-	plugin_state *ret = new plugin_state();
+	auto ret = new plugin_state();
 
 	if (!in || !in->tables)
 	{
@@ -93,7 +95,7 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
 		ret->lasterr = "can't access thread table";
 		return ret;
 	}
-	
+
 	// get an accessor to the file descriptor tables owned by each thread info
 	ret->table_field_envtable = in->tables->fields.get_table_field(
 		ret->thread_table, "env", ss_plugin_state_type::SS_PLUGIN_ST_TABLE);
@@ -140,19 +142,19 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
 	return ret;
 }
 
-static void plugin_destroy(ss_plugin_t* s)
+void plugin_destroy(ss_plugin_t* s)
 {
-	delete ((plugin_state *) s);
+	delete reinterpret_cast<plugin_state*>(s);
 }
 
-static const char* plugin_get_last_error(ss_plugin_t* s)
+const char* plugin_get_last_error(ss_plugin_t* s)
 {
 	return ((plugin_state *) s)->lasterr.c_str();
 }
 
-static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
+ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
 {
-	plugin_state *ps = (plugin_state *) s;
+	auto ps = reinterpret_cast<plugin_state*>(s);
 	ss_plugin_state_data key;
 	ss_plugin_state_data out;
 	ss_plugin_state_data data;
@@ -175,7 +177,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 	ss_plugin_table_t* envtable = out.table;
 
 	//add entries to the envtable
-	if(ps->step == 0) 
+	if(ps->step == 0)
 	{
 		int max_iterations = 10;
 		for (int i = 0; i < max_iterations; i++)
@@ -229,7 +231,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 	}
 
 	// remove one entry from the envtable
-	if(ps->step == 1) 
+	if(ps->step == 1)
 	{
 		key.s64 = 0;
 		auto res = in->table_writer_ext->erase_table_entry(envtable, &key);
@@ -246,7 +248,7 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 	}
 
 	// clear the envtable
-	if(ps->step == 2) 
+	if(ps->step == 2)
 	{
 		auto res = in->table_writer_ext->clear_table(envtable);
 		if (res != SS_PLUGIN_SUCCESS)
@@ -263,6 +265,8 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 
 	return SS_PLUGIN_SUCCESS;
 }
+
+} // anonynous namespace
 
 void get_plugin_api_sample_syscall_subtables_array(plugin_api& out)
 {

--- a/userspace/libsinsp/test/plugins/syscall_tables.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_tables.cpp
@@ -24,6 +24,8 @@ limitations under the License.
 #include "sample_table.h"
 #include "test_plugins.h"
 
+namespace {
+
 /**
  * Example of plugin that accesses the thread table and that exposes its own
  * sta table. The goal is to test all the methods of the table API.
@@ -39,47 +41,47 @@ struct plugin_state
 	ss_plugin_table_field_t* internal_dynamic_field;
 };
 
-static const char* plugin_get_required_api_version()
+const char* plugin_get_required_api_version()
 {
 	return PLUGIN_API_VERSION_STR;
 }
 
-static const char* plugin_get_version()
+const char* plugin_get_version()
 {
 	return "0.1.0";
 }
 
-static const char* plugin_get_name()
+const char* plugin_get_name()
 {
 	return "sample_tables";
 }
 
-static const char* plugin_get_description()
+const char* plugin_get_description()
 {
 	return "some desc";
 }
 
-static const char* plugin_get_contact()
+const char* plugin_get_contact()
 {
 	return "some contact";
 }
 
-static const char* plugin_get_parse_event_sources()
+const char* plugin_get_parse_event_sources()
 {
 	return "[\"syscall\"]";
 }
 
-static uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
+uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s)
 {
 	static uint16_t *types = {};
 	*num_types = 0;
 	return types;
 }
 
-static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
+ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc)
 {
 	*rc = SS_PLUGIN_SUCCESS;
-	plugin_state *ret = new plugin_state();
+	auto ret = new plugin_state();
 
 	if (!in || !in->tables)
 	{
@@ -155,24 +157,24 @@ static ss_plugin_t* plugin_init(const ss_plugin_init_input* in, ss_plugin_rc* rc
 	return ret;
 }
 
-static void plugin_destroy(ss_plugin_t* s)
+void plugin_destroy(ss_plugin_t* s)
 {
-	delete ((plugin_state *) s);
+	delete reinterpret_cast<plugin_state*>(s);
 }
 
-static const char* plugin_get_last_error(ss_plugin_t* s)
+const char* plugin_get_last_error(ss_plugin_t* s)
 {
 	return ((plugin_state *) s)->lasterr.c_str();
 }
 
 // parses events and keeps a count for each thread about the syscalls of the open family
-static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
+ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_input *ev, const ss_plugin_event_parse_input* in)
 {
 	static int64_t s_new_thread_tid = 999999;
 	int step = 0;
 	ss_plugin_state_data tmp;
 	ss_plugin_table_entry_t* thread;
-	plugin_state *ps = (plugin_state *) s;
+	auto ps = reinterpret_cast<plugin_state*>(s);
 
 	// get table name
 	step++;
@@ -526,6 +528,8 @@ static ss_plugin_rc plugin_parse_event(ss_plugin_t *s, const ss_plugin_event_inp
 
 	return SS_PLUGIN_SUCCESS;
 }
+
+} // anonymous namespace
 
 void get_plugin_api_sample_syscall_tables(plugin_api& out)
 {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
The struct `plugin_state` is defined several times with different definitions in different compilation units. This would not be a problem, but if you try to apply link-time optimization (LTO) the linker complains and raises an error because the one-definition rule (ODR) has been broken. The fix is easy, the duplicate definitions are only used within their .cpp file and can be enclosed in an anonymous namespace, so that they'll have internal linkage.
This is one of several changes to make `falcosecurity-libs` (and its client code) amenable to LTO, should one want to experiment with it. There are other such cases that will be handled in other PR's.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Some minor cleanup has been performed to prefer an explicit `reinterpret_cast` rather than an generic C-style cast and similar.
- The word `static` has been removed from functions that fell inside the anonymous namespace as this already gives them internal linkage.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
