### PR TITLE
wip: new(driver/modern_bpf): home-made bpf_loop for sendmmsg and recvmmsg.

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -35,12 +35,89 @@ int BPF_PROG(recvmmsg_e, struct pt_regs *regs, long id) {
 
 /*=============================== EXIT EVENT ===========================*/
 
+static __always_inline long handle_exit(uint32_t index, void *ctx);
+
 typedef struct {
 	uint32_t fd;
 	struct mmsghdr *mmh;
 	struct pt_regs *regs;
 	void *ctx;
 } recvmmsg_data_t;
+
+// This is some pre-processor magic (X_MACROs) to allow us to mimic `bpf_loop` behavior
+// without using the helper, that triggers a verifier issue;
+// See
+// https://lore.kernel.org/bpf/CAGQdkDt9zyQwr5JyftXqL=OLKscNcqUtEteY4hvOkx2S4GdEkQ@mail.gmail.com/T/#u.
+
+#define RECVMMSG_EXTRA_TAIL_CALLS \
+	X(0)                          \
+	X(1)                          \
+	X(2)                          \
+	X(3)                          \
+	X(4)                          \
+	X(5)                          \
+	X(6)                          \
+	X(7)
+
+#define TAIL_CALL(ctx, value) \
+	bpf_tail_call(ctx, &extra_recvmmsg_calls, RECVMMSG_EXTRA_TAIL_CALL_##value)
+
+enum extra_recvmmsg_codes {
+#define X(value) RECVMMSG_EXTRA_TAIL_CALL_##value,
+	RECVMMSG_EXTRA_TAIL_CALLS
+#undef X
+	        RECVMMSG_EXTRA_TAIL_CALL_MAX
+};
+
+/*
+ * FORWARD DECLARATIONS:
+ * See the `BPF_PROG` macro in libbpf `libbpf/src/bpf_tracing.h`
+ * #define BPF_PROG(name, args...)		\
+ *    name(unsigned long long *ctx);	\
+ */
+#define X(value) int recvmmsg_t_##value(unsigned long long *ctx);
+RECVMMSG_EXTRA_TAIL_CALLS
+#undef X
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, RECVMMSG_EXTRA_TAIL_CALL_MAX);
+	__uint(key_size, sizeof(__u32));
+	__array(values, int(void *));
+} extra_recvmmsg_calls SEC(".maps") = {
+        .values =
+                {
+#define X(value) [value] = (void *)&recvmmsg_t_##value,
+                        RECVMMSG_EXTRA_TAIL_CALLS
+#undef X
+                },
+};
+
+#define X(value)                                                                 \
+	SEC("tp_btf/sys_exit")                                                       \
+	int BPF_PROG(recvmmsg_t_##value, struct pt_regs *regs, long ret) {           \
+		unsigned long args[2];                                                   \
+		extract__network_args(args, 2, regs);                                    \
+		recvmmsg_data_t data = {                                                 \
+		        .fd = args[0],                                                   \
+		        .mmh = (struct mmsghdr *)args[1],                                \
+		        .regs = regs,                                                    \
+		        .ctx = ctx,                                                      \
+		};                                                                       \
+		int i;                                                                   \
+		int start = value * MAX_SENDMMSG_RECVMMSG_SIZE;                          \
+		for(i = start; i < ret && i < start + MAX_SENDMMSG_RECVMMSG_SIZE; i++) { \
+			handle_exit(i, &data);                                               \
+		}                                                                        \
+		if(i == ret)                                                             \
+			return 0;                                                            \
+		if(value + 1 == RECVMMSG_EXTRA_TAIL_CALL_MAX)                            \
+			return 0;                                                            \
+		TAIL_CALL(ctx, value + 1);                                               \
+		return 0;                                                                \
+	}
+RECVMMSG_EXTRA_TAIL_CALLS
+#undef X
 
 static __always_inline long handle_exit(uint32_t index, void *ctx) {
 	recvmmsg_data_t *data = (recvmmsg_data_t *)ctx;
@@ -149,26 +226,23 @@ int BPF_PROG(recvmmsg_x, struct pt_regs *regs, long ret) {
 		return 0;
 	}
 
-	/* Collect parameters at the beginning to manage socketcalls */
-	unsigned long args[2];
-	extract__network_args(args, 2, regs);
-	recvmmsg_data_t data = {
-	        .fd = args[0],
-	        .mmh = (struct mmsghdr *)args[1],
-	        .regs = regs,
-	        .ctx = ctx,
-	};
-
 	// We can't use bpf_loop() helper since the below check triggers a verifier failure:
 	// see
 	// https://lore.kernel.org/bpf/CAGQdkDt9zyQwr5JyftXqL=OLKscNcqUtEteY4hvOkx2S4GdEkQ@mail.gmail.com/T/#u
 	/*if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop)) {
+	    // Collect parameters at the beginning to manage socketcalls
+	    unsigned long args[2];
+	    extract__network_args(args, 2, regs);
+	    recvmmsg_data_t data = {
+	        .fd = args[0],
+	        .mmh = (struct mmsghdr *)args[1],
+	        .regs = regs,
+	        .ctx = ctx,
+	    };
 	    uint32_t nr_loops = ret < 1024 ? ret : 1024;
 	    bpf_loop(nr_loops, handle_exit, &data, 0);
 	} else {*/
-	for(int i = 0; i < ret && i < MAX_SENDMMSG_RECVMMSG_SIZE; i++) {
-		handle_exit(i, &data);
-	}
+	TAIL_CALL(ctx, 0);
 	//}
 
 	return 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

For sendmmsg and recvmmsg in modern_bpf probe we could not use `bpf_loop` helper because it caused verifier issues on kernels prior to 5.13 (see https://github.com/falcosecurity/libs/pull/2027#issuecomment-2568997393).
Therefore we used a loop up to 16; then we noticed that 16 was too high, thus we lowered the limit to 8 (https://github.com/falcosecurity/libs/commit/600fefb36d2b0d70007bf6665103e06356d317af).
This means we can only read first 8 messages sent through `sendmmsg` and `recvmmsg`.

This PR's scope is to increase the limit up to 256 (in the first proposed draft, i limit it to 64).
The idea is to build an `X_MACRO` that let us easily chain tail-calls. 
EBPF tail call limit is MAX_TAIL_CALL_CNT, ie 32 on older kernels, and 33 nowadays. For now, i capped the implementation to 8 (and each tail-call loops 8 times, this 64 total).

```
The good: we support up to 8x32=256messages (that is a far better situation than now)
The bad: we need to extract network args at each iteration because we can't share state between tail calls
The ugly: well, the code gets a bit convoluted but it does the trick. It's just plain old C anyway :) 
```

Note also that to make it a little bit less verbose, i could also create a new header with all the macros and share them between the 2 source files, since they are basically identical (naming aside). I decided to keep it as easy as possible, but it is a possibility (and it would be more future proof since we would only have a single place to update if needed).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Putting it in `wip` to allow a discussion. 
**THIS IS NOT FOR 0.20.0**.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
