### PR TITLE
fix(libsinsp): add function to set compiler filter and filter string

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1661,7 +1661,7 @@ void sinsp::start_dropping_mode(uint32_t sampling_ratio)
 }
 #endif // _WIN32
 
-void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter, const std::optional<std::string>& filterstring)
+void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter, const std::string& filterstring)
 {
 	if(m_filter != NULL)
 	{
@@ -1670,7 +1670,7 @@ void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter, const std::optional
 	}
 
 	m_filter = std::move(filter);
-	m_filterstring = filterstring.value_or("");
+	m_filterstring = filterstring;
 }
 
 void sinsp::set_filter(const std::string& filter)

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1661,7 +1661,7 @@ void sinsp::start_dropping_mode(uint32_t sampling_ratio)
 }
 #endif // _WIN32
 
-void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter)
+void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter, const std::optional<std::string>& filterstring)
 {
 	if(m_filter != NULL)
 	{
@@ -1670,6 +1670,7 @@ void sinsp::set_filter(std::unique_ptr<sinsp_filter> filter)
 	}
 
 	m_filter = std::move(filter);
+	m_filterstring = filterstring.value_or("");
 }
 
 void sinsp::set_filter(const std::string& filter)
@@ -1685,13 +1686,6 @@ void sinsp::set_filter(const std::string& filter)
 	m_filterstring = filter;
 	m_internal_flt_ast = compiler.get_filter_ast();
 }
-
-void sinsp::set_filter(const std::string& filterstring, std::unique_ptr<sinsp_filter> filter)
-{
-	set_filter(std::move(filter));
-	m_filterstring = filterstring;
-}
-
 
 std::string sinsp::get_filter() const
 {

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1686,6 +1686,13 @@ void sinsp::set_filter(const std::string& filter)
 	m_internal_flt_ast = compiler.get_filter_ast();
 }
 
+void sinsp::set_filter(const std::string& filterstring, std::unique_ptr<sinsp_filter> filter)
+{
+	set_filter(std::move(filter));
+	m_filterstring = filterstring;
+}
+
+
 std::string sinsp::get_filter() const
 {
 	return m_filterstring;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -303,7 +303,7 @@ public:
 
 	  \param filter the runtime filter object
 	*/
-	void set_filter(std::unique_ptr<sinsp_filter> filter, const std::optional<std::string>& filterstring);
+	void set_filter(std::unique_ptr<sinsp_filter> filter, const std::string& filterstring = "");
 
 	/*!
 	  \brief Return the filter set for this capture.

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -306,6 +306,17 @@ public:
 	void set_filter(std::unique_ptr<sinsp_filter> filter);
 
 	/*!
+	  \brief Installs the given capture runtime filter object and accordingly
+	  sets the filter string.
+
+	  \param filter the filter string. Refer to the filtering language
+	   section for information about the filtering
+	   syntax.
+	  \param filter the runtime filter object
+	*/
+	void set_filter(const std::string& filterstring, std::unique_ptr<sinsp_filter> filter);
+
+	/*!
 	  \brief Return the filter set for this capture.
 
 	  \return the filter previously set with \ref set_filter(), or an empty

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -303,18 +303,7 @@ public:
 
 	  \param filter the runtime filter object
 	*/
-	void set_filter(std::unique_ptr<sinsp_filter> filter);
-
-	/*!
-	  \brief Installs the given capture runtime filter object and accordingly
-	  sets the filter string.
-
-	  \param filter the filter string. Refer to the filtering language
-	   section for information about the filtering
-	   syntax.
-	  \param filter the runtime filter object
-	*/
-	void set_filter(const std::string& filterstring, std::unique_ptr<sinsp_filter> filter);
+	void set_filter(std::unique_ptr<sinsp_filter> filter, const std::optional<std::string>& filterstring);
 
 	/*!
 	  \brief Return the filter set for this capture.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

When setting the compiled filter through `set_filter`, we lose the filter string information and never populate the `m_filterstring`. This adds a method to set them both.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
