### PR TITLE
fix: dangling pointer and mixed-signedness warning

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -1399,13 +1399,13 @@ void event_test::assert_ipv4_string(const char* desired_ipv4, int starting_index
 
 void event_test::assert_port_string(const char* desired_port, int starting_index, direction dir) {
 	uint16_t port = *(uint16_t*)(m_event_params[m_current_param].valptr + starting_index);
-	const char* port_string = std::to_string(port).c_str();
+	auto port_string = std::to_string(port);
 
 	if(dir == DEST) {
-		ASSERT_STREQ(port_string, desired_port)
+		ASSERT_STREQ(port_string.c_str(), desired_port)
 		        << VALUE_NOT_CORRECT << m_current_param << "(dest port)" << std::endl;
 	} else {
-		ASSERT_STREQ(port_string, desired_port)
+		ASSERT_STREQ(port_string.c_str(), desired_port)
 		        << VALUE_NOT_CORRECT << m_current_param << "(source port)" << std::endl;
 	}
 }

--- a/userspace/libscap/engine/savefile/converter/converter.cpp
+++ b/userspace/libscap/engine/savefile/converter/converter.cpp
@@ -359,7 +359,7 @@ static conversion_result convert_event(scap_evt *new_evt,
 	scap_evt *tmp_evt = NULL;
 
 	// We iterate over the instructions
-	for(int i = 0; i < ci.m_instrs.size(); i++, param_to_populate++) {
+	for(size_t i = 0; i < ci.m_instrs.size(); i++, param_to_populate++) {
 		PRINT_MESSAGE("Instruction n° %d. Param to populate: %d\n", i, param_to_populate);
 
 		switch(ci.m_instrs[i].flags) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build
/area tests

**Does this PR require a change in the driver versions?**
No

**What this PR does / why we need it**:
Fixes an error when taking the address of a temporary string and a warning about mixed sign integer comparison with clang 18.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
