### PR TITLE
FixTheCompatibilityIssueWithCgroupv2

### DIFF
--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -496,6 +496,11 @@ static int32_t get_cgroup_subsystems_v2(struct scap_cgroup_interface* cgi, struc
 
 	char line[SCAP_MAX_PATH_SIZE];
 	snprintf(line, sizeof(line), "%s/cgroup.controllers", cgroup_mount);
+	if (access(line, F_OK) == -1) {
+                // If the file does not exist, return success. Skip
+                return SCAP_SUCCESS;
+        }
+
 	FILE* cgroup_controllers = fopen(line, "r");
 	if(!cgroup_controllers)
 	{


### PR DESCRIPTION
Fix the issue of cgroup subsystem controller files not being present when Calico is present

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> /area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-SCHEMA-version-major

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Environmental: 
K8s installed, there is calico present
The system information is as follows
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian

There will be no files in the/proc/1/root/run/calico/cgroup/directory

Will cause the following fd issues
06-19 05:30:06.012043 total threads in the table:86, total fds in all threads:0

Add a check on the existence of the cgroup subsystem controller file to skip parsing the file and solve the problem

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #
Fix the error in the absence of subsystem controller files in cgroupv2 under Ubuntu environment, which prevents the collection of fd thread information

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
