### PR TITLE
fix(sinsp): ensure on_accept observer always gets a valid fdinfo

### DIFF
--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -74,7 +74,7 @@ inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd) 
 
 inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::add_ref(
         int64_t fd,
-        std::unique_ptr<sinsp_fdinfo> fdinfo) {
+        std::shared_ptr<sinsp_fdinfo>&& fdinfo) {
 	if(fdinfo->dynamic_fields() != dynamic_fields()) {
 		throw sinsp_exception("adding entry with incompatible dynamic defs to fd table");
 	}
@@ -207,7 +207,7 @@ sinsp_fdinfo* sinsp_fdtable::find(int64_t fd) {
 	return find_ref(fd).get();
 }
 
-sinsp_fdinfo* sinsp_fdtable::add(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo) {
+sinsp_fdinfo* sinsp_fdtable::add(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo) {
 	return add_ref(fd, std::move(fdinfo)).get();
 }
 

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -38,7 +38,7 @@ public:
 
 	sinsp_fdinfo* find(int64_t fd);
 
-	sinsp_fdinfo* add(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
+	sinsp_fdinfo* add(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 
 	inline bool const_loop(const fdtable_const_visitor_t callback) const {
 		for(auto it = m_table.begin(); it != m_table.end(); ++it) {
@@ -119,5 +119,6 @@ private:
 
 	inline void lookup_device(sinsp_fdinfo& fdi) const;
 	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd);
-	const std::shared_ptr<sinsp_fdinfo>& add_ref(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
+	const std::shared_ptr<sinsp_fdinfo>& add_ref(int64_t fd,
+	                                             std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 };

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3127,9 +3127,14 @@ void sinsp_parser::parse_accept_exit(sinsp_evt *evt) {
 	// If there's a listener, add a callback to later invoke it.
 	//
 	if(get_observer()) {
-		m_post_process_cbs.emplace([fd, packed_data](sinsp_observer *observer, sinsp_evt *evt) {
-			observer->on_accept(evt, fd, packed_data, evt->get_fd_info());
-		});
+		m_post_process_cbs.emplace(
+		        [fd, packed_data, fdi](sinsp_observer *observer, sinsp_evt *evt) {
+			        auto fd_info = evt->get_fd_info();
+			        if(fd_info == nullptr) {
+				        fd_info = fdi.get();
+			        }
+			        observer->on_accept(evt, fd, packed_data, fd_info);
+		        });
 	}
 
 	//

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3088,7 +3088,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt *evt) {
 	//
 	// Populate the fd info class
 	//
-	auto fdi = m_fdinfo_factory.create();
+	std::shared_ptr fdi = m_fdinfo_factory.create();
 	if(*packed_data == PPM_AF_INET) {
 		set_ipv4_addresses_and_ports(fdi.get(), packed_data);
 		fdi->m_type = SCAP_FD_IPV4_SOCK;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -790,7 +790,7 @@ sinsp_threadinfo* sinsp_threadinfo::get_ancestor_process(uint32_t n) {
 	return mt;
 }
 
-sinsp_fdinfo* sinsp_threadinfo::add_fd(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo) {
+sinsp_fdinfo* sinsp_threadinfo::add_fd(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo) {
 	sinsp_fdtable* fd_table_ptr = get_fd_table();
 	if(fd_table_ptr == NULL) {
 		return NULL;

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -522,7 +522,7 @@ public:
 	// return true if, based on the current inspector filter, this thread should be kept
 	void init(scap_threadinfo* pi);
 	void fix_sockets_coming_from_proc();
-	sinsp_fdinfo* add_fd(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinfo);
+	sinsp_fdinfo* add_fd(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 	void add_fd_from_scap(scap_fdinfo* fdinfo);
 	void remove_fd(int64_t fd);
 	void update_cwd(std::string_view cwd);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

    When the fd table is full, evt->get_fd_info is reset to NULL, which
    causes a crash when the observer accesses the fdinfo. Revert to
    the previous behavior, where we always called the observer with
    a valid fdinfo, even if the fd got later dropped.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
