### PR TITLE
cleanup: remove some commits from the blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,14 @@
+# These commits altered the blame only to change types
+89ec22f38ce06145a10d52fd9be2cb1b872bfd11
+4dd9c8a2517dcda5aab0fc7a26197e74bf557fd6
+9326b1dd23efd095908a723a1d94acbe91032cab
+c8b971ecbff766003c736f01c0455e73dbd0efb3
+a5730f7a18e2e81b270105c2f81cf6c6a0201feb
+56b6e591cf8bf6849c27adfccc1557835daa1529
+93240ff1106f54add1e620e861bdfe890cf99108
+5c9b3cd3eb485ff8e4a3c364383f246d79146194
+0736581e22da38f260e01b64a9c73a4d66c7c02a
+2bea7ba762ed916eaf283066b20ad989b77276a6
 # This commit formatted the libs code for the first time.
 215db2d9de0cb15061873a2e3bea33f731a54cab
 # This commit has completely rewritten the history of file `userspace/libscap/engine/savefile/scap_savefile.c`. 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**


**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR removes some commits from the blame since they just convert types from u32 to uint32_t and similar. When looking for information like when a field was added to a struct it would be better to ignore these commits

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
