### PR TITLE
fix(libsinsp): use size_type in basename transformer

### DIFF
--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -197,9 +197,9 @@ bool sinsp_filter_transformer::transform_values(std::vector<extract_value_t>& ve
     {
         return string_transformer(vec, t, [](std::string_view in, storage_t& out) -> bool {
             auto last_slash_pos = in.find_last_of("/");
-            ssize_t start_idx = last_slash_pos == std::string_view::npos ? 0 : last_slash_pos + 1;
+            std::string_view::size_type start_idx = last_slash_pos == std::string_view::npos ? 0 : last_slash_pos + 1;
 
-            for (ssize_t i = start_idx; i < in.length(); i++)
+            for (std::string_view::size_type i = start_idx; i < in.length(); i++)
             {
                 out.push_back(in[i]);
             }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

As per title

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): use size_type in basename transformer, fix build on Windows
```
