### PR TITLE
fix(libsinsp/runc): use old logic and fallback for containerd

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -577,6 +577,7 @@ void sinsp_container_manager::create_engines() {
 			cri_settings.add_cri_unix_socket_path("/run/containerd/containerd.sock");
 			cri_settings.add_cri_unix_socket_path("/run/crio/crio.sock");
 			cri_settings.add_cri_unix_socket_path("/run/k3s/containerd/containerd.sock");
+			cri_settings.add_cri_unix_socket_path("/run/host-containerd/containerd.sock");
 		}
 
 		const auto& cri_socket_paths = cri_settings.get_cri_unix_socket_paths();

--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -569,6 +569,7 @@ void sinsp_container_manager::create_engines() {
 		m_container_engine_by_type[CT_DOCKER].push_back(docker_engine);
 	}
 
+	size_t engine_index = 0;
 	if(m_container_engine_mask & ((1 << CT_CRI) | (1 << CT_CRIO) | (1 << CT_CONTAINERD))) {
 		// Get CRI socket paths from settings
 		libsinsp::cri::cri_settings& cri_settings = libsinsp::cri::cri_settings::get();
@@ -582,13 +583,13 @@ void sinsp_container_manager::create_engines() {
 
 		const auto& cri_socket_paths = cri_settings.get_cri_unix_socket_paths();
 
-		size_t engine_index = 0;
 		for(auto socket_path : cri_socket_paths) {
 			auto cri_engine =
 			        std::make_shared<container_engine::cri>(*this, socket_path, engine_index);
 			m_container_engines.push_back(cri_engine);
 			m_container_engine_by_type[CT_CRI].push_back(cri_engine);
 			m_container_engine_by_type[CT_CRIO].push_back(cri_engine);
+			m_container_engine_by_type[CT_CONTAINERD].push_back(cri_engine);
 			engine_index++;
 		}
 	}
@@ -618,7 +619,8 @@ void sinsp_container_manager::create_engines() {
 		m_container_engine_by_type[CT_BPM].push_back(bpm_engine);
 	}
 	if(m_container_engine_mask & (1 << CT_CONTAINERD)) {
-		auto containerd_engine = std::make_shared<container_engine::containerd>(*this);
+		auto containerd_engine =
+		        std::make_shared<container_engine::containerd>(*this, engine_index);
 		m_container_engines.push_back(containerd_engine);
 		m_container_engine_by_type[CT_CONTAINERD].push_back(containerd_engine);
 	}

--- a/userspace/libsinsp/container_engine/containerd.h
+++ b/userspace/libsinsp/container_engine/containerd.h
@@ -100,7 +100,7 @@ private:
 
 class containerd : public container_engine_base {
 public:
-	containerd(container_cache_interface& cache);
+	containerd(container_cache_interface& cache, size_t engine_index);
 
 	void parse_containerd(const containerd_lookup_request& request,
 	                      container_cache_interface* cache);
@@ -108,6 +108,7 @@ public:
 
 private:
 	std::unique_ptr<containerd_async_source> m_containerd_info_source;
+	size_t m_engine_index;
 };
 
 }  // namespace container_engine

--- a/userspace/libsinsp/test/container_engine/cri_settings.ut.cpp
+++ b/userspace/libsinsp/test/container_engine/cri_settings.ut.cpp
@@ -35,9 +35,10 @@ TEST_F(sinsp_with_test_input, default_cri_socket_paths) {
 
 	auto socket_paths = cri_settings.get_cri_unix_socket_paths();
 
-	ASSERT_EQ(socket_paths.size(), 3);
+	ASSERT_EQ(socket_paths.size(), 4);
 	ASSERT_TRUE("/run/containerd/containerd.sock" == socket_paths[0]);
 	ASSERT_TRUE("/run/crio/crio.sock" == socket_paths[1]);
 	ASSERT_TRUE("/run/k3s/containerd/containerd.sock" == socket_paths[2]);
+	ASSERT_TRUE("/run/host-containerd/containerd.sock" == socket_paths[3]);
 }
 #endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The new logic is not always accurate. This readopts the old logic and adds a fallback to support containerd vanilla containers.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
