### PR TITLE
feat(sinsp-example): Add throughput profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           cd userspace/libsinsp/examples
           export PKG_CONFIG_PATH=/tmp/libs-test/lib/pkgconfig
-          g++ -o sinsp-example test.cpp util.cpp cpu_usage.cpp $(pkg-config --cflags --libs libsinsp)
+          g++ -o sinsp-example *.cpp $(pkg-config --cflags --libs libsinsp)
 
       - name: Test sinsp-example runtime linker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           cd userspace/libsinsp/examples
           export PKG_CONFIG_PATH=/tmp/libs-test/lib/pkgconfig
-          g++ -o sinsp-example test.cpp util.cpp $(pkg-config --cflags --libs libsinsp)
+          g++ -o sinsp-example test.cpp util.cpp cpu_usage.cpp $(pkg-config --cflags --libs libsinsp)
 
       - name: Test sinsp-example runtime linker
         run: |

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 include(jsoncpp)
 
-add_executable(sinsp-example util.cpp test.cpp)
+add_executable(sinsp-example util.cpp test.cpp cpu_usage.cpp)
 
 target_link_libraries(sinsp-example sinsp "${JSONCPP_LIB}")
 

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -15,7 +15,13 @@
 
 include(jsoncpp)
 
-add_executable(sinsp-example util.cpp test.cpp cpu_usage.cpp)
+set(sources util.cpp test.cpp)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	set(sources ${sources} cpu_usage.cpp)
+endif()
+
+add_executable(sinsp-example ${sources})
 
 target_link_libraries(sinsp-example sinsp "${JSONCPP_LIB}")
 

--- a/userspace/libsinsp/examples/cpu_usage.cpp
+++ b/userspace/libsinsp/examples/cpu_usage.cpp
@@ -11,9 +11,7 @@
 #include <unistd.h>
 
 // Utility function to calculate CPU usage
-int get_cpu_usage_percent()
-{
-
+int get_cpu_usage_percent() {
 	constexpr uint64_t USECS_PER_SEC = 1000L * 1000;
 	static uint64_t cpu_time_last_run_us = 0;
 	static uint64_t time_last_run_us = 0;
@@ -21,11 +19,12 @@ int get_cpu_usage_percent()
 
 	// Get the current timestamp in usecs
 	auto time_since_epoch = std::chrono::steady_clock::now().time_since_epoch();
-	auto curr_time_us = std::chrono::duration_cast<std::chrono::microseconds>(time_since_epoch).count();
+	auto curr_time_us =
+	        std::chrono::duration_cast<std::chrono::microseconds>(time_since_epoch).count();
 
 	// Get the current thread's CPU times
 	struct rusage usage;
-	if (getrusage(RUSAGE_THREAD, &usage) != 0) {
+	if(getrusage(RUSAGE_THREAD, &usage) != 0) {
 		return -1;
 	}
 
@@ -33,7 +32,7 @@ int get_cpu_usage_percent()
 	uint64_t curr_cpu_time_us = (usage.ru_utime.tv_sec * USECS_PER_SEC + usage.ru_utime.tv_usec) +
 	                            (usage.ru_stime.tv_sec * USECS_PER_SEC + usage.ru_stime.tv_usec);
 
-	if (time_last_run_us != 0) {
+	if(time_last_run_us != 0) {
 		// Calculate the CPU usage percentage since the last iteration
 		uint64_t time_diff_us = (double)(curr_time_us - time_last_run_us);
 		uint64_t cpu_diff_us = (double)(curr_cpu_time_us - cpu_time_last_run_us);

--- a/userspace/libsinsp/examples/cpu_usage.cpp
+++ b/userspace/libsinsp/examples/cpu_usage.cpp
@@ -1,0 +1,46 @@
+#include <thread>
+#include <fstream>
+#include <sstream>
+#include <chrono>
+#include <iostream>
+#include <cstring>
+#include <cstdint>
+
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// Utility function to calculate CPU usage
+int get_cpu_usage_percent()
+{
+
+	constexpr uint64_t USECS_PER_SEC = 1000L * 1000;
+	static uint64_t cpu_time_last_run_us = 0;
+	static uint64_t time_last_run_us = 0;
+	double cpu_usage = 0.0;
+
+	// Get the current timestamp in usecs
+	auto time_since_epoch = std::chrono::steady_clock::now().time_since_epoch();
+	auto curr_time_us = std::chrono::duration_cast<std::chrono::microseconds>(time_since_epoch).count();
+
+	// Get the current thread's CPU times
+	struct rusage usage;
+	if (getrusage(RUSAGE_THREAD, &usage) != 0) {
+		return -1;
+	}
+
+	// Calculate the thread's CPU time (user + system) in usecs
+	uint64_t curr_cpu_time_us = (usage.ru_utime.tv_sec * USECS_PER_SEC + usage.ru_utime.tv_usec) +
+	                            (usage.ru_stime.tv_sec * USECS_PER_SEC + usage.ru_stime.tv_usec);
+
+	if (time_last_run_us != 0) {
+		// Calculate the CPU usage percentage since the last iteration
+		uint64_t time_diff_us = (double)(curr_time_us - time_last_run_us);
+		uint64_t cpu_diff_us = (double)(curr_cpu_time_us - cpu_time_last_run_us);
+		cpu_usage = ((double)cpu_diff_us * 100.0) / time_diff_us;
+	}
+
+	cpu_time_last_run_us = curr_cpu_time_us;
+	time_last_run_us = curr_time_us;
+	return cpu_usage;
+}

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -42,6 +42,9 @@ extern "C" {
 
 using namespace std;
 
+// Utility function to calculate CPU usage
+int get_cpu_usage_percent();
+
 // Functions used for dumping to stdout
 void raw_dump(sinsp&, sinsp_evt* ev);
 void formatted_dump(sinsp&, sinsp_evt* ev);
@@ -55,6 +58,7 @@ static bool ppm_sc_modifies_state = false;
 static bool ppm_sc_repair_state = false;
 static bool ppm_sc_state_remove_io_sc = false;
 static bool enable_glogger = false;
+static bool perftest = false;
 static string engine_string;
 static string filter_string = "";
 static string file_path = "";
@@ -123,6 +127,7 @@ Options:
   -q, --remove-io-sc-state                   Remove ppm sc codes belonging to `io_sc_set` from `sinsp_state_sc_set` sinsp state enforcement, defaults to false and only applies when choosing `-z` option, used for e2e testing of sinsp state.
   -g, --enable-glogger                       Enable libs g_logger, set to SEV_DEBUG. For a different severity adjust the test binary source and re-compile.
   -r, --raw                                  raw event ouput
+  -t, --perftest                             Run in performance test mode
 )";
 	cout << usage << endl;
 }
@@ -158,6 +163,7 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 	                                       {"enable-glogger", no_argument, 0, 'g'},
 	                                       {"raw", no_argument, 0, 'r'},
 	                                       {"gvisor", optional_argument, 0, 'G'},
+										   {"perftest", no_argument, 0, 't'},
 	                                       {0, 0, 0, 0}};
 
 	bool format_set = false;
@@ -165,7 +171,7 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 	int long_index = 0;
 	while((op = getopt_long(argc,
 	                        argv,
-	                        "hf:jab:mks:p:d:o:En:zxqgrG::",
+	                        "hf:jab:mks:p:d:o:En:zxqgrtG::",
 	                        long_options,
 	                        &long_index)) != -1) {
 		switch(op) {
@@ -266,6 +272,10 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 			break;
 		case 'r':
 			dump = raw_dump;
+			break;
+		case 't':
+			perftest = true;
+			break;
 		default:
 			break;
 		}
@@ -481,6 +491,7 @@ int main(int argc, char** argv) {
 	open_engine(inspector, events_sc_codes);
 
 	std::cout << "-- Start capture" << std::endl;
+	double max_throughput = 0.0;
 
 	inspector.start_capture();
 
@@ -494,16 +505,36 @@ int main(int argc, char** argv) {
 	        std::make_unique<sinsp_evt_formatter>(&inspector, plugin_output, *filter_list.get());
 
 	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-	uint64_t num_events = 0;
+	uint64_t num_events = 0, last_events = 0;
+	uint64_t last_ts_ns = 0;
+	uint64_t cpu_total = 0;
+	uint64_t num_samples = 0;
 	while(!g_interrupted && num_events < max_events) {
 		sinsp_evt* ev = get_event(inspector, [](const std::string& error_msg) {
 			cout << "[ERROR] " << error_msg << endl;
 		});
 		if(ev != nullptr) {
+			uint64_t ts_ns = ev->get_ts();
 			sinsp_threadinfo* thread = ev->get_thread_info();
-			if(!thread || g_all_threads || thread->is_main_thread()) {
+			++num_events;
+			uint64_t evt_diff = num_events - last_events;
+			if(perftest) {
+				// Perftest mode does not print individual events but instead prints a running throughput every second
+				if(ts_ns - last_ts_ns > 1'000'000'000) {
+					int cpu_usage = get_cpu_usage_percent();
+					cpu_total += cpu_usage;
+					++num_samples;
+					long double curr_throughput = evt_diff / (long double)1000;
+					std::cout << "Events: " << (num_events - last_events) << " Events/ms: " << curr_throughput
+					          << " CPU: " << cpu_usage << "%                      \r" << std::flush;
+					if(curr_throughput > max_throughput) {
+						max_throughput = curr_throughput;
+					}
+					last_ts_ns = ts_ns;
+					last_events = num_events;
+				}
+			} else if(!thread || g_all_threads || thread->is_main_thread()) {
 				dump(inspector, ev);
-				num_events++;
 			}
 		}
 	}
@@ -513,11 +544,17 @@ int main(int argc, char** argv) {
 
 	inspector.stop_capture();
 
-	std::cout << "-- Stop capture" << std::endl;
+	std::cout << "-- Stop capture                                                                    " << std::endl;
 	std::cout << "Retrieved events: " << std::to_string(num_events) << std::endl;
 	std::cout << "Time spent: " << duration << "ms" << std::endl;
 	if(duration > 0) {
 		std::cout << "Events/ms: " << num_events / (long double)duration << std::endl;
+	}
+	if (max_throughput > 0) {
+		std::cout << "Max throughput observed: " << max_throughput << " events / ms" << std::endl;
+	}
+	if (num_samples > 0) {
+		std::cout << "Average CPU usage: " << cpu_total / num_samples << "%" << std::endl;
 	}
 
 	return 0;

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -42,8 +42,10 @@ extern "C" {
 
 using namespace std;
 
+#if __linux__
 // Utility function to calculate CPU usage
 int get_cpu_usage_percent();
+#endif // __linux__
 
 // Functions used for dumping to stdout
 void raw_dump(sinsp&, sinsp_evt* ev);
@@ -519,6 +521,7 @@ int main(int argc, char** argv) {
 			++num_events;
 			uint64_t evt_diff = num_events - last_events;
 			if(perftest) {
+#if __linux__
 				// Perftest mode does not print individual events but instead prints a running throughput every second
 				if(ts_ns - last_ts_ns > 1'000'000'000) {
 					int cpu_usage = get_cpu_usage_percent();
@@ -532,6 +535,18 @@ int main(int argc, char** argv) {
 					}
 					last_ts_ns = ts_ns;
 					last_events = num_events;
+#else  // __linux__
+				if(ts_ns - last_ts_ns > 1'000'000'000) {
+					++num_samples;
+					long double curr_throughput = evt_diff / (long double)1000;
+					std::cout << "Events: " << (num_events - last_events) << " Events/ms: " << curr_throughput
+					          << "                      \r" << std::flush;
+					if(curr_throughput > max_throughput) {
+						max_throughput = curr_throughput;
+					}
+					last_ts_ns = ts_ns;
+					last_events = num_events;
+#endif // __linux__
 				}
 			} else if(!thread || g_all_threads || thread->is_main_thread()) {
 				dump(inspector, ev);

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -45,7 +45,7 @@ using namespace std;
 #if __linux__
 // Utility function to calculate CPU usage
 int get_cpu_usage_percent();
-#endif // __linux__
+#endif  // __linux__
 
 // Functions used for dumping to stdout
 void raw_dump(sinsp&, sinsp_evt* ev);
@@ -165,7 +165,7 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 	                                       {"enable-glogger", no_argument, 0, 'g'},
 	                                       {"raw", no_argument, 0, 'r'},
 	                                       {"gvisor", optional_argument, 0, 'G'},
-										   {"perftest", no_argument, 0, 't'},
+	                                       {"perftest", no_argument, 0, 't'},
 	                                       {0, 0, 0, 0}};
 
 	bool format_set = false;
@@ -522,31 +522,34 @@ int main(int argc, char** argv) {
 			uint64_t evt_diff = num_events - last_events;
 			if(perftest) {
 #if __linux__
-				// Perftest mode does not print individual events but instead prints a running throughput every second
+				// Perftest mode does not print individual events but instead prints a running
+				// throughput every second
 				if(ts_ns - last_ts_ns > 1'000'000'000) {
 					int cpu_usage = get_cpu_usage_percent();
 					cpu_total += cpu_usage;
 					++num_samples;
 					long double curr_throughput = evt_diff / (long double)1000;
-					std::cout << "Events: " << (num_events - last_events) << " Events/ms: " << curr_throughput
-					          << " CPU: " << cpu_usage << "%                      \r" << std::flush;
+					std::cout << "Events: " << (num_events - last_events)
+					          << " Events/ms: " << curr_throughput << " CPU: " << cpu_usage
+					          << "%                      \r" << std::flush;
 					if(curr_throughput > max_throughput) {
 						max_throughput = curr_throughput;
 					}
 					last_ts_ns = ts_ns;
 					last_events = num_events;
-#else  // __linux__
+#else   // __linux__
 				if(ts_ns - last_ts_ns > 1'000'000'000) {
 					++num_samples;
 					long double curr_throughput = evt_diff / (long double)1000;
-					std::cout << "Events: " << (num_events - last_events) << " Events/ms: " << curr_throughput
-					          << "                      \r" << std::flush;
+					std::cout << "Events: " << (num_events - last_events)
+					          << " Events/ms: " << curr_throughput << "                      \r"
+					          << std::flush;
 					if(curr_throughput > max_throughput) {
 						max_throughput = curr_throughput;
 					}
 					last_ts_ns = ts_ns;
 					last_events = num_events;
-#endif // __linux__
+#endif  // __linux__
 				}
 			} else if(!thread || g_all_threads || thread->is_main_thread()) {
 				dump(inspector, ev);
@@ -559,16 +562,18 @@ int main(int argc, char** argv) {
 
 	inspector.stop_capture();
 
-	std::cout << "-- Stop capture                                                                    " << std::endl;
+	std::cout
+	        << "-- Stop capture                                                                    "
+	        << std::endl;
 	std::cout << "Retrieved events: " << std::to_string(num_events) << std::endl;
 	std::cout << "Time spent: " << duration << "ms" << std::endl;
 	if(duration > 0) {
 		std::cout << "Events/ms: " << num_events / (long double)duration << std::endl;
 	}
-	if (max_throughput > 0) {
+	if(max_throughput > 0) {
 		std::cout << "Max throughput observed: " << max_throughput << " events / ms" << std::endl;
 	}
-	if (num_samples > 0) {
+	if(num_samples > 0) {
 		std::cout << "Average CPU usage: " << cpu_total / num_samples << "%" << std::endl;
 	}
 


### PR DESCRIPTION
/kind feature
/area libsinsp

This PR introduces a new mode into `sinsp-example` which will allow the profiling of event processing throughput. 

I believe this change will be useful to libs developers, as it provides a simple way to benchmark performance-related changes. A goal of this change is to be as non-intrusive as possible while still providing valuable running information on the performance of the system. 

### Sample output

**While running**
```
Events: 80336 Events/ms: 80.336 CPU: 8%  
```

**At the end of the run**
```
Retrieved events: 3943497
Time spent: 35955ms
Events/ms: 109.679
Max throughput observed: 472.409 events / ms
Average CPU usage: 11%
```

```release-note
NONE
```

Signed-off-by: Nathan Baker <nathan.baker@sysdig.com>
