### PR TITLE
new(userspace/libsinsp): support regular expression operator in sinsp filters

### DIFF
--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -258,7 +258,10 @@ private:
 	void visit(const libsinsp::filter::ast::field_transformer_expr*) override;
 	std::string create_filtercheck_name(const std::string& name, const std::string& arg);
 	std::unique_ptr<sinsp_filter_check> create_filtercheck(std::string_view field);
-	void check_value_and_add_warnings(const libsinsp::filter::ast::pos_info& pos, const std::string& v);
+	void check_value_and_add_warnings(cmpop op, const libsinsp::filter::ast::pos_info& pos, const std::string& v);
+	void check_warnings_regex_value(const libsinsp::filter::ast::pos_info& pos, const std::string& v);
+	void check_warnings_field_value(const libsinsp::filter::ast::pos_info& pos, const std::string& str, const std::string& strippedstr);
+	void check_warnings_transformer_value(const libsinsp::filter::ast::pos_info& pos, const std::string& str, const std::string& strippedstr);
 
 	libsinsp::filter::ast::pos_info m_pos;
 	boolop m_last_boolop;

--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -78,7 +78,7 @@ static const std::vector<std::string> s_binary_num_ops =
 static const std::vector<std::string> s_binary_str_ops =
 {
 	"==", "=", "!=", "glob ", "iglob ", "contains ", "icontains ",
-	"bcontains ", "startswith ", "bstartswith ", "endswith ",
+	"bcontains ", "startswith ", "bstartswith ", "endswith ", "regex ",
 };
 
 static const std::vector<std::string> s_binary_list_ops =

--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -139,6 +139,10 @@ cmpop str_to_cmpop(std::string_view str)
 	{
 		return CO_IGLOB;
 	}
+	else if(str == "regex")
+	{
+		return CO_REGEX;
+	}
 
 	throw sinsp_exception("unrecognized filter comparison operator '" + std::string(str) + "'");
 }
@@ -166,6 +170,7 @@ bool cmpop_to_str(cmpop op, std::string& out)
 	case CO_INTERSECTS: { out = "intersects"; return true; }
 	case CO_BCONTAINS: { out = "bcontains"; return true; }
 	case CO_BSTARTSWITH: { out = "bstartswith"; return true; }
+	case CO_REGEX: { out = "regex"; return true; }
 	default:
 		ASSERT(false);
 		out = "unknown";
@@ -196,6 +201,7 @@ std::string std::to_string(cmpop c)
 	case CO_INTERSECTS: return "INTERSECTS";
 	case CO_BCONTAINS: return "BCONTAINS";
 	case CO_BSTARTSWITH: return "BSTARTSWITH";
+	case CO_REGEX: return "REGEX";
 	default:
 		ASSERT(false);
 		return "<unset>";
@@ -262,6 +268,7 @@ static inline bool flt_is_comparable_string(cmpop op, std::string& err)
 	case CO_ENDSWITH:
 	case CO_INTERSECTS:
 	case CO_IGLOB:
+	case CO_REGEX:
 		return true;
 	default:
 		std::string opname;
@@ -480,7 +487,8 @@ static inline bool flt_compare_string(cmpop op, char* operand1, char* operand2)
 	case CO_GE:
 		return (strcmp(operand1, operand2) >= 0);
 	case CO_PMATCH:
-		// note: pmatch is not handled here
+	case CO_REGEX:
+		// note: pmatch and regex operators are not handled here
 		return false;
 	default:
 		_throw_if_not_comparable(op, flt_is_comparable_string);

--- a/userspace/libsinsp/filter_compare.h
+++ b/userspace/libsinsp/filter_compare.h
@@ -49,6 +49,7 @@ enum cmpop: uint8_t
 	CO_BCONTAINS = 16,
 	CO_BSTARTSWITH = 17,
 	CO_IGLOB = 18,
+	CO_REGEX = 19,
 };
 
 cmpop str_to_cmpop(std::string_view str);

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -32,6 +32,8 @@ limitations under the License.
 #include <unordered_set>
 #include <memory>
 
+namespace re2 { class RE2; };
+
 enum boolop: uint8_t
 {
 	BO_NONE = 0,
@@ -264,6 +266,9 @@ private:
 	std::unique_ptr<path_prefix_search> m_val_storages_paths;
 	uint32_t m_val_storages_min_size;
 	uint32_t m_val_storages_max_size;
+
+	struct default_re2_deleter { void operator()(re2::RE2* __ptr) const; };
+	std::unique_ptr<re2::RE2, default_re2_deleter> m_val_regex;
 
 	static constexpr const size_t s_min_filter_value_buf_size = 16;
 	static constexpr const size_t s_max_filter_value_buf_size = 256;

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -291,6 +291,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.rawtime bcontains 303000", true);
 	test_filter_compile(factory, "evt.rawtime bstartswith 303000", true);
 	test_filter_compile(factory, "evt.rawtime iglob 1", true);
+	test_filter_compile(factory, "evt.rawtime regex '1'", true);
 	
 	// PT_BOOL
 	test_filter_compile(factory, "evt.is_io exists");
@@ -311,6 +312,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.is_io bcontains 7472756500", true);
 	test_filter_compile(factory, "evt.is_io bstartswith 7472756500", true);
 	test_filter_compile(factory, "evt.is_io iglob true", true);
+	test_filter_compile(factory, "evt.is_io regex '1'", true);
 
 	// PT_BYTEBUF
 	test_filter_compile(factory, "evt.buffer exists");
@@ -331,6 +333,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.buffer bcontains 303000");
 	test_filter_compile(factory, "evt.buffer bstartswith 303000");
 	test_filter_compile(factory, "evt.buffer iglob test", true);
+	test_filter_compile(factory, "evt.buffer regex '.*'", true);
 
 	// PT_CHARBUF
 	test_filter_compile(factory, "fd.name exists");
@@ -351,6 +354,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "fd.name bcontains 303000", true);
 	test_filter_compile(factory, "fd.name bstartswith 303000", true);
 	test_filter_compile(factory, "fd.name iglob true");
+	test_filter_compile(factory, "fd.name regex '/home/.*/dev'");
 
 	// PT_DOUBLE
 	test_filter_compile(factory, "thread.cpu exists");
@@ -373,6 +377,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "thread.cpu bcontains 303000", true);
 	test_filter_compile(factory, "thread.cpu bstartswith 303000", true);
 	test_filter_compile(factory, "thread.cpu iglob 1", true);
+	test_filter_compile(factory, "thread.cpu regex '1'", true);
 
 	// PT_INT16
 	test_filter_compile(factory, "evt.cpu exists");
@@ -393,6 +398,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.cpu bcontains 303000", true);
 	test_filter_compile(factory, "evt.cpu bstartswith 303000", true);
 	test_filter_compile(factory, "evt.cpu iglob 1", true);
+	test_filter_compile(factory, "evt.cpu regex '1'", true);
 
 	// PT_INT32
 	test_filter_compile(factory, "fd.dev exists");
@@ -413,6 +419,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "fd.dev bcontains 303000", true);
 	test_filter_compile(factory, "fd.dev bstartswith 303000", true);
 	test_filter_compile(factory, "fd.dev iglob 1", true);
+	test_filter_compile(factory, "fd.dev regex '1'", true);
 
 	// PT_INT64
 	test_filter_compile(factory, "proc.pid exists");
@@ -433,6 +440,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "proc.pid bcontains 303000", true);
 	test_filter_compile(factory, "proc.pid bstartswith 303000", true);
 	test_filter_compile(factory, "proc.pid iglob 1", true);
+	test_filter_compile(factory, "proc.pid regex '1'", true);
 
 	// PT_IPADDR
 	test_filter_compile(factory, "fd.ip exists");
@@ -453,6 +461,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "fd.ip bcontains 3132372e302e302e3100", true);
 	test_filter_compile(factory, "fd.ip bstartswith 3132372e302e302e3100", true);
 	test_filter_compile(factory, "fd.ip iglob 127.0.0.1", true);
+	test_filter_compile(factory, "fd.ip regex '.*'", true);
 
 	// PT_IPNET
 	test_filter_compile(factory, "fd.net exists");
@@ -473,6 +482,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "fd.net bcontains 3132372e302e302e312f333200", true);
 	test_filter_compile(factory, "fd.net bstartswith 3132372e302e302e312f333200", true);
 	test_filter_compile(factory, "fd.net iglob 127.0.0.1/32", true);
+	test_filter_compile(factory, "fd.net regex '.*'", true);
 
 	// PT_PORT
 	test_filter_compile(factory, "fd.port exists");
@@ -493,6 +503,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "fd.port bcontains 303000", true);
 	test_filter_compile(factory, "fd.port bstartswith 303000", true);
 	test_filter_compile(factory, "fd.port iglob 1", true);
+	test_filter_compile(factory, "fd.port regex '1'", true);
 
 	// PT_RELTIME
 	test_filter_compile(factory, "proc.pid.ts exists");
@@ -513,6 +524,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "proc.pid.ts bcontains 303000", true);
 	test_filter_compile(factory, "proc.pid.ts bstartswith 303000", true);
 	test_filter_compile(factory, "proc.pid.ts iglob 1", true);
+	test_filter_compile(factory, "proc.pid.ts regex '1'", true);
 
 	// PT_UINT32
 	test_filter_compile(factory, "evt.count exists");
@@ -533,6 +545,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.count bcontains 303000", true);
 	test_filter_compile(factory, "evt.count bstartswith 303000", true);
 	test_filter_compile(factory, "evt.count iglob 1", true);
+	test_filter_compile(factory, "evt.count regex '1'", true);
 
 	// PT_UINT64
 	test_filter_compile(factory, "evt.num exists");
@@ -553,6 +566,7 @@ TEST(sinsp_filter_compiler, operators_field_types_compatibility)
 	test_filter_compile(factory, "evt.num bcontains 303000", true);
 	test_filter_compile(factory, "evt.num bstartswith 303000", true);
 	test_filter_compile(factory, "evt.num iglob 1", true);
+	test_filter_compile(factory, "evt.num regex '1'", true);
 }
 
 TEST(sinsp_filter_compiler, complex_filter)
@@ -793,4 +807,30 @@ TEST_F(sinsp_with_test_input, filter_cache_corner_cases)
 	EXPECT_EQ(cf->metrics->m_num_extract, 4);
 	EXPECT_EQ(cf->metrics->m_num_extract_cache, 2);
 	cf->metrics->reset();
+}
+
+TEST_F(sinsp_with_test_input, filter_regex_operator_evaluation)
+{
+	// Basic case just to assert that the basic setup works
+	add_default_init_thread();
+	open_inspector();
+
+	auto evt = generate_getcwd_failed_entry_event();
+
+	// legit use case with a string
+	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "evt.source regex '^[s]{1}ysca[l]{2}$'", evt));
+	
+	// respect anchors
+	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex 'yscal.*'", evt));
+	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex '.*yscal'", evt));
+	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "evt.source regex 'syscal.*'", evt));
+
+	// legit use case with a string, evaluating as false
+	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex '^unknown$'", evt));
+
+	// legit use case with a string, also using transformers
+	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "toupper(evt.source) regex '^[A-Z]+$'", evt));
+
+	// can't be used with field-to-field comparisons
+	EXPECT_THROW(evaluate_filter_str(&m_inspector, "evt.plugininfo regex val(evt.source)", evt), sinsp_exception);
 }

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -879,19 +879,19 @@ TEST_F(sinsp_with_test_input, filter_regex_operator_evaluation)
 	auto evt = generate_getcwd_failed_entry_event();
 
 	// legit use case with a string
-	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "evt.source regex '^[s]{1}ysca[l]{2}$'", evt));
+	EXPECT_TRUE(eval_filter(evt, "evt.source regex '^[s]{1}ysca[l]{2}$'"));
 	
 	// respect anchors
-	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex 'yscal.*'", evt));
-	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex '.*yscal'", evt));
-	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "evt.source regex 'syscal.*'", evt));
+	EXPECT_FALSE(eval_filter(evt, "evt.source regex 'yscal.*'"));
+	EXPECT_FALSE(eval_filter(evt, "evt.source regex '.*yscal'"));
+	EXPECT_TRUE(eval_filter(evt, "evt.source regex 'syscal.*'"));
 
 	// legit use case with a string, evaluating as false
-	EXPECT_FALSE(evaluate_filter_str(&m_inspector, "evt.source regex '^unknown$'", evt));
+	EXPECT_FALSE(eval_filter(evt, "evt.source regex '^unknown$'"));
 
 	// legit use case with a string, also using transformers
-	EXPECT_TRUE(evaluate_filter_str(&m_inspector, "toupper(evt.source) regex '^[A-Z]+$'", evt));
+	EXPECT_TRUE(eval_filter(evt, "toupper(evt.source) regex '^[A-Z]+$'"));
 
 	// can't be used with field-to-field comparisons
-	EXPECT_THROW(evaluate_filter_str(&m_inspector, "evt.plugininfo regex val(evt.source)", evt), sinsp_exception);
+	EXPECT_THROW(eval_filter(evt, "evt.plugininfo regex val(evt.source)"), sinsp_exception);
 }

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -82,7 +82,7 @@ TEST(parser, supported_operators)
 	static vector<string> expected_all = {
 		"=", "==", "!=", "<=", ">=", "<", ">", "exists",
 		"contains", "icontains", "bcontains", "glob", "iglob", "bstartswith",
-		"startswith", "endswith", "in", "intersects", "pmatch"};
+		"startswith", "endswith", "in", "intersects", "pmatch", "regex"};
 	static vector<string> expected_list_only = {
 		"in", "intersects", "pmatch"};
 	


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This has been requested by the community since a long time (~6 years) both publicly and in private channels. The main concern of supporting regular expressions is the potential performance impact on high events throughput such as the one of syscalls. However, I consider the project mature enough and in need of serving a multitude of different use cases, so I'm proposing to support this feature and empowering the user with the choice and wisdom on how best using it.

The contribution implements a new `regex` operator that can be used with string fields such as `fd.name regex [a-z]*/proc/[0-9]+/cmdline` or similars. The supported standard is the one of https://github.com/google/re2, on which we base our regex implementation.

This has also the benefit of making performance predictable, as RE2 does not support backtracking and full regex support (from my understanding). On top of that, I added few filter compilation heuristic warnings/checks (with tests) to inform users in cases where regular expression operators are used but not truly needed.

It is crucial that this operator is used with parsimony and only where strictly needed. From my personal benchmarks, the `regex` operator is 5x to 10x than a simple equality comparison for simple examples. As such, existing more trivial operators are always preferable in case they can implement the same check logic.

**Which issue(s) this PR fixes**:

Fixes:
- https://github.com/falcosecurity/falco/issues/438

**Special notes for your reviewer**:

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
new(userpsac/libsinsp): support regular expression operator in sinsp filters
```
