### PR TITLE
chore(libsinsp): reduce max proc lookup number log severity

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1983,13 +1983,13 @@ const threadinfo_map_t::ptr_t& sinsp_thread_manager::get_thread_ref(int64_t tid,
 			m_n_proc_lookups++;
 
 			if(m_n_proc_lookups == m_max_n_proc_lookups) {
-				libsinsp_logger()->format(sinsp_logger::SEV_INFO,
+				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
 				                          "Reached max process lookup number, duration=%" PRIu64
 				                          "ms",
 				                          m_n_proc_lookups_duration_ns / 1000000);
 			}
 			if(scan_sockets && m_n_proc_lookups == m_max_n_proc_socket_lookups) {
-				libsinsp_logger()->format(sinsp_logger::SEV_INFO,
+				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
 				                          "Reached max socket lookup number, tid=%" PRIu64
 				                          ", duration=%" PRIu64 "ms",
 				                          tid,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Lower _Reached max process/socket lookup number_ log severity.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
