### PR TITLE
fix(driver): simplify exe_upper_layer extraction

### DIFF
--- a/driver/bpf/missing_definitions.h
+++ b/driver/bpf/missing_definitions.h
@@ -10,37 +10,6 @@ or GPL2.txt for full copies of the license.
 #ifndef __BPF_MISSING_DEFINITIONS_H__
 #define __BPF_MISSING_DEFINITIONS_H__
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long has_upper;
-			bool opaque;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	struct path lowerstack[];
-};
-#else
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long flags;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	//struct ovl_path lowerstack[];
-};
-
-enum ovl_entry_flag {
-	OVL_E_UPPER_ALIAS,
-	OVL_E_OPAQUE,
-	OVL_E_CONNECTED,
-};
-#endif
-
 #include <linux/mount.h>
 /* This require the inlclude `linux/mount.h` for `vfsmount` definition */
 struct mount {

--- a/driver/modern_bpf/definitions/missing_definitions.h
+++ b/driver/modern_bpf/definitions/missing_definitions.h
@@ -1586,9 +1586,4 @@
 #define MODULE_INIT_COMPRESSED_FILE    4
 /*==================================== FINIT   FLAGS ================================*/
 
-/*==================================== OVERLAY FLAGS ================================*/
-#define DCACHE_DISCONNECTED 0x20
-#define OVL_E_UPPER_ALIAS      0
-/*==================================== OVERLAY FLAGS ================================*/
-
 #endif /* __MISSING_DEFINITIONS_H__ */

--- a/driver/modern_bpf/definitions/struct_flavors.h
+++ b/driver/modern_bpf/definitions/struct_flavors.h
@@ -52,11 +52,6 @@ struct inode___v6_7 {
 	struct timespec64 __i_mtime;
 };
 
-struct ovl_entry___before_v6_5
-{
-	long unsigned int flags;
-};
-
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop
 #endif

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -170,7 +170,7 @@ int BPF_PROG(t1_sched_p_exec,
 	{
 		flags |= PPM_EXE_WRITABLE;
 	}
-	if(extract__exe_upper_layer(exe_inode, exe_file))
+	if(extract__exe_upper_layer(exe_file))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -230,7 +230,7 @@ int BPF_PROG(t1_execve_x,
 	{
 		flags |= PPM_EXE_WRITABLE;
 	}
-	if(extract__exe_upper_layer(exe_inode, exe_file))
+	if(extract__exe_upper_layer(exe_file))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -244,7 +244,7 @@ int BPF_PROG(t1_execveat_x,
 	{
 		flags |= PPM_EXE_WRITABLE;
 	}
-	if(extract__exe_upper_layer(exe_inode, exe_file))
+	if(extract__exe_upper_layer(exe_file))
 	{
 		flags |= PPM_EXE_UPPER_LAYER;
 	}

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -853,6 +853,7 @@ static uint32_t ppm_get_tty(void)
 
 static bool ppm_is_upper_layer(struct file *file)
 {
+	// 3.18 is the Kernel version where overlayfs was introduced
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 18, 0)
 	return false;
 #else 
@@ -884,24 +885,29 @@ static bool ppm_is_upper_layer(struct file *file)
 	}
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
-	struct ovl_entry *oe = (struct ovl_entry*)(dentry->d_fsdata);
-	if(!oe)
+	// New scope to avoid `ISO C90 forbids mixed declarations and code` error
 	{
-		return false;
+		struct ovl_entry *oe = (struct ovl_entry*)(dentry->d_fsdata);
+		if(!oe)
+		{
+			return false;
+		}
+		upper_dentry = oe->__upperdentry;
 	}
-	upper_dentry = oe->__upperdentry;
 #else
-	char *vfs_inode = (char*)dentry->d_inode;
-	if(!vfs_inode)
 	{
-		return false;
-	}
+		char *vfs_inode = (char*)dentry->d_inode;
+		if(!vfs_inode)
+		{
+			return false;
+		}
 
-	// Pointer arithmetics due to unexported ovl_inode struct
-	// warning: this works if and only if the dentry pointer
-	// is placed right after the inode struct
-	// todo!: this is dangerous we should find a way to check it at compile time.
-	upper_dentry = *(struct dentry **)(vfs_inode + sizeof(struct inode));
+		// Pointer arithmetics due to unexported ovl_inode struct
+		// warning: this works if and only if the dentry pointer
+		// is placed right after the inode struct
+		// todo!: this is dangerous we should find a way to check it at compile time.
+		upper_dentry = *(struct dentry **)(vfs_inode + sizeof(struct inode));
+	}
 #endif // LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 	if(!upper_dentry)
 	{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -900,14 +900,14 @@ static bool ppm_is_upper_layer(struct file *file)
 	// Pointer arithmetics due to unexported ovl_inode struct
 	// warning: this works if and only if the dentry pointer
 	// is placed right after the inode struct
-	upper_dentry = (struct dentry *)(vfs_inode + sizeof(struct inode));
+	// todo!: this is dangerous we should find a way to check it at compile time.
+	upper_dentry = *(struct dentry **)(vfs_inode + sizeof(struct inode));
 #endif // LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 	if(!upper_dentry)
 	{
 		return false;
 	}
 
-	// WARNING: this could cause undefined behavior if the upper dentry is not immediately after the vfs_inode
 	upper_ino = upper_dentry->d_inode;
 	if(!upper_ino)
 	{

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -61,35 +61,6 @@ struct ovl_entry {
 	unsigned numlower;
 	struct path lowerstack[];
 };
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long has_upper;
-			bool opaque;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	struct path lowerstack[];
-};
-#else
-struct ovl_entry {
-	union {
-		struct {
-			unsigned long flags;
-		};
-		struct rcu_head rcu;
-	};
-	unsigned numlower;
-	//struct ovl_path lowerstack[];
-};
-
-enum ovl_entry_flag {
-	OVL_E_UPPER_ALIAS,
-	OVL_E_OPAQUE,
-	OVL_E_CONNECTED,
-};
 #endif
 
 #define merge_64(hi, lo) ((((unsigned long long)(hi)) << 32) + ((lo) & 0xffffffffUL))
@@ -880,54 +851,70 @@ static uint32_t ppm_get_tty(void)
 	return tty_nr;
 }
 
-static bool ppm_is_upper_layer(struct file *exe_file){
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
-	struct super_block *sb = NULL;
-	unsigned long sb_magic = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
-	sb = exe_file->f_path.dentry->d_sb;
-#else
-	sb = exe_file->f_inode->i_sb;
-#endif
-	if(sb)
-	{
-		struct ovl_entry *oe = (struct ovl_entry*)(exe_file->f_path.dentry->d_fsdata);
-		sb_magic = sb->s_magic;
-		if(sb_magic == PPM_OVERLAYFS_SUPER_MAGIC && oe)
-		{
-			unsigned long has_upper = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
-			if(oe->__upperdentry)
-			{
-				return true;
-			}
-#else
-			struct dentry *upper_dentry = NULL;
-			unsigned int d_flags = exe_file->f_path.dentry->d_flags;
-			bool disconnected = (d_flags & DCACHE_DISCONNECTED);
-
-			// Pointer arithmetics due to unexported ovl_inode struct
-			// warning: this works if and only if the dentry pointer
-			// is placed right after the inode struct
-			upper_dentry = (struct dentry *)((char *)exe_file->f_path.dentry->d_inode + sizeof(struct inode));
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-			has_upper = oe->has_upper;
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
-			has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
-#else
-			has_upper = test_bit(OVL_E_UPPER_ALIAS, (unsigned long*)&oe);
-#endif
-
-			if(upper_dentry && (has_upper || disconnected))
-			{
-				return true;
-			}
-#endif
-		}
-	}
-#endif
+static bool ppm_is_upper_layer(struct file *file)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 18, 0)
 	return false;
+#else 
+	struct dentry * dentry = NULL;
+	struct super_block* sb = NULL;
+	struct dentry *upper_dentry = NULL;
+	struct inode * upper_ino = NULL;
+	
+	if(!file)
+	{
+		return false;
+	}
+
+	dentry = file->f_path.dentry;
+	if(!dentry)
+	{
+		return false;
+	}
+	
+	sb = dentry->d_sb;
+	if(!sb)
+	{
+		return false;
+	}
+	
+	if(sb->s_magic != PPM_OVERLAYFS_SUPER_MAGIC)
+	{
+		return false;
+	}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
+	struct ovl_entry *oe = (struct ovl_entry*)(dentry->d_fsdata);
+	if(!oe)
+	{
+		return false;
+	}
+	upper_dentry = oe->__upperdentry;
+#else
+	char *vfs_inode = (char*)dentry->d_inode;
+	if(!vfs_inode)
+	{
+		return false;
+	}
+
+	// Pointer arithmetics due to unexported ovl_inode struct
+	// warning: this works if and only if the dentry pointer
+	// is placed right after the inode struct
+	upper_dentry = (struct dentry *)(vfs_inode + sizeof(struct inode));
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
+	if(!upper_dentry)
+	{
+		return false;
+	}
+
+	// WARNING: this could cause undefined behavior if the upper dentry is not immediately after the vfs_inode
+	upper_ino = upper_dentry->d_inode;
+	if(!upper_ino)
+	{
+		return false;
+	}
+	return upper_ino->i_ino != 0;
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(3, 18, 0)
 }
 
 int f_proc_startupdate(struct event_filler_arguments *args)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR provides a fix for https://github.com/falcosecurity/falco/issues/3276.

The page fault was due to a backport in RHEL9. 

More in detail this commit https://github.com/torvalds/linux/commit/0af950f57fefabab628f1963af881e6b9bfe7f38 was backported to kernel versions older than 6.5.

So when our drivers run this code:

```c
#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
			has_upper = oe->has_upper;
#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
			has_upper = test_bit(OVL_E_UPPER_ALIAS, &(oe->flags));
#else
			has_upper = test_bit(OVL_E_UPPER_ALIAS, (unsigned long*)&oe);
#endif
```

they enter in the `#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)`, they try to dereference `oe->flags` but the field `flags` is no more there. This is bad for every driver because we are reading random memory but it is even worse for the kmod because it could lead to undefined behavior (and so a host crash) if the address is not aligned.

Even with the new approach proposed with this patch, we are still subject to possible crashes... if the layout of the `struct ovl_inode` changes, and the `__upperdentry` field is not immediately after the `vfs_inode` field, the following code could cause undefined behaviors:

```c
        // Pointer arithmetics due to unexported ovl_inode struct
	// warning: this works if and only if the dentry pointer
	// is placed right after the inode struct
	upper_dentry = (struct dentry *)(vfs_inode + sizeof(struct inode));
```

Just for reference, this is the actual layout of the `struct ovl_inode`

```c
struct ovl_inode {
  ...
  struct inode vfs_inode;
  struct dentry *__upperdentry;
  ...
}
```

**Which issue(s) this PR fixes**:

Ref https://github.com/falcosecurity/falco/issues/3276

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(driver): simplify exe_upper_layer extraction
```
