### PR TITLE
new: introduce `proc.{stdin,stdout,stderr}.{name,type}` fields

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -126,6 +126,9 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 	{PT_UINT64, EPF_NONE, PF_DEC, "thread.vmrss", "Thread VM RSS (kb)", "For the process main thread, this is the resident non-swapped memory for the process (as kb). For the other threads, this field is zero."},
 	{PT_UINT64, EPF_TABLE_ONLY, PF_DEC, "thread.vmsize.b", "Thread VM Size (b)", "For the process main thread, this is the total virtual memory for the process (in bytes). For the other threads, this field is zero."},
 	{PT_UINT64, EPF_TABLE_ONLY, PF_DEC, "thread.vmrss.b", "Thread VM RSS (b)", "For the process main thread, this is the resident non-swapped memory for the process (in bytes). For the other threads, this field is zero."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdin.type", "Standard Input fd type", "The type of file descriptor 0, corresponding to stdin, of the process generating the event."}, 
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdout.type", "Standard Output fd type", "The type of file descriptor 1, corresponding to stdout, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stderr.type", "Standard Error fd type", "The type of file descriptor 2, corresponding to stderr, of the process generating the event."},
 };
 
 sinsp_filter_check_thread::sinsp_filter_check_thread()
@@ -1611,6 +1614,51 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, uint32_t* len
 			{
 				return NULL;
 			}
+		}
+	case TYPE_FD_STDIN_TYPE:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(0);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->get_typestring();
+			RETURN_EXTRACT_STRING(m_tstr);
+		}
+	case TYPE_FD_STDOUT_TYPE:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(1);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->get_typestring();
+			RETURN_EXTRACT_STRING(m_tstr);
+		}
+	case TYPE_FD_STDERR_TYPE:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(2);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->get_typestring();
+			RETURN_EXTRACT_STRING(m_tstr);
 		}
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -126,12 +126,12 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 	{PT_UINT64, EPF_NONE, PF_DEC, "thread.vmrss", "Thread VM RSS (kb)", "For the process main thread, this is the resident non-swapped memory for the process (as kb). For the other threads, this field is zero."},
 	{PT_UINT64, EPF_TABLE_ONLY, PF_DEC, "thread.vmsize.b", "Thread VM Size (b)", "For the process main thread, this is the total virtual memory for the process (in bytes). For the other threads, this field is zero."},
 	{PT_UINT64, EPF_TABLE_ONLY, PF_DEC, "thread.vmrss.b", "Thread VM RSS (b)", "For the process main thread, this is the resident non-swapped memory for the process (in bytes). For the other threads, this field is zero."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdin.type", "Standard Input fd type", "The type of file descriptor 0, corresponding to stdin, of the process generating the event."}, 
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdout.type", "Standard Output fd type", "The type of file descriptor 1, corresponding to stdout, of the process generating the event."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stderr.type", "Standard Error fd type", "The type of file descriptor 2, corresponding to stderr, of the process generating the event."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdin.name", "Standard Input fd name", "The name of the file descriptor 0, corresponding to stdin, of the process generating the event."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdout.name", "Standard Output fd name", "The name of the file descriptor 1, corresponding to stdout, of the process generating the event."},
-	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stderr.name", "Standard Error fd name", "The name of the file descriptor 2, corresponding to stderr, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stdin.type", "Standard Input fd type", "The type of file descriptor 0, corresponding to stdin, of the process generating the event."}, 
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stdout.type", "Standard Output fd type", "The type of file descriptor 1, corresponding to stdout, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stderr.type", "Standard Error fd type", "The type of file descriptor 2, corresponding to stderr, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stdin.name", "Standard Input fd name", "The name of the file descriptor 0, corresponding to stdin, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stdout.name", "Standard Output fd name", "The name of the file descriptor 1, corresponding to stdout, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.stderr.name", "Standard Error fd name", "The name of the file descriptor 2, corresponding to stderr, of the process generating the event."},
 };
 
 sinsp_filter_check_thread::sinsp_filter_check_thread()

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -129,6 +129,9 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] =
 	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdin.type", "Standard Input fd type", "The type of file descriptor 0, corresponding to stdin, of the process generating the event."}, 
 	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdout.type", "Standard Output fd type", "The type of file descriptor 1, corresponding to stdout, of the process generating the event."},
 	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stderr.type", "Standard Error fd type", "The type of file descriptor 2, corresponding to stderr, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdin.name", "Standard Input fd name", "The name of the file descriptor 0, corresponding to stdin, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stdout.name", "Standard Output fd name", "The name of the file descriptor 1, corresponding to stdout, of the process generating the event."},
+	{PT_CHARBUF, EPF_NONE, PF_NA, "proc.fd.stderr.name", "Standard Error fd name", "The name of the file descriptor 2, corresponding to stderr, of the process generating the event."},
 };
 
 sinsp_filter_check_thread::sinsp_filter_check_thread()
@@ -1660,6 +1663,51 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, uint32_t* len
 			m_tstr = fdinfo->get_typestring();
 			RETURN_EXTRACT_STRING(m_tstr);
 		}
+	case TYPE_FD_STDIN_NAME:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(0);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->m_name.c_str();
+			RETURN_EXTRACT_STRING(m_tstr);
+		}
+	case TYPE_FD_STDOUT_NAME:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(1);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->m_name.c_str();
+			RETURN_EXTRACT_STRING(m_tstr);
+		}
+	case TYPE_FD_STDERR_NAME:
+		{
+			auto fdtable_ptr = tinfo->get_fd_table();
+			if (fdtable_ptr == nullptr)
+			{
+				return NULL;
+			}
+			auto fdinfo = fdtable_ptr->find(2);
+			if (fdinfo == nullptr)
+			{
+				return NULL;
+			}
+			m_tstr = fdinfo->m_name.c_str();
+			RETURN_EXTRACT_STRING(m_tstr);
+		}	
 	default:
 		ASSERT(false);
 		return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -1619,43 +1619,28 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, uint32_t* len
 			}
 		}
 	case TYPE_FD_STDIN_TYPE:
-		{
-			auto fdtable_ptr = tinfo->get_fd_table();
-			if (fdtable_ptr == nullptr)
-			{
-				return NULL;
-			}
-			auto fdinfo = fdtable_ptr->find(0);
-			if (fdinfo == nullptr)
-			{
-				return NULL;
-			}
-			m_tstr = fdinfo->get_typestring();
-			RETURN_EXTRACT_STRING(m_tstr);
-		}
 	case TYPE_FD_STDOUT_TYPE:
-		{
-			auto fdtable_ptr = tinfo->get_fd_table();
-			if (fdtable_ptr == nullptr)
-			{
-				return NULL;
-			}
-			auto fdinfo = fdtable_ptr->find(1);
-			if (fdinfo == nullptr)
-			{
-				return NULL;
-			}
-			m_tstr = fdinfo->get_typestring();
-			RETURN_EXTRACT_STRING(m_tstr);
-		}
 	case TYPE_FD_STDERR_TYPE:
 		{
+			int64_t fd = -1;
+			if (m_field_id == TYPE_FD_STDIN_TYPE)
+			{
+				fd = 0;
+			}
+			else if (m_field_id == TYPE_FD_STDOUT_TYPE)
+			{
+				fd = 1;
+			}
+			else if (m_field_id == TYPE_FD_STDERR_TYPE)
+			{
+				fd = 2;
+			}
 			auto fdtable_ptr = tinfo->get_fd_table();
 			if (fdtable_ptr == nullptr)
 			{
 				return NULL;
 			}
-			auto fdinfo = fdtable_ptr->find(2);
+			auto fdinfo = fdtable_ptr->find(fd);
 			if (fdinfo == nullptr)
 			{
 				return NULL;
@@ -1664,43 +1649,28 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt *evt, uint32_t* len
 			RETURN_EXTRACT_STRING(m_tstr);
 		}
 	case TYPE_FD_STDIN_NAME:
-		{
-			auto fdtable_ptr = tinfo->get_fd_table();
-			if (fdtable_ptr == nullptr)
-			{
-				return NULL;
-			}
-			auto fdinfo = fdtable_ptr->find(0);
-			if (fdinfo == nullptr)
-			{
-				return NULL;
-			}
-			m_tstr = fdinfo->m_name.c_str();
-			RETURN_EXTRACT_STRING(m_tstr);
-		}
 	case TYPE_FD_STDOUT_NAME:
-		{
-			auto fdtable_ptr = tinfo->get_fd_table();
-			if (fdtable_ptr == nullptr)
-			{
-				return NULL;
-			}
-			auto fdinfo = fdtable_ptr->find(1);
-			if (fdinfo == nullptr)
-			{
-				return NULL;
-			}
-			m_tstr = fdinfo->m_name.c_str();
-			RETURN_EXTRACT_STRING(m_tstr);
-		}
 	case TYPE_FD_STDERR_NAME:
 		{
+			int64_t fd = -1;
+			if (m_field_id == TYPE_FD_STDIN_NAME)
+			{
+				fd = 0;
+			}
+			else if (m_field_id == TYPE_FD_STDOUT_NAME)
+			{
+				fd = 1;
+			}
+			else if (m_field_id == TYPE_FD_STDERR_NAME)
+			{
+				fd = 2;
+			}
 			auto fdtable_ptr = tinfo->get_fd_table();
 			if (fdtable_ptr == nullptr)
 			{
 				return NULL;
 			}
-			auto fdinfo = fdtable_ptr->find(2);
+			auto fdinfo = fdtable_ptr->find(fd);
 			if (fdinfo == nullptr)
 			{
 				return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -106,6 +106,9 @@ public:
 		TYPE_THREAD_VMRSS,
 		TYPE_THREAD_VMSIZE_B,
 		TYPE_THREAD_VMRSS_B,
+		TYPE_FD_STDIN_TYPE,
+		TYPE_FD_STDOUT_TYPE,
+		TYPE_FD_STDERR_TYPE,
 	};
 
 	sinsp_filter_check_thread();

--- a/userspace/libsinsp/sinsp_filtercheck_thread.h
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.h
@@ -109,6 +109,9 @@ public:
 		TYPE_FD_STDIN_TYPE,
 		TYPE_FD_STDOUT_TYPE,
 		TYPE_FD_STDERR_TYPE,
+		TYPE_FD_STDIN_NAME,
+		TYPE_FD_STDOUT_NAME,
+		TYPE_FD_STDERR_NAME,
 	};
 
 	sinsp_filter_check_thread();

--- a/userspace/libsinsp/test/filterchecks/proc.cpp
+++ b/userspace/libsinsp/test/filterchecks/proc.cpp
@@ -138,13 +138,13 @@ TEST_F(sinsp_with_test_input, PROC_FILTER_stdin_stdout_stderr)
 
 	// Exec a process and check stdin, stdout and stderr types and names
 	evt = generate_execve_enter_and_exit_event(0, 1, 1, 1, 1, "/proc_filter_stdin_stdout_stderr", "proc_filter_stdin_stdout_stderr", "/usr/bin/proc_filter_stdin_stdout_stderr");
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stdin.type"), "ipv4");
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stdout.type"), "ipv4");
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stderr.type"), "ipv4");
+	ASSERT_EQ(get_field_as_string(evt, "proc.stdin.type"), "ipv4");
+	ASSERT_EQ(get_field_as_string(evt, "proc.stdout.type"), "ipv4");
+	ASSERT_EQ(get_field_as_string(evt, "proc.stderr.type"), "ipv4");
 
 	std::string tuple_str = std::string(DEFAULT_IPV4_CLIENT_STRING) + ":" + std::to_string(DEFAULT_CLIENT_PORT) + "->" + std::string(DEFAULT_IPV4_SERVER_STRING) + ":" + std::to_string(DEFAULT_SERVER_PORT);
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stdin.name"), tuple_str);
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stdout.name"), tuple_str);
-	ASSERT_EQ(get_field_as_string(evt, "proc.fd.stderr.name"), tuple_str);
+	ASSERT_EQ(get_field_as_string(evt, "proc.stdin.name"), tuple_str);
+	ASSERT_EQ(get_field_as_string(evt, "proc.stdout.name"), tuple_str);
+	ASSERT_EQ(get_field_as_string(evt, "proc.stderr.name"), tuple_str);
 }
 #endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Please check the motivations for this PR in https://github.com/falcosecurity/libs/issues/1894
If we all agree on this direction, my call is to start a deprecation process for `fd.types` because:
- it can't be used with any syscall. Even if we work to achieve this, it wouldn't be correct as per documentation says, the fd category should be used only against event types that handle/create file descriptors
- the `fd.types` used as output field is useless, given that it returns an unordered list of types
- we only really care about stdin, stdout, and stderr, and having them explicitly expressed helps readability (instead of using 0,1,2 as arguments of the field).
- also, exposing the `name` part allow us for better detection and actionability (e.g in case of rev shell we see the connection tuple, in case of shell redirection to file the file itself and so on)

Curious to get your feedback!
(example condition for rev shells: `evt.type=execve and evt.dir=< and proc.stdin.type=ipv4 and proc.name contains bash`)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1894

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new: introduce proc.{stdin,stdout,stderr}.{name,type} fields
```
