### PR TITLE
new(libscap): dump ringbuffer contents after detecting corruption

### DIFF
--- a/userspace/libscap/CMakeLists.txt
+++ b/userspace/libscap/CMakeLists.txt
@@ -143,6 +143,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 		scap_engine_util.c
 		ringbuffer/devset.c
 		ringbuffer/ringbuffer.c
+		ringbuffer/ringbuffer_dump.c
 	)
 	add_dependencies(scap_engine_util uthash)
 	target_include_directories(scap_engine_util

--- a/userspace/libscap/ringbuffer/ringbuffer.h
+++ b/userspace/libscap/ringbuffer/ringbuffer.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <stdint.h>
 
 #include <libscap/ringbuffer/devset.h>
+#include <libscap/ringbuffer/ringbuffer_dump.h>
 #include <driver/ppm_ringbuffer.h>
 #include <libscap/scap_barrier.h>
 #include <libscap/scap_sleep.h>
@@ -282,6 +283,7 @@ static inline int32_t ringbuffer_next(struct scap_device_set* devset, scap_evt**
 			if(pe->len > dev->m_sn_len)
 			{
 				snprintf(devset->m_lasterr, SCAP_LASTERR_SIZE, "scap_next buffer corruption");
+				dump_ringbuffer(dev);
 
 				/* if you get the following assertion, first recompile the driver and `libscap` */
 				ASSERT(false);

--- a/userspace/libscap/ringbuffer/ringbuffer_dump.c
+++ b/userspace/libscap/ringbuffer/ringbuffer_dump.c
@@ -1,0 +1,356 @@
+#include <driver/ppm_ringbuffer.h>
+#include <libscap/ringbuffer/devset.h>
+#include <libscap/ringbuffer/ringbuffer_dump.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libscap/scap.h>
+#include <libscap/scap-int.h>
+
+static inline bool all_zeros(const char* addr, size_t len)
+{
+	for(int i = 0; i < len; i++)
+	{
+		if(addr[i] != 0)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+struct tick
+{
+	size_t offset;
+	char marker;
+};
+
+struct dump_span
+{
+	size_t start;
+	size_t end;
+	const char* label;
+	char marker;
+
+	struct tick* ticks;
+	size_t num_ticks;
+};
+
+static inline bool intervals_overlap(size_t start1, size_t end1, size_t start2, size_t end2)
+{
+	// Handle the complement case for the first interval
+	if(end1 < start1)
+	{
+		return (start1 < end2 || start2 < end1);
+	}
+	// Handle the complement case for the second interval
+	if(end2 < start2)
+	{
+		return (start2 < end1 || start1 < end2);
+	}
+	// Normal case
+	return (start1 < end2) && (start2 < end1);
+}
+
+static inline bool in_span(const struct dump_span* span, size_t offset)
+{
+	if(span->start <= span->end)
+	{
+		// normal case
+		return offset >= span->start && offset < span->end;
+	}
+	else
+	{
+		// inverted case, the actual span is [0, end) + [start, buffer_size]
+		return offset < span->end || offset >= span->start;
+	}
+}
+
+static inline bool next_in_span(const struct dump_span* span, size_t offset, size_t len)
+{
+	if(offset + 1 < len)
+	{
+		return in_span(span, offset + 1);
+	}
+	return span->start > span->end;
+}
+
+static inline int next_tick(int current_tick, size_t offset, const struct dump_span* span)
+{
+	for(int i = current_tick + 1; i < span->num_ticks; i++)
+	{
+		if(span->ticks[i].offset >= offset)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static int compare_ticks(const void* a, const void* b)
+{
+	const struct tick* ta = a;
+	const struct tick* tb = b;
+
+	return ta->offset - tb->offset;
+}
+
+static inline void draw_span(size_t offset, size_t len, size_t bytes_per_line, const struct dump_span* span, void* tag,
+			     size_t total_len)
+{
+	if(!intervals_overlap(offset, offset + len, span->start, span->end))
+	{
+		return;
+	}
+
+	fprintf(stderr, "RINGBUFFER DUMP[%p] %-8s  ", tag, span->label);
+
+	int current_tick = -1;
+
+	for(int i = 0; i < len; i++)
+	{
+		char c[4] = "   ";
+		char s = ' ';
+		if(in_span(span, offset + i))
+		{
+			c[0] = span->marker;
+			c[1] = span->marker;
+			c[2] = '>';
+			if(next_in_span(span, offset + i, total_len))
+			{
+				c[2] = span->marker;
+				s = span->marker;
+			}
+		}
+		else if(next_in_span(span, offset + i, total_len))
+		{
+			c[2] = '<';
+		}
+
+		if(current_tick != -1)
+		{
+			if(span->ticks[current_tick].offset == offset + i)
+			{
+				c[0] = span->ticks[current_tick].marker;
+				current_tick = next_tick(current_tick, offset + i, span);
+			}
+		}
+		else
+		{
+			current_tick = next_tick(current_tick, offset + i, span);
+		}
+
+		fprintf(stderr, "%s", c);
+
+		if(i == bytes_per_line / 2 - 1)
+		{
+			fprintf(stderr, "%c", s);
+		}
+	}
+
+	fprintf(stderr, "\n");
+}
+
+static inline void hexdump(const char* buffer, size_t len, void* tag, const struct dump_span* spans, size_t num_spans)
+{
+	size_t i;
+	size_t j;
+	const size_t bytes_per_line = 32;
+	bool blanks = false;
+
+	for(i = 0; i < len; i += bytes_per_line)
+	{
+		if(all_zeros(buffer + i, MIN(len - i, bytes_per_line)))
+		{
+			blanks = true;
+			continue;
+		}
+		else if(blanks)
+		{
+			fprintf(stderr, "RINGBUFFER DUMP[%p] ...\n", tag);
+			blanks = false;
+		}
+
+		// Print offset
+		fprintf(stderr, "RINGBUFFER DUMP[%p] %08zx  ", tag, i);
+
+		// Print hex values
+		for(j = 0; j < bytes_per_line; j++)
+		{
+			if(i + j < len)
+			{
+				fprintf(stderr, "%02x ", (unsigned char)buffer[i + j]);
+			}
+			else
+			{
+				fprintf(stderr, "   ");
+			}
+
+			if(j == bytes_per_line / 2 - 1)
+			{
+				fprintf(stderr, " ");
+			}
+		}
+
+		// Print ASCII values
+		fprintf(stderr, " | ");
+		for(j = 0; j < bytes_per_line; j++)
+		{
+			if(i + j < len)
+			{
+				char c = buffer[i + j];
+				if(c >= 32 && c <= 126) // printable ASCII range
+				{
+					fprintf(stderr, "%c", c);
+				}
+				else
+				{
+					fprintf(stderr, ".");
+				}
+			}
+
+			if(j == bytes_per_line / 2 - 1)
+			{
+				fprintf(stderr, " ");
+			}
+		}
+		fprintf(stderr, "\n");
+
+		for(int k = 0; k < num_spans; k++)
+		{
+			draw_span(i, MIN(len - i, bytes_per_line), bytes_per_line, &spans[k], tag, len);
+		}
+	}
+}
+
+static inline const char* push_event_ticks(const char* event, struct dump_span* span, size_t offset, size_t buffer_size)
+{
+	if(!in_span(span, offset))
+	{
+		fprintf(stderr, "tick %zu outside span (%zu, %zu)\n", offset, span->start, span->end);
+		return NULL;
+	}
+
+	struct tick* new_ticks = realloc(span->ticks, (span->num_ticks + 5) * sizeof(struct tick));
+	if(new_ticks == NULL)
+	{
+		fprintf(stderr, "Failed to allocate memory for ticks\n");
+		return NULL;
+	}
+
+	new_ticks[span->num_ticks].offset = offset; // tid
+	new_ticks[span->num_ticks].marker = 't';
+
+	new_ticks[span->num_ticks + 1].offset = (offset + 8) % buffer_size; // ts
+	new_ticks[span->num_ticks + 1].marker = 'T';
+
+	new_ticks[span->num_ticks + 2].offset = (offset + 16) % buffer_size; // len
+	new_ticks[span->num_ticks + 2].marker = 'l';
+
+	new_ticks[span->num_ticks + 3].offset = (offset + 20) % buffer_size; // type
+	new_ticks[span->num_ticks + 3].marker = '^';
+
+	new_ticks[span->num_ticks + 4].offset = (offset + 22) % buffer_size; // nparams
+	new_ticks[span->num_ticks + 4].marker = 'n';
+
+	span->ticks = new_ticks;
+	span->num_ticks += 5;
+
+	uint32_t nparams = ((scap_evt*)event)->nparams;
+	size_t param_offset = offset + 26 + nparams * 2;
+	new_ticks = realloc(span->ticks, (span->num_ticks + nparams) * sizeof(struct tick));
+	if(new_ticks == NULL)
+	{
+		fprintf(stderr, "Failed to allocate memory for ticks\n");
+		return NULL;
+	}
+
+	for(int i = 0; i < nparams; i++)
+	{
+		// none of the kernel-generated events use large param sizes
+		uint16_t len = ((uint16_t*)(event + sizeof(scap_evt)))[i];
+
+		new_ticks[span->num_ticks].offset = param_offset % buffer_size; // param value
+		new_ticks[span->num_ticks].marker = '0' + i;
+
+		param_offset += len;
+
+		span->ticks = new_ticks;
+		span->num_ticks += 1;
+	}
+
+	return event + ((scap_evt*)event)->len;
+}
+
+void dump_ringbuffer(struct scap_device* dev)
+{
+	char* buf_copy = malloc(dev->m_buffer_size);
+	if(buf_copy == NULL)
+	{
+		fprintf(stderr, "RINGBUFFER_DUMP[%p] Failed to allocate buffer for ringbuffer dump\n", dev);
+	}
+	else
+	{
+		// do this soon so that the producer doesn't overwrite *too* much
+		memcpy(buf_copy, dev->m_buffer, dev->m_buffer_size);
+	}
+	fprintf(stderr, "RINGBUFFER DUMP[%p] Ringbuffer metadata:\n", dev);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] m_buffer_size: 0x%lx\n", dev, dev->m_buffer_size);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] m_lastreadsize: 0x%x\n", dev, dev->m_lastreadsize);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] m_sn_next_event: 0x%lx\n", dev, dev->m_sn_next_event - dev->m_buffer);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] m_sn_len: 0x%x\n", dev, dev->m_sn_len);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] head: 0x%x\n", dev, dev->m_bufinfo->head);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] tail: 0x%x\n", dev, dev->m_bufinfo->tail);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] ---\n", dev);
+	fprintf(stderr, "RINGBUFFER DUMP[%p] last read: 0x%x .. 0x%x\n", dev, dev->m_bufinfo->tail,
+		dev->m_bufinfo->tail + dev->m_lastreadsize);
+
+	struct dump_span spans[] = {
+		{.start = dev->m_bufinfo->tail,
+		 .end = (dev->m_bufinfo->tail + dev->m_lastreadsize) % dev->m_buffer_size,
+		 .label = "lastread",
+		 .marker = '~'},
+		{.start = dev->m_sn_next_event - dev->m_buffer,
+		 .end = (dev->m_sn_next_event - dev->m_buffer + dev->m_sn_len) % dev->m_buffer_size,
+		 .label = "next evt",
+		 .marker = '*'},
+		{.start = dev->m_bufinfo->tail, .end = dev->m_bufinfo->head, .label = "used", .marker = '-'},
+	};
+
+	const char* event = dev->m_buffer + dev->m_bufinfo->tail;
+	while(event && event < dev->m_buffer + dev->m_bufinfo->tail + dev->m_lastreadsize)
+	{
+		push_event_ticks(event, &spans[0], event - dev->m_buffer, dev->m_buffer_size);
+		event += ((scap_evt*)event)->len;
+	}
+	qsort(spans[0].ticks, spans[0].num_ticks, sizeof(struct tick), compare_ticks);
+
+	event = dev->m_sn_next_event;
+	while(event && event < dev->m_sn_next_event + dev->m_sn_len)
+	{
+		push_event_ticks(event, &spans[1], event - dev->m_buffer, dev->m_buffer_size);
+		event += ((scap_evt*)event)->len;
+	}
+	qsort(spans[1].ticks, spans[1].num_ticks, sizeof(struct tick), compare_ticks);
+
+	if(buf_copy != NULL)
+	{
+		fprintf(stderr,
+			"RINGBUFFER DUMP[%p] Buffer content: "
+			"-------------------------------------------------------------------------------------------\n",
+			dev);
+		hexdump(buf_copy, dev->m_buffer_size, dev, spans, sizeof(spans) / sizeof(spans[0]));
+		fprintf(stderr,
+			"RINGBUFFER DUMP[%p] End of buffer content "
+			"-------------------------------------------------------------------------------------\n",
+			dev);
+		free(buf_copy);
+	}
+
+	free(spans[0].ticks);
+	free(spans[1].ticks);
+}

--- a/userspace/libscap/ringbuffer/ringbuffer_dump.h
+++ b/userspace/libscap/ringbuffer/ringbuffer_dump.h
@@ -1,0 +1,4 @@
+#pragma once
+
+struct scap_device;
+__attribute__((cold)) void dump_ringbuffer(struct scap_device* dev);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Whenever we detect ring buffer corruption, our only diagnostic is "yeah, corrupted". Without a local repro it's basically impossible to fix these issues. This PR adds a hex dump of the whole ring buffer, annotated to simplify the analysis.

A snippet of sample output looks like:

```
RINGBUFFER DUMP[0x74e220190010] 00001980  00 00 00 00 00 00 00 c0 03 00 00 6b 93 42 2f 7b  97 e7 17 07 00 00 00 00 00 00 00 76 00 00 00 07  | ...........k.B/{ ...........v....
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~~~~~~~~~~~~~~~~~~~1~~~~~~~~~~~t~~~~~~~~~~~~~~~~~~~~~~~~T~~~~~~~~~~~~~~~~~~~~~~~l~~~~~~~~~~~^~~
RINGBUFFER DUMP[0x74e220190010] next evt                                  <t************************T***********************l***********^**
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 000019a0  00 02 00 00 00 08 00 50 00 c0 03 00 00 00 00 00  00 7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00  | .......P........ ..ELF...........
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~n~~~~~~~~~~~~~~~~~~~~~~~0~~~~~~~~~~~~~~~~~~~~~~~~1~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
RINGBUFFER DUMP[0x74e220190010] next evt  ***n***********************0************************1********************************************
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 000019c0  00 03 00 3e 00 01 00 00 00 00 00 00 00 00 00 00  00 40 00 00 00 00 00 00 00 30 cc 27 00 00 00 00  | ...>............ .@.......0.'....
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
RINGBUFFER DUMP[0x74e220190010] next evt  *************************************************************************************************
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 000019e0  00 00 00 00 00 40 00 38 00 0a 00 40 00 1a 00 19  00 01 00 00 00 04 00 00 00 00 00 00 00 00 00 00  | .....@.8...@.... ................
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
RINGBUFFER DUMP[0x74e220190010] next evt  *************************************************************************************************
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 00001a00  00 19 e3 42 2f 7b 97 e7 17 07 00 00 00 00 00 00  00 4e 00 00 00 a0 00 06 00 00 00 08 00 08 00 04  | ...B/{.......... .N..............
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~t~~~~~~~~~~~~~~~~~~~~~~~T~~~~~~~~~~~~~~~~~~~~~~~~l~~~~~~~~~~~^~~~~~n~~~~~~~~~~~~~~~~~~~~~~~~~~
RINGBUFFER DUMP[0x74e220190010] next evt  ***t***********************T************************l***********^*****n**************************
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 00001a20  00 04 00 08 00 08 00 00 00 00 00 00 00 00 00 00  20 28 00 00 00 00 00 01 00 00 00 02 00 00 00 03  | ................  (..............
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~~~~~~~~~~~~~~~~~~~0~~~~~~~~~~~~~~~~~~~~~~~1~~~~~~~~~~~~~~~~~~~~~~~~2~~~~~~~~~~~3~~~~~~~~~~~4~~
RINGBUFFER DUMP[0x74e220190010] next evt  *********************0***********************1************************2***********3***********4**
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
RINGBUFFER DUMP[0x74e220190010] 00001a40  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 25  2d 43 2f 7b 97 e7 17 07 00 00 00 00 00 00 00 36  | ...............% -C/{...........6
RINGBUFFER DUMP[0x74e220190010] lastread  ~~~~~~~~~~~~~~~~~~~~~5~~~~~~~~~~~~~~~~~~~~~~~t~~~~~~~~~~~~~~~~~~~~~~~~T~~~~~~~~~~~~~~~~~~~~~~~l~~
RINGBUFFER DUMP[0x74e220190010] next evt  *********************5***********************t************************T***********************l**
RINGBUFFER DUMP[0x74e220190010] used      -------------------------------------------------------------------------------------------------
```
(this goes on for megabytes, though all-zero rows are skipped)

There are three spans:

lastread (~) shows the current event batch (what scap is currently locking in the ring buffer), should cover exactly a series of events
next evt (*) shows the unconsumed events from the current batch (starting with the next event we were about to return but detected corruption)
used (-) shows the portion of the ringbuffer filled with event data
The marks on the lastread and next evt lines are:

T: timestamp (first field of each event)
t: tid
l: event length
^: event type (I ran out of cases for t)
n: number of parameters
0-9: individual parameters (if there are over 10, we'll go higher in the ascii table: 0123456789:;<=>?@abcdef...)
the three lines are mostly redundant but since we're looking for corruption, let's not assume things make sense
the marks on lastread and next evt should always coincide, unless something is severely broken
The event-related markers are best effort (based on the current values of the ring buffer pointers), but if they do not mark realistic events, then that is the corruption we're looking for.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libscap): upon detecting ring buffer corruption, an annotated dump of the whole ring buffer will be printed to stderr
```
