### PR TITLE
fix(sinsp): invalid threads shoudln't be in a pid namespace

### DIFF
--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -198,7 +198,8 @@ public:
 	*/
 	inline bool is_in_pid_namespace() const
 	{
-		return (m_flags & PPM_CL_CHILD_IN_PIDNS || m_tid != m_vtid);
+		// m_tid should be always valid because we read it from the scap event header
+		return (m_flags & PPM_CL_CHILD_IN_PIDNS || (m_tid != m_vtid && m_vtid >= 0));
 	}
 
 	/*!


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:
When a thread is "invalid" it has a `vtid = -1 ` so when we check `m_tid != m_vtid` in `is_in_pid_namespace` we will always return true. we need to perform the check only if both identifiers are valid

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
