### PR TITLE
fix(userspace/libsinsp): allow plugin filterchecks args to be both index or key

### DIFF
--- a/userspace/libsinsp/plugin_filtercheck.h
+++ b/userspace/libsinsp/plugin_filtercheck.h
@@ -66,7 +66,7 @@ private:
 	// format is valid, otherwise it throws an exception.
 	// `full_field_name` has the format "field[argument]" and it is necessary
 	// to throw an exception.
-	void extract_arg_index(std::string_view full_field_name);
+	void extract_arg_index(std::string_view full_field_name, bool required);
 
 	// extract_arg_key() extracts a valid string from the argument. If we pass
 	// a numeric argument, it will be converted to string.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Plugin filterchecks support having an arg that is either index or key, but not both together; that's because we try to parse the `[%arg]` as index first, and if we are not able to, we throw an exception without further checking if we need to try to parse the arg as string key too.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): allow plugin filterchecks args to be both index or key
```
