### PR TITLE
fix(ci): fix build-scap-open-w-extern-bpf-skeleton job

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -296,7 +296,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Download skeleton
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: bpf_probe_x86_64.skel.h
           path: /tmp
@@ -338,13 +338,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download X64 matrix
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_X64
           path: matrix_X64
 
       - name: Download ARM64 matrix
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_ARM64
           path: matrix_ARM64

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -281,36 +281,18 @@ jobs:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     needs: [paths-filter,build-modern-bpf-skeleton]
-    # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
     runs-on: 'ubuntu-latest'
     if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
-    container: centos:7
     steps:
-      # Always install deps before invoking checkout action, to properly perform a full clone.
-      - name: Fix mirrors to use vault.centos.org
-        run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-
-      - name: Install scl repos
-        run: |
-          yum -y install centos-release-scl
-
-      - name: Fix new mirrors to use vault.centos.org
-        run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-
       - name: Install build dependencies
         run: |
-          yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++
-          source /opt/rh/devtoolset-9/enable
-          yum install -y wget git make m4 rpm-build perl-IPC-Cmd
+          sudo apt update
+          sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 llvm-14 git pkg-config autoconf automake libtool libelf-dev libcap-dev
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
+          sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
+          sudo update-alternatives --install /usr/bin/llc llc /usr/bin/llc-14 90
 
       - name: Checkout
-        # It is not possible to upgrade the checkout action to versions >= v4.0.0 because of incompatibilities with centos 7's libc.
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Download skeleton
@@ -319,18 +301,9 @@ jobs:
           name: bpf_probe_x86_64.skel.h
           path: /tmp
 
-      - name: Install updated cmake
-        run: |
-          curl -L -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-$(uname -m).tar.gz
-          gzip -d /tmp/cmake.tar.gz
-          tar -xpf /tmp/cmake.tar --directory=/tmp
-          cp -R /tmp/cmake-3.22.5-linux-$(uname -m)/* /usr
-          rm -rf /tmp/cmake-3.22.5-linux-$(uname -m)
-
       - name: Prepare project
         run: |
           mkdir build && cd build
-          source /opt/rh/devtoolset-9/enable
           cmake \
               -DCMAKE_BUILD_TYPE=Release \
               -DUSE_BUNDLED_DEPS=On \
@@ -343,7 +316,6 @@ jobs:
       - name: Build project
         run: |
           cd build
-          source /opt/rh/devtoolset-9/enable
           make scap-open -j6
 
   # Only runs on pull request since on master branch it is already triggered by pages CI.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Download matrix X64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_X64
 
@@ -96,7 +96,7 @@ jobs:
         run: mv matrix.md docs/matrix_X64.md
 
       - name: Download matrix ARM64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_ARM64
 
@@ -109,7 +109,7 @@ jobs:
           sed -i '1s/^/---\nhide:\n- toc\n---\n\n/' docs/matrix_ARM64.md
 
       - name: Download perf svg files
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: perf_svg
 

--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -136,7 +136,7 @@ jobs:
           echo "" >> release-body.md
 
       - name: Download matrix X64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_X64
 
@@ -144,7 +144,7 @@ jobs:
         run: mv matrix.md matrix_X64.md
 
       - name: Download matrix ARM64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: matrix_ARM64
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since we do not rely upon centos7 anymore, drop it.
Moreover, bump actions/download-artifact to latest release to be able to communicate correctly with actions/upload-artifact.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
