### PR TITLE
cleanup(libsinsp): introduce param->as<std::string>(), add error for unsupported types

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2150,7 +2150,7 @@ void sinsp_evt::save_enter_event_params(sinsp_evt* enter_evt)
 		param = enter_evt->get_param_by_name(pname);
 		if(param)
 		{
-			std::string val {param->as<std::string_view>()};
+			std::string val = param->as<std::string>();
 			m_enter_path_param[pname] = val;
 		}
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1227,7 +1227,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	child_tinfo->m_vpid = child_tinfo->m_pid;
 
 	/* exe */
-	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
+	child_tinfo->m_exe = evt->get_param(1)->as<std::string>();
 
 	/* args */
 	child_tinfo->set_args(evt->get_param(2)->as<std::vector<std::string>>());
@@ -1248,7 +1248,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid)
 	case PPME_SYSCALL_VFORK_17_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		child_tinfo->m_comm = evt->get_param(13)->as<std::string_view>();
+		child_tinfo->m_comm = evt->get_param(13)->as<std::string>();
 		break;
 	default:
 		ASSERT(false);
@@ -1660,7 +1660,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	 */
 
 	/* exe */
-	child_tinfo->m_exe = evt->get_param(1)->as<std::string_view>();
+	child_tinfo->m_exe = evt->get_param(1)->as<std::string>();
 
 	/* comm */
 	switch(etype)
@@ -1678,7 +1678,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt)
 	case PPME_SYSCALL_VFORK_17_X:
 	case PPME_SYSCALL_VFORK_20_X:
 	case PPME_SYSCALL_CLONE3_X:
-		child_tinfo->m_comm = evt->get_param(13)->as<std::string_view>();
+		child_tinfo->m_comm = evt->get_param(13)->as<std::string>();
 		break;
 	default:
 		ASSERT(false);
@@ -2067,7 +2067,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	case PPME_SYSCALL_EXECVE_19_X:
 	case PPME_SYSCALL_EXECVEAT_X:
 		// Get the comm
-		evt->get_tinfo()->m_comm = evt->get_param(13)->as<std::string_view>();
+		evt->get_tinfo()->m_comm = evt->get_param(13)->as<std::string>();
 		break;
 	default:
 		ASSERT(false);
@@ -4446,7 +4446,7 @@ void sinsp_parser::parse_getcwd_exit(sinsp_evt *evt)
 			return;
 		}
 
-		std::string cwd = std::string(evt->get_param(1)->as<std::string_view>());
+		std::string cwd = evt->get_param(1)->as<std::string>();
 
 #ifdef _DEBUG
 		if(cwd != "/")

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -457,7 +457,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, uint32_t *len
 			// Get the file path directly from the ring buffer.
 			// concatenate_paths takes care of resolving the path
 			//
-			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string_view>());
+			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string>());
 
 			RETURN_EXTRACT_STRING(m_strstorage);
 		}
@@ -1708,7 +1708,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt *evt, uint32_t* len,
 
 			if(etype == PPME_INFRASTRUCTURE_EVENT_E)
 			{
-				std::string descstr{evt->get_param(2)->as<std::string_view>()};
+				std::string descstr{evt->get_param(2)->as<std::string>()};
 				vector<string> elements = sinsp_split(descstr, ';');
 				for(string ute : elements)
 				{

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -258,7 +258,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, uint32_t
 		}
 	case PPME_SYSCALL_OPEN_BY_HANDLE_AT_X:
 		{
-			m_tstr = evt->get_param(3)->as<std::string_view>();
+			m_tstr = evt->get_param(3)->as<std::string>();
 
 			if(sanitize_strings)
 			{

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -43,7 +43,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 
 	// this, and the following similar checks, verify that the internal state is set as we need right now.
 	// if the internal state changes we can remove or update this check
-	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
+	ASSERT_EQ(evt->get_param(1)->as<std::string>(), "<NA>");
 
 	/* `PPME_SYSCALL_CREAT_E` is a simple event that uses a `PT_FSPATH`
 	 * A `NULL` `PT_FSPATH` param is always converted to `<NA>`.
@@ -51,7 +51,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CREAT_E, 2, NULL, 0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param(0)->as<std::string_view>().data(), "<NA>");
+	ASSERT_EQ(evt->get_param(0)->as<std::string>(), "<NA>");
 
 	int64_t dirfd = 0;
 
@@ -61,7 +61,7 @@ TEST_F(sinsp_with_test_input, charbuf_empty_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EXECVEAT_E, 3, dirfd, NULL, 0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.pathname"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
+	ASSERT_EQ(evt->get_param(1)->as<std::string>(), "<NA>");
 }
 
 /* Assert that a `PT_CHARBUF` with `len==1` (just the `\0`) is not changed. */
@@ -81,7 +81,7 @@ TEST_F(sinsp_with_test_input, param_charbuf_len_1)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "");
 
-	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "");
+	ASSERT_EQ(evt->get_param(1)->as<std::string>(), "");
 }
 
 /* Assert that a "(NULL)" `PT_CHARBUF` param is converted to `<NA>`
@@ -101,7 +101,7 @@ TEST_F(sinsp_with_test_input, charbuf_NULL_param)
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_CHDIR_X, 2, test_errno, "(NULL)");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.path"), "<NA>");
 
-	ASSERT_STREQ(evt->get_param(1)->as<std::string_view>().data(), "<NA>");
+	ASSERT_EQ(evt->get_param(1)->as<std::string>(), "<NA>");
 }
 
 /* Assert that an empty `PT_BYTEBUF` param is NOT converted to `<NA>` */


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Addressing feedback received.

A contributor tried to set up a test with something like `evt->get_param(1)->as<std::string>()` and was confused by the fact that (1) `std::string` was not directly supported and (2) this did not result in a compilation error but in a runtime error which was hard to understand, as the engine tried to reinterpret a char string as an `std::string` basically setting the raw bytes of the string object and then erroring out because of the wrong size.

So to make it easier to work with this this PR does two things:
* Adds a param conversion type `std::string`
* Adds a compile time error for unsupported types

/milestone 0.18.0

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Code that does `some_stuct->some_string = evt->get_param(N)->as<std::string>()` does _not_ copy the string. It creates it once and then, if necessary uses the move assignment operator.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(libsinsp): introduce param->as<std::string>(), add error for unsupported types
```
