### PR TITLE
cleanup(build): move NOMINMAX definition at compile time for windows builds

### DIFF
--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -144,8 +144,8 @@ else() # MSVC
 	set(CMAKE_CXX_FLAGS_RELEASE "${FALCOSECURITY_LIBS_RELEASE_FLAGS}")
 
 	# "_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" enables a workaround for windows GH runner issue, see
-	# https://github.com/actions/runner-images/issues/10004
+	# https://github.com/actions/runner-images/issues/10004 Also, define NOMINMAX globally.
 	add_compile_definitions(
-		_HAS_STD_BYTE=0 WIN32_LEAN_AND_MEAN _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+		_HAS_STD_BYTE=0 WIN32_LEAN_AND_MEAN _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR NOMINMAX
 	)
 endif()

--- a/userspace/libscap/scap_print_event.c
+++ b/userspace/libscap/scap_print_event.c
@@ -17,10 +17,6 @@ limitations under the License.
 #include <libscap/scap.h>
 #include <libscap/scap-int.h>
 #if defined(_WIN32)
-/* This prevents including <windows.h> when including Ws2tcpip.h */
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <Ws2tcpip.h>
 #else
 #include <arpa/inet.h>

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -24,7 +24,6 @@ limitations under the License.
 #include <algorithm>
 #include <unistd.h>
 #else
-#define NOMINMAX
 #define localtime_r(a, b) (localtime_s(b, a) == 0 ? b : NULL)
 #endif
 

--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -22,7 +22,6 @@ limitations under the License.
 #include <libsinsp/memmem.h>
 
 #ifdef _WIN32
-#define NOMINMAX
 #pragma comment(lib, "Ws2_32.lib")
 #include <WinSock2.h>
 #include <WS2tcpip.h>

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 #ifdef _WIN32
-#define NOMINMAX
 #include <winsock2.h>
 #else
 #include <sys/socket.h>

--- a/userspace/libsinsp/sinsp_inet.h
+++ b/userspace/libsinsp/sinsp_inet.h
@@ -18,10 +18,6 @@ limitations under the License.
 #pragma once
 
 #if defined(_WIN32)
-/* This prevents including <windows.h> when including Ws2tcpip.h */
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <Ws2tcpip.h>
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

We define `NOMINMAX` in multiple places to avoid `windows.h` re-defining `min` and `max` macros under the hood.
Since this is super error prone because windows headers can be included in so many places (even by included headers from deps), i though it was a good idea to just add a compile definition for it.

Another (possibly better) solution would have been to drop `NOMINMAX` and use `std::min<type>` (and same for `max`); in that case, the macro would not be able to replace our code. But, there is always a but, at least `re2` uses `std::min()` without the small trick to avoid the replacement, therefore we cannot do that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
