### PR TITLE
fix(ci): fixed latest-kernel CI usage of steps/jobs outputs.

### DIFF
--- a/.github/workflows/latest-kernel.yml
+++ b/.github/workflows/latest-kernel.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   compute-latest-version:
     outputs:
-      latest_vers: ${{ steps.latest-version.latest_vers }}
+      latest_vers: ${{ steps.latest-version.outputs.latest_vers }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout Archlinux mainline package ⤵️
@@ -70,7 +70,7 @@ jobs:
       - name: Test drivers build
         id: build
         run: |
-          echo "Testing build of drivers against: ${{ needs.compute-latest-version.latest_vers }}"
+          echo "Testing build of drivers against: ${{ needs.compute-latest-version.outputs.latest_vers }}"
           chmod +x driverkit
           ./driverkit docker -c dk.yaml -l debug
 
@@ -95,7 +95,7 @@ jobs:
       - name: Test drivers build
         id: build
         run: |
-          echo "Testing build of drivers against: ${{ needs.compute-latest-version.latest_vers }}"
+          echo "Testing build of drivers against: ${{ needs.compute-latest-version.outputs.latest_vers }}"
           chmod +x driverkit
           ./driverkit docker -c dk.yaml -l debug
 
@@ -111,5 +111,5 @@ jobs:
           gistID: 1cbc5d42edf8e3a02fb75e76625f1072
           filename: kernel.json
           label: Drivers build
-          message: ${{ needs.compute-latest-version.latest_vers }}
-          color: ${{ (needs.build-latest-kernel-amd64.build != 'success' || needs.build-latest-kernel-arm64.build != 'success') && 'red' || 'brightgreen' }}
+          message: ${{ needs.compute-latest-version.outputs.latest_vers }}
+          color: ${{ (needs.build-latest-kernel-amd64.outputs.build != 'success' || needs.build-latest-kernel-arm64.outputs.build != 'success') && 'red' || 'brightgreen' }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fixed small issues introduced in https://github.com/falcosecurity/libs/pull/2114: properly use `.outputs` for steps/jobs outputs in latest-kernel CI.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
