### PR TITLE
wip: chore(ci): improve e2e CI run time by avoiding caching `build` folder and the bundled deps build

### DIFF
--- a/.github/workflows/e2e_ci.yml
+++ b/.github/workflows/e2e_ci.yml
@@ -82,8 +82,6 @@ jobs:
             cmake \
                 -DBUILD_BPF=ON \
                 -DUSE_BUNDLED_DEPS=OFF \
-                -DUSE_ASAN=ON \
-                -DUSE_UBSAN=ON \
                 -DENABLE_LIBSINSP_E2E_TESTS=ON \
                 -DBUILD_LIBSCAP_MODERN_BPF=ON \
                 -DBUILD_LIBSCAP_GVISOR=OFF \

--- a/.github/workflows/e2e_ci.yml
+++ b/.github/workflows/e2e_ci.yml
@@ -13,12 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test-e2e:
-    name: build-test-e2e-${{ matrix.arch }} 😇 (bundled_deps)
+  test-test-e2e:
+    name: test-e2e-${{ matrix.arch }}-${{ matrix.driver.name }} 😇 (system_deps)
     runs-on: ${{ (matrix.arch == 'arm64' && 'actuated-arm64-8cpu-16gb') || 'ubuntu-22.04' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
+        driver: [ {name: kmod, option: -k}, {name: bpf, option: -b}, {name: modern-bpf, option: -m} ]
       fail-fast: false
     steps:
       - name: Checkout Libs ⤵️
@@ -35,7 +36,6 @@ jobs:
             clang-14 llvm-14 \
             git \
             clang \
-            ccache \
             llvm \
             pkg-config \
             autoconf \
@@ -54,7 +54,9 @@ jobs:
             libgrpc++-dev \
             protobuf-compiler-grpc \
             libgtest-dev \
-            libprotobuf-dev
+            libprotobuf-dev \
+            python3 \
+            quota
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
           sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
           sudo update-alternatives --install /usr/bin/llc llc /usr/bin/llc-14 90
@@ -73,20 +75,13 @@ jobs:
         run: |
           sudo apt install -y --no-install-recommends linux-headers-$(uname -r) gcc-multilib g++-multilib
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
-
       - name: Build e2e tests 🏗️
-        env:
-          SCCACHE_GHA_ENABLED: "true"
         run: |
           mkdir -p build
           cd build && \
             cmake \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                 -DBUILD_BPF=ON \
-                -DUSE_BUNDLED_DEPS=ON \
+                -DUSE_BUNDLED_DEPS=OFF \
                 -DUSE_ASAN=ON \
                 -DUSE_UBSAN=ON \
                 -DENABLE_LIBSINSP_E2E_TESTS=ON \
@@ -96,78 +91,12 @@ jobs:
                 -DUSE_BUNDLED_GTEST=ON \
                 ..
           make -j6 libsinsp_e2e_tests
-          sudo rm -vfr test/libsinsp_e2e/resources/_proc
-          cd ..
 
-      - name: Cache build
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        if: always()
-        id: cache
-        with:
-          path: build
-          key: build-e2e-${{ matrix.arch }}-${{ github.run_id }}
-
-  test-e2e:
-    name: test-e2e-${{ matrix.arch }}-${{ matrix.driver.name }} 😇 (bundled_deps)
-    needs: [build-test-e2e]
-    runs-on: ${{ (matrix.arch == 'arm64' && 'actuated-arm64-8cpu-16gb') || 'ubuntu-22.04' }}
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-        driver: [ {name: kmod, option: -k}, {name: bpf, option: -b}, {name: modern-bpf, option: -m} ]
-      fail-fast: false
-    steps:
-      - name: Checkout Libs ⤵️
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-
-      - name: Restore build
-        id: cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: build
-          key: build-e2e-${{ matrix.arch }}-${{ github.run_id }}
-          restore-keys: build-e2e-
-          
       - name: Fix kernel mmap rnd bits
         # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
         # high-entropy ASLR in much newer kernels that GitHub runners are
         # using leading to random crashes: https://reviews.llvm.org/D148280
         run: sudo sysctl vm.mmap_rnd_bits=28
-
-      - name: Update apt index
-        run: |
-          sudo apt update
-
-      - name: Install multilib
-        if: matrix.arch == 'amd64'
-        run: |
-          sudo apt install -y --no-install-recommends gcc-multilib g++-multilib
-
-      - name: Install deps
-        run: |
-          sudo apt install -y --no-install-recommends clang gcc llvm build-essential cmake python3 quota
-
-      - name: Install kernel headers (actuated)
-        uses: self-actuated/get-kernel-sources@201eed7d915ac0a6021fb402cde5be7a6b945b59
-        if: matrix.arch == 'arm64'
-
-      - name: Install kernel headers and gcc
-        if: matrix.arch == 'amd64'
-        run: |
-          sudo apt install -y --no-install-recommends linux-headers-$(uname -r) gcc-multilib g++-multilib
-
-        # We have no guarantees that the kernel version is the same for the
-        # different workers, so we rebuild the drivers.
-      - name: Rebuild drivers
-        run: |
-          pushd build
-          make -B driver bpf
-          pushd test/libsinsp_e2e/resources/
-          sudo tar xzf fake-proc.tar.gz
-          popd
-          popd
 
       - name: Run e2e tests with ${{ matrix.driver.name }} 🏎️
         if: matrix.arch == 'amd64'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
