### PR TITLE
chore(ci): bump actions/cache version to latest.

### DIFF
--- a/.github/actions/install-zig/action.yml
+++ b/.github/actions/install-zig/action.yml
@@ -18,7 +18,7 @@ runs:
     # We cache it to keep it alive.
     - name: Download zig (cached)
       id: cache-zig
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: zig
         key: zig-${{ runner.os }}-${{ runner.arch }}-${{ steps.store.outputs.zig_version }}

--- a/.github/actions/install-zig/action.yml
+++ b/.github/actions/install-zig/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       id: store
       env:
-        ZIG_VERSION: '0.14.0-dev.2591+5333d2443'
+        ZIG_VERSION: '0.14.0-dev.3188+34644511b'
       run: |
         echo "zig_version=${ZIG_VERSION}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We were using a deprecated (and retired) github actions/cache version. Use the newest one. 
This should fix zig related CI.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
