### PR TITLE
chore(libsinsp): remove unused plugin table API functions

### DIFF
--- a/userspace/libsinsp/plugin_table_api.cpp
+++ b/userspace/libsinsp/plugin_table_api.cpp
@@ -76,22 +76,6 @@ static inline void convert_types(const From& from, To& to) {
 	to = from;
 }
 
-// special cases for strings
-template<>
-inline void convert_types(const std::string& from, const char*& to) {
-	to = from.c_str();
-}
-
-template<>
-inline void convert_types(libsinsp::state::base_table* const& from, ss_plugin_table_t*& to) {
-	to = static_cast<ss_plugin_table_t*>(from);
-}
-
-template<>
-inline void convert_types(ss_plugin_table_t* const& from, libsinsp::state::base_table*& to) {
-	to = static_cast<libsinsp::state::base_table*>(from);
-}
-
 static void noop_release_table_entry(ss_plugin_table_t*, ss_plugin_table_entry_t*) {}
 
 static ss_plugin_bool noop_iterate_entries(ss_plugin_table_t*,

--- a/userspace/libsinsp/state/table.cpp
+++ b/userspace/libsinsp/state/table.cpp
@@ -76,17 +76,6 @@ static inline void convert_types(const From& from, To& to) {
 	to = from;
 }
 
-// special cases for strings
-template<>
-inline void convert_types(const std::string& from, const char*& to) {
-	to = from.c_str();
-}
-
-template<>
-inline void convert_types(libsinsp::state::base_table* const& from, ss_plugin_table_t*& to) {
-	to = static_cast<ss_plugin_table_t*>(from);
-}
-
 template<>
 inline void convert_types(ss_plugin_table_t* const& from, libsinsp::state::base_table*& to) {
 	to = static_cast<libsinsp::state::base_table*>(from);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Clean up unused functions from the table API. Fixes some build warnings.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
