### PR TITLE
fix(modern): move args declaration at the beginning

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/bind.bpf.c
@@ -13,7 +13,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(bind_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to easily manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long socket_fd = 0;
 	extract__network_args(&socket_fd, 1, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/listen.bpf.c
@@ -12,7 +12,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(listen_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[2] = {0};
 	extract__network_args(args, 2, regs);
 
@@ -46,7 +48,9 @@ int BPF_PROG(listen_e, struct pt_regs *regs, long id) {
 
 SEC("tp_btf/sys_exit")
 int BPF_PROG(listen_x, struct pt_regs *regs, long ret) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[2] = {0};
 	extract__network_args(args, 2, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -13,7 +13,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(recv_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[3] = {0};
 	extract__network_args(args, 3, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -13,7 +13,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(recvfrom_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to  manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[3] = {0};
 	extract__network_args(args, 3, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -13,7 +13,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(recvmsg_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long socket_fd = 0;
 	extract__network_args(&socket_fd, 1, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -13,7 +13,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(send_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[3] = {0};
 	extract__network_args(args, 3, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/shutdown.bpf.c
@@ -12,7 +12,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(shutdown_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to easily manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[2] = {0};
 	extract__network_args(args, 2, regs);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socketpair.bpf.c
@@ -12,7 +12,9 @@
 
 SEC("tp_btf/sys_enter")
 int BPF_PROG(socketpair_e, struct pt_regs *regs, long id) {
-	/* Collect parameters at the beginning to manage socketcalls */
+	/* We need to keep this at the beginning of the program because otherwise we alter the state of
+	 * the ebpf registers causing a verifier issue.
+	 */
 	unsigned long args[3] = {0};
 	extract__network_args(args, 3, regs);
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
