### PR TITLE
fix(driver): fixed build against linux 6.11.

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -2914,7 +2914,10 @@ FILLER(execve_extra_tail_1, true)
 	struct timespec64 time = {0};
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	time.tv_sec = _READ(inode->i_ctime_sec);
+	time.tv_nsec = _READ(inode->i_ctime_nsec);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
 #else
 	time = _READ(inode->i_ctime);
@@ -2923,7 +2926,10 @@ FILLER(execve_extra_tail_1, true)
 	CHECK_RES(res);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	time.tv_sec = _READ(inode->i_mtime_sec);
+	time.tv_nsec = _READ(inode->i_mtime_nsec);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 	time = _READ(inode->__i_mtime);
 #else
 	time = _READ(inode->i_mtime);
@@ -6822,7 +6828,10 @@ FILLER(sched_prog_exec_4, false)
 	struct timespec64 time = {0};
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type: PT_ABSTIME) */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	time.tv_sec = _READ(inode->i_ctime_sec);
+	time.tv_nsec = _READ((inode->i_ctime_nsec);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	time = _READ(inode->__i_ctime);
 #else
 	time = _READ(inode->i_ctime);
@@ -6831,7 +6840,10 @@ FILLER(sched_prog_exec_4, false)
 	CHECK_RES(res);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type: PT_ABSTIME) */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	time.tv_sec = _READ(inode->i_mtime_sec);
+	time.tv_nsec = _READ(inode->i_mtime_nsec);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
 	time = _READ(inode->__i_mtime);
 #else
 	time = _READ(inode->i_mtime);

--- a/driver/modern_bpf/definitions/struct_flavors.h
+++ b/driver/modern_bpf/definitions/struct_flavors.h
@@ -52,6 +52,13 @@ struct inode___v6_7 {
 	struct timespec64 __i_mtime;
 };
 
+struct inode___v6_11 {
+	int64_t	i_mtime_sec;
+	int64_t	i_ctime_sec;
+	uint32_t i_mtime_nsec;
+	uint32_t i_ctime_nsec;
+};
+
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop
 #endif

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -207,7 +207,16 @@ int BPF_PROG(t1_sched_p_exec,
 	else
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		if(bpf_core_field_exists(exe_inode_v6_6->__i_ctime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_ctime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_ctime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
@@ -219,7 +228,16 @@ int BPF_PROG(t1_sched_p_exec,
 	else
 	{
 		struct inode___v6_7 *exe_inode_v6_7 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		if(bpf_core_field_exists(exe_inode_v6_7->__i_mtime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_mtime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_mtime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execve.bpf.c
@@ -267,7 +267,16 @@ int BPF_PROG(t1_execve_x,
 	else
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		if(bpf_core_field_exists(exe_inode_v6_6->__i_ctime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_ctime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_ctime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
@@ -279,7 +288,16 @@ int BPF_PROG(t1_execve_x,
 	else
 	{
 		struct inode___v6_7 *exe_inode_v6_7 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		if(bpf_core_field_exists(exe_inode_v6_7->__i_mtime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_mtime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_mtime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/execveat.bpf.c
@@ -280,7 +280,16 @@ int BPF_PROG(t1_execveat_x,
 	else
 	{
 		struct inode___v6_6 *exe_inode_v6_6 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		if(bpf_core_field_exists(exe_inode_v6_6->__i_ctime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_6, __i_ctime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_ctime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_ctime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 
@@ -292,7 +301,16 @@ int BPF_PROG(t1_execveat_x,
 	else
 	{
 		struct inode___v6_7 *exe_inode_v6_7 = (void *)exe_inode;
-		BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		if(bpf_core_field_exists(exe_inode_v6_7->__i_mtime))
+		{
+			BPF_CORE_READ_INTO(&time, exe_inode_v6_7, __i_mtime);
+		}
+		else
+		{
+			struct inode___v6_11 *exe_inode_v6_11 = (void *)exe_inode;
+			BPF_CORE_READ_INTO(&time.tv_sec, exe_inode_v6_11, i_mtime_sec);
+			BPF_CORE_READ_INTO(&time.tv_nsec, exe_inode_v6_11, i_mtime_nsec);
+		}
 	}
 	auxmap__store_u64_param(auxmap, extract__epoch_ns_from_time(time));
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf
/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fixes build against latest linux 6.11-rc{1...4}; the breaking commit is: https://github.com/torvalds/linux/commit/3aa63a569c64e708df547a8913c84e64a06e7853

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): fixed build against linux 6.11.
```

/hold for now, until we are at least at rc6, as always.