### PR TITLE
fix(userspace/libsinsp): disable HTTP proxy for CRI connection

### DIFF
--- a/userspace/libsinsp/cri.hpp
+++ b/userspace/libsinsp/cri.hpp
@@ -33,8 +33,10 @@ namespace cri {
 
 template<typename api>
 inline cri_interface<api>::cri_interface(const std::string &cri_path) {
+	grpc::ChannelArguments args;
+	args.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY, 0);
 	std::shared_ptr<grpc::Channel> channel =
-	        libsinsp::grpc_channel_registry::get_channel("unix://" + cri_path);
+	        libsinsp::grpc_channel_registry::get_channel("unix://" + cri_path, &args);
 
 	m_cri = api::RuntimeService::NewStub(channel);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This change explicitly configures GRPC channel used for CRI socket communication to skip HTTP proxy configuration.
Since the CRI path already hardcodes `unix://`, the proxy will not be used anyway, but by disabling it we are silencing the unnecessary error message.
See https://github.com/grpc/grpc/blob/2de2e8dd8921e1f7d043e01faf7fe8a291fbb072/src/core/ext/filters/client_channel/http_proxy.cc#L111 and https://github.com/grpc/grpc/blob/2de2e8dd8921e1f7d043e01faf7fe8a291fbb072/src/core/ext/filters/client_channel/http_proxy.cc#L122-L125 .

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
