### PR TITLE
new(ci): enable kernel testing on PRs.

### DIFF
--- a/.github/workflows/create-comment-kernel-testing.yml
+++ b/.github/workflows/create-comment-kernel-testing.yml
@@ -1,11 +1,11 @@
 # NOTE: This has read-write repo token and access to secrets, so this must
 # not run any untrusted code.
 # see: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-name: Comment with Perf diff on pull requests
+name: Comment with Kernel testing resulsts on pull requests
 
 on:
   workflow_run:
-    workflows: ["Perf CI"]
+    workflows: ["Drivers CI Build"]
     types:
       - completed
 

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -335,3 +335,42 @@ jobs:
       # Use real branch's HEAD sha, not the merge commit
       libsversion: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
+
+  kernel-tests-upload:
+    needs: kernel-tests-dev
+    if: github.event_name == 'pull_request' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download X64 matrix
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: matrix_X64
+          path: matrix_X64
+
+      - name: Download ARM64 matrix
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: matrix_ARM64
+          path: matrix_ARM64
+
+      - name: Save PR info
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          touch ./pr/COMMENT
+          echo "# X64 kernel testing matrix" >> ./pr/COMMENT
+          echo "$(head -n $(grep -n -v -m1 '^|' matrix_X64/matrix.md | awk -F':'  '{ print $1 }') matrix_X64/matrix.md)" >> ./pr/COMMENT
+          echo "" > ./pr/COMMENT
+          echo "# ARM64 kernel testing matrix" >> ./pr/COMMENT
+          echo "$(head -n $(grep -n -v -m1 '^|' matrix_ARM64/matrix.md | awk -F':'  '{ print $1 }') matrix_ARM64/matrix.md)" >> ./pr/COMMENT
+          echo Uploading PR info...
+          cat ./pr/COMMENT
+          echo ""
+
+      - name: Upload PR info as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: pr/
+          retention-days: 1
+          if-no-files-found: warn

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -185,7 +185,7 @@ jobs:
         run: echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
       - name: Build and test drivers on ppc64le node via ssh
-        if: needs.paths-filter.outputs.driver_needs_rebuild
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.PPC64LE_HOST }}
@@ -325,3 +325,13 @@ jobs:
           cd build
           source /opt/rh/devtoolset-9/enable
           make scap-open -j6          
+
+  # Only runs on pull request since on master branch it is already triggered by pages CI.
+  kernel-tests-dev:
+    needs: paths-filter
+    if: github.event_name == 'pull_request' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
+    uses: ./.github/workflows/reusable_kernel_tests.yaml
+    with:
+      # Use real branch's HEAD sha, not the merge commit
+      libsversion: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR enables kernel-testing framework on PRs.
I discovered that, for self hosted runners, there is no parallelism: each job's request is enqueued. 
The only parallelism would happen if we had multiple self hosted runners under same tags, then the jobs would be distributed among them.
See https://github.com/orgs/community/discussions/26769#discussioncomment-3253321

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
