### PR TITLE
new(libsinsp): print LIST() in markdown format for list fields

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -660,6 +660,10 @@ sinsp_filter_factory::check_infos_to_fieldclass_infos(
 				info.tags.insert("ARG_ALLOWED");
 			}
 
+			if(fld->m_flags & EPF_IS_LIST) {
+				info.tags.insert("EPF_IS_LIST");
+			}
+
 			cinfo.fields.emplace_back(std::move(info));
 		}
 
@@ -677,6 +681,10 @@ bool sinsp_filter_factory::filter_field_info::is_skippable() const {
 bool sinsp_filter_factory::filter_field_info::is_deprecated() const {
 	// Skip fields with the EPF_DEPRECATED flag.
 	return (tags.find("EPF_DEPRECATED") != tags.end());
+}
+
+bool sinsp_filter_factory::filter_field_info::is_list() const {
+	return (tags.find("EPF_IS_LIST") != tags.end());
 }
 
 uint32_t sinsp_filter_factory::filter_fieldclass_info::s_rightblock_start = 30;
@@ -740,8 +748,12 @@ std::string sinsp_filter_factory::filter_fieldclass_info::as_markdown(
 			continue;
 		}
 
-		os << "`" << fld_info.name << "` | " << fld_info.data_type << " | " << fld_info.desc
-		   << std::endl;
+		std::string data_type = fld_info.data_type;
+		if(fld_info.is_list()) {
+			data_type = "LIST(" + data_type + ")";
+		}
+
+		os << "`" << fld_info.name << "` | " << data_type << " | " << fld_info.desc << std::endl;
 	}
 
 	if(deprecated_count == fields.size()) {

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -112,6 +112,7 @@ public:
 
 		bool is_skippable() const;
 		bool is_deprecated() const;
+		bool is_list() const;
 	};
 
 	// Describes a group of filtercheck fields ("ka")


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently the documentation website lists field arguments as if they were regular. If they are lists of charbufs for example we would like to print `LIST(CHARBUF)` instead of `CHARBUF`. This PR does exactly that.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2092

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): print LIST() in markdown format for list fields
```
