### PR TITLE
fix(build): make pkgconfig work again

### DIFF
--- a/cmake/modules/BuildPkgConfigDependencies.cmake
+++ b/cmake/modules/BuildPkgConfigDependencies.cmake
@@ -34,7 +34,7 @@ function(add_pkgconfig_library LIBDIRS_VAR LIBS_VAR lib ignored)
 					TARGET ${dep}
 					PROPERTY TYPE
 				)
-				if(${dep_target_type} STREQUAL "STATIC_LIBRARY")
+				if(NOT ${dep_target_type} STREQUAL "SHARED_LIBRARY")
 					continue()
 				endif()
 			else()
@@ -52,6 +52,27 @@ function(add_pkgconfig_library LIBDIRS_VAR LIBS_VAR lib ignored)
 			if(NOT TARGET ${dep})
 				get_filename_component(filename ${dep} NAME)
 				set(dep "\${libdir}/${LIBS_PACKAGE_NAME}/${filename}")
+			else()
+				get_property(
+					dep_target_type
+					TARGET ${dep}
+					PROPERTY TYPE
+				)
+				if(${dep_target_type} STREQUAL "OBJECT_LIBRARY")
+					# skip object libraries
+					continue()
+				endif()
+
+				# if the library is imported, use the IMPORTED_LOCATION instead
+				get_property(
+					dep_imported_location
+					TARGET ${dep}
+					PROPERTY IMPORTED_LOCATION
+				)
+				if(NOT ${dep_imported_location} STREQUAL "")
+					get_filename_component(filename ${dep_imported_location} NAME)
+					set(dep "\${libdir}/${LIBS_PACKAGE_NAME}/${filename}")
+				endif()
 			endif()
 		endif()
 

--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -23,7 +23,7 @@ elseif(NOT USE_BUNDLED_LIBBPF)
 	find_path(LIBBPF_INCLUDE bpf/libbpf.h)
 	find_library(LIBBPF_LIB NAMES bpf)
 	if(LIBBPF_INCLUDE AND LIBBPF_LIB)
-		add_library(lbpf STATIC IMPORTED)
+		add_library(lbpf STATIC IMPORTED GLOBAL)
 		set_target_properties(lbpf PROPERTIES IMPORTED_LOCATION ${LIBBPF_LIB})
 		target_include_directories(lbpf INTERFACE $<BUILD_INTERFACE:${LIBBPF_INCLUDE}>)
 		target_link_libraries(lbpf INTERFACE elf ${ZLIB_LIB})
@@ -64,7 +64,7 @@ else()
 		BUILD_BYPRODUCTS ${LIBBPF_LIB}
 	)
 
-	add_library(lbpf STATIC IMPORTED)
+	add_library(lbpf STATIC IMPORTED GLOBAL)
 	set_target_properties(lbpf PROPERTIES IMPORTED_LOCATION ${LIBBPF_LIB})
 	file(MAKE_DIRECTORY ${LIBBPF_INCLUDE}) # necessary to make target_include_directories() work
 	target_include_directories(lbpf INTERFACE $<BUILD_INTERFACE:${LIBBPF_INCLUDE}>)

--- a/cmake/modules/libelf.cmake
+++ b/cmake/modules/libelf.cmake
@@ -54,9 +54,9 @@ elseif(NOT USE_BUNDLED_LIBELF)
 	endif()
 
 	if(BUILD_SHARED_LIBS OR USE_SHARED_LIBELF)
-		add_library(elf SHARED IMPORTED)
+		add_library(elf SHARED IMPORTED GLOBAL)
 	else()
-		add_library(elf STATIC IMPORTED)
+		add_library(elf STATIC IMPORTED GLOBAL)
 	endif()
 
 	set_target_properties(elf PROPERTIES IMPORTED_LOCATION ${LIBELF_LIB})

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -275,7 +275,7 @@ if(NOT WIN32)
 				container_engine/containerd containerd_interface containers images descriptor
 			)
 
-			target_link_libraries(sinsp PRIVATE cri_v1alpha2 cri_v1 containerd_interface)
+			target_link_libraries(sinsp PUBLIC cri_v1alpha2 cri_v1 containerd_interface)
 
 			if(NOT MUSL_OPTIMIZED_BUILD)
 				find_library(LIB_ANL anl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Changes to libbpf/libelf builds broke pkgconfig again. In particular:
* we were trying to link to object libraries in pkgconfig, which can't really work (they're only libraries as far as cmake is concerned)
* IMPORTED targets are private by default, so we couldn't inspect them and replace with the actual library location

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

1. ~Shared builds are still broken for me (even without pkgconfig, sinsp unit tests fail to link due to missing grpc dependency). I'll either update this PR or send another one once I fix that.~ UPDATE: fixed
2. The zoo of STATIC libraries I made a while back should probably be converted into object libraries instead (we don't really need the tons of tiny .a files). I'll get around to it, eventually :)

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
