### PR TITLE
fix(sinsp): fix `fs.path` filterchecks for relative paths (add `dirfd` concept)

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2531,14 +2531,17 @@ std::string sinsp_parser::parse_dirfd(sinsp_evt *evt, std::string_view name, int
 		return ".";
 	}
 
+	if(evt->get_tinfo() == NULL)
+	{
+		// In this case we can
+		// - neither retrieve the cwd when dirfd == PPM_AT_FDCWD
+		// - nor attempt to query the threadtable for the dirfd fd_info
+		return "<UNKNOWN>";
+	}
+
 	if(dirfd == PPM_AT_FDCWD)
 	{
-		if(evt->get_tinfo() != NULL)
-		{
-			return evt->get_tinfo()->get_cwd();
-		}
-
-		return "<UNKNOWN>";
+		return evt->get_tinfo()->get_cwd();
 	}
 
 	evt->set_fd_info(evt->get_tinfo()->get_fd(dirfd));

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2736,7 +2736,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 
 		name = evt->get_param(3)->as<std::string_view>();
 
-		if(etype == PPME_SYSCALL_OPEN_BY_HANDLE_AT_X && evt->get_num_params() > 4)
+		if(evt->get_num_params() > 4)
 		{
 			dev = evt->get_param(4)->as<uint32_t>();
 			if (evt->get_num_params() > 5)
@@ -2745,7 +2745,8 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 			}
 		}
 
-		// since open_by_handle_at returns an absolute path we will always start at /
+		// The driver implementation always serves an absolute path for open_by_handle_at using dpath traversal;
+		// hence there is no need to interpret the path relative to mountfd.
 		sdir = "";
 	}
 	else

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -58,6 +58,7 @@ private:
 	bool extract_fspath(sinsp_evt* evt,
 			    std::vector<extract_value_t>& values,
 			    const std::shared_ptr<filtercheck_map_t>& map);
+	std::string parse_dirfd_stateless(sinsp_evt *evt, std::string_view name, int64_t dirfd);
 	std::string m_tstr;
 
 	std::shared_ptr<filtercheck_map_t> m_success_checks;

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.h
@@ -58,7 +58,7 @@ private:
 	bool extract_fspath(sinsp_evt* evt,
 			    std::vector<extract_value_t>& values,
 			    const std::shared_ptr<filtercheck_map_t>& map);
-	std::string parse_dirfd_stateless(sinsp_evt *evt, std::string_view name, int64_t dirfd);
+
 	std::string m_tstr;
 
 	std::shared_ptr<filtercheck_map_t> m_success_checks;

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -64,7 +64,7 @@ protected:
 	int64_t res = 0;
 	int64_t failed_res = -1;
 	int64_t evt_dirfd = 2;
-	int64_t evt_dirfd_cwd = AT_FDCWD;
+	int64_t evt_dirfd_cwd = PPM_AT_FDCWD;
 	int64_t olddirfd = evt_dirfd;
 	int64_t newdirfd = evt_dirfd;
 	int64_t linkdirfd = evt_dirfd;

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -213,7 +213,8 @@ protected:
 			case PPME_SYSCALL_UNLINKAT_2_X:
 				{
 					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 2, evt_dirfd, dirfd_path);
-					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 5, evt_dirfd, evt_dirfd, dirfd_path, open_flags, mode);
+					// pass PPM_O_DIRECTORY since we are creating a folder!
+					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 5, evt_dirfd, evt_dirfd, dirfd_path, open_flags | PPM_O_DIRECTORY, mode);
 				}
 				break;	
 			default:
@@ -242,7 +243,7 @@ protected:
 			case PPME_SYSCALL_SYMLINKAT_X:
 				{
 					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 2, evt_dirfd, dirfd_path);
-					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 5, evt_dirfd, evt_dirfd, dirfd_path, open_flags, mode);
+					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 5, evt_dirfd, evt_dirfd, dirfd_path, open_flags | PPM_O_DIRECTORY, mode);
 				}
 				break;
 			default:

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -50,7 +50,9 @@ protected:
 	const char *rel_oldpath = "tmp/oldpath";
 	const char *rel_newpath = "tmp/newpath";
 	const char *resolved_rel_oldpath = "/root/tmp/oldpath";
+	const char *resolved_rel_oldpath_at = "/tmp/dirfd1/dirfd2/dirfd3/dirfd4/dirfd5/dirfd6/dirfd7/dirfd8/tmp/oldpath";
 	const char *resolved_rel_newpath = "/root/tmp/newpath";
+	const char *resolved_rel_newpath_at = "/tmp/dirfd1/dirfd2/dirfd3/dirfd4/dirfd5/dirfd6/dirfd7/dirfd8/tmp/newpath";
 	const char *linkpath = "/tmp/linkpath";
 	const char *targetpath = "/tmp/targetpath";
 	const char *rel_linkpath = "tmp/linkpath";
@@ -241,6 +243,7 @@ protected:
 		{
 			case PPME_SYSCALL_LINKAT_2_X:
 			case PPME_SYSCALL_SYMLINKAT_X:
+			case PPME_SYSCALL_RENAMEAT2_X:
 				{
 					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_E, 2, evt_dirfd, dirfd_path);
 					add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPENAT2_X, 5, evt_dirfd, evt_dirfd, dirfd_path, open_flags | PPM_O_DIRECTORY, mode);
@@ -526,6 +529,14 @@ TEST_F(fspath, renameat2)
 	test_enter(PPME_SYSCALL_RENAMEAT2_E, 0);
 	test_exit_source_target(oldpath, oldpath, newpath, newpath, PPME_SYSCALL_RENAMEAT2_X, 5, res, olddirfd, oldpath, newdirfd, newpath, flags);
 	test_failed_exit(PPME_SYSCALL_RENAMEAT2_X, 5, failed_res, olddirfd, oldpath, newdirfd, newpath, flags);
+}
+
+TEST_F(fspath, renameat2_relative)
+{
+	test_enter(PPME_SYSCALL_RENAMEAT2_E, 0);
+	test_exit_source_target(resolved_rel_oldpath_at, rel_oldpath,
+					resolved_rel_newpath_at, rel_newpath,
+					PPME_SYSCALL_RENAMEAT2_X, 5, res, olddirfd, rel_oldpath, newdirfd, rel_newpath, flags);
 }
 
 TEST_F(fspath, link)

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -30,6 +30,7 @@ protected:
 	const char *resolved_filename = "/tmp/filename.txt";
 	const char *rel_filename = "tmp/filename.txt";
 	const char *resolved_rel_filename_cwd = "/root/tmp/filename.txt";
+	const char *resolved_rel_filename2_cwd = "/root/tmp/name.txt";
 
 	const char *rel_filename_complex = "../\\.../../tmp/filename_complex";
 	const char *resolved_rel_filename_complex = "/tmp/dirfd1/dirfd2/dirfd3/dirfd4/dirfd5/dirfd6/dirfd7/tmp/filename_complex";
@@ -173,14 +174,14 @@ protected:
 		}
 		switch (event_type)
 		{
-			// case PPME_SYSCALL_OPENAT_2_X: // those 2 are currently failing
-			// case PPME_SYSCALL_OPENAT2_X:
+			case PPME_SYSCALL_OPENAT_2_X: // involves dirfd resolution
+			case PPME_SYSCALL_OPENAT2_X: // involves dirfd resolution
 			case PPME_SYSCALL_OPEN_X:
 			case PPME_SYSCALL_OPEN_BY_HANDLE_AT_X:
 				{
 					verify_fd_name_same_fs_path_name(evt);
 				}
-				break;	
+				break;
 			default:
 				break;
 		}
@@ -365,20 +366,19 @@ TEST_F(fspath, openat2)
 	test_failed_exit(PPME_SYSCALL_OPENAT2_X, 6, failed_res, evt_dirfd, name, open_flags, mode, resolve);
 }
 
-TEST_F(fspath, openat2_relative)
+TEST_F(fspath, openat2_relative_dirfd)
 {
 	test_enter(PPME_SYSCALL_OPENAT2_E, 5, evt_dirfd, name, open_flags, mode, resolve);
 	test_exit_path(resolved_rel_name, rel_name, PPME_SYSCALL_OPENAT2_X, 6, fd, evt_dirfd, rel_name, open_flags, mode, resolve);
 	test_failed_exit(PPME_SYSCALL_OPENAT2_X, 6, failed_res, evt_dirfd, name, open_flags, mode, resolve);
 }
 
-TEST_F(fspath, openat2_relative_dirfd_cwd)
+TEST_F(fspath, openat2_relative_cwd)
 {
 	// Also test scenario where relative path should be interpreted relative to the cwd and not dirfd
-	const char *resolved_rel_name_dirfd_cwd = "/root/tmp/name.txt";
-	test_enter(PPME_SYSCALL_OPENAT2_E, 5, PPM_AT_FDCWD, name, open_flags, mode, resolve);
-	test_exit_path(resolved_rel_name_dirfd_cwd, rel_name, PPME_SYSCALL_OPENAT2_X, 6, fd, PPM_AT_FDCWD, rel_name, open_flags, mode, resolve);
-	test_failed_exit(PPME_SYSCALL_OPENAT2_X, 6, failed_res, PPM_AT_FDCWD, name, open_flags, mode, resolve);
+	test_enter(PPME_SYSCALL_OPENAT2_E, 5, evt_dirfd_cwd, name, open_flags, mode, resolve);
+	test_exit_path(resolved_rel_filename2_cwd, rel_name, PPME_SYSCALL_OPENAT2_X, 6, fd, evt_dirfd_cwd, rel_name, open_flags, mode, resolve);
+	test_failed_exit(PPME_SYSCALL_OPENAT2_X, 6, failed_res, evt_dirfd_cwd, name, open_flags, mode, resolve);
 }
 
 TEST_F(fspath, fchmodat)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

While working on the anomalydetection plugin i was looking into the fd fallbacks and noticed that there are a few cases off in libs.
- `fs.path` fields incorrectly do not incorporate the concept of `dirfd` and as such they differ from the more correct `fd.name` value if applicable.
- Missing `dirfd` handling for `PPME_SYSCALL_OPEN_BY_HANDLE_AT_X` throughout.

@LucaGuerra and @FedeDP (when you are back), could you help take a look? We all were involved in recent fixes in these areas. Thank you.
CC @mstemm 

@leogr these fixes will result in subtle semantic changes of the affected filtercheck fields. Please note that these changes are corrections meaning the current values are off in the here addressed cases.

Currently still in WIP as I need more time to seriously improve our test cases throughout.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2039

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
