### PR TITLE
new(driver): add sanity check for kmod and ebpf configure systems

### DIFF
--- a/driver/bpf/configure/0__SANITY/test.c
+++ b/driver/bpf/configure/0__SANITY/test.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+
+Copyright (C) 2024 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+/*
+ * Check that the build system is sane.
+ */
+
+#include "../../quirks.h"
+#include "../../ppm_events_public.h"
+#include "../../types.h"
+
+BPF_PROBE("sanity/", sanity, sanity_args) {
+	return 0;
+}
+
+char __license[] __bpf_section("license") = "Dual MIT/GPL";

--- a/driver/bpf/configure/Makefile.inc.in
+++ b/driver/bpf/configure/Makefile.inc.in
@@ -12,3 +12,12 @@ HAS_@CONFIGURE_MODULE@_OUT := $(subst @@NEWLINE@@,$(newline),$(HAS_@CONFIGURE_MO
 $(info [configure-bpf] Build output for HAS_@CONFIGURE_MODULE@:)
 $(info [configure-bpf] $(HAS_@CONFIGURE_MODULE@_OUT))
 endif
+
+ifeq ('@CONFIGURE_MODULE@','0__SANITY')
+    ifeq ($(HAS_@CONFIGURE_MODULE@),0)
+        $(info [configure-bpf] Build system is sane)
+    else
+        $(info [configure-bpf] Build system is broken, please see above errors)
+        $(error The build system is broken, please see above errors)
+    endif
+endif

--- a/driver/bpf/configure/Makefile.inc.in
+++ b/driver/bpf/configure/Makefile.inc.in
@@ -7,7 +7,8 @@ ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure-bpf] Setting HAS_@CONFIGURE_MODULE@ flag)
 KBUILD_CPPFLAGS += -DHAS_@CONFIGURE_MODULE@
 else
-HAS_@CONFIGURE_MODULE@_OUT := $(shell cat $(MODULE_MAKEFILE_DIR)/build.log)
+HAS_@CONFIGURE_MODULE@_OUT1 := $(shell cat $(MODULE_MAKEFILE_DIR)/build.log | sed -n ':a;N;$$$!ba;s/\n/@@NEWLINE@@/g;P')
+HAS_@CONFIGURE_MODULE@_OUT := $(subst @@NEWLINE@@,$(newline),$(HAS_@CONFIGURE_MODULE@_OUT1))
 $(info [configure-bpf] Build output for HAS_@CONFIGURE_MODULE@:)
 $(info [configure-bpf] $(HAS_@CONFIGURE_MODULE@_OUT))
 endif

--- a/driver/configure/0__SANITY/test.c
+++ b/driver/configure/0__SANITY/test.c
@@ -1,0 +1,26 @@
+/*
+
+Copyright (C) 2023 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+/*
+ * Check that the build environment is sane
+ */
+
+#include <linux/module.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("the Falco authors");
+
+static int empty_init(void) {
+	return 0;
+}
+
+static void empty_exit(void) {}
+
+module_init(empty_init);
+module_exit(empty_exit);

--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -14,3 +14,12 @@ HAS_@CONFIGURE_MODULE@_OUT := $(subst @@NEWLINE@@,$(newline),$(HAS_@CONFIGURE_MO
 $(info [configure-kmod] Build output for HAS_@CONFIGURE_MODULE@:)
 $(info [configure-kmod] $(HAS_@CONFIGURE_MODULE@_OUT))
 endif
+
+ifeq ('@CONFIGURE_MODULE@','0__SANITY')
+    ifeq ($(HAS_@CONFIGURE_MODULE@),0)
+        $(info [configure-kmod] Build system is sane)
+    else
+        $(info [configure-kmod] Build system is broken, please see above errors)
+        $(error The build system is broken, please see above errors)
+    endif
+endif

--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -9,7 +9,8 @@ ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure-kmod] Setting HAS_@CONFIGURE_MODULE@ flag)
 ccflags-y += -DHAS_@CONFIGURE_MODULE@
 else
-HAS_@CONFIGURE_MODULE@_OUT := $(shell cat $(MODULE_MAKEFILE_DIR)/build.log)
+HAS_@CONFIGURE_MODULE@_OUT1 := $(shell cat $(MODULE_MAKEFILE_DIR)/build.log | sed -n ':a;N;$$$!ba;s/\n/@@NEWLINE@@/g;P')
+HAS_@CONFIGURE_MODULE@_OUT := $(subst @@NEWLINE@@,$(newline),$(HAS_@CONFIGURE_MODULE@_OUT1))
 $(info [configure-kmod] Build output for HAS_@CONFIGURE_MODULE@:)
 $(info [configure-kmod] $(HAS_@CONFIGURE_MODULE@_OUT))
 endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Both kmod and legacy eBPF have a configure system to evaluate whether the kernel enables certain features introduced by a certain kernel release, mainly to catch RedHat backporting cutting edge features on “their stable” kernels.

The approach consists in trying to build a stub module and if it goes through, claim the feature is supported. However, the build might fail for completely unrelated reasons, leading to a wrong assumption which will then cause the actual build to fail with cryptic compile errors.

This PR introduces a one-code-fits-all configure check named __SANITY which does essentially nothing and is therefore guaranteed to compile on every kernel, provided the build environment is sane. When this check fails, we let the whole build fail fast.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
