### PR TITLE
new(userspace): added new `addOutput` json entry for plugin `get_field()` API

### DIFF
--- a/userspace/libsinsp/filter_field.h
+++ b/userspace/libsinsp/filter_field.h
@@ -50,6 +50,7 @@ enum filtercheck_field_flags {
 	        1 << 13,  ///< data pointers extracted by this field may change across subsequent
 	                  ///< extractions (even of other fields), which makes them unsafe to be used
 	                  ///< with filter caching or field-to-field comparisons
+	EPF_FORMAT_SUGGESTED = 1 << 14,  ///< this field is suggested to be used as output field
 };
 
 /**
@@ -105,6 +106,11 @@ struct filtercheck_field_info {
 	// through a memory buffer copy (e.g. with a FTR_STORAGE transformer)
 	//
 	inline bool is_ptr_unstable() const { return m_flags & EPF_NO_PTR_STABILITY; }
+
+	//
+	// Returns true if this field is a suggested as output
+	//
+	inline bool is_format_suggested() const { return m_flags & EPF_FORMAT_SUGGESTED; }
 };
 
 /**

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -521,7 +521,9 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string& errstr) {
 				}
 
 				if(jvoutput.asBool()) {
-					m_output_fields.emplace("%" + fname);
+					tf.m_flags = (filtercheck_field_flags)((int)tf.m_flags |
+					                                       (int)filtercheck_field_flags::
+					                                               EPF_FORMAT_SUGGESTED);
 				}
 			}
 

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -513,6 +513,18 @@ bool sinsp_plugin::resolve_dylib_symbols(std::string& errstr) {
 				}
 			}
 
+			const Json::Value& jvoutput = root[j].get("addOutput", Json::Value::null);
+			if(!jvoutput.isNull()) {
+				if(!jvoutput.isBool()) {
+					throw sinsp_exception(string("error in plugin ") + name() + ": field " + fname +
+					                      " addOutput property is not boolean ");
+				}
+
+				if(jvoutput.asBool()) {
+					m_output_fields.emplace("%" + fname);
+				}
+			}
+
 			resolve_dylib_field_arg(root[j].get("arg", Json::Value::null), tf);
 
 			const Json::Value& jvProperties = root[j].get("properties", Json::Value::null);

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -116,6 +116,7 @@ public:
 	        m_scap_source_plugin(),
 	        m_fields_info(),
 	        m_fields(),
+	        m_output_fields(),
 	        m_extract_event_sources(),
 	        m_extract_event_codes(),
 	        m_parse_event_sources(),
@@ -173,6 +174,14 @@ public:
 	std::vector<open_param> list_open_params() const;
 
 	/** Field Extraction **/
+	inline const std::unordered_set<std::string>& append_outputs_fields(std::string& source) const {
+		static std::unordered_set<std::string> empty_set;
+		if(m_extract_event_sources.find(source) != m_extract_event_sources.end()) {
+			return m_output_fields;
+		}
+		return empty_set;
+	}
+
 	inline const std::unordered_set<std::string>& extract_event_sources() const {
 		return m_extract_event_sources;
 	}
@@ -236,6 +245,7 @@ private:
 	/** Field Extraction **/
 	filter_check_info m_fields_info;
 	std::vector<filtercheck_field_info> m_fields;
+	std::unordered_set<std::string> m_output_fields;
 	std::unordered_set<std::string> m_extract_event_sources;
 	libsinsp::events::set<ppm_event_code> m_extract_event_codes;
 

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -173,19 +173,6 @@ public:
 	std::vector<open_param> list_open_params() const;
 
 	/** Field Extraction **/
-	inline std::unordered_set<std::string> suggested_output_formats(
-	        const std::string& source) const {
-		std::unordered_set<std::string> output_fields;
-		if(m_extract_event_sources.find(source) != m_extract_event_sources.end()) {
-			for(const auto& field : m_fields) {
-				if(field.is_format_suggested()) {
-					output_fields.emplace("%" + field.m_name);
-				}
-			}
-		}
-		return output_fields;
-	}
-
 	inline const std::unordered_set<std::string>& extract_event_sources() const {
 		return m_extract_event_sources;
 	}

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -116,7 +116,6 @@ public:
 	        m_scap_source_plugin(),
 	        m_fields_info(),
 	        m_fields(),
-	        m_output_fields(),
 	        m_extract_event_sources(),
 	        m_extract_event_codes(),
 	        m_parse_event_sources(),
@@ -174,12 +173,17 @@ public:
 	std::vector<open_param> list_open_params() const;
 
 	/** Field Extraction **/
-	inline const std::unordered_set<std::string>& append_outputs_fields(std::string& source) const {
-		static std::unordered_set<std::string> empty_set;
+	inline std::unordered_set<std::string> suggested_output_formats(
+	        const std::string& source) const {
+		std::unordered_set<std::string> output_fields;
 		if(m_extract_event_sources.find(source) != m_extract_event_sources.end()) {
-			return m_output_fields;
+			for(const auto& field : m_fields) {
+				if(field.is_format_suggested()) {
+					output_fields.emplace("%" + field.m_name);
+				}
+			}
 		}
-		return empty_set;
+		return output_fields;
 	}
 
 	inline const std::unordered_set<std::string>& extract_event_sources() const {
@@ -245,7 +249,6 @@ private:
 	/** Field Extraction **/
 	filter_check_info m_fields_info;
 	std::vector<filtercheck_field_info> m_fields;
-	std::unordered_set<std::string> m_output_fields;
 	std::unordered_set<std::string> m_extract_event_sources;
 	libsinsp::events::set<ppm_event_code> m_extract_event_codes;
 

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -190,13 +190,13 @@ TEST_F(sinsp_with_test_input, plugin_syscall_extract) {
 	// its value should be present in the output.
 	std::string output_fmt;
 	bool first = true;
-	for(const auto& output_field : pl->append_outputs_fields(syscall_source_name)) {
+	for(const auto& fmt : pl->suggested_output_formats(syscall_source_name)) {
 		if(!first) {
 			output_fmt += " ";
 		} else {
 			first = false;
 		}
-		output_fmt += output_field;
+		output_fmt += fmt;
 	}
 	auto formatter = sinsp_evt_formatter(&m_inspector, output_fmt, pl_flist);
 	std::string output;
@@ -381,13 +381,13 @@ TEST_F(sinsp_with_test_input, plugin_custom_source) {
 	// its value should be present in the output.
 	std::string output_fmt;
 	bool first = true;
-	for(const auto& output_field : ext_pl->append_outputs_fields(evt_source)) {
+	for(const auto& fmt : ext_pl->suggested_output_formats(evt_source)) {
 		if(!first) {
 			output_fmt += " ";
 		} else {
 			first = false;
 		}
-		output_fmt += output_field;
+		output_fmt += fmt;
 	}
 	auto formatter = sinsp_evt_formatter(&m_inspector, output_fmt, filterlist);
 	std::string output;

--- a/userspace/libsinsp/test/plugins/plugin_extract.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_extract.cpp
@@ -64,7 +64,7 @@ const char* plugin_get_contact() {
 const char* plugin_get_fields() {
 	return "["
 	       "{\"type\": \"string\", \"name\": \"sample.hello\", \"desc\": \"A constant hello world "
-	       "string\"}"
+	       "string\", \"addOutput\": true}"
 	       "]";
 }
 

--- a/userspace/libsinsp/test/plugins/syscall_extract.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_extract.cpp
@@ -86,7 +86,8 @@ const char* plugin_get_fields() {
 	{
 		"type": "uint64",
 		"name": "sample.is_open",
-		"desc": "Value is 1 if event is of open family"
+		"desc": "Value is 1 if event is of open family",
+		"addOutput": true
 	},
 	{
 		"type": "uint64",

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -29,7 +29,7 @@ extern "C" {
 //
 // todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
-#define PLUGIN_API_VERSION_MINOR 7
+#define PLUGIN_API_VERSION_MINOR 8
 #define PLUGIN_API_VERSION_PATCH 0
 
 //
@@ -843,7 +843,7 @@ typedef struct {
 		//     "name": a string with a name for the field
 		//     "type": one of "string", "uint64", "bool", "reltime", "abstime",
 		//             "ipaddr", "ipnet"
-		//     "isList: (optional) If present and set to true, notes
+		//     "isList: (optional) if present and set to true, notes
 		//              that the field extracts a list of values.
 		//     "arg": (optional) if present, notes that the field can accept
 		//             an argument e.g. field[arg]. More precisely, the following
@@ -860,9 +860,11 @@ typedef struct {
 		//                display the field instead of the name. Used in tools
 		//                like wireshark.
 		//     "desc": a string with a description of the field
+		//     "addOutput": (optional) if true, suggest this field to be appended to the
+		//				  output string for compatible event sources.
 		// Example return value:
 		// [
-		//    {"type": "uint64", "name": "field1", "desc": "Describing field 1"},
+		//    {"type": "uint64", "name": "field1", "desc": "Describing field 1", "addOutput": true},
 		//    {"type": "string", "name": "field2", "arg": {"isRequired": true, "isIndex": true},
 		//    "desc": "Describing field 2"},
 		// ]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

The new field suggests to the agent that some fields should be enforced to all compatible sources output by default.
It is up to the agent to implement the logic to actually use these suggested fields.
PR contains also updated tests.

For example, k8smeta plugin could expose eg: `k8smeta.pod.name` and `k8smeta.pod.uid` as `addOutput` fields; this way for `syscall` event source (see `get_extract_event_sources`: https://github.com/falcosecurity/plugins/blob/main/plugins/k8smeta/src/plugin.h#L154) those fields will always be appended to the output with no further intervention.

Idea is then to have a for-plugin config option in Falco to disable this behavior by default. 

Basically, this feat would allow us to avoid leaking plugin-related knowledge about which output should be appended by default, up to Falco. For example, we could drop the `pk` Falco option that is used by charts when enabling the k8smeta collector: https://github.com/falcosecurity/charts/blob/master/charts/falco/templates/pod-template.tpl#L78

Long term goal is to drop all `print` related Falco CLI options: https://github.com/falcosecurity/falco/blob/master/userspace/falco/app/actions/init_falco_engine.cpp#L55
when:
* container support becomes a plugin
* gvisor becomes a plugin

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(userspace): added new `addOutput` json entry for plugin `get_field()` API
```
