### PR TITLE
fix(userspace/libsinsp): explicitly include <cstdint> to fix build with gcc-15

### DIFF
--- a/userspace/libsinsp/filter/ast.h
+++ b/userspace/libsinsp/filter/ast.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <algorithm>


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

/area libsinsp

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

Fixes build with gcc-15

**Which issue(s) this PR fixes**:

Fixes #2012 

**Special notes for your reviewer**:

You're welcome :)

**Does this PR introduce a user-facing change?**:

Not sure if this needs a release note.

```release-note
NONE
```
