### PR TITLE
new(libsinsp): add debug information for corrupted (mismatched len) events

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -39,6 +39,7 @@ limitations under the License.
 #include <libscap/strl.h>
 
 #include <libscap/scap.h>
+#include <libsinsp/utils.h>
 
 extern sinsp_evttables g_infotables;
 
@@ -2179,10 +2180,14 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const
 
 	std::stringstream ss;
 	ss << "could not parse param " << m_idx << " (" << parinfo->name << ") for event "
-		<< m_evt->get_num() << " of type " << m_evt->get_type() << " (" << m_evt->get_name() << "): expected length "
-		<< requested_length << ", found " << m_len;
+		<< m_evt->get_num() << " of type " << m_evt->get_type() << " (" << m_evt->get_name() << "), for tid " << m_evt->get_tid() 
+		<< ": expected length " << requested_length << ", found " << m_len;
+	std::string error_string = ss.str();
 
-	throw sinsp_exception(ss.str());
+	libsinsp_logger()->log(error_string, sinsp_logger::SEV_DEBUG);
+	libsinsp_logger()->log("parameter raw data: \n" + buffer_to_multiline_hex(m_val, m_len), sinsp_logger::SEV_DEBUG);
+
+	throw sinsp_exception(error_string);
 }
 
 const ppm_param_info* sinsp_evt_param::get_info() const

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -2184,8 +2184,8 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const
 		<< ": expected length " << requested_length << ", found " << m_len;
 	std::string error_string = ss.str();
 
-	libsinsp_logger()->log(error_string, sinsp_logger::SEV_DEBUG);
-	libsinsp_logger()->log("parameter raw data: \n" + buffer_to_multiline_hex(m_val, m_len), sinsp_logger::SEV_DEBUG);
+	libsinsp_logger()->log(error_string, sinsp_logger::SEV_ERROR);
+	libsinsp_logger()->log("parameter raw data: \n" + buffer_to_multiline_hex(m_val, m_len), sinsp_logger::SEV_ERROR);
 
 	throw sinsp_exception(error_string);
 }

--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <libsinsp/filter_compare.h>
 #include <libsinsp/sinsp_exception.h>
 #include <libsinsp/utils.h>
+#include <libsinsp/memmem.h>
 
 #ifdef _WIN32
 #define NOMINMAX
@@ -28,41 +29,6 @@ limitations under the License.
 #else
 #include "arpa/inet.h"
 #include <netdb.h>
-#endif
-
-//
-// Fallback implementation of memmem
-//
-#if !defined(_GNU_SOURCE) && !defined(__APPLE__)
-#include <string.h>
-
-static inline void *memmem(const void *haystack, size_t haystacklen,
-	const void *needle, size_t needlelen)
-{
-	const unsigned char *ptr;
-	const unsigned char *end;
-
-	if(needlelen == 0)
-	{
-		return (void *)haystack;
-	}
-
-	if(haystacklen < needlelen)
-	{
-		return NULL;
-	}
-
-	end = (const unsigned char *)haystack + haystacklen - needlelen;
-	for(ptr = (const unsigned char *)haystack; ptr <= end; ptr++)
-	{
-		if(!memcmp(ptr, needle, needlelen))
-		{
-			return (void *)ptr;
-		}
-	}
-
-	return NULL;
-}
 #endif
 
 cmpop str_to_cmpop(std::string_view str)

--- a/userspace/libsinsp/memmem.h
+++ b/userspace/libsinsp/memmem.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+//
+// Fallback implementation of memmem
+//
+#if !defined(_GNU_SOURCE) && !defined(__APPLE__)
+#include <string.h>
+
+static inline void *memmem(const void *haystack, size_t haystacklen,
+	const void *needle, size_t needlelen)
+{
+	const unsigned char *ptr;
+	const unsigned char *end;
+
+	if(needlelen == 0)
+	{
+		return (void *)haystack;
+	}
+
+	if(haystacklen < needlelen)
+	{
+		return NULL;
+	}
+
+	end = (const unsigned char *)haystack + haystacklen - needlelen;
+	for(ptr = (const unsigned char *)haystack; ptr <= end; ptr++)
+	{
+		if(!memcmp(ptr, needle, needlelen))
+		{
+			return (void *)ptr;
+		}
+	}
+
+	return NULL;
+}
+#endif

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -37,6 +37,8 @@ sinsp_with_test_input::~sinsp_with_test_input()
 	{
 		free(el);
 	}
+
+	libsinsp_logger()->reset();
 }
 
 void sinsp_with_test_input::open_inspector(sinsp_mode_t mode) {

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1963,3 +1963,28 @@ std::string concat_set_in_order(const std::set<std::string>& s, const std::strin
 	std::string s_str = ss.str();
 	return s_str.substr(0, s_str.size() - delim.size());
 }
+
+#define SINSP_UTILS_FORMATBUF_LEN 32
+
+std::string buffer_to_multiline_hex(const char *buf, size_t size)
+{
+	char format_buf[SINSP_UTILS_FORMATBUF_LEN];
+	std::stringstream ss;
+
+	for(size_t i = 0; i < size; i++)
+	{
+		if (i % 16 == 0)
+		{
+			if (i != 0)
+			{
+				ss << "\n";
+			}
+			snprintf(format_buf, SINSP_UTILS_FORMATBUF_LEN, "%03lx | ", i);
+			ss << format_buf;
+		}
+		snprintf(format_buf, SINSP_UTILS_FORMATBUF_LEN, "%02x ", buf[i]);
+		ss << format_buf;
+	}
+
+	return ss.str();
+}

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -294,6 +294,8 @@ std::string& trim(std::string& s);
 std::string& replace_in_place(std::string& s, const std::string& search, const std::string& replacement);
 std::string replace(const std::string& str, const std::string& search, const std::string& replacement);
 
+std::string buffer_to_multiline_hex(const char *buf, size_t size);
+
 ///////////////////////////////////////////////////////////////////////////////
 // number parser
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/3275 , one option is to add a debug print when we find this kind of issue. This can help us debug the driver in case something unexpected happen. Also, add a test for a corrupted string in an event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): add debug information for corrupted (mismatched len) events
```
