### PR TITLE
chore(driver/bpf): properly include sched.h in types.h since it uses `TASK_COMM_LEN`

### DIFF
--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -14,7 +14,6 @@ or GPL2.txt for full copies of the license.
 #if __has_include(<asm/rwonce.h>)
 #include <asm/rwonce.h>
 #endif
-#include <linux/sched.h>
 
 #include "driver_config.h"
 #include "ppm_events_public.h"

--- a/driver/bpf/types.h
+++ b/driver/bpf/types.h
@@ -12,6 +12,8 @@ or GPL2.txt for full copies of the license.
 
 #ifdef __KERNEL__
 
+#include <linux/sched.h>  // TASK_COMM_LEN definition
+
 #define __bpf_section(NAME) __attribute__((section(NAME), used))
 
 #ifndef __always_inline


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Per #2086 it might happen that none of the include before `types.h` does provide `TASK_COMM_LEN` declaration, ie: that `linux/sched.h` is not included by any of the `linux/` headers included by `quirks.h`.
Since `types.h` needs `TASK_COMM_LEN`, make it directly include `sched.h` and avoid implicitly hoping for the inclusion of that macro.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2086

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
