### PR TITLE
cleanup(userspace/libsinsp): drop user and group infos embedded in threadinfo

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1311,7 +1311,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 
 		child_tinfo->m_tty = caller_tinfo->m_tty;
 
-		child_tinfo->set_loginuser(caller_tinfo->m_loginuid);
+		child_tinfo->set_loginuid(caller_tinfo->m_loginuid);
 
 		child_tinfo->m_cap_permitted = caller_tinfo->m_cap_permitted;
 
@@ -1349,11 +1349,10 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 		return;
 	}
 
-	/* Refresh user / loginuser / group */
+	/* Refresh user / group */
 	if(new_child->m_container_id.empty() == false) {
 		new_child->set_group(new_child->m_gid);
 		new_child->set_user(new_child->m_uid);
-		new_child->set_loginuser(new_child->m_loginuid);
 	}
 
 	/* If there's a listener, invoke it */
@@ -1626,7 +1625,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 
 		child_tinfo->m_tty = lookup_tinfo->m_tty;
 
-		child_tinfo->set_loginuser(lookup_tinfo->m_loginuid);
+		child_tinfo->set_loginuid(lookup_tinfo->m_loginuid);
 
 		child_tinfo->m_cap_permitted = lookup_tinfo->m_cap_permitted;
 
@@ -1840,11 +1839,10 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	 */
 	evt->set_tinfo(new_child.get());
 
-	/* Refresh user / loginuser / group */
+	/* Refresh user / group */
 	if(new_child->m_container_id.empty() == false) {
 		new_child->set_group(new_child->m_gid);
 		new_child->set_user(new_child->m_uid);
-		new_child->set_loginuser(new_child->m_loginuid);
 	}
 
 	//
@@ -2227,7 +2225,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 
 	// Get the loginuid
 	if(evt->get_num_params() > 18) {
-		evt->get_tinfo()->set_loginuser(evt->get_param(18)->as<uint32_t>());
+		evt->get_tinfo()->set_loginuid(evt->get_param(18)->as<uint32_t>());
 	}
 
 	// Get execve flags
@@ -2317,13 +2315,12 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 	evt->get_tinfo()->compute_program_hash();
 
 	//
-	// Refresh user / loginuser / group
+	// Refresh user / group
 	// if we happen to change container id
 	//
 	if(container_id != evt->get_tinfo()->m_container_id) {
 		evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
 		evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-		evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuid);
 	}
 
 	//
@@ -5071,13 +5068,12 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt) {
 		        evt->get_tinfo(),
 		        m_inspector->is_live() || m_inspector->is_syscall_plugin());
 		//
-		// Refresh user / loginuser / group
+		// Refresh user / group
 		// if we happen to change container id
 		//
 		if(container_id != evt->get_tinfo()->m_container_id) {
 			evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
 			evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-			evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuid);
 		}
 	}
 }

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1240,7 +1240,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 	default:
 		ASSERT(false);
 	}
-	child_tinfo->m_uid = uid;
+	child_tinfo->set_user(uid);
 
 	/* gid */
 	int32_t gid = 0;
@@ -1267,7 +1267,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 	default:
 		ASSERT(false);
 	}
-	child_tinfo->m_gid = gid;
+	child_tinfo->set_group(gid);
 
 	/* Set cgroups and heuristically detect container id */
 	switch(etype) {
@@ -1311,7 +1311,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 
 		child_tinfo->m_tty = caller_tinfo->m_tty;
 
-		child_tinfo->m_loginuid = caller_tinfo->m_loginuid;
+		child_tinfo->set_loginuser(caller_tinfo->m_loginuid);
 
 		child_tinfo->m_cap_permitted = caller_tinfo->m_cap_permitted;
 
@@ -1347,6 +1347,13 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 	if(!new_child) {
 		// note: we expect the thread manager to log a warning already
 		return;
+	}
+
+	/* Refresh user / loginuser / group */
+	if(new_child->m_container_id.empty() == false) {
+		new_child->set_group(new_child->m_gid);
+		new_child->set_user(new_child->m_uid);
+		new_child->set_loginuser(new_child->m_loginuid);
 	}
 
 	/* If there's a listener, invoke it */
@@ -1619,7 +1626,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 
 		child_tinfo->m_tty = lookup_tinfo->m_tty;
 
-		child_tinfo->m_loginuid = lookup_tinfo->m_loginuid;
+		child_tinfo->set_loginuser(lookup_tinfo->m_loginuid);
 
 		child_tinfo->m_cap_permitted = lookup_tinfo->m_cap_permitted;
 
@@ -1760,7 +1767,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	default:
 		ASSERT(false);
 	}
-	child_tinfo->m_uid = uid;
+	child_tinfo->set_user(uid);
 
 	/* gid */
 	int32_t gid = 0;
@@ -1787,7 +1794,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	default:
 		ASSERT(false);
 	}
-	child_tinfo->m_gid = gid;
+	child_tinfo->set_group(gid);
 
 	/* Set cgroups and heuristically detect container id */
 	switch(etype) {
@@ -1832,6 +1839,13 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	 * callback will use updated info.
 	 */
 	evt->set_tinfo(new_child.get());
+
+	/* Refresh user / loginuser / group */
+	if(new_child->m_container_id.empty() == false) {
+		new_child->set_group(new_child->m_gid);
+		new_child->set_user(new_child->m_uid);
+		new_child->set_loginuser(new_child->m_loginuid);
+	}
 
 	//
 	// If there's a listener, invoke it
@@ -2213,7 +2227,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 
 	// Get the loginuid
 	if(evt->get_num_params() > 18) {
-		evt->get_tinfo()->m_loginuid = evt->get_param(18)->as<uint32_t>();
+		evt->get_tinfo()->set_loginuser(evt->get_param(18)->as<uint32_t>());
 	}
 
 	// Get execve flags
@@ -2259,7 +2273,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 
 	// Get uid
 	if(evt->get_num_params() > 26) {
-		evt->get_tinfo()->m_uid = evt->get_param(26)->as<uint32_t>();
+		evt->get_tinfo()->set_user(evt->get_param(26)->as<uint32_t>());
 	}
 
 	// Get pgid
@@ -2301,6 +2315,16 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 	// Recompute the program hash
 	//
 	evt->get_tinfo()->compute_program_hash();
+
+	//
+	// Refresh user / loginuser / group
+	// if we happen to change container id
+	//
+	if(container_id != evt->get_tinfo()->m_container_id) {
+		evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
+		evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
+		evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuid);
+	}
 
 	//
 	// If there's a listener, invoke it
@@ -4493,7 +4517,7 @@ void sinsp_parser::parse_setresuid_exit(sinsp_evt *evt) {
 		if(new_euid < std::numeric_limits<uint32_t>::max()) {
 			sinsp_threadinfo *ti = evt->get_thread_info();
 			if(ti) {
-				ti->m_uid = new_euid;
+				ti->set_user(new_euid);
 			}
 		}
 	}
@@ -4513,7 +4537,7 @@ void sinsp_parser::parse_setreuid_exit(sinsp_evt *evt) {
 		if(new_euid < std::numeric_limits<uint32_t>::max()) {
 			sinsp_threadinfo *ti = evt->get_thread_info();
 			if(ti) {
-				ti->m_uid = new_euid;
+				ti->set_user(new_euid);
 			}
 		}
 	}
@@ -4534,7 +4558,7 @@ void sinsp_parser::parse_setresgid_exit(sinsp_evt *evt) {
 		if(new_egid < std::numeric_limits<uint32_t>::max()) {
 			sinsp_threadinfo *ti = evt->get_thread_info();
 			if(ti) {
-				ti->m_gid = new_egid;
+				ti->set_group(new_egid);
 			}
 		}
 	}
@@ -4554,7 +4578,7 @@ void sinsp_parser::parse_setregid_exit(sinsp_evt *evt) {
 		if(new_egid < std::numeric_limits<uint32_t>::max()) {
 			sinsp_threadinfo *ti = evt->get_thread_info();
 			if(ti) {
-				ti->m_gid = new_egid;
+				ti->set_group(new_egid);
 			}
 		}
 	}
@@ -4573,7 +4597,7 @@ void sinsp_parser::parse_setuid_exit(sinsp_evt *evt) {
 		uint32_t new_euid = enter_evt->get_param(0)->as<uint32_t>();
 		sinsp_threadinfo *ti = evt->get_thread_info();
 		if(ti) {
-			ti->m_uid = new_euid;
+			ti->set_user(new_euid);
 		}
 	}
 }
@@ -4591,7 +4615,7 @@ void sinsp_parser::parse_setgid_exit(sinsp_evt *evt) {
 		uint32_t new_egid = enter_evt->get_param(0)->as<uint32_t>();
 		sinsp_threadinfo *ti = evt->get_thread_info();
 		if(ti) {
-			ti->m_gid = new_egid;
+			ti->set_group(new_egid);
 		}
 	}
 }
@@ -5046,6 +5070,15 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt) {
 		m_inspector->m_container_manager.resolve_container(
 		        evt->get_tinfo(),
 		        m_inspector->is_live() || m_inspector->is_syscall_plugin());
+		//
+		// Refresh user / loginuser / group
+		// if we happen to change container id
+		//
+		if(container_id != evt->get_tinfo()->m_container_id) {
+			evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
+			evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
+			evt->get_tinfo()->set_loginuser(evt->get_tinfo()->m_loginuid);
+		}
 	}
 }
 

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -67,11 +67,13 @@ uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt* evt,
 
 	switch(m_field_id) {
 	case TYPE_GID:
-		m_gid = tinfo->m_group.gid();
+		m_gid = tinfo->m_gid;
 		RETURN_EXTRACT_VAR(m_gid);
-	case TYPE_NAME:
-		m_name = tinfo->m_group.name();
+	case TYPE_NAME: {
+		auto group = tinfo->get_group();
+		m_name = group->name;
 		RETURN_EXTRACT_STRING(m_name);
+	}
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -100,27 +100,29 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_STRING(container_info->m_container_user);
 	}
 
+	auto user = tinfo->get_user();
+	auto loginuser = tinfo->get_loginuser();
 	switch(m_field_id) {
 	case TYPE_UID:
-		m_val.u32 = tinfo->m_user.uid();
+		m_val.u32 = tinfo->m_uid;
 		RETURN_EXTRACT_VAR(m_val.u32);
 	case TYPE_NAME:
-		m_strval = tinfo->m_user.name();
+		m_strval = user->name;
 		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_HOMEDIR:
-		m_strval = tinfo->m_user.homedir();
+		m_strval = user->homedir;
 		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_SHELL:
-		m_strval = tinfo->m_user.shell();
+		m_strval = user->shell;
 		RETURN_EXTRACT_STRING(m_strval);
 	case TYPE_LOGINUID:
 		m_val.s64 = (int64_t)-1;
-		if(tinfo->m_loginuser.uid() < UINT32_MAX) {
-			m_val.s64 = (int64_t)tinfo->m_loginuser.uid();
+		if(tinfo->m_loginuid < UINT32_MAX) {
+			m_val.s64 = (int64_t)tinfo->m_loginuid;
 		}
 		RETURN_EXTRACT_VAR(m_val.s64);
 	case TYPE_LOGINNAME:
-		m_strval = tinfo->m_loginuser.name();
+		m_strval = loginuser->name;
 		RETURN_EXTRACT_STRING(m_strval);
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/test/parsers/parse_setregid.cpp
+++ b/userspace/libsinsp/test/parsers/parse_setregid.cpp
@@ -33,7 +33,7 @@ TEST_F(sinsp_with_test_input, SETREGID_failure) {
 
 	sinsp_threadinfo* ti = m_inspector.get_thread_ref(p2_t2_tid, false).get();
 	ASSERT_TRUE(ti);
-	ASSERT_TRUE(ti->m_user.gid() == 0);
+	ASSERT_TRUE(ti->m_gid == 0);
 }
 
 TEST_F(sinsp_with_test_input, SETREGID_success) {
@@ -50,5 +50,5 @@ TEST_F(sinsp_with_test_input, SETREGID_success) {
 
 	sinsp_threadinfo* ti = m_inspector.get_thread_ref(p2_t2_tid, false).get();
 	ASSERT_TRUE(ti);
-	ASSERT_TRUE(ti->m_user.gid() == 1337);
+	ASSERT_TRUE(ti->m_gid == 1337);
 }

--- a/userspace/libsinsp/test/parsers/parse_setreuid.cpp
+++ b/userspace/libsinsp/test/parsers/parse_setreuid.cpp
@@ -33,7 +33,7 @@ TEST_F(sinsp_with_test_input, SETREUID_failure) {
 
 	sinsp_threadinfo* ti = m_inspector.get_thread_ref(p2_t2_tid, false).get();
 	ASSERT_TRUE(ti);
-	ASSERT_TRUE(ti->m_user.uid() == 0);
+	ASSERT_TRUE(ti->m_uid == 0);
 }
 
 TEST_F(sinsp_with_test_input, SETREUID_success) {
@@ -50,5 +50,5 @@ TEST_F(sinsp_with_test_input, SETREUID_success) {
 
 	sinsp_threadinfo* ti = m_inspector.get_thread_ref(p2_t2_tid, false).get();
 	ASSERT_TRUE(ti);
-	ASSERT_TRUE(ti->m_user.uid() == 1337);
+	ASSERT_TRUE(ti->m_uid == 1337);
 }

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -376,6 +376,10 @@ public:
 	 */
 	std::string get_path_for_dir_fd(int64_t dir_fd);
 
+	void set_user(uint32_t uid);
+	void set_group(uint32_t gid);
+	void set_loginuser(uint32_t loginuid);
+
 	using cgroups_t = std::vector<std::pair<std::string, std::string>>;
 	const cgroups_t& cgroups() const;
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -62,64 +62,6 @@ struct erase_fd_params {
 */
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry {
 public:
-	class sinsp_userinfo {
-	public:
-		sinsp_userinfo() {
-			m_uid = 0xffffffff;
-			m_gid = 0xffffffff;
-		}
-		uint32_t uid() const { return m_uid; }
-		uint32_t gid() const { return m_gid; }
-		std::string name() const {
-			if(m_name.empty()) {
-				return (m_uid == 0) ? "root" : "<NA>";
-			} else {
-				return m_name;
-			}
-		};
-		std::string homedir() const {
-			if(m_homedir.empty()) {
-				return (m_uid == 0) ? "/root" : "<NA>";
-			} else {
-				return m_homedir;
-			}
-		};
-		std::string shell() const { return m_shell.empty() ? "<NA>" : m_shell; };
-
-		void set_uid(uint32_t uid) { m_uid = uid; };
-		void set_gid(uint32_t gid) { m_gid = gid; };
-		void set_name(char* name, size_t length) { m_name.assign(name, length); };
-		void set_homedir(char* homedir, size_t length) { m_homedir.assign(homedir, length); };
-		void set_shell(char* shell, size_t length) { m_shell.assign(shell, length); };
-
-	private:
-		uint32_t m_uid;         ///< User ID
-		uint32_t m_gid;         ///< Group ID
-		std::string m_name;     ///< Username
-		std::string m_homedir;  ///< Home directory
-		std::string m_shell;    ///< Shell program
-	};
-
-	class sinsp_groupinfo {
-	public:
-		sinsp_groupinfo() { m_gid = 0xffffffff; }
-		uint32_t gid() const { return m_gid; };
-		std::string name() const {
-			if(m_name.empty()) {
-				return (m_gid == 0) ? "root" : "<NA>";
-			} else {
-				return m_name;
-			}
-		};
-
-		void set_gid(uint32_t gid) { m_gid = gid; };
-		void set_name(char* name, size_t length) { m_name.assign(name, length); };
-
-	private:
-		uint32_t m_gid;      ///< Group ID
-		std::string m_name;  ///< Group name
-	};
-
 	sinsp_threadinfo(sinsp* inspector = nullptr,
 	                 const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
 	                         dyn_fields = nullptr);
@@ -141,6 +83,21 @@ public:
 	  \brief Return the full executable path of the process containing this thread, e.g. "/bin/top".
 	*/
 	std::string get_exepath() const;
+
+	/*!
+	  \brief Return the full info about thread uid.
+	*/
+	scap_userinfo* get_user() const;
+
+	/*!
+	  \brief Return the full info about thread gid.
+	*/
+	scap_groupinfo* get_group() const;
+
+	/*!
+	  \brief Return the full info about thread loginuid.
+	*/
+	scap_userinfo* get_loginuser() const;
 
 	/*!
 	  \brief Return the working directory of the process containing this thread.
@@ -419,10 +376,6 @@ public:
 	 */
 	std::string get_path_for_dir_fd(int64_t dir_fd);
 
-	void set_user(uint32_t uid);
-	void set_group(uint32_t gid);
-	void set_loginuser(uint32_t loginuid);
-
 	using cgroups_t = std::vector<std::pair<std::string, std::string>>;
 	const cgroups_t& cgroups() const;
 
@@ -449,9 +402,9 @@ public:
 	std::string m_container_id;       ///< heuristic-based container id
 	uint32_t m_flags;   ///< The thread flags. See the PPM_CL_* declarations in ppm_events_public.h.
 	int64_t m_fdlimit;  ///< The maximum number of FDs this thread can open
-	sinsp_userinfo m_user;       ///< user infos
-	sinsp_userinfo m_loginuser;  ///< loginuser infos (auid)
-	sinsp_groupinfo m_group;     ///< group infos
+	uint32_t m_uid;     ///< uid
+	uint32_t m_gid;     ///< gid
+	uint32_t m_loginuid;         ///< loginuid
 	uint64_t m_cap_permitted;    ///< permitted capabilities
 	uint64_t m_cap_effective;    ///< effective capabilities
 	uint64_t m_cap_inheritable;  ///< inheritable capabilities

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -378,7 +378,7 @@ public:
 
 	void set_user(uint32_t uid);
 	void set_group(uint32_t gid);
-	void set_loginuser(uint32_t loginuid);
+	void set_loginuid(uint32_t loginuid);
 
 	using cgroups_t = std::vector<std::pair<std::string, std::string>>;
 	const cgroups_t& cgroups() const;
@@ -607,6 +607,8 @@ private:
 	                  struct iovec& iov,
 	                  uint32_t& alen,
 	                  std::string& rem) const;
+
+	scap_userinfo* get_user(uint32_t id) const;
 
 	//
 	// Parameters that can't be accessed directly because they could be in the

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -135,20 +135,6 @@ void sinsp_usergroup_manager::subscribe_container_mgr() {
 		        [&](const sinsp_container_info &cinfo) -> void {
 			        delete_container_users_groups(cinfo);
 		        });
-		// Emplace container manager listener to load users/groups from new containers
-		m_inspector->m_container_manager.subscribe_on_new_container(
-		        [&](const sinsp_container_info & /*cinfo*/, sinsp_threadinfo *tinfo) -> void {
-			        const bool notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
-			        add_user(tinfo->m_container_id,
-			                 tinfo->m_pid,
-			                 tinfo->m_uid,
-			                 tinfo->m_gid,
-			                 {},
-			                 {},
-			                 {},
-			                 notify);
-			        add_group(tinfo->m_container_id, tinfo->m_pid, tinfo->m_gid, {}, notify);
-		        });
 	}
 }
 

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -135,6 +135,20 @@ void sinsp_usergroup_manager::subscribe_container_mgr() {
 		        [&](const sinsp_container_info &cinfo) -> void {
 			        delete_container_users_groups(cinfo);
 		        });
+		// Emplace container manager listener to load users/groups from new containers
+		m_inspector->m_container_manager.subscribe_on_new_container(
+		        [&](const sinsp_container_info & /*cinfo*/, sinsp_threadinfo *tinfo) -> void {
+			        const bool notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
+			        add_user(tinfo->m_container_id,
+			                 tinfo->m_pid,
+			                 tinfo->m_uid,
+			                 tinfo->m_gid,
+			                 {},
+			                 {},
+			                 {},
+			                 notify);
+			        add_group(tinfo->m_container_id, tinfo->m_pid, tinfo->m_gid, {}, notify);
+		        });
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Only store `uid`, `gid` and `loginuid` info.
Storing full info was done to workaround scenarios like:
* thread X starts with user 1000 "foo"
* user 1000 gets deleted while thread X runs
* user 1000 gets recreated with name "bar"
* extracting user from thread now will give "bar"; with previous impl it would have given "foo".

Basically, we are now respecting what unix expects us to do, since user 1000 will now be mapped to "bar".

Moreover, since threadinfo is used many times, not embedding those bytes saves us lots of memory.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
