### PR TITLE
fix: Ignore NSS user and group entries

### DIFF
--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -169,13 +169,13 @@ protected:
 
 		{
 			std::ofstream ofs(etc + "/passwd");
-			ofs << "toor:x:0:0:toor:/toor:/bin/ash" << std::endl;
-			ofs.close();
+			ofs << "toor:x:0:0:toor:/toor:/bin/ash\n"
+			    << "+testuser::::::\n";
 		}
 		{
 			std::ofstream ofs(etc + "/group");
-			ofs << "toor:x:0:toor" << std::endl;
-			ofs.close();
+			ofs << "toor:x:0:toor\n"
+			    << "+testgroup::::::\n";
 		}
 	}
 
@@ -210,5 +210,20 @@ TEST_F(usergroup_manager_host_root_test, host_root_lookup)
 	ASSERT_NE(group, nullptr);
 	ASSERT_EQ(group->gid, 0);
 	ASSERT_STREQ(group->name, "toor");
+}
+
+TEST_F(usergroup_manager_host_root_test, nss_user_lookup)
+{
+	std::string container_id; // empty container_id means host
+
+	sinsp_usergroup_manager mgr(&m_inspector);
+	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
+	mgr.add_user(container_id, -1, 65534, 0, {}, {}, {});
+
+	auto* usr = mgr.add_user(container_id, -1, 0, 0, "+test_user", "", "");
+	ASSERT_EQ(usr, nullptr);
+
+	auto* grp = mgr.add_group(container_id, -1, 0, "+test_group");
+	ASSERT_EQ(grp, nullptr);
 }
 #endif

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -240,12 +240,6 @@ scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(
 	std::string_view home,
 	std::string_view shell)
 {
-	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
-	{
-		// ignore NSS entries
-		return nullptr;
-	}
-
 	auto &usr = map[uid];
 	usr.uid = uid;
 	usr.gid = gid;
@@ -263,12 +257,6 @@ scap_groupinfo *sinsp_usergroup_manager::groupinfo_map_insert(
 	uint32_t gid,
 	std::string_view name)
 {
-	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
-	{
-		// ignore NSS entries
-		return nullptr;
-	}
-
 	auto &grp = map[gid];
 	grp.gid = gid;
 	strlcpy(grp.name, (name.data() != nullptr) ? std::string(name).c_str() : "<NA>", MAX_CREDENTIALS_STR_LEN);
@@ -278,6 +266,14 @@ scap_groupinfo *sinsp_usergroup_manager::groupinfo_map_insert(
 
 scap_userinfo *sinsp_usergroup_manager::add_user(const std::string &container_id, int64_t pid, uint32_t uid, uint32_t gid, std::string_view name, std::string_view home, std::string_view shell, bool notify)
 {
+	// ignore NSS entries
+	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
+	{
+		libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
+			"NSS user ignored: %.*s", static_cast<int>(name.length()), name.data());
+		return nullptr;
+	}
+
 	if (!m_import_users)
 	{
 		m_fallback_user.uid = uid;
@@ -413,6 +409,14 @@ bool sinsp_usergroup_manager::rm_user(const string &container_id, uint32_t uid, 
 
 scap_groupinfo *sinsp_usergroup_manager::add_group(const string &container_id, int64_t pid, uint32_t gid, std::string_view name, bool notify)
 {
+	// ignore NSS entries
+	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
+	{
+		libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
+			"NSS group ignored: %.*s", static_cast<int>(name.length()), name.data());
+		return nullptr;
+	}
+
 	if (!m_import_users)
 	{
 		m_fallback_grp.gid = gid;

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -240,6 +240,12 @@ scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(
 	std::string_view home,
 	std::string_view shell)
 {
+	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
+	{
+		// ignore NSS entries
+		return nullptr;
+	}
+
 	auto &usr = map[uid];
 	usr.uid = uid;
 	usr.gid = gid;
@@ -257,6 +263,12 @@ scap_groupinfo *sinsp_usergroup_manager::groupinfo_map_insert(
 	uint32_t gid,
 	std::string_view name)
 {
+	if(!name.empty() && (name[0] == '+' || name[0] == '-'))
+	{
+		// ignore NSS entries
+		return nullptr;
+	}
+
 	auto &grp = map[gid];
 	grp.gid = gid;
 	strlcpy(grp.name, (name.data() != nullptr) ? std::string(name).c_str() : "<NA>", MAX_CREDENTIALS_STR_LEN);


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area libsinsp

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
NSS (Named Service Switch) users can be listed in `/etc/passwd` with a name starting with a `+` or `-` sign and an empty _uid_ field (the same idea applies to groups in `/etc/group`). For instance a line in `/etc/passwd` can take the form `+@r_unix::::::` and, when parsed by function `fgetpwent()`, it translates the empty _uid_ field in a zero. This _uid_ is then used as key to an internal map, effectively overwriting the data of the root user, which typically gets _uid_ equal to zero.
This PR aims at ignoring such users and groups (the ones with a `+` or `-` prefix) that cannot find a place in the map in any case, having all the same zeroed _uid_.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
