### PR TITLE
fix(ci): avoid running drivers CI jobs that need secrets in PR coming from forks

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-22.04
     # Avoid running on forks since this job uses a private secret
     # not available on forks, leading to failures.
-    if: github.repository == 'falcosecurity/libs'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'falcosecurity/libs'
     needs: paths-filter
     steps:
       - name: Extract branch name
@@ -351,7 +351,7 @@ jobs:
     needs: paths-filter
     # Avoid running on forks since this job uses a private secret
     # not available on forks, leading to failures.
-    if: github.repository == 'falcosecurity/libs' && github.event_name == 'pull_request' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'falcosecurity/libs' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
     uses: ./.github/workflows/reusable_kernel_tests.yaml
     with:
       # Use real branch's HEAD sha, not the merge commit
@@ -362,7 +362,7 @@ jobs:
     needs: kernel-tests-dev
     # Avoid running on forks since this job uses a private secret
     # not available on forks, leading to failures.
-    if: github.repository == 'falcosecurity/libs' && github.event_name == 'pull_request' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'falcosecurity/libs' && (needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Download X64 matrix


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The current solution is not working because `github.repository` resolves to the target github repository that is always `falcosecurity/libs`.
That trick is needed to avoid run a github action on forks.
Instead, we need to avoid running a github action on PRs coming from forks; we need to rely on `github.event.pull_request.head.repo.full_name`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
