### PR TITLE
new(ci,benchmarks): added more benchmarks and make use of them in perf CI

### DIFF
--- a/.github/actions/composite-perf/action.yml
+++ b/.github/actions/composite-perf/action.yml
@@ -14,6 +14,9 @@ outputs:
   heaptrack_scap:
     description: "Scap file heaptrack data"
     value: ${{ steps.store-outputs.outputs.heaptrack_scap }}
+  gbench_json:
+    description: "Google benchmarks json data"
+    value: ${{ steps.store-outputs.outputs.gbench_json }}
 
 runs:
   using: "composite"
@@ -28,8 +31,9 @@ runs:
       shell: bash
       run: |
         mkdir -p build
-        cd build && cmake -DUSE_BUNDLED_DEPS=False -DCMAKE_BUILD_TYPE=Debug ../
+        cd build && cmake -DUSE_BUNDLED_DEPS=False -DCMAKE_BUILD_TYPE=Debug -DENABLE_BENCHMARKS=True ../
         make unit-test-libsinsp -j4
+        make bench -j4
         make sinsp-example -j4
 
     - name: Download scap file
@@ -70,6 +74,12 @@ runs:
         cd build
         sudo heaptrack -o heaptrack_scap.data ./libsinsp/examples/sinsp-example -s traces-positive/falco-event-generator.scap
 
+    - name: Run - gbench
+      shell: bash
+      run: |
+        cd build
+        ./benchmark/bench --benchmark_report_aggregates_only --benchmark_out=gbench_data.json --benchmark_out_format=json
+
     - name: Set Outputs
       id: store-outputs
       shell: bash
@@ -79,3 +89,4 @@ runs:
         echo "perf_scap=$(realpath perf_scap.data)" >> $GITHUB_OUTPUT
         echo "heaptrack_tests=$(realpath heaptrack_tests.data.zst)" >> $GITHUB_OUTPUT
         echo "heaptrack_scap=$(realpath heaptrack_scap.data.zst)" >> $GITHUB_OUTPUT
+        echo "gbench_json=$(realpath gbench_data.json)" >> $GITHUB_OUTPUT

--- a/.github/actions/composite-perf/action.yml
+++ b/.github/actions/composite-perf/action.yml
@@ -78,7 +78,7 @@ runs:
       shell: bash
       run: |
         cd build
-        ./benchmark/bench --benchmark_report_aggregates_only --benchmark_out=gbench_data.json --benchmark_out_format=json
+        ./benchmark/bench --benchmark_repetitions=20 --benchmark_report_aggregates_only --benchmark_out=gbench_data.json --benchmark_out_format=json
 
     - name: Set Outputs
       id: store-outputs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,7 @@ jobs:
             ${{ steps.perf.outputs.perf_scap }}
             ${{ steps.perf.outputs.heaptrack_tests }}
             ${{ steps.perf.outputs.heaptrack_scap }}
+            ${{ steps.perf.outputs.gbench_json }}
           if-no-files-found: error
 
       - name: Checkout Flamegraph ⤵️

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Checkout Libs ⤵️
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Checkout Google benchmark ⤵️
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: 'google/benchmark'
+          ref: 'v1.9.0'
+          path: google-benchmark/
+
       - name: Run perf
         id: perf
         uses: ./.github/actions/composite-perf
@@ -45,22 +52,8 @@ jobs:
 
       - name: Diff from master - gbench
         run: |
-          sudo apt update && sudo apt install -y --no-install-recommends jq
-          echo "test | master | head | diff | diff %" > gbench_diff.txt
-          # Load keys from master gbench json
-          keys=$(jq -r '.benchmarks[] | select(.name | test("_mean")) | .name' gbench_data.json)
-          for key in $keys; do
-            # Load master real time value
-            master_val=$(jq -r '.benchmarks[] | select(.name == "$key") | .real_time' gbench_data.json)
-            # Load PR head real time value         
-            head_val=$(jq -r '.benchmarks[] | select(.name == "$key") | .real_time' ${{ steps.perf.outputs.gbench_json }})
-            # Only dump existing keys in current head (ie: if test was renamed/removed, skip it)
-            if [[ ! -z $head_val ]]; then
-              diff_val=$(jq -n '$head_val-$master_val')
-              diff_val_pct=$(jq -n '$diff_val/$master_val*100')
-              echo "$key | $master_val | $head_val | $diff_val | $diff_val_pct" >> gbench_diff.txt
-            fi
-          done
+          pip3 install -r google-benchmark/tools/requirements.txt
+          python3 google-benchmark/tools/compare.py --no-color benchmarks gbench_data.json ${{ steps.perf.outputs.gbench_json }} &> gbench_diff.txt
 
       - name: Archive perf diff
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
@@ -163,8 +156,9 @@ jobs:
       - name: Check >= 5% slowdown on google benchmarks
         if: always() # Even if other threshold checks failed
         run: |
-          tail -n+2 gbench_diff.txt | while read p; do
-            diff_pct=$(echo $p | awk '{print $NF}')
+          # Remove first 3 lines and last line that are no tests results
+          tail -n+4 gbench_diff.txt | head -n -1 | while read p; do
+            diff_pct=$(echo "$p" | awk '{print $3}' | tr -d '+')
             if (( $(echo "$diff_pct >= 5.0" | bc -l) )); then
               exit 1
             fi

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -43,6 +43,25 @@ jobs:
         run: |
           sudo heaptrack_print heaptrack_scap.data.zst -d ${{ steps.perf.outputs.heaptrack_scap }} &> heaptrack_scap_diff.txt
 
+      - name: Diff from master - gbench
+        run: |
+          sudo apt update && sudo apt install -y --no-install-recommends jq
+          echo "test | master | head | diff | diff %" > gbench_diff.txt
+          # Load keys from master gbench json
+          keys=$(jq -r '.benchmarks[] | select(.name | test("_mean")) | .name' gbench_data.json)
+          for key in $keys; do
+            # Load master real time value
+            master_val=$(jq -r '.benchmarks[] | select(.name == "$key") | .real_time' gbench_data.json)
+            # Load PR head real time value         
+            head_val=$(jq -r '.benchmarks[] | select(.name == "$key") | .real_time' ${{ steps.perf.outputs.gbench_json }})
+            # Only dump existing keys in current head (ie: if test was renamed/removed, skip it)
+            if [[ ! -z $head_val ]]; then
+              diff_val=$(jq -n '$head_val-$master_val')
+              diff_val_pct=$(jq -n '$diff_val/$master_val*100')
+              echo "$key | $master_val | $head_val | $diff_val | $diff_val_pct" >> gbench_diff.txt
+            fi
+          done
+
       - name: Archive perf diff
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
@@ -74,6 +93,10 @@ jobs:
           echo "# Heap diff from master - scap file" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
           tail -n3 "heaptrack_scap_diff.txt" >> ./pr/COMMENT
+          echo "\`\`\`" >> ./pr/COMMENT
+          echo "# Benchmarks diff from master" >> ./pr/COMMENT
+          echo "\`\`\`" >> ./pr/COMMENT
+          cat "gbench_diff.txt" >> ./pr/COMMENT
           echo "\`\`\`" >> ./pr/COMMENT
           echo Uploading PR info...
           cat ./pr/COMMENT
@@ -135,3 +158,14 @@ jobs:
           if [ -s heaptrack_scap_diff_above_thresh.txt ]; then
             exit 2
           fi
+
+      # Check will fail if there any google benchmark is slowed more than 5%
+      - name: Check >= 5% slowdown on google benchmarks
+        if: always() # Even if other threshold checks failed
+        run: |
+          tail -n+2 gbench_diff.txt | while read p; do
+            diff_pct=$(echo $p | awk '{print $NF}')
+            if (( $(echo "$diff_pct >= 5.0" | bc -l) )); then
+              exit 1
+            fi
+          done

--- a/benchmark/libsinsp/utils.cpp
+++ b/benchmark/libsinsp/utils.cpp
@@ -29,7 +29,7 @@ static void BM_sinsp_split(benchmark::State& state)
 }
 BENCHMARK(BM_sinsp_split);
 
-static void BM_sinsp_concatenate_paths_relative_path2(benchmark::State& state)
+static void BM_sinsp_concatenate_paths_relative_path(benchmark::State& state)
 {
 	std::string path1 = "/tmp/";
 	std::string path2 = "foo/bar";
@@ -38,9 +38,9 @@ static void BM_sinsp_concatenate_paths_relative_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_relative_path2);
+BENCHMARK(BM_sinsp_concatenate_paths_relative_path);
 
-static void BM_sinsp_concatenate_paths_empty_path2(benchmark::State& state)
+static void BM_sinsp_concatenate_paths_empty_path(benchmark::State& state)
 {
 	std::string path1 = "/tmp/";
 	std::string path2 = "";
@@ -49,9 +49,9 @@ static void BM_sinsp_concatenate_paths_empty_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_empty_path2);
+BENCHMARK(BM_sinsp_concatenate_paths_empty_path);
 
-static void BM_sinsp_concatenate_paths_absolute_path2(benchmark::State& state)
+static void BM_sinsp_concatenate_paths_absolute_path(benchmark::State& state)
 {
 	std::string path1 = "/tmp/";
 	std::string path2 = "/foo/bar";
@@ -60,7 +60,7 @@ static void BM_sinsp_concatenate_paths_absolute_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_absolute_path2);
+BENCHMARK(BM_sinsp_concatenate_paths_absolute_path);
 
 static void BM_sinsp_split_container_image(benchmark::State& state)
 {

--- a/benchmark/libsinsp/utils.cpp
+++ b/benchmark/libsinsp/utils.cpp
@@ -28,3 +28,47 @@ static void BM_sinsp_split(benchmark::State& state)
 	}
 }
 BENCHMARK(BM_sinsp_split)->Repetitions(2);
+
+static void BM_sinsp_concatenate_paths_relative_path2(benchmark::State& state)
+{
+	std::string path1 = "/tmp/";
+	std::string path2 = "foo/bar";
+	for(auto _ : state)
+	{
+		sinsp_utils::concatenate_paths(path1, path2);
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_relative_path2)->Repetitions(2);
+
+static void BM_sinsp_concatenate_paths_empty_path2(benchmark::State& state)
+{
+	std::string path1 = "/tmp/";
+	std::string path2 = "";
+	for(auto _ : state)
+	{
+		sinsp_utils::concatenate_paths(path1, path2);
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_empty_path2)->Repetitions(2);
+
+static void BM_sinsp_concatenate_paths_absolute_path2(benchmark::State& state)
+{
+	std::string path1 = "/tmp/";
+	std::string path2 = "/foo/bar";
+	for(auto _ : state)
+	{
+		sinsp_utils::concatenate_paths(path1, path2);
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_absolute_path2)->Repetitions(2);
+
+static void BM_sinsp_split_container_image(benchmark::State& state)
+{
+	std::string container_image = "localhost:12345/library/busybox:1.27.2@sha256:da39a3ee5e6b4b0d3255bfef95601890afd80709";
+	std::string hostname, port, name, tag, digest;
+	for(auto _ : state)
+	{
+		sinsp_utils::split_container_image(container_image, hostname, port, name, tag, digest);
+	}
+}
+BENCHMARK(BM_sinsp_split_container_image)->Repetitions(2);

--- a/benchmark/libsinsp/utils.cpp
+++ b/benchmark/libsinsp/utils.cpp
@@ -27,7 +27,7 @@ static void BM_sinsp_split(benchmark::State& state)
 		sinsp_split(str, ',');
 	}
 }
-BENCHMARK(BM_sinsp_split)->Repetitions(2);
+BENCHMARK(BM_sinsp_split);
 
 static void BM_sinsp_concatenate_paths_relative_path2(benchmark::State& state)
 {
@@ -38,7 +38,7 @@ static void BM_sinsp_concatenate_paths_relative_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_relative_path2)->Repetitions(2);
+BENCHMARK(BM_sinsp_concatenate_paths_relative_path2);
 
 static void BM_sinsp_concatenate_paths_empty_path2(benchmark::State& state)
 {
@@ -49,7 +49,7 @@ static void BM_sinsp_concatenate_paths_empty_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_empty_path2)->Repetitions(2);
+BENCHMARK(BM_sinsp_concatenate_paths_empty_path2);
 
 static void BM_sinsp_concatenate_paths_absolute_path2(benchmark::State& state)
 {
@@ -60,7 +60,7 @@ static void BM_sinsp_concatenate_paths_absolute_path2(benchmark::State& state)
 		sinsp_utils::concatenate_paths(path1, path2);
 	}
 }
-BENCHMARK(BM_sinsp_concatenate_paths_absolute_path2)->Repetitions(2);
+BENCHMARK(BM_sinsp_concatenate_paths_absolute_path2);
 
 static void BM_sinsp_split_container_image(benchmark::State& state)
 {
@@ -71,4 +71,4 @@ static void BM_sinsp_split_container_image(benchmark::State& state)
 		sinsp_utils::split_container_image(container_image, hostname, port, name, tag, digest);
 	}
 }
-BENCHMARK(BM_sinsp_split_container_image)->Repetitions(2);
+BENCHMARK(BM_sinsp_split_container_image);

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1363,7 +1363,7 @@ std::vector<std::string> sinsp_split(std::string_view sv, char delim)
 	}
 
 	std::string_view::size_type start = 0;
-    for (std::string_view::size_type i = 0; i < sv.size(); i++)
+    	for (std::string_view::size_type i = 0; i < sv.size(); i++)
 	{
 		if (sv[i] == delim)
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Adds some more benchmarks (around sinsp `concatenate_paths` and `split_container_image` utils).
Moreover, it adds support for benchmark results in our perf CI.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
