### PR TITLE
fix(userspace/libsinsp): fixed CO_IN filter crafted value.

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -1069,6 +1069,7 @@ bool sinsp_filter_check::compare_rhs(cmpop op, ppm_param_type type, const void* 
 			return false;
 		default:
 			auto item = craft_filter_value(type, operand1, op1_len);
+
 			if (op == CO_IN || op == CO_INTERSECTS)
 			{
 				// CO_INTERSECTS is really more interesting when a filtercheck can extract
@@ -1076,8 +1077,8 @@ bool sinsp_filter_check::compare_rhs(cmpop op, ppm_param_type type, const void* 
 				// against the set of rhs values. sinsp_filter_checks only extract a
 				// single value, so CO_INTERSECTS is really the same as CO_IN.
 				ensure_unique_ptr_allocated(m_val_storages_members);
-				if(op1_len >= m_val_storages_min_size &&
-				   op1_len <= m_val_storages_max_size &&
+				if(item.second >= m_val_storages_min_size &&
+				   item.second <= m_val_storages_max_size &&
 				   m_val_storages_members->find(item) != m_val_storages_members->end())
 				{
 					return true;

--- a/userspace/libsinsp/test/filterchecks/proc.cpp
+++ b/userspace/libsinsp/test/filterchecks/proc.cpp
@@ -106,6 +106,24 @@ TEST_F(sinsp_with_test_input, PROC_FILTER_pexepath_aexepath)
 	ASSERT_FALSE(field_has_value(evt, "proc.aexepath[6]"));
 }
 
+TEST_F(sinsp_with_test_input, PROC_FILTER_aname)
+{
+	DEFAULT_TREE
+
+	// proc.aname[0]=good-exe, proc.aname[1]=bash, proc.aname[2]=bash, proc.aname[3]=bash, proc.aname[4]=bash, proc.aname[5]=init
+	auto evt = generate_execve_enter_and_exit_event(0, p6_t1_tid, p6_t1_tid, p6_t1_pid, p6_t1_ptid, "/good-exe", "good-exe", "/good-exe");
+
+	EXPECT_TRUE(eval_filter(evt, "proc.aname in (init)"));
+	EXPECT_TRUE(eval_filter(evt, "proc.aname in (bash)"));
+	EXPECT_TRUE(eval_filter(evt, "proc.aname in (good-exe, init)"));
+	EXPECT_TRUE(eval_filter(evt, "proc.aname = bash"));
+	EXPECT_TRUE(eval_filter(evt, "proc.aname = init"));
+
+	EXPECT_FALSE(eval_filter(evt, "proc.aname in (good-exe)"));
+	EXPECT_FALSE(eval_filter(evt, "proc.aname = good-exe"));
+	EXPECT_FALSE(eval_filter(evt, "proc.aname in (bad-exe)"));
+}
+
 #if !defined(_WIN32) && !defined(__EMSCRIPTEN__) && !defined(__APPLE__)
 TEST_F(sinsp_with_test_input, PROC_FILTER_stdin_stdout_stderr)
 {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

#1904 had a small refactor of the management of `CO_IN` comparison for `PT_CHARBUF` fields: https://github.com/falcosecurity/libs/pull/1904/files#diff-1058cd2ebabb1fdd8503ea762a0f06f33af56cf993b3eae8a5f1919f9ef2f5d2L1026
Basically, `craft_filter_value` is now responsible of returning a correctly-sized `item` for `PT_CHARBUF`, but L1041 (https://github.com/falcosecurity/libs/pull/1904/files#diff-1058cd2ebabb1fdd8503ea762a0f06f33af56cf993b3eae8a5f1919f9ef2f5d2L1041) was not updated to use the newly-computed operator len.

Special thanks to @LucaGuerra for spotting the issue and working 4-hands with me on this.

**Which issue(s) this PR fixes**:

Fixes #2018 

**Special notes for your reviewer**:

The newly added test was double-checked against libs 0.17.3 were it was fully green.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): fixed CO_IN filter crafted value.
```
