### PR TITLE
fix: some issues with Clang 18

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,15 +2,24 @@
 	"version": 3,
 	"configurePresets": [
 		{
-			"name": "scap-drivers",
-			"displayName": "Build scap drivers and their tests",
-			"description": "Build all scap drivers (modern eBPF, legacy eBPF, kmod) and their tests",
+			"name": "base",
+			"hidden": true,
 			"generator": "Unix Makefiles",
-			"binaryDir": "${sourceDir}/build-scap-drivers",
 			"cacheVariables": {
 				"CMAKE_BUILD_TYPE": "Release",
-				"BUILD_BPF": "ON",
+				"CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
 				"BUILD_DRIVER": "ON",
+				"BUILD_BPF": "ON",
+				"BUILD_WARNINGS_AS_ERRORS": "ON"
+			}
+		},
+		{
+			"name": "scap-drivers",
+			"inherits": "base",
+			"displayName": "Build scap drivers and their tests",
+			"description": "Build all scap drivers (modern eBPF, legacy eBPF, kmod) and their tests",
+			"binaryDir": "${sourceDir}/build-scap-drivers",
+			"cacheVariables": {
 				"USE_BUNDLED_DEPS": "ON",
 				"ENABLE_DRIVERS_TESTS": "ON",
 				"MODERN_BPF_DEBUG_MODE": "ON",
@@ -18,27 +27,20 @@
 				"BUILD_LIBSCAP_GVISOR": "OFF",
 				"CREATE_TEST_TARGETS": "ON",
 				"ENABLE_LIBSCAP_TESTS": "ON",
-				"SCAP_FILES_SUITE_ENABLE": "OFF",
-				"CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-				"BUILD_WARNINGS_AS_ERRORS": "ON"
+				"SCAP_FILES_SUITE_ENABLE": "OFF"
 			}
 		},
 		{
 			"name": "sinsp-minimal",
+			"inherits": "base",
 			"displayName": "Build sinsp in minimal build",
 			"description": "Build sinsp in minimal build with its tests",
-			"generator": "Unix Makefiles",
 			"binaryDir": "${sourceDir}/build-sinsp-minimal",
 			"cacheVariables": {
-				"CMAKE_BUILD_TYPE": "Release",
-				"BUILD_DRIVER": "ON",
-				"BUILD_BPF": "ON",
 				"USE_BUNDLED_DEPS": "ON",
 				"CREATE_TEST_TARGETS": "ON",
 				"MINIMAL_BUILD": "ON",
-				"SCAP_FILES_SUITE_ENABLE": "OFF",
-				"CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-				"BUILD_WARNINGS_AS_ERRORS": "ON"
+				"SCAP_FILES_SUITE_ENABLE": "OFF"
 			}
 		}
 	]

--- a/test/drivers/test_suites/syscall_exit_suite/getcwd_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/getcwd_x.cpp
@@ -8,7 +8,7 @@ TEST(SyscallExit, getcwdX_success) {
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	unsigned long size = 200;
+	const unsigned long size = 200;
 	char path[size];
 	uint32_t read_bytes = syscall(__NR_getcwd, path, size);
 	assert_syscall_state(SYSCALL_SUCCESS, "getcwd", read_bytes, NOT_EQUAL, -1);
@@ -49,7 +49,7 @@ TEST(SyscallExit, getcwdX_fail) {
 
 	/*=============================== TRIGGER SYSCALL ===========================*/
 
-	long size = 2;
+	const long size = 2;
 	char path[size];
 	assert_syscall_state(SYSCALL_FAILURE, "getcwd", syscall(__NR_getcwd, path, size));
 	int64_t errno_value = -errno;

--- a/test/drivers/test_suites/syscall_exit_suite/readv_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/readv_x.cpp
@@ -64,7 +64,7 @@ TEST(SyscallExit, readvX_success) {
 	          strlen(test_string) + 1);
 
 	/* Try to read the string with readv using three buffers */
-	int32_t iovcnt = 3;
+	const int32_t iovcnt = 3;
 	iovec iov[iovcnt];
 	size_t buf_size = 15;
 	ASSERT_GT(iovcnt * buf_size, strlen(test_string) + 1);

--- a/userspace/libscap/linux/scap_cgroup.c
+++ b/userspace/libscap/linux/scap_cgroup.c
@@ -746,7 +746,7 @@ static int32_t scap_cgroup_resolve_v2(struct scap_cgroup_interface* cgi,
 		return SCAP_FAILURE;
 	}
 
-	struct scap_cgroup_set found_subsystems = {.len = 0, {'\0'}};
+	struct scap_cgroup_set found_subsystems = {.len = 0, .path = {'\0'}};
 	while(1)  // not reached cgroup mountpoint yet
 	{
 		struct scap_cgroup_set current_subsystems;

--- a/userspace/libsinsp/filter_check_list.cpp
+++ b/userspace/libsinsp/filter_check_list.cpp
@@ -31,6 +31,8 @@ using namespace std;
 // sinsp_filter_check_list implementation
 ///////////////////////////////////////////////////////////////////////////////
 
+filter_check_list::~filter_check_list() = default;
+
 void filter_check_list::add_filter_check(std::unique_ptr<sinsp_filter_check> filter_check) {
 	// If a filtercheck already exists with this name and
 	// shortdesc, don't add it--this can occur when plugins are

--- a/userspace/libsinsp/filter_check_list.h
+++ b/userspace/libsinsp/filter_check_list.h
@@ -33,7 +33,7 @@ class sinsp;
 class filter_check_list {
 public:
 	filter_check_list() = default;
-	virtual ~filter_check_list() = default;
+	virtual ~filter_check_list();
 
 	void add_filter_check(std::unique_ptr<sinsp_filter_check> filter_check);
 	void get_all_fields(std::vector<const filter_check_info*>&) const;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
Fix a few warnings and errors that came up during a build with Clang 18.
In addition, I've been working with a simplified version of `CMakePresets.json` where parameters common to several presets are factored out in a base preset. I took the liberty of adding these minor changes here.

**Which issue(s) this PR fixes**:
Compilation errors and warnings with recent compilers.

Fixes #
n/a

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
