### PR TITLE
cleanup(sinsp): add set_static_container method

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -41,13 +41,10 @@ limitations under the License.
 
 using namespace libsinsp;
 
-sinsp_container_manager::sinsp_container_manager(sinsp* inspector, bool static_container, const std::string static_id, const std::string static_name, const std::string static_image) :
+sinsp_container_manager::sinsp_container_manager(sinsp* inspector) :
 	m_last_flush_time_ns(0),
 	m_inspector(inspector),
-	m_static_container(static_container),
-	m_static_id(static_id),
-	m_static_name(static_name),
-	m_static_image(static_image),
+	m_static_container(false),
 	m_container_engine_mask(~0ULL)
 {
 	if (m_inspector != nullptr)

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -54,11 +54,7 @@ public:
 	 * right now being "static" or not. I'm sure we will find time in the future to do this
 	 * in a more general way. 2020/11/24
 	 */
-	sinsp_container_manager(sinsp* inspector,
-	                        bool static_container = false,
-	                        const std::string static_id = "",
-	                        const std::string static_name = "",
-	                        const std::string static_image = "");
+	sinsp_container_manager(sinsp* inspector);
 
 	virtual ~sinsp_container_manager() = default;
 
@@ -162,6 +158,26 @@ public:
 	inline void set_container_engine_mask(uint64_t mask)
 	{
 		m_container_engine_mask = mask;
+	}
+
+	/**
+	 * @brief Set static container information
+	 * @param id the id for the static container.
+	 * @param name the name for the static container.
+	 * @param image the used by the static container.
+	 *
+	 *  Note: the CRI engine handles multiple container types which can only
+	 *  be enabled or disabled together.
+	 *
+	 *  This method *must* be called before the first container detection,
+	 *  i.e. before inspector->open()
+	 */
+	inline void set_static_container(const std::string& id, const std::string& name, const std::string& image)
+	{
+		m_static_id = id;
+		m_static_name = name;
+		m_static_image = image;
+		m_static_container = true;
 	}
 
 	void create_engines();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -64,13 +64,13 @@ int32_t on_new_entry_from_proc(void* context, char* error, int64_t tid, scap_thr
 ///////////////////////////////////////////////////////////////////////////////
 std::atomic<int> sinsp::instance_count{0};
 
-sinsp::sinsp(bool static_container, const std::string &static_id, const std::string &static_name, const std::string &static_image, bool with_metrics) :
+sinsp::sinsp(bool with_metrics) :
 	m_external_event_processor(),
 	m_sinsp_stats_v2(with_metrics ? std::make_shared<sinsp_stats_v2>() : nullptr),
 	m_evt(this),
 	m_lastevent_ts(0),
 	m_host_root(scap_get_host_root()),
-	m_container_manager(this, static_container, static_id, static_name, static_image),
+	m_container_manager(this),
 	m_usergroup_manager(this),
 	m_async_events_queue(DEFAULT_ASYNC_EVENT_QUEUE_SIZE),
 	m_suppressed_comms(),

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -154,11 +154,7 @@ enum sinsp_mode_t
 class SINSP_PUBLIC sinsp : public capture_stats_source
 {
 public:
-	sinsp(bool static_container = false,
-		  const std::string &static_id = "",
-		  const std::string &static_name = "",
-		  const std::string &static_image = "",
-	          bool with_metrics = false);
+	sinsp(bool with_metrics = false);
 
 	virtual ~sinsp() override;
 
@@ -929,6 +925,10 @@ public:
 	inline void set_container_engine_mask(uint64_t mask)
 	{
 		m_container_manager.set_container_engine_mask(mask);
+	}
+
+	inline void set_static_container(const std::string& id, const std::string& name, const std::string& image) {
+		m_container_manager.set_static_container(id, name, image);
 	}
 
 	// Add comm to the list of comms for which the inspector

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -40,7 +40,7 @@ protected:
 	sinsp_with_test_input();
 	~sinsp_with_test_input();
 
-	sinsp m_inspector = sinsp(false, "", "", "", true);
+	sinsp m_inspector = sinsp(true);
 
 	void open_inspector(sinsp_mode_t mode = SINSP_MODE_TEST);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This change splits configuration of the static container data away from the sinsp constructor and into a separate set_static_container method. 

The motivation behind this change is two fold:
- Configuration of other container engines is handled by a call to set_container_engine_mask() before starting the inspector, the new method is closer to this implementation.
- Enabling metrics collection should not require adopters to pass in 4 unrelated arguments to the sinsp constructor.

These changes will require some modifications into the Falco main repo, as far as I can tell they should be relatively straight forward.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Remove static container arguments from sinsp constructor.
Add set_static_container method.
```
