### PR TITLE
fix(libscap): use the correct memory barrier for ARM64

### DIFF
--- a/userspace/libpman/src/ringbuffer_definitions.h
+++ b/userspace/libpman/src/ringbuffer_definitions.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "state.h"
 #include <linux/bpf.h>
+#include <libscap/scap_barrier.h>
 
 /* Taken from libbpf: /src/ringbuf.c */
 struct ring {
@@ -50,23 +51,3 @@ static inline int roundup_len(uint32_t len) {
 	/* round up to 8 byte alignment */
 	return (len + 7) / 8 * 8;
 }
-
-/* Taken from libbpf: `include/linux/compiler.h` */
-
-#define READ_ONCE(x) (*(volatile typeof(x) *)&x)
-#define WRITE_ONCE(x, v) (*(volatile typeof(x) *)&x) = (v)
-
-#define barrier() asm volatile("" ::: "memory")
-
-#define smp_store_release(p, v) \
-	do {                        \
-		barrier();              \
-		WRITE_ONCE(*p, v);      \
-	} while(0)
-
-#define smp_load_acquire(p)              \
-	({                                   \
-		typeof(*p) ___p = READ_ONCE(*p); \
-		barrier();                       \
-		___p;                            \
-	})

--- a/userspace/libscap/engine/bpf/scap_bpf.h
+++ b/userspace/libscap/engine/bpf/scap_bpf.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <libscap/compat/bpf.h>
 #include <libscap/compat/perf_event.h>
+#include <libscap/scap_barrier.h>
 
 struct perf_event_sample {
 	struct perf_event_header header;
@@ -49,9 +50,7 @@ static inline void scap_bpf_get_buf_pointers(scap_device *dev,
 	*phead = header->data_head;
 	*ptail = header->data_tail;
 
-	// clang-format off
-	asm volatile("" ::: "memory");
-	// clang-format on
+	mem_barrier();
 
 	uint64_t cons = *ptail % header->data_size;  // consumer position
 	uint64_t prod = *phead % header->data_size;  // producer position
@@ -154,9 +153,7 @@ static inline void scap_bpf_advance_tail(struct scap_device *dev) {
 
 	header = (struct perf_event_mmap_page *)dev->m_buffer;
 
-	// clang-format off
-	asm volatile("" ::: "memory");
-	// clang-format on
+	mem_barrier();
 
 	ASSERT(dev->m_lastreadsize > 0);
 	/* `header->data_tail` is the consumer position. */

--- a/userspace/libscap/linux/barrier.h
+++ b/userspace/libscap/linux/barrier.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2024 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,4 +17,61 @@ limitations under the License.
 */
 #pragma once
 
-#define mem_barrier() __sync_synchronize()
+// This is taken from kernel headers `/include/linux/compiler.h`
+// Used by libpman and scap_bpf engine
+
+#define READ_ONCE(x) (*(volatile typeof(x) *)&x)
+#define WRITE_ONCE(x, v) (*(volatile typeof(x) *)&x) = (v)
+
+#define barrier() asm volatile("" ::: "memory")
+
+#if defined(__x86_64__)
+
+#define smp_mb() asm volatile("lock; addl $0,-132(%%rsp)" ::: "memory", "cc")
+
+#define smp_store_release(p, v) \
+	do {                        \
+		barrier();              \
+		WRITE_ONCE(*p, v);      \
+	} while(0)
+
+#define smp_load_acquire(p)              \
+	({                                   \
+		typeof(*p) ___p = READ_ONCE(*p); \
+		barrier();                       \
+		___p;                            \
+	})
+
+#elif defined(__aarch64__)
+
+#define smp_mb() asm volatile("dmb ish" ::: "memory")
+
+#endif
+
+#ifndef smp_mb
+#define smp_mb() __sync_synchronize()
+#endif
+
+#ifndef smp_store_release
+#define smp_store_release(p, v) \
+	do {                        \
+		smp_mb();               \
+		WRITE_ONCE(*p, v);      \
+	} while(0)
+#endif
+
+#ifndef smp_load_acquire
+#define smp_load_acquire(p)              \
+	({                                   \
+		typeof(*p) ___p = READ_ONCE(*p); \
+		smp_mb();                        \
+		___p;                            \
+	})
+#endif
+
+// This is defined by us
+#if defined(__x86_64__)
+#define mem_barrier() barrier()
+#else
+#define mem_barrier() smp_mb()
+#endif


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-bpf

/area libscap-engine-kmod

/area libpman

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR should fix https://github.com/falcosecurity/libs/issues/2061. 
Today `smp_load_acquire` and `smp_store_release` use the synchronization primitives of x86 also on other architectures... but thanks to the nature of our code we never noticed it until this PR https://github.com/falcosecurity/libs/pull/2009.

More detail in the addition of 
```c
	if(g_state.cons_pos[pos] == g_state.prod_pos[pos]) {
			return NULL;
	}
```

caused the `g_state.prod_pos[pos]` value to be used immediately after the fetch. So if it was a wrong value we might end up reading some junk from the buffer... And this is exactly what is happening here https://github.com/falcosecurity/libs/issues/2061. This is for the modern ebpf.

 the other drivers also used the wrong primitives, but again, probably due to some luck and rare race conditions we never faced any issues...btw I tried to fix them

The fix is to use the right synchronization primitives! Unfortunately, the definitions of these primitives are in the kernel headers so to avoid the constraint of having the headers when building libscap engines, I decided to copy the needed definitions, not sure if we want to take other directions here...


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2061

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
