### PR TITLE
fix(libsinsp/tests): assorted fixes (memory layout, synchronization)

### DIFF
--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -581,12 +581,12 @@ TEST_F(sinsp_with_test_input, plugin_tables)
 	// we open a capture and iterate, so that we make sure that all
 	// the state operations keep working at every round of the loop
 	open_inspector();
-	auto asyncname = "sampleasync";
-	auto sample_plugin_evtdata = "hello world";
+	const char* asyncname = "sampleasync";
+	const char* sample_plugin_evtdata = "hello world";
 	uint64_t max_iterations = 10000;
 	for (uint64_t i = 0; i < max_iterations; i++)
 	{
-		auto evt = add_event_advance_ts(increasing_ts(), 1, PPME_ASYNCEVENT_E, 3, (uint32_t) 0, asyncname, scap_const_sized_buffer{&sample_plugin_evtdata, strlen(sample_plugin_evtdata) + 1});
+		auto evt = add_event_advance_ts(increasing_ts(), 1, PPME_ASYNCEVENT_E, 3, (uint32_t) 0, asyncname, scap_const_sized_buffer{sample_plugin_evtdata, strlen(sample_plugin_evtdata) + 1});
 		ASSERT_EQ(evt->get_type(), PPME_ASYNCEVENT_E);
 		ASSERT_EQ(evt->get_source_idx(), 0);
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

I noticed a couple inconsistencies in libsinsp tests:
1. in a spot we had `auto` for a string literal which may be interpreted as `char [N]` and trip asan. Use a `const char*` instead.
2. In an attempt to reduce flakiness in our async key value tests, I introduced a bit more thread safety in some of our tests, especially when there were no synchronization primitives and the use of two threads.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
