### PR TITLE
chore: add CMakePresets.json file

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,41 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "scap-drivers",
+            "displayName": "Build scap drivers and their tests",
+            "description": "Build all scap drivers (modern eBPF, legacy eBPF, kmod) and their tests",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-scap-drivers",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_BPF": "ON",
+                "BUILD_DRIVER": "ON",
+                "USE_BUNDLED_DEPS": "ON",
+                "ENABLE_DRIVERS_TESTS": "ON",
+                "MODERN_BPF_DEBUG_MODE": "ON",
+                "BUILD_LIBSCAP_MODERN_BPF": "ON",
+                "BUILD_LIBSCAP_GVISOR": "OFF",
+                "CREATE_TEST_TARGETS": "ON",
+                "ENABLE_LIBSCAP_TESTS": "ON",
+                "SCAP_FILES_SUITE_ENABLE": "OFF"
+            }
+        },
+        {
+            "name": "sinsp-minimal",
+            "displayName": "Build sinsp in minimal build",
+            "description": "Build sinsp in minimal build with its tests",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build-sinsp-minimal",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_DRIVER": "ON",
+                "BUILD_BPF": "ON",
+                "USE_BUNDLED_DEPS": "ON",
+                "CREATE_TEST_TARGETS": "ON",
+                "MINIMAL_BUILD": "ON",
+                "SCAP_FILES_SUITE_ENABLE": "OFF"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

These days I'm building scap drivers tests over several machines and every time I need to type an infinite cmake to configure them (getting it wrong every time). If you are like me this `CMakePresets.json` file should help you. Configure drivers test should be as simple as:

```bash
cmake --presets scap-drivers
```

Then to build different targets you should enter the directory created for you by the preset and run the `make` command`

```bash
cd build-scap-drivers
make drivers_test
make scap-open
make libscap_test
...
```

Here I provide just 2 presets that I often use while developing, i hope this could be useful to other folks who build libs every day

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

You can read more on presets usage here https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
