### PR TITLE
chore(libsinsp): avoid useless allocation

### DIFF
--- a/userspace/libsinsp/test/async_key_value_source.ut.cpp
+++ b/userspace/libsinsp/test/async_key_value_source.ut.cpp
@@ -358,7 +358,7 @@ TEST(async_key_value_source_test, prune_old_metadata) {
 	ASSERT_FALSE(source.lookup(key1, response));
 
 	// Wait long enough for the old entry to require pruning
-	std::this_thread::sleep_for(std::chrono::milliseconds(2 * TTL_MS));
+	usleep(1000 * 2 * TTL_MS);
 
 	// Request the other key.  This should wake up the thread and actually
 	// preform the pruning.
@@ -366,7 +366,7 @@ TEST(async_key_value_source_test, prune_old_metadata) {
 
 	// Wait long enough for the async thread to get woken up and to
 	// prune the old entry
-	std::this_thread::sleep_for(std::chrono::milliseconds(TTL_MS));
+	usleep(1000 * TTL_MS);
 
 	// Since the first key should have been pruned, a second call to
 	// fetch the first key should also return false.

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1264,13 +1264,13 @@ std::vector<std::string> sinsp_split(std::string_view sv, char delim) {
 	std::string_view::size_type start = 0;
 	for(std::string_view::size_type i = 0; i < sv.size(); i++) {
 		if(sv[i] == delim) {
-			res.push_back(std::string(sv.substr(start, i - start)));
+			res.emplace_back(sv.substr(start, i - start));
 			start = i + 1;
 		}
 	}
 
 	if(start <= sv.length()) {
-		res.push_back(std::string(sv.substr(start)));
+		res.emplace_back(sv.substr(start));
 	}
 
 	return res;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This avoids the allocation of a temporary object: to do that `emplace_back` needs the arguments of the constructor underlying object.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
