### PR TITLE
fix(libsinsp/test): use correct iterator type in plugin tests

### DIFF
--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -718,8 +718,8 @@ TEST_F(sinsp_with_test_input, plugin_subtables)
 
 	// get an accessor to a dynamic field declared by the plugin
 	ASSERT_EQ(subtable->dynamic_fields()->fields().size(), 1);
-	const auto& dfield = subtable->dynamic_fields()->fields().find("custom");
-	ASSERT_NE(dfield, table->dynamic_fields()->fields().end());
+	auto dfield = subtable->dynamic_fields()->fields().find("custom");
+	ASSERT_NE(dfield, subtable->dynamic_fields()->fields().end());
 	auto dfieldacc = dfield->second.new_accessor<std::string>();
 
 	// start the event capture
@@ -792,8 +792,8 @@ TEST_F(sinsp_with_test_input, plugin_subtables_array)
 
 	// get an accessor to a dynamic field representing the array's values
 	ASSERT_EQ(subtable->dynamic_fields()->fields().size(), 1);
-	const auto& dfield = subtable->dynamic_fields()->fields().find("value");
-	ASSERT_NE(dfield, table->dynamic_fields()->fields().end());
+	auto dfield = subtable->dynamic_fields()->fields().find("value");
+	ASSERT_NE(dfield, subtable->dynamic_fields()->fields().end());
 	ASSERT_EQ(dfield->second.readonly(), false);
 	ASSERT_EQ(dfield->second.valid(), true);
 	ASSERT_EQ(dfield->second.name(), "value");

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -461,11 +461,11 @@ TEST(thread_manager, fdtable_access)
 
 	//checking if the new field has been added
 	ASSERT_EQ(subtable->dynamic_fields()->fields().size(), 1);
-	ASSERT_NE(subtable->dynamic_fields()->fields().find("str_val"), table->dynamic_fields()->fields().end());
+	ASSERT_NE(subtable->dynamic_fields()->fields().find("str_val"), subtable->dynamic_fields()->fields().end());
 
 	//checking if the new field has been added to the other subtable
 	ASSERT_EQ(subtable2->dynamic_fields()->fields().size(), 1);
-	ASSERT_NE(subtable2->dynamic_fields()->fields().find("str_val"), table->dynamic_fields()->fields().end());
+	ASSERT_NE(subtable2->dynamic_fields()->fields().find("str_val"), subtable2->dynamic_fields()->fields().end());
 
 	auto sfieldacc = sfield->second.new_accessor<int64_t>();
 	auto dfieldacc = dfield.new_accessor<std::string>();


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

It is incorrect to do `something.find("...") != something_else.end()`. Some debug versions will error on this. Fix this in tests.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
