### PR TITLE
fix(userspace/libpman): fix modern ebpf failures in master kernel-testing

### DIFF
--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -42,7 +42,8 @@ int pman_prepare_progs_before_loading() {
 			bool should_disable = chosen_idx != -1;
 			if(!should_disable) {
 				if(progs[idx].feat > 0 &&
-				   libbpf_probe_bpf_helper(BPF_PROG_TYPE_TRACING, progs[idx].feat, NULL) == 0) {
+				   libbpf_probe_bpf_helper(BPF_PROG_TYPE_RAW_TRACEPOINT, progs[idx].feat, NULL) ==
+				           0) {
 					snprintf(msg,
 					         MAX_ERROR_MESSAGE_LEN,
 					         "BPF program '%s' did not satisfy required feature [%d]",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-modern-bpf
/area libpman

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Master kernel-testing did break on multiple modern ebpf kernels since #2255. See the comment on that PR: https://github.com/falcosecurity/libs/pull/2255#issuecomment-2609374353
Checking the edits on that comment, it seems like the culprit commit is https://github.com/falcosecurity/libs/pull/2255/commits/3e0e122497898d9e72cb00c2de3941443ca9d957.

Here the issue i think lies in the usage of `BPF_PROG_TYPE_TRACING`; indeed in `pman_check_support` we have a fallback for it:
```C
        res = libbpf_probe_bpf_prog_type(BPF_PROG_TYPE_TRACING, NULL) > 0;
	if(!res) {
		// The above function checks for the `BPF_TRACE_FENTRY` attach type presence, while we need
		// to check for the `BPF_TRACE_RAW_TP` one. If `BPF_TRACE_FENTRY` is defined we are
		// sure `BPF_TRACE_RAW_TP` is defined as well, in all other cases, we need to search
		// for it in the `vmlinux` file.
		res = probe_BPF_TRACE_RAW_TP_type();
		if(!res) {
			// Clear the errno for `pman_print_error`
			errno = 0;
			pman_print_error("prog 'BPF_TRACE_RAW_TP' is not supported");
			return res;
		}
	}
```

I think that what's happening is that the check:
```C
libbpf_probe_bpf_helper(BPF_PROG_TYPE_TRACING, progs[idx].feat, NULL) == 0)
```
in lifecycle.c is failing because it cannot find `BPF_PROG_TYPE_TRACING` (and we don't have any fallback in that case).
Since it works fine too using `BPF_PROG_TYPE_RAW_TRACEPOINT`, revert to use it instead.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
