### PR TITLE
fix(userspace/libsinsp): allow evt.rawarg to be used with transformers and as rhs field check

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -80,7 +80,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] =
 	{PT_INT16, EPF_NONE, PF_ID, "evt.cpu", "CPU Number", "number of the CPU where this event happened."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.args", "Arguments", "all the event arguments, aggregated into a single string."},
 	{PT_CHARBUF, EPF_ARG_REQUIRED, PF_NA, "evt.arg", "Argument", "one of the event arguments specified by name or by number. Some events (e.g. return codes or FDs) will be converted into a text representation when possible. E.g. 'evt.arg.fd' or 'evt.arg[0]'."},
-	{PT_DYN, EPF_ARG_REQUIRED | EPF_NO_RHS | EPF_NO_TRANSFORMER, PF_NA, "evt.rawarg", "Raw Argument", "one of the event arguments specified by name. E.g. 'evt.rawarg.fd'."},
+	{PT_DYN, EPF_ARG_REQUIRED, PF_NA, "evt.rawarg", "Raw Argument", "one of the event arguments specified by name. E.g. 'evt.rawarg.fd'."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "evt.info", "Information", "for most events, this field returns the same value as evt.args. However, for some events (like writes to /dev/log) it provides higher level information coming from decoding the arguments."},
 	{PT_BYTEBUF, EPF_NONE, PF_NA, "evt.buffer", "Buffer", "the binary data buffer for events that have one, like read(), recvfrom(), etc. Use this field in filters with 'contains' to search into I/O data buffers."},
 	{PT_UINT64, EPF_NONE, PF_DEC, "evt.buflen", "Buffer Length", "the length of the binary data buffer for events that have one, like read(), recvfrom(), etc."},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

For safety reasons we made the conservative choice of not letting `arg.rawarg` being used with field transformers or in chck with field-to-field comparisons due to its dynamic typing nature. However, looking twice I realized that the typing of the field is automatically resolved at runtime by the time those checks happen, thus being safe (and useful) to be used alongside those new features.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

cc @Andreagit97 for another opinion, having worked on this

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): allow evt.rawarg to be used with transformers and as rhs field check
```
