### PR TITLE
fix(libsinsp-e2e-tests): stop capture upon stop_capture()

### DIFF
--- a/test/libsinsp_e2e/event_capture.cpp
+++ b/test/libsinsp_e2e/event_capture.cpp
@@ -178,6 +178,7 @@ void event_capture::capture() {
 void event_capture::stop_capture() {
 	{
 		std::scoped_lock init_lock(m_inspector_mutex, m_object_state_mutex);
+		get_inspector()->stop_capture();
 		m_capture_stopped = true;
 		m_condition_stopped.notify_one();
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

I have noticed some tests from the e2e suite hanging on my machine, after some `hours_wasted_here++` I noticed that it looks like `event_capture::stop_capture()` was not stopping the capture, but it was acquiring the inspector lock so I believe deep in its heart it really wanted to stop the capture. I wonder how this ever worked or if it will fully work after this patch.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
