### PR TITLE
refactor(userspace/libsinsp): polish and enable filter caching

### DIFF
--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -41,23 +41,6 @@ class sinsp_evt;
 ///////////////////////////////////////////////////////////////////////////////
 // Event arguments
 ///////////////////////////////////////////////////////////////////////////////
-enum filtercheck_field_flags
-{
-	EPF_NONE              = 0,
-	EPF_FILTER_ONLY       = 1 << 0, ///< this field can only be used as a filter.
-	EPF_PRINT_ONLY        = 1 << 1, ///< this field can only be printed.
-	EPF_ARG_REQUIRED      = 1 << 2, ///< this field includes an argument, under the form 'property.argument'.
-	EPF_TABLE_ONLY        = 1 << 3, ///< this field is designed to be used in a table and won't appear in the field listing.
-	EPF_INFO              = 1 << 4, ///< this field contains summary information about the event.
-	EPF_CONVERSATION      = 1 << 5, ///< this field can be used to identify conversations.
-	EPF_IS_LIST           = 1 << 6, ///< this field is a list of values.
-	EPF_ARG_ALLOWED       = 1 << 7, ///< this field optionally includes an argument.
-	EPF_ARG_INDEX         = 1 << 8, ///< this field accepts numeric arguments.
-	EPF_ARG_KEY           = 1 << 9, ///< this field accepts string arguments.
-	EPF_DEPRECATED        = 1 << 10,///< this field is deprecated.
-	EPF_NO_TRANSFORMER    = 1 << 11,///< this field cannot have a field transformer.
-	EPF_NO_RHS            = 1 << 12,///< this field cannot have a right-hand side filter check, and cannot be used as a right-hand side filter check.
-};
 
 /** @defgroup event Event manipulation
  * Classes to manipulate events, extract their content and convert them into strings.

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -58,7 +58,6 @@ public:
 	}
 
 	bool compare(sinsp_evt*) override;
-	bool extract(sinsp_evt*, std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
 
 	void add_check(std::unique_ptr<sinsp_filter_check> chk);
 
@@ -81,7 +80,7 @@ public:
 class SINSP_PUBLIC sinsp_filter
 {
 public:
-	sinsp_filter(sinsp* inspector);
+	sinsp_filter();
 	virtual ~sinsp_filter() = default;
 
 	bool run(sinsp_evt *evt);
@@ -94,8 +93,6 @@ public:
 
 private:
 	sinsp_filter_expression* m_curexpr;
-
-	sinsp* m_inspector;
 };
 
 class sinsp_filter_factory
@@ -163,8 +160,6 @@ public:
 
 	virtual ~sinsp_filter_factory() = default;
 
-	virtual std::unique_ptr<sinsp_filter> new_filter() const;
-
 	virtual std::unique_ptr<sinsp_filter_check> new_filtercheck(std::string_view fldname) const;
 
 	virtual std::list<filter_fieldclass_info> get_fields() const;
@@ -206,7 +201,8 @@ public:
 	*/
 	sinsp_filter_compiler(
 		sinsp* inspector,
-		const std::string& fltstr);
+		const std::string& fltstr,
+		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
 
 	/*!
 		\brief Constructs the compiler
@@ -217,7 +213,8 @@ public:
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<sinsp_filter_factory> factory,
-		const std::string& fltstr);
+		const std::string& fltstr,
+		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
 
 	/*!
 		\brief Constructs the compiler
@@ -229,7 +226,8 @@ public:
 	*/
 	sinsp_filter_compiler(
 		std::shared_ptr<sinsp_filter_factory> factory,
-		const libsinsp::filter::ast::expr* fltast);
+		const libsinsp::filter::ast::expr* fltast,
+		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
 
 	/*!
 		\brief Builds a filtercheck tree and bundles it in sinsp_filter
@@ -272,6 +270,7 @@ private:
 	std::shared_ptr<libsinsp::filter::ast::expr> m_internal_flt_ast;
 	const libsinsp::filter::ast::expr* m_flt_ast = nullptr;
 	std::shared_ptr<sinsp_filter_factory> m_factory;
+	std::shared_ptr<sinsp_filter_cache_factory> m_cache_factory;
 	std::vector<message> m_warnings;
 	sinsp_filter_check_list m_default_filterlist;
 };

--- a/userspace/libsinsp/filter_cache.h
+++ b/userspace/libsinsp/filter_cache.h
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <libsinsp/event.h>
+#include <libsinsp/filter_field.h>
+#include <libsinsp/filter_compare.h>
+#include <libsinsp/filter/ast.h>
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * @brief Represents a value extracted when evaluating a filter
+*/
+struct extract_value_t
+{
+    uint8_t* ptr = nullptr;
+    uint32_t len = 0;
+};
+
+/**
+ * @brief Represents a cache value storage for value extraction in filters
+*/
+class sinsp_filter_extract_cache
+{
+public:
+    inline void reset()
+    {
+        m_evtnum = UINT64_MAX;
+    }
+
+    inline bool is_valid(const sinsp_evt* evt) const
+    {
+        return evt->get_num() != 0 && m_evtnum != UINT64_MAX && evt->get_num() == m_evtnum;
+    }
+
+    inline void update(const sinsp_evt* evt, bool res, const std::vector<extract_value_t>& values, bool deepcopy = false)
+    {
+        m_evtnum = evt->get_num();
+        m_result = res;
+        if (!deepcopy)
+        {
+            m_values = values;
+            return;
+        }
+
+        auto len = m_values.size();
+        m_values.resize(len);
+        resize_if_smaller(m_storage, len);
+        for (size_t i = 0; i < len; i++)
+        {
+            auto v = values[i];
+            resize_if_smaller(m_storage[i], v.len);
+            if (v.len > 0)
+            {
+                ASSERT(v.ptr != nullptr);
+                memcpy(m_storage[i].data(), v.ptr, v.len);
+            }
+            v.ptr = m_storage[i].data();
+            m_values[i] = v;
+        }
+    }
+
+    inline const std::vector<extract_value_t>& values() const
+    {
+        return m_values;
+    }
+
+    inline bool result() const
+    {
+        return m_result;
+    }
+
+private:
+    template <typename T> static inline void resize_if_smaller(T& v, size_t len)
+    {
+        if (v.size() < len)
+        {
+            v.resize(len);
+        }
+    }
+
+    uint64_t m_evtnum = UINT64_MAX;
+    bool m_result = false;
+    std::vector<extract_value_t> m_values;
+    std::vector<std::vector<uint8_t>> m_storage;
+};
+
+/**
+ * @brief Represents a cache value storage for comparisons in filters
+*/
+class sinsp_filter_compare_cache
+{
+public:
+    inline void reset()
+    {
+        m_evtnum = UINT64_MAX;
+    }
+
+    inline bool is_valid(const sinsp_evt* evt) const
+    {
+        return evt->get_num() != 0 && m_evtnum != UINT64_MAX && evt->get_num() == m_evtnum;
+    }
+
+    inline void update(const sinsp_evt* evt, bool res)
+    {
+        m_evtnum = evt->get_num();
+        m_result = res;
+    }
+
+    inline bool result() const
+    {
+        return m_result;
+    }
+
+private:
+    uint64_t m_evtnum = UINT64_MAX;
+    bool m_result = false;
+};
+
+/**
+ * @brief Represents a set of metrics and counters related to the usage
+ * of cache optimizations in filters
+*/
+struct sinsp_filter_cache_metrics
+{
+    inline void reset()
+    {
+        m_num_extract = 0;
+        m_num_extract_cache = 0;
+        m_num_compare = 0;
+        m_num_compare_cache = 0;
+    }
+
+    // The number of times extract() was called
+    uint64_t m_num_extract = 0;
+
+    // The number of times extract() could use a cached value
+    uint64_t m_num_extract_cache = 0;
+
+    // The number of times compare() was called
+    uint64_t m_num_compare = 0;
+
+    // The number of times compare() could use a cached value
+    uint64_t m_num_compare_cache = 0;
+};
+
+/**
+ * @brief Interface for factories of filter cache objects
+*/
+class sinsp_filter_cache_factory
+{
+public:
+    using ast_expr_t = libsinsp::filter::ast::expr;
+    
+    /**
+     * @brief Input struct representing information about a filter AST node
+    */
+    struct node_info_t
+    {
+        // For nodes representing a field extraction, the information about the field.
+        // For nodes with a comparison, the information about the left-hand side field.
+        // Left to null in all other cases.
+        const filtercheck_field_info* m_field = nullptr;
+
+        // For nodes with a comparison, the information about the right-hand side field.
+        // Left to null in all other cases.
+        const filtercheck_field_info* m_right_field = nullptr;
+
+        // For nodes with a comparison, the comparison operator.
+        // Left to CO_NONE in all other cases.
+        cmpop m_compare_operator = cmpop::CO_NONE;
+    };
+
+    virtual ~sinsp_filter_cache_factory() = default;
+
+    /**
+     * @brief Resets the state of the given factory instance
+    */
+    virtual void reset()
+    {
+        // do nothing
+    }
+
+    /**
+     * @brief Given the provided AST node of a filter expression, returns a pointer
+     * to an extraction cache usable in the compiled filter derived from that node.
+     * Can return `nullptr` in case no cache is available for the node.
+    */
+    virtual std::shared_ptr<sinsp_filter_extract_cache> new_extract_cache(const ast_expr_t* e, node_info_t& info)
+    {
+        return nullptr;
+    }
+
+    /**
+     * @brief Given the provided AST node of a filter expression, returns a pointer
+     * to an comparison cache usable in the compiled filter derived from that node.
+     * Can return `nullptr` in case no cache is available for the node.
+    */
+    virtual std::shared_ptr<sinsp_filter_compare_cache> new_compare_cache(const ast_expr_t* e, node_info_t& info)
+    {
+        return nullptr;
+    }
+
+    /**
+     * @brief Given the provided AST node of a filter expression, returns a pointer
+     * to an cache metrics storage usable in the compiled filter derived from that node.
+     * Can return `nullptr` in case no metrics are available for the node.
+    */
+    virtual std::shared_ptr<sinsp_filter_cache_metrics> new_metrics(const ast_expr_t* e, node_info_t& info)
+    {
+        return nullptr;
+    }
+};
+
+/**
+ * @brief An implementation of sinsp_filter_cache_factory that creates shared
+ * cache objects indexed by the string representation of AST expressions
+ * (obtained through libsinsp::filter::ast::as_string).
+*/
+class exprstr_sinsp_filter_cache_factory: public sinsp_filter_cache_factory
+{
+public:
+    virtual ~exprstr_sinsp_filter_cache_factory() = default;
+
+    void reset() override
+    {
+        m_extract_caches.clear();
+        m_compare_caches.clear();
+    }
+
+    std::shared_ptr<sinsp_filter_extract_cache> new_extract_cache(const ast_expr_t* e, node_info_t& info) override
+    {
+        // avoid caching fields for which it would be unsafe
+        if (info.m_field && info.m_field->m_type == PT_IPNET)
+        {
+            return nullptr;
+        }
+        auto key = libsinsp::filter::ast::as_string(e);
+        return get_or_insert_ptr(key, m_extract_caches);
+    }
+
+    std::shared_ptr<sinsp_filter_compare_cache> new_compare_cache(const ast_expr_t* e, node_info_t& info) override
+    {
+        // avoid caching fields for which it would be unsafe
+        if (info.m_field && info.m_field->m_type == PT_IPNET)
+        {
+            return nullptr;
+        }
+        auto key = libsinsp::filter::ast::as_string(e);
+        return get_or_insert_ptr(key, m_compare_caches);
+    }
+
+    inline const std::unordered_map<std::string, std::shared_ptr<sinsp_filter_extract_cache>>& extract_cache() const
+    {
+        return m_extract_caches;
+    }
+
+    inline const std::unordered_map<std::string, std::shared_ptr<sinsp_filter_compare_cache>>& compare_cache() const
+    {
+        return m_compare_caches;
+    }
+
+private:
+    template<typename T>
+    static inline std::shared_ptr<T> get_or_insert_ptr(
+            const std::string& key,
+            std::unordered_map<std::string, std::shared_ptr<T>>& map)
+    {
+        auto it = map.find(key);
+        if (it == map.end())
+        {
+            return map.emplace(key, std::make_shared<T>()).first->second;
+        }
+        return it->second;
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<sinsp_filter_extract_cache>> m_extract_caches;
+    std::unordered_map<std::string, std::shared_ptr<sinsp_filter_compare_cache>> m_compare_caches;
+};

--- a/userspace/libsinsp/filter_field.h
+++ b/userspace/libsinsp/filter_field.h
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <libsinsp/filter/ast.h>
+#include <libscap/scap.h>
+
+#include <cstdint>
+#include <vector>
+#include <string>
+
+/**
+ * @brief Flags used for describing a field used in a filter or in a formatter
+*/
+enum filtercheck_field_flags
+{
+	EPF_NONE              = 0,
+	EPF_FILTER_ONLY       = 1 << 0, ///< this field can only be used as a filter.
+	EPF_PRINT_ONLY        = 1 << 1, ///< this field can only be printed.
+	EPF_ARG_REQUIRED      = 1 << 2, ///< this field includes an argument, under the form 'property.argument'.
+	EPF_TABLE_ONLY        = 1 << 3, ///< this field is designed to be used in a table and won't appear in the field listing.
+	EPF_INFO              = 1 << 4, ///< this field contains summary information about the event.
+	EPF_CONVERSATION      = 1 << 5, ///< this field can be used to identify conversations.
+	EPF_IS_LIST           = 1 << 6, ///< this field is a list of values.
+	EPF_ARG_ALLOWED       = 1 << 7, ///< this field optionally includes an argument.
+	EPF_ARG_INDEX         = 1 << 8, ///< this field accepts numeric arguments.
+	EPF_ARG_KEY           = 1 << 9, ///< this field accepts string arguments.
+	EPF_DEPRECATED        = 1 << 10,///< this field is deprecated.
+	EPF_NO_TRANSFORMER    = 1 << 11,///< this field cannot have a field transformer.
+	EPF_NO_RHS            = 1 << 12,///< this field cannot have a right-hand side filter check, and cannot be used as a right-hand side filter check.
+};
+
+/**
+ * @brief Information about field using in a filter or in a formatter
+*/
+struct filtercheck_field_info
+{
+	ppm_param_type m_type = ppm_param_type::PT_NONE; ///< Field type.
+	uint32_t m_flags = 0;  ///< Field flags.
+	ppm_print_format m_print_format = ppm_print_format::PF_NA;  ///< If this is a numeric field, this flag specifies if it should be rendered as octal, decimal or hex.
+	std::string m_name;  ///< Field name.
+	std::string m_display;  ///< Field display name (short description). May be empty.
+	std::string m_description;  ///< Field description.
+
+	//
+	// Return true if this field must have an argument
+	//
+	inline bool is_arg_required() const
+	{
+		return m_flags & EPF_ARG_REQUIRED;
+	}
+
+	//
+	// Return true if this field can optionally have an argument
+	//
+	inline bool is_arg_allowed() const
+	{
+		return m_flags & EPF_ARG_REQUIRED;
+	}
+
+	//
+	// Returns true if this field can have an argument, either
+	// optionally or mandatorily
+	//
+	inline bool is_arg_supported() const
+	{
+		return (m_flags & EPF_ARG_REQUIRED) || (m_flags & EPF_ARG_ALLOWED);
+	}
+
+	//
+	// Returns true if this field is a list of values
+	//
+	inline bool is_list() const
+	{
+		return m_flags & EPF_IS_LIST;
+	}
+
+	//
+	// Returns true if this filter check can support a rhs filter check instead of a const value.
+	//
+	inline bool is_rhs_field_supported() const
+	{
+		return !(m_flags & EPF_NO_RHS);
+	}
+
+	//
+	// Returns true if this filter check can support an extraction transformer on it.
+	//
+	inline bool is_transformer_supported() const
+	{
+		return !(m_flags & EPF_NO_TRANSFORMER);
+	}
+};
+
+/**
+ * @brief Information about a group of filter/formatting fields.
+*/
+class filter_check_info
+{
+public:
+	enum flags: uint8_t
+	{
+		FL_NONE = 0,
+		FL_HIDDEN = (1 << 0),	///< This filter check class won't be shown by fields/filter listings.
+	};
+
+	std::string m_name; ///< Field class name.
+	std::string m_shortdesc; ///< short (< 10 words) description of this filtercheck. Can be blank.
+	std::string m_desc; ///< Field class description.
+	int32_t m_nfields = 0; ///< Number of fields in this field group.
+	const filtercheck_field_info* m_fields = nullptr; ///< Array containing m_nfields field descriptions.
+	uint32_t m_flags = flags::FL_NONE;
+};

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -542,9 +542,9 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string &errstr)
 						string("error in plugin ") + name() + ": field JSON entry has no desc");
 			}
 
-			strlcpy(tf.m_name, fname.c_str(), sizeof(tf.m_name));
-			strlcpy(tf.m_display, fdisplay.c_str(), sizeof(tf.m_display));
-			strlcpy(tf.m_description, fdesc.c_str(), sizeof(tf.m_description));
+			tf.m_name = fname;
+			tf.m_display = fdisplay;
+			tf.m_description = fdesc;
 			tf.m_print_format = PF_DEC;
 			if(s_pt_lut.find(ftype) != s_pt_lut.end()) {
 				tf.m_type = s_pt_lut.at(ftype);

--- a/userspace/libsinsp/plugin_filtercheck.cpp
+++ b/userspace/libsinsp/plugin_filtercheck.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<sinsp_filter_check> sinsp_filter_check_plugin::allocate_new()
 	return std::make_unique<sinsp_filter_check_plugin>(*this);
 }
 
-bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, std::vector<extract_value_t>& values, bool sanitize_strings)
+bool sinsp_filter_check_plugin::extract_nocache(sinsp_evt *evt, std::vector<extract_value_t>& values, bool sanitize_strings)
 {
 	// reject the event if it comes from an unknown event source
 	if (evt->get_source_idx() == sinsp_no_event_source_idx)
@@ -166,7 +166,7 @@ bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, std::vector<extract_valu
 	// populate the field to extract for the plugin
 	ss_plugin_extract_field efield;
 	efield.field_id = m_field_id;
-	efield.field = m_info->m_fields[m_field_id].m_name;
+	efield.field = m_info->m_fields[m_field_id].m_name.c_str();
 	efield.arg_key = m_arg_key;
 	efield.arg_index = m_arg_index;
 	efield.arg_present = m_arg_present;
@@ -218,7 +218,7 @@ bool sinsp_filter_check_plugin::extract(sinsp_evt *evt, std::vector<extract_valu
 		values.push_back(res);
 	}
 
-	return apply_transformers(values);
+	return true;
 }
 
 void sinsp_filter_check_plugin::extract_arg_index(std::string_view full_field_name)

--- a/userspace/libsinsp/plugin_filtercheck.h
+++ b/userspace/libsinsp/plugin_filtercheck.h
@@ -48,7 +48,8 @@ public:
 		bool alloc_state,
 		bool needed_for_filtering) override;
 
-	bool extract(
+protected:
+	bool extract_nocache(
 		sinsp_evt *evt,
 		std::vector<extract_value_t>& values,
 		bool sanitize_strings = true) override;

--- a/userspace/libsinsp/sinsp_filter_transformer.h
+++ b/userspace/libsinsp/sinsp_filter_transformer.h
@@ -20,12 +20,7 @@ limitations under the License.
 #include <functional>
 #include <driver/ppm_events_public.h>
 #include <libsinsp/sinsp_exception.h>
-
-struct extract_value_t
-{
-	uint8_t* ptr = nullptr;
-	uint32_t len = 0;
-};
+#include <libsinsp/filter_cache.h>
 
 enum filter_transformer_type: uint8_t
 {

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -418,7 +418,7 @@ uint8_t* sinsp_filter_check_fd::extract_from_null_fd(sinsp_evt *evt, uint32_t* l
 	}
 }
 
-bool sinsp_filter_check_fd::extract(sinsp_evt *evt, std::vector<extract_value_t>& values, bool sanitize_strings)
+bool sinsp_filter_check_fd::extract_nocache(sinsp_evt *evt, std::vector<extract_value_t>& values, bool sanitize_strings)
 {
 	values.clear();
 
@@ -463,7 +463,7 @@ bool sinsp_filter_check_fd::extract(sinsp_evt *evt, std::vector<extract_value_t>
 		return true;
 	}
 
-	return sinsp_filter_check::extract(evt, values, sanitize_strings);
+	return sinsp_filter_check::extract_nocache(evt, values, sanitize_strings);
 }
 
 uint8_t* sinsp_filter_check_fd::extract_single(sinsp_evt *evt, uint32_t* len, bool sanitize_strings)

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -76,9 +76,9 @@ public:
 
 	std::unique_ptr<sinsp_filter_check> allocate_new() override;
 	int32_t parse_field_name(std::string_view, bool alloc_state, bool needed_for_filtering) override;
-	bool extract(sinsp_evt*, std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
 
 protected:
+	bool extract_nocache(sinsp_evt*, std::vector<extract_value_t>& values, bool sanitize_strings = true) override;
 	uint8_t* extract_single(sinsp_evt*, uint32_t* len, bool sanitize_strings = true) override;
 	bool compare_nocache(sinsp_evt*) override;
 

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -57,7 +57,7 @@ public:
 		throw sinsp_exception("unexpected right-hand side filter comparison");
 	}
 
-	inline bool extract(sinsp_evt *e, vector<extract_value_t>& v, bool) override
+	inline bool extract_nocache(sinsp_evt *e, vector<extract_value_t>& v, bool) override
 	{
 		return false;
 	}
@@ -72,11 +72,6 @@ class mock_compiler_filter_factory: public sinsp_filter_factory
 {
 public:
 	mock_compiler_filter_factory(sinsp *inspector): sinsp_filter_factory(inspector, m_filterlist) {}
-
-	inline std::unique_ptr<sinsp_filter> new_filter() const override
-	{
-		return std::make_unique<sinsp_filter>(m_inspector);
-	}
 
 	inline std::unique_ptr<sinsp_filter_check> new_filtercheck(std::string_view fldname) const override
 	{

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -76,7 +76,7 @@ public:
 	}
 
 protected:
-	bool extract(sinsp_evt* evt, std::vector<extract_value_t>& values, bool sanitize_strings) override
+	bool extract_nocache(sinsp_evt* evt, std::vector<extract_value_t>& values, bool sanitize_strings) override
 	{
 		static const char* list_value_1 = "value1";
 		static const char* list_value_2 = "charbuf";
@@ -96,7 +96,7 @@ protected:
 			values.push_back(val2);
 			return true;
 		}
-		return sinsp_filter_check::extract(evt, values, sanitize_strings);
+		return sinsp_filter_check::extract_nocache(evt, values, sanitize_strings);
 	}
 
 	uint8_t* extract_single(sinsp_evt*, uint32_t* len, bool sanitize_strings = true) override

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -147,6 +147,7 @@ static uint16_t* plugin_get_extract_event_types(uint32_t* num_types, ss_plugin_t
         PPME_SYSCALL_INOTIFY_INIT1_E,
         PPME_SYSCALL_INOTIFY_INIT1_X,
         PPME_ASYNCEVENT_E, // used for catching async events
+        PPME_SYSCALL_GETCWD_X, // general purpose, used for other unit tests
     };
     *num_types = sizeof(types) / sizeof(uint16_t);
     return &types[0];

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -497,18 +497,25 @@ std::string sinsp_with_test_input::get_field_as_string(sinsp_evt* evt, std::stri
 	return result;
 }
 
-bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string_view filter_str)
+bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string_view filter_str, std::shared_ptr<sinsp_filter_cache_factory> cachef)
 {
-	return eval_filter(evt, filter_str, m_default_filterlist);
+	return eval_filter(evt, filter_str, m_default_filterlist, cachef);
 }
 
-bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string_view filter_str, filter_check_list &flist)
+bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string_view filter_str, filter_check_list &flist, std::shared_ptr<sinsp_filter_cache_factory> cachef)
 {
 	auto factory = std::make_shared<sinsp_filter_factory>(&m_inspector, flist);
-	sinsp_filter_compiler compiler(factory, std::string(filter_str));
+	sinsp_filter_compiler compiler(factory, std::string(filter_str), cachef);
 
 	auto filter = compiler.compile();
 
+	return filter->run(evt);
+}
+
+bool sinsp_with_test_input::eval_filter(sinsp_evt* evt, std::string_view filter_str, std::shared_ptr<sinsp_filter_factory> filterf, std::shared_ptr<sinsp_filter_cache_factory> cachef)
+{
+	sinsp_filter_compiler compiler(filterf, std::string(filter_str), cachef);
+	auto filter = compiler.compile();
 	return filter->run(evt);
 }
 

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -199,8 +199,9 @@ protected:
 	bool field_has_value(sinsp_evt*, std::string_view field_name, filter_check_list&);
 	std::string get_field_as_string(sinsp_evt*, std::string_view field_name);
 	std::string get_field_as_string(sinsp_evt*, std::string_view field_name, filter_check_list&);
-	bool eval_filter(sinsp_evt* evt, std::string_view filter_str);
-	bool eval_filter(sinsp_evt* evt, std::string_view filter_str, filter_check_list&);
+	bool eval_filter(sinsp_evt* evt, std::string_view filter_str, std::shared_ptr<sinsp_filter_cache_factory> cachef = nullptr);
+	bool eval_filter(sinsp_evt* evt, std::string_view filter_str, filter_check_list&, std::shared_ptr<sinsp_filter_cache_factory> cachef = nullptr);
+	bool eval_filter(sinsp_evt* evt, std::string_view filter_str, std::shared_ptr<sinsp_filter_factory> filterf, std::shared_ptr<sinsp_filter_cache_factory> cachef = nullptr);
 	bool filter_compiles(std::string_view filter_str);
 	bool filter_compiles(std::string_view filter_str, filter_check_list&);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The usage of caching in sinsp filters (and thus, Falco rules) has been a shy experiment from some time ago that was never finalized. I think this is generally something that could be useful and could help saving few CPU % points on high loads, even though from my synthetic measurements this could account for a max of 1-2% savings.

This PR refactors the code area involved, and enables caching in filters. It does so by introducing an abstract interface that can be used as-is or customized by the different adopters, and the whole installation into filters is taken care of by the filter compiler. This moves on from the previous scratch implementation with raw pointers and no clear injection point. Tests have been added accordingly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/libsinsp): polish and enable filter caching
```