### PR TITLE
chore(ci): disable unstable scap-related perf test from perf PR comment and check

### DIFF
--- a/.github/workflows/create-comment-perf.yml
+++ b/.github/workflows/create-comment-perf.yml
@@ -42,13 +42,34 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Taken from https://github.com/actions/github-script/blob/main/.github/workflows/pull-request-test.yml
           script: |
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('./NR'));
             var comment_body = fs.readFileSync('./COMMENT');
-            await github.rest.issues.createComment({
+
+            // Get the existing comments.
+            const {data: comments} = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: comment_body.toString('utf8')
             });
+
+            // Find any comment already made by the bot.
+            const botComment = comments.find(comment => comment.user.id === 41898282 && comment.body.includes('# Perf diff from master'));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: comment_body.toString('utf8')
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: comment_body.toString('utf8')
+              });
+            }

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -60,11 +60,12 @@ jobs:
           head -n10 "perf_tests_diff.txt" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
           echo "" >> ./pr/COMMENT
-          echo "# Perf diff from master - scap file" >> ./pr/COMMENT
-          echo "\`\`\`" >> ./pr/COMMENT
-          head -n10 "perf_scap_diff.txt" >> ./pr/COMMENT
-          echo "\`\`\`" >> ./pr/COMMENT
-          echo "" >> ./pr/COMMENT
+          # Drop unstable perf results!
+          # echo "# Perf diff from master - scap file" >> ./pr/COMMENT
+          # echo "\`\`\`" >> ./pr/COMMENT
+          # head -n10 "perf_scap_diff.txt" >> ./pr/COMMENT
+          # echo "\`\`\`" >> ./pr/COMMENT
+          # echo "" >> ./pr/COMMENT
           echo "# Heap diff from master - unit tests" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
           tail -n3 "heaptrack_tests_diff.txt" >> ./pr/COMMENT
@@ -98,13 +99,14 @@ jobs:
 
       # Check will fail if sum of all differences is >= 1%.
       # But we will always comment with the perf diff from master
-      - name: Check >= 1% threshold - perf scap file
-        if: always() # Even if other threshold checks failed
-        run: |
-          sum=$(awk '{sum+=sprintf("%f",$2)}END{printf "%.6f\n",sum}' perf_scap_diff.txt | tr ',' '.')
-          if (( $(echo "$sum >= 1.0" | bc -l) )); then
-            exit 1
-          fi
+      # CHECK DISABLED: UNSTABLE PERF TEST.
+#      - name: Check >= 1% threshold - perf scap file
+#        if: always() # Even if other threshold checks failed
+#        run: |
+#          sum=$(awk '{sum+=sprintf("%f",$2)}END{printf "%.6f\n",sum}' perf_scap_diff.txt | tr ',' '.')
+#          if (( $(echo "$sum >= 1.0" | bc -l) )); then
+#            exit 1
+#          fi
 
       # Check will fail if there is any heap memory usage difference >= 1M,
       # or if there is new memory leaked.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

It disables the flaky scap-related perf test; moreover, it avoids polluting PRs with perf-related bot comments, instead editing existing one.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
