### PR TITLE
fix(scap): remove a static global from event converter

### DIFF
--- a/userspace/libscap/engine/savefile/converter/converter.h
+++ b/userspace/libscap/engine/savefile/converter/converter.h
@@ -29,13 +29,19 @@ typedef struct ppm_evt_hdr scap_evt;
 // 50 consecutive conversions on the same event should be more than enough
 #define MAX_CONVERSION_BOUNDARY 50
 
-conversion_result scap_convert_event(scap_evt* new_evt, scap_evt* evt_to_convert, char* error);
+struct scap_convert_buffer;
+
+struct scap_convert_buffer* scap_convert_alloc_buffer();
+conversion_result scap_convert_event(struct scap_convert_buffer* buf,
+                                     scap_evt* new_evt,
+                                     scap_evt* evt_to_convert,
+                                     char* error);
+void scap_convert_free_buffer(struct scap_convert_buffer* buf);
 
 bool is_conversion_needed(scap_evt* evt_to_convert);
 
 // Only for testing purposes
-scap_evt* scap_retrieve_evt_from_converter_storage(uint64_t tid);
-void scap_clear_converter_storage();
+scap_evt* scap_retrieve_evt_from_converter_storage(struct scap_convert_buffer* buf, uint64_t tid);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/engine/savefile/savefile.h
+++ b/userspace/libscap/engine/savefile/savefile.h
@@ -113,4 +113,5 @@ struct savefile_engine {
 	// Used by the scap-file converter
 	char* m_new_evt;
 	char* m_to_convert_evt;
+	struct scap_convert_buffer* m_converter_buf;
 };

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -2053,7 +2053,8 @@ static int32_t next(struct scap_engine_handle engine,
 	    conv_num++) {
 		// Before each conversion we move the current event into the storage
 		memcpy(handle->m_to_convert_evt, *pevent, (*pevent)->len);
-		conv_res = scap_convert_event((scap_evt *)handle->m_new_evt,
+		conv_res = scap_convert_event(handle->m_converter_buf,
+		                              (scap_evt *)handle->m_new_evt,
 		                              (scap_evt *)handle->m_to_convert_evt,
 		                              handle->m_lasterr);
 		// At the end of the conversion in any case we swith to the new event pointer
@@ -2239,6 +2240,14 @@ static int32_t init(struct scap *main_handle, struct scap_open_args *oargs) {
 		}
 	}
 
+	handle->m_converter_buf = scap_convert_alloc_buffer();
+	if(!handle->m_converter_buf) {
+		snprintf(main_handle->m_lasterr,
+		         SCAP_LASTERR_SIZE,
+		         "error allocating the conversion buffer");
+		return SCAP_FAILURE;
+	}
+
 	return SCAP_SUCCESS;
 }
 
@@ -2266,6 +2275,11 @@ static int32_t scap_savefile_close(struct scap_engine_handle engine) {
 	if(handle->m_to_convert_evt) {
 		free(handle->m_to_convert_evt);
 		handle->m_to_convert_evt = NULL;
+	}
+
+	if(handle->m_converter_buf) {
+		scap_convert_free_buffer(handle->m_converter_buf);
+		handle->m_converter_buf = NULL;
 	}
 
 	return SCAP_SUCCESS;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The scap event converter uses a static global buffer to hold the previous events. This breaks when reading scap files in parallel from multiple sinsps.

As we expose a C API and the storage is a C++ map, we need to provide alloc/free functions as well (and remove `scap_clear_converter_storage` as it's no longer needed).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
