### PR TITLE
fix(userspace/libsinsp): solve fdtables 'type' field returning random data

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -152,6 +152,7 @@ libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const
 	define_static_field(ret, this, m_mount_id, "mount_id");
 	define_static_field(ret, this, m_ino, "ino");
 	define_static_field(ret, this, m_pid, "pid");
+	define_static_field(ret, this, m_fd, "fd");
 
 	// in this case we have a union, so many of the following exposed fields
 	// will point to the same memory areas, but this should not be an issue
@@ -176,6 +177,7 @@ libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const
 	define_static_field(ret, this, m_sockinfo.m_ipv6serverinfo.m_l4proto, "socket_ipv6_server_l4_proto");
 	define_static_field(ret, this, m_sockinfo.m_unixinfo.m_fields.m_source, "socket_unix_src");
 	define_static_field(ret, this, m_sockinfo.m_unixinfo.m_fields.m_dest, "socket_unix_dest");
+
 	return ret;
 }
 

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -394,7 +394,7 @@ TEST(thread_manager, table_access)
 TEST(thread_manager, fdtable_access)
 {
     // note: used for regression checks, keep this updated as we make new fields available
-    static const int s_fdinfo_static_fields_count = 31;
+    static const int s_fdinfo_static_fields_count = 32;
 
     sinsp inspector;
 	auto& reg = inspector.get_table_registry();


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

I discovered that the `type` field exposed by the fd tables through the state & plugin API is returning wrong/unrelated data since it's been available. Unfortunately, IMO the safest fix is to turn its type into uint8, which is essentially a breaking change for whoever was accessing it (the type change will cause errors to be returned). However, considering the information returned has never been valid I think this is something we can afford, specially considering that the latest libs version has been released just few weeks ago.

I also noted that we're not exporting the `fd` field, which I just added being very trivial.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): solve fdtables 'type' field returning random data
```
