### PR TITLE
wip: chore(userspace/libsinsp): move user group manager on container_id changed refresh to a RAII object

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1274,12 +1274,6 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 		return;
 	}
 
-	/* Refresh user / group */
-	if(new_child->m_container_id.empty() == false) {
-		new_child->set_group(new_child->m_gid);
-		new_child->set_user(new_child->m_uid);
-	}
-
 	/* If there's a listener, invoke it */
 	if(m_inspector->get_observer()) {
 		m_inspector->get_observer()->on_clone(evt, new_child.get(), tid_collision);
@@ -1764,12 +1758,6 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	 */
 	evt->set_tinfo(new_child.get());
 
-	/* Refresh user / group */
-	if(new_child->m_container_id.empty() == false) {
-		new_child->set_group(new_child->m_gid);
-		new_child->set_user(new_child->m_uid);
-	}
-
 	//
 	// If there's a listener, invoke it
 	//
@@ -2238,15 +2226,6 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 	// Recompute the program hash
 	//
 	evt->get_tinfo()->compute_program_hash();
-
-	//
-	// Refresh user / group
-	// if we happen to change container id
-	//
-	if(container_id != evt->get_tinfo()->m_container_id) {
-		evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
-		evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-	}
 
 	//
 	// If there's a listener, invoke it
@@ -4992,14 +4971,6 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt) {
 		m_inspector->m_container_manager.resolve_container(
 		        evt->get_tinfo(),
 		        m_inspector->is_live() || m_inspector->is_syscall_plugin());
-		//
-		// Refresh user / group
-		// if we happen to change container id
-		//
-		if(container_id != evt->get_tinfo()->m_container_id) {
-			evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
-			evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-		}
 	}
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1297,6 +1297,11 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 	{
 		// Object that uses RAII to enable event filtered out flag
 		sinsp_evt_filter evt_filter(evt);
+		// Object that uses RAII to automatically update user/group associated with a threadinfo
+		// upon threadinfo's container_id changes.
+		// Since the threadinfo state might get changed from a plugin parser,
+		// evaluate this one after all parsers get run.
+		user_group_updater usr_grp_updater(evt);
 
 		if(!evt->is_filtered_out()) {
 			//

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 #include <libsinsp/user.h>
-#include <libsinsp/event.h>
 #include <libsinsp/procfs_utils.h>
 #include <libsinsp/utils.h>
 #include <libsinsp/logger.h>


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

If a way similar to #2182, move logic to refresh user/group info upon container_id changes to a RAII object instantiated by `sinsp::next()`.
This allows to take into consideration eventual "container_id" changes made by plugin parsers.
While right now there is no need for this, it will be mandatory for the container plugin, since it will be responsible to actually write the `container_id` state entry for threadinfo.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
