### PR TITLE
fix(libsinsp): fix crash in string transformers when called on an empty string

### DIFF
--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -57,7 +57,7 @@ bool sinsp_filter_transformer::string_transformer(std::vector<extract_value_t>& 
         }
 
         // we insert a null terminator in case we miss one, just to stay safe
-        if (buf[buf.size() - 1] != '\0')
+        if (buf.size() == 0 || buf[buf.size() - 1] != '\0')
         {
             buf.push_back('\0');
         }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix a potential crash in string transformers when attempting to read an empty output buffer.
Also, lightly refactor tests and cover the empty string case.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): fix crash in string transformers when called on an empty string
```
