### PR TITLE
fix(libsinsp): solve field-field comparison pointer instability issues 

### DIFF
--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -270,7 +270,6 @@ private:
 	libsinsp::filter::ast::pos_info m_pos;
 	boolop m_last_boolop;
 	std::unique_ptr<sinsp_filter_check> m_last_node_field;
-	bool m_last_node_field_is_plugin;
 	std::string m_flt_str;
 	std::unique_ptr<sinsp_filter> m_filter;
 	std::vector<std::string> m_field_values;

--- a/userspace/libsinsp/filter_field.h
+++ b/userspace/libsinsp/filter_field.h
@@ -46,6 +46,10 @@ enum filtercheck_field_flags {
 	EPF_NO_TRANSFORMER = 1 << 11,  ///< this field cannot have a field transformer.
 	EPF_NO_RHS = 1 << 12,  ///< this field cannot have a right-hand side filter check, and cannot be
 	                       ///< used as a right-hand side filter check.
+	EPF_NO_PTR_STABILITY =
+	        1 << 13,  ///< data pointers extracted by this field may change across subsequent
+	                  ///< extractions (even of other fields), which makes them unsafe to be used
+	                  ///< with filter caching or field-to-field comparisons
 };
 
 /**
@@ -93,6 +97,14 @@ struct filtercheck_field_info {
 	// Returns true if this filter check can support an extraction transformer on it.
 	//
 	inline bool is_transformer_supported() const { return !(m_flags & EPF_NO_TRANSFORMER); }
+
+	//
+	// Return true if this field extracts unstable data pointers that may change
+	// at subsequent extractions (even of other fields), thus not being safe to
+	// be used with caches or field-to-field filter comparisons, unless protected
+	// through a memory buffer copy (e.g. with a FTR_STORAGE transformer)
+	//
+	inline bool is_ptr_unstable() const { return m_flags & EPF_NO_PTR_STABILITY; }
 };
 
 /**

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -463,7 +463,9 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string& errstr) {
 		m_fields.clear();
 		for(Json::Value::ArrayIndex j = 0; j < root.size(); j++) {
 			filtercheck_field_info tf;
-			tf.m_flags = EPF_NONE;
+
+			// plugin fields can't ever be trusted for pointer stability
+			tf.m_flags = EPF_NO_PTR_STABILITY;
 
 			const Json::Value& jvtype = root[j]["type"];
 			string ftype = jvtype.asString();

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -688,7 +688,8 @@ void sinsp_filter_check::add_filter_value(std::unique_ptr<sinsp_filter_check> rh
 	}
 
 	if(!rhs_chk->get_transformed_field_info()->is_rhs_field_supported()) {
-		throw sinsp_exception("field '" + std::string(get_transformed_field_info()->m_name) +
+		throw sinsp_exception("field '" +
+		                      std::string(rhs_chk->get_transformed_field_info()->m_name) +
 		                      "' can't be used as a right-hand side field");
 	}
 

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -37,12 +37,6 @@ extern sinsp_evttables g_infotables;
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_PTR(x) \
-	do {                      \
-		*len = sizeof(*(x));  \
-		return (uint8_t*)(x); \
-	} while(0)
-
 #define RETURN_EXTRACT_STRING(x)      \
 	do {                              \
 		*len = (x).size();            \
@@ -162,7 +156,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] = {
          "Arguments",
          "all the event arguments, aggregated into a single string."},
         {PT_CHARBUF,
-         EPF_ARG_REQUIRED,
+         EPF_ARG_REQUIRED | EPF_NO_PTR_STABILITY,
          PF_NA,
          "evt.arg",
          "Argument",
@@ -184,7 +178,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] = {
          "(like writes to /dev/log) it provides higher level information coming from decoding the "
          "arguments."},
         {PT_BYTEBUF,
-         EPF_NONE,
+         EPF_NO_PTR_STABILITY,
          PF_NA,
          "evt.buffer",
          "Buffer",
@@ -198,7 +192,7 @@ const filtercheck_field_info sinsp_filter_check_event_fields[] = {
          "the length of the binary data buffer for events that have one, like read(), recvfrom(), "
          "etc."},
         {PT_CHARBUF,
-         EPF_NONE,
+         EPF_NO_PTR_STABILITY,
          PF_DEC,
          "evt.res",
          "Return Value",

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -827,6 +827,19 @@ TEST_F(sinsp_with_test_input, filter_cache_corner_cases) {
 	cf->metrics->reset();
 }
 
+TEST_F(sinsp_with_test_input, filter_cache_pointer_instability) {
+	sinsp_filter_check_list flist;
+
+	add_default_init_thread();
+	open_inspector();
+
+	auto ff = std::make_shared<sinsp_filter_factory>(&m_inspector, flist);
+	auto cf = std::make_shared<test_sinsp_filter_cache_factory>();
+	auto evt = generate_proc_exit_event(2, INIT_TID);
+
+	EXPECT_FALSE(eval_filter(evt, "(evt.arg.ret = val(evt.arg.reaper_tid))"));
+}
+
 TEST_F(sinsp_with_test_input, filter_regex_operator_evaluation) {
 	// Basic case just to assert that the basic setup works
 	add_default_init_thread();

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -321,13 +321,14 @@ sinsp_evt* sinsp_with_test_input::generate_proc_exit_event(int64_t tid_to_remove
 	// Scaffolding needed to call the PPME_PROCEXIT_1_E
 	int64_t not_relevant_64 = 0;
 	uint8_t not_relevant_8 = 0;
+	int64_t ret_err_perm = -1;  // mostly non-relevant, used in few tests
 
 	return add_event_advance_ts(increasing_ts(),
 	                            tid_to_remove,
 	                            PPME_PROCEXIT_1_E,
 	                            5,
 	                            not_relevant_64,
-	                            not_relevant_64,
+	                            ret_err_perm,
 	                            not_relevant_8,
 	                            not_relevant_8,
 	                            reaper_tid);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Internal tests demonstrated that field-to-field comparisons and/or filter caching can't just be broken with plugin fields (for which we enforced a STORAGE transformer layer in the compiler), but also with other fields were pointer stability between subsequent extractions on the same events (even on different fields) is not guaranteed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): solve field-field comparison pointer instability issues 
```
