### PR TITLE
fix(userspace/libsinsp): avoid possible UB when calling `back` or `front` without checking string emptiness

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2384,7 +2384,7 @@ std::string sinsp_parser::parse_dirfd(sinsp_evt *evt, std::string_view name, int
 		return "<UNKNOWN>";
 	}
 
-	if(fdinfo->m_name.back() == '/') {
+	if(fdinfo->m_name.empty() || fdinfo->m_name.back() == '/') {
 		return fdinfo->m_name;
 	}
 	return fdinfo->m_name + '/';

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -233,7 +233,7 @@ uint8_t *sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt,
 		pos += 10;
 	}
 
-	if(m_strval.size() != 0) {
+	if(!m_strval.empty()) {
 		if(m_strval.back() == ',') {
 			m_strval = m_strval.substr(0, m_strval.size() - 1);
 		}

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -291,7 +291,7 @@ static inline std::string format_dirfd(sinsp_evt* evt) {
 		return "<UNKNOWN>";
 	}
 
-	if(fd_info_dirfd->m_name.back() == '/') {
+	if(fd_info_dirfd->m_name.empty() || fd_info_dirfd->m_name.back() == '/') {
 		return fd_info_dirfd->m_name;
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
