### PR TITLE
fix(libsinsp): fix regression in signed comparison

### DIFF
--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -415,7 +415,7 @@ static inline void _throw_if_not_comparable(cmpop op, Check c)
 }
 
 template<typename T>
-static inline bool flt_compare_numeric(cmpop op, uint64_t operand1, uint64_t operand2)
+static inline bool flt_compare_numeric(cmpop op, T operand1, T operand2)
 {
 	switch(op)
 	{

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -107,6 +107,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_parser.ut.cpp
 	filter_op_bcontains.ut.cpp
 	filter_op_pmatch.ut.cpp
+	filter_op_numeric_compare.ut.cpp
 	filter_compiler.ut.cpp
 	filter_transformer.ut.cpp
 	user.ut.cpp

--- a/userspace/libsinsp/test/filter_op_numeric_compare.ut.cpp
+++ b/userspace/libsinsp/test/filter_op_numeric_compare.ut.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"));
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <libsinsp/sinsp.h>
+#include <gtest/gtest.h>
+
+#include <sinsp_with_test_input.h>
+
+TEST_F(sinsp_with_test_input, signed_int_compare)
+{
+	add_default_init_thread();
+
+	open_inspector();
+
+	sinsp_evt * evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE_X, 1, (uint64_t)-22);
+
+	EXPECT_EQ(get_field_as_string(evt, "evt.cpu"), "1");
+
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu < 300"));
+	EXPECT_FALSE(eval_filter(evt, "evt.cpu > 300"));
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu < 2"));
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu > -500"));
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu < 500"));
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu <= 500"));
+
+	EXPECT_TRUE(eval_filter(evt, "evt.cpu <= 1025"));
+	EXPECT_FALSE(eval_filter(evt, "evt.cpu >= 1025"));
+
+	EXPECT_FALSE(eval_filter(evt, "evt.rawarg.res > 0"));
+	EXPECT_TRUE(eval_filter(evt, "evt.rawarg.res < 0"));
+	EXPECT_FALSE(eval_filter(evt, "evt.rawarg.res > 4294967295"));
+	EXPECT_TRUE(eval_filter(evt, "evt.rawarg.res < -1"));
+	EXPECT_TRUE(eval_filter(evt, "evt.rawarg.res > -65535"));
+
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", PPM_O_NONE, 0666);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_X, 6, (int64_t)(-1), "/tmp/the_file", PPM_O_NONE, 0666, 123, (uint64_t)456);
+
+	EXPECT_FALSE(eval_filter(evt, "fd.num >= 0"));
+	EXPECT_FALSE(eval_filter(evt, "fd.num > 0"));
+	EXPECT_TRUE(eval_filter(evt, "fd.num < 0"));
+	EXPECT_FALSE(eval_filter(evt, "fd.num > 4294967295"));
+	EXPECT_FALSE(eval_filter(evt, "fd.num < -1"));
+	EXPECT_TRUE(eval_filter(evt, "fd.num > -65535"));
+}

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -497,6 +497,20 @@ std::string sinsp_with_test_input::get_field_as_string(sinsp_evt* evt, std::stri
 	return result;
 }
 
+bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string filter_str)
+{
+	auto factory = std::make_shared<sinsp_filter_factory>(&m_inspector, m_default_filterlist);
+	sinsp_filter_compiler compiler(factory, filter_str);
+
+	auto filter = compiler.compile();
+	if (!filter)
+	{
+		throw sinsp_exception(std::string("could not compile filter ") + filter_str);
+	}
+
+	return filter->run(evt);
+}
+
 sinsp_evt* sinsp_with_test_input::next_event()
 {
 	sinsp_evt* evt;

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -192,12 +192,15 @@ protected:
 	void add_default_init_thread();
 	void add_simple_thread(int64_t tid, int64_t pid, int64_t ptid, const std::string& comm = "random");
 	uint64_t increasing_ts();
+
 	bool field_exists(sinsp_evt*, std::string_view field_name);
 	bool field_exists(sinsp_evt*, std::string_view field_name, filter_check_list&);
 	bool field_has_value(sinsp_evt*, std::string_view field_name);
 	bool field_has_value(sinsp_evt*, std::string_view field_name, filter_check_list&);
 	std::string get_field_as_string(sinsp_evt*, std::string_view field_name);
 	std::string get_field_as_string(sinsp_evt*, std::string_view field_name, filter_check_list&);
+	bool eval_filter(sinsp_evt* evt, std::string filter);
+
 	sinsp_evt* next_event();
 
 	scap_test_input_data m_test_data;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Libs 0.17.0 had some changes in numeric compare and casting. However, it looks like we are now doing unsigned comparison even if the data is signed, meaning that sinsp is thinking that `-1 > 10000`. This requires a bit of testing to see if it is the case but we need to fix it for the next patch release. Also cover comparisons with tests.

See: https://github.com/falcosecurity/falco/issues/3245

/milestone 0.17.2

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): fix signed compare operator
```
