### PR TITLE
fix(ci): introduce "libsinsp" component for test coverage

### DIFF
--- a/.github/workflows/test_coverage_ci.yml
+++ b/.github/workflows/test_coverage_ci.yml
@@ -48,13 +48,12 @@ jobs:
 
       - name: Generate libsinsp coverage report
         run: |
-          gcovr --filter ".*/userspace/libsinsp/.*" --exclude ".*/third-party/.*" --xml -o ./libsinsp.coverage.xml
+          gcovr --xml -o ./libsinsp.coverage.xml
 
       - name: Upload to codecov
         uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3 # v4.5.0
         with:
           fail_ci_if_error: true
           files: ./libsinsp.coverage.xml
-          flags: libsinsp
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+component_management:
+  individual_components:
+    - component_id: libsinsp
+      name: libsinsp
+      paths:
+        - userspace/libsinsp/**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

It seems like we can specify a "component" in this case `libsinsp` so we can have coverage there. The actual line coverage computed locally is about 74% but codecov seems to compute percentages a bit differently, probably because it factors in branch coverage somehow. Anyhow, let's add the `libsinsp` component

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
