### PR TITLE
fix(libsinsp): cache invalidation and potential use-after-free in state table api for plugins and sinsp

### DIFF
--- a/userspace/libsinsp/state/table.cpp
+++ b/userspace/libsinsp/state/table.cpp
@@ -635,6 +635,10 @@ ss_plugin_rc libsinsp::state::built_in_table<KeyType>::read_entry_field(
 	};
 	if(a->data_type == ss_plugin_state_type::SS_PLUGIN_ST_TABLE) {
 		auto* subtable_ptr = out->table;
+		if(!subtable_ptr) {
+			t->m_owner_plugin->m_last_owner_err.clear();
+			return SS_PLUGIN_FAILURE;
+		}
 		__CATCH_ERR_MSG(owner->m_last_owner_err,
 		                { __PLUGIN_STATETYPE_SWITCH(a->subtable_key_type); });
 	}

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -38,7 +38,6 @@ struct sinsp_field_accessor_wrapper {
 	void* accessor = nullptr;
 	bool dynamic = false;
 	ss_plugin_state_type data_type = ss_plugin_state_type::SS_PLUGIN_ST_INT8;
-	ss_plugin_state_type subtable_key_type = ss_plugin_state_type::SS_PLUGIN_ST_INT8;
 
 	inline sinsp_field_accessor_wrapper() = default;
 	~sinsp_field_accessor_wrapper();

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -1212,13 +1212,6 @@ void sinsp_threadinfo::strvec_to_iovec(const std::vector<std::string>& strs,
 	}
 }
 
-void sinsp_threadinfo::update_main_fdtable() {
-	auto fdtable = get_fd_table();
-	if(fdtable) {
-		m_main_fdtable = static_cast<const libsinsp::state::base_table*>(fdtable->table_ptr());
-	}
-}
-
 void sinsp_threadinfo::set_exepath(std::string&& exepath) {
 	constexpr char suffix[] = " (deleted)";
 	constexpr size_t suffix_len = sizeof(suffix) - 1;  // Exclude null terminator
@@ -1384,8 +1377,6 @@ void sinsp_thread_manager::create_thread_dependencies(
 		return;
 	}
 	parent_thread->add_child(tinfo);
-
-	tinfo->update_main_fdtable();
 }
 
 std::unique_ptr<sinsp_threadinfo> sinsp_thread_manager::new_threadinfo() const {
@@ -2008,6 +1999,7 @@ const threadinfo_map_t::ptr_t& sinsp_thread_manager::find_thread(int64_t tid, bo
 		// This allows us to avoid performing an actual timestamp lookup
 		// for something that may not need to be precise
 		m_last_tinfo->m_lastaccess_ts = m_inspector->get_lastevent_ts();
+		m_last_tinfo->update_main_fdtable();
 		return m_last_tinfo;
 	}
 
@@ -2026,6 +2018,7 @@ const threadinfo_map_t::ptr_t& sinsp_thread_manager::find_thread(int64_t tid, bo
 			m_last_tinfo = thr;
 			thr->m_lastaccess_ts = m_inspector->get_lastevent_ts();
 		}
+		thr->update_main_fdtable();
 		return thr;
 	} else {
 		if(m_sinsp_stats_v2 != nullptr) {

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -577,7 +577,12 @@ public:
 	        const std::function<std::string(sinsp_threadinfo*)>& get_field_str,
 	        bool is_virtual_id = false);
 
-	void update_main_fdtable();
+	inline void update_main_fdtable() {
+		auto fdtable = get_fd_table();
+		m_main_fdtable =
+		        !fdtable ? nullptr
+		                 : static_cast<const libsinsp::state::base_table*>(fdtable->table_ptr());
+	}
 
 	void set_exepath(std::string&& exepath);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

This is a follow up for the issues fixed in https://github.com/falcosecurity/libs/pull/2257. I discovered that due to how thread management works, there may be corner cases where the last cached thread ref or the cached fd tables pointer might become stale, thus potentially causing use after free issues.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
