### PR TITLE
fix(libpman): avoid truncated verifier logs

### DIFF
--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -70,6 +70,13 @@ int pman_load_probe()
 		return errno;
 	}
 	pman_save_attached_progs();
+	// Programs are loaded so we passed the verifier we can free the 16 MB
+	if(g_state.log_buf)
+	{
+		free(g_state.log_buf);
+		g_state.log_buf = NULL;
+		g_state.log_buf_size = 0;
+	}
 	return 0;
 }
 

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -32,6 +32,9 @@ limitations under the License.
 /* Pay attention this need to be bumped every time we add a new bpf program that is directly attached into the kernel */
 #define MODERN_BPF_PROG_ATTACHED_MAX 9
 
+#define BPF_LOG_BIG_BUF_SIZE (UINT32_MAX >> 8) /* Recommended log buffer size, taken from libbpf. Used for verifier logs */
+#define BPF_LOG_SMALL_BUF_SIZE 8192 /* Used for libbpf non-verifier logs */
+
 struct metrics_v2;
 
 struct internal_state
@@ -58,7 +61,8 @@ struct internal_state
 								     collect stats */
 	uint16_t n_attached_progs;				  /* number of attached progs */
 	struct metrics_v2* stats;				  /* array of stats collected by libpman */
-
+	char* log_buf; /* buffer used to store logs before sending them to the log_fn */
+	size_t log_buf_size; /* size of the log buffer */
 	falcosecurity_log_fn log_fn;
 };
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libpman

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Without this fix, verifier logs are almost always truncated...we are using a buffer of 4096 bytes but this is not enough for long verifier logs. We need to use the same dimension provided by libbpf `(UINT32_MAX >> 8)`. This is ~16 MB so when we are sure the verifier is passed we probably want to free this memory...if libbpf wants to log again we provide a smaller buffer (8192) that should be enough for normal logs. @Molter73 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
