### PR TITLE
update(ci): use codecov flag for libsinsp

### DIFF
--- a/.github/workflows/test_coverage_ci.yml
+++ b/.github/workflows/test_coverage_ci.yml
@@ -57,3 +57,4 @@ jobs:
           files: ./libsinsp.coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+          flags: libsinsp

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,16 @@
-component_management:
-  individual_components:
-    - component_id: libsinsp
-      name: libsinsp
-      paths:
-        - userspace/libsinsp/**
+coverage:
+  status:
+    project:
+      default: off
+      libsinsp:
+        flags:
+          - libsinsp
+
+flags:
+  libsinsp:
+    paths:
+      - userspace/libsinsp/
+
+parsers:
+  cobertura:
+    partials_as_hits: true


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Trying to get codecov to behave even if not all tests are computing coverage at this point.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
