### PR TITLE
chore: update pre-commit stages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
   rev: v0.6.13
   hooks:
   - id: cmake-format
-    stages: [commit]
+    stages: [pre-commit]
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v18.1.8
   hooks:
   - id: clang-format
     types_or: [c++, c]
-    stages: [commit]
+    stages: [pre-commit]
 - repo: local
   hooks:
   - id: dco-hook-local


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup


**Any specific area of the project related to this PR?**

/area build


**Does this PR require a change in the driver versions?**
no

**What this PR does / why we need it**:

Address pre-commit warnings:

```
[WARNING] hook id `cmake-format` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `clang-format` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
