### PR TITLE
fix(driver/kmod): count the right number of events and drops

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2068,6 +2068,7 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 			ring_info->n_drops_buffer++;
 			drops_buffer_syscall_categories_counters(event_type, ring_info);
 		} else {
+			ring_info->n_drops_buffer++;
 			ASSERT(false);
 		}
 	}

--- a/driver/main.c
+++ b/driver/main.c
@@ -1826,7 +1826,6 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 	ASSERT(ring);
 
 	ring_info = ring->info;
-	ring_info->n_evts++;
 	if (event_datap->category == PPMC_CONTEXT_SWITCH && event_datap->event_info.context_data.sched_prev != NULL) {
 		if (event_type != PPME_SCAPEVENT_E && event_type != PPME_CPU_HOTPLUG_E) {
 			ASSERT(event_datap->event_info.context_data.sched_prev != NULL);
@@ -1851,13 +1850,14 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 		 * This means that effectively those events would be lost.
 		 */
 		if (event_type != PPME_PAGE_FAULT_E) {
-			ring_info->n_preemptions++;
 			ASSERT(false);
 		}
+		ring_info->n_preemptions++;
 		atomic_dec(&ring->preempt_count);
 		put_cpu();
 		return res;
 	}
+	ring_info->n_evts++;
 
 	/*
 	 * Calculate the space currently available in the buffer


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR provides 2 fixes:
* The preemptions are now taken into consideration and we don't increment the `n_evts` since the event is always dropped.
* In case of some unknown error we had just an `ASSERT(false)` but not a `n_drops_buffer` increment. This means that in production we were not able to detect if we fell into the wrong branch or not. Now we increment the `n_drops_buffer` metric.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
