### PR TITLE
cleanup(ci): use github-provided arm runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-libs-linux:
     name: build-libs-linux-${{ matrix.arch }} 😁 (${{ matrix.name }})
-    runs-on: ${{ (matrix.arch == 'arm64' && 'github-arm64-2c-8gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -39,7 +39,7 @@ jobs:
   # This job run all engine tests and scap-open
   test-scap:
     name: test-scap-${{ matrix.arch }} 😆 (bundled_deps)
-    runs-on: ${{ (matrix.arch == 'arm64' && 'github-arm64-2c-8gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     needs: paths-filter
     strategy:
       matrix:
@@ -104,7 +104,7 @@ jobs:
 
   test-drivers:
     name: test-drivers-${{ matrix.arch }} 😇 (bundled_deps)
-    runs-on: ${{ (matrix.arch == 'arm64' && 'github-arm64-2c-8gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     needs: paths-filter
     strategy:
       matrix:

--- a/.github/workflows/e2e_ci.yml
+++ b/.github/workflows/e2e_ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-test-e2e:
     name: build-test-e2e-${{ matrix.arch }} 😇 (bundled_deps)
-    runs-on: ${{ (matrix.arch == 'arm64' && 'github-arm64-2c-8gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -105,7 +105,7 @@ jobs:
   test-e2e:
     name: test-e2e-${{ matrix.arch }}-${{ matrix.driver.name }} 😇 (bundled_deps)
     needs: [build-test-e2e]
-    runs-on: ${{ (matrix.arch == 'arm64' && 'github-arm64-2c-8gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/.github/workflows/latest-kernel.yml
+++ b/.github/workflows/latest-kernel.yml
@@ -78,7 +78,7 @@ jobs:
     needs: 'compute-latest-version'
     outputs:
       build: ${{ steps.build.outcome }}
-    runs-on: 'github-arm64-2c-8gb'
+    runs-on: 'ubuntu-22.04-arm'
     steps:
       - name: Download driverkit config
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

In the end, i ported our CI to use the shiny new github provided ARM runners: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
