### PR TITLE
fix(userspace/libsinsp): stringop-overflow on libvirt_lxc

### DIFF
--- a/userspace/libsinsp/container_engine/libvirt_lxc.cpp
+++ b/userspace/libsinsp/container_engine/libvirt_lxc.cpp
@@ -42,14 +42,13 @@ bool libvirt_lxc::match(sinsp_threadinfo* tinfo, sinsp_container_info& container
 		//
 		pos = cgroup.find("-lxc\\x2");
 		if(pos != std::string::npos) {
-			std::string delimiter = ".scope";
-			size_t pos2 = cgroup.find(delimiter);
 			// For cgroups like:
 			// /machine.slice/machine-lxc\x2d2293906\x2dlibvirt\x2dcontainer.scope/libvirt,
 			// account for /libvirt below.
-			if(cgroup.find(".scope/libvirt") != std::string::npos) {
-				delimiter = ".scope/libvirt";
-			}
+			std::string delimiter = (cgroup.find(".scope/libvirt") != std::string::npos)
+			                                ? ".scope/libvirt"
+			                                : ".scope";
+			size_t pos2 = cgroup.find(delimiter);
 			if(pos2 != std::string::npos && pos2 == cgroup.length() - delimiter.length()) {
 				container_info.m_type = CT_LIBVIRT_LXC;
 				container_info.m_id =


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
> /area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Building with Red Hat g++ 11.2.1-9 we get the following error on string assignment:
```
[ 34%] Building CXX object libsinsp/CMakeFiles/sinsp.dir/container_engine/libvirt_lxc.cpp.o
In file included from /opt/rh/devtoolset-11/root/usr/include/c++/11/ios:40,
                 from /opt/rh/devtoolset-11/root/usr/include/c++/11/ostream:38,
                 from /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/unique_ptr.h:42,
                 from /opt/rh/devtoolset-11/root/usr/include/c++/11/memory:76,
                 from /code/agent/deps/agent-libs/userspace/libsinsp/container_engine/container_engine_base.h:21,
                 from /code/agent/deps/agent-libs/userspace/libsinsp/container_engine/libvirt_lxc.h:24,
                 from /code/agent/deps/agent-libs/userspace/libsinsp/container_engine/libvirt_lxc.cpp:19:
In static member function 'static constexpr std::char_traits<char>::char_type* std::char_traits<char>::copy(std::char_traits<char>::char_type*, const char_type*, std::size_t)',
    inlined from 'static void std::basic_string<_CharT, _Traits, _Alloc>::_M_copy(_CharT*, const _CharT*, std::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/basic_string.h:3464:21,
    inlined from 'std::basic_string<_CharT, _Traits, _Allocator>& std::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*, std::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/basic_string.tcc:701:13,
    inlined from 'std::basic_string<_CharT, _Traits, _Allocator>& std::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*, std::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/basic_string.tcc:689:5,
    inlined from 'std::basic_string<_CharT, _Traits, _Alloc>& std::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/basic_string.h:4461:21,
    inlined from 'std::basic_string<_CharT, _Traits, _Alloc>& std::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/basic_string.h:3784:28,
    inlined from 'bool libsinsp::container_engine::libvirt_lxc::match(sinsp_threadinfo*, sinsp_container_info&)' at /code/agent/deps/agent-libs/userspace/libsinsp/container_engine/libvirt_lxc.cpp:51:17:
/opt/rh/devtoolset-11/root/usr/include/c++/11/bits/char_traits.h:437:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' writing 14 bytes into a region of size 7 overflows the destination [-Werror=stringop-overflow=]
  437 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

Let's just do a single assignment, and avoid eventual resize.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
