### PR TITLE
fix(libsinsp): do not invalidate thread manager cache when using plugin state api

### DIFF
--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -781,7 +781,7 @@ public:
 	}
 
 	std::shared_ptr<libsinsp::state::table_entry> get_entry(const int64_t& key) override {
-		return find_thread(key, false);
+		return find_thread(key, true);
 	}
 
 	std::shared_ptr<libsinsp::state::table_entry> add_entry(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

During an investigation, we discovered an issue with the accessors used by plugins and the internal state api for retrieving thread infos from the state tables. By not declaring the access as "lookup only", plugins have the potential of invalidating the thread manager cache and potentially lead to invalidating the raw threadinfo pointer assigned to the parsed event, thus violating the internal threadinfo ownership/liveness guarantees.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
