### PR TITLE
fix(userspace/libsinsp): solve issues with negate comparisons on ip and ipnet checks

### DIFF
--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -493,7 +493,7 @@ struct SINSP_PUBLIC unary_check_expr: expr
     bool is_equal(const expr* other) const override
     {
         auto o = dynamic_cast<const unary_check_expr*>(other);
-        return o != nullptr && left->is_equal(o->left.get());
+        return o != nullptr && left->is_equal(o->left.get()) && op == o->op;
     }
 
     std::unique_ptr<expr> left;

--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -650,25 +650,25 @@ bool flt_compare(cmpop op, ppm_param_type type, const void* operand1, const void
 	case PT_IPV4ADDR:
 		if (op2_len != sizeof(struct in_addr))
 		{
-			return false;
+			return op == CO_NE;
 		}
 		return flt_compare_ipv4addr(op, flt_cast<uint32_t, uint64_t>(operand1), flt_cast<uint32_t, uint64_t>(operand2));
 	case PT_IPV4NET:
 		if (op2_len != sizeof(ipv4net))
 		{
-			return false;
+			return op == CO_NE;
 		}
 		return flt_compare_ipv4net(op, (uint64_t)*(uint32_t*)operand1, (ipv4net*)operand2);
 	case PT_IPV6ADDR:
 		if (op2_len != sizeof(ipv6addr))
 		{
-			return false;
+			return op == CO_NE;
 		}
 		return flt_compare_ipv6addr(op, (ipv6addr *)operand1, (ipv6addr *)operand2);
 	case PT_IPV6NET:
 		if (op2_len != sizeof(ipv6net))
 		{
-			return false;
+			return op == CO_NE;
 		}
 		return flt_compare_ipv6net(op, (ipv6addr *)operand1, (ipv6net*)operand2);
 	case PT_IPADDR:
@@ -676,7 +676,7 @@ bool flt_compare(cmpop op, ppm_param_type type, const void* operand1, const void
 		{
 			if (op2_len != sizeof(struct in_addr))
 			{
-				return false;
+				return op == CO_NE;
 			}
 			return flt_compare(op, PT_IPV4ADDR, operand1, operand2, op1_len, op2_len);
 		}
@@ -684,7 +684,7 @@ bool flt_compare(cmpop op, ppm_param_type type, const void* operand1, const void
 		{
 			if (op2_len != sizeof(ipv6addr))
 			{
-				return false;
+				return op == CO_NE;
 			}
 			return flt_compare(op, PT_IPV6ADDR, operand1, operand2, op1_len, op2_len);
 		}
@@ -697,7 +697,7 @@ bool flt_compare(cmpop op, ppm_param_type type, const void* operand1, const void
 		{
 			if (op2_len != sizeof(ipv4net))
 			{
-				return false;
+				return op == CO_NE;
 			}
 			return flt_compare(op, PT_IPV4NET, operand1, operand2, op1_len, op2_len);
 		}
@@ -705,7 +705,7 @@ bool flt_compare(cmpop op, ppm_param_type type, const void* operand1, const void
 		{
 			if (op2_len != sizeof(ipv6net))
 			{
-				return false;
+				return op == CO_NE;
 			}
 			return flt_compare(op, PT_IPV6NET, operand1, operand2, op1_len, op2_len);
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Our comparison logic in the filters introduced a regression that misinterprets checks such as `fd.ip != "0:0:0:0:0:0:0:1"` and `not fd.ip = "0:0:0:0:0:0:0:1"`. Those are supposed to be functionally equal, however when the underlying comparison involves ip addresses of different sizes (ipv4, ipv6) the two expressions diverge.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): solve issues with negate comparisons on ip and ipnet checks
```
