### PR TITLE
new(drivers): add dns dynamic snaplen

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -591,6 +591,10 @@ static __always_inline uint32_t bpf_compute_snaplen(struct filler_data *data, ui
 	{
 		return res > SNAPLEN_EXTENDED ? res : SNAPLEN_EXTENDED;
 	}
+	else if(port_remote == PPM_PORT_DNS)
+	{
+		return res > SNAPLEN_DNS_UDP ? res : SNAPLEN_DNS_UDP;
+	}
 	else if((port_local == PPM_PORT_MYSQL || port_remote == PPM_PORT_MYSQL) && lookahead_size >= 5)
 	{
 		if((get_buf(0) == 3 || get_buf(1) == 3 || get_buf(2) == 3 || get_buf(3) == 3 || get_buf(4) == 3) ||

--- a/driver/capture_macro.h
+++ b/driver/capture_macro.h
@@ -13,6 +13,7 @@ or GPL2.txt for full copies of the license.
 // #define SNAPLEN_TRACERS_ENABLED 4096 // note: deprecated
 #define SNAPLEN_FULLCAPTURE_PORT 16000
 #define SNAPLEN_MAX 65000
+#define SNAPLEN_DNS_UDP 512
 
 /* Deep packet inspection logic */
 #define DPI_LOOKAHEAD_SIZE 16
@@ -20,6 +21,7 @@ or GPL2.txt for full copies of the license.
 #define PPM_PORT_POSTGRES 5432
 #define PPM_PORT_STATSD 8125
 #define PPM_PORT_MONGODB 27017
+#define PPM_PORT_DNS 53
 
 /* HTTP */
 #define BPF_HTTP_GET 0x20544547

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -1603,6 +1603,12 @@ static __always_inline void apply_dynamic_snaplen(struct pt_regs *regs, uint16_t
 		*snaplen = *snaplen > SNAPLEN_EXTENDED ? *snaplen : SNAPLEN_EXTENDED;
 		return;
 	}
+	else if(port_remote == PPM_PORT_DNS)
+	{
+		/* Expanded snaplen for DNS port */
+		*snaplen = *snaplen > SNAPLEN_DNS_UDP ? *snaplen : SNAPLEN_DNS_UDP;
+		return;
+	}
 
 	/* If we check only port range without reading syscall data we can stop here */
 	if(only_port_range)

--- a/driver/ppm_events.c
+++ b/driver/ppm_events.c
@@ -418,6 +418,11 @@ inline uint32_t compute_snaplen(struct event_filler_arguments *args, char *buf, 
 		res = res > SNAPLEN_EXTENDED ? res : SNAPLEN_EXTENDED;
 		goto done;
 	}
+	else if(port_remote == PPM_PORT_DNS)
+	{
+		res = res > SNAPLEN_DNS_UDP ? res : SNAPLEN_DNS_UDP;
+		goto done;
+	}
 	else if((port_local == PPM_PORT_MYSQL || port_remote == PPM_PORT_MYSQL) && lookahead_size >= 5)
 	{
 		if((buf[0] == 3 || buf[1] == 3 || buf[2] == 3 || buf[3] == 3 || buf[4] == 3) ||

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -43,7 +43,7 @@ struct send_data {
 	bool null_sockaddr;
 };
 
-struct receive_data {
+struct recv_data {
 	int syscall_num;
 	bool null_sockaddr;
 	bool null_receiver_buffer;
@@ -60,6 +60,14 @@ enum protocol_L3
 {
 	IPv4 = 0,
 	IPv6 = 1,
+};
+
+struct network_config
+{
+	protocol_L3 proto_L3;
+	protocol_L4 proto_L4;
+	int32_t client_port;
+	int32_t server_port;
 };
 
 /* Assertion operators */
@@ -355,12 +363,16 @@ public:
 	void connect_ipv4_udp_client_to_server(int32_t* client_socket, struct sockaddr_in* client_sockaddr, int32_t* server_socket, struct sockaddr_in* server_sockaddr, int32_t client_port = IPV4_PORT_CLIENT, int32_t server_port = IPV4_PORT_SERVER);
 
 	// todo!: we should rename it into `connect_ipv6_client_to_server`
-	void connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr);
-	void connect_ipv6_udp_client_to_server(int32_t* client_socket, sockaddr_in6* client_sockaddr, int32_t* server_socket, sockaddr_in6* server_sockaddr);
+	void connect_ipv6_client_to_server(int32_t* client_socket, struct sockaddr_in6* client_sockaddr, int32_t* server_socket, struct sockaddr_in6* server_sockaddr, int32_t client_port = IPV6_PORT_CLIENT, int32_t server_port = IPV6_PORT_SERVER);
+	void connect_ipv6_udp_client_to_server(int32_t* client_socket, sockaddr_in6* client_sockaddr, int32_t* server_socket, sockaddr_in6* server_sockaddr, int32_t client_port = IPV6_PORT_CLIENT, int32_t server_port = IPV6_PORT_SERVER);
 
 	void connect_unix_client_to_server(int32_t* client_socket, struct sockaddr_un* client_sockaddr, int32_t* server_socket, struct sockaddr_un* server_sockaddr);
 
-	void client_to_server(send_data send_d, receive_data receive_d, protocol_L3 proto_L3, protocol_L4 proto_L4);
+	void client_to_server(send_data send_d, recv_data receive_d, network_config net_config);
+	void client_to_server_ipv4_tcp(send_data send_d, recv_data receive_d = {.skip_recv_phase = true}, int32_t client_port = IP_PORT_CLIENT, int32_t server_port = IP_PORT_SERVER);
+	void client_to_server_ipv4_udp(send_data send_d, recv_data receive_d = {.skip_recv_phase = true}, int32_t client_port = IP_PORT_CLIENT, int32_t server_port = IP_PORT_SERVER);
+	void client_to_server_ipv6_tcp(send_data send_d, recv_data receive_d = {.skip_recv_phase = true}, int32_t client_port = IP_PORT_CLIENT, int32_t server_port = IP_PORT_SERVER);
+	void client_to_server_ipv6_udp(send_data send_d, recv_data receive_d = {.skip_recv_phase = true}, int32_t client_port = IP_PORT_CLIENT, int32_t server_port = IP_PORT_SERVER);
 	
 	/////////////////////////////////
 	// GENERIC EVENT ASSERTIONS

--- a/test/drivers/event_class/network_utils.h
+++ b/test/drivers/event_class/network_utils.h
@@ -16,22 +16,34 @@
 /* Server queue length. */
 #define QUEUE_LENGTH 2
 
+/* IP ports 
+ * todo!: The distinction between ipv4 and ipv6 ports is not necessary.
+ * at the moment we keep them just too avoid to touch many files.
+ */
+#define IP_PORT_DNS 53
+#define IP_PORT_EMPTY 0
+#define IP_PORT_EMPTY_STRING "0"
+#define IP_PORT_CLIENT 51789
+#define IP_PORT_CLIENT_STRING "51789"
+#define IP_PORT_SERVER 52889
+#define IP_PORT_SERVER_STRING "52889"
+
 /*=============================== IPV4 ===========================*/
 
 /* Empty endpoint */
 #define IPV4_EMPTY "0.0.0.0"
-#define IPV4_PORT_EMPTY 0
-#define IPV4_PORT_EMPTY_STRING "0"
+#define IPV4_PORT_EMPTY IP_PORT_EMPTY
+#define IPV4_PORT_EMPTY_STRING IP_PORT_EMPTY_STRING
 
 /* IPv4 Client */
 #define IPV4_CLIENT "127.0.21.34"
-#define IPV4_PORT_CLIENT 51789
-#define IPV4_PORT_CLIENT_STRING "51789"
+#define IPV4_PORT_CLIENT IP_PORT_CLIENT
+#define IPV4_PORT_CLIENT_STRING IP_PORT_CLIENT_STRING
 
 /* IPv4 Server */
 #define IPV4_SERVER "127.59.21.35"
-#define IPV4_PORT_SERVER 52889
-#define IPV4_PORT_SERVER_STRING "52889"
+#define IPV4_PORT_SERVER IP_PORT_SERVER
+#define IPV4_PORT_SERVER_STRING IP_PORT_SERVER_STRING
 
 /*=============================== IPV4 ===========================*/
 
@@ -39,13 +51,13 @@
 
 /* IPv6 Client */
 #define IPV6_CLIENT "::ffff:127.0.0.4"
-#define IPV6_PORT_CLIENT 51790
-#define IPV6_PORT_CLIENT_STRING "51790"
+#define IPV6_PORT_CLIENT IP_PORT_CLIENT
+#define IPV6_PORT_CLIENT_STRING IP_PORT_CLIENT_STRING
 
 /* IPv6 Server */
 #define IPV6_SERVER "::ffff:127.0.0.5"
-#define IPV6_PORT_SERVER 52890
-#define IPV6_PORT_SERVER_STRING "52890"
+#define IPV6_PORT_SERVER IP_PORT_SERVER
+#define IPV6_PORT_SERVER_STRING IP_PORT_SERVER_STRING
 
 /*=============================== IPV6 ===========================*/
 

--- a/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendmsg_e.cpp
@@ -13,8 +13,7 @@ TEST(SyscallEnter, sendmsgE_ipv4_tcp)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -53,8 +52,7 @@ TEST(SyscallEnter, sendmsgE_ipv4_tcp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .null_sockaddr = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendmsg, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -104,8 +102,7 @@ TEST(SyscallEnter, sendmsgE_ipv4_udp)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
+++ b/test/drivers/test_suites/syscall_enter_suite/sendto_e.cpp
@@ -13,8 +13,7 @@ TEST(SyscallEnter, sendtoE_ipv4_tcp)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -53,8 +52,7 @@ TEST(SyscallEnter, sendtoE_ipv4_tcp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .null_sockaddr = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -104,8 +102,7 @@ TEST(SyscallEnter, sendtoE_ipv4_udp)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/read_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/read_x.cpp
@@ -153,8 +153,8 @@ TEST(SyscallExit, readX_ipv4_tcp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_read}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					    recv_data{.syscall_num = __NR_read});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -198,8 +198,8 @@ TEST(SyscallExit, readX_ipv4_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_read}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					    recv_data{.syscall_num = __NR_read});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -244,8 +244,8 @@ TEST(SyscallExit, readX_ipv4_udp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_read}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					    recv_data{.syscall_num = __NR_read});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -287,8 +287,8 @@ TEST(SyscallExit, readX_ipv4_udp_message_truncated_fullcapture_client_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_read}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					    recv_data{.syscall_num = __NR_read});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -332,16 +332,16 @@ TEST(SyscallExit, readX_ipv4_udp_message_not_truncated_fullcapture_server_port)
 
 	evt_test->set_do_dynamic_snaplen(true);
 
-	// In this case we should be able to retrieve the server port from the kernel socket because it is the local port
-	// We are receiving on the server.
+	// In this case we should be able to retrieve the server port from the kernel socket because it is the local
+	// port We are receiving on the server.
 	evt_test->set_fullcapture_port_range(IPV4_PORT_SERVER, IPV4_PORT_SERVER);
 
 	evt_test->enable_capture();
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_read}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					    recv_data{.syscall_num = __NR_read});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvfrom_x.cpp
@@ -16,8 +16,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -61,8 +61,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -109,8 +109,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -165,8 +165,8 @@ TEST(SyscallExit, recvfromX_ipv6_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv6, protocol_L4::TCP);
+	evt_test->client_to_server_ipv6_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -216,9 +216,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -270,9 +269,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_message_not_truncated_fullcapture_port_NULL
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -322,9 +320,8 @@ TEST(SyscallExit, recvfromX_ipv4_tcp_NULL_buffer)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_receiver_buffer = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_receiver_buffer = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -369,8 +366,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -412,8 +409,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -460,8 +457,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -511,8 +508,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -564,8 +561,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_message_truncated_fullcapture_port_NULL_soc
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -615,8 +612,8 @@ TEST(SyscallExit, recvfromX_ipv4_udp_NULL_buffer)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvfrom, .null_receiver_buffer = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvfrom, .null_receiver_buffer = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvmsg_x.cpp
@@ -16,8 +16,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_message_shorter_than_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -80,8 +80,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_message_longer_than_snaplen_truncated)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -127,8 +127,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_message_longer_than_snaplen_not_truncated_fu
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -181,8 +181,8 @@ TEST(SyscallExit, recvmsgX_ipv6_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv6, protocol_L4::TCP);
+	evt_test->client_to_server_ipv6_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -230,9 +230,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -294,9 +293,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_message_longer_than_snaplen_not_truncated_fu
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -344,9 +342,8 @@ TEST(SyscallExit, recvmsgX_ipv4_tcp_NULL_buffer)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_receiver_buffer = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_receiver_buffer = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -389,8 +386,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_message_shorter_than_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -438,8 +435,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_message_longer_than_snaplen_truncated)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -485,8 +482,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_message_longer_than_snaplen_not_truncated_fu
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -531,9 +528,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_NULL_sockaddr)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -596,9 +592,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_message_longer_than_snaplen_truncated_fullca
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -643,9 +638,8 @@ TEST(SyscallExit, recvmsgX_ipv4_udp_NULL_buffer)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.syscall_num = __NR_recvmsg, .null_receiver_buffer = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
+					recv_data{.syscall_num = __NR_recvmsg, .null_receiver_buffer = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmsg_x.cpp
@@ -15,8 +15,7 @@ TEST(SyscallExit, sendmsgX_ipv4_tcp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -54,8 +53,7 @@ TEST(SyscallExit, sendmsgX_ipv4_tcp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -98,8 +96,7 @@ TEST(SyscallExit, sendmsgX_ipv4_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -149,8 +146,7 @@ TEST(SyscallExit, sendmsgX_ipv6_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv6, protocol_L4::TCP);
+	evt_test->client_to_server_ipv6_tcp(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -199,9 +195,8 @@ TEST(SyscallExit, sendmsgX_ipv4_tcp_message_not_truncated_fullcapture_port_NULL_
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(
-		send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true, .null_sockaddr = true},
-		receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(
+		send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -248,8 +243,7 @@ TEST(SyscallExit, sendmsgX_ipv4_udp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendmsg});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -287,8 +281,7 @@ TEST(SyscallExit, sendmsgX_ipv4_udp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -330,8 +323,7 @@ TEST(SyscallExit, sendmsgX_ipv4_udp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendmsg, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendto_x.cpp
@@ -15,8 +15,7 @@ TEST(SyscallExit, sendtoX_ipv4_tcp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -54,8 +53,7 @@ TEST(SyscallExit, sendtoX_ipv4_tcp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -98,8 +96,7 @@ TEST(SyscallExit, sendtoX_ipv4_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -149,8 +146,7 @@ TEST(SyscallExit, sendtoX_ipv6_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv6, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -199,9 +195,8 @@ TEST(SyscallExit, sendtoX_ipv4_tcp_message_not_truncated_fullcapture_port_NULL_s
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(
-		send_data{.syscall_num = __NR_sendto, .greater_snaplen = true, .null_sockaddr = true},
-		receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(
+		send_data{.syscall_num = __NR_sendto, .greater_snaplen = true, .null_sockaddr = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -248,8 +243,7 @@ TEST(SyscallExit, sendtoX_ipv4_udp_message_not_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto}, receive_data{.skip_recv_phase = true},
-					protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -287,8 +281,7 @@ TEST(SyscallExit, sendtoX_ipv4_udp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -330,8 +323,7 @@ TEST(SyscallExit, sendtoX_ipv4_udp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::UDP);
+	evt_test->client_to_server_ipv4_udp(send_data{.syscall_num = __NR_sendto, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 

--- a/test/drivers/test_suites/syscall_exit_suite/write_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/write_x.cpp
@@ -188,8 +188,7 @@ TEST(SyscallExit, writeX_ipv4_tcp_message_truncated_by_snaplen)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_write, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_write, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
@@ -231,8 +230,7 @@ TEST(SyscallExit, writeX_ipv4_tcp_message_not_truncated_fullcapture_port)
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
-	evt_test->client_to_server(send_data{.syscall_num = __NR_write, .greater_snaplen = true},
-					receive_data{.skip_recv_phase = true}, protocol_L3::IPv4, protocol_L4::TCP);
+	evt_test->client_to_server_ipv4_tcp(send_data{.syscall_num = __NR_write, .greater_snaplen = true});
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**


**What this PR does / why we need it**:

See the payload of DNS query/response could be usually interesting. This patch increases the dynamic snaplen when the DNS PORT (53) is detected. It is disabled by default if `do_dynamic_snaplen` is not enabled.

This PR continues the reactor of network drivers tests

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
