### PR TITLE
Fix binary check expr is equal

### DIFF
--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -535,6 +535,7 @@ struct SINSP_PUBLIC binary_check_expr: expr
         auto o = dynamic_cast<const binary_check_expr*>(other);
         return o != nullptr
             && left->is_equal(o->left.get())
+	    && op == o->op
             && right->is_equal(o->right.get());
     }
 

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -82,6 +82,7 @@ endif()
 file(GLOB_RECURSE TEST_HELPERS ${CMAKE_CURRENT_SOURCE_DIR}/helpers/*.cpp)
 
 set(LIBSINSP_UNIT_TESTS_SOURCES
+	ast_exprs.ut.cpp
 	test_utils.cpp
 	sinsp_with_test_input.cpp
 	cgroup_list_counter.ut.cpp

--- a/userspace/libsinsp/test/ast_exprs.ut.cpp
+++ b/userspace/libsinsp/test/ast_exprs.ut.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <libsinsp/filter/parser.h>
+#include <gtest/gtest.h>
+
+using namespace libsinsp::filter::ast;
+
+static std::unique_ptr<expr> make_expr(const std::string& cond)
+{
+	libsinsp::filter::parser p(cond);
+
+	std::unique_ptr<expr> e = p.parse();
+
+	return e;
+}
+
+TEST(ast, compare_binary_check_exprs)
+{
+	std::unique_ptr<expr> e1 = make_expr("evt.num >= 0");
+	std::unique_ptr<expr> e2 = make_expr("evt.num = 0");
+	ASSERT_FALSE(e1->is_equal(e2.get()));
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix a bug in `libsinsp::filter::ast::binary_check_expr::is_equal()`. The method should compare the operators but isn't. So an expression `evt.num >= 0` is mistakenly being considered equal to `evt.num = 0`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Fix a bug in libsinsp::filter::ast::binary_check_expr::is_equal(), where two binary check expressions were considered equal even if they had different operators. For example evt.num >= 0 was mistakenly considered equal to evt.num = 0.
```
