### PR TITLE
new(ci): added perf CI job around scap file read.

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -30,12 +30,21 @@ jobs:
           mkdir -p build
           cd build && cmake -DUSE_BUNDLED_DEPS=False ../
           make unit-test-libsinsp -j4
+          make sinsp-example -j4
 
-      - name: Run Perf
+      - name: Run Perf - unit tests
         shell: bash
         run: |
           cd build
-          sudo perf record --call-graph dwarf -o perf.data -q libsinsp/test/unit-test-libsinsp
+          sudo perf record --call-graph dwarf -o perf_tests.data -q libsinsp/test/unit-test-libsinsp
+
+      - name: Run Perf - scap file
+        shell: bash
+        run: |
+          cd build
+          wget https://download.falco.org/fixtures/trace-files/traces-positive.zip
+          unzip traces-positive.zip
+          sudo perf record --call-graph dwarf -o perf_scap.data -q ./libsinsp/examples/sinsp-example -s traces-positive/falco-event-generator.scap   
 
       - name: Archive master perf report
         if: github.event_name == 'push'
@@ -43,39 +52,56 @@ jobs:
         with:
           name: perf_report
           retention-days: 30 # 30 days because this is the artifact on master; we need to retain it to be able to properly diff it
-          path: build/perf.data
+          path: build/perf_*.data
           if-no-files-found: error
 
       - name: Download latest master report
         if: github.event_name == 'pull_request'
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: ci.yml
+          workflow: perf.yml
           branch: master
           event: push
           name: perf_report
 
-      - name: Diff from master
+      - name: Diff from master - unit tests
         if: github.event_name == 'pull_request'
         run: |
-          sudo perf diff perf.data build/perf.data -d unit-test-libsinsp -b -o 0 --percentage relative -q &> perf_diff.txt
+          sudo perf diff perf_tests.data build/perf_tests.data -d unit-test-libsinsp -b -o 1 --percentage relative -q &> perf_tests_diff.txt
+
+      - name: Diff from master - scap file
+        if: github.event_name == 'pull_request'
+        run: |
+          sudo perf diff perf_scap.data build/perf_scap.data -d sinsp-example -b -o 1 --percentage relative -q &> perf_scap_diff.txt    
 
       - name: Archive perf diff
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: perf_diff
-          path: perf_diff.txt
+          path: perf_*_diff.txt
           if-no-files-found: error
 
       # Check will fail if there is any function slowed down >2%
       # But we will always comment with the perf diff from master
-      - name: Check > 2% threshold
+      - name: Check > 2% threshold - unit tests
         if: github.event_name == 'pull_request'
-        id: compare
+        id: compare_tests
         run: |
-          echo "comment_file=perf_diff.txt" >> $GITHUB_OUTPUT
-          awk '{if (substr($2,RSTART+RLENGTH)+0 > 2) print }' perf_diff.txt &> perf_diff_above_thresh.txt
+          echo "diff=perf_tests_diff.txt" >> $GITHUB_OUTPUT
+          awk '{if (substr($2,RSTART+RLENGTH)+0 > 2) print }' perf_tests_diff.txt &> perf_diff_above_thresh.txt
+          if [ -s perf_diff_above_thresh.txt ]; then
+            exit 1
+          fi
+
+      # Check will fail if there is any function slowed down >2%
+      # But we will always comment with the perf diff from master
+      - name: Check > 2% threshold - scap file
+        if: github.event_name == 'pull_request'
+        id: compare_scap
+        run: |
+          echo "diff=perf_scap_diff.txt" >> $GITHUB_OUTPUT
+          awk '{if (substr($2,RSTART+RLENGTH)+0 > 2) print }' perf_scap_diff.txt &> perf_diff_above_thresh.txt
           if [ -s perf_diff_above_thresh.txt ]; then
             exit 1
           fi
@@ -86,9 +112,14 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
           touch ./pr/COMMENT
-          echo "# Perf diff from master" >> ./pr/COMMENT
+          echo "# Perf diff from master - unit tests" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
-          cat "${{ steps.compare.outputs.comment_file }}" >> ./pr/COMMENT
+          head -n10 "${{ steps.compare_tests.outputs.diff }}" >> ./pr/COMMENT
+          echo "\`\`\`" >> ./pr/COMMENT
+          echo "" >> ./pr/COMMENT
+          echo "# Perf diff from master - scap file" >> ./pr/COMMENT
+          echo "\`\`\`" >> ./pr/COMMENT
+          head -n10 "${{ steps.compare_scap.outputs.diff }}" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
           echo Uploading PR info...
           cat ./pr/COMMENT


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Expands #1918 adding a perf CI job to test scap file read from sinsp-example.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The CI will break because master perf_report has no scap file related perf data.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(ci): added perf CI job around scap file read.
```
