### PR TITLE
new(libsinsp): add len() filter transformer

### DIFF
--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -90,12 +90,11 @@ static const std::vector<std::string> s_binary_list_ops = {
 
 static constexpr const char* s_field_transformer_val = "val(";
 
-static const std::vector<std::string> s_field_transformers = {
-        "tolower(",
-        "toupper(",
-        "b64(",
-        "basename(",
-};
+static const std::vector<std::string> s_field_transformers = {"tolower(",
+                                                              "toupper(",
+                                                              "b64(",
+                                                              "basename(",
+                                                              "len("};
 
 static inline void update_pos(const char c, ast::pos_info& pos) {
 	pos.col++;

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -69,7 +69,7 @@ class RE2;
 //                             | 'startswith ' | 'bstartswith ' | 'endswith '
 //     ListOperator        ::= 'intersects' | 'in' | 'pmatch'
 //     FieldTransformerVal    ::= 'val('
-//     FieldTransformerType   ::= 'tolower(' | 'toupper(' | 'b64(' | 'basename('
+//     FieldTransformerType   ::= 'tolower(' | 'toupper(' | 'b64(' | 'basename(' | 'len('
 //
 // Tokens (Regular Expressions):
 //     Identifier          ::= [a-zA-Z]+[a-zA-Z0-9_]*

--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -203,6 +203,7 @@ bool sinsp_filter_transformer::transform_values(std::vector<extract_value_t>& ve
 	}
 	case FTR_LEN: {
 		assert((void("len() type must be PT_UINT64"), t == PT_UINT64));
+		m_storage_values.clear();
 		if(is_list) {
 			uint64_t len = static_cast<uint64_t>(vec.size());
 			auto stored_val = store_scalar(len);
@@ -227,8 +228,9 @@ bool sinsp_filter_transformer::transform_values(std::vector<extract_value_t>& ve
 		}
 
 		if(vec.size() == 0) {
-			// nothing to do
-			return true;
+			// should never happen since there is no way to
+			// call len() with no arguments
+			return false;
 		}
 
 		// we are assuming that if this is not a list then it's a single element

--- a/userspace/libsinsp/sinsp_filter_transformer.cpp
+++ b/userspace/libsinsp/sinsp_filter_transformer.cpp
@@ -116,7 +116,7 @@ bool sinsp_filter_transformer::transform_type(ppm_param_type& t, uint32_t& flags
 	case FTR_LEN: {
 		if(is_list) {
 			t = PT_UINT64;
-			flags = 0;
+			flags = flags & ~EPF_IS_LIST;
 			return true;
 		}
 		switch(t) {

--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -448,7 +448,7 @@ char* sinsp_filter_check::tostring(sinsp_evt* evt) {
 	}
 
 	auto ftype = get_transformed_field_info()->m_type;
-	if(m_field->m_flags & EPF_IS_LIST) {
+	if(get_transformed_field_info()->m_flags & EPF_IS_LIST) {
 		std::string res = "(";
 		for(auto& val : m_extracted_values) {
 			if(res.size() > 1) {
@@ -478,7 +478,7 @@ Json::Value sinsp_filter_check::tojson(sinsp_evt* evt) {
 		}
 
 		auto ftype = get_transformed_field_info()->m_type;
-		if(m_field->m_flags & EPF_IS_LIST) {
+		if(get_transformed_field_info()->m_flags & EPF_IS_LIST) {
 			for(auto& val : m_extracted_values) {
 				jsonval.append(rawval_to_json(val.ptr, ftype, m_field->m_print_format, val.len));
 			}
@@ -1045,11 +1045,12 @@ void sinsp_filter_check::add_transformer(filter_transformer_type trtype) {
 	// apply type transformation, both as a feasibility check and
 	// as an information to be returned later on
 	sinsp_filter_transformer tr(trtype);
-	if(!tr.transform_type(m_transformed_field->m_type)) {
+	if(!tr.transform_type(m_transformed_field->m_type, m_transformed_field->m_flags)) {
 		throw sinsp_exception("can't add field transformer: type '" +
 		                      std::string(param_type_to_string(m_transformed_field->m_type)) +
 		                      "' is not supported by '" + filter_transformer_type_str(trtype) +
-		                      "' transformer applied on field '" +
+		                      "' transformer applied on " +
+		                      (m_transformed_field->is_list() ? "list " : "") + "field '" +
 		                      std::string(get_field_info()->m_name) + "'");
 	}
 
@@ -1062,9 +1063,11 @@ void sinsp_filter_check::add_transformer(filter_transformer_type trtype) {
 }
 
 bool sinsp_filter_check::apply_transformers(std::vector<extract_value_t>& values) {
-	auto type = get_field_info()->m_type;
+	const filtercheck_field_info* field_info = get_field_info();
+	auto field_type = field_info->m_type;
+	auto field_flags = field_info->m_flags;
 	for(auto& tr : m_transformers) {
-		if(!tr.transform_values(values, type)) {
+		if(!tr.transform_values(values, field_type, field_flags)) {
 			return false;
 		}
 	}

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -137,7 +137,7 @@ public:
 	//
 	// Extract the field from the event. If sanitize_strings is true, any
 	// string values are sanitized to remove nonprintable characters.
-	// By default, this fills the vector with only one value, retireved by calling the single-result
+	// By default, this fills the vector with only one value, retrieved by calling the single-result
 	// extract method.
 	// If a NULL value is returned by extract, the vector is emptied.
 	// Subclasses are meant to either override this, or the single-valued extract method.

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -293,7 +293,7 @@ static const filtercheck_field_info sinsp_filter_check_fd_fields[] = {
          "FD full name raw. Just like fd.name, but only used if fd is a file path. File path is "
          "kept raw with limited sanitization and without deriving the absolute path."},
         {PT_CHARBUF,
-         EPF_IS_LIST | EPF_ARG_ALLOWED | EPF_NO_RHS | EPF_NO_TRANSFORMER,
+         EPF_IS_LIST | EPF_ARG_ALLOWED | EPF_NO_RHS,
          PF_DEC,
          "fd.types",
          "FD Type",

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -87,7 +87,7 @@ TEST(parser, supported_operators) {
 
 TEST(parser, supported_field_transformers) {
 	std::string expected_val = "val";
-	std::vector<std::string> expected = {"tolower", "toupper", "b64", "basename"};
+	std::vector<std::string> expected = {"tolower", "toupper", "b64", "basename", "len"};
 
 	auto actual = parser::supported_field_transformers();
 	ASSERT_EQ(actual.size(), expected.size());

--- a/userspace/libsinsp/test/filter_transformer.ut.cpp
+++ b/userspace/libsinsp/test/filter_transformer.ut.cpp
@@ -31,51 +31,80 @@ static std::set<ppm_param_type> all_param_types() {
 	return ret;
 }
 
-static std::string supported_type_msg(ppm_param_type t, bool flags, bool support_expected) {
-	return std::string("expected ") + (flags ? "list " : "") + "param type to" +
-	       std::string((support_expected ? " " : " not ")) +
-	       "be supported: " + std::string(param_type_to_string(t));
-}
-
-static std::string eq_test_msg(const std::pair<std::string, std::string> &tc) {
-	return "expected '" + tc.first + "' (length: " + std::to_string(tc.first.length()) + ")" +
-	       " to be equal to '" + tc.second + "' (length: " + std::to_string(tc.second.length()) +
-	       ")";
-}
-
-static extract_value_t const_str_to_extract_value(const char *v) {
-	extract_value_t ret;
-	ret.ptr = (uint8_t *)v;
-	ret.len = strlen(v) + 1;
-	return ret;
-}
-
 template<class T>
-static T extract_value_to_scalar(const extract_value_t &val) {
+static T extract_value_to_scalar(const extract_value_t& val) {
 	T ret;
 	EXPECT_EQ(val.len, sizeof(T));
 	memcpy(&ret, val.ptr, val.len);
 	return ret;
 }
 
-static void check_unsupported_types(sinsp_filter_transformer &tr,
-                                    std::set<std::pair<ppm_param_type, bool>> &supported_types,
-                                    std::vector<extract_value_t> sample_vals) {
+static std::string supported_type_msg(ppm_param_type t, bool flags, bool support_expected) {
+	return std::string("expected ") + (flags ? "list " : "") + "param type to" +
+	       std::string((support_expected ? " " : " not ")) +
+	       "be supported: " + std::string(param_type_to_string(t));
+}
+
+static std::string eq_test_msg(extract_value_t actual, extract_value_t expected) {
+	return "expected '" + std::string(reinterpret_cast<const char*>(actual.ptr)) +
+	       "' (length: " + std::to_string(actual.len) + ")" + " to be equal to '" +
+	       std::string(reinterpret_cast<const char*>(expected.ptr)) +
+	       "' (length: " + std::to_string(expected.len) + ")";
+}
+
+struct ex_value : public extract_value_t {
+	ex_value(const ex_value& val) {
+		m_storage = val.m_storage;
+		len = val.len;
+
+		ptr = (uint8_t*)m_storage.data();
+	}
+
+	ex_value(std::string val) {
+		m_storage = std::vector<uint8_t>(val.c_str(), val.c_str() + val.size() + 1);
+
+		len = m_storage.size();
+		ptr = (uint8_t*)m_storage.data();
+	}
+
+	ex_value(uint64_t val) {
+		uint8_t* bytes = reinterpret_cast<uint8_t*>(&val);
+		m_storage = std::vector<uint8_t>(bytes, bytes + sizeof(uint64_t));
+
+		len = sizeof(val);
+		ptr = (uint8_t*)m_storage.data();
+	}
+
+	std::vector<uint8_t> m_storage;
+};
+
+struct test_case_entry {
+	uint32_t flags;
+	ppm_param_type input_type;
+	std::vector<ex_value> input;
+	ppm_param_type expected_type;
+	std::vector<ex_value> expected;
+};
+
+static void check_unsupported_types(sinsp_filter_transformer& tr,
+                                    std::set<ppm_param_type>& supported_types,
+                                    std::set<ppm_param_type>& supported_list_types) {
 	auto all_types = all_param_types();
 
 	for(auto t : all_types) {
 		uint32_t flags = EPF_IS_LIST;
-		if(supported_types.find({t, flags}) == supported_types.end()) {
-			auto vals = sample_vals;
+		if(supported_list_types.find(t) == supported_list_types.end()) {
 			EXPECT_FALSE(tr.transform_type(t, flags)) << supported_type_msg(t, flags, false);
+			// vals is empty for simplicity, should not affect the test
+			std::vector<extract_value_t> vals{};
 			EXPECT_ANY_THROW(tr.transform_values(vals, t, flags))
 			        << supported_type_msg(t, flags, false);
 		}
 
 		flags = 0;
-		if(supported_types.find({t, flags}) == supported_types.end()) {
-			auto vals = sample_vals;
+		if(supported_types.find(t) == supported_types.end()) {
 			EXPECT_FALSE(tr.transform_type(t, flags)) << supported_type_msg(t, flags, false);
+			std::vector<extract_value_t> vals{};
 			EXPECT_ANY_THROW(tr.transform_values(vals, t, flags))
 			        << supported_type_msg(t, flags, false);
 		}
@@ -85,46 +114,46 @@ static void check_unsupported_types(sinsp_filter_transformer &tr,
 TEST(sinsp_filter_transformer, toupper) {
 	sinsp_filter_transformer tr(filter_transformer_type::FTR_TOUPPER);
 
-	auto all_types = all_param_types();
+	std::set<ppm_param_type> supported_types{PT_CHARBUF, PT_FSPATH, PT_FSRELPATH};
+	std::set<ppm_param_type> supported_list_types = supported_types;
 
-	auto supported_types = std::set<std::pair<ppm_param_type, bool>>(
-	        {{PT_CHARBUF, false}, {PT_FSPATH, false}, {PT_FSRELPATH, false}});
+	check_unsupported_types(tr, supported_types, supported_list_types);
 
-	auto test_cases = std::vector<std::pair<std::string, std::string>>{
-	        {"hello", "HELLO"},
-	        {"world", "WORLD"},
-	        {"eXcItED", "EXCITED"},
-	        {"", ""},
+	std::vector<test_case_entry> test_cases{
+	        {0, PT_CHARBUF, {{"hello"}}, PT_CHARBUF, {{"HELLO"}}},
+	        {0, PT_CHARBUF, {{"WORLD"}}, PT_CHARBUF, {{"WORLD"}}},
+	        {0, PT_CHARBUF, {{"eXcItED"}}, PT_CHARBUF, {{"EXCITED"}}},
+	        {0, PT_CHARBUF, {{""}}, PT_CHARBUF, {{""}}},
+	        {0,
+	         PT_CHARBUF,
+	         {{"hello"}, {"wOrLd"}, {"ONE_1234"}},
+	         PT_CHARBUF,
+	         {{"HELLO"}, {"WORLD"}, {"ONE_1234"}}},
 	};
 
-	std::vector<extract_value_t> sample_vals;
-
-	for(auto &tc : test_cases) {
-		sample_vals.push_back(const_str_to_extract_value(tc.first.c_str()));
-	}
-
-	check_unsupported_types(tr, supported_types, sample_vals);
-
-	// check for supported types
-	for(auto t : supported_types) {
-		auto original_type = t.first;
-		uint32_t flags = t.second ? EPF_IS_LIST : 0;
-		auto transformed_type = original_type;
+	for(auto const& tc : test_cases) {
+		auto transformed_type = tc.input_type;
+		uint32_t flags = tc.flags;
+		bool is_list = flags & EPF_IS_LIST;
 		EXPECT_TRUE(tr.transform_type(transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type,
-		          transformed_type);  // note: toupper is expected not to alter the type
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(transformed_type, tc.expected_type);
 
-		auto vals = sample_vals;
+		std::vector<extract_value_t> vals{};
+		for(auto const& val : tc.input) {
+			vals.push_back(val);
+		}
+
+		transformed_type = tc.input_type;
 		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type, transformed_type);
-		EXPECT_EQ(vals.size(), test_cases.size());
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(vals.size(), tc.expected.size());
 
-		for(uint32_t i = 0; i < test_cases.size(); i++) {
-			EXPECT_EQ(std::string((const char *)vals[i].ptr), test_cases[i].second)
-			        << eq_test_msg(test_cases[i]);
-			EXPECT_EQ(vals[i].len, test_cases[i].second.length() + 1) << eq_test_msg(test_cases[i]);
+		for(std::vector<extract_value_t>::size_type i = 0; i < vals.size(); i++) {
+			std::string actual = (const char*)vals[i].ptr;
+			std::string expected = (const char*)tc.expected[i].ptr;
+			EXPECT_EQ(actual, expected) << eq_test_msg(vals[i], tc.expected[i]);
+			EXPECT_EQ(vals[i].len, tc.expected[i].len) << eq_test_msg(vals[i], tc.expected[i]);
 		}
 	}
 }
@@ -132,46 +161,47 @@ TEST(sinsp_filter_transformer, toupper) {
 TEST(sinsp_filter_transformer, tolower) {
 	sinsp_filter_transformer tr(filter_transformer_type::FTR_TOLOWER);
 
-	auto all_types = all_param_types();
+	std::set<ppm_param_type> supported_types{PT_CHARBUF, PT_FSPATH, PT_FSRELPATH};
+	std::set<ppm_param_type> supported_list_types = supported_types;
 
-	auto supported_types = std::set<std::pair<ppm_param_type, bool>>(
-	        {{PT_CHARBUF, false}, {PT_FSPATH, false}, {PT_FSRELPATH, false}});
+	check_unsupported_types(tr, supported_types, supported_list_types);
 
-	auto test_cases = std::vector<std::pair<std::string, std::string>>{
-	        {"HELLO", "hello"},
-	        {"world", "world"},
-	        {"NoT_eXcItED", "not_excited"},
-	        {"", ""},
+	std::vector<test_case_entry> test_cases{
+	        {0, PT_CHARBUF, {{"HELLO"}}, PT_CHARBUF, {{"hello"}}},
+	        {0, PT_CHARBUF, {{"world"}}, PT_CHARBUF, {{"world"}}},
+	        {0, PT_CHARBUF, {{"NoT eXcItED"}}, PT_CHARBUF, {{"not excited"}}},
+	        {0, PT_CHARBUF, {{""}}, PT_CHARBUF, {{""}}},
+	        {EPF_IS_LIST,
+	         PT_CHARBUF,
+	         {{"HELLO"}, {"wOrLd"}, {"one_1234"}},
+	         PT_CHARBUF,
+	         {{"hello"}, {"world"}, {"one_1234"}}},
 	};
 
-	std::vector<extract_value_t> sample_vals;
+	for(auto const& tc : test_cases) {
+		bool is_list = tc.flags & EPF_IS_LIST;
+		uint32_t flags = tc.flags;
+		auto transformed_type = tc.input_type;
 
-	for(auto &tc : test_cases) {
-		sample_vals.push_back(const_str_to_extract_value(tc.first.c_str()));
-	}
-
-	check_unsupported_types(tr, supported_types, sample_vals);
-
-	// check for supported types
-	for(auto t : supported_types) {
-		auto original_type = t.first;
-		uint32_t flags = t.second ? EPF_IS_LIST : 0;
-		auto transformed_type = original_type;
 		EXPECT_TRUE(tr.transform_type(transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type,
-		          transformed_type);  // note: tolower is expected not to alter the type
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(transformed_type, tc.expected_type);
 
-		auto vals = sample_vals;
+		std::vector<extract_value_t> vals{};
+		for(auto const& val : tc.input) {
+			vals.push_back(val);
+		}
+
+		transformed_type = tc.input_type;
 		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type, transformed_type);
-		EXPECT_EQ(vals.size(), test_cases.size());
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(vals.size(), tc.expected.size());
 
-		for(uint32_t i = 0; i < test_cases.size(); i++) {
-			EXPECT_EQ(std::string((const char *)vals[i].ptr), test_cases[i].second)
-			        << eq_test_msg(test_cases[i]);
-			EXPECT_EQ(vals[i].len, test_cases[i].second.length() + 1) << eq_test_msg(test_cases[i]);
+		for(std::vector<extract_value_t>::size_type i = 0; i < vals.size(); i++) {
+			std::string actual = (const char*)vals[i].ptr;
+			std::string expected = (const char*)tc.expected[i].ptr;
+			EXPECT_EQ(actual, expected) << eq_test_msg(vals[i], tc.expected[i]);
+			EXPECT_EQ(vals[i].len, tc.expected[i].len) << eq_test_msg(vals[i], tc.expected[i]);
 		}
 	}
 }
@@ -179,163 +209,142 @@ TEST(sinsp_filter_transformer, tolower) {
 TEST(sinsp_filter_transformer, b64) {
 	sinsp_filter_transformer tr(filter_transformer_type::FTR_BASE64);
 
-	auto all_types = all_param_types();
+	std::set<ppm_param_type> supported_types{PT_CHARBUF, PT_FSPATH, PT_FSRELPATH, PT_BYTEBUF};
+	std::set<ppm_param_type> supported_list_types = supported_types;
 
-	auto supported_types =
-	        std::set<std::pair<ppm_param_type, bool>>({{PT_CHARBUF, false}, {PT_BYTEBUF, false}});
+	check_unsupported_types(tr, supported_types, supported_list_types);
 
-	auto test_cases = std::vector<std::pair<std::string, std::string>>{
-	        {"aGVsbG8=", "hello"},
-	        {"d29ybGQgIQ==", "world !"},
-	        {"", ""},
+	std::vector<test_case_entry> test_cases{
+	        {0, PT_CHARBUF, {{"aGVsbG8="}}, PT_CHARBUF, {{"hello"}}},
+	        {0, PT_CHARBUF, {{"d29ybGQgIQ=="}}, PT_CHARBUF, {{"world !"}}},
+	        {0, PT_CHARBUF, {{""}}, PT_CHARBUF, {{""}}},
 	};
 
-	std::vector<std::string> invalid_test_cases{"!!!"};
+	for(auto const& tc : test_cases) {
+		bool is_list = tc.flags & EPF_IS_LIST;
+		uint32_t flags = tc.flags;
+		auto transformed_type = tc.input_type;
 
-	std::vector<extract_value_t> sample_vals;
-	for(auto &tc : test_cases) {
-		sample_vals.push_back(const_str_to_extract_value(tc.first.c_str()));
-	}
-
-	check_unsupported_types(tr, supported_types, sample_vals);
-
-	// check for supported types
-	for(auto t : supported_types) {
-		auto original_type = t.first;
-		uint32_t flags = t.second ? EPF_IS_LIST : 0;
-		auto transformed_type = original_type;
 		EXPECT_TRUE(tr.transform_type(transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type, transformed_type);  // note: b64 is expected not to alter the type
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(transformed_type, tc.expected_type);
 
-		auto vals = sample_vals;
-		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type, transformed_type);
-		EXPECT_EQ(vals.size(), test_cases.size());
-
-		for(uint32_t i = 0; i < test_cases.size(); i++) {
-			EXPECT_EQ(std::string((const char *)vals[i].ptr), test_cases[i].second)
-			        << eq_test_msg(test_cases[i]);
-			EXPECT_EQ(vals[i].len, test_cases[i].second.length() + 1) << eq_test_msg(test_cases[i]);
+		std::vector<extract_value_t> vals{};
+		for(auto const& val : tc.input) {
+			vals.push_back(val);
 		}
-	}
 
-	std::vector<extract_value_t> invalid_vals;
-	for(auto &tc : invalid_test_cases) {
-		invalid_vals.push_back(const_str_to_extract_value(tc.c_str()));
-	}
+		transformed_type = tc.input_type;
+		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(vals.size(), tc.expected.size());
 
-	// check invalid input being rejected
-	{
-		auto t = PT_CHARBUF;
-		uint32_t flags = 0;
-		EXPECT_FALSE(tr.transform_values(invalid_vals, t, flags));
-		EXPECT_EQ(t, PT_CHARBUF);
+		for(std::vector<extract_value_t>::size_type i = 0; i < vals.size(); i++) {
+			std::string actual = (const char*)vals[i].ptr;
+			std::string expected = (const char*)tc.expected[i].ptr;
+			EXPECT_EQ(actual, expected) << eq_test_msg(vals[i], tc.expected[i]);
+			EXPECT_EQ(vals[i].len, tc.expected[i].len) << eq_test_msg(vals[i], tc.expected[i]);
+		}
 	}
 }
 
 TEST(sinsp_filter_transformer, basename) {
 	sinsp_filter_transformer tr(filter_transformer_type::FTR_BASENAME);
 
-	auto all_types = all_param_types();
+	std::set<ppm_param_type> supported_types{PT_CHARBUF, PT_FSPATH, PT_FSRELPATH};
+	std::set<ppm_param_type> supported_list_types = supported_types;
 
-	auto supported_types = std::set<std::pair<ppm_param_type, bool>>(
-	        {{PT_CHARBUF, false}, {PT_FSPATH, false}, {PT_FSRELPATH, false}});
+	check_unsupported_types(tr, supported_types, supported_list_types);
 
-	auto test_cases = std::vector<std::pair<std::string, std::string>>{
-	        {"/home/ubuntu/hello.txt", "hello.txt"},
-	        {"/usr/local/bin/cat", "cat"},
-	        {"/", ""},
-	        {"", ""},
-	        {"/hello/", ""},
-	        {"hello", "hello"},
+	std::vector<test_case_entry> test_cases{
+	        {0, PT_CHARBUF, {{"/home/ubuntu/hello.txt"}}, PT_CHARBUF, {{"hello.txt"}}},
+	        {0, PT_FSPATH, {{"/usr/local/bin/cat"}}, PT_FSPATH, {{"cat"}}},
+	        {0, PT_FSPATH, {{"/"}}, PT_FSPATH, {{""}}},
+	        {0, PT_CHARBUF, {{"/hello/"}}, PT_CHARBUF, {{""}}},
+	        {0, PT_CHARBUF, {{"hello"}}, PT_CHARBUF, {{"hello"}}},
+	        {0, PT_CHARBUF, {{""}}, PT_CHARBUF, {{""}}},
 	};
 
-	std::vector<extract_value_t> sample_vals;
+	for(auto const& tc : test_cases) {
+		bool is_list = tc.flags & EPF_IS_LIST;
+		uint32_t flags = tc.flags;
+		auto transformed_type = tc.input_type;
 
-	for(auto &tc : test_cases) {
-		sample_vals.push_back(const_str_to_extract_value(tc.first.c_str()));
-	}
-
-	check_unsupported_types(tr, supported_types, sample_vals);
-
-	// check for supported types
-	for(auto t : supported_types) {
-		auto original_type = t.first;
-		uint32_t flags = t.second ? EPF_IS_LIST : 0;
-		auto transformed_type = original_type;
 		EXPECT_TRUE(tr.transform_type(transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type,
-		          transformed_type);  // note: basename is expected not to alter the type
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(transformed_type, tc.expected_type);
 
-		auto vals = sample_vals;
+		std::vector<extract_value_t> vals{};
+		for(auto const& val : tc.input) {
+			vals.push_back(val);
+		}
+
+		transformed_type = tc.input_type;
 		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
-		        << supported_type_msg(original_type, t.second, true);
-		EXPECT_EQ(original_type, transformed_type);
-		EXPECT_EQ(vals.size(), test_cases.size());
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(vals.size(), tc.expected.size());
 
-		for(uint32_t i = 0; i < test_cases.size(); i++) {
-			EXPECT_EQ(std::string((const char *)vals[i].ptr), test_cases[i].second)
-			        << eq_test_msg(test_cases[i]);
-			EXPECT_EQ(vals[i].len, test_cases[i].second.length() + 1) << eq_test_msg(test_cases[i]);
+		for(std::vector<extract_value_t>::size_type i = 0; i < vals.size(); i++) {
+			std::string actual = (const char*)vals[i].ptr;
+			std::string expected = (const char*)tc.expected[i].ptr;
+			EXPECT_EQ(actual, expected) << eq_test_msg(vals[i], tc.expected[i]);
+			EXPECT_EQ(vals[i].len, tc.expected[i].len) << eq_test_msg(vals[i], tc.expected[i]);
 		}
 	}
 }
 
-TEST(sinsp_filter_transformer, len_list) {
+TEST(sinsp_filter_transformer, len) {
 	sinsp_filter_transformer tr(filter_transformer_type::FTR_LEN);
 
-	auto all_types = all_param_types();
+	std::set<ppm_param_type> supported_types{PT_CHARBUF, PT_FSPATH, PT_FSRELPATH, PT_BYTEBUF};
+	std::set<ppm_param_type> supported_list_types = all_param_types();
 
-	std::vector<std::string> list_values = {"value 1", "value 2", "value 3", "value 4"};
-	std::vector<extract_value_t> list;
+	check_unsupported_types(tr, supported_types, supported_list_types);
 
-	for(auto &tc : list_values) {
-		list.push_back(const_str_to_extract_value(tc.c_str()));
+	std::vector<test_case_entry> test_cases{
+	        {0, PT_CHARBUF, {{"/home/ubuntu/hello.txt"}}, PT_UINT64, {{22}}},
+	        {0, PT_FSPATH, {{"/"}}, PT_UINT64, {{1}}},
+	        {EPF_IS_LIST, PT_FSPATH, {{"/hello"}}, PT_UINT64, {{1}}},
+	        {EPF_IS_LIST, PT_CHARBUF, {}, PT_UINT64, {{0}}},
+	        {EPF_IS_LIST, PT_UINT64, {{1}, {2}, {3}, {4}, {5}}, PT_UINT64, {{5}}},
+	};
+
+	for(auto const& tc : test_cases) {
+		bool is_list = tc.flags & EPF_IS_LIST;
+		uint32_t flags = tc.flags;
+		auto transformed_type = tc.input_type;
+
+		EXPECT_TRUE(tr.transform_type(transformed_type, flags))
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(transformed_type, tc.expected_type);
+
+		std::vector<extract_value_t> vals{};
+		for(auto const& val : tc.input) {
+			vals.push_back(val);
+		}
+
+		transformed_type = tc.input_type;
+		flags = tc.flags;
+		EXPECT_TRUE(tr.transform_values(vals, transformed_type, flags))
+		        << supported_type_msg(tc.input_type, is_list, true);
+		EXPECT_EQ(vals.size(), tc.expected.size());
+
+		for(std::vector<extract_value_t>::size_type i = 0; i < vals.size(); i++) {
+			uint64_t actual = extract_value_to_scalar<uint64_t>(vals[i]);
+			uint64_t expected = extract_value_to_scalar<uint64_t>(tc.expected[i]);
+			EXPECT_EQ(actual, expected);
+		}
 	}
-
-	auto original_type = PT_CHARBUF;
-	uint32_t original_flags = EPF_IS_LIST;
-	auto type = original_type;
-	auto flags = original_flags;
-	EXPECT_TRUE(tr.transform_type(type, flags)) << supported_type_msg(original_type, true, true);
-	EXPECT_EQ(type, PT_UINT64);
-	EXPECT_EQ(flags & EPF_IS_LIST, 0);
-
-	type = original_type;
-	flags = original_flags;
-	auto vals = list;
-	EXPECT_TRUE(tr.transform_values(vals, type, flags))
-	        << supported_type_msg(original_type, true, true);
-	EXPECT_EQ(type, PT_UINT64);
-	EXPECT_EQ(flags & EPF_IS_LIST, 0);
-	ASSERT_EQ(vals.size(), 1);
-
-	EXPECT_EQ(extract_value_to_scalar<uint64_t>(vals[0]), list_values.size());
-
-	std::vector<extract_value_t> empty_list;
-	type = original_type;
-	flags = original_flags;
-	vals = empty_list;
-	EXPECT_TRUE(tr.transform_values(vals, type, flags))
-	        << supported_type_msg(original_type, true, true);
-	EXPECT_EQ(type, PT_UINT64);
-	EXPECT_EQ(flags & EPF_IS_LIST, 0);
-	ASSERT_EQ(vals.size(), 1);
-
-	EXPECT_EQ(extract_value_to_scalar<uint64_t>(vals[0]), 0);
 }
 
 TEST_F(sinsp_with_test_input, basename_transformer) {
 	add_default_init_thread();
 	open_inspector();
 
-	sinsp_evt *evt;
+	sinsp_evt* evt;
 
 	int64_t dirfd = 3;
-	const char *file_to_run = "/tmp/file_to_run";
+	const char* file_to_run = "/tmp/file_to_run";
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
@@ -356,10 +365,10 @@ TEST_F(sinsp_with_test_input, len_transformer) {
 	add_default_init_thread();
 	open_inspector();
 
-	sinsp_evt *evt;
+	sinsp_evt* evt;
 
 	int64_t dirfd = 3;
-	const char *file_to_run = "/tmp/file_to_run";
+	const char* file_to_run = "/tmp/file_to_run";
 
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
@@ -391,4 +400,14 @@ TEST_F(sinsp_with_test_input, len_transformer) {
 
 	// fd.types = (ipv4,file)
 	EXPECT_TRUE(eval_filter(evt, "len(fd.types) = 2"));
+
+	uint8_t read_buf[] = {'\x01', '\x02', '\x03', '\x04', '\x05', '\x06'};
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_READ_X,
+	                           2,
+	                           (int64_t)0,
+	                           scap_const_sized_buffer{read_buf, sizeof(read_buf)});
+
+	EXPECT_TRUE(eval_filter(evt, "len(evt.arg.data) == 6"));
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This introduces a new `len()` transformer which acts like you'd expect:
* `len(some_list)` evaluates to the number of elements in the list
* `len(some_string)` evaluates to the length of the string (excluding null terminator of course)
* `len(some_buffer)` evaluates to the number of bytes in the buffer

This is also a handy way to check if lists are empty, since we couldn't do it before, which was apparent after a discussion with @leogr and @jasondellaluce .

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2127

**Special notes for your reviewer**:

* The implementation slightly changes the transformer interface which now takes the element flags as well
* Do you see any potential corner cases with plugins?

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
new(libsinsp): add len() filter transformer
```
