### PR TITLE
fix(libsinsp): do not reformat input buffer strings while applying arg filters

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1198,18 +1198,17 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 
 		ASSERT(m_inspector != NULL);
 
+		sinsp_evt::param_fmt format =
+		        m_is_compare ? sinsp_evt::param_fmt::PF_NORMAL : m_inspector->get_buffer_format();
+
 		if(m_argid != -1) {
 			if(m_argid >= (int32_t)evt->get_num_params()) {
 				return NULL;
 			}
 
-			argstr = evt->get_param_as_str(m_argid,
-			                               &resolved_argstr,
-			                               m_inspector->get_buffer_format());
+			argstr = evt->get_param_as_str(m_argid, &resolved_argstr, format);
 		} else {
-			argstr = evt->get_param_value_str(m_argname,
-			                                  &resolved_argstr,
-			                                  m_inspector->get_buffer_format());
+			argstr = evt->get_param_value_str(m_argname, &resolved_argstr, format);
 		}
 
 		if(resolved_argstr != NULL && resolved_argstr[0] != 0) {


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

See https://github.com/falcosecurity/falco/issues/3437 for a description of the effect of this issue on Falco. Filters should not be affected by the output format.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): do not reformat input buffer strings while applying arg filters
```
