### PR TITLE
new(scap,pman): add new per-CPU driver metrics

### DIFF
--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -129,6 +129,60 @@ TEST(bpf, double_scap_stats_call)
 	scap_close(h);
 }
 
+TEST(bpf, metrics_v2_check_per_CPU_stats)
+{
+	char error_buffer[FILENAME_MAX] = {0};
+	int ret = 0;
+	scap_t* h = open_bpf_engine(error_buffer, &ret, 4 * 4096, LIBSCAP_TEST_BPF_PROBE_PATH);
+	ASSERT_FALSE(!h || ret != SCAP_SUCCESS) << "unable to open bpf engine: " << error_buffer << std::endl;
+
+	ssize_t num_possible_CPUs = num_possible_cpus();
+
+	// We want to check our CPUs counters
+	uint32_t flags = METRICS_V2_KERNEL_COUNTERS;
+	uint32_t nstats = 0;
+	int32_t rc = 0;
+	const metrics_v2* stats_v2 = scap_get_stats_v2(h, flags, &nstats, &rc);
+	ASSERT_EQ(rc, SCAP_SUCCESS);
+	ASSERT_TRUE(stats_v2);
+	ASSERT_GT(nstats, 0);
+
+	uint32_t i = 0;
+	ssize_t found = 0;
+	char expected_name[METRIC_NAME_MAX] = "";
+	snprintf(expected_name, METRIC_NAME_MAX, N_EVENTS_PER_CPU_PREFIX"%ld", found);
+
+	while(i < nstats)
+	{
+		// `sizeof(N_EVENTS_PER_CPU_PREFIX)-1` because we need to exclude the `\0`
+		if(strncmp(stats_v2[i].name, N_EVENTS_PER_CPU_PREFIX, sizeof(N_EVENTS_PER_CPU_PREFIX)-1) == 0)
+		{
+			i++;
+			// The next metric should be the number of drops
+			snprintf(expected_name, METRIC_NAME_MAX, N_DROPS_PER_CPU_PREFIX"%ld", found);
+			if(strncmp(stats_v2[i].name, N_DROPS_PER_CPU_PREFIX, sizeof(N_DROPS_PER_CPU_PREFIX)-1) == 0)
+			{
+				i++;
+				found++;
+			}
+			else
+			{
+				FAIL() << "Missing CPU drops for CPU " << found;
+			}
+		} 
+		else
+		{
+			i++;
+		}
+	}
+
+	// This test could fail in case of rare race conditions in which the number of available CPUs changes
+	// between the scap_open and the `num_possible_cpus` function. In CI we shouldn't have hot plugs so probably we
+	// can live with this. 
+	ASSERT_EQ(num_possible_CPUs, found) << "We didn't find the stats for all the CPUs";
+	scap_close(h);
+}
+
 TEST(bpf, metrics_v2_check_results)
 {
 	char error_buffer[SCAP_LASTERR_SIZE] = {0};

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -80,8 +80,14 @@ void pman_clear_state()
 	g_state.buffer_bytes_dim = 0;
 	g_state.last_ring_read = -1;
 	g_state.last_event_size = 0;
-	g_state.n_attached_progs = 0;
+
+	for(int j = 0; j < MODERN_BPF_PROG_ATTACHED_MAX; j++)
+	{
+		g_state.attached_progs_fds[j] = -1;
+	}
+	
 	g_state.stats = NULL;
+	g_state.nstats = 0;
 	g_state.log_fn = NULL;
 	if(g_state.log_buf)
 	{

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -32,7 +32,6 @@ int pman_open_probe()
 
 static void pman_save_attached_progs()
 {
-	g_state.n_attached_progs = 0;
 	g_state.attached_progs_fds[0] = bpf_program__fd(g_state.skel->progs.sys_enter);
 	g_state.attached_progs_fds[1] = bpf_program__fd(g_state.skel->progs.sys_exit);
 	g_state.attached_progs_fds[2] = bpf_program__fd(g_state.skel->progs.sched_proc_exit);
@@ -48,18 +47,6 @@ static void pman_save_attached_progs()
 	g_state.attached_progs_fds[7] = bpf_program__fd(g_state.skel->progs.pf_kernel);
 #endif
 	g_state.attached_progs_fds[8] = bpf_program__fd(g_state.skel->progs.signal_deliver);
-
-	for(int j = 0; j < MODERN_BPF_PROG_ATTACHED_MAX; j++)
-	{
-		if(g_state.attached_progs_fds[j] < 1)
-		{
-			g_state.attached_progs_fds[j] = -1;
-		}
-		else
-		{
-			g_state.n_attached_progs++;
-		}
-	}
 }
 
 int pman_load_probe()
@@ -85,16 +72,19 @@ void pman_close_probe()
 	if(g_state.stats)
 	{
 		free(g_state.stats);
+		g_state.stats = NULL;
 	}
 
 	if(g_state.cons_pos)
 	{
 		free(g_state.cons_pos);
+		g_state.cons_pos = NULL;
 	}
 
 	if(g_state.prod_pos)
 	{
 		free(g_state.prod_pos);
+		g_state.prod_pos = NULL;
 	}
 
 	if(g_state.skel)

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -59,8 +59,8 @@ struct internal_state
 	/* Stats v2 utilities */
 	int32_t attached_progs_fds[MODERN_BPF_PROG_ATTACHED_MAX]; /* file descriptors of attached programs, used to
 								     collect stats */
-	uint16_t n_attached_progs;				  /* number of attached progs */
 	struct metrics_v2* stats;				  /* array of stats collected by libpman */
+	uint32_t nstats;	/* number of stats */
 	char* log_buf; /* buffer used to store logs before sending them to the log_fn */
 	size_t log_buf_size; /* size of the log buffer */
 	falcosecurity_log_fn log_fn;

--- a/userspace/libscap/engine/kmod/kmod.h
+++ b/userspace/libscap/engine/kmod/kmod.h
@@ -32,5 +32,6 @@ struct kmod_engine
 	uint64_t m_api_version;
 	uint64_t m_schema_version;
 	bool capturing;
-	metrics_v2 m_stats[KMOD_MAX_KERNEL_COUNTERS_STATS];
+	metrics_v2* m_stats;
+	uint32_t m_nstats;
 };

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -67,6 +67,8 @@ static struct kmod_engine* alloc_handle(scap_t* main_handle, char* lasterr_ptr)
 	if(engine)
 	{
 		engine->m_lasterr = lasterr_ptr;
+		engine->m_stats = NULL;
+		engine->m_nstats = 0;
 	}
 	return engine;
 }
@@ -522,7 +524,12 @@ int32_t scap_kmod_close(struct scap_engine_handle engine)
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
 
 	devset_free(devset);
-
+	
+	if(engine.m_handle->m_stats)
+	{
+		free(engine.m_handle->m_stats);
+		engine.m_handle->m_stats = NULL;
+	}
 	return SCAP_SUCCESS;
 }
 
@@ -578,34 +585,57 @@ int32_t scap_kmod_get_stats(struct scap_engine_handle engine, scap_stats* stats)
 	return SCAP_SUCCESS;
 }
 
+static void set_u64_monotonic_kernel_counter(struct metrics_v2* m, uint64_t val)
+{
+	m->type = METRIC_VALUE_TYPE_U64;
+	m->flags = METRICS_V2_KERNEL_COUNTERS;
+	m->unit = METRIC_VALUE_UNIT_COUNT;
+	m->metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
+	m->value.u64 = val;
+}
+
 const struct metrics_v2* scap_kmod_get_stats_v2(struct scap_engine_handle engine, uint32_t flags, uint32_t* nstats, int32_t* rc)
 {
 	struct kmod_engine *handle = engine.m_handle;
 	struct scap_device_set *devset = &handle->m_dev_set;
-	uint32_t j;
-	*nstats = 0;
-	metrics_v2* stats = handle->m_stats;
 
-	if (!stats)
+	*rc = SCAP_FAILURE;
+	*nstats = 0;
+
+	// If it is the first time we call this function, we allocate the stats
+	if(handle->m_stats == NULL)
 	{
-		*rc = SCAP_FAILURE;
-		return NULL;
+		// The difference with other drivers is that here we consider only ONLINE CPUs and not the AVILABLE ones.
+		// At the moment for each ONLINE CPU we want:
+		// - the number of events.
+		// - the number of drops.
+		uint32_t per_dev_stats = devset->m_ndevs* 2;
+
+		handle->m_nstats = KMOD_MAX_KERNEL_COUNTERS_STATS + per_dev_stats;
+		handle->m_stats = (metrics_v2*)calloc(handle->m_nstats, sizeof(metrics_v2));
+		if(!handle->m_stats)
+		{
+			handle->m_nstats = 0;
+			*rc = scap_errprintf(handle->m_lasterr, -1, "unable to allocate memory for 'metrics_v2' array");
+			return NULL;
+		}
 	}
 
+	// offset in stats buffer
+	int offset = 0;
+	metrics_v2* stats = handle->m_stats;
+
+	/* KERNEL COUNTER STATS */
 	if ((flags & METRICS_V2_KERNEL_COUNTERS))
 	{
-		/* KERNEL SIDE STATS COUNTERS */
 		for(uint32_t stat = 0; stat < KMOD_MAX_KERNEL_COUNTERS_STATS; stat++)
 		{
-			stats[stat].type = METRIC_VALUE_TYPE_U64;
-			stats[stat].flags = METRICS_V2_KERNEL_COUNTERS;
-			stats[stat].unit = METRIC_VALUE_UNIT_COUNT;
-			stats[stat].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
-			stats[stat].value.u64 = 0;
-			strlcpy(stats[stat].name, kmod_kernel_counters_stats_names[stat], METRIC_NAME_MAX);
+			set_u64_monotonic_kernel_counter(&(stats[stat]), 0);
+			strlcpy(stats[stat].name, (char*)kmod_kernel_counters_stats_names[stat], METRIC_NAME_MAX);
 		}
 
-		for(j = 0; j < devset->m_ndevs; j++)
+		uint32_t pos = KMOD_MAX_KERNEL_COUNTERS_STATS;
+		for(uint32_t j = 0; j < devset->m_ndevs; j++)
 		{
 			struct scap_device *dev = &devset->m_devs[j];
 			stats[KMOD_N_EVTS].value.u64 += dev->m_bufinfo->n_evts;
@@ -628,10 +658,21 @@ const struct metrics_v2* scap_kmod_get_stats_v2(struct scap_engine_handle engine
 			stats[KMOD_N_DROPS].value.u64 += dev->m_bufinfo->n_drops_buffer +
 					dev->m_bufinfo->n_drops_pf;
 			stats[KMOD_N_PREEMPTIONS].value.u64 += dev->m_bufinfo->n_preemptions;
+
+			// We set the num events for that CPU.
+			set_u64_monotonic_kernel_counter(&(stats[pos]), dev->m_bufinfo->n_evts);
+			snprintf(stats[pos].name, METRIC_NAME_MAX, N_EVENTS_PER_DEVICE_PREFIX"%d", j);
+			pos++;
+
+			// We set the drops for that CPU.
+			set_u64_monotonic_kernel_counter(&(stats[pos]), dev->m_bufinfo->n_drops_buffer + dev->m_bufinfo->n_drops_pf);
+			snprintf(stats[pos].name, METRIC_NAME_MAX, N_DROPS_PER_DEVICE_PREFIX"%d", j);
+			pos++;
 		}
-		*nstats = KMOD_MAX_KERNEL_COUNTERS_STATS;
+		offset = pos;
 	}
 
+	*nstats = offset;
 	*rc = SCAP_SUCCESS;
 	return stats;
 }

--- a/userspace/libscap/metrics_v2.h
+++ b/userspace/libscap/metrics_v2.h
@@ -31,6 +31,18 @@ extern "C" {
 #define METRIC_NAME_MAX 512
 
 //
+// Prefix names for per-CPU metrics (Used by legacy ebpf and modern ebpf)
+//
+#define N_EVENTS_PER_CPU_PREFIX "n_evts_cpu_"
+#define N_DROPS_PER_CPU_PREFIX "n_drops_cpu_"
+
+//
+// Prefix names for per-Device metrics (Used by kernel module)
+//
+#define N_EVENTS_PER_DEVICE_PREFIX "n_evts_dev_"
+#define N_DROPS_PER_DEVICE_PREFIX "n_drops_dev_"
+
+//
 // metrics_v2 flags
 //
 #define METRICS_V2_KERNEL_COUNTERS (1 << 0)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

/area libscap

/area libpman

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR introduces new per-CPU stats for our drivers. When collecting some metrics about drops in our drivers, it could be useful to understand where we are dropping. It could be useful to know how drops and events are distributed between our CPUs, whether it is just one CPU under pressure or if the whole system is having a hard time.

This is an example of the output on 8 CPUs with `scap-open`

```
[1] n_evts: 88939
[1] n_drops: 0
[1] n_evts_cpu_0: 10326
[1] n_drops_cpu_0: 0
[1] n_evts_cpu_1: 12517
[1] n_drops_cpu_1: 0
[1] n_evts_cpu_2: 11418
[1] n_drops_cpu_2: 0
[1] n_evts_cpu_3: 11937
[1] n_drops_cpu_3: 0
[1] n_evts_cpu_4: 10960
[1] n_drops_cpu_4: 0
[1] n_evts_cpu_5: 6675
[1] n_drops_cpu_5: 0
[1] n_evts_cpu_6: 11195
[1] n_drops_cpu_6: 0
[1] n_evts_cpu_7: 13911
[1] n_drops_cpu_7: 0
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
