### PR TITLE
update(libsinsp/filter): parse wider whitespace combinations in filter expressions

### DIFF
--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -66,7 +66,8 @@ static const std::vector<std::string> s_unary_ops = {"exists"};
 
 static const std::vector<std::string> s_binary_num_ops = {"<=", "<", ">=", ">"};
 
-// todo(jasondellaluce): we should accept any blank after these (even line breaks)
+// note: by convention, we put a space at the end of operators requiring
+// a blank character after them (i.e. whitespace, line break, ...)
 static const std::vector<std::string> s_binary_str_ops = {
         "==",
         "=",
@@ -592,19 +593,19 @@ inline bool parser::lex_bare_str() {
 }
 
 inline bool parser::lex_unary_op() {
-	return lex_helper_str_list(s_unary_ops);
+	return lex_helper_operator_list(s_unary_ops);
 }
 
 inline bool parser::lex_num_op() {
-	return lex_helper_str_list(s_binary_num_ops);
+	return lex_helper_operator_list(s_binary_num_ops);
 }
 
 inline bool parser::lex_str_op() {
-	return lex_helper_str_list(s_binary_str_ops);
+	return lex_helper_operator_list(s_binary_str_ops);
 }
 
 inline bool parser::lex_list_op() {
-	return lex_helper_str_list(s_binary_list_ops);
+	return lex_helper_operator_list(s_binary_list_ops);
 }
 
 inline bool parser::lex_field_transformer_val() {
@@ -638,6 +639,25 @@ bool parser::lex_helper_str_list(const std::vector<std::string>& list) {
 	for(auto& op : list) {
 		if(lex_helper_str(op)) {
 			return true;
+		}
+	}
+	return false;
+}
+
+bool parser::lex_helper_operator_list(const std::vector<std::string>& list) {
+	for(auto& op : list) {
+		// if there's no ending whitespace, just parse the operator as-is
+		if(op.back() != ' ') {
+			if(lex_helper_str(op)) {
+				return true;
+			}
+			continue;
+		}
+
+		// if there's an ending whitespace, we need to make sure there's
+		// a blank after the operator (as long as we have an operator lexer match)
+		if(lex_helper_str(trim_str(op))) {
+			return lex_blank();
 		}
 	}
 	return false;

--- a/userspace/libsinsp/filter/parser.h
+++ b/userspace/libsinsp/filter/parser.h
@@ -178,6 +178,7 @@ private:
 	inline bool lex_helper_rgx(const re2::RE2& rgx);
 	inline bool lex_helper_str(const std::string& str);
 	inline bool lex_helper_str_list(const std::vector<std::string>& list);
+	inline bool lex_helper_operator_list(const std::vector<std::string>& list);
 	inline const char* cursor();
 	inline std::string trim_str(std::string str);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

The parser for filter expressions (used in Falco rules conditions) has historically been a bit strict with the way it accepts whitespaces when required between a comparison operator and right-hand values. This now supports also line breaks, which has been reported being rejected in some corner cases.

Additionally, the parser tests has been updated to "fuzz" a bit the whitespaces handled by each of the existing test cases, with the purpose of extending our coverage from this perspective.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
