### PR TITLE
new(libsinsp): add basename() string transformer

### DIFF
--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -90,7 +90,7 @@ static constexpr const char* s_field_transformer_val = "val(";
 
 static const std::vector<std::string> s_field_transformers =
 {
-	"tolower(", "toupper(", "b64(",
+	"tolower(", "toupper(", "b64(", "basename(",
 };
 
 static inline void update_pos(const char c, ast::pos_info& pos)

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -67,7 +67,7 @@ namespace re2 { class RE2; };
 //                             | 'startswith ' | 'bstartswith ' | 'endswith '
 //     ListOperator        ::= 'intersects' | 'in' | 'pmatch' 
 //     FieldTransformerVal    ::= 'val('
-//     FieldTransformerType   ::= 'tolower(' | 'toupper(' | 'b64('
+//     FieldTransformerType   ::= 'tolower(' | 'toupper(' | 'b64(' | 'basename('
 // 
 // Tokens (Regular Expressions):
 //     Identifier          ::= [a-zA-Z]+[a-zA-Z0-9_]*

--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -115,6 +115,19 @@ bool sinsp_filter_transformer::transform_type(ppm_param_type& t) const
         // for STORAGE, the transformed type is the same as the input type
         return true;
     }
+    case FTR_BASENAME:
+    {
+        switch(t)
+        {
+        case PT_CHARBUF:
+        case PT_FSPATH:
+        case PT_FSRELPATH:
+            // for BASENAME, the transformed type is the same as the input type
+            return true;
+        default:
+            return false;
+        }
+    }
     default:
         throw_unsupported_err(m_type);
         return false;
@@ -179,6 +192,20 @@ bool sinsp_filter_transformer::transform_values(std::vector<extract_value_t>& ve
             // `vec[i].len` is the same as before
         }
         return true;
+    }
+    case FTR_BASENAME:
+    {
+        return string_transformer(vec, t, [](std::string_view in, storage_t& out) -> bool {
+            auto last_slash_pos = in.find_last_of("/");
+            ssize_t start_idx = last_slash_pos == std::string_view::npos ? 0 : last_slash_pos + 1;
+
+            for (ssize_t i = start_idx; i < in.length(); i++)
+            {
+                out.push_back(in[i]);
+            }
+
+            return true;
+        });
     }
     default:
         throw_unsupported_err(m_type);

--- a/userspace/libsinsp/sinsp_filter_transformer.h
+++ b/userspace/libsinsp/sinsp_filter_transformer.h
@@ -28,6 +28,7 @@ enum filter_transformer_type: uint8_t
 	FTR_TOLOWER = 1,
 	FTR_BASE64 = 2,
 	FTR_STORAGE = 3, // This transformer is only used internally
+	FTR_BASENAME = 4,
 };
 
 static inline std::string filter_transformer_type_str(filter_transformer_type m)
@@ -42,6 +43,8 @@ static inline std::string filter_transformer_type_str(filter_transformer_type m)
 		return "b64";
 	case FTR_STORAGE:
 		return "storage";
+	case FTR_BASENAME:
+		return "basename";
 	default:
 		throw sinsp_exception("unknown field transfomer id " + std::to_string(m));
 	}
@@ -64,6 +67,10 @@ static inline filter_transformer_type filter_transformer_from_str(const std::str
 	if (str == "storage")
 	{
 		return filter_transformer_type::FTR_STORAGE;
+	}
+	if (str == "basename")
+	{
+		return filter_transformer_type::FTR_BASENAME;
 	}
 	throw sinsp_exception("unknown field transfomer '" + str + "'");
 }

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -111,7 +111,7 @@ TEST(parser, supported_field_transformers)
 {
 	std::string expected_val = "val";
 	std::vector<std::string> expected = {
-		"tolower", "toupper", "b64" };
+		"tolower", "toupper", "b64", "basename" };
 	
 	auto actual = parser::supported_field_transformers();
 	ASSERT_EQ(actual.size(), expected.size());


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Introduce `basename()` as transformer. This allows, for instance, to write expressions like `basename(proc.exepath) = cat` to match against the original executable name even if it has been symlinked without knowing the full path, or any other file name based detection.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1927

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): add basename() string transformer
```
