### PR TITLE
fix(libsinsp): check ipvXnet size before comparing

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -1501,17 +1501,33 @@ bool sinsp_filter_check_fd::compare_net(sinsp_evt *evt)
 	switch (m_fdinfo->m_type)
 	{
 	case SCAP_FD_IPV4_SERVSOCK:
+		if (filter_value_len() != sizeof(ipv4net))
+		{
+			return m_cmpop == CO_NE;
+		}
 		return flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, (ipv4net*)filter_value_p());
 
 	case SCAP_FD_IPV6_SERVSOCK:
+		if (filter_value_len() != sizeof(ipv6net))
+		{
+			return m_cmpop == CO_NE;
+		}
 		return flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, (ipv6net*)filter_value_p());
 
 	case SCAP_FD_IPV4_SOCK:
+		if (filter_value_len() != sizeof(ipv4net))
+		{
+			return m_cmpop == CO_NE;
+		}
 		sip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, (ipv4net*)filter_value_p());
 		dip_cmp = flt_compare_ipv4net(m_cmpop, m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, (ipv4net*)filter_value_p());
 		break;
 
 	case SCAP_FD_IPV6_SOCK:
+		if (filter_value_len() != sizeof(ipv6net))
+		{
+			return m_cmpop == CO_NE;
+		}
 		sip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, (ipv6net*)filter_value_p());
 		dip_cmp = flt_compare_ipv6net(m_cmpop, &m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, (ipv6net*)filter_value_p());
 		break;

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -110,6 +110,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_op_bcontains.ut.cpp
 	filter_op_contains.ut.cpp
 	filter_op_pmatch.ut.cpp
+	filter_op_net_compare.ut.cpp
 	filter_op_numeric_compare.ut.cpp
 	filter_compiler.ut.cpp
 	filter_transformer.ut.cpp
@@ -140,6 +141,7 @@ if(WIN32)
 		events_net.ut.cpp
 		events_proc.ut.cpp
 		events_user.ut.cpp
+		filter_op_net_compare.ut.cpp
 		user.ut.cpp
 		thread_table.ut.cpp
 		public_sinsp_API/sinsp_logger.cpp
@@ -147,6 +149,7 @@ if(WIN32)
 elseif(APPLE OR EMSCRIPTEN)
 	list(REMOVE_ITEM LIBSINSP_UNIT_TESTS_SOURCES
 		events_net.ut.cpp
+		filter_op_net_compare.ut.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/parsers/parse_connect.cpp
 	)
 endif()

--- a/userspace/libsinsp/test/filter_op_net_compare.ut.cpp
+++ b/userspace/libsinsp/test/filter_op_net_compare.ut.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <libsinsp/sinsp.h>
+#include <gtest/gtest.h>
+
+#include <sinsp_with_test_input.h>
+
+TEST_F(sinsp_with_test_input, net_ipv4_compare)
+{
+	add_default_init_thread();
+	open_inspector();
+	sinsp_evt* evt = NULL;
+
+	int64_t client_fd = 9;
+	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, (uint32_t) PPM_AF_INET, (uint32_t) SOCK_STREAM, (uint32_t) 0);
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_X, 1, client_fd);
+
+	int64_t return_value = 0;
+
+	sockaddr_in client = test_utils::fill_sockaddr_in(54321, "172.40.111.222");
+	sockaddr_in server = test_utils::fill_sockaddr_in(443, "142.251.111.147");
+
+	std::vector<uint8_t> server_sockaddr = test_utils::pack_sockaddr(reinterpret_cast<sockaddr*>(&server));
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, client_fd, scap_const_sized_buffer{server_sockaddr.data(), server_sockaddr.size()});
+
+	std::vector<uint8_t> socktuple = test_utils::pack_socktuple(reinterpret_cast<sockaddr*>(&client), reinterpret_cast<sockaddr*>(&server));
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 3, return_value, scap_const_sized_buffer{socktuple.data(), socktuple.size()}, client_fd);
+
+	EXPECT_TRUE(eval_filter(evt, "fd.ip == 142.251.111.147"));
+	EXPECT_TRUE(eval_filter(evt, "fd.sip == 142.251.111.147"));
+	EXPECT_TRUE(eval_filter(evt, "fd.lip == 142.251.111.147"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.rip == 172.40.111.222"));
+	EXPECT_TRUE(eval_filter(evt, "fd.cip == 172.40.111.222"));
+
+	EXPECT_FALSE(eval_filter(evt, "fd.ip != 142.251.111.147"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.sip != 0:0:0:0:0:0:0:1"));
+	EXPECT_FALSE(eval_filter(evt, "fd.sip == '0:0:0:0:0:0:0:1'"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 142.0.0.0/4"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 142.251.0.0/8"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 142.251.111.0/16"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net != 10.0.0.0/8"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net != 2001:db8:abcd:0012::0/64"));
+
+	EXPECT_FALSE(eval_filter(evt, "fd.net == 10.0.0.0/8"));
+	EXPECT_FALSE(eval_filter(evt, "fd.net == 2001:db8:abcd:0012::0/64"));
+}
+
+TEST_F(sinsp_with_test_input, net_ipv6_compare)
+{
+	add_default_init_thread();
+	open_inspector();
+	sinsp_evt* evt = NULL;
+
+	int64_t client_fd = 9;
+	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_E, 3, (uint32_t) PPM_AF_INET6, (uint32_t) SOCK_DGRAM, (uint32_t) 0);
+	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_SOCKET_X, 1, client_fd);
+
+	int64_t return_value = 0;
+
+	sockaddr_in6 client = test_utils::fill_sockaddr_in6(54321, "::1");
+	sockaddr_in6 server1 = test_utils::fill_sockaddr_in6(443, "2001:4860:4860::8888");
+
+	std::vector<uint8_t> server1_sockaddr = test_utils::pack_sockaddr(reinterpret_cast<sockaddr*>(&server1));
+
+	add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, client_fd, scap_const_sized_buffer{server1_sockaddr.data(), server1_sockaddr.size()});
+
+	std::vector<uint8_t> socktuple = test_utils::pack_socktuple(reinterpret_cast<sockaddr*>(&client), reinterpret_cast<sockaddr*>(&server1));
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_X, 3, return_value, scap_const_sized_buffer{socktuple.data(), socktuple.size()}, client_fd);
+
+	EXPECT_TRUE(eval_filter(evt, "fd.ip == 2001:4860:4860::8888"));
+	EXPECT_TRUE(eval_filter(evt, "fd.sip == 2001:4860:4860::8888"));
+	EXPECT_TRUE(eval_filter(evt, "fd.lip == 2001:4860:4860::8888"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.rip == ::1"));
+	EXPECT_TRUE(eval_filter(evt, "fd.cip == ::1"));
+
+	EXPECT_FALSE(eval_filter(evt, "fd.ip != 2001:4860:4860::8888"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.sip != 127.0.0.1"));
+	EXPECT_FALSE(eval_filter(evt, "fd.sip == '127.0.0.1'"));
+
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 2001::0/16"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 2001:4860::0/32"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net == 2001:4860:4860::8888/48"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net != 10::0/16"));
+	EXPECT_TRUE(eval_filter(evt, "fd.net != 10.0.0.0/8"));
+
+	EXPECT_FALSE(eval_filter(evt, "fd.net == 10.0.0.0/8"));
+	EXPECT_FALSE(eval_filter(evt, "fd.net == 2001:db8:abcd:0012::0/64"));
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Very similar to https://github.com/falcosecurity/libs/pull/1953 but in the "fd.net" part of the filterchecks. In this case we could get a type confusion for the parameter value, leading to an incorrect comparison (ipv4 vs ipv6).

We still need tests for these cases because they are very tricky.

cc @jasondellaluce , can you think of other places where this may happen?

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): check ipv4/ipv6 size on fd.*net comparisons
```
