### PR TITLE
fix(userspace/libsinsp): multiple fixes related to rawargs.

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -139,6 +139,8 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 
 	case PT_L4PROTO:  // This can be resolved in the future
 	case PT_UINT8:
+	case PT_FLAGS8:
+	case PT_ENUMFLAGS8:
 		if(print_format == PF_DEC || print_format == PF_ID) {
 			return *(uint8_t*)rawval;
 		} else if(print_format == PF_OCT || print_format == PF_HEX) {
@@ -150,6 +152,8 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 
 	case PT_PORT:  // This can be resolved in the future
 	case PT_UINT16:
+	case PT_FLAGS16:
+	case PT_ENUMFLAGS16:
 		if(print_format == PF_DEC || print_format == PF_ID) {
 			return *(uint16_t*)rawval;
 		} else if(print_format == PF_OCT || print_format == PF_HEX) {
@@ -160,6 +164,10 @@ Json::Value sinsp_filter_check::rawval_to_json(uint8_t* rawval,
 		}
 
 	case PT_UINT32:
+	case PT_FLAGS32:
+	case PT_ENUMFLAGS32:
+	case PT_UID:
+	case PT_GID:
 		if(print_format == PF_DEC || print_format == PF_ID) {
 			return *(uint32_t*)rawval;
 		} else if(print_format == PF_OCT || print_format == PF_HEX) {
@@ -292,12 +300,14 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		return m_getpropertystr_storage.data();
 	case PT_L4PROTO:  // This can be resolved in the future
 	case PT_UINT8:
+	case PT_FLAGS8:
+	case PT_ENUMFLAGS8:
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo8;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
 			prfmt = (char*)"%" PRIu8;
 		} else if(print_format == PF_HEX) {
-			prfmt = (char*)"%" PRIu8;
+			prfmt = (char*)"%" PRIX8;
 		} else {
 			ASSERT(false);
 			return NULL;
@@ -311,12 +321,14 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		return m_getpropertystr_storage.data();
 	case PT_PORT:  // This can be resolved in the future
 	case PT_UINT16:
+	case PT_FLAGS16:
+	case PT_ENUMFLAGS16:
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo16;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
 			prfmt = (char*)"%" PRIu16;
 		} else if(print_format == PF_HEX) {
-			prfmt = (char*)"%" PRIu16;
+			prfmt = (char*)"%" PRIX16;
 		} else {
 			ASSERT(false);
 			return NULL;
@@ -329,12 +341,16 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		         rawval_cast<uint16_t>(rawval));
 		return m_getpropertystr_storage.data();
 	case PT_UINT32:
+	case PT_FLAGS32:
+	case PT_ENUMFLAGS32:
+	case PT_UID:
+	case PT_GID:
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo32;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
 			prfmt = (char*)"%" PRIu32;
 		} else if(print_format == PF_HEX) {
-			prfmt = (char*)"%" PRIu32;
+			prfmt = (char*)"%" PRIX32;
 		} else {
 			ASSERT(false);
 			return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -110,6 +110,7 @@ private:
 	uint8_t* extract_error_count(sinsp_evt* evt, uint32_t* len);
 	uint8_t* extract_abspath(sinsp_evt* evt, uint32_t* len);
 	inline uint8_t* extract_buflen(sinsp_evt* evt, uint32_t* len);
+	uint8_t* extract_argraw(sinsp_evt* evt, uint32_t* len, const char* argname);
 
 	union {
 		uint16_t u16;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Firstly, properly refresh m_arginfo and m_customfield type and print format given current event while extracting rawarg values.
Secondly, properly support PT_FLAGS, PT_ENUMFLAGS, PT_UID and PT_GID types in `rawval_to_json` and `rawval_to_string`.
Lastly, honor PF_HEX print format for 8,16,32bits types.

Also, added a test.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

These issues were found by @Andreagit97 while working on the syscall enter dropping (https://github.com/falcosecurity/libs/pull/2068) 

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): multiple fixes related to rawargs.
```
