### PR TITLE
chore: improve libcurl dependency reference

### DIFF
--- a/cmake/modules/curl.cmake
+++ b/cmake/modules/curl.cmake
@@ -90,6 +90,7 @@ else()
 			FILES_MATCHING
 			PATTERN "*.h"
 		)
+		find_package(CURL REQUIRED)
 	endif()
 endif()
 

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -167,8 +167,14 @@ set_sinsp_target_properties(sinsp)
 target_link_libraries(
 	sinsp
 	PUBLIC scap
-	PRIVATE "${CURL_LIBRARIES}" "${JSONCPP_LIB}" "${RE2_LIB}"
+	PRIVATE ${JSONCPP_LIB} ${RE2_LIB}
 )
+
+if(NOT MINIMAL_BUILD)
+	if(NOT WIN32 AND NOT EMSCRIPTEN)
+		target_link_libraries(sinsp PRIVATE CURL::libcurl)
+	endif()
+endif()
 
 if(NOT EMSCRIPTEN)
 	target_link_libraries(


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:
Library `libcurl` can be referenced in a more structured way by using CMake's `find_package` mechanism. This allows `falcosecurity-lib` to build also in other scenarios, e.g. with Vcpkg as a package manager.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
