### PR TITLE
fix(userspace/libsinsp): use `comm` file instead of `status` to get proc comm

### DIFF
--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -559,7 +559,7 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 	//
 	// Gather the command name
 	//
-	snprintf(filename, sizeof(filename), "%sstatus", dir_name);
+	snprintf(filename, sizeof(filename), "%scomm", dir_name);
 
 	f = fopen(filename, "r");
 	if(f == NULL) {
@@ -567,13 +567,15 @@ static int32_t scap_proc_add_from_proc(struct scap_linux_platform* linux_platfor
 	} else {
 		ASSERT(sizeof(line) >= SCAP_MAX_PATH_SIZE);
 
-		if(fgets(line, SCAP_MAX_PATH_SIZE, f) == NULL) {
-			fclose(f);
-			return scap_errprintf(error, errno, "can't read from %s", filename);
+		filesize = fread(line, 1, SCAP_MAX_ARGS_SIZE, f);
+		if(filesize > 0) {
+			// In case `comm` is greater than `SCAP_MAX_ARGS_SIZE` it could be
+			// truncated so we put a `/0` at the end manually.
+			line[filesize - 1] = 0;
+			snprintf(tinfo.comm, SCAP_MAX_PATH_SIZE, "%s", line);
+		} else {
+			tinfo.comm[0] = 0;
 		}
-
-		line[SCAP_MAX_PATH_SIZE - 1] = 0;
-		sscanf(line, "Name:%1024s", tinfo.comm);
 		fclose(f);
 	}
 

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -111,7 +111,7 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] = {
          "Name",
          "The process name (truncated after 16 characters) generating the event (task->comm). "
          "Truncation is determined by kernel settings and not by Falco. This field is collected "
-         "from the syscalls args or, as a fallback, extracted from /proc/PID/status. The name of "
+         "from the syscalls args or, as a fallback, extracted from /proc/PID/comm. The name of "
          "the process and the name of the executable file on disk (if applicable) can be different "
          "if a process is given a custom name which is often the case for example for java "
          "applications."},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**What this PR does / why we need it**:

When scanning proc from scap, make sure to use `comm` file to parse threadinfo comm field, instead of using `status` file and grepping for `Name:%1024s`. Also, using `sscanf` in that way  does not support strings with spaces, ie: if a status file was like
```
Name: foo bar
```
we would only load `foo`. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): use `comm` file instead of `status` to get proc comm
```
