### PR TITLE
fix: multiple definitions for scap_engine_handle

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1163,23 +1163,23 @@ int32_t scap_bpf_stop_capture(struct scap_engine_handle engine)
 static int32_t calibrate_socket_file_ops(struct scap_engine_handle engine)
 {
 	/* We just need to enable the socket syscall for the socket calibration */
-	engine.m_handle->curr_sc_set.ppm_sc[PPM_SC_SOCKET] = 1;
+	((SCAP_HANDLE_T*)engine.m_handle)->curr_sc_set.ppm_sc[PPM_SC_SOCKET] = 1;
 	if(scap_bpf_start_capture(engine) != SCAP_SUCCESS)
 	{
-		return scap_errprintf(engine.m_handle->m_lasterr, errno, "unable to set the socket syscall for the calibration");
+		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to set the socket syscall for the calibration");
 	}
 
 	int fd = socket(AF_INET, SOCK_DGRAM, 0);
 	if(fd == -1)
 	{
-		return scap_errprintf(engine.m_handle->m_lasterr, errno, "unable to create a socket for the calibration");
+		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to create a socket for the calibration");
 	}
 	close(fd);
 
 	/* We need to stop the capture */
 	if(scap_bpf_stop_capture(engine) != SCAP_SUCCESS)
 	{
-		return scap_errprintf(engine.m_handle->m_lasterr, errno, "unable to stop the capture after the calibration");
+		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to stop the capture after the calibration");
 	}
 
 	return SCAP_SUCCESS;
@@ -1890,7 +1890,7 @@ int32_t scap_bpf_get_n_tracepoint_hit(struct scap_engine_handle engine, long* re
 
 static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pdevid, uint32_t *pflags)
 {
-	return ringbuffer_next(&engine.m_handle->m_dev_set, pevent, pdevid, pflags);
+	return ringbuffer_next(&((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set, pevent, pdevid, pflags);
 }
 
 static int32_t unsupported_config(struct scap_engine_handle engine, const char* msg)
@@ -1985,7 +1985,7 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	struct scap_bpf_engine_params *params = oargs->engine_params;
 	strlcpy(bpf_probe_buf, params->bpf_probe, SCAP_MAX_PATH_SIZE);
 
-	if(check_buffer_bytes_dim(engine.m_handle->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
+	if(check_buffer_bytes_dim(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, params->buffer_bytes_dim) != SCAP_SUCCESS)
 	{
 		return SCAP_FAILURE;
 	}
@@ -1996,18 +1996,18 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	ssize_t num_cpus = sysconf(_SC_NPROCESSORS_CONF);
 	if(num_cpus == -1)
 	{
-		return scap_errprintf(engine.m_handle->m_lasterr, errno, "cannot obtain the number of available CPUs from '_SC_NPROCESSORS_CONF'");
+		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "cannot obtain the number of available CPUs from '_SC_NPROCESSORS_CONF'");
 	}
 
-	engine.m_handle->m_ncpus = num_cpus;
+	((SCAP_HANDLE_T*)engine.m_handle)->m_ncpus = num_cpus;
 
 	ssize_t num_devs = sysconf(_SC_NPROCESSORS_ONLN);
 	if(num_devs == -1)
 	{
-		return scap_errprintf(engine.m_handle->m_lasterr, errno, "cannot obtain the number of online CPUs from '_SC_NPROCESSORS_ONLN'");
+		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "cannot obtain the number of online CPUs from '_SC_NPROCESSORS_ONLN'");
 	}
 
-	rc = devset_init(&engine.m_handle->m_dev_set, num_devs, engine.m_handle->m_lasterr);
+	rc = devset_init(&((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set, num_devs, ((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr);
 	if(rc != SCAP_SUCCESS)
 	{
 		return rc;
@@ -2028,12 +2028,12 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 	}
 
 	/* Store interesting sc codes */
-	memcpy(&engine.m_handle->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
+	memcpy(&((SCAP_HANDLE_T*)engine.m_handle)->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
 
-	engine.m_handle->m_flags = 0;
+	((SCAP_HANDLE_T*)engine.m_handle)->m_flags = 0;
 	if(scap_get_bpf_stats_enabled())
 	{
-		engine.m_handle->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
+		((SCAP_HANDLE_T*)engine.m_handle)->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
 	}
 
 	return SCAP_SUCCESS;
@@ -2041,19 +2041,19 @@ static int32_t init(scap_t* handle, scap_open_args *oargs)
 
 static uint64_t get_flags(struct scap_engine_handle engine)
 {
-	return engine.m_handle->m_flags;
+	return ((SCAP_HANDLE_T*)engine.m_handle)->m_flags;
 }
 
 static uint32_t get_n_devs(struct scap_engine_handle engine)
 {
-	return engine.m_handle->m_dev_set.m_ndevs;
+	return ((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set.m_ndevs;
 }
 
 static uint64_t get_max_buf_used(struct scap_engine_handle engine)
 {
 	uint64_t i;
 	uint64_t max = 0;
-	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
+	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
 
 	for(i = 0; i < devset->m_ndevs; i++)
 	{
@@ -2066,19 +2066,19 @@ static uint64_t get_max_buf_used(struct scap_engine_handle engine)
 
 uint64_t scap_bpf_get_api_version(struct scap_engine_handle engine)
 {
-	return engine.m_handle->m_api_version;
+	return ((SCAP_HANDLE_T*)engine.m_handle)->m_api_version;
 }
 
 uint64_t scap_bpf_get_schema_version(struct scap_engine_handle engine)
 {
-	return engine.m_handle->m_schema_version;
+	return ((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version;
 }
 
 const struct scap_vtable scap_bpf_engine = {
 	.name = BPF_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
 	.init = init,
 	.get_flags = get_flags,
 	.free_handle = free_handle,

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -149,34 +149,34 @@ SCAP_HANDLE_T* gvisor_alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 
 int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
-	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
+	auto gv = (SCAP_HANDLE_T*)main_handle->m_engine.m_handle;
 	auto params = (scap_gvisor_engine_params*)oargs->engine_params;
 	return gv->init(params->gvisor_config_path, params->gvisor_root_path, params->no_events, params->gvisor_epoll_timeout, params->gvisor_platform);
 }
 
 void gvisor_free_handle(scap_engine_handle engine)
 {
-	delete engine.m_handle;
+	delete (SCAP_HANDLE_T*)engine.m_handle;
 }
 
 int32_t gvisor_start_capture(scap_engine_handle engine)
 {
-	return engine.m_handle->start_capture();
+	return ((SCAP_HANDLE_T*)engine.m_handle)->start_capture();
 }
 
 int32_t gvisor_close(scap_engine_handle engine)
 {
-	return engine.m_handle->close();
+	return ((SCAP_HANDLE_T*)engine.m_handle)->close();
 }
 
 int32_t gvisor_stop_capture(scap_engine_handle engine)
 {
-	return engine.m_handle->stop_capture();
+	return ((SCAP_HANDLE_T*)engine.m_handle)->stop_capture();
 }
 
 int32_t gvisor_next(scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
-	return engine.m_handle->next(pevent, pdevid, pflags);
+	return ((SCAP_HANDLE_T*)engine.m_handle)->next(pevent, pdevid, pflags);
 }
 
 int32_t gvisor_configure(scap_engine_handle engine, scap_setting setting, unsigned long arg1, unsigned long arg2)
@@ -186,12 +186,12 @@ int32_t gvisor_configure(scap_engine_handle engine, scap_setting setting, unsign
 
 int32_t gvisor_get_stats(scap_engine_handle engine, scap_stats* stats)
 {
-	return engine.m_handle->get_stats(stats);
+	return ((SCAP_HANDLE_T*)engine.m_handle)->get_stats(stats);
 }
 
 const metrics_v2* gvisor_get_stats_v2(scap_engine_handle engine, uint32_t flags, uint32_t* nstats, int32_t* rc)
 {
-	return engine.m_handle->get_stats_v2(flags, nstats, rc);
+	return ((SCAP_HANDLE_T*)engine.m_handle)->get_stats_v2(flags, nstats, rc);
 }
 
 int32_t gvisor_get_n_tracepoint_hit(scap_engine_handle engine, long* ret)
@@ -215,7 +215,7 @@ extern const scap_vtable scap_gvisor_engine = {
 	.name = GVISOR_ENGINE,
 	.savefile_ops = nullptr,
 
-	.alloc_handle = gvisor_alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))gvisor_alloc_handle,
 	.init = gvisor_init,
 	.get_flags = nullptr,
 	.free_handle = gvisor_free_handle,

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -23,7 +23,8 @@ limitations under the License.
 #include <errno.h>
 #include <sys/mman.h>
 
-#define SCAP_HANDLE_T struct kmod_engine
+#define HANDLE(engine) ((struct kmod_engine*)(engine.m_handle))
+
 #include <libscap/engine/kmod/kmod.h>
 #include <libscap/scap.h>
 #include <driver_config.h>
@@ -61,7 +62,7 @@ static const char * const kmod_kernel_counters_stats_names[] = {
 	[KMOD_N_PREEMPTIONS] = "n_preemptions",
 };
 
-static struct kmod_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+static void* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct kmod_engine *engine = calloc(1, sizeof(struct kmod_engine));
 	if(engine)
@@ -347,7 +348,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 		return scap_errprintf(handle->m_lasterr, errno, "cannot obtain the number of online CPUs from '_SC_NPROCESSORS_ONLN'");
 	}
 
-	rc = devset_init(&((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set, ndevs, handle->m_lasterr);
+	rc = devset_init(&HANDLE(engine)->m_dev_set, ndevs, handle->m_lasterr);
 	if(rc != SCAP_SUCCESS)
 	{
 		return rc;
@@ -358,7 +359,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	//
 	mapped_len = single_buffer_dim * 2;
 
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	uint32_t online_idx = 0;
 	// devset->m_ndevs = online CPUs in the system.
 	// ncpus = available CPUs in the system.
@@ -406,7 +407,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			return scap_errprintf(handle->m_lasterr, err, "Kernel module does not support PPM_IOCTL_GET_API_VERSION");
 		}
 		// Make sure all devices report the same API version
-		if (((SCAP_HANDLE_T*)engine.m_handle)->m_api_version != 0 && ((SCAP_HANDLE_T*)engine.m_handle)->m_api_version != api_version)
+		if (HANDLE(engine)->m_api_version != 0 && HANDLE(engine)->m_api_version != api_version)
 		{
 			int err = errno;
 			close(dev->m_fd);
@@ -415,14 +416,14 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 					      PPM_API_VERSION_MAJOR(api_version),
 					      PPM_API_VERSION_MINOR(api_version),
 					      PPM_API_VERSION_PATCH(api_version),
-					      PPM_API_VERSION_MAJOR(((SCAP_HANDLE_T*)engine.m_handle)->m_api_version),
-					      PPM_API_VERSION_MINOR(((SCAP_HANDLE_T*)engine.m_handle)->m_api_version),
-					      PPM_API_VERSION_PATCH(((SCAP_HANDLE_T*)engine.m_handle)->m_api_version)
+					      PPM_API_VERSION_MAJOR(HANDLE(engine)->m_api_version),
+					      PPM_API_VERSION_MINOR(HANDLE(engine)->m_api_version),
+					      PPM_API_VERSION_PATCH(HANDLE(engine)->m_api_version)
 			);
 		}
 		// Set the API version from the first device
 		// (for subsequent devices it's a no-op thanks to the check above)
-		((SCAP_HANDLE_T*)engine.m_handle)->m_api_version = api_version;
+		HANDLE(engine)->m_api_version = api_version;
 
 		// Check the schema version reported
 		if (ioctl(dev->m_fd, PPM_IOCTL_GET_SCHEMA_VERSION, &schema_version) < 0)
@@ -432,21 +433,21 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 			return scap_errprintf(handle->m_lasterr, err, "Kernel module does not support PPM_IOCTL_GET_SCHEMA_VERSION");
 		}
 		// Make sure all devices report the same schema version
-		if (((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version != 0 && ((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version != schema_version)
+		if (HANDLE(engine)->m_schema_version != 0 && HANDLE(engine)->m_schema_version != schema_version)
 		{
 			return scap_errprintf(handle->m_lasterr, 0, "Schema version mismatch: device %s reports schema version %llu.%llu.%llu, expected %llu.%llu.%llu",
 					      filename,
 					      PPM_API_VERSION_MAJOR(schema_version),
 					      PPM_API_VERSION_MINOR(schema_version),
 					      PPM_API_VERSION_PATCH(schema_version),
-					      PPM_API_VERSION_MAJOR(((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version),
-					      PPM_API_VERSION_MINOR(((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version),
-					      PPM_API_VERSION_PATCH(((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version)
+					      PPM_API_VERSION_MAJOR(HANDLE(engine)->m_schema_version),
+					      PPM_API_VERSION_MINOR(HANDLE(engine)->m_schema_version),
+					      PPM_API_VERSION_PATCH(HANDLE(engine)->m_schema_version)
 			);
 		}
 		// Set the schema version from the first device
 		// (for subsequent devices it's a no-op thanks to the check above)
-		((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version = schema_version;
+		HANDLE(engine)->m_schema_version = schema_version;
 
 		//
 		// Map the ring buffer
@@ -512,14 +513,14 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	}
 
 	/* Store interesting sc codes */
-	memcpy(&((SCAP_HANDLE_T*)engine.m_handle)->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
+	memcpy(&HANDLE(engine)->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
 
 	return SCAP_SUCCESS;
 }
 
 int32_t scap_kmod_close(struct scap_engine_handle engine)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 
 	devset_free(devset);
 
@@ -529,17 +530,17 @@ int32_t scap_kmod_close(struct scap_engine_handle engine)
 int32_t scap_kmod_next(struct scap_engine_handle engine, scap_evt **pevent, uint16_t *pdevid,
 		       uint32_t *pflags)
 {
-	return ringbuffer_next(&((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set, pevent, pdevid, pflags);
+	return ringbuffer_next(&HANDLE(engine)->m_dev_set, pevent, pdevid, pflags);
 }
 
 uint32_t scap_kmod_get_n_devs(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set.m_ndevs;
+	return HANDLE(engine)->m_dev_set.m_ndevs;
 }
 
 uint64_t scap_kmod_get_max_buf_used(struct scap_engine_handle engine)
 {
-	return ringbuffer_get_max_buf_used(&((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set);
+	return ringbuffer_get_max_buf_used(&HANDLE(engine)->m_dev_set);
 }
 
 //
@@ -547,7 +548,7 @@ uint64_t scap_kmod_get_max_buf_used(struct scap_engine_handle engine)
 //
 int32_t scap_kmod_get_stats(struct scap_engine_handle engine, scap_stats* stats)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	uint32_t j;
 
 	for(j = 0; j < devset->m_ndevs; j++)
@@ -645,7 +646,7 @@ int32_t scap_kmod_stop_capture(struct scap_engine_handle engine)
 	handle->capturing = false;
 
 	/* This could happen if we fail to instantiate `m_devs` in the init method */
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	if(devset->m_devs == NULL)
 	{
 		return SCAP_SUCCESS;
@@ -681,7 +682,7 @@ int32_t scap_kmod_start_capture(struct scap_engine_handle engine)
 
 static int32_t scap_kmod_set_dropping_mode(struct scap_engine_handle engine, int request, uint32_t sampling_ratio)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	if(devset->m_ndevs)
 	{
 		ASSERT((request == PPM_IOCTL_ENABLE_DROPPING_MODE &&
@@ -696,7 +697,7 @@ static int32_t scap_kmod_set_dropping_mode(struct scap_engine_handle engine, int
 
 		if(ioctl(devset->m_devs[0].m_fd, request, sampling_ratio))
 		{
-			return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "%s, request %d for sampling ratio %u",
+			return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "%s, request %d for sampling ratio %u",
 					      __FUNCTION__, request, sampling_ratio);
 		}
 	}
@@ -715,13 +716,13 @@ int32_t scap_kmod_start_dropping_mode(struct scap_engine_handle engine, uint32_t
 
 int32_t scap_kmod_set_snaplen(struct scap_engine_handle engine, uint32_t snaplen)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	//
 	// Tell the driver to change the snaplen
 	//
 	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_SET_SNAPLEN, snaplen))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "scap_set_snaplen failed");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "scap_set_snaplen failed");
 	}
 
 	uint32_t j;
@@ -743,9 +744,9 @@ int32_t scap_kmod_set_snaplen(struct scap_engine_handle engine, uint32_t snaplen
 int32_t scap_kmod_handle_dropfailed(struct scap_engine_handle engine, bool enable)
 {
 	int req = enable ? PPM_IOCTL_ENABLE_DROPFAILED : PPM_IOCTL_DISABLE_DROPFAILED;
-	if(ioctl(((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set.m_devs[0].m_fd, req))
+	if(ioctl(HANDLE(engine)->m_dev_set.m_devs[0].m_fd, req))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "scap_enable_dynamic_snaplen failed");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "scap_enable_dynamic_snaplen failed");
 	}
 	return SCAP_SUCCESS;
 }
@@ -756,18 +757,18 @@ int32_t scap_kmod_handle_dynamic_snaplen(struct scap_engine_handle engine, bool 
 	// Tell the driver to change the snaplen
 	//
 	int req = enable ? PPM_IOCTL_ENABLE_DYNAMIC_SNAPLEN : PPM_IOCTL_DISABLE_DYNAMIC_SNAPLEN;
-	if(ioctl(((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set.m_devs[0].m_fd, req))
+	if(ioctl(HANDLE(engine)->m_dev_set.m_devs[0].m_fd, req))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "scap_enable_dynamic_snaplen failed");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "scap_enable_dynamic_snaplen failed");
 	}
 	return SCAP_SUCCESS;
 }
 
 int32_t scap_kmod_get_n_tracepoint_hit(struct scap_engine_handle engine, long* ret)
 {
-	if(ioctl(((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set.m_devs[0].m_fd, PPM_IOCTL_GET_N_TRACEPOINT_HIT, ret))
+	if(ioctl(HANDLE(engine)->m_dev_set.m_devs[0].m_fd, PPM_IOCTL_GET_N_TRACEPOINT_HIT, ret))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "scap_get_n_tracepoint_hit failed");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "scap_get_n_tracepoint_hit failed");
 	}
 
 	return SCAP_SUCCESS;
@@ -775,7 +776,7 @@ int32_t scap_kmod_get_n_tracepoint_hit(struct scap_engine_handle engine, long* r
 
 int32_t scap_kmod_set_fullcapture_port_range(struct scap_engine_handle engine, uint16_t range_start, uint16_t range_end)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	//
 	// Encode the port range
 	//
@@ -786,7 +787,7 @@ int32_t scap_kmod_set_fullcapture_port_range(struct scap_engine_handle engine, u
 	//
 	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_SET_FULLCAPTURE_PORT_RANGE, arg))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "scap_set_fullcapture_port_range failed");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "scap_set_fullcapture_port_range failed");
 	}
 
 	uint32_t j;
@@ -808,13 +809,13 @@ int32_t scap_kmod_set_fullcapture_port_range(struct scap_engine_handle engine, u
 
 int32_t scap_kmod_set_statsd_port(struct scap_engine_handle engine, const uint16_t port)
 {
-	struct scap_device_set *devset = &((SCAP_HANDLE_T*)engine.m_handle)->m_dev_set;
+	struct scap_device_set *devset = &HANDLE(engine)->m_dev_set;
 	//
 	// Beam the value down to the module
 	//
 	if(ioctl(devset->m_devs[0].m_fd, PPM_IOCTL_SET_STATSD_PORT, port))
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr,
+		return scap_errprintf(HANDLE(engine)->m_lasterr,
 				      errno, "scap_set_statsd_port: ioctl failed");
 	}
 
@@ -953,12 +954,12 @@ int32_t scap_kmod_getpid_global(struct scap_engine_handle engine, int64_t* pid, 
 
 uint64_t scap_kmod_get_api_version(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_api_version;
+	return HANDLE(engine)->m_api_version;
 }
 
 uint64_t scap_kmod_get_schema_version(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version;
+	return HANDLE(engine)->m_schema_version;
 }
 
 const struct scap_linux_vtable scap_kmod_linux_vtable = {
@@ -972,7 +973,7 @@ struct scap_vtable scap_kmod_engine = {
 	.name = KMOD_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
+	.alloc_handle = alloc_handle,
 	.init = scap_kmod_init,
 	.free_handle = free_handle,
 	.close = scap_kmod_close,

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -20,7 +20,8 @@ limitations under the License.
 #include <stdio.h>
 #include <sys/socket.h>
 
-#define SCAP_HANDLE_T struct modern_bpf_engine
+#define HANDLE(engine) ((struct modern_bpf_engine*)(engine.m_handle))
+
 #include <libscap/engine/modern_bpf/scap_modern_bpf.h>
 #include <libpman.h>
 #include <libscap/scap.h>
@@ -34,7 +35,7 @@ limitations under the License.
 #include <libscap/strerror.h>
 #include <driver/syscall_compat.h>
 
-static struct modern_bpf_engine* scap_modern_bpf__alloc_engine(scap_t* main_handle, char* lasterr_ptr)
+static void* scap_modern_bpf__alloc_engine(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct modern_bpf_engine* engine = calloc(1, sizeof(struct modern_bpf_engine));
 	if(engine)
@@ -60,13 +61,13 @@ static int32_t scap_modern_bpf__next(struct scap_engine_handle engine, scap_evt*
 	if((*pevent) == NULL)
 	{
 		/* The first time we sleep 500 us, if we have consecutive timeouts we can reach also 30 ms. */
-		usleep(((SCAP_HANDLE_T*)engine.m_handle)->m_retry_us);
-		((SCAP_HANDLE_T*)engine.m_handle)->m_retry_us = MIN(((SCAP_HANDLE_T*)engine.m_handle)->m_retry_us * 2, BUFFER_EMPTY_WAIT_TIME_US_MAX);
+		usleep(HANDLE(engine)->m_retry_us);
+		HANDLE(engine)->m_retry_us = MIN(HANDLE(engine)->m_retry_us * 2, BUFFER_EMPTY_WAIT_TIME_US_MAX);
 		return SCAP_TIMEOUT;
 	}
 	else
 	{
-		((SCAP_HANDLE_T*)engine.m_handle)->m_retry_us = BUFFER_EMPTY_WAIT_TIME_US_START;
+		HANDLE(engine)->m_retry_us = BUFFER_EMPTY_WAIT_TIME_US_START;
 	}
 	*pflags = 0;
 	return SCAP_SUCCESS;
@@ -176,23 +177,23 @@ static int32_t calibrate_socket_file_ops(struct scap_engine_handle engine)
 	pman_set_scap_tid(scap_tid);
 
 	/* We just need to enable the socket syscall for the socket calibration */
-	((SCAP_HANDLE_T*)engine.m_handle)->curr_sc_set.ppm_sc[PPM_SC_SOCKET] = 1;
+	HANDLE(engine)->curr_sc_set.ppm_sc[PPM_SC_SOCKET] = 1;
 	if(scap_modern_bpf__start_capture(engine) != SCAP_SUCCESS)
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to start the capture for the socket calibration");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "unable to start the capture for the socket calibration");
 	}
 
 	int fd = socket(AF_INET, SOCK_DGRAM, 0);
 	if(fd == -1)
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to create a socket for the calibration");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "unable to create a socket for the calibration");
 	}
 	close(fd);
 
 	/* We need to stop the capture */
 	if(scap_modern_bpf__stop_capture(engine) != SCAP_SUCCESS)
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, errno, "unable to stop the capture after the calibration");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, errno, "unable to stop the capture after the calibration");
 	}
 
 	/* We need to read the socket event from the buffer */
@@ -230,7 +231,7 @@ static int32_t calibrate_socket_file_ops(struct scap_engine_handle engine)
 
 	if(!found)
 	{
-		return scap_errprintf(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, 0, "unable to find the socket event for the calibration in the ringbuffers");
+		return scap_errprintf(HANDLE(engine)->m_lasterr, 0, "unable to find the socket event for the calibration in the ringbuffers");
 	}
 	return SCAP_SUCCESS;
 }
@@ -268,7 +269,7 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	}
 
 	/* Set an initial sleep time in case of timeouts. */
-	((SCAP_HANDLE_T*)engine.m_handle)->m_retry_us = BUFFER_EMPTY_WAIT_TIME_US_START;
+	HANDLE(engine)->m_retry_us = BUFFER_EMPTY_WAIT_TIME_US_START;
 
 	/* Load and attach */
 	ret = pman_open_probe();
@@ -297,15 +298,15 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	}
 
 	/* Store interesting sc codes */
-	memcpy(&((SCAP_HANDLE_T*)engine.m_handle)->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
+	memcpy(&HANDLE(engine)->curr_sc_set, &oargs->ppm_sc_of_interest, sizeof(interesting_ppm_sc_set));
 
-	((SCAP_HANDLE_T*)engine.m_handle)->m_api_version = pman_get_probe_api_ver();
-	((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version = pman_get_probe_schema_ver();
+	HANDLE(engine)->m_api_version = pman_get_probe_api_ver();
+	HANDLE(engine)->m_schema_version = pman_get_probe_schema_ver();
 
-	((SCAP_HANDLE_T*)engine.m_handle)->m_flags = 0;
+	HANDLE(engine)->m_flags = 0;
 	if(scap_get_bpf_stats_enabled())
 	{
-		((SCAP_HANDLE_T*)engine.m_handle)->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
+		HANDLE(engine)->m_flags |= ENGINE_FLAG_BPF_STATS_ENABLED;
 	}
 
 	return SCAP_SUCCESS;
@@ -313,7 +314,7 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 
 static uint64_t scap_modern_bpf__get_flags(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_flags;
+	return HANDLE(engine)->m_flags;
 }
 
 int32_t scap_modern_bpf__close(struct scap_engine_handle engine)
@@ -358,19 +359,19 @@ int32_t scap_modern_bpf__get_n_tracepoint_hit(struct scap_engine_handle engine, 
 
 uint64_t scap_modern_bpf__get_api_version(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_api_version;
+	return HANDLE(engine)->m_api_version;
 }
 
 uint64_t scap_modern_bpf__get_schema_version(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_schema_version;
+	return HANDLE(engine)->m_schema_version;
 }
 
 struct scap_vtable scap_modern_bpf_engine = {
 	.name = MODERN_BPF_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))scap_modern_bpf__alloc_engine,
+	.alloc_handle = scap_modern_bpf__alloc_engine,
 	.init = scap_modern_bpf__init,
 	.get_flags = scap_modern_bpf__get_flags,
 	.free_handle = scap_modern_bpf__free_engine,

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -65,7 +65,7 @@ const struct scap_vtable scap_nodriver_engine = {
 	.name = NODRIVER_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine/nodriver/nodriver.c
+++ b/userspace/libscap/engine/nodriver/nodriver.c
@@ -19,7 +19,7 @@ limitations under the License.
 #include <stdio.h>
 #include <stdlib.h>
 
-#define SCAP_HANDLE_T struct nodriver_engine
+#define HANDLE(engine) ((struct nodriver_engine*)(engine.m_handle))
 
 #include <libscap/engine/nodriver/nodriver.h>
 #include <libscap/engine/noop/noop.h>
@@ -29,7 +29,7 @@ limitations under the License.
 #include <libscap/scap_gettimeofday.h>
 #include <libscap/scap_sleep.h>
 
-static struct nodriver_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+static void* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct nodriver_engine *engine = calloc(1, sizeof(struct nodriver_engine));
 	if(engine)
@@ -65,7 +65,7 @@ const struct scap_vtable scap_nodriver_engine = {
 	.name = NODRIVER_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
+	.alloc_handle = alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine/noop/noop.c
+++ b/userspace/libscap/engine/noop/noop.c
@@ -24,13 +24,13 @@ struct noop_engine
 	char *m_lasterr;
 };
 
-#define SCAP_HANDLE_T struct noop_engine
+#define HANDLE(engine) ((struct noop_engine*)(engine.m_handle))
 
 #include <libscap/engine/noop/noop.h>
 #include <libscap/scap.h>
 #include <libscap/strl.h>
 
-struct noop_engine* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+void* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct noop_engine *engine = calloc(1, sizeof(struct noop_engine));
 	if(engine)
@@ -79,7 +79,7 @@ int32_t noop_configure(struct scap_engine_handle engine, enum scap_setting setti
 	{
 		return SCAP_SUCCESS;
 	}
-	return unimplemented_op(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, SCAP_LASTERR_SIZE);
+	return unimplemented_op(HANDLE(engine)->m_lasterr, SCAP_LASTERR_SIZE);
 }
 
 int32_t noop_get_stats(struct scap_engine_handle engine, scap_stats* stats)
@@ -113,7 +113,7 @@ const struct scap_vtable scap_noop_engine = {
 	.name = "noop",
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))noop_alloc_handle,
+	.alloc_handle = noop_alloc_handle,
 	.init = NULL,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine/noop/noop.c
+++ b/userspace/libscap/engine/noop/noop.c
@@ -79,7 +79,7 @@ int32_t noop_configure(struct scap_engine_handle engine, enum scap_setting setti
 	{
 		return SCAP_SUCCESS;
 	}
-	return unimplemented_op(engine.m_handle->m_lasterr, SCAP_LASTERR_SIZE);
+	return unimplemented_op(((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr, SCAP_LASTERR_SIZE);
 }
 
 int32_t noop_get_stats(struct scap_engine_handle engine, scap_stats* stats)
@@ -113,7 +113,7 @@ const struct scap_vtable scap_noop_engine = {
 	.name = "noop",
 	.savefile_ops = NULL,
 
-	.alloc_handle = noop_alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))noop_alloc_handle,
 	.init = NULL,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine/noop/noop.h
+++ b/userspace/libscap/engine/noop/noop.h
@@ -26,7 +26,7 @@ typedef struct ppm_evt_hdr scap_evt;
 typedef struct scap_stats scap_stats;
 typedef struct metrics_v2 metrics_v2;
 
-struct noop_engine* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr);
+void* noop_alloc_handle(scap_t* main_handle, char* lasterr_ptr);
 void noop_free_handle(struct scap_engine_handle engine);
 int noop_close_engine(struct scap_engine_handle engine);
 int32_t noop_next(struct scap_engine_handle handle, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags);

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2059,13 +2059,13 @@ static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_
 
 uint64_t scap_savefile_ftell(struct scap_engine_handle engine)
 {
-	scap_reader_t* reader = engine.m_handle->m_reader;
+	scap_reader_t* reader = ((SCAP_HANDLE_T*)engine.m_handle)->m_reader;
 	return reader->tell(reader);
 }
 
 void scap_savefile_fseek(struct scap_engine_handle engine, uint64_t off)
 {
-	scap_reader_t* reader = engine.m_handle->m_reader;
+	scap_reader_t* reader = ((SCAP_HANDLE_T*)engine.m_handle)->m_reader;
 	reader->seek(reader, off, SEEK_SET);
 }
 
@@ -2276,7 +2276,7 @@ static int32_t scap_savefile_restart_capture(scap_t* handle)
 
 static int64_t get_readfile_offset(struct scap_engine_handle engine)
 {
-	return engine.m_handle->m_reader->offset(engine.m_handle->m_reader);
+	return ((SCAP_HANDLE_T*)engine.m_handle)->m_reader->offset(((SCAP_HANDLE_T*)engine.m_handle)->m_reader);
 }
 
 static struct scap_savefile_vtable savefile_ops = {
@@ -2291,7 +2291,7 @@ struct scap_vtable scap_savefile_engine = {
 	.name = SAVEFILE_ENGINE,
 	.savefile_ops = &savefile_ops,
 
-	.alloc_handle = alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
 	.init = init,
 	.free_handle = free_handle,
 	.close = scap_savefile_close,

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -30,7 +30,8 @@ struct iovec {
 };
 #endif
 
-#define SCAP_HANDLE_T struct savefile_engine
+#define HANDLE(engine) ((struct savefile_engine*)(engine.m_handle))
+
 #include <libscap/engine/savefile/savefile.h>
 #include <libscap/scap.h>
 #include <libscap/scap-int.h>
@@ -2059,13 +2060,13 @@ static int32_t next(struct scap_engine_handle engine, scap_evt **pevent, uint16_
 
 uint64_t scap_savefile_ftell(struct scap_engine_handle engine)
 {
-	scap_reader_t* reader = ((SCAP_HANDLE_T*)engine.m_handle)->m_reader;
+	scap_reader_t* reader = HANDLE(engine)->m_reader;
 	return reader->tell(reader);
 }
 
 void scap_savefile_fseek(struct scap_engine_handle engine, uint64_t off)
 {
-	scap_reader_t* reader = ((SCAP_HANDLE_T*)engine.m_handle)->m_reader;
+	scap_reader_t* reader = HANDLE(engine)->m_reader;
 	reader->seek(reader, off, SEEK_SET);
 }
 
@@ -2115,7 +2116,7 @@ struct scap_platform *scap_savefile_alloc_platform(proc_entry_callback proc_call
 	return &platform->m_generic;
 }
 
-static struct savefile_engine* alloc_handle(struct scap* main_handle, char* lasterr_ptr)
+static void* alloc_handle(struct scap* main_handle, char* lasterr_ptr)
 {
 	struct savefile_engine *engine = calloc(1, sizeof(struct savefile_engine));
 	if(engine)
@@ -2276,7 +2277,7 @@ static int32_t scap_savefile_restart_capture(scap_t* handle)
 
 static int64_t get_readfile_offset(struct scap_engine_handle engine)
 {
-	return ((SCAP_HANDLE_T*)engine.m_handle)->m_reader->offset(((SCAP_HANDLE_T*)engine.m_handle)->m_reader);
+	return HANDLE(engine)->m_reader->offset(HANDLE(engine)->m_reader);
 }
 
 static struct scap_savefile_vtable savefile_ops = {
@@ -2291,7 +2292,7 @@ struct scap_vtable scap_savefile_engine = {
 	.name = SAVEFILE_ENGINE,
 	.savefile_ops = &savefile_ops,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
+	.alloc_handle = alloc_handle,
 	.init = init,
 	.free_handle = free_handle,
 	.close = scap_savefile_close,

--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -159,7 +159,7 @@ static int close_engine(struct scap_engine_handle engine)
 static int32_t next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
 	struct source_plugin_engine *handle = engine.m_handle;
-	char *lasterr = engine.m_handle->m_lasterr;
+	char *lasterr = ((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr;
 
 	/* we have to read a new batch */
 	if(handle->m_input_plugin_batch_idx >= handle->m_input_plugin_batch_nevts)
@@ -252,7 +252,7 @@ static int32_t next(struct scap_engine_handle engine, scap_evt** pevent, uint16_
 		// plugin events have no thread associated
 		evt->tid = (uint64_t) -1;
 	}
-	
+
 	// automatically set timestamp if none was specified
 	if(evt->ts == UINT64_MAX)
 	{
@@ -305,7 +305,7 @@ const struct scap_vtable scap_source_plugin_engine = {
 	.name = SOURCE_PLUGIN_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = close_engine,

--- a/userspace/libscap/engine/source_plugin/source_plugin.c
+++ b/userspace/libscap/engine/source_plugin/source_plugin.c
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-#define SCAP_HANDLE_T struct source_plugin_engine
+#define HANDLE(engine) ((struct source_plugin_engine*)(engine.m_handle))
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -101,7 +101,7 @@ static int32_t plugin_rc_to_scap_rc(ss_plugin_rc plugin_rc)
 	return SCAP_FAILURE;
 }
 
-static struct source_plugin_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+static void* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct source_plugin_engine *engine = calloc(1, sizeof(struct source_plugin_engine));
 	if(engine)
@@ -159,7 +159,7 @@ static int close_engine(struct scap_engine_handle engine)
 static int32_t next(struct scap_engine_handle engine, scap_evt** pevent, uint16_t* pdevid, uint32_t* pflags)
 {
 	struct source_plugin_engine *handle = engine.m_handle;
-	char *lasterr = ((SCAP_HANDLE_T*)engine.m_handle)->m_lasterr;
+	char *lasterr = HANDLE(engine)->m_lasterr;
 
 	/* we have to read a new batch */
 	if(handle->m_input_plugin_batch_idx >= handle->m_input_plugin_batch_nevts)
@@ -305,7 +305,7 @@ const struct scap_vtable scap_source_plugin_engine = {
 	.name = SOURCE_PLUGIN_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
+	.alloc_handle = alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = close_engine,

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -30,7 +30,7 @@ struct test_input_engine
 
 typedef struct test_input_engine test_input_engine;
 
-#define SCAP_HANDLE_T struct test_input_engine
+#define HANDLE(engine) ((struct test_input_engine*)(engine.m_handle))
 
 #include <libscap/engine/noop/noop.h>
 
@@ -39,7 +39,7 @@ typedef struct test_input_engine test_input_engine;
 #include <libscap/scap_proc_util.h>
 #include <libscap/strl.h>
 
-static struct test_input_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
+static void* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 {
 	struct test_input_engine *engine = calloc(1, sizeof(struct test_input_engine));
 	if(engine == NULL)
@@ -88,7 +88,7 @@ const struct scap_vtable scap_test_input_engine = {
 	.name = TEST_INPUT_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
+	.alloc_handle = alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine/test_input/test_input.c
+++ b/userspace/libscap/engine/test_input/test_input.c
@@ -88,7 +88,7 @@ const struct scap_vtable scap_test_input_engine = {
 	.name = TEST_INPUT_ENGINE,
 	.savefile_ops = NULL,
 
-	.alloc_handle = alloc_handle,
+	.alloc_handle = (void* (*)(scap_t*, char*))alloc_handle,
 	.init = init,
 	.free_handle = noop_free_handle,
 	.close = noop_close_engine,

--- a/userspace/libscap/engine_handle.h
+++ b/userspace/libscap/engine_handle.h
@@ -18,10 +18,6 @@ limitations under the License.
 
 #pragma once
 
-#ifndef SCAP_HANDLE_T
-#error "You need to define SCAP_HANDLE_T to a concrete type before including engine_handle.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +25,7 @@ extern "C" {
 // this is passed by value everywhere so keep it small
 // it only contains a pointer to a struct containing the engine-specific bits
 struct scap_engine_handle {
-	SCAP_HANDLE_T* m_handle;
+	void* m_handle;
 };
 
 #ifdef __cplusplus

--- a/userspace/libscap/linux/scap_linux_platform.h
+++ b/userspace/libscap/linux/scap_linux_platform.h
@@ -22,10 +22,6 @@ limitations under the License.
 extern "C" {
 #endif
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/linux/scap_cgroup.h>
 #include <libscap/scap_platform_impl.h>
 #include <libscap/engine_handle.h>

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -22,10 +22,6 @@ limitations under the License.
 
 #pragma once
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/engine_handle.h>
 #include <libscap/scap_vtable.h>
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -26,7 +26,6 @@ limitations under the License.
 #include <libscap/scap_api_version.h>
 #include <libscap/scap_platform.h>
 
-#define SCAP_HANDLE_T void
 #include <libscap/scap_engines.h>
 
 #ifdef __linux__

--- a/userspace/libscap/scap_api_version.h
+++ b/userspace/libscap/scap_api_version.h
@@ -21,10 +21,6 @@ limitations under the License.
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/engine_handle.h>
 
 struct scap_vtable;
@@ -41,4 +37,3 @@ bool scap_apply_semver_check(uint32_t current_major, uint32_t current_minor, uin
 			     uint32_t required_major, uint32_t required_minor, uint32_t required_patch);
 
 int32_t check_api_compatibility(const struct scap_vtable* vtable, struct scap_engine_handle engine, char *error);
-

--- a/userspace/libscap/scap_engines.h
+++ b/userspace/libscap/scap_engines.h
@@ -18,10 +18,6 @@ limitations under the License.
 
 #pragma once
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/scap_vtable.h>
 #include <libscap/scap_config.h>
 

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -21,10 +21,6 @@ limitations under the License.
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/scap_limits.h>
 #include <libscap/scap_procs.h>
 #include <driver/ppm_events_public.h>

--- a/userspace/libscap/scap_platform.h
+++ b/userspace/libscap/scap_platform.h
@@ -20,9 +20,6 @@ limitations under the License.
 
 #include <stdint.h>
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
 #include <libscap/engine_handle.h>
 
 #include <libscap/scap_procs.h>

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -28,10 +28,6 @@ limitations under the License.
 extern "C" {
 #endif
 
-#ifndef SCAP_HANDLE_T
-#define SCAP_HANDLE_T void
-#endif
-
 #include <libscap/engine_handle.h>
 #include <libscap/scap_machine_info.h>
 #include <libscap/scap_procs.h>

--- a/userspace/libscap/scap_vtable.h
+++ b/userspace/libscap/scap_vtable.h
@@ -131,7 +131,7 @@ struct scap_vtable {
 	 *                    in the engine handle for easier access
 	 * @return pointer to the newly allocated handle or NULL
 	 */
-	SCAP_HANDLE_T* (*alloc_handle)(scap_t* main_handle, char *lasterr_ptr);
+	void* (*alloc_handle)(scap_t* main_handle, char* lasterr_ptr);
 
 	/**
 	 * @brief perform engine-specific initialization


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
Class `scap_engine_handle` is defined once in its header file, but has a single pointer data member `SCAP_HANDLE_T* m_handle` that contains a macro that changes depending on what source file is including it. This is by design, the idea being that it is a sort of hierarchy of classes that share the same functions. However this is not without problems as if one tries to enable link-time optimization (LTO) the linker presents an error that the one-definition rule (ODR) has been broken.
This PR solves the issue by using a generic `void*` for the data member and using a cast to the appropriate type each time is is used in a function. This is possible as manipulating functions are specialized for each type, so knowledge of the type is available.
The technique sacrifices somewhat the "beauty" of the previous approach: each cast is syntactically "ugly", but saves the ODR and overcomes linker errors when LTO is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
