### PR TITLE
fix(userspace/libsinsp): user id 0 or group id 0 default values

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -285,9 +285,8 @@ void sinsp::init() {
 	m_inited = true;
 }
 
-void sinsp::set_import_users(bool import_users, bool user_details) {
+void sinsp::set_import_users(bool import_users) {
 	m_usergroup_manager.m_import_users = import_users;
-	m_usergroup_manager.m_user_details_enabled = user_details;
 }
 
 /*=============================== OPEN METHODS ===============================*/

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -271,18 +271,12 @@ public:
 	  creating them can increase the startup time. Moreover, they contain
 	  information that could be privacy sensitive.
 
-	  \param user_details if set to false, no extended user information will be
-	  stored in sinsp_threadinfo, only user id/group id will be available. By
-	  default thread information is enriched with the full set of user
-	  information, i.e. name, homedir, shell, group name. The parameter
-	  controls this behavior, an can be used to reduce memory footprint.
-
 	  \note default behavior is import_users=true, user_details=true
 
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-	void set_import_users(bool import_users, bool user_details = true);
+	void set_import_users(bool import_users);
 
 	/*!
 	  \brief temporarily pauses event capture.
@@ -737,11 +731,6 @@ public:
 	  \brief Returns true if the debug mode is enabled.
 	*/
 	inline bool is_debug_enabled() const { return m_isdebug_enabled; }
-
-	/*!
-	  \brief Returns true if extended user information is collected.
-	*/
-	inline bool is_user_details_enabled() { return m_usergroup_manager.m_user_details_enabled; }
 
 	/*!
 	  \brief Set a flag indicating if the command line requested to show container information.

--- a/userspace/libsinsp/test/filterchecks/user.cpp
+++ b/userspace/libsinsp/test/filterchecks/user.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <test/helpers/threads_helpers.h>
+
+TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
+	add_default_init_thread();
+
+	auto& thread = m_threads.front();
+	thread.uid = 1000;
+	thread.gid = 1000;
+	thread.loginuid = 0;
+
+	open_inspector();
+
+	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "foo", "/bar", "/bin/bash");
+
+	std::string path = "/home/file.txt";
+	int64_t fd = 3;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_OPEN_E,
+	                                fd,
+	                                path.c_str(),
+	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
+	                                (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
+	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "foo");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/bar");
+	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "/bin/bash");
+	// Loginname default at root for 0 uid without an user entry in user group manager.
+	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
+}
+
+TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_unexistent_user_entry) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	// The entry gets created when the inspector is opened and its threadtable created.
+	// Since default thread uid is 0, the entry is created with "root" name and "/root" homedir.
+	ASSERT_NE(m_inspector.m_usergroup_manager.get_user("", 0), nullptr);
+
+	std::string path = "/home/file.txt";
+	int64_t fd = 3;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_OPEN_E,
+	                                fd,
+	                                path.c_str(),
+	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
+	                                (uint32_t)0);
+
+	// For non-existent entries whose uid is 0, "root" and "/root"
+	// are automatically filled by threadinfo::get_user() method.
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "root");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/root");
+}
+
+TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_without_metadata) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	// Creating the entry in the user group manager will override
+	// the one created by the inspector threadtable initial load.
+	// Since we set empty metadata, we don't expect any metadata in the output fields.
+	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 0, 0, "", "", "");
+
+	std::string path = "/home/file.txt";
+	int64_t fd = 3;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_OPEN_E,
+	                                fd,
+	                                path.c_str(),
+	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
+	                                (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "");
+}

--- a/userspace/libsinsp/test/filterchecks/user.cpp
+++ b/userspace/libsinsp/test/filterchecks/user.cpp
@@ -28,7 +28,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 
 	open_inspector();
 
-	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "foo", "/bar", "/bin/bash");
+	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "foo", "/foo", "/bin/bash");
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
@@ -43,13 +43,33 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
 	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "foo");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/foo");
+	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "/bin/bash");
+	// Loginname default at root for 0 uid without an user entry in user group manager.
+	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
+
+	// Now remove the user
+	m_inspector.m_usergroup_manager.rm_user("", 1000);
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
+	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "<NA>");
+	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "<NA>");
+	// Loginname default at root for 0 uid without an user entry in user group manager.
+	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
+
+	// Add back a new user
+	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "bar", "/bar", "/bin/bash");
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
+	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "bar");
 	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/bar");
 	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "/bin/bash");
 	// Loginname default at root for 0 uid without an user entry in user group manager.
 	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
 }
 
-TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_unexistent_user_entry) {
+TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_default_user_entry) {
 	add_default_init_thread();
 
 	open_inspector();
@@ -57,6 +77,10 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_unexistent_user_entry) {
 	// The entry gets created when the inspector is opened and its threadtable created.
 	// Since default thread uid is 0, the entry is created with "root" name and "/root" homedir.
 	ASSERT_NE(m_inspector.m_usergroup_manager.get_user("", 0), nullptr);
+
+	// remove the loaded "root" user to test defaults for uid 0
+	m_inspector.m_usergroup_manager.rm_user("", 0);
+	ASSERT_EQ(m_inspector.m_usergroup_manager.get_user("", 0), nullptr);
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
@@ -74,6 +98,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_unexistent_user_entry) {
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "root");
 	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/root");
+	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "<NA>");
 }
 
 TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_without_metadata) {
@@ -83,7 +108,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_witho
 
 	// Creating the entry in the user group manager will override
 	// the one created by the inspector threadtable initial load.
-	// Since we set empty metadata, we don't expect any metadata in the output fields.
+	// Since we set "" metadatas, we don't expect any metadata in the output fields.
 	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 0, 0, "", "", "");
 
 	std::string path = "/home/file.txt";
@@ -99,4 +124,30 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_witho
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "");
 	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "");
+	ASSERT_EQ(get_field_as_string(evt, "user.shell"), "");
+}
+
+TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_loaded_user_entry) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	// Creating the entry in the user group manager will override
+	// the one created by the inspector threadtable initial load.
+	// Since we set **empty** metadata, we expect metadata to be loaded from the system.
+	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 0, 0, {}, {}, {});
+
+	std::string path = "/home/file.txt";
+	int64_t fd = 3;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_OPEN_E,
+	                                fd,
+	                                path.c_str(),
+	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
+	                                (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
+	ASSERT_EQ(get_field_as_string(evt, "user.name"), "root");
+	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/root");
 }

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -551,6 +551,7 @@ void sinsp_threadinfo::set_group(uint32_t gid) {
 	scap_groupinfo* group = m_inspector->m_usergroup_manager.get_group(m_container_id, gid);
 	if(!group) {
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
+		// For uid 0 force set root related infos
 		std::string name;
 		if(gid == 0) {
 			name = "root";

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -535,8 +535,14 @@ void sinsp_threadinfo::set_user(uint32_t uid) {
 	scap_userinfo* user = m_inspector->m_usergroup_manager.get_user(m_container_id, uid);
 	if(!user) {
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
+		std::string name, home;
+		// For uid 0 force set root related infos
+		if(uid == 0) {
+			name = "root";
+			home = "/root";
+		}
 		m_inspector->m_usergroup_manager
-		        .add_user(m_container_id, m_pid, uid, m_gid, {}, {}, {}, notify);
+		        .add_user(m_container_id, m_pid, uid, m_gid, name, home, {}, notify);
 	}
 }
 
@@ -545,7 +551,11 @@ void sinsp_threadinfo::set_group(uint32_t gid) {
 	scap_groupinfo* group = m_inspector->m_usergroup_manager.get_group(m_container_id, gid);
 	if(!group) {
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
-		m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, {}, notify);
+		std::string name;
+		if(gid == 0) {
+			name = "root";
+		}
+		m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, name, notify);
 	}
 }
 

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -608,8 +608,6 @@ private:
 	                  uint32_t& alen,
 	                  std::string& rem) const;
 
-	scap_userinfo* get_user(uint32_t id) const;
-
 	//
 	// Parameters that can't be accessed directly because they could be in the
 	// parent thread info

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -109,7 +109,6 @@ using namespace std;
 // clang-format off
 sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector)
 	: m_import_users(true)
-	, m_user_details_enabled(true)
 	, m_last_flush_time_ns(0)
 	, m_inspector(inspector)
 	, m_host_root(m_inspector->get_host_root())

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -152,8 +152,6 @@ public:
 	//
 	bool m_import_users;
 
-	bool m_user_details_enabled;
-
 private:
 	scap_userinfo *add_host_user(uint32_t uid,
 	                             uint32_t gid,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp
/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Fixed a possible case were the `root`, `/root` default values for uid 0 users and gid 0 groups were not set (after https://github.com/falcosecurity/libs/pull/2165).
Moreover, properly use different `static` members for `threadinfo::get_user()` and `threadinfo::get_loginuser`.
Also, added tests to avoid future failures.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
