### PR TITLE
fix(libsinsp/state): ensure deep copy semantics and proper memory ownership in dynamic structs

### DIFF
--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -112,6 +112,10 @@ public:
 
     virtual void set_dynamic_fields(const std::shared_ptr<dynamic_struct::field_infos>& dynf)
     {
+        if (m_dynamic_fields.get() == dynf.get())
+        {
+            return;
+        }
         if (!dynf)
         {
             throw sinsp_exception("null definitions passed to set_dynamic_fields");

--- a/userspace/libsinsp/state/table_adapters.h
+++ b/userspace/libsinsp/state/table_adapters.h
@@ -127,6 +127,11 @@ protected:
 		}
 	}
 
+	virtual void destroy_dynamic_fields() override final
+	{
+		// nothing to do
+	}
+
 private:
 	T* m_value;
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

With some random tests I figured that dynamic structs implemented shallow copy semantics, whereas the intended behavior was deep copy of the allocated values. For example, storing a dynamic field in the file descriptor subtable would end up having lost information when cloning file descriptor infos during the parsing phase of fork-family syscalls.

Tests have been added.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp/state): ensure deep copy semantics and proper memory ownership in dynamic structs
```
