### PR TITLE
fix(userspace/libscap): scap-gvisor does need to depend upon jsoncpp.

### DIFF
--- a/userspace/libscap/engine/gvisor/CMakeLists.txt
+++ b/userspace/libscap/engine/gvisor/CMakeLists.txt
@@ -56,15 +56,11 @@ add_custom_command(
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-if(USE_BUNDLED_JSONCPP)
-	add_dependencies(scap jsoncpp)
-endif()
-
 add_library(
 	scap_engine_gvisor ${scap_engine_gvisor_sources} ${scap_engine_gvisor_generated_sources}
 )
 
-add_dependencies(scap_engine_gvisor uthash)
+add_dependencies(scap_engine_gvisor uthash jsoncpp)
 target_link_libraries(
 	scap_engine_gvisor PUBLIC scap_platform_util scap_error ${CMAKE_THREAD_LIBS_INIT}
 							  ${PROTOBUF_LIB} ${JSONCPP_LIB}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-gvisor

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since gvisor sources use jsoncpp, it must depend upon it. Most probably that was an unintentional typo.
See https://github.com/falcosecurity/falco/actions/runs/11324106507/job/31488703414?pr=3380 for a failing CI, where scap_engine_gvisor gets build before jsoncpp and therefore gvisor cannot find `json/json.h` include.
This is something purely time-based, ie: i am pretty sure that if we compile with a different `-jX` it would pass the build. 

I think the time issue got somewhat exacerbated by https://github.com/falcosecurity/libs/pull/2005 changes.

In the end:
* scap depends upon jsoncpp
* sinsp depends upon jsoncpp
* scap-gvisor does not, so while building scap as dep of sinsp, jsoncpp and scap-gvisor are built in parallel leading to timing issues because scap-gvisor needs jsoncpp

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
