### PR TITLE
new(ci): add libsinsp unit test code coverage

### DIFF
--- a/.github/workflows/test_coverage_ci.yml
+++ b/.github/workflows/test_coverage_ci.yml
@@ -1,0 +1,52 @@
+name: Test Coverage CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# Checks if any concurrent jobs under the same pull request or branch are being executed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test-libsinsp-coverage:
+    name: unit-test-libsinsp-coverage 🧐
+    runs-on: 'ubuntu-22.04'
+    container:
+      image: debian:buster
+    steps:
+      - name: Install deps ⛓️
+        run: |
+          apt update && apt install -y --no-install-recommends ca-certificates \
+            cmake build-essential git clang llvm pkg-config autoconf automake \
+            libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev \
+            libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc \
+            libgtest-dev libprotobuf-dev linux-headers-amd64 \
+            gcovr
+
+      - name: Checkout Libs ⤵️
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Install deps ⛓️
+        run: |
+          .github/install-deps.sh
+
+      - name: Git safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Build and test 🏗️🧪
+        run: |
+          mkdir -p build
+          cd build && cmake -DBUILD_WARNINGS_AS_ERRORS=True -DENABLE_COVERAGE=True -DUSE_BUNDLED_DEPS=False ../
+          KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4
+          make run-unit-tests
+
+      - name: Generate libsinsp coverage report
+        run: |
+          gcovr --filter ".*/userspace/libsinsp/.*" --exclude ".*/third-party/.*" --xml -o ./libsinsp.coverage.xml
+

--- a/.github/workflows/test_coverage_ci.yml
+++ b/.github/workflows/test_coverage_ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: unit-test-libsinsp-coverage 🧐
     runs-on: 'ubuntu-22.04'
     container:
-      image: debian:buster
+      image: debian:bookworm
     steps:
       - name: Install deps ⛓️
         run: |
@@ -24,7 +24,7 @@ jobs:
             libtool libelf-dev wget libc-ares-dev libcurl4-openssl-dev libssl-dev \
             libtbb-dev libjq-dev libjsoncpp-dev libgrpc++-dev protobuf-compiler-grpc \
             libgtest-dev libprotobuf-dev linux-headers-amd64 \
-            gcovr
+            gpg gpg-agent gcovr
 
       - name: Checkout Libs ⤵️
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -50,3 +50,11 @@ jobs:
         run: |
           gcovr --filter ".*/userspace/libsinsp/.*" --exclude ".*/third-party/.*" --xml -o ./libsinsp.coverage.xml
 
+      - name: Upload to codecov
+        uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3 # v4.5.0
+        with:
+          fail_ci_if_error: true
+          files: ./libsinsp.coverage.xml
+          flags: libsinsp
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Add code coverage reports for libsinsp unit tests via [codecov](https://about.codecov.io/)

Part of: https://github.com/falcosecurity/libs/issues/1784

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
