### PR TITLE
feat(cri): make CRI lookup retry parameters configurable

### DIFF
--- a/userspace/libsinsp/container.cpp
+++ b/userspace/libsinsp/container.cpp
@@ -687,6 +687,18 @@ void sinsp_container_manager::set_cri_timeout(int64_t timeout_ms) {
 #endif
 }
 
+void sinsp_container_manager::set_cri_retry_parameters(const ::libsinsp::cri::retry_parameters& v) {
+#if !defined(MINIMAL_BUILD) && !defined(__EMSCRIPTEN__)
+	if(!libsinsp::cri::cri_settings::set_cri_retry_parameters(v)) {
+		libsinsp_logger()->format(
+		        sinsp_logger::SEV_WARNING,
+		        "CRI retry parameters out of range, using defaults. Wanted: %s, Using: %s",
+		        v.to_string().c_str(),
+		        libsinsp::cri::cri_settings::get_cri_retry_parameters().to_string().c_str());
+	}
+#endif
+}
+
 void sinsp_container_manager::set_cri_async(bool async) {
 #if !defined(MINIMAL_BUILD) && !defined(__EMSCRIPTEN__)
 	libsinsp::container_engine::cri::set_async(async);

--- a/userspace/libsinsp/container.h
+++ b/userspace/libsinsp/container.h
@@ -27,6 +27,7 @@ limitations under the License.
 
 #include <libsinsp/event.h>
 #include <libsinsp/container_info.h>
+#include <libsinsp/cri_settings.h>
 
 #if !defined(_WIN32) && !defined(MINIMAL_BUILD) && !defined(__EMSCRIPTEN__)
 #include <curl/curl.h>
@@ -194,6 +195,7 @@ public:
 	void set_cri_socket_path(const std::string& path);
 	void add_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_retry_parameters(const ::libsinsp::cri::retry_parameters& v);
 	void set_cri_async(bool async);
 	void set_container_labels_max_len(uint32_t max_label_len);
 	sinsp* get_inspector() { return m_inspector; }

--- a/userspace/libsinsp/container_engine/container_async_source.h
+++ b/userspace/libsinsp/container_engine/container_async_source.h
@@ -47,6 +47,10 @@ public:
 
 	bool lookup(const key_type& key, sinsp_container_info& value, const callback_handler& handler);
 
+	bool lookup_delayed(const key_type& key,
+	                    sinsp_container_info& value,
+	                    std::chrono::milliseconds delay);
+
 	bool lookup_sync(const key_type& key, sinsp_container_info& value);
 
 	void source_callback(const key_type& key, const sinsp_container_info& res);

--- a/userspace/libsinsp/container_engine/container_async_source.tpp
+++ b/userspace/libsinsp/container_engine/container_async_source.tpp
@@ -56,6 +56,20 @@ bool container_async_source<key_type>::lookup(const key_type& key,
 }
 
 template<typename key_type>
+bool container_async_source<key_type>::lookup_delayed(const key_type& key, sinsp_container_info& value, std::chrono::milliseconds delay)
+{
+    return parent_type::lookup_delayed(
+        key,
+        value,
+        delay,
+        std::bind(
+            &container_async_source::source_callback,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2));
+}
+
+template<typename key_type>
 bool container_async_source<key_type>::lookup_sync(const key_type& key, sinsp_container_info& value)
 {
 	value.set_lookup_status(sinsp_container_lookup::state::SUCCESSFUL);

--- a/userspace/libsinsp/cri.h
+++ b/userspace/libsinsp/cri.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include <libsinsp/cri-v1.grpc.pb.h>
 #endif  // MINIMAL_BUILD
 
+#include <libsinsp/cri_settings.h>
 #include <libsinsp/container_info.h>
 #include <libsinsp/cgroup_limits.h>
 
@@ -40,57 +41,6 @@ limitations under the License.
 
 namespace libsinsp {
 namespace cri {
-
-class cri_settings {
-public:
-	cri_settings();
-	~cri_settings();
-	static cri_settings &get();
-
-	static const std::vector<std::string> &get_cri_unix_socket_paths() {
-		return get().m_cri_unix_socket_paths;
-	}
-
-	static void set_cri_unix_socket_paths(const std::vector<std::string> &v) {
-		get().m_cri_unix_socket_paths = v;
-	}
-
-	static const int64_t &get_cri_timeout() { return get().m_cri_timeout; }
-
-	static void set_cri_timeout(const int64_t &v) { get().m_cri_timeout = v; }
-
-	static const int64_t &get_cri_size_timeout() { return get().m_cri_size_timeout; }
-
-	static void set_cri_size_timeout(const int64_t &v) { get().m_cri_size_timeout = v; }
-
-	static const sinsp_container_type &get_cri_runtime_type() { return get().m_cri_runtime_type; }
-
-	static void set_cri_runtime_type(const sinsp_container_type &v) {
-		get().m_cri_runtime_type = v;
-	}
-
-	static const bool &get_cri_extra_queries() { return get().m_cri_extra_queries; }
-
-	static void set_cri_extra_queries(const bool &v) { get().m_cri_extra_queries = v; }
-
-	static void add_cri_unix_socket_path(const std::string &v) {
-		get().m_cri_unix_socket_paths.emplace_back(v);
-	}
-
-	static void clear_cri_unix_socket_paths() { get().m_cri_unix_socket_paths.clear(); }
-
-private:
-	static std::unique_ptr<cri_settings> s_instance;
-
-	cri_settings(const cri_settings &) = delete;
-	cri_settings &operator=(const cri_settings &) = delete;
-
-	std::vector<std::string> m_cri_unix_socket_paths;
-	int64_t m_cri_timeout;
-	int64_t m_cri_size_timeout;
-	sinsp_container_type m_cri_runtime_type;
-	bool m_cri_extra_queries;
-};
 
 class cri_api_v1alpha2 {
 public:

--- a/userspace/libsinsp/cri_settings.cpp
+++ b/userspace/libsinsp/cri_settings.cpp
@@ -16,15 +16,82 @@ limitations under the License.
 
 */
 
-#include <libsinsp/cri.hpp>
+#include <libsinsp/cri_settings.h>
+
+#include <string>
+#include <sstream>
 
 namespace libsinsp {
 namespace cri {
+
+bool retry_parameters::set_max_retries(int16_t retries) {
+	static constexpr int16_t min_val = 0;
+	if(retries < min_val) {
+		return false;
+	}
+	max_retries = retries;
+	return true;
+}
+
+bool retry_parameters::set_max_interval_ms(std::chrono::milliseconds interval) {
+	static constexpr std::chrono::milliseconds min_val(10), max_val(60000);
+	if(interval < min_val || interval > max_val) {
+		return false;
+	}
+	max_interval_ms = std::move(interval);
+	return true;
+}
+
+bool retry_parameters::set_global_timeout_s(std::chrono::seconds timeout) {
+	static constexpr std::chrono::seconds min_val(1), max_val(600);
+	if(timeout < min_val || timeout > max_val) {
+		return false;
+	}
+	global_timeout_s = std::move(timeout);
+	return true;
+}
+
+bool retry_parameters::set_initial_delay_ms(std::chrono::milliseconds delay) {
+	static constexpr std::chrono::milliseconds min_val(0), max_val(60000);
+	if(delay < min_val || delay > max_val) {
+		return false;
+	}
+	initial_delay_ms = std::move(delay);
+	return true;
+}
+
+retry_parameters& retry_parameters::operator=(const retry_parameters& other) noexcept {
+	assert(other.initial_delay_ms < other.global_timeout_s);
+	set_max_retries(other.max_retries);
+	set_max_interval_ms(other.max_interval_ms);
+	set_global_timeout_s(other.global_timeout_s);
+	set_initial_delay_ms(other.initial_delay_ms);
+	return *this;
+}
+
+std::string retry_parameters::to_string() const {
+	std::stringstream ss;
+	ss << "max_retries: " << max_retries << ", "
+	   << "max_interval_ms: " << max_interval_ms.count() << "ms, "
+	   << "global_timeout_s: " << global_timeout_s.count() << "s, "
+	   << "initial_delay_ms: " << initial_delay_ms.count() << "ms";
+	return ss.str();
+}
+
+bool retry_parameters::operator==(const retry_parameters& other) const {
+	return max_retries == other.max_retries && max_interval_ms == other.max_interval_ms &&
+	       global_timeout_s == other.global_timeout_s && initial_delay_ms == other.initial_delay_ms;
+}
+
+bool retry_parameters::operator!=(const retry_parameters& other) const {
+	return !(*this == other);
+}
 
 cri_settings::cri_settings():
         m_cri_unix_socket_paths(),
         m_cri_timeout(1000),
         m_cri_size_timeout(10000),
+        m_cri_retry_parameters(),
         m_cri_runtime_type(CT_CRI),
         m_cri_extra_queries(true) {}
 
@@ -37,6 +104,11 @@ cri_settings& cri_settings::get() {
 		s_instance = std::make_unique<cri_settings>();
 	}
 	return *s_instance;
+}
+
+bool cri_settings::set_cri_retry_parameters(const retry_parameters& v) {
+	get().m_cri_retry_parameters = v;
+	return v == get().m_cri_retry_parameters;
 }
 
 }  // namespace cri

--- a/userspace/libsinsp/cri_settings.h
+++ b/userspace/libsinsp/cri_settings.h
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <libsinsp/container_info.h>
+
+#include <chrono>
+#include <string>
+
+namespace libsinsp {
+namespace cri {
+
+using namespace std::chrono_literals;
+
+/**
+ * Store the parameters for retrying CRI API calls.
+ * The retry behavior is exponential backoff with an initial interval of 250ms
+ * and an exponential factor of 2.
+ */
+struct retry_parameters {
+	// The maximum number of retries for CRI API calls used to get container
+	// metadata.
+	int16_t max_retries = 7;
+	// The maximum interval between retries in milliseconds used to cap the
+	// exponential backoff.
+	std::chrono::milliseconds max_interval_ms = 2s;
+	// The maximum time to wait for a successful lookup in milliseconds,
+	// regardless of the number of retries.
+	std::chrono::seconds global_timeout_s = 30s;
+	// The initial delay in milliseconds before the first attempt.
+	std::chrono::milliseconds initial_delay_ms = 0ms;
+	// Setters applying the values only if they are within the allowed range
+	bool set_max_retries(int16_t retries);
+	bool set_max_interval_ms(std::chrono::milliseconds interval);
+	bool set_global_timeout_s(std::chrono::seconds timeout);
+	bool set_initial_delay_ms(std::chrono::milliseconds delay);
+	// Move assignement operator that checks the values are within the allowed range
+	retry_parameters &operator=(const retry_parameters &other) noexcept;
+	// Basic operators
+	std::string to_string() const;
+	bool operator==(const retry_parameters &other) const;
+	bool operator!=(const retry_parameters &other) const;
+};
+
+class cri_settings {
+public:
+	cri_settings();
+	~cri_settings();
+	static cri_settings &get();
+
+	static const std::vector<std::string> &get_cri_unix_socket_paths() {
+		return get().m_cri_unix_socket_paths;
+	}
+
+	static void set_cri_unix_socket_paths(const std::vector<std::string> &v) {
+		get().m_cri_unix_socket_paths = v;
+	}
+
+	static const int64_t &get_cri_timeout() { return get().m_cri_timeout; }
+
+	static void set_cri_timeout(const int64_t &v) { get().m_cri_timeout = v; }
+
+	static const int64_t &get_cri_size_timeout() { return get().m_cri_size_timeout; }
+
+	static void set_cri_size_timeout(const int64_t &v) { get().m_cri_size_timeout = v; }
+
+	/**
+	 * Get the retry parameters for CRI API calls used to fetch the container
+	 * metadata.
+	 *
+	 * @return the maximum number of retries
+	 */
+	static const retry_parameters &get_cri_retry_parameters() {
+		return get().m_cri_retry_parameters;
+	}
+
+	/**
+	 * Set the retry parameters for CRI API calls used to fetch the container
+	 * metadata.
+	 *
+	 * @param v the retry parameters used to determine the retry behavior.
+	 * @return true if the parameters were set without changes, false if the
+	 * values were out of range and were adjusted.
+	 */
+	static bool set_cri_retry_parameters(const retry_parameters &v);
+
+	static const sinsp_container_type &get_cri_runtime_type() { return get().m_cri_runtime_type; }
+
+	static void set_cri_runtime_type(const sinsp_container_type &v) {
+		get().m_cri_runtime_type = v;
+	}
+
+	static const bool &get_cri_extra_queries() { return get().m_cri_extra_queries; }
+
+	static void set_cri_extra_queries(const bool &v) { get().m_cri_extra_queries = v; }
+
+	static void add_cri_unix_socket_path(const std::string &v) {
+		get().m_cri_unix_socket_paths.emplace_back(v);
+	}
+
+	static void clear_cri_unix_socket_paths() { get().m_cri_unix_socket_paths.clear(); }
+
+private:
+	static std::unique_ptr<cri_settings> s_instance;
+
+	cri_settings(const cri_settings &) = delete;
+	cri_settings &operator=(const cri_settings &) = delete;
+
+	std::vector<std::string> m_cri_unix_socket_paths;
+	int64_t m_cri_timeout;
+	int64_t m_cri_size_timeout;
+	retry_parameters m_cri_retry_parameters;
+	sinsp_container_type m_cri_runtime_type;
+	bool m_cri_extra_queries;
+};
+
+}  // namespace cri
+}  // namespace libsinsp

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1437,6 +1437,10 @@ void sinsp::set_cri_timeout(int64_t timeout_ms) {
 	m_container_manager.set_cri_timeout(timeout_ms);
 }
 
+void sinsp::set_cri_retry_parameters(const ::libsinsp::cri::retry_parameters& retry_params) {
+	m_container_manager.set_cri_retry_parameters(retry_params);
+}
+
 void sinsp::set_cri_async(bool async) {
 	m_container_manager.set_cri_async(async);
 }

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -46,6 +46,7 @@ limitations under the License.
 
 #include <libsinsp/capture_stats_source.h>
 #include <libsinsp/container.h>
+#include <libsinsp/cri_settings.h>
 #include <libsinsp/dumper.h>
 #include <libsinsp/event.h>
 #include <libsinsp/fdinfo.h>
@@ -875,6 +876,7 @@ public:
 	*/
 	void add_cri_socket_path(const std::string& path);
 	void set_cri_timeout(int64_t timeout_ms);
+	void set_cri_retry_parameters(const ::libsinsp::cri::retry_parameters& retry_parameters);
 	void set_cri_async(bool async);
 
 	void set_container_labels_max_len(uint32_t max_label_len);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Make the CRI retry lookup configurable.
- maximum elapsed time
- number of retries
- maximum retry interval
- initial delay before the first attempt
We observed that in some environments, it may take seconds from the time a new container is detected to when it gets exposed from CRI.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
