### PR TITLE
chore(e2e): fix e2e build without bundled deps

### DIFF
--- a/test/libsinsp_e2e/CMakeLists.txt
+++ b/test/libsinsp_e2e/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
 	add_dependencies(libsinsp_e2e_tests driver)
 endif()
 
-target_link_libraries(libsinsp_e2e_tests sinsp GTest::gtest pthread)
+target_link_libraries(libsinsp_e2e_tests sinsp "${GTEST_LIB}" "${GTEST_MAIN_LIB}" pthread)
 
 target_include_directories(
 	libsinsp_e2e_tests PRIVATE ${PROJECT_BINARY_DIR}/driver/src "${CMAKE_CURRENT_BINARY_DIR}"
@@ -68,7 +68,7 @@ target_include_directories(
 
 add_executable(test_helper test_helper.cpp)
 target_link_libraries(test_helper pthread)
-add_dependencies(libsinsp_e2e_tests test_helper)
+add_dependencies(libsinsp_e2e_tests test_helper gtest)
 
 add_executable(vtidcollision vtidcollision.c)
 add_dependencies(libsinsp_e2e_tests vtidcollision)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When compiling without bundled deps the e2e sinsp tests failed because gtest is not a dependency. Example of cmake variables provided

```
"CMAKE_BUILD_TYPE": "Release",
"BUILD_BPF": "ON",
"BUILD_DRIVER": "ON",
"USE_BUNDLED_DEPS": "OFF",
"MODERN_BPF_DEBUG_MODE": "ON",
"BUILD_LIBSCAP_MODERN_BPF": "ON",
"BUILD_LIBSCAP_GVISOR": "OFF",
"CREATE_TEST_TARGETS": "ON",
"USE_BUNDLED_VALIJSON": "ON",
"USE_BUNDLED_OPENSSL": "ON",
"USE_BUNDLED_RE2": "ON",
"USE_BUNDLED_LIBBPF": "ON",
"SCAP_FILES_SUITE_ENABLE": "ON",
"BUILD_WARNINGS_AS_ERRORS": "Off",
"ENABLE_DRIVERS_TESTS": "ON",
"ENABLE_LIBSCAP_TESTS": "ON",
"ENABLE_LIBSINSP_E2E_TESTS": "ON"
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
