### PR TITLE
chore(libsinsp): fix unused value for fscanf

### DIFF
--- a/userspace/libsinsp/metrics_collector.cpp
+++ b/userspace/libsinsp/metrics_collector.cpp
@@ -488,7 +488,7 @@ void libs_resource_utilization::get_container_memory_used()
 	if (filepath == nullptr)
 	{
 		// No need for scap_get_host_root since we look at the container pid namespace (if applicable)
-		// Known collison for VM memory usage, but this default value is configurable
+		// Known collision for VM memory usage, but this default value is configurable
 		filepath = "/sys/fs/cgroup/memory/memory.usage_in_bytes";
 	}
 
@@ -499,10 +499,13 @@ void libs_resource_utilization::get_container_memory_used()
 	}
 
 	/* memory size returned in bytes */
-	fscanf(f, "%" SCNu64, &m_container_memory_used);
-	fclose(f);
+	int fscanf_matched = fscanf(f, "%" SCNu64, &m_container_memory_used);
+	if (fscanf_matched != 1)
+	{
+		m_container_memory_used = 0;
+	}
 
-	return;
+	fclose(f);
 }
 
 libs_state_counters::libs_state_counters(std::shared_ptr<sinsp_stats_v2> sinsp_stats_v2, sinsp_thread_manager* thread_manager) : m_sinsp_stats_v2(sinsp_stats_v2), m_n_fds(0), m_n_threads(0) {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This fixes a warning/error when compiling with warnings as errors

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
