### PR TITLE
fix(ci): avoid create comment workflows failing when required worfklows did not run

### DIFF
--- a/.github/workflows/create-comment-kernel-testing.yml
+++ b/.github/workflows/create-comment-kernel-testing.yml
@@ -23,9 +23,13 @@ jobs:
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr-kernel-testing"
-            })[0];
+            });
+            if (matchArtifacts == null) {
+              exit 0;
+            }
+            var matchArtifact = matchArtifacts[0];
             var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -36,7 +40,10 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
 
       - name: 'Unpack artifact'
-        run: unzip pr.zip
+        run:
+          if [ -f pr.zip ]; then
+            unzip pr.zip
+          fi
 
       - name: 'Comment on PR'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -45,6 +52,9 @@ jobs:
           # Taken from https://github.com/actions/github-script/blob/main/.github/workflows/pull-request-test.yml
           script: |
             var fs = require('fs');
+            if (!fs.existsSync('./NR')) {
+              exit 0;
+            }
             var issue_number = Number(fs.readFileSync('./NR'));
             var comment_body = fs.readFileSync('./COMMENT');
 

--- a/.github/workflows/create-comment-perf.yml
+++ b/.github/workflows/create-comment-perf.yml
@@ -23,9 +23,13 @@ jobs:
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr-perf"
-            })[0];
+            });
+            if (matchArtifacts == null) {
+              exit 0;
+            }
+            var matchArtifact = matchArtifacts[0];
             var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -36,7 +40,10 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
 
       - name: 'Unpack artifact'
-        run: unzip pr.zip
+        run: |
+          if [ -f pr.zip ]; then
+            unzip pr.zip
+          fi
 
       - name: 'Comment on PR'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -45,6 +52,9 @@ jobs:
           # Taken from https://github.com/actions/github-script/blob/main/.github/workflows/pull-request-test.yml
           script: |
             var fs = require('fs');
+            if (!fs.existsSync('./NR')) {
+              exit 0;
+            }
             var issue_number = Number(fs.readFileSync('./NR'));
             var comment_body = fs.readFileSync('./COMMENT');
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Avoids all the failings like: https://github.com/falcosecurity/libs/actions/workflows/create-comment-kernel-testing.yml

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
