### PR TITLE
new(userspace/libsinsp): expose threadinfo `category` to state table API

### DIFF
--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -352,7 +352,7 @@ TEST(table_registry, defs_and_access) {
 TEST(thread_manager, table_access) {
 	// note: used for regression checks, keep this updated as we make
 	// new fields available
-	static const int s_threadinfo_static_fields_count = 30;
+	static const int s_threadinfo_static_fields_count = 31;
 
 	sinsp inspector;
 	auto table = static_cast<libsinsp::state::table<int64_t>*>(inspector.m_thread_manager.get());

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -102,7 +102,7 @@ libsinsp::state::static_struct::field_infos sinsp_threadinfo::static_fields() co
 	// m_program_hash
 	// m_program_hash_scripts
 	define_static_field(ret, this, m_tty, "tty");
-	// m_category
+	define_static_field(ret, this, m_category, "category");
 	// m_clone_ts
 	// m_lastexec_ts
 	// m_latency

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -502,7 +502,8 @@ public:
 		CAT_READINESS_PROBE
 	};
 
-	command_category m_category;
+	// enum command_category type; uint16_t to be easily exported to our state table API.
+	uint16_t m_category;
 
 	//
 	// State for multi-event processing


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
