### PR TITLE
cleanup(libsinsp): update g_invalidchar for windows

### DIFF
--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -173,9 +173,10 @@ struct g_invalidchar
 {
 	bool operator()(char c) const
 	{
+		unsigned char uc = static_cast<unsigned char>(c);
 		// Exclude all non-printable characters and control characters while
 		// including a wide range of languages (emojis, cyrillic, chinese etc)
-		return !(isprint((unsigned)c));
+		return (!(isprint(uc)));
 	}
 };
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In some setups (Windows, for instance) the `isprint()` check might fail in debug mode for chars outside of that range.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(libsinsp): do not crash on g_invalidchar in windows debug builds
```
