### PR TITLE
cleanup(engines): detach per-cpu kernel metrics from global kernel metrics

### DIFF
--- a/test/libscap/test_suites/engines/bpf/bpf.cpp
+++ b/test/libscap/test_suites/engines/bpf/bpf.cpp
@@ -138,8 +138,8 @@ TEST(bpf, metrics_v2_check_per_CPU_stats)
 
 	ssize_t num_possible_CPUs = num_possible_cpus();
 
-	// We want to check our CPUs counters
-	uint32_t flags = METRICS_V2_KERNEL_COUNTERS;
+	// Enabling `METRICS_V2_KERNEL_COUNTERS_PER_CPU` we also enable `METRICS_V2_KERNEL_COUNTERS`
+	uint32_t flags = METRICS_V2_KERNEL_COUNTERS_PER_CPU;
 	uint32_t nstats = 0;
 	int32_t rc = 0;
 	const metrics_v2* stats_v2 = scap_get_stats_v2(h, flags, &nstats, &rc);
@@ -151,9 +151,18 @@ TEST(bpf, metrics_v2_check_per_CPU_stats)
 	ssize_t found = 0;
 	char expected_name[METRIC_NAME_MAX] = "";
 	snprintf(expected_name, METRIC_NAME_MAX, N_EVENTS_PER_CPU_PREFIX"%ld", found);
+	bool check_general_kernel_counters_presence = false;
 
 	while(i < nstats)
 	{
+		// We check if `METRICS_V2_KERNEL_COUNTERS` are enabled as well
+		if(strncmp(stats_v2[i].name, N_EVENTS_PREFIX, sizeof(N_EVENTS_PREFIX)) == 0)
+		{
+			check_general_kernel_counters_presence = true;
+			i++;
+			continue;
+		}
+
 		// `sizeof(N_EVENTS_PER_CPU_PREFIX)-1` because we need to exclude the `\0`
 		if(strncmp(stats_v2[i].name, N_EVENTS_PER_CPU_PREFIX, sizeof(N_EVENTS_PER_CPU_PREFIX)-1) == 0)
 		{
@@ -175,6 +184,8 @@ TEST(bpf, metrics_v2_check_per_CPU_stats)
 			i++;
 		}
 	}
+
+	ASSERT_TRUE(check_general_kernel_counters_presence) << "per-CPU counter are enabled but general kernel counters are not";
 
 	// This test could fail in case of rare race conditions in which the number of available CPUs changes
 	// between the scap_open and the `num_possible_cpus` function. In CI we shouldn't have hot plugs so probably we
@@ -220,6 +231,16 @@ TEST(bpf, metrics_v2_check_results)
 			FAIL() << "unable to find stat '" << stat_name << "' into the array";
 		}
 	}
+
+	// Check per-CPU stats are not enabled since we didn't provide the flag.
+	for(i = 0; i < nstats; i++)
+	{
+		if(strncmp(stats_v2[i].name, N_EVENTS_PER_CPU_PREFIX, sizeof(N_EVENTS_PER_CPU_PREFIX)-1) == 0)
+		{
+			FAIL() << "per-CPU counters are enabled but we didn't provide the flag!";	
+		} 
+	}
+
 	scap_close(h);
 }
 

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -257,8 +257,8 @@ TEST(modern_bpf, metrics_v2_check_per_CPU_stats)
 
 	ssize_t num_possible_CPUs = num_possible_cpus();
 
-	// We want to check our CPUs counters
-	uint32_t flags = METRICS_V2_KERNEL_COUNTERS;
+	// Enabling `METRICS_V2_KERNEL_COUNTERS_PER_CPU` we also enable `METRICS_V2_KERNEL_COUNTERS`
+	uint32_t flags = METRICS_V2_KERNEL_COUNTERS_PER_CPU;
 	uint32_t nstats = 0;
 	int32_t rc = 0;
 	const metrics_v2* stats_v2 = scap_get_stats_v2(h, flags, &nstats, &rc);
@@ -270,9 +270,18 @@ TEST(modern_bpf, metrics_v2_check_per_CPU_stats)
 	ssize_t found = 0;
 	char expected_name[METRIC_NAME_MAX] = "";
 	snprintf(expected_name, METRIC_NAME_MAX, N_EVENTS_PER_CPU_PREFIX"%ld", found);
+	bool check_general_kernel_counters_presence = false;
 
 	while(i < nstats)
 	{
+		// We check if `METRICS_V2_KERNEL_COUNTERS` are enabled as well
+		if(strncmp(stats_v2[i].name, N_EVENTS_PREFIX, sizeof(N_EVENTS_PREFIX)) == 0)
+		{
+			check_general_kernel_counters_presence = true;
+			i++;
+			continue;
+		}
+
 		// `sizeof(N_EVENTS_PER_CPU_PREFIX)-1` because we need to exclude the `\0`
 		if(strncmp(stats_v2[i].name, N_EVENTS_PER_CPU_PREFIX, sizeof(N_EVENTS_PER_CPU_PREFIX)-1) == 0)
 		{
@@ -294,6 +303,8 @@ TEST(modern_bpf, metrics_v2_check_per_CPU_stats)
 			i++;
 		}
 	}
+
+	ASSERT_TRUE(check_general_kernel_counters_presence) << "per-CPU counter are enabled but general kernel counters are not";
 
 	// This test could fail in case of rare race conditions in which the number of available CPUs changes
 	// between the scap_open and the `num_possible_cpus` function. In CI we shouldn't have hot plugs so probably we
@@ -340,6 +351,16 @@ TEST(modern_bpf, metrics_v2_check_results)
 			FAIL() << "unable to find stat '" << stat_name << "' into the array";
 		}
 	}
+
+	// Check per-CPU stats are not enabled since we didn't provide the flag.
+	for(i = 0; i < nstats; i++)
+	{
+		if(strncmp(stats_v2[i].name, N_EVENTS_PER_CPU_PREFIX, sizeof(N_EVENTS_PER_CPU_PREFIX)-1) == 0)
+		{
+			FAIL() << "per-CPU counters are enabled but we didn't provide the flag!";	
+		} 
+	}
+	
 	scap_close(h);
 }
 

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -140,10 +140,10 @@ clean_print_stats:
 	return errno;
 }
 
-static void set_u64_monotonic_kernel_counter(uint32_t pos, uint64_t val, uint32_t metric_type)
+static void set_u64_monotonic_kernel_counter(uint32_t pos, uint64_t val, uint32_t metric_flag)
 {
 	g_state.stats[pos].type = METRIC_VALUE_TYPE_U64;
-	g_state.stats[pos].flags = metric_type;
+	g_state.stats[pos].flags = metric_flag;
 	g_state.stats[pos].unit = METRIC_VALUE_UNIT_COUNT;
 	g_state.stats[pos].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 	g_state.stats[pos].value.u64 = val;

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -292,24 +292,22 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 				g_state.stats[offset].type = METRIC_VALUE_TYPE_U64;
 				g_state.stats[offset].flags = METRICS_V2_LIBBPF_STATS;
 				strlcpy(g_state.stats[offset].name, info.name, METRIC_NAME_MAX);
+				strlcat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[stat], sizeof(g_state.stats[offset].name));
 				switch(stat)
 				{
 				case RUN_CNT:
-					strlcat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_CNT], sizeof(g_state.stats[offset].name));
-					g_state.stats[stat].unit = METRIC_VALUE_UNIT_COUNT;
-					g_state.stats[stat].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
+					g_state.stats[offset].unit = METRIC_VALUE_UNIT_COUNT;
+					g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 					g_state.stats[offset].value.u64 = info.run_cnt;
 					break;
 				case RUN_TIME_NS:
-					strlcat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(g_state.stats[offset].name));
-					g_state.stats[stat].unit = METRIC_VALUE_UNIT_TIME_NS_COUNT;
-					g_state.stats[stat].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
+					g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS_COUNT;
+					g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 					g_state.stats[offset].value.u64 = info.run_time_ns;
 					break;
 				case AVG_TIME_NS:
-					strlcat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(g_state.stats[offset].name));
-					g_state.stats[stat].unit = METRIC_VALUE_UNIT_TIME_NS;
-					g_state.stats[stat].metric_type = METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT;
+					g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS;
+					g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT;
 					g_state.stats[offset].value.u64 = 0;
 					if(info.run_cnt > 0)
 					{

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -333,7 +333,6 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 				{
 				case RUN_CNT:
 					strlcat(g_state.stats[offset].name, modern_bpf_libbpf_stats_names[RUN_CNT], sizeof(g_state.stats[offset].name));
-					g_state.stats[stat].flags = METRICS_V2_KERNEL_COUNTERS;
 					g_state.stats[stat].unit = METRIC_VALUE_UNIT_COUNT;
 					g_state.stats[stat].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 					g_state.stats[offset].value.u64 = info.run_cnt;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1688,10 +1688,10 @@ int32_t scap_bpf_get_stats(struct scap_engine_handle engine, scap_stats* stats)
 	return SCAP_SUCCESS;
 }
 
-static void set_u64_monotonic_kernel_counter(struct metrics_v2* m, uint64_t val, uint32_t metric_type)
+static void set_u64_monotonic_kernel_counter(struct metrics_v2* m, uint64_t val, uint32_t metric_flag)
 {
 	m->type = METRIC_VALUE_TYPE_U64;
-	m->flags = metric_type;
+	m->flags = metric_flag;
 	m->unit = METRIC_VALUE_UNIT_COUNT;
 	m->metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 	m->value.u64 = val;

--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1856,22 +1856,20 @@ const struct metrics_v2* scap_bpf_get_stats_v2(struct scap_engine_handle engine,
 				{
 					strlcpy(stats[offset].name, info.name, METRIC_NAME_MAX);
 				}
+				strlcat(stats[offset].name, bpf_libbpf_stats_names[stat], sizeof(stats[offset].name));
 				switch(stat)
 				{
 				case RUN_CNT:
-					strlcat(stats[offset].name, bpf_libbpf_stats_names[RUN_CNT], sizeof(stats[offset].name));
 					stats[offset].value.u64 = info.run_cnt;
 					stats[offset].unit = METRIC_VALUE_UNIT_COUNT;
 					stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 					break;
 				case RUN_TIME_NS:
-					strlcat(stats[offset].name, bpf_libbpf_stats_names[RUN_TIME_NS], sizeof(stats[offset].name));
 					stats[offset].value.u64 = info.run_time_ns;
 					stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS_COUNT;
 					stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 					break;
 				case AVG_TIME_NS:
-					strlcat(stats[offset].name, bpf_libbpf_stats_names[AVG_TIME_NS], sizeof(stats[offset].name));
 					stats[offset].value.u64 = 0;
 					stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS;
 					stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT;

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -586,10 +586,10 @@ int32_t scap_kmod_get_stats(struct scap_engine_handle engine, scap_stats* stats)
 	return SCAP_SUCCESS;
 }
 
-static void set_u64_monotonic_kernel_counter(struct metrics_v2* m, uint64_t val, uint32_t metric_type)
+static void set_u64_monotonic_kernel_counter(struct metrics_v2* m, uint64_t val, uint32_t metric_flag)
 {
 	m->type = METRIC_VALUE_TYPE_U64;
-	m->flags = metric_type;
+	m->flags = metric_flag;
 	m->unit = METRIC_VALUE_UNIT_COUNT;
 	m->metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
 	m->value.u64 = val;

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -40,7 +40,7 @@ limitations under the License.
 #include <assert.h>
 
 static const char * const kmod_kernel_counters_stats_names[] = {
-	[KMOD_N_EVTS] = "n_evts",
+	[KMOD_N_EVTS] = N_EVENTS_PREFIX,
 	[KMOD_N_DROPS_BUFFER_TOTAL] = "n_drops_buffer_total",
 	[KMOD_N_DROPS_BUFFER_CLONE_FORK_ENTER] = "n_drops_buffer_clone_fork_enter",
 	[KMOD_N_DROPS_BUFFER_CLONE_FORK_EXIT] = "n_drops_buffer_clone_fork_exit",
@@ -666,7 +666,6 @@ const struct metrics_v2* scap_kmod_get_stats_v2(struct scap_engine_handle engine
 					dev->m_bufinfo->n_drops_pf;
 			stats[KMOD_N_PREEMPTIONS].value.u64 += dev->m_bufinfo->n_preemptions;
 
-			// This is just a way to avoid the double loop on the number of devices.
 			if((flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU))
 			{
 				// We set the num events for that CPU.
@@ -681,28 +680,6 @@ const struct metrics_v2* scap_kmod_get_stats_v2(struct scap_engine_handle engine
 			}
 		}
 		offset = pos;
-	}
-
-	/* KERNEL COUNTERS PER CPU STATS 
-	 * The following `if` handle the case in which we want to get the metrics per CPU but not the global ones.
-	 * It is an unsual case but at the moment we support it.
-	 */
-	if ((flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU) && !(flags & METRICS_V2_KERNEL_COUNTERS))
-	{
-		for(uint32_t j = 0; j < devset->m_ndevs; j++)
-		{
-			struct scap_device *dev = &devset->m_devs[j];
-
-			// We set the num events for that CPU.
-			set_u64_monotonic_kernel_counter(&(stats[offset]), dev->m_bufinfo->n_evts, METRICS_V2_KERNEL_COUNTERS_PER_CPU);
-			snprintf(stats[offset].name, METRIC_NAME_MAX, N_EVENTS_PER_DEVICE_PREFIX"%d", j);
-			offset++;
-
-			// We set the drops for that CPU.
-			set_u64_monotonic_kernel_counter(&(stats[offset]), dev->m_bufinfo->n_drops_buffer + dev->m_bufinfo->n_drops_pf, METRICS_V2_KERNEL_COUNTERS_PER_CPU);
-			snprintf(stats[offset].name, METRIC_NAME_MAX, N_DROPS_PER_DEVICE_PREFIX"%d", j);
-			offset++;
-		}
 	}
 
 	*nstats = offset;

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -866,7 +866,7 @@ void print_stats()
 {
 	gettimeofday(&tval_end, NULL);
 	timersub(&tval_end, &tval_start, &tval_result);
-	uint32_t flags = METRICS_V2_KERNEL_COUNTERS | METRICS_V2_LIBBPF_STATS;
+	uint32_t flags = METRICS_V2_KERNEL_COUNTERS | METRICS_V2_LIBBPF_STATS | METRICS_V2_KERNEL_COUNTERS_PER_CPU;
 	uint32_t nstats;
 	int32_t rc;
 	const metrics_v2* stats_v2;

--- a/userspace/libscap/metrics_v2.h
+++ b/userspace/libscap/metrics_v2.h
@@ -31,6 +31,11 @@ extern "C" {
 #define METRIC_NAME_MAX 512
 
 //
+// Prefix name for n_evts metric (Used by all drivers)
+//
+#define N_EVENTS_PREFIX "n_evts"
+
+//
 // Prefix names for per-CPU metrics (Used by legacy ebpf and modern ebpf)
 //
 #define N_EVENTS_PER_CPU_PREFIX "n_evts_cpu_"

--- a/userspace/libscap/metrics_v2.h
+++ b/userspace/libscap/metrics_v2.h
@@ -52,6 +52,7 @@ extern "C" {
 #define METRICS_V2_RULE_COUNTERS (1 << 4)
 #define METRICS_V2_MISC (1 << 5)
 #define METRICS_V2_PLUGINS (1 << 6)
+#define METRICS_V2_KERNEL_COUNTERS_PER_CPU (1 << 7)
 
 typedef union metrics_v2_value {
 	uint32_t u32;

--- a/userspace/libscap/metrics_v2.h
+++ b/userspace/libscap/metrics_v2.h
@@ -57,7 +57,7 @@ extern "C" {
 #define METRICS_V2_RULE_COUNTERS (1 << 4)
 #define METRICS_V2_MISC (1 << 5)
 #define METRICS_V2_PLUGINS (1 << 6)
-#define METRICS_V2_KERNEL_COUNTERS_PER_CPU (1 << 7)
+#define METRICS_V2_KERNEL_COUNTERS_PER_CPU (1 << 7) // Requesting this does also silently enable METRICS_V2_KERNEL_COUNTERS
 
 typedef union metrics_v2_value {
 	uint32_t u32;

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -302,6 +302,12 @@ int32_t scap_get_stats(scap_t* handle, scap_stats* stats)
 //
 const struct metrics_v2* scap_get_stats_v2(scap_t* handle, uint32_t flags, uint32_t* nstats, int32_t* rc)
 {
+	// If we enable per-cpu counters, we also enable kernel global counters by default.
+	if(flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU)
+	{
+		flags |= METRICS_V2_KERNEL_COUNTERS;
+	}
+
 	if(handle && handle->m_vtable)
 	{
 		return handle->m_vtable->get_stats_v2(handle->m_engine, flags, nstats, rc);

--- a/userspace/libsinsp/metrics_collector.cpp
+++ b/userspace/libsinsp/metrics_collector.cpp
@@ -696,7 +696,7 @@ void libs_metrics_collector::snapshot()
 	 * libscap metrics
 	 */
 
-	if((m_metrics_flags & METRICS_V2_KERNEL_COUNTERS) || (m_metrics_flags & METRICS_V2_LIBBPF_STATS))
+	if((m_metrics_flags & METRICS_V2_KERNEL_COUNTERS) || (m_metrics_flags & METRICS_V2_LIBBPF_STATS) || (m_metrics_flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU))
 	{
 		uint32_t nstats = 0;
 		int32_t rc = 0;

--- a/userspace/libsinsp/metrics_collector.h
+++ b/userspace/libsinsp/metrics_collector.h
@@ -339,7 +339,7 @@ public:
 private:
 	sinsp* m_inspector;
 	std::shared_ptr<sinsp_stats_v2> m_sinsp_stats_v2;
-	uint32_t m_metrics_flags = METRICS_V2_KERNEL_COUNTERS | METRICS_V2_LIBBPF_STATS | METRICS_V2_RESOURCE_UTILIZATION | METRICS_V2_STATE_COUNTERS | METRICS_V2_PLUGINS;
+	uint32_t m_metrics_flags = METRICS_V2_KERNEL_COUNTERS | METRICS_V2_LIBBPF_STATS | METRICS_V2_RESOURCE_UTILIZATION | METRICS_V2_STATE_COUNTERS | METRICS_V2_PLUGINS | METRICS_V2_KERNEL_COUNTERS_PER_CPU;
 	std::vector<metrics_v2> m_metrics;
 };
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libscap-engine-modern-bpf

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

As explained in issue #2028, it is better to split the per-CPU counters from the global counters for verbosity reasons. 
More in detail when the per-CPU counters are enabled, libscap under the hood also enables the global counters. This is done to avoid a double loop over all the CPUs and to keep the code simpler without duplications. The idea behind this choice is that usually, a user should enable the per-cpu stats to obtain more insights with respect to the global ones so the global ones should be already enabled...

**Which issue(s) this PR fixes**:

Fixes #2028 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cleanup(engines): detach per-cpu kernel metrics from global kernel metrics
```
