### PR TITLE
new(test): add test for gvisor config generator

### DIFF
--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -95,6 +95,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	events_proc.ut.cpp
 	events_user.ut.cpp
 	external_processor.ut.cpp
+	gvisor_config.ut.cpp
 	mpsc_priority_queue.ut.cpp
 	token_bucket.ut.cpp
 	ppm_api_version.ut.cpp

--- a/userspace/libsinsp/test/gvisor_config.ut.cpp
+++ b/userspace/libsinsp/test/gvisor_config.ut.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+#include <libsinsp/gvisor_config.h>
+#include <libscap/engine/gvisor/gvisor.h>
+
+TEST(gvisor_config, generate_parse)
+{
+	std::string socket_path = "/run/falco/gvisor.sock";
+	std::string config = gvisor_config::generate(socket_path);
+	Json::Value root;
+	Json::CharReaderBuilder builder;
+	const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+	std::string err;
+
+	// check that the output is valid json
+	bool json_parse = reader->parse(config.c_str(), config.c_str() + config.size(), &root, &err);
+	EXPECT_TRUE(json_parse) << "Could not parse configuration file contents: " + err;
+
+	// check that the sink is defined
+	// according to https://github.com/google/gvisor/blob/master/tools/tracereplay/README.md#how-to-use-it
+	EXPECT_EQ(root["trace_session"]["sinks"][0]["config"]["endpoint"].asCString(), socket_path);
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

As per title. I had this test locally, I think from the latest gvisor fix, and I needed to fix it up and subimit it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
