### PR TITLE
new(userspace): plugin api to dump async events

### DIFF
--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -72,7 +72,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
 		if(p->caps() & CAP_ASYNC) {
-			p->dump(*this);
+			p->dump_state(*this);
 		}
 	}
 
@@ -99,7 +99,7 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress) {
 	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
 		if(p->caps() & CAP_ASYNC) {
-			p->dump(*this);
+			p->dump_state(*this);
 		}
 	}
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -69,7 +69,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	inspector->m_container_manager.dump_containers(*this);
 	inspector->m_usergroup_manager.dump_users_groups(*this);
 
-	// notify registered plugins of capture open
+	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
 		if(p->caps() & CAP_ASYNC) {
 			if(!p->dump(*this)) {

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -72,10 +72,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
 		if(p->caps() & CAP_ASYNC) {
-			if(!p->dump(*this)) {
-				throw sinsp_exception("dump error for plugin '" + p->name() +
-				                      "' : " + p->get_last_error());
-			}
+			p->dump(*this);
 		}
 	}
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -96,6 +96,13 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress) {
 	inspector->m_container_manager.dump_containers(*this);
 	inspector->m_usergroup_manager.dump_users_groups(*this);
 
+	// ask registered ASYNC plugins for a dump of their state
+	for(auto& p : inspector->m_plugin_manager->plugins()) {
+		if(p->caps() & CAP_ASYNC) {
+			p->dump(*this);
+		}
+	}
+
 	m_nevts = 0;
 }
 

--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -71,7 +71,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 
 	// notify registered plugins of capture open
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
-		if(p->caps() & CAP_DUMPING) {
+		if(p->caps() & CAP_ASYNC) {
 			if(!p->dump(*this)) {
 				throw sinsp_exception("dump error for plugin '" + p->name() +
 				                      "' : " + p->get_last_error());

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -1176,7 +1176,7 @@ bool sinsp_plugin::set_async_event_handler(async_event_handler_t handler) {
 	return rc == SS_PLUGIN_SUCCESS;
 }
 
-bool sinsp_plugin::dump(sinsp_dumper& dumper) {
+bool sinsp_plugin::dump_state(sinsp_dumper& dumper) {
 	if(!m_inited) {
 		throw sinsp_exception(std::string(s_not_init_err) + ": " + m_name);
 	}
@@ -1185,7 +1185,7 @@ bool sinsp_plugin::dump(sinsp_dumper& dumper) {
 		throw sinsp_exception("plugin " + m_name + "without async events cap used as dumper");
 	}
 
-	if(!m_handle->api.dump) {
+	if(!m_handle->api.dump_state) {
 		return false;
 	}
 
@@ -1239,7 +1239,7 @@ bool sinsp_plugin::dump(sinsp_dumper& dumper) {
 		return SS_PLUGIN_SUCCESS;
 	};
 
-	if(m_handle->api.dump(m_state, this, callback) != SS_PLUGIN_SUCCESS) {
+	if(m_handle->api.dump_state(m_state, this, callback) != SS_PLUGIN_SUCCESS) {
 		throw sinsp_exception("dump error for plugin '" + m_name + "' : " + m_last_owner_err);
 	}
 	return true;

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -162,7 +162,7 @@ public:
 	sinsp_thread_pool::routine_id_t subscribe_routine(ss_plugin_routine_fn_t routine_fn,
 	                                                  ss_plugin_routine_state_t* routine_state);
 	bool unsubscribe_routine(sinsp_thread_pool::routine_id_t routine_id);
-	bool dump(sinsp_dumper& dumper);
+	bool dump_state(sinsp_dumper& dumper);
 
 	/** Event Sourcing **/
 	inline uint32_t id() const { return m_id; }

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -161,6 +161,7 @@ public:
 	sinsp_thread_pool::routine_id_t subscribe_routine(ss_plugin_routine_fn_t routine_fn,
 	                                                  ss_plugin_routine_state_t* routine_state);
 	bool unsubscribe_routine(sinsp_thread_pool::routine_id_t routine_id);
+	bool dump(sinsp_dumper& dumper);
 
 	/** Event Sourcing **/
 	inline uint32_t id() const { return m_id; }

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -208,6 +208,8 @@ public:
 	using async_event_handler_t =
 	        std::function<void(const sinsp_plugin&, std::unique_ptr<sinsp_evt>)>;
 
+	using async_dump_handler_t = std::function<void(std::unique_ptr<sinsp_evt>)>;
+
 	bool set_async_event_handler(async_event_handler_t handler);
 
 	// note(jasondellaluce): we set these as protected in order to allow unit
@@ -250,9 +252,14 @@ private:
 	std::unordered_set<std::string> m_async_event_names;
 	std::atomic<async_event_handler_t*>
 	        m_async_evt_handler;  // note: we don't have thread-safe smart pointers
+	async_dump_handler_t m_async_dump_handler;
+
 	static ss_plugin_rc handle_plugin_async_event(ss_plugin_owner_t* o,
 	                                              const ss_plugin_event* evt,
 	                                              char* err);
+	static ss_plugin_rc handle_plugin_async_dump(ss_plugin_owner_t* o,
+	                                             const ss_plugin_event* evt,
+	                                             char* err);
 
 	/** Generic helpers **/
 	void validate_config(std::string& config);

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <atomic>
 #include <libscap/engine/source_plugin/source_plugin_public.h>
 #include <libsinsp/event.h>
+#include <libsinsp/dumper.h>
 #include <libsinsp/sinsp_filtercheck.h>
 #include <libsinsp/version.h>
 #include <libsinsp/events/sinsp_events.h>

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -159,7 +159,7 @@ bool sinsp::is_initialstate_event(scap_evt* pevent) const {
 	return pevent->type == PPME_CONTAINER_E || pevent->type == PPME_CONTAINER_JSON_E ||
 	       pevent->type == PPME_CONTAINER_JSON_2_E || pevent->type == PPME_USER_ADDED_E ||
 	       pevent->type == PPME_USER_DELETED_E || pevent->type == PPME_GROUP_ADDED_E ||
-	       pevent->type == PPME_GROUP_DELETED_E;
+	       pevent->type == PPME_GROUP_DELETED_E || pevent->type == PPME_ASYNCEVENT_E;
 }
 
 void sinsp::consume_initialstate_events() {
@@ -181,7 +181,7 @@ void sinsp::consume_initialstate_events() {
 		if(res == SCAP_SUCCESS) {
 			// Setting these to non-null will make sinsp::next use them as a scap event
 			// to avoid a call to scap_next. In this way, we can avoid the state parsing phase
-			// once we reach a container-unrelated event.
+			// once we reach a non-initialstate event.
 			m_replay_scap_evt = pevent;
 			m_replay_scap_cpuid = pcpuid;
 			m_replay_scap_flags = flags;
@@ -228,9 +228,9 @@ void sinsp::init() {
 	m_fds_to_remove.clear();
 
 	//
-	// If we're reading from file, we try to pre-parse the container events before
+	// If we're reading from file, we try to pre-parse all initial state-building events before
 	// importing the thread table, so that thread table filtering will work with
-	// container filters
+	// full information.
 	//
 	if(is_capture()) {
 		consume_initialstate_events();

--- a/userspace/libsinsp/sinsp_cycledumper.cpp
+++ b/userspace/libsinsp/sinsp_cycledumper.cpp
@@ -110,7 +110,7 @@ void sinsp_cycledumper::autodump_start(const std::string& dump_filename) {
 	std::for_each(m_open_file_callbacks.begin(), m_open_file_callbacks.end(), std::ref(*this));
 
 	m_dumper->open(m_inspector,
-	               dump_filename.c_str(),
+	               dump_filename,
 	               m_compress ? SCAP_COMPRESSION_GZIP : SCAP_COMPRESSION_NONE);
 
 	m_inspector->set_dumping(true);

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -404,6 +404,14 @@ private:
 };
 
 // scenario: a plugin with dump capability is requested a dump and then the capture file is read.
+// * register a plugin with async event capability
+// * open inspector in no driver mode
+// * request a scap file dump to a temporary text file
+// * at this stage, the plugin will be requested to dump its state; in our test case, the plugin
+// will just dump 10 fake events
+// * open a replay inspector to read the generated scap file
+// * register our event processor that just counts number of PPME_ASYNC_EVENT_E
+// * remove the test scap file
 // note: emscripten has trouble with the nodriver engine and async events
 #if !defined(__EMSCRIPTEN__)
 TEST_F(sinsp_with_test_input, plugin_dump) {

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -404,6 +404,8 @@ private:
 };
 
 // scenario: a plugin with dump capability is requested a dump and then the capture file is read.
+// note: emscripten has trouble with the nodriver engine and async events
+#if !defined(__EMSCRIPTEN__)
 TEST_F(sinsp_with_test_input, plugin_dump) {
 	uint64_t max_count = 1;
 	uint64_t period_ns = 1000000;  // 1ms
@@ -436,6 +438,7 @@ TEST_F(sinsp_with_test_input, plugin_dump) {
 	replay_inspector.close();
 	remove("test.scap");
 }
+#endif
 
 TEST(sinsp_plugin, plugin_extract_compatibility) {
 	std::string tmp;

--- a/userspace/libsinsp/test/plugins/syscall_async.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_async.cpp
@@ -141,7 +141,7 @@ ss_plugin_rc plugin_set_async_event_handler(ss_plugin_t* s,
 				        err,
 				        PPME_ASYNCEVENT_E,
 				        3,
-				        0,
+				        (uint32_t)0,
 				        "unsupportedname",
 				        scap_const_sized_buffer{data, strlen(data) + 1});
 				ps->async_evt->tid = 1;
@@ -161,7 +161,7 @@ ss_plugin_rc plugin_set_async_event_handler(ss_plugin_t* s,
 				        err,
 				        PPME_ASYNCEVENT_E,
 				        3,
-				        0,
+				        (uint32_t)0,
 				        name,
 				        scap_const_sized_buffer{data, strlen(data) + 1});
 				ps->async_evt->tid = 1;
@@ -188,6 +188,33 @@ ss_plugin_rc plugin_set_async_event_handler(ss_plugin_t* s,
 	return SS_PLUGIN_SUCCESS;
 }
 
+ss_plugin_rc plugin_dump(ss_plugin_t* s, uint32_t* nevts, ss_plugin_event*** evts) {
+	static uint8_t evt_buf[10][256];
+	static ss_plugin_event* evt[10];
+	const char* name = "sampleticker";
+	const char* data = "hello world";
+	for(int i = 0; i < 10; i++) {
+		evt[i] = (ss_plugin_event*)evt_buf[i];
+		char error[SCAP_LASTERR_SIZE];
+		int32_t encode_res =
+		        scap_event_encode_params(scap_sized_buffer{evt[i], sizeof(evt_buf[i])},
+		                                 nullptr,
+		                                 error,
+		                                 PPME_ASYNCEVENT_E,
+		                                 3,
+		                                 (uint32_t)0,
+		                                 name,
+		                                 scap_const_sized_buffer{(void*)data, strlen(data) + 1});
+
+		if(encode_res == SCAP_FAILURE) {
+			return SS_PLUGIN_FAILURE;
+		}
+	}
+	*evts = evt;
+	*nevts = 10;
+	return SS_PLUGIN_SUCCESS;
+}
+
 }  // anonymous namespace
 
 void get_plugin_api_sample_syscall_async(plugin_api& out) {
@@ -203,4 +230,5 @@ void get_plugin_api_sample_syscall_async(plugin_api& out) {
 	out.get_async_event_sources = plugin_get_async_event_sources;
 	out.get_async_events = plugin_get_async_events;
 	out.set_async_event_handler = plugin_set_async_event_handler;
+	out.dump = plugin_dump;
 }

--- a/userspace/libsinsp/test/plugins/syscall_async.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_async.cpp
@@ -188,9 +188,9 @@ ss_plugin_rc plugin_set_async_event_handler(ss_plugin_t* s,
 	return SS_PLUGIN_SUCCESS;
 }
 
-ss_plugin_rc plugin_dump(ss_plugin_t* s,
-                         ss_plugin_owner_t* owner,
-                         const ss_plugin_async_event_handler_t handler) {
+ss_plugin_rc plugin_dump_state(ss_plugin_t* s,
+                               ss_plugin_owner_t* owner,
+                               const ss_plugin_async_event_handler_t handler) {
 	static uint8_t evt_buf[256];
 	static ss_plugin_event* evt;
 	char err[PLUGIN_MAX_ERRLEN];
@@ -240,5 +240,5 @@ void get_plugin_api_sample_syscall_async(plugin_api& out) {
 	out.get_async_event_sources = plugin_get_async_event_sources;
 	out.get_async_events = plugin_get_async_events;
 	out.set_async_event_handler = plugin_set_async_event_handler;
-	out.dump = plugin_dump;
+	out.dump_state = plugin_dump_state;
 }

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -1060,11 +1060,18 @@ typedef struct {
 		// Required: no
 		// Arguments:
 		// - s: the plugin state, returned by init(). Can be NULL.
-		// - nevts: number of events retrieved.
-		// - evts: events retrieved. Events MUST be of type PPME_ASYNCEVENT_E.
+		// - owner: Opaque pointer to the plugin's owner. Must be passed
+		//	 as an argument to the async event function handler.
+		// - handler: Function handler to be used for sending events to be dumped
+		//   to the plugin's owner. The handler must be invoked with
+		//   the same owner opaque pointer passed to this function, and with
+		//   an event pointer owned and controlled by the plugin. The event
+		//   pointer is not retained by the handler after it returns.
 		//
 		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
-		ss_plugin_rc (*dump)(ss_plugin_t* s, uint32_t* nevts, ss_plugin_event*** evts);
+		ss_plugin_rc (*dump)(ss_plugin_t* s,
+		                     ss_plugin_owner_t* owner,
+		                     const ss_plugin_async_event_handler_t handler);
 	};
 
 	// Sets a new plugin configuration when provided by the framework.

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -1104,6 +1104,21 @@ typedef struct {
 		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
 		ss_plugin_rc (*capture_close)(ss_plugin_t* s, const ss_plugin_capture_listen_input* i);
 	};
+
+	// Events dumping capability API
+	struct {
+		//
+		// Called by the framework when a capture file dump is requested.
+		//
+		// Required: yes
+		// Arguments:
+		// - s: the plugin state, returned by init(). Can be NULL.
+		// - evts: input containing vtables for performing table operations and
+		// subscribe/unsubscribe async routines
+		//
+		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
+		ss_plugin_rc (*dump)(ss_plugin_t* s, uint32_t* nevts, ss_plugin_event*** evts);
+	};
 } plugin_api;
 
 #ifdef __cplusplus

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -1069,9 +1069,9 @@ typedef struct {
 		//   pointer is not retained by the handler after it returns.
 		//
 		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
-		ss_plugin_rc (*dump)(ss_plugin_t* s,
-		                     ss_plugin_owner_t* owner,
-		                     const ss_plugin_async_event_handler_t handler);
+		ss_plugin_rc (*dump_state)(ss_plugin_t* s,
+		                           ss_plugin_owner_t* owner,
+		                           const ss_plugin_async_event_handler_t handler);
 	};
 
 	// Sets a new plugin configuration when provided by the framework.

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -29,7 +29,7 @@ extern "C" {
 //
 // todo(jasondellaluce): when/if major changes to v4, check and solve all todos
 #define PLUGIN_API_VERSION_MAJOR 3
-#define PLUGIN_API_VERSION_MINOR 9
+#define PLUGIN_API_VERSION_MINOR 10
 #define PLUGIN_API_VERSION_PATCH 0
 
 //

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -1053,6 +1053,18 @@ typedef struct {
 		ss_plugin_rc (*set_async_event_handler)(ss_plugin_t* s,
 		                                        ss_plugin_owner_t* owner,
 		                                        const ss_plugin_async_event_handler_t handler);
+
+		//
+		// Called by the framework when a capture file dump is requested.
+		//
+		// Required: no
+		// Arguments:
+		// - s: the plugin state, returned by init(). Can be NULL.
+		// - nevts: number of events retrieved.
+		// - evts: events retrieved. Events MUST be of type PPME_ASYNCEVENT_E.
+		//
+		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
+		ss_plugin_rc (*dump)(ss_plugin_t* s, uint32_t* nevts, ss_plugin_event*** evts);
 	};
 
 	// Sets a new plugin configuration when provided by the framework.
@@ -1103,21 +1115,6 @@ typedef struct {
 		//
 		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
 		ss_plugin_rc (*capture_close)(ss_plugin_t* s, const ss_plugin_capture_listen_input* i);
-	};
-
-	// Events dumping capability API
-	struct {
-		//
-		// Called by the framework when a capture file dump is requested.
-		//
-		// Required: yes
-		// Arguments:
-		// - s: the plugin state, returned by init(). Can be NULL.
-		// - evts: input containing vtables for performing table operations and
-		// subscribe/unsubscribe async routines
-		//
-		// Return value: A ss_plugin_rc with values SS_PLUGIN_SUCCESS or SS_PLUGIN_FAILURE.
-		ss_plugin_rc (*dump)(ss_plugin_t* s, uint32_t* nevts, ss_plugin_event*** evts);
 	};
 } plugin_api;
 

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -122,11 +122,11 @@ plugin_handle_t* plugin_load(const char* path, char* err) {
 	SYM_RESOLVE(ret, get_async_event_sources);
 	SYM_RESOLVE(ret, get_async_events);
 	SYM_RESOLVE(ret, set_async_event_handler);
+	SYM_RESOLVE(ret, dump);
 	SYM_RESOLVE(ret, set_config);
 	SYM_RESOLVE(ret, get_metrics);
 	SYM_RESOLVE(ret, capture_open);
 	SYM_RESOLVE(ret, capture_close);
-	SYM_RESOLVE(ret, dump);
 	return ret;
 }
 
@@ -280,10 +280,6 @@ plugin_caps_t plugin_get_capabilities(const plugin_handle_t* h, char* err) {
 		           "must implement both 'plugin_capture_open' and 'plugin_capture_close' (capture "
 		           "listening)",
 		           ", ");
-	}
-
-	if(h->api.dump != NULL) {
-		caps = (plugin_caps_t)((uint32_t)caps | (uint32_t)CAP_DUMPING);
 	}
 
 	return caps;

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -126,6 +126,7 @@ plugin_handle_t* plugin_load(const char* path, char* err) {
 	SYM_RESOLVE(ret, get_metrics);
 	SYM_RESOLVE(ret, capture_open);
 	SYM_RESOLVE(ret, capture_close);
+	SYM_RESOLVE(ret, dump);
 	return ret;
 }
 
@@ -279,6 +280,10 @@ plugin_caps_t plugin_get_capabilities(const plugin_handle_t* h, char* err) {
 		           "must implement both 'plugin_capture_open' and 'plugin_capture_close' (capture "
 		           "listening)",
 		           ", ");
+	}
+
+	if(h->api.dump != NULL) {
+		caps = (plugin_caps_t)((uint32_t)caps | (uint32_t)CAP_DUMPING);
 	}
 
 	return caps;

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -122,7 +122,7 @@ plugin_handle_t* plugin_load(const char* path, char* err) {
 	SYM_RESOLVE(ret, get_async_event_sources);
 	SYM_RESOLVE(ret, get_async_events);
 	SYM_RESOLVE(ret, set_async_event_handler);
-	SYM_RESOLVE(ret, dump);
+	SYM_RESOLVE(ret, dump_state);
 	SYM_RESOLVE(ret, set_config);
 	SYM_RESOLVE(ret, get_metrics);
 	SYM_RESOLVE(ret, capture_open);

--- a/userspace/plugin/plugin_loader.h
+++ b/userspace/plugin/plugin_loader.h
@@ -44,6 +44,7 @@ typedef enum {
 	CAP_PARSING = 1 << 2,
 	CAP_ASYNC = 1 << 3,
 	CAP_CAPTURE_LISTENING = 1 << 4,
+	CAP_DUMPING = 1 << 5,
 	CAP_BROKEN = 1 << 31,  // used to report inconsistencies
 } plugin_caps_t;
 

--- a/userspace/plugin/plugin_loader.h
+++ b/userspace/plugin/plugin_loader.h
@@ -44,7 +44,6 @@ typedef enum {
 	CAP_PARSING = 1 << 2,
 	CAP_ASYNC = 1 << 3,
 	CAP_CAPTURE_LISTENING = 1 << 4,
-	CAP_DUMPING = 1 << 5,
 	CAP_BROKEN = 1 << 31,  // used to report inconsistencies
 } plugin_caps_t;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This PR adds a new `dump()` API under the `async events` plugin capability.
It is used to dump plugin state (as list of `PPME_ASYNCEVENT_E` events) when a scap file dump is requested.
Note:
* only `PPME_ASYNCEVENT_E` can be dumped
* `PPME_ASYNCEVENT_E` dumped must have a name supported by the plugin (see `get_async_events()` API)

Moreover, enable initialstate consuming of `PPME_ASYNCEVENT_E` events while opening the inspector.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(userspace): plugin api to dump async events
```
