### PR TITLE
fix(libpman): try to get a new event on the same CPU after increasing the producer

### DIFF
--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -260,13 +260,13 @@ static inline void *ringbuf__get_first_ring_event(struct ring *r, int pos)
 	/* If the consumer reaches the producer update the producer position to
 	 * get the newly collected events.
 	 */
-	if(g_state.cons_pos[pos] >= g_state.prod_pos[pos])
+	if(g_state.cons_pos[pos] == g_state.prod_pos[pos])
 	{
 		// We try to increment the producer and continue. It is likely that the producer
 		// has produced new events on this CPU and these events could have a timestamp
 		// lowest than all the other events in the other buffers.
 		g_state.prod_pos[pos] = smp_load_acquire(r->producer_pos);
-		if(g_state.cons_pos[pos] >= g_state.prod_pos[pos])
+		if(g_state.cons_pos[pos] == g_state.prod_pos[pos])
 		{
 			return NULL;
 		}

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -261,8 +261,14 @@ static inline void *ringbuf__get_first_ring_event(struct ring *r, int pos)
 	 */
 	if(g_state.cons_pos[pos] >= g_state.prod_pos[pos])
 	{
+		// We try to increment the producer and continue. It is likely that the producer
+		// has produced new events on this CPU and these events could have a timestamp
+		// lowest than all the other events in the other buffers.
 		g_state.prod_pos[pos] = smp_load_acquire(r->producer_pos);
-		return NULL;
+		if(g_state.cons_pos[pos] >= g_state.prod_pos[pos])
+		{
+			return NULL;
+		}
 	}
 
 	len_ptr = r->data + (g_state.cons_pos[pos] & r->mask);

--- a/userspace/libpman/src/ringbuffer_debug_macro.h
+++ b/userspace/libpman/src/ringbuffer_debug_macro.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <stdint.h>
+
+// Debugging Macros
+#define RINGBUF_DEBUGGING 0
+
+#if RINGBUF_DEBUGGING
+// R_D stands for Ringbuffer Debugging
+#define R_D_MSG(...) printf(__VA_ARGS__)
+
+#define R_D_EVENT(event, ring_id)                                                                                      \
+	if(event == NULL)                                                                                              \
+	{                                                                                                              \
+		R_D_MSG("[NULL Event] buf: %d\n", ring_id);                                                            \
+	}                                                                                                              \
+	else                                                                                                           \
+	{                                                                                                              \
+		R_D_MSG("[Event] ts: %ld, buf: %d\n", (event)->ts, ring_id);                                           \
+	}
+
+#else
+#define R_D_MSG(...)
+#define R_D_EVENT(event, ring_id)
+#endif


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libpman

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR reduces the possibility of facing out-of-order events with the modern ebpf probe. When we reach the producer the right thing to do is to insist on the same CPU to check if the producer has pushed some new events instead of skipping the current buffer returning a NULL event. Otherwise, there is the risk that we skip some events with a lower timestamp with respect to the others in the other buffers.

Added also some handy debug print. Example

```
-----------------------------
Iterate over all the buffers
[NULL Event] buf: 0
[NULL Event] buf: 1
[NULL Event] buf: 2
[NULL Event] buf: 3
[NULL Event] buf: 4
[NULL Event] buf: 5
[Event] ts: 1724060673955668930, buf: 6
Found new min with ts '1724060673955668930'  on buffer 6
[NULL Event] buf: 7
Send event -> [Event] ts: 1724060673955668930, buf: 6

-----------------------------
Iterate over all the buffers
[NULL Event] buf: 0
[NULL Event] buf: 1
[NULL Event] buf: 2
[NULL Event] buf: 3
[NULL Event] buf: 4
[NULL Event] buf: 5
[Event] ts: 1724060673955681382, buf: 6
Found new min with ts '1724060673955681382'  on buffer 6
[NULL Event] buf: 7
Send event -> [Event] ts: 1724060673955681382, buf: 6
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(libpman): try to get a new event on the same CPU after increasing the producer
```
