### PR TITLE
fix(libsinsp): don't filter out procexit events

### DIFF
--- a/userspace/libsinsp/sinsp_suppress.cpp
+++ b/userspace/libsinsp/sinsp_suppress.cpp
@@ -120,12 +120,13 @@ int32_t libsinsp::sinsp_suppress::process_event(scap_evt *e) {
 	case PPME_PROCEXIT_1_E: {
 		auto it = m_suppressed_tids.find(tid);
 		if(it != m_suppressed_tids.end()) {
+			// Given that the process is exiting, we remove the
+			// tid from the suppressed tids.
 			m_suppressed_tids.erase(it);
-			m_num_suppressed_events++;
-			return SCAP_FILTERED_EVENT;
-		} else {
-			return SCAP_SUCCESS;
 		}
+		// We don't filter out procexit event otherwise
+		// we'll keep stale threadinfo in the threadtable.
+		return SCAP_SUCCESS;
 	}
 
 	default:

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -108,6 +108,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	user.ut.cpp
 	sinsp_utils.ut.cpp
 	state.ut.cpp
+	suppress.ut.cpp
 	dns_manager.ut.cpp
 	eventformatter.ut.cpp
 	sinsp_metrics.ut.cpp

--- a/userspace/libsinsp/test/suppress.ut.cpp
+++ b/userspace/libsinsp/test/suppress.ut.cpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include <sinsp_with_test_input.h>
+#include <test_utils.h>
+
+#define generate_execve_x(pid, file_to_run, comm)                                   \
+	add_event_advance_ts(increasing_ts(),                                           \
+	                     pid,                                                       \
+	                     PPME_SYSCALL_EXECVE_19_X,                                  \
+	                     29,                                                        \
+	                     (int64_t)0,                          /* res */             \
+	                     file_to_run,                         /* exe */             \
+	                     scap_const_sized_buffer{nullptr, 0}, /* args */            \
+	                     (uint64_t)pid,                       /* tid */             \
+	                     (uint64_t)pid,                       /* pid */             \
+	                     (uint64_t)pid,                       /* ptid */            \
+	                     "",                                  /* cwd */             \
+	                     (uint64_t)0,                         /* fdlimit */         \
+	                     (uint64_t)0,                         /* pgft_maj */        \
+	                     (uint64_t)0,                         /* pgft_min */        \
+	                     0,                                   /* vm_size */         \
+	                     0,                                   /* vm_rss */          \
+	                     0,                                   /* vm_swap */         \
+	                     comm,                                /* comm */            \
+	                     scap_const_sized_buffer{nullptr, 0}, /* cgroups */         \
+	                     scap_const_sized_buffer{nullptr, 0}, /* env */             \
+	                     0,                                   /* tty */             \
+	                     (uint64_t)0,                         /* vpgid */           \
+	                     0,                                   /* loginuid */        \
+	                     0,                                   /* flags */           \
+	                     (uint64_t)0,                         /* cap_inheritable */ \
+	                     (uint64_t)0,                         /* cap_permitted */   \
+	                     (uint64_t)0,                         /* cap_effective */   \
+	                     (uint64_t)0,                         /* exe_ino */         \
+	                     (uint64_t)0,                         /* exe_ino_ctime */   \
+	                     (uint64_t)0,                         /* exe_ino_mtime */   \
+	                     (uint32_t)0,                         /* uid */             \
+	                     "",                                  /* trusted_exepath */ \
+	                     (uint64_t)0)                         /* pgid */
+
+TEST_F(sinsp_with_test_input, suppress_comm) {
+	//
+	// init (pid 1)
+	//   └── sh (pid 17)
+	//
+
+	add_default_init_thread();
+
+	m_inspector.clear_suppress_events_comm();
+	m_inspector.suppress_events_comm("sh");
+
+	open_inspector();
+
+	uint64_t pid = 17;
+	generate_clone_x_event(pid, INIT_TID, INIT_TID, INIT_TID);
+
+	const char* file_to_run = "/bin/sh";
+
+	add_event_advance_ts(increasing_ts(), pid, PPME_SYSCALL_EXECVE_19_E, 1, file_to_run);
+
+	EXPECT_ANY_THROW(generate_execve_x(pid, file_to_run, "sh"));
+
+	add_event_advance_ts(increasing_ts(), pid, PPME_PROCEXIT_1_E, 0);
+
+	// dummy event to actually delete the thread from the threadtable.
+	add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_RENAME_E, 0);
+
+	auto tinfo = m_inspector.get_thread_ref(pid);
+
+	EXPECT_EQ(tinfo, nullptr);
+
+	scap_stats st;
+	m_inspector.get_capture_stats(&st);
+	EXPECT_EQ(st.n_suppressed, 1);
+	EXPECT_EQ(st.n_tids_suppressed, 0);
+}
+
+TEST_F(sinsp_with_test_input, suppress_comm_execve) {
+	//
+	// init (pid 1)
+	//   └── sh (pid 17)
+	//
+	// then sh calls execve
+	//
+	// init (pid 1)
+	//   └── /bin/test-exe (pid 17)
+	//
+
+	add_default_init_thread();
+
+	m_inspector.clear_suppress_events_comm();
+	m_inspector.suppress_events_comm("sh");
+
+	open_inspector();
+
+	uint64_t pid = 17;
+	generate_clone_x_event(pid, INIT_TID, INIT_TID, INIT_TID);
+
+	const char* file_to_run = "/bin/sh";
+	add_event_advance_ts(increasing_ts(), pid, PPME_SYSCALL_EXECVE_19_E, 1, file_to_run);
+	EXPECT_ANY_THROW(generate_execve_x(pid, file_to_run, "sh"));
+
+	EXPECT_ANY_THROW(add_event_advance_ts(increasing_ts(),
+	                                      pid,
+	                                      PPME_SYSCALL_EXECVE_19_E,
+	                                      1,
+	                                      "/bin/test-exe"));
+	EXPECT_ANY_THROW(generate_execve_x(pid, "/bin/test-exe", "test-exe"));
+
+	add_event_advance_ts(increasing_ts(), pid, PPME_PROCEXIT_1_E, 0);
+
+	// dummy event to actually delete the thread from the threadtable.
+	add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_RENAME_E, 0);
+
+	auto tinfo = m_inspector.get_thread_ref(pid);
+
+	EXPECT_EQ(tinfo, nullptr);
+
+	scap_stats st;
+	m_inspector.get_capture_stats(&st);
+	EXPECT_EQ(st.n_suppressed, 3);
+	EXPECT_EQ(st.n_tids_suppressed, 0);
+}

--- a/userspace/libsinsp/test/suppress.ut.cpp
+++ b/userspace/libsinsp/test/suppress.ut.cpp
@@ -77,16 +77,18 @@ TEST_F(sinsp_with_test_input, suppress_comm) {
 
 	add_event_advance_ts(increasing_ts(), pid, PPME_SYSCALL_EXECVE_19_E, 1, file_to_run);
 
+	// Whenever we try to add an event to sinsp_with_test_input, if
+	// the event is suppressed we get an exception.
 	EXPECT_ANY_THROW(generate_execve_x(pid, file_to_run, "sh"));
+
+	EXPECT_NE(m_inspector.get_thread_ref(pid), nullptr);
 
 	add_event_advance_ts(increasing_ts(), pid, PPME_PROCEXIT_1_E, 0);
 
 	// dummy event to actually delete the thread from the threadtable.
 	add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_RENAME_E, 0);
 
-	auto tinfo = m_inspector.get_thread_ref(pid);
-
-	EXPECT_EQ(tinfo, nullptr);
+	EXPECT_EQ(m_inspector.get_thread_ref(pid), nullptr);
 
 	scap_stats st;
 	m_inspector.get_capture_stats(&st);
@@ -117,6 +119,9 @@ TEST_F(sinsp_with_test_input, suppress_comm_execve) {
 
 	const char* file_to_run = "/bin/sh";
 	add_event_advance_ts(increasing_ts(), pid, PPME_SYSCALL_EXECVE_19_E, 1, file_to_run);
+
+	// Whenever we try to add an event to sinsp_with_test_input, if
+	// the event is suppressed we get an exception.
 	EXPECT_ANY_THROW(generate_execve_x(pid, file_to_run, "sh"));
 
 	EXPECT_ANY_THROW(add_event_advance_ts(increasing_ts(),
@@ -126,14 +131,14 @@ TEST_F(sinsp_with_test_input, suppress_comm_execve) {
 	                                      "/bin/test-exe"));
 	EXPECT_ANY_THROW(generate_execve_x(pid, "/bin/test-exe", "test-exe"));
 
+	EXPECT_NE(m_inspector.get_thread_ref(pid), nullptr);
+
 	add_event_advance_ts(increasing_ts(), pid, PPME_PROCEXIT_1_E, 0);
 
 	// dummy event to actually delete the thread from the threadtable.
 	add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_RENAME_E, 0);
 
-	auto tinfo = m_inspector.get_thread_ref(pid);
-
-	EXPECT_EQ(tinfo, nullptr);
+	EXPECT_EQ(m_inspector.get_thread_ref(pid), nullptr);
 
 	scap_stats st;
 	m_inspector.get_capture_stats(&st);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently the suppress logic filters out procexit events causing an accumulation of stale threadinfo in the threadtable. The new logic always process the procexit events.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
