### PR TITLE
fix(userspace/libsinsp): always initialize sinsp_evt with a proper source_idx and source_name

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -79,27 +79,13 @@ sinsp_evt::sinsp_evt():
         m_errorcode(0),
         m_rawbuf_str_len(0),
         m_filtered_out(false),
-        m_event_info_table(g_infotables.m_event_info) {}
+        m_event_info_table(g_infotables.m_event_info),
+        m_source_idx(sinsp_no_event_source_idx),
+        m_source_name(NULL) {}
 
-sinsp_evt::sinsp_evt(sinsp *inspector):
-        m_inspector(inspector),
-        m_pevt(NULL),
-        m_pevt_storage(NULL),
-        m_cpuid(0),
-        m_evtnum(0),
-        m_flags(EF_NONE),
-        m_params_loaded(false),
-        m_info(NULL),
-        m_paramstr_storage(1024),
-        m_resolved_paramstr_storage(1024),
-        m_tinfo(NULL),
-        m_fdinfo(NULL),
-        m_fdinfo_name_changed(false),
-        m_iosize(0),
-        m_errorcode(0),
-        m_rawbuf_str_len(0),
-        m_filtered_out(false),
-        m_event_info_table(g_infotables.m_event_info) {}
+sinsp_evt::sinsp_evt(sinsp *inspector): sinsp_evt() {
+	m_inspector = inspector;
+}
 
 sinsp_evt::~sinsp_evt() {
 	if(m_pevt_storage) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This also fixes a bug where using sinsp `m_filter` on a plugin-exposed field in scap replay mode would SIGABRT. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
