### PR TITLE
fix(driver/bpf): fixed small verifier bug in old bpf probe.

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -4614,11 +4614,11 @@ FILLER(sys_sendmmsg_x_failure, true) {
 	CHECK_RES(res);
 
 	/* Parameter 3: size (type: PT_UINT32) */
-	bpf_push_u32_to_ring(data, 0);
+	res = bpf_push_u32_to_ring(data, 0);
 	CHECK_RES(res);
 
 	/* Parameter 4: data (type: PT_BYTEBUF) */
-	bpf_push_empty_param(data);
+	res = bpf_push_empty_param(data);
 	CHECK_RES(res);
 
 	/* Parameter 5: tuple (type: PT_SOCKTUPLE) */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

On my machine, the currect bpf probe code caused a verifier bug:
```
639: (85) call bpf_perf_event_output#25
R5 min value is negative, either use unsigned or 'var &= const'
processed 603 insns (limit 1000000) max_states_per_insn 0 total_states 13 peak_states 13 mark_read 7

-- END PROG LOAD LOG --
terminate called after throwing an instance of 'scap_open_exception'
  what():  libscap: bpf_load_program() event=raw_tracepoint/filler/sys_sendmmsg_x_failure: Operation not permitted
Annullato
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver/bpf): fixed small verifier bug in old bpf probe.
```
