### PR TITLE
cleanup(sinsp): handle path too long in a better way

### DIFF
--- a/test/libsinsp_e2e/sys_call_test.cpp
+++ b/test/libsinsp_e2e/sys_call_test.cpp
@@ -2180,7 +2180,7 @@ TEST_F(sys_call_test, thread_lookup_live) {
 TEST_F(sys_call_test, fd_name_max_path) {
 	int callnum = 0;
 	std::string pathname("/");
-	// Using only 1022 chars otherwise the path will be "/PATH_TOO_LONG".
+	// Using only 1022 chars otherwise the path will be "/DIR_TOO_LONG/FILENAME_TOO_LONG".
 	pathname.insert(1, 1021, 'A');
 
 	event_filter_t filter = [&](sinsp_evt* evt) {

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -207,7 +207,9 @@ TEST_F(sinsp_with_test_input, path_too_long) {
 	                           (uint32_t)0,
 	                           (uint32_t)5,
 	                           (uint64_t)123);
-	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/PATH_TOO_LONG");
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/DIR_TOO_LONG/FILENAME_TOO_LONG");
+	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/DIR_TOO_LONG");
+	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "FILENAME_TOO_LONG");
 
 	fd = 4;
 	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_BY_HANDLE_AT_E, 0);
@@ -220,8 +222,8 @@ TEST_F(sinsp_with_test_input, path_too_long) {
 	                           PPM_O_RDWR,
 	                           long_path.c_str());
 
-	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/PATH_TOO_LONG");
-	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/PATH_TOO_LONG");
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/DIR_TOO_LONG/FILENAME_TOO_LONG");
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/DIR_TOO_LONG/FILENAME_TOO_LONG");
 }
 
 TEST_F(sinsp_with_test_input, creates_fd_generic) {

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -182,6 +182,12 @@ TEST(sinsp_utils_test, concatenate_paths) {
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/app", res);
 
+	// This path is too long so we should receive our predefined string.
+	path1 = std::string(1500, 'C');
+	path2 = "dir/term";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG", res);
+
 	/* No unicode support
 	path1 = "/root/";
 	path2 = "../😉";

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -703,7 +703,7 @@ static inline bool concatenate_paths_(char* target,
                                       const char* path2,
                                       uint32_t len2) {
 	if(targetlen < (len1 + len2 + 1)) {
-		strlcpy(target, "/PATH_TOO_LONG", targetlen);
+		strlcpy(target, "/DIR_TOO_LONG/FILENAME_TOO_LONG", targetlen);
 		return false;
 	}
 

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -112,7 +112,8 @@ public:
 	// Concatenate posix-style path1 and path2 up to max_len in size, normalizing the result.
 	// path1 MUST be '/' terminated and is not sanitized.
 	// If path2 is absolute, the result will be equivalent to path2.
-	// If the result would be too long, the output will contain the string "/PATH_TOO_LONG" instead.
+	// If the result would be too long, the output will contain the string
+	// "/DIR_TOO_LONG/FILENAME_TOO_LONG" instead.
 	//
 	static std::string concatenate_paths(std::string_view path1, std::string_view path2);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:

Today in case of path is too long we return `/PATH_TOO_LONG`. This means:
* `fd_directory`  = "/"
* `fd_filename` = "PATH_TOO_LONG"

The directory is definitely wrong and misleading as a workaround I propose something like this `/DIR_TOO_LONG/FILENAME_TOO_LONG`, so:
* `fd_directory`  = "/DIR_TOO_LONG"
* `fd_filename` = "FILENAME_TOO_LONG"

We probably need to find something better but at least we remove the wrong dir

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
