### PR TITLE
chore(ci): add an empty run for scap file before perf'ing it.

### DIFF
--- a/.github/actions/composite-perf/action.yml
+++ b/.github/actions/composite-perf/action.yml
@@ -38,8 +38,6 @@ runs:
         cd build
         wget https://download.falco.org/fixtures/trace-files/traces-positive.zip
         unzip traces-positive.zip
-        mkdir -p /dev/shm/libs-${{ github.run_id }}
-        mv traces-positive/falco-event-generator.scap /dev/shm/libs-${{ github.run_id }}/falco-event-generator.scap
 
     - name: Run - perf unit tests
       shell: bash
@@ -47,11 +45,18 @@ runs:
         cd build
         sudo perf record --call-graph dwarf -o perf_tests.data -q libsinsp/test/unit-test-libsinsp
 
+    # First empty run to stabilize disk IO (scap file read) perf
+    - name: Run - load scap file
+      shell: bash
+      run: |
+        cd build
+        sudo ./libsinsp/examples/sinsp-example -s traces-positive/falco-event-generator.scap &> /dev/null
+
     - name: Run - perf scap file
       shell: bash
       run: |
         cd build
-        sudo nice ionice -c 1 -n 0 perf record --call-graph dwarf -o perf_scap.data -q ./libsinsp/examples/sinsp-example -s /dev/shm/libs-${{ github.run_id }}/falco-event-generator.scap
+        sudo perf record --call-graph dwarf -o perf_scap.data -q ./libsinsp/examples/sinsp-example -s traces-positive/falco-event-generator.scap
 
     - name: Run - heaptrack unit tests
       shell: bash
@@ -63,11 +68,7 @@ runs:
       shell: bash
       run: |
         cd build
-        sudo nice ionice -c 1 -n 0 heaptrack -o heaptrack_scap.data ./libsinsp/examples/sinsp-example -s /dev/shm/libs-${{ github.run_id }}/falco-event-generator.scap
-
-    - name: Cleanup tmpfs
-      shell: bash
-      run: rm -rf /dev/shm/libs-${{ github.run_id }}/
+        sudo heaptrack -o heaptrack_scap.data ./libsinsp/examples/sinsp-example -s traces-positive/falco-event-generator.scap
 
     - name: Set Outputs
       id: store-outputs


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Add a step where the scap file gets loaded (read by sinsp-example) before `perf`ing it, so that we get more stable results.
Also, removed /dev/shm tmpfs workaround introduced in #1975 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
