### PR TITLE
Use absolute path for clang executable in modern_bpf driver

### DIFF
--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -61,7 +61,7 @@ if(NOT MODERN_CLANG_EXE)
 endif()
 
 # If it is a relative path we convert it to an absolute one relative to the root source directory.
-get_filename_component(MODERN_CLANG_EXE "${MODERN_CLANG_EXE}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+get_filename_component(MODERN_CLANG_EXE "${MODERN_CLANG_EXE}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
 message(STATUS "${MODERN_BPF_LOG_PREFIX} clang used by the modern bpf probe: '${MODERN_CLANG_EXE}'")
 
 # Check the right clang version (>=12)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**


/area build

/area driver-modern-bpf

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a very small change that should have no major impact on how the build works. However, when using ccache, having the clang executable resolve to the real path completely breaks compilation for the modern probe.

I know there are other ways to configure ccache that would potentially be possible to have it working, but I would rather not have a custom configuration just for this component.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**: I can't think of a particular reason to use the real versus the absolute path for clang other than getting it as part of a compilation error, but I would argue anyone building the modern probe should be skillful enough to track down what clang binary is being used without this. If there's any other reason, please do let me know.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
