### PR TITLE
fix(userspace/libsinsp): assorted pass-by-reference performance optimizations

### DIFF
--- a/userspace/libsinsp/cgroup_limits.cpp
+++ b/userspace/libsinsp/cgroup_limits.cpp
@@ -68,7 +68,7 @@ bool read_cgroup_vals(const std::string &path, std::istream &stream, int64_t &ou
  *          reasonable being [0; CGROUP_VAL_MAX)
  */
 template<typename... Args>
-bool read_cgroup_val(std::shared_ptr<std::string> &subsys,
+bool read_cgroup_val(const std::shared_ptr<std::string> &subsys,
 		     const std::string &cgroup,
 		     const std::string &filename,
 		     int64_t &out,

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -278,7 +278,7 @@ std::string sinsp_container_manager::container_to_json(const sinsp_container_inf
 	return Json::FastWriter().write(obj);
 }
 
-bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo, char *scap_err)
+bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::unique_ptr<sinsp_threadinfo> tinfo, char *scap_err)
 {
 	uint32_t json_len = json.length() + 1;
 	size_t totlen = sizeof(scap_evt) + sizeof(uint32_t) + json_len;
@@ -300,8 +300,9 @@ bool sinsp_container_manager::container_to_sinsp_event(const std::string& json, 
 	}
 
 	evt->init();
-	evt->set_tinfo_ref(tinfo);
-	evt->set_tinfo(tinfo.get());
+	std::shared_ptr<sinsp_threadinfo> stinfo = std::move(tinfo);
+	evt->set_tinfo_ref(stinfo);
+	evt->set_tinfo(stinfo.get());
 
 	return true;
 }

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -235,7 +235,7 @@ public:
 
 
 private:
-	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::shared_ptr<sinsp_threadinfo> tinfo, char* scap_err);
+	bool container_to_sinsp_event(const std::string& json, sinsp_evt* evt, std::unique_ptr<sinsp_threadinfo> tinfo, char* scap_err);
 	std::string get_docker_env(const Json::Value &env_vars, const std::string &mti);
 
 	std::list<std::shared_ptr<libsinsp::container_engine::container_engine_base>> m_container_engines;

--- a/userspace/libsinsp/container_info.cpp
+++ b/userspace/libsinsp/container_info.cpp
@@ -148,9 +148,9 @@ const sinsp_container_info::container_mount_info *sinsp_container_info::mount_by
 	return NULL;
 }
 
-std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspector) const
+std::unique_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspector) const
 {
-	std::shared_ptr<sinsp_threadinfo> tinfo(inspector->build_threadinfo().release());
+	auto tinfo = inspector->build_threadinfo();
 	tinfo->m_tid = -1;
 	tinfo->m_pid = -1;
 	tinfo->m_vtid = -2;
@@ -158,7 +158,6 @@ std::shared_ptr<sinsp_threadinfo> sinsp_container_info::get_tinfo(sinsp* inspect
 	tinfo->m_comm = "container:" + m_id;
 	tinfo->m_exe = "container:" + m_id;
 	tinfo->m_container_id = m_id;
-
 	return tinfo;
 }
 

--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -300,7 +300,7 @@ public:
 		return m_lookup.get_status();
 	}
 
-	std::shared_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
+	std::unique_ptr<sinsp_threadinfo> get_tinfo(sinsp* inspector) const;
 
 	// Match a process against the set of health probes
 	container_health_probe::probe_type match_health_probe(sinsp_threadinfo *tinfo) const;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -764,12 +764,12 @@ public:
 		return m_tinfo_ref;
 	}
 
-	inline std::shared_ptr<sinsp_threadinfo> get_tinfo_ref()
+	inline const std::shared_ptr<sinsp_threadinfo>& get_tinfo_ref()
 	{
 		return m_tinfo_ref;
 	}
 
-	inline void set_tinfo_ref(std::shared_ptr<sinsp_threadinfo> v)
+	inline void set_tinfo_ref(const std::shared_ptr<sinsp_threadinfo>& v)
 	{
 		m_tinfo_ref = v;
 	}
@@ -794,12 +794,12 @@ public:
 		return m_fdinfo_ref;
 	}
 
-	inline std::shared_ptr<sinsp_fdinfo> get_fdinfo_ref()
+	inline const std::shared_ptr<sinsp_fdinfo>& get_fdinfo_ref()
 	{
 		return m_fdinfo_ref;
 	}
 
-	inline void set_fdinfo_ref(std::shared_ptr<sinsp_fdinfo> v)
+	inline void set_fdinfo_ref(const std::shared_ptr<sinsp_fdinfo>& v)
 	{
 		m_fdinfo_ref = v;
 	}

--- a/userspace/libsinsp/eventformatter.h
+++ b/userspace/libsinsp/eventformatter.h
@@ -127,7 +127,7 @@ private:
 		bool has_transformers = false;
 
 		resolution_token(const std::string& n, token_t t, bool h)
-			: name(n), token(t), has_transformers(h) { }
+			: name(n), token(std::move(t)), has_transformers(h) { }
 	};
 
 	output_format m_output_format;

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -123,7 +123,7 @@ const char* sinsp_fdinfo::get_typestring() const
 	}
 }
 
-sinsp_fdinfo::sinsp_fdinfo(std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> dyn_fields)
+sinsp_fdinfo::sinsp_fdinfo(const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields)
 	: table_entry(dyn_fields) 
 {
 }
@@ -309,7 +309,7 @@ sinsp_fdtable::sinsp_fdtable(sinsp* inspector)
 	reset_cache();
 }
 
-inline std::shared_ptr<sinsp_fdinfo> sinsp_fdtable::find_ref(int64_t fd)
+inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd)
 {
 	//
 	// Try looking up in our simple cache
@@ -334,7 +334,7 @@ inline std::shared_ptr<sinsp_fdinfo> sinsp_fdtable::find_ref(int64_t fd)
 		{
 			m_sinsp_stats_v2->m_n_failed_fd_lookups++;
 		}
-		return nullptr;
+		return m_nullptr_ret;
 	}
 	else
 	{
@@ -350,7 +350,7 @@ inline std::shared_ptr<sinsp_fdinfo> sinsp_fdtable::find_ref(int64_t fd)
 	}
 }
 
-inline std::shared_ptr<sinsp_fdinfo> sinsp_fdtable::add_ref(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo)
+inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::add_ref(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo)
 {
 	if (fdinfo->dynamic_fields() != dynamic_fields())
 	{
@@ -386,7 +386,7 @@ inline std::shared_ptr<sinsp_fdinfo> sinsp_fdtable::add_ref(int64_t fd, std::uni
 		}
 		else
 		{
-			return nullptr;
+			return m_nullptr_ret;
 		}
 	}
 	else

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -111,7 +111,7 @@ public:
 		FLAGS_CONNECTION_FAILED = (1 << 16),
 	};
 
-	sinsp_fdinfo(std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> dyn_fields = nullptr);
+	sinsp_fdinfo(const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields = nullptr);
 	sinsp_fdinfo(sinsp_fdinfo&& o) = default;
 	sinsp_fdinfo& operator=(sinsp_fdinfo&& o) = default;
 	sinsp_fdinfo(const sinsp_fdinfo& o) = default;
@@ -558,9 +558,10 @@ private:
 	int64_t m_last_accessed_fd;
 	std::shared_ptr<sinsp_fdinfo> m_last_accessed_fdinfo;
 	uint64_t m_tid;
+	std::shared_ptr<sinsp_fdinfo> m_nullptr_ret; // needed for returning a reference
 
 private:
 	inline void lookup_device(sinsp_fdinfo* fdi, uint64_t fd);
-	std::shared_ptr<sinsp_fdinfo> find_ref(int64_t fd);
-	std::shared_ptr<sinsp_fdinfo> add_ref(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
+	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd);
+	const std::shared_ptr<sinsp_fdinfo>& add_ref(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
 };

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -188,7 +188,7 @@ void sinsp_filter::add_check(std::unique_ptr<sinsp_filter_check> chk)
 sinsp_filter_compiler::sinsp_filter_compiler(
 		sinsp* inspector,
 		const std::string& fltstr,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory)
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory)
 	: m_flt_str(fltstr),
 	  m_factory(std::make_shared<sinsp_filter_factory>(inspector, m_default_filterlist)),
 	  m_cache_factory(cache_factory)
@@ -196,9 +196,9 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
-		std::shared_ptr<sinsp_filter_factory> factory,
+		const std::shared_ptr<sinsp_filter_factory>& factory,
 		const std::string& fltstr,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory)
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory)
 	: m_flt_str(fltstr),
 	  m_factory(factory),
 	  m_cache_factory(cache_factory)
@@ -206,9 +206,9 @@ sinsp_filter_compiler::sinsp_filter_compiler(
 }
 
 sinsp_filter_compiler::sinsp_filter_compiler(
-		std::shared_ptr<sinsp_filter_factory> factory,
+		const std::shared_ptr<sinsp_filter_factory>& factory,
 		const libsinsp::filter::ast::expr* fltast,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory)
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory)
 	: m_flt_ast(fltast),
 	  m_factory(factory),
 	  m_cache_factory(cache_factory)

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -202,7 +202,7 @@ public:
 	sinsp_filter_compiler(
 		sinsp* inspector,
 		const std::string& fltstr,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory = nullptr);
 
 	/*!
 		\brief Constructs the compiler
@@ -212,9 +212,9 @@ public:
 		\param fltstr The filter string to compile
 	*/
 	sinsp_filter_compiler(
-		std::shared_ptr<sinsp_filter_factory> factory,
+		const std::shared_ptr<sinsp_filter_factory>& factory,
 		const std::string& fltstr,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory = nullptr);
 
 	/*!
 		\brief Constructs the compiler
@@ -225,9 +225,9 @@ public:
 		tree
 	*/
 	sinsp_filter_compiler(
-		std::shared_ptr<sinsp_filter_factory> factory,
+		const std::shared_ptr<sinsp_filter_factory>& factory,
 		const libsinsp::filter::ast::expr* fltast,
-		std::shared_ptr<sinsp_filter_cache_factory> cache_factory = nullptr);
+		const std::shared_ptr<sinsp_filter_cache_factory>& cache_factory = nullptr);
 
 	/*!
 		\brief Builds a filtercheck tree and bundles it in sinsp_filter
@@ -237,9 +237,9 @@ public:
 	*/
 	std::unique_ptr<sinsp_filter> compile();
 
-	std::shared_ptr<const libsinsp::filter::ast::expr> get_filter_ast() const { return m_internal_flt_ast; }
+	const std::shared_ptr<libsinsp::filter::ast::expr> get_filter_ast() const { return m_internal_flt_ast; }
 
-	std::shared_ptr<libsinsp::filter::ast::expr> get_filter_ast() { return m_internal_flt_ast; }
+	const std::shared_ptr<libsinsp::filter::ast::expr>& get_filter_ast() { return m_internal_flt_ast; }
 
 	const libsinsp::filter::ast::pos_info& get_pos() const { return m_pos; }
 

--- a/userspace/libsinsp/gvisor_config.cpp
+++ b/userspace/libsinsp/gvisor_config.cpp
@@ -333,7 +333,7 @@ static const std::vector<gvisor_point_info_t> s_gvisor_points = {
 
 constexpr unsigned int max_retries = 3;
 
-std::string generate(std::string socket_path)
+std::string generate(const std::string& socket_path)
 {
 	Json::Value jpoints;
 	for(const auto &point_info : s_gvisor_points)

--- a/userspace/libsinsp/gvisor_config.h
+++ b/userspace/libsinsp/gvisor_config.h
@@ -22,5 +22,5 @@ limitations under the License.
 
 namespace gvisor_config 
 {
-	std::string generate(std::string socket_path);
+	std::string generate(const std::string& socket_path);
 }

--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -144,7 +144,7 @@ sinsp_logger::severity sinsp_logger::get_severity() const
 	return m_sev;
 }
 
-void sinsp_logger::log(std::string msg, const severity sev)
+void sinsp_logger::log(const std::string& m, const severity sev)
 {
 	sinsp_logger_callback cb = nullptr;
 
@@ -153,6 +153,7 @@ void sinsp_logger::log(std::string msg, const severity sev)
 		return;
 	}
 
+	std::string msg = m;
 	if((m_flags & sinsp_logger::OT_NOTS) == 0)
 	{
 		struct timeval ts = {};

--- a/userspace/libsinsp/logger.h
+++ b/userspace/libsinsp/logger.h
@@ -127,7 +127,7 @@ public:
 	 * Emit the given msg to the configured log sink if the given sev
 	 * is greater than or equal to the minimum configured logging severity.
 	 */
-	void log(std::string msg, severity sev = SEV_INFO);
+	void log(const std::string& m, severity sev = SEV_INFO);
 
 	/**
 	 * Write the given printf-style log message of the given severity

--- a/userspace/libsinsp/metrics_collector.cpp
+++ b/userspace/libsinsp/metrics_collector.cpp
@@ -508,7 +508,7 @@ void libs_resource_utilization::get_container_memory_used()
 	fclose(f);
 }
 
-libs_state_counters::libs_state_counters(std::shared_ptr<sinsp_stats_v2> sinsp_stats_v2, sinsp_thread_manager* thread_manager) : m_sinsp_stats_v2(sinsp_stats_v2), m_n_fds(0), m_n_threads(0) {
+libs_state_counters::libs_state_counters(const std::shared_ptr<sinsp_stats_v2>& sinsp_stats_v2, sinsp_thread_manager* thread_manager) : m_sinsp_stats_v2(sinsp_stats_v2), m_n_fds(0), m_n_threads(0) {
 	if (thread_manager != nullptr)
 	{
 		m_n_threads = thread_manager->get_thread_count();

--- a/userspace/libsinsp/metrics_collector.h
+++ b/userspace/libsinsp/metrics_collector.h
@@ -303,7 +303,7 @@ private:
 class libs_state_counters : libsinsp_metrics
 {
 public:
-	libs_state_counters(std::shared_ptr<sinsp_stats_v2> sinsp_stats_v2, sinsp_thread_manager* thread_manager);
+	libs_state_counters(const std::shared_ptr<sinsp_stats_v2>& sinsp_stats_v2, sinsp_thread_manager* thread_manager);
 
 	std::vector<metrics_v2> to_metrics() override;
 

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -134,7 +134,7 @@ std::shared_ptr<sinsp_plugin> sinsp_plugin::create(
 	return plugin;
 }
 
-bool sinsp_plugin::is_plugin_loaded(std::string &filepath)
+bool sinsp_plugin::is_plugin_loaded(const std::string &filepath)
 {
 	return plugin_is_loaded(filepath.c_str());
 }

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -958,7 +958,7 @@ std::vector<metrics_v2> sinsp_plugin::get_metrics() const
 
 /** Field Extraction CAP **/
 
-std::unique_ptr<sinsp_filter_check> sinsp_plugin::new_filtercheck(std::shared_ptr<sinsp_plugin> plugin)
+std::unique_ptr<sinsp_filter_check> sinsp_plugin::new_filtercheck(const std::shared_ptr<sinsp_plugin>& plugin)
 {
 	return std::make_unique<sinsp_filter_check_plugin>(plugin);
 }

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -72,7 +72,7 @@ public:
 	/**
 	 * @brief Return whether a filesystem dynamic library object is loaded.
 	 */
-	static bool is_plugin_loaded(std::string& filepath);
+	static bool is_plugin_loaded(const std::string& filepath);
 
 	/**
 	 * @brief If the plugin has CAP_EXTRACTION capability, returns a

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -80,7 +80,7 @@ public:
 	 *
 	 * todo(jasondellaluce): make this return a unique_ptr
 	 */
-	static std::unique_ptr<sinsp_filter_check> new_filtercheck(std::shared_ptr<sinsp_plugin> plugin);
+	static std::unique_ptr<sinsp_filter_check> new_filtercheck(const std::shared_ptr<sinsp_plugin>& plugin);
 
 	/**
 	 * @brief Returns true if the source is compatible with the given set

--- a/userspace/libsinsp/plugin_filtercheck.cpp
+++ b/userspace/libsinsp/plugin_filtercheck.cpp
@@ -27,7 +27,7 @@ sinsp_filter_check_plugin::sinsp_filter_check_plugin()
 	m_eplugin = nullptr;
 }
 
-sinsp_filter_check_plugin::sinsp_filter_check_plugin(std::shared_ptr<sinsp_plugin> plugin)
+sinsp_filter_check_plugin::sinsp_filter_check_plugin(const std::shared_ptr<sinsp_plugin>& plugin)
 {
 	if (!(plugin->caps() & CAP_EXTRACTION))
 	{

--- a/userspace/libsinsp/plugin_filtercheck.h
+++ b/userspace/libsinsp/plugin_filtercheck.h
@@ -35,7 +35,7 @@ class sinsp_filter_check_plugin : public sinsp_filter_check
 public:
 	sinsp_filter_check_plugin();
 
-	explicit sinsp_filter_check_plugin(std::shared_ptr<sinsp_plugin> plugin);
+	explicit sinsp_filter_check_plugin(const std::shared_ptr<sinsp_plugin>& plugin);
 
 	explicit sinsp_filter_check_plugin(const sinsp_filter_check_plugin &p);
 

--- a/userspace/libsinsp/plugin_manager.h
+++ b/userspace/libsinsp/plugin_manager.h
@@ -49,7 +49,7 @@ public:
 	/**
 	 * @brief Adds a plugin in the manager.
 	 */
-	void add(std::shared_ptr<sinsp_plugin> plugin)
+	void add(const std::shared_ptr<sinsp_plugin>& plugin)
 	{
 		for(auto& it : m_plugins)
 		{
@@ -117,14 +117,14 @@ public:
 	 * the CAP_EVENT_SOURCE capability. Returns nullptr if no plugin exists
 	 * with the given ID.
 	 */
-	inline std::shared_ptr<sinsp_plugin> plugin_by_id(uint32_t plugin_id) const
+	inline const std::shared_ptr<sinsp_plugin>& plugin_by_id(uint32_t plugin_id) const
 	{
 		if (plugin_id != m_last_id_in)
 		{
 			auto it = m_plugins_id_index.find(plugin_id);
 			if(it == m_plugins_id_index.end())
 			{
-				return nullptr;
+				return m_nullptr_ret;
 			}
 			m_last_id_in = plugin_id;
 			m_last_id_out = it->second;
@@ -136,13 +136,13 @@ public:
 	 * @brief  Returns a plugin given an event. The plugin is guaranteed to have
 	 * the CAP_EVENT_SOURCE capability.
 	 */
-	inline std::shared_ptr<sinsp_plugin> plugin_by_evt(sinsp_evt* evt) const
+	inline const std::shared_ptr<sinsp_plugin>& plugin_by_evt(sinsp_evt* evt) const
 	{
 		if(evt && evt->get_type() == PPME_PLUGINEVENT_E)
 		{
 			return plugin_by_id(evt->get_param(0)->as<int32_t>());
 		}
-		return nullptr;
+		return m_nullptr_ret;
 	}
 
 	/**
@@ -186,4 +186,7 @@ private:
 	mutable size_t m_last_id_out;
 	mutable size_t m_last_source_in;
 	mutable size_t m_last_source_out;
+
+	/* Used internally just for the sake of returning a reference */
+	const std::shared_ptr<sinsp_plugin> m_nullptr_ret;
 };

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1691,11 +1691,6 @@ std::string sinsp::get_filter() const
 	return m_filterstring;
 }
 
-std::shared_ptr<libsinsp::filter::ast::expr> sinsp::get_filter_ast()
-{
-	return m_internal_flt_ast;
-}
-
 bool sinsp::run_filters_on_evt(sinsp_evt *evt)
 {
 	//

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -670,7 +670,7 @@ bool sinsp::check_current_engine(const std::string& engine_name) const
 
 /*=============================== Engine related ===============================*/
 
-std::string sinsp::generate_gvisor_config(std::string socket_path)
+std::string sinsp::generate_gvisor_config(const std::string& socket_path)
 {
 	return gvisor_config::generate(socket_path);
 }
@@ -1800,7 +1800,7 @@ void sinsp::set_log_callback(sinsp_logger_callback cb)
 	}
 }
 
-void sinsp::set_log_file(std::string filename)
+void sinsp::set_log_file(const std::string& filename)
 {
 	libsinsp_logger()->add_file_log(filename);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -184,7 +184,7 @@ public:
 		scap_fseek(m_h, filepos);
 	}
 
-	std::string generate_gvisor_config(std::string socket_path);
+	std::string generate_gvisor_config(const std::string& socket_path);
 
 
 	/*!
@@ -338,7 +338,7 @@ public:
 	/*!
 	  \brief Instruct sinsp to write its log messages to the given file.
 	*/
-	void set_log_file(std::string filename);
+	void set_log_file(const std::string& filename);
 
 	/*!
 	  \brief Instruct sinsp to write its log messages to stderr.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -156,8 +156,6 @@ enum sinsp_mode_t
 class SINSP_PUBLIC sinsp : public capture_stats_source
 {
 public:
-	typedef std::shared_ptr<sinsp> ptr;
-
 	sinsp(bool static_container = false,
 		  const std::string &static_id = "",
 		  const std::string &static_name = "",
@@ -322,7 +320,10 @@ public:
 
 	  \return the AST (wrapped in a shared pointer) corresponding to the filter previously set with \ref set_filter()..
 	*/
-	std::shared_ptr<libsinsp::filter::ast::expr> get_filter_ast();
+	inline const std::shared_ptr<libsinsp::filter::ast::expr>& get_filter_ast()
+	{
+		return m_internal_flt_ast;
+	}
 
 	bool run_filters_on_evt(sinsp_evt *evt);
 
@@ -470,7 +471,7 @@ public:
 	  \brief Return sinsp stats v2 containing continually updated counters around thread and fd state tables.
 
 	*/
-	inline std::shared_ptr<sinsp_stats_v2> get_sinsp_stats_v2()
+	inline const std::shared_ptr<sinsp_stats_v2>& get_sinsp_stats_v2()
 	{
 		return m_sinsp_stats_v2;
 	}
@@ -1027,7 +1028,7 @@ public:
 
 	bool remove_inactive_threads();
 
-	inline std::shared_ptr<sinsp_threadinfo> add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo)
+	inline const std::shared_ptr<sinsp_threadinfo>& add_thread(std::unique_ptr<sinsp_threadinfo> ptinfo)
 	{
 		return m_thread_manager->add_thread(std::move(ptinfo), false);
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -212,10 +212,10 @@ void sinsp_filter_check_fspath::create_fspath_checks()
 	m_success_checks->emplace(PPME_SYSCALL_UMOUNT2_X, evt_arg_res_eq_0);
 }
 
-void sinsp_filter_check_fspath::set_fspath_checks(std::shared_ptr<filtercheck_map_t> success_checks,
-						  std::shared_ptr<filtercheck_map_t> path_checks,
-						  std::shared_ptr<filtercheck_map_t> source_checks,
-						  std::shared_ptr<filtercheck_map_t> target_checks)
+void sinsp_filter_check_fspath::set_fspath_checks(const std::shared_ptr<filtercheck_map_t>& success_checks,
+						  const std::shared_ptr<filtercheck_map_t>& path_checks,
+						  const std::shared_ptr<filtercheck_map_t>& source_checks,
+						  const std::shared_ptr<filtercheck_map_t>& target_checks)
 {
 	m_success_checks = success_checks;
 	m_path_checks = path_checks;
@@ -368,7 +368,7 @@ uint8_t* sinsp_filter_check_fspath::extract_single(sinsp_evt* evt, uint32_t* len
 
 bool sinsp_filter_check_fspath::extract_fspath(sinsp_evt* evt,
 					       std::vector<extract_value_t>& values,
-					       std::shared_ptr<filtercheck_map_t> checks)
+					       const std::shared_ptr<filtercheck_map_t>& checks)
 {
 	sinsp_evt* extract_evt = evt;
 

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -51,13 +51,13 @@ private:
 	std::shared_ptr<sinsp_filter_check> create_fd_check(const char *name);
 
 	void create_fspath_checks();
-	void set_fspath_checks(std::shared_ptr<filtercheck_map_t> success_checks,
-			       std::shared_ptr<filtercheck_map_t> path_checks,
-			       std::shared_ptr<filtercheck_map_t> source_checks,
-			       std::shared_ptr<filtercheck_map_t> target_checks);
+	void set_fspath_checks(const std::shared_ptr<filtercheck_map_t>& success_checks,
+			       const std::shared_ptr<filtercheck_map_t>& path_checks,
+			       const std::shared_ptr<filtercheck_map_t>& source_checks,
+			       const std::shared_ptr<filtercheck_map_t>& target_checks);
 	bool extract_fspath(sinsp_evt* evt,
 			    std::vector<extract_value_t>& values,
-			    std::shared_ptr<filtercheck_map_t> map);
+			    const std::shared_ptr<filtercheck_map_t>& map);
 	std::string m_tstr;
 
 	std::shared_ptr<filtercheck_map_t> m_success_checks;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -111,8 +111,6 @@ Json::Value sinsp_filter_check_gen_event::extract_as_js(sinsp_evt *evt, uint32_t
 
 uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, uint32_t* len, bool sanitize_strings)
 {
-
-	std::shared_ptr<sinsp_plugin> plugin;
 	const scap_machine_info* minfo;
 
 	*len = 0;
@@ -163,7 +161,8 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, uint32_t* 
 		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_PLUGINNAME:
 	case TYPE_PLUGININFO:
-		plugin = m_inspector->get_plugin_manager()->plugin_by_evt(evt);
+	{
+		const auto& plugin = m_inspector->get_plugin_manager()->plugin_by_evt(evt);
 		if (plugin == nullptr)
 		{
 			return NULL;
@@ -179,6 +178,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt *evt, uint32_t* 
 		}
 
 		RETURN_EXTRACT_STRING(m_strstorage);
+	}
 	case TYPE_SOURCE:
 		if (evt->get_source_idx() == sinsp_no_event_source_idx
 			|| evt->get_source_name() == sinsp_no_event_source_name)

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -105,12 +105,12 @@ public:
      * be allocated and accessible for all the present and future entries
      * present in the table.
      */
-    virtual std::shared_ptr<dynamic_struct::field_infos> dynamic_fields() const
+    virtual const std::shared_ptr<dynamic_struct::field_infos>& dynamic_fields() const
     {
         return m_dynamic_fields;
     }
 
-    virtual void set_dynamic_fields(std::shared_ptr<dynamic_struct::field_infos> dynf)
+    virtual void set_dynamic_fields(const std::shared_ptr<dynamic_struct::field_infos>& dynf)
     {
         if (!dynf)
         {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -628,7 +628,7 @@ void sinsp_threadinfo::set_args(const char* args, size_t len)
 	set_args(sinsp_split(args, len, '\0'));
 }
 
-void sinsp_threadinfo::set_args(std::vector<std::string> args)
+void sinsp_threadinfo::set_args(const std::vector<std::string>& args)
 {
 	m_args = args;
 }
@@ -742,11 +742,11 @@ void sinsp_threadinfo::set_cgroups(const char* cgroups, size_t len)
 	set_cgroups(sinsp_split(cgroups, len, '\0'));
 }
 
-void sinsp_threadinfo::set_cgroups(std::vector<std::string> cgroups)
+void sinsp_threadinfo::set_cgroups(const std::vector<std::string>& cgroups)
 {
-	decltype(m_cgroups) tmp_cgroups(new cgroups_t);
+	auto tmp_cgroups = std::make_unique<sinsp_threadinfo::cgroups_t>();
 
-	for( auto &def : cgroups)
+	for(const auto &def : cgroups)
 	{
 		std::string::size_type eq_pos = def.find("=");
 		if (eq_pos == std::string::npos)
@@ -2050,7 +2050,7 @@ const threadinfo_map_t::ptr_t& sinsp_thread_manager::get_thread_ref(int64_t tid,
         {
             libsinsp_logger()->format(sinsp_logger::SEV_INFO, "%s: Unable to complete for tid=%"
                             PRIu64 ": sinsp::scap_t* is uninitialized", __func__, tid);
-            return NULL;
+            return m_nullptr_tinfo_ret;
         }
 
         scap_threadinfo scap_proc {};

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -640,10 +640,10 @@ public:
 	void remove_fd(int64_t fd);
 	void update_cwd(std::string_view cwd);
 	void set_args(const char* args, size_t len);
-	void set_args(std::vector<std::string> args);
+	void set_args(const std::vector<std::string>& args);
 	void set_env(const char* env, size_t len);
 	void set_cgroups(const char* cgroups, size_t len);
-	void set_cgroups(std::vector<std::string> cgroups);
+	void set_cgroups(const std::vector<std::string>& cgroups);
 	bool is_lastevent_data_valid() const;
 	inline void set_lastevent_data_validity(bool isvalid)
 	{

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -869,7 +869,7 @@ void sinsp_utils::split_container_image(const std::string &image,
 					std::string &digest,
 					bool split_repo)
 {
-	auto split = [](const std::string &src, std::string &part1, std::string &part2, const std::string sep)
+	auto split = [](const std::string &src, std::string &part1, std::string &part2, const std::string& sep)
 	{
 		size_t pos = src.find(sep);
 		if(pos != std::string::npos)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When looking at performance profiles of Falco, I discovered that we unwillingly pass variables by value more than needed. Specially with shared pointers, we occasionally prevent compilers from inlining and eliding reference counting that causes a non-negligible cost when running on high event throughput. At the same time, we use shared pointers even when not needed on internal functions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/milestone 0.18.0

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/libsinsp): assorted pass-by-reference performance optimizations
```
