### PR TITLE
chore(userspace/libsinsp): move user group manager on container_id changed refresh to a RAII object

### DIFF
--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <libsinsp/dumper.h>
 #include <libsinsp/plugin.h>
 #include <libsinsp/plugin_manager.h>
+#include <libsinsp/user.h>
 
 sinsp_dumper::sinsp_dumper() {
 	m_dumper = NULL;
@@ -67,7 +68,7 @@ void sinsp_dumper::open(sinsp* inspector, const std::string& filename, bool comp
 
 	inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	inspector->m_container_manager.dump_containers(*this);
-	inspector->m_usergroup_manager.dump_users_groups(*this);
+	inspector->m_usergroup_manager->dump_users_groups(*this);
 
 	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {
@@ -94,7 +95,7 @@ void sinsp_dumper::fdopen(sinsp* inspector, int fd, bool compress) {
 
 	inspector->m_thread_manager->dump_threads_to_file(m_dumper);
 	inspector->m_container_manager.dump_containers(*this);
-	inspector->m_usergroup_manager.dump_users_groups(*this);
+	inspector->m_usergroup_manager->dump_users_groups(*this);
 
 	// ask registered ASYNC plugins for a dump of their state
 	for(auto& p : inspector->m_plugin_manager->plugins()) {

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -36,6 +36,7 @@ limitations under the License.
 
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
+#include <libsinsp/user.h>
 #include <libscap/strl.h>
 
 #include <libscap/scap.h>
@@ -1325,7 +1326,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			sinsp_threadinfo *tinfo = get_thread_info();
 			scap_userinfo *user_info = NULL;
 			if(tinfo) {
-				user_info = m_inspector->m_usergroup_manager.get_user(tinfo->m_container_id, val);
+				user_info = m_inspector->m_usergroup_manager->get_user(tinfo->m_container_id, val);
 			}
 			if(user_info != NULL) {
 				strcpy_sanitized(&m_resolved_paramstr_storage[0],
@@ -1354,7 +1355,8 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			sinsp_threadinfo *tinfo = get_thread_info();
 			scap_groupinfo *group_info = NULL;
 			if(tinfo) {
-				group_info = m_inspector->m_usergroup_manager.get_group(tinfo->m_container_id, val);
+				group_info =
+				        m_inspector->m_usergroup_manager->get_group(tinfo->m_container_id, val);
 			}
 			if(group_info != NULL) {
 				strcpy_sanitized(&m_resolved_paramstr_storage[0],

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -41,6 +41,7 @@ limitations under the License.
 #include <libsinsp/plugin_manager.h>
 #include <libsinsp/sinsp_observer.h>
 #include <libsinsp/sinsp_int.h>
+#include <libsinsp/user.h>
 
 #if !defined(MINIMAL_BUILD) && !defined(__EMSCRIPTEN__)
 #include <libsinsp/container_engine/docker/async_source.h>
@@ -1274,12 +1275,6 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt *evt, int64_t child_tid) {
 		return;
 	}
 
-	/* Refresh user / group */
-	if(new_child->m_container_id.empty() == false) {
-		new_child->set_group(new_child->m_gid);
-		new_child->set_user(new_child->m_uid);
-	}
-
 	/* If there's a listener, invoke it */
 	if(m_inspector->get_observer()) {
 		m_inspector->get_observer()->on_clone(evt, new_child.get(), tid_collision);
@@ -1764,12 +1759,6 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt *evt) {
 	 */
 	evt->set_tinfo(new_child.get());
 
-	/* Refresh user / group */
-	if(new_child->m_container_id.empty() == false) {
-		new_child->set_group(new_child->m_gid);
-		new_child->set_user(new_child->m_uid);
-	}
-
 	//
 	// If there's a listener, invoke it
 	//
@@ -2238,15 +2227,6 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt) {
 	// Recompute the program hash
 	//
 	evt->get_tinfo()->compute_program_hash();
-
-	//
-	// Refresh user / group
-	// if we happen to change container id
-	//
-	if(container_id != evt->get_tinfo()->m_container_id) {
-		evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
-		evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-	}
 
 	//
 	// If there's a listener, invoke it
@@ -4894,9 +4874,9 @@ void sinsp_parser::parse_user_evt(sinsp_evt *evt) {
 
 	if(evt->get_scap_evt()->type == PPME_USER_ADDED_E) {
 		m_inspector->m_usergroup_manager
-		        .add_user(std::string(container_id), -1, uid, gid, name, home, shell);
+		        ->add_user(std::string(container_id), -1, uid, gid, name, home, shell);
 	} else {
-		m_inspector->m_usergroup_manager.rm_user(std::string(container_id), uid);
+		m_inspector->m_usergroup_manager->rm_user(std::string(container_id), uid);
 	}
 }
 
@@ -4907,9 +4887,9 @@ void sinsp_parser::parse_group_evt(sinsp_evt *evt) {
 	std::string_view container_id = evt->get_param(2)->as<std::string_view>();
 
 	if(evt->get_scap_evt()->type == PPME_GROUP_ADDED_E) {
-		m_inspector->m_usergroup_manager.add_group(container_id.data(), -1, gid, name.data());
+		m_inspector->m_usergroup_manager->add_group(container_id.data(), -1, gid, name.data());
 	} else {
-		m_inspector->m_usergroup_manager.rm_group(container_id.data(), gid);
+		m_inspector->m_usergroup_manager->rm_group(container_id.data(), gid);
 	}
 }
 
@@ -4992,14 +4972,6 @@ void sinsp_parser::parse_chroot_exit(sinsp_evt *evt) {
 		m_inspector->m_container_manager.resolve_container(
 		        evt->get_tinfo(),
 		        m_inspector->is_live() || m_inspector->is_syscall_plugin());
-		//
-		// Refresh user / group
-		// if we happen to change container id
-		//
-		if(container_id != evt->get_tinfo()->m_container_id) {
-			evt->get_tinfo()->set_group(evt->get_tinfo()->m_gid);
-			evt->get_tinfo()->set_user(evt->get_tinfo()->m_uid);
-		}
 	}
 }
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -45,6 +45,7 @@ limitations under the License.
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <user.h>
 
 /**
  * This is the maximum size assigned to the concurrent asynchronous event
@@ -148,7 +149,6 @@ sinsp::sinsp(bool with_metrics):
         m_lastevent_ts(0),
         m_host_root(scap_get_host_root()),
         m_container_manager(this),
-        m_usergroup_manager(this),
         m_async_events_queue(DEFAULT_ASYNC_EVENT_QUEUE_SIZE),
         m_suppressed_comms(),
         m_inited(false) {
@@ -163,6 +163,7 @@ sinsp::sinsp(bool with_metrics):
 	m_is_dumping = false;
 	m_parser = std::make_unique<sinsp_parser>(this);
 	m_thread_manager = std::make_unique<sinsp_thread_manager>(this);
+	m_usergroup_manager = std::make_unique<sinsp_usergroup_manager>(this);
 	m_max_fdtable_size = MAX_FD_TABLE_SIZE;
 	m_containers_purging_scan_time_ns = DEFAULT_INACTIVE_CONTAINER_SCAN_TIME_S * ONE_SECOND_IN_NS;
 	m_usergroups_purging_scan_time_ns = DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S * ONE_SECOND_IN_NS;
@@ -359,7 +360,7 @@ void sinsp::init() {
 }
 
 void sinsp::set_import_users(bool import_users) {
-	m_usergroup_manager.m_import_users = import_users;
+	m_usergroup_manager->m_import_users = import_users;
 }
 
 /*=============================== OPEN METHODS ===============================*/
@@ -376,11 +377,7 @@ void sinsp::open_common(scap_open_args* oargs,
 	/* We need to save the actual mode and the engine used by the inspector. */
 	m_mode = mode;
 
-	oargs->import_users = m_usergroup_manager.m_import_users;
-	// We need to subscribe to container manager notifiers before
-	// scap starts scanning proc.
-	m_usergroup_manager.subscribe_container_mgr();
-
+	oargs->import_users = m_usergroup_manager->m_import_users;
 	oargs->log_fn = &sinsp_scap_log_fn;
 	oargs->proc_scan_timeout_ms = m_proc_scan_timeout_ms;
 	oargs->proc_scan_log_interval_ms = m_proc_scan_log_interval_ms;
@@ -990,17 +987,17 @@ void sinsp::import_user_list() {
 
 	if(ul) {
 		for(j = 0; j < ul->nusers; j++) {
-			m_usergroup_manager.add_user("",
-			                             -1,
-			                             ul->users[j].uid,
-			                             ul->users[j].gid,
-			                             ul->users[j].name,
-			                             ul->users[j].homedir,
-			                             ul->users[j].shell);
+			m_usergroup_manager->add_user("",
+			                              -1,
+			                              ul->users[j].uid,
+			                              ul->users[j].gid,
+			                              ul->users[j].name,
+			                              ul->users[j].homedir,
+			                              ul->users[j].shell);
 		}
 
 		for(j = 0; j < ul->ngroups; j++) {
-			m_usergroup_manager.add_group("", -1, ul->groups[j].gid, ul->groups[j].name);
+			m_usergroup_manager->add_group("", -1, ul->groups[j].gid, ul->groups[j].name);
 		}
 	}
 }
@@ -1267,7 +1264,7 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 	}
 
 	if(m_auto_usergroups_purging && !is_offline()) {
-		m_usergroup_manager.clear_host_users_groups();
+		m_usergroup_manager->clear_host_users_groups();
 	}
 
 	//
@@ -1297,6 +1294,11 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 	{
 		// Object that uses RAII to enable event filtered out flag
 		sinsp_evt_filter evt_filter(evt);
+		// Object that uses RAII to automatically update user/group associated with a threadinfo
+		// upon threadinfo's container_id changes.
+		// Since the threadinfo state might get changed from a plugin parser,
+		// evaluate this one after all parsers get run.
+		user_group_updater usr_grp_updater(evt);
 
 		if(!evt->is_filtered_out()) {
 			//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -73,7 +73,6 @@ limitations under the License.
 #include <libsinsp/metrics_collector.h>
 #include <libsinsp/threadinfo.h>
 #include <libsinsp/tuples.h>
-#include <libsinsp/user.h>
 #include <libsinsp/utils.h>
 
 #include <list>
@@ -91,6 +90,7 @@ class sinsp_filter;
 class sinsp_plugin;
 class sinsp_plugin_manager;
 class sinsp_observer;
+class sinsp_usergroup_manager;
 
 /*!
   \brief The user agent string to use for any libsinsp connection, can be changed at compile time
@@ -1062,7 +1062,7 @@ public:
 
 	sinsp_container_manager m_container_manager;
 
-	sinsp_usergroup_manager m_usergroup_manager;
+	std::unique_ptr<sinsp_usergroup_manager> m_usergroup_manager;
 
 	//
 	// True if the command line argument is set to show container information

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -195,7 +195,7 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_check_evt_arg_uid) {
 
 	// we are adding a user on the host so the `pid` parameter is not considered
 	ASSERT_TRUE(m_inspector.m_usergroup_manager
-	                    .add_user(container_id, 0, user_id, 6, "test", "/test", "/bin/test"));
+	                    ->add_user(container_id, 0, user_id, 6, "test", "/test", "/bin/test"));
 
 	// Now we should have the necessary info
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "test");
@@ -203,8 +203,8 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_check_evt_arg_uid) {
 	ASSERT_EQ(get_field_as_string(evt, "evt.args"), "uid=5(test)");
 
 	// We remove the user, and the fields should be empty again
-	m_inspector.m_usergroup_manager.rm_user(container_id, user_id);
-	ASSERT_FALSE(m_inspector.m_usergroup_manager.get_user(container_id, user_id));
+	m_inspector.m_usergroup_manager->rm_user(container_id, user_id);
+	ASSERT_FALSE(m_inspector.m_usergroup_manager->get_user(container_id, user_id));
 
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "<NA>");
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg[0]"), "<NA>");

--- a/userspace/libsinsp/test/filterchecks/user.cpp
+++ b/userspace/libsinsp/test/filterchecks/user.cpp
@@ -28,7 +28,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 
 	open_inspector();
 
-	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "foo", "/foo", "/bin/bash");
+	m_inspector.m_usergroup_manager->add_user("", INIT_TID, 1000, 1000, "foo", "/foo", "/bin/bash");
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
@@ -49,7 +49,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
 
 	// Now remove the user
-	m_inspector.m_usergroup_manager.rm_user("", 1000);
+	m_inspector.m_usergroup_manager->rm_user("", 1000);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
 	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "<NA>");
@@ -59,7 +59,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 	ASSERT_EQ(get_field_as_string(evt, "user.loginname"), "root");
 
 	// Add back a new user
-	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 1000, 1000, "bar", "/bar", "/bin/bash");
+	m_inspector.m_usergroup_manager->add_user("", INIT_TID, 1000, 1000, "bar", "/bar", "/bin/bash");
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
 	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "bar");
@@ -76,11 +76,11 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_default_user_entry) {
 
 	// The entry gets created when the inspector is opened and its threadtable created.
 	// Since default thread uid is 0, the entry is created with "root" name and "/root" homedir.
-	ASSERT_NE(m_inspector.m_usergroup_manager.get_user("", 0), nullptr);
+	ASSERT_NE(m_inspector.m_usergroup_manager->get_user("", 0), nullptr);
 
 	// remove the loaded "root" user to test defaults for uid 0
-	m_inspector.m_usergroup_manager.rm_user("", 0);
-	ASSERT_EQ(m_inspector.m_usergroup_manager.get_user("", 0), nullptr);
+	m_inspector.m_usergroup_manager->rm_user("", 0);
+	ASSERT_EQ(m_inspector.m_usergroup_manager->get_user("", 0), nullptr);
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
@@ -109,7 +109,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_witho
 	// Creating the entry in the user group manager will override
 	// the one created by the inspector threadtable initial load.
 	// Since we set "" metadatas, we don't expect any metadata in the output fields.
-	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 0, 0, "", "", "");
+	m_inspector.m_usergroup_manager->add_user("", INIT_TID, 0, 0, "", "", "");
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
@@ -135,7 +135,7 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_loaded_user_entry) {
 	// Creating the entry in the user group manager will override
 	// the one created by the inspector threadtable initial load.
 	// Since we set **empty** metadata, we expect metadata to be loaded from the system.
-	m_inspector.m_usergroup_manager.add_user("", INIT_TID, 0, 0, {}, {}, {});
+	m_inspector.m_usergroup_manager->add_user("", INIT_TID, 0, 0, {}, {}, {});
 
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include <libscap/scap.h>
 #include <libsinsp/sinsp.h>
+#include <libsinsp/user.h>
 #include <libsinsp/filterchecks.h>
 #include <libscap/strl.h>
 #include <libsinsp_test_var.h>

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
 #include <libscap/scap-int.h>
+#include <libsinsp/user.h>
 
 constexpr static const char* s_thread_table_name = "threads";
 
@@ -532,30 +533,30 @@ std::string sinsp_threadinfo::get_exepath() const {
 
 void sinsp_threadinfo::set_user(uint32_t uid) {
 	m_uid = uid;
-	scap_userinfo* user = m_inspector->m_usergroup_manager.get_user(m_container_id, uid);
+	scap_userinfo* user = m_inspector->m_usergroup_manager->get_user(m_container_id, uid);
 	if(!user) {
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
 		// For uid 0 force set root related infos
 		if(uid == 0) {
 			m_inspector->m_usergroup_manager
-			        .add_user(m_container_id, m_pid, uid, m_gid, "root", "/root", {}, notify);
+			        ->add_user(m_container_id, m_pid, uid, m_gid, "root", "/root", {}, notify);
 		} else {
 			m_inspector->m_usergroup_manager
-			        .add_user(m_container_id, m_pid, uid, m_gid, {}, {}, {}, notify);
+			        ->add_user(m_container_id, m_pid, uid, m_gid, {}, {}, {}, notify);
 		}
 	}
 }
 
 void sinsp_threadinfo::set_group(uint32_t gid) {
 	m_gid = gid;
-	scap_groupinfo* group = m_inspector->m_usergroup_manager.get_group(m_container_id, gid);
+	scap_groupinfo* group = m_inspector->m_usergroup_manager->get_group(m_container_id, gid);
 	if(!group) {
 		auto notify = m_inspector->is_live() || m_inspector->is_syscall_plugin();
 		// For gid 0 force set root related info
 		if(gid == 0) {
-			m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, "root", notify);
+			m_inspector->m_usergroup_manager->add_group(m_container_id, m_pid, gid, "root", notify);
 		} else {
-			m_inspector->m_usergroup_manager.add_group(m_container_id, m_pid, gid, {}, notify);
+			m_inspector->m_usergroup_manager->add_group(m_container_id, m_pid, gid, {}, notify);
 		}
 	}
 }
@@ -565,7 +566,7 @@ void sinsp_threadinfo::set_loginuid(uint32_t loginuid) {
 }
 
 scap_userinfo* sinsp_threadinfo::get_user() const {
-	auto user = m_inspector->m_usergroup_manager.get_user(m_container_id, m_uid);
+	auto user = m_inspector->m_usergroup_manager->get_user(m_container_id, m_uid);
 	if(user != nullptr) {
 		return user;
 	}
@@ -579,7 +580,7 @@ scap_userinfo* sinsp_threadinfo::get_user() const {
 }
 
 scap_groupinfo* sinsp_threadinfo::get_group() const {
-	auto group = m_inspector->m_usergroup_manager.get_group(m_container_id, m_gid);
+	auto group = m_inspector->m_usergroup_manager->get_group(m_container_id, m_gid);
 	if(group != nullptr) {
 		return group;
 	}
@@ -590,7 +591,7 @@ scap_groupinfo* sinsp_threadinfo::get_group() const {
 }
 
 scap_userinfo* sinsp_threadinfo::get_loginuser() const {
-	auto user = m_inspector->m_usergroup_manager.get_user(m_container_id, m_loginuid);
+	auto user = m_inspector->m_usergroup_manager->get_user(m_container_id, m_loginuid);
 	if(user != nullptr) {
 		return user;
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

If a way similar to #2182, move logic to refresh user/group info upon container_id changes to a RAII object instantiated by `sinsp::next()`.
This allows to take into consideration eventual "container_id" changes made by plugin parsers.
While right now there is no need for this, it will be mandatory for the container plugin, since it will be responsible to actually write the `container_id` state entry for threadinfo.

Also, avoid relying upon container manager `on_remove_container` callback; instead check if a `procexit` event was received on container's init pid.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
