### PR TITLE
fix: send enter events also with scap files not only in live captures

### DIFF
--- a/test/libscap/test_suites/userspace/event_table.cpp
+++ b/test/libscap/test_suites/userspace/event_table.cpp
@@ -190,3 +190,27 @@ TEST(event_table, check_exit_param_names) {
 		}
 	}
 }
+
+// todo!: revisit this test after we remove the enter event support in sinsp
+TEST(event_table, check_EF_USED_FD) {
+	for(int evt = 0; evt < PPM_EVENT_MAX; evt++) {
+		auto evt_info = scap_get_event_info_table()[evt];
+		if((evt_info.flags & EF_USES_FD) == 0) {
+			continue;
+		}
+
+		if(PPME_IS_ENTER(evt)) {
+			int location = get_enter_event_fd_location((ppm_event_code)evt);
+			ASSERT_EQ(evt_info.params[location].type, PT_FD)
+			        << "event_type " << evt << " uses a wrong location " << location;
+		}
+
+		if(PPME_IS_EXIT(evt) && evt_info.flags & EF_TMP_CONVERTER_MANAGED) {
+			int location = get_exit_event_fd_location((ppm_event_code)evt);
+			ASSERT_NE(location, -1)
+			        << "event_type " << evt << " uses a wrong location " << location;
+			ASSERT_EQ(evt_info.params[location].type, PT_FD)
+			        << "event_type " << evt << " uses a wrong location " << location;
+		}
+	}
+}

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2027,7 +2027,6 @@ static int32_t next(struct scap_engine_handle engine,
                     uint16_t *pdevid,
                     uint32_t *pflags) {
 	struct savefile_engine *handle = engine.m_handle;
-read_event:;
 	int32_t res = next_event_from_file(handle, pevent, pdevid, pflags);
 	// If we fail we don't convert the event.
 	if(res != SCAP_SUCCESS) {
@@ -2065,10 +2064,8 @@ read_event:;
 	case CONVERSION_ERROR:
 		return SCAP_FAILURE;
 
+	// today with CONVERSION_SKIP we send the event to userspace, tomorrow we could drop it.
 	case CONVERSION_SKIP:
-		// Probably an enter event that we don't want to consider. So we read another event.
-		goto read_event;
-
 	case CONVERSION_COMPLETED:
 	case CONVERSION_CONTINUE:
 	default:

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -874,7 +874,8 @@ typedef enum scap_print_info {
 	PRINT_FULL,
 } scap_print_info;
 void scap_print_event(scap_evt* ev, scap_print_info i);
-
+int get_enter_event_fd_location(ppm_event_code etype);
+int get_exit_event_fd_location(ppm_event_code etype);
 /*@}*/
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -496,3 +496,45 @@ scap_evt *scap_create_event(char *error,
 	va_end(args);
 	return ret;
 }
+
+// Only enter events have a convention on the fd parameter position.
+// Should be always the first parameter apart from some exceptions.
+int get_enter_event_fd_location(ppm_event_code etype) {
+	ASSERT(etype < PPM_EVENT_MAX);
+	ASSERT(PPME_IS_ENTER(etype));
+	ASSERT(scap_get_event_info_table()[etype].flags & EF_USES_FD);
+
+	// For almost all parameters the default position is `0`
+	int location = 0;
+	switch(etype) {
+	case PPME_SYSCALL_MMAP_E:
+	case PPME_SYSCALL_MMAP2_E:
+		location = 4;
+		break;
+	case PPME_SYSCALL_SPLICE_E:
+		location = 1;
+		break;
+	default:
+		break;
+	}
+	return location;
+}
+
+// In the exit events we don't have a precise convension on the fd parameter position.
+int get_exit_event_fd_location(ppm_event_code etype) {
+	ASSERT(etype < PPM_EVENT_MAX);
+	ASSERT(PPME_IS_EXIT(etype));
+	ASSERT(scap_get_event_info_table()[etype].flags & EF_USES_FD);
+
+	// we want to return -1 as location if we forgot to handle something
+	int location = -1;
+	switch(etype) {
+	case PPME_SYSCALL_READ_X:
+	case PPME_SYSCALL_PREAD_X:
+		location = 2;
+		break;
+	default:
+		break;
+	}
+	return location;
+}

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -769,6 +769,10 @@ public:
 		}
 	}
 
+	inline bool uses_fd() const { return get_info_flags() & EF_USES_FD; }
+
+	inline bool creates_fd() const { return get_info_flags() & EF_CREATES_FD; }
+
 private:
 	sinsp* m_inspector;
 	scap_evt* m_pevt;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -116,12 +116,6 @@ void sinsp_parser::process_event(sinsp_evt *evt) {
 	case PPME_SYSCALL_EXECVEAT_E:
 		store_event(evt);
 		break;
-	case PPME_SYSCALL_WRITE_E:
-		if(!m_inspector->is_dumping() && evt->get_tinfo() != nullptr) {
-			// note(jasondellaluce): this may be useless now that we removed tracers support
-			evt->set_fd_info(evt->get_tinfo()->get_fd(evt->get_tinfo()->m_lastevent_fd));
-		}
-		break;
 	case PPME_SYSCALL_MKDIR_X:
 	case PPME_SYSCALL_RMDIR_X:
 	case PPME_SYSCALL_LINK_X:

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -622,10 +622,10 @@ bool sinsp_parser::reset(sinsp_evt *evt) {
 			tinfo->set_lastevent_data_validity(true);
 		} else {
 			tinfo->set_lastevent_data_validity(false);
-
-			if(tinfo->get_lastevent_type() != PPME_TRACER_E) {
-				return false;
-			}
+			// We cannot be sure that the lastevent_fd is something valid, it could be the socket of
+			// the previous `socket` syscall or it could be something completely unrelated, for now
+			// we don't trust it in any case.
+			tinfo->m_lastevent_fd = -1;
 		}
 
 		//

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -151,7 +151,6 @@ private:
 	void swap_addresses(sinsp_fdinfo* fdinfo);
 	uint8_t* reserve_event_buffer();
 	void free_event_buffer(uint8_t*);
-	inline int get_fd_location(uint16_t etype);
 
 	//
 	// Pointers to inspector context

--- a/userspace/libsinsp/test/parsers/parse_brk.cpp
+++ b/userspace/libsinsp/test/parsers/parse_brk.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <sinsp_with_test_input.h>
+
+TEST_F(sinsp_with_test_input, parse_brk_updated_prog_break) {
+	add_default_init_thread();
+	open_inspector();
+
+	// if the program break is updated the res should be equal to `addr`
+	uint64_t res = 83983092;
+	uint32_t vm_size = 294;
+	uint32_t vm_rss = 295;
+	uint32_t vm_swap = 296;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_BRK_4_X,
+	                                4,
+	                                res,
+	                                vm_size,
+	                                vm_rss,
+	                                vm_swap);
+
+	auto init_tinfo = m_inspector.get_thread_ref(INIT_TID, false, true).get();
+	ASSERT_TRUE(init_tinfo);
+	ASSERT_EQ(init_tinfo->m_vmsize_kb, vm_size);
+	ASSERT_EQ(init_tinfo->m_vmrss_kb, vm_rss);
+	ASSERT_EQ(init_tinfo->m_vmswap_kb, vm_swap);
+
+	assert_return_value(evt, res);
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[1]"), std::to_string(vm_size));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.vm_size"), std::to_string(vm_size));
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[2]"), std::to_string(vm_rss));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.vm_rss"), std::to_string(vm_rss));
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[3]"), std::to_string(vm_swap));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.vm_swap"), std::to_string(vm_swap));
+}
+
+TEST_F(sinsp_with_test_input, parse_brk_no_update) {
+	add_default_init_thread();
+	open_inspector();
+
+	// if the program break is different from `addr`.
+	uint64_t res = 83983090;
+	uint32_t vm_size = 294;
+	uint32_t vm_rss = 295;
+	uint32_t vm_swap = 296;
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                INIT_TID,
+	                                PPME_SYSCALL_BRK_4_X,
+	                                4,
+	                                res,
+	                                vm_size,
+	                                vm_rss,
+	                                vm_swap);
+
+	auto init_tinfo = m_inspector.get_thread_ref(INIT_TID, false, true).get();
+	ASSERT_TRUE(init_tinfo);
+	// We should always update the info
+	ASSERT_EQ(init_tinfo->m_vmsize_kb, vm_size);
+	ASSERT_EQ(init_tinfo->m_vmrss_kb, vm_rss);
+	ASSERT_EQ(init_tinfo->m_vmswap_kb, vm_swap);
+
+	// BRK can update or not update the program break according to the value we provide. Today we
+	// don't consider a failure if the program break in not updated, we consider a failure only if
+	// the syscall sets an errno.
+	assert_return_value(evt, res);
+}

--- a/userspace/libsinsp/test/parsers/parse_pread.cpp
+++ b/userspace/libsinsp/test/parsers/parse_pread.cpp
@@ -1,0 +1,88 @@
+
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <sinsp_with_test_input.h>
+
+TEST_F(sinsp_with_test_input, parse_pread_success) {
+	add_default_init_thread();
+	open_inspector();
+
+	auto evt = generate_open_x_event();
+	ASSERT_TRUE(evt->get_fd_info());
+
+	std::string data = "hello";
+	uint32_t size = data.size();
+	uint64_t pos = 0;
+	evt = add_event_advance_ts(increasing_ts(),
+	                           INIT_TID,
+	                           PPME_SYSCALL_PREAD_X,
+	                           5,
+	                           (int64_t)size,
+	                           scap_const_sized_buffer{data.c_str(), size},
+	                           sinsp_test_input::open_params::default_fd,
+	                           size,
+	                           pos);
+
+	ASSERT_TRUE(evt->get_fd_info());
+	assert_fd_fields(evt,
+	                 sinsp_test_input::fd_info_fields{
+	                         .fd_num = sinsp_test_input::open_params::default_fd,
+	                         .fd_name = sinsp_test_input::open_params::default_path,
+	                         .fd_name_raw = sinsp_test_input::open_params::default_path,
+	                         .fd_directory = sinsp_test_input::open_params::default_directory,
+	                         .fd_filename = sinsp_test_input::open_params::default_filename});
+
+	assert_return_value(evt, size);
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[1]"), data);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.data"), data);
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[2]"),
+	          std::string("<f>") + sinsp_test_input::open_params::default_path);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.fd"),
+	          std::to_string(sinsp_test_input::open_params::default_fd));
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[3]"), std::to_string(size));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.size"), std::to_string(size));
+}
+
+TEST_F(sinsp_with_test_input, parse_pread_failure) {
+	add_default_init_thread();
+	open_inspector();
+
+	auto evt = generate_open_x_event();
+
+	std::string data = "hello";
+	uint32_t size = data.size();
+	int64_t errno_code = -3;
+	uint64_t pos = 0;
+	evt = add_event_advance_ts(increasing_ts(),
+	                           INIT_TID,
+	                           PPME_SYSCALL_PREAD_X,
+	                           5,
+	                           errno_code,
+	                           scap_const_sized_buffer{data.c_str(), size},
+	                           sinsp_test_input::open_params::default_fd,
+	                           size,
+	                           pos);
+
+	// Check we have the correct fd info associated with the event
+	auto fdinfo = evt->get_fd_info();
+	ASSERT_TRUE(fdinfo);
+	ASSERT_EQ(fdinfo->m_fd, sinsp_test_input::open_params::default_fd);
+
+	// Assert return value filterchecks
+	assert_return_value(evt, errno_code);
+}

--- a/userspace/libsinsp/test/parsers/parse_read.cpp
+++ b/userspace/libsinsp/test/parsers/parse_read.cpp
@@ -1,0 +1,84 @@
+
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <sinsp_with_test_input.h>
+
+TEST_F(sinsp_with_test_input, parse_read_success) {
+	add_default_init_thread();
+	open_inspector();
+
+	auto evt = generate_open_x_event();
+	ASSERT_TRUE(evt->get_fd_info());
+
+	std::string data = "hello";
+	uint32_t size = data.size();
+	evt = add_event_advance_ts(increasing_ts(),
+	                           INIT_TID,
+	                           PPME_SYSCALL_READ_X,
+	                           4,
+	                           (int64_t)size,
+	                           scap_const_sized_buffer{data.c_str(), size},
+	                           sinsp_test_input::open_params::default_fd,
+	                           size);
+
+	ASSERT_TRUE(evt->get_fd_info());
+	assert_fd_fields(evt,
+	                 sinsp_test_input::fd_info_fields{
+	                         .fd_num = sinsp_test_input::open_params::default_fd,
+	                         .fd_name = sinsp_test_input::open_params::default_path,
+	                         .fd_name_raw = sinsp_test_input::open_params::default_path,
+	                         .fd_directory = sinsp_test_input::open_params::default_directory,
+	                         .fd_filename = sinsp_test_input::open_params::default_filename});
+
+	assert_return_value(evt, size);
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[1]"), data);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.data"), data);
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[2]"),
+	          std::string("<f>") + sinsp_test_input::open_params::default_path);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.fd"),
+	          std::to_string(sinsp_test_input::open_params::default_fd));
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg[3]"), std::to_string(size));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.size"), std::to_string(size));
+}
+
+TEST_F(sinsp_with_test_input, parse_read_failure) {
+	add_default_init_thread();
+	open_inspector();
+
+	auto evt = generate_open_x_event();
+
+	std::string data = "hello";
+	uint32_t size = data.size();
+	int64_t errno_code = -3;
+	evt = add_event_advance_ts(increasing_ts(),
+	                           INIT_TID,
+	                           PPME_SYSCALL_READ_X,
+	                           4,
+	                           errno_code,
+	                           scap_const_sized_buffer{data.c_str(), size},
+	                           sinsp_test_input::open_params::default_fd,
+	                           size);
+
+	// Check we have the correct fd info associated with the event
+	auto fdinfo = evt->get_fd_info();
+	ASSERT_TRUE(fdinfo);
+	ASSERT_EQ(fdinfo->m_fd, sinsp_test_input::open_params::default_fd);
+
+	// Assert return value filterchecks
+	assert_return_value(evt, errno_code);
+}

--- a/userspace/libsinsp/test/scap_files/converter_tests.cpp
+++ b/userspace/libsinsp/test/scap_files/converter_tests.cpp
@@ -27,13 +27,12 @@ limitations under the License.
 // READ
 ////////////////////////////
 
-TEST_F(scap_file_test, no_read_e) {
+TEST_F(scap_file_test, read_e_same_number_of_events) {
 	open_filename("scap_2013.scap");
-	// we shouldn't see the enter events
-	assert_no_event_type(PPME_SYSCALL_READ_E);
+	assert_num_event_type(PPME_SYSCALL_READ_E, 24956);
 }
 
-TEST_F(scap_file_test, read_x_same_number_of_exit_events) {
+TEST_F(scap_file_test, read_x_same_number_of_events) {
 	open_filename("scap_2013.scap");
 	assert_num_event_type(PPME_SYSCALL_READ_X, 24957);
 }
@@ -80,12 +79,12 @@ TEST_F(scap_file_test, read_x_check_final_converted_event) {
 // PREAD
 ////////////////////////////
 
-TEST_F(scap_file_test, no_pread_e) {
+TEST_F(scap_file_test, pread_e_same_number_of_events) {
 	open_filename("kexec_arm64.scap");
-	assert_no_event_type(PPME_SYSCALL_PREAD_E);
+	assert_num_event_type(PPME_SYSCALL_PREAD_E, 3216);
 }
 
-TEST_F(scap_file_test, pread_x_same_number_of_exit_events) {
+TEST_F(scap_file_test, pread_x_same_number_of_events) {
 	open_filename("kexec_arm64.scap");
 	assert_num_event_type(PPME_SYSCALL_PREAD_X, 3216);
 }

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -36,19 +36,28 @@ limitations under the License.
 
 namespace sinsp_test_input {
 struct open_params {
-	static constexpr int32_t default_fd = 4;
+	static constexpr int64_t default_fd = 4;
 	static constexpr const char* default_path = "/home/file.txt";
 	// Used for some filter checks
 	static constexpr const char* default_directory = "/home";
 	static constexpr const char* default_filename = "file.txt";
 
-	int32_t fd = default_fd;
+	int64_t fd = default_fd;
 	const char* path = default_path;
 	uint32_t flags = 0;
 	uint32_t mode = 0;
 	uint32_t dev = 0;
 	uint64_t ino = 0;
 };
+
+struct fd_info_fields {
+	std::optional<int64_t> fd_num = std::nullopt;
+	std::optional<std::string> fd_name = std::nullopt;
+	std::optional<std::string> fd_name_raw = std::nullopt;
+	std::optional<std::string> fd_directory = std::nullopt;
+	std::optional<std::string> fd_filename = std::nullopt;
+};
+
 }  // namespace sinsp_test_input
 
 class sinsp_with_test_input : public ::testing::Test {
@@ -280,6 +289,9 @@ protected:
 	                 std::shared_ptr<sinsp_filter_cache_factory> cachef = nullptr);
 	bool filter_compiles(std::string_view filter_str);
 	bool filter_compiles(std::string_view filter_str, filter_check_list&);
+
+	void assert_return_value(sinsp_evt* evt, int64_t expected_retval);
+	void assert_fd_fields(sinsp_evt* evt, sinsp_test_input::fd_info_fields fields = {});
 
 	sinsp_evt* next_event();
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap-engine-savefile

/area libscap

/area libsinsp

/area tests

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:

This PR provides 2 main fixes:
* today sinsp skip the event reset phase if the enter event is dropped. Sometimes this is dangerous because we are not able to associate the fd to the event. See the `connect` or the `close` case.
* before this PR enter events for pread and read were skipped by the scap file converter but this is probably not what we want, with scap-file we want to emulate the same behavior of the live capture, so populate the state only with exit events but always send the enter ones... This PR reintroduce the enter events for pread/read changing the behavior of the scap-file converter

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
