### PR TITLE
fix(userspace/libscap): fix build without `USE_ZLIB` macro.

### DIFF
--- a/userspace/libscap/scap_zlib.h
+++ b/userspace/libscap/scap_zlib.h
@@ -27,6 +27,10 @@ limitations under the License.
 #include <zlib.h>
 #else
 #include <stdio.h>
+
+#define Z_OK 0
+#define Z_BUF_ERROR 1
+
 #define gzFile FILE*
 #define gzflush(X, Y) fflush(X)
 #define gzopen fopen
@@ -36,9 +40,11 @@ limitations under the License.
 #define gzwrite(F, B, S) fwrite(B, 1, S, F)
 #define gzread(F, B, S) fread(B, 1, S, F)
 #define gztell(F) ftell(F)
+#define gzclearerr(F) clearerr(F)
 inline static const char *gzerror(FILE *F, int *E) {
 	*E = ferror(F);
 	return "error reading file descriptor";
 }
+
 #define gzseek fseek
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We always tried to support building libscap without `USE_ZLIB` macro (that is hard-defined in scap/settings.h).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
