### PR TITLE
chore(cmake): workaround CI issue for windows.

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -106,8 +106,12 @@ else() # MSVC
 	set(CMAKE_C_FLAGS_RELEASE "${FALCOSECURITY_LIBS_RELEASE_FLAGS}")
 	set(CMAKE_CXX_FLAGS_RELEASE "${FALCOSECURITY_LIBS_RELEASE_FLAGS}")
 
+	# "_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" enables a
+	# workaround for windows GH runner issue, see
+        # https://github.com/actions/runner-images/issues/10004
 	add_compile_definitions(
 		_HAS_STD_BYTE=0
 		WIN32_LEAN_AND_MEAN
+		_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 	)
 endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR workarounds an issue with the github windows runner: https://github.com/actions/runner-images/issues/10004

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
