### PR TITLE
refactor(libsinsp): export static fields via static methods in `threadinfo` and `fdinfo`

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -124,6 +124,8 @@ sinsp_fdinfo::sinsp_fdinfo(
         table_entry(dyn_fields) {}
 
 libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const {
+	using self = sinsp_fdinfo;
+
 	libsinsp::state::static_struct::field_infos ret;
 
 	// the m_type is weird because it's a C-defined non-scoped enum, meaning that it
@@ -134,73 +136,71 @@ libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const 
 	// of the targeted architecture
 	auto is_big_endian = htonl(12) == 12;  // the chosen number does not matter
 	size_t type_byte_offset = is_big_endian ? (sizeof(scap_fd_type) - 1) : 0;
-	define_static_field(ret, this, ((uint8_t*)(&m_type))[type_byte_offset], "type");
+	define_static_field<uint8_t>(ret,
+	                             OFFSETOF_STATIC_FIELD(self, m_type) + type_byte_offset,
+	                             "type");
 
 	// the rest fo the fields are more trivial to expose
-	define_static_field(ret, this, m_openflags, "open_flags");
-	define_static_field(ret, this, m_name, "name");
-	define_static_field(ret, this, m_name_raw, "name_raw");
-	define_static_field(ret, this, m_oldname, "old_name");
-	define_static_field(ret, this, m_flags, "flags");
-	define_static_field(ret, this, m_dev, "dev");
-	define_static_field(ret, this, m_mount_id, "mount_id");
-	define_static_field(ret, this, m_ino, "ino");
-	define_static_field(ret, this, m_pid, "pid");
-	define_static_field(ret, this, m_fd, "fd");
+	DEFINE_STATIC_FIELD(ret, self, m_openflags, "open_flags");
+	DEFINE_STATIC_FIELD(ret, self, m_name, "name");
+	DEFINE_STATIC_FIELD(ret, self, m_name_raw, "name_raw");
+	DEFINE_STATIC_FIELD(ret, self, m_oldname, "old_name");
+	DEFINE_STATIC_FIELD(ret, self, m_flags, "flags");
+	DEFINE_STATIC_FIELD(ret, self, m_dev, "dev");
+	DEFINE_STATIC_FIELD(ret, self, m_mount_id, "mount_id");
+	DEFINE_STATIC_FIELD(ret, self, m_ino, "ino");
+	DEFINE_STATIC_FIELD(ret, self, m_pid, "pid");
+	DEFINE_STATIC_FIELD(ret, self, m_fd, "fd");
 
 	// in this case we have a union, so many of the following exposed fields
 	// will point to the same memory areas, but this should not be an issue
-	define_static_field(ret, this, m_sockinfo.m_ipv4info.m_fields.m_sip, "socket_ipv4_src_ip");
-	define_static_field(ret, this, m_sockinfo.m_ipv4info.m_fields.m_dip, "socket_ipv4_dest_dip");
-	define_static_field(ret, this, m_sockinfo.m_ipv4info.m_fields.m_sport, "socket_ipv4_src_port");
-	define_static_field(ret, this, m_sockinfo.m_ipv4info.m_fields.m_dport, "socket_ipv4_dst_port");
-	define_static_field(ret,
-	                    this,
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4info.m_fields.m_sip, "socket_ipv4_src_ip");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4info.m_fields.m_dip, "socket_ipv4_dest_dip");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4info.m_fields.m_sport, "socket_ipv4_src_port");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4info.m_fields.m_dport, "socket_ipv4_dst_port");
+	DEFINE_STATIC_FIELD(ret,
+	                    self,
 	                    m_sockinfo.m_ipv4info.m_fields.m_l4proto,
 	                    "socket_ipv4_l4_proto");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6info.m_fields.m_sip)[0],
-	                    "socket_ipv6_src_ip_low");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6info.m_fields.m_sip)[1],
-	                    "socket_ipv6_src_ip_high");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6info.m_fields.m_dip)[0],
-	                    "socket_ipv6_dest_ip_low");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6info.m_fields.m_dip)[1],
-	                    "socket_ipv6_dest_ip_high");
-	define_static_field(ret, this, m_sockinfo.m_ipv6info.m_fields.m_sport, "socket_ipv6_src_port");
-	define_static_field(ret, this, m_sockinfo.m_ipv6info.m_fields.m_dport, "socket_ipv6_dst_port");
-	define_static_field(ret,
-	                    this,
+	define_static_field<uint64_t>(ret,
+	                              OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip),
+	                              "socket_ipv6_src_ip_low");
+	define_static_field<uint64_t>(
+	        ret,
+	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip) + 8,
+	        "socket_ipv6_src_ip_high");
+	define_static_field<uint64_t>(ret,
+	                              OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip),
+	                              "socket_ipv6_dest_ip_low");
+	define_static_field<uint64_t>(
+	        ret,
+	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip) + 8,
+	        "socket_ipv6_dest_ip_high");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_sport, "socket_ipv6_src_port");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_dport, "socket_ipv6_dst_port");
+	DEFINE_STATIC_FIELD(ret,
+	                    self,
 	                    m_sockinfo.m_ipv6info.m_fields.m_l4proto,
 	                    "socket_ipv6_l4_proto");
-	define_static_field(ret, this, m_sockinfo.m_ipv4serverinfo.m_ip, "socket_ipv4_server_ip");
-	define_static_field(ret, this, m_sockinfo.m_ipv4serverinfo.m_port, "socket_ipv4_server_port");
-	define_static_field(ret,
-	                    this,
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4serverinfo.m_ip, "socket_ipv4_server_ip");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv4serverinfo.m_port, "socket_ipv4_server_port");
+	DEFINE_STATIC_FIELD(ret,
+	                    self,
 	                    m_sockinfo.m_ipv4serverinfo.m_l4proto,
 	                    "socket_ipv4_server_l4_proto");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6serverinfo.m_ip)[0],
-	                    "socket_ipv6_server_ip_low");
-	define_static_field(ret,
-	                    this,
-	                    ((uint64_t*)&m_sockinfo.m_ipv6serverinfo.m_ip)[1],
-	                    "socket_ipv6_server_ip_high");
-	define_static_field(ret, this, m_sockinfo.m_ipv6serverinfo.m_port, "socket_ipv6_server_port");
-	define_static_field(ret,
-	                    this,
+	define_static_field<uint64_t>(ret,
+	                              OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip),
+	                              "socket_ipv6_server_ip_low");
+	define_static_field<uint64_t>(ret,
+	                              OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip) + 8,
+	                              "socket_ipv6_server_ip_high");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6serverinfo.m_port, "socket_ipv6_server_port");
+	DEFINE_STATIC_FIELD(ret,
+	                    self,
 	                    m_sockinfo.m_ipv6serverinfo.m_l4proto,
 	                    "socket_ipv6_server_l4_proto");
-	define_static_field(ret, this, m_sockinfo.m_unixinfo.m_fields.m_source, "socket_unix_src");
-	define_static_field(ret, this, m_sockinfo.m_unixinfo.m_fields.m_dest, "socket_unix_dest");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_unixinfo.m_fields.m_source, "socket_unix_src");
+	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_unixinfo.m_fields.m_dest, "socket_unix_dest");
 
 	return ret;
 }

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -124,6 +124,10 @@ sinsp_fdinfo::sinsp_fdinfo(
         table_entry(dyn_fields) {}
 
 libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const {
+	return get_static_fields();
+}
+
+libsinsp::state::static_struct::field_infos sinsp_fdinfo::get_static_fields() {
 	using self = sinsp_fdinfo;
 
 	libsinsp::state::static_struct::field_infos ret;

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -339,6 +339,12 @@ public:
 
 	inline void set_overlay_lower() { m_flags |= FLAGS_OVERLAY_LOWER; }
 
+	/*!
+	  \brief A static version of static_fields()
+	  \return The group of field infos available.
+	 */
+	static static_struct::field_infos get_static_fields();
+
 	scap_fd_type m_type =
 	        SCAP_FD_UNINITIALIZED;  ///< The fd type, e.g. file, directory, IPv4 socket...
 	uint32_t m_openflags = 0;  ///< If this FD is a file, the flags that were used when opening it.

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 #include <libscap/scap-int.h>
 #include <libsinsp/fdtable.h>
 
-static const auto s_fdtable_static_fields = sinsp_fdinfo().static_fields();
+static const auto s_fdtable_static_fields = sinsp_fdinfo::get_static_fields();
 
 sinsp_fdtable::sinsp_fdtable(sinsp* inspector):
         built_in_table("file_descriptors", &s_fdtable_static_fields) {

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -233,6 +233,14 @@ public:
 	 */
 	inline const base_table* const& table_ptr() const { return m_this_ptr; }
 
+	/**
+	 * @brief Returns the offset of m_this_ptr. Here for convenience as required in other code
+	 * parts.
+	 */
+	static size_t table_ptr_offset() {
+		return OFFSETOF_STATIC_FIELD(built_in_table<KeyType>, m_this_ptr);
+	}
+
 	const char* name() const override { return m_name.c_str(); }
 
 	/**

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -361,7 +361,7 @@ TEST(thread_manager, table_access) {
 	// empty table state and info
 	ASSERT_EQ(table->name(), std::string("threads"));
 	ASSERT_EQ(table->key_info(), libsinsp::state::typeinfo::of<int64_t>());
-	ASSERT_EQ(*table->static_fields(), sinsp_threadinfo().static_fields());
+	ASSERT_EQ(*table->static_fields(), sinsp_threadinfo::get_static_fields());
 	ASSERT_NE(table->dynamic_fields(), nullptr);
 	ASSERT_EQ(table->dynamic_fields()->fields().size(), 0);
 	ASSERT_EQ(table->entries_count(), 0);

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -34,8 +34,8 @@ TEST(static_struct, defs_and_access) {
 	struct err_multidef_struct : public libsinsp::state::static_struct {
 		libsinsp::state::static_struct::field_infos static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
-			define_static_field(ret, this, m_num, "num");
-			define_static_field(ret, this, m_num, "num");
+			DEFINE_STATIC_FIELD(ret, err_multidef_struct, m_num, "num");
+			DEFINE_STATIC_FIELD(ret, err_multidef_struct, m_num, "num");
 			return ret;
 		}
 
@@ -46,8 +46,8 @@ TEST(static_struct, defs_and_access) {
 	public:
 		libsinsp::state::static_struct::field_infos static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
-			define_static_field(ret, this, m_num, "num");
-			define_static_field(ret, this, m_str, "str", true);
+			DEFINE_STATIC_FIELD(ret, sample_struct, m_num, "num");
+			DEFINE_STATIC_FIELD_READONLY(ret, sample_struct, m_str, "str");
 			return ret;
 		}
 
@@ -65,7 +65,7 @@ TEST(static_struct, defs_and_access) {
 	public:
 		libsinsp::state::static_struct::field_infos static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
-			define_static_field(ret, this, m_num, "num");
+			DEFINE_STATIC_FIELD(ret, sample_struct2, m_num, "num");
 			return ret;
 		}
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -59,6 +59,10 @@ sinsp_threadinfo::sinsp_threadinfo(
 }
 
 libsinsp::state::static_struct::field_infos sinsp_threadinfo::static_fields() const {
+	return get_static_fields();
+}
+
+libsinsp::state::static_struct::field_infos sinsp_threadinfo::get_static_fields() {
 	using self = sinsp_threadinfo;
 
 	libsinsp::state::static_struct::field_infos ret;
@@ -1337,7 +1341,7 @@ static void fd_to_scap(scap_fdinfo* dst, sinsp_fdinfo* src) {
 	}
 }
 
-static const auto s_threadinfo_static_fields = sinsp_threadinfo().static_fields();
+static const auto s_threadinfo_static_fields = sinsp_threadinfo::get_static_fields();
 
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_thread_manager implementation

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -59,34 +59,49 @@ sinsp_threadinfo::sinsp_threadinfo(
 }
 
 libsinsp::state::static_struct::field_infos sinsp_threadinfo::static_fields() const {
+	using self = sinsp_threadinfo;
+
 	libsinsp::state::static_struct::field_infos ret;
 	// todo(jasondellaluce): support missing fields that are vectors, maps, or sub-tables
-	define_static_field(ret, this, m_tid, "tid");
-	define_static_field(ret, this, m_pid, "pid");
-	define_static_field(ret, this, m_ptid, "ptid");
-	define_static_field(ret, this, m_reaper_tid, "reaper_tid");
-	define_static_field(ret, this, m_sid, "sid");
-	define_static_field(ret, this, m_comm, "comm");
-	define_static_field(ret, this, m_exe, "exe");
-	define_static_field(ret, this, m_exepath, "exe_path");
-	define_static_field(ret, this, m_exe_writable, "exe_writable");
-	define_static_field(ret, this, m_exe_upper_layer, "exe_upper_layer");
-	define_static_field(ret, this, m_exe_lower_layer, "exe_lower_layer");
-	define_static_field(ret, this, m_exe_from_memfd, "exe_from_memfd");
-	define_static_field(ret, this, m_args_table_adapter.table_ptr(), "args", true);
-	define_static_field(ret, this, m_env_table_adapter.table_ptr(), "env", true);
-	define_static_field(ret, this, m_cgroups_table_adapter.table_ptr(), "cgroups", true);
-	define_static_field(ret, this, m_flags, "flags");
-	define_static_field(ret, this, m_fdlimit, "fd_limit");
-	define_static_field(ret, this, m_uid, "uid");
-	define_static_field(ret, this, m_gid, "gid");
-	define_static_field(ret, this, m_loginuid, "loginuid");
+	DEFINE_STATIC_FIELD(ret, self, m_tid, "tid");
+	DEFINE_STATIC_FIELD(ret, self, m_pid, "pid");
+	DEFINE_STATIC_FIELD(ret, self, m_ptid, "ptid");
+	DEFINE_STATIC_FIELD(ret, self, m_reaper_tid, "reaper_tid");
+	DEFINE_STATIC_FIELD(ret, self, m_sid, "sid");
+	DEFINE_STATIC_FIELD(ret, self, m_comm, "comm");
+	DEFINE_STATIC_FIELD(ret, self, m_exe, "exe");
+	DEFINE_STATIC_FIELD(ret, self, m_exepath, "exe_path");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_writable, "exe_writable");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_upper_layer, "exe_upper_layer");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_lower_layer, "exe_lower_layer");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_from_memfd, "exe_from_memfd");
+	const auto table_ptr_offset = libsinsp::state::built_in_table<uint64_t>::table_ptr_offset();
+	define_static_field<libsinsp::state::base_table*>(
+	        ret,
+	        OFFSETOF_STATIC_FIELD(self, m_args_table_adapter) + table_ptr_offset,
+	        "args",
+	        true);
+	define_static_field<libsinsp::state::base_table*>(
+	        ret,
+	        OFFSETOF_STATIC_FIELD(self, m_env_table_adapter) + table_ptr_offset,
+	        "env",
+	        true);
+	define_static_field<libsinsp::state::base_table*>(
+	        ret,
+	        OFFSETOF_STATIC_FIELD(self, m_cgroups_table_adapter) + table_ptr_offset,
+	        "cgroups",
+	        true);
+	DEFINE_STATIC_FIELD(ret, self, m_flags, "flags");
+	DEFINE_STATIC_FIELD(ret, self, m_fdlimit, "fd_limit");
+	DEFINE_STATIC_FIELD(ret, self, m_uid, "uid");
+	DEFINE_STATIC_FIELD(ret, self, m_gid, "gid");
+	DEFINE_STATIC_FIELD(ret, self, m_loginuid, "loginuid");
 	// m_cap_permitted
 	// m_cap_effective
 	// m_cap_inheritable
-	define_static_field(ret, this, m_exe_ino, "exe_ino");
-	define_static_field(ret, this, m_exe_ino_ctime, "exe_ino_ctime");
-	define_static_field(ret, this, m_exe_ino_mtime, "exe_ino_mtime");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_ino, "exe_ino");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_ino_ctime, "exe_ino_ctime");
+	DEFINE_STATIC_FIELD(ret, self, m_exe_ino_mtime, "exe_ino_mtime");
 	// m_exe_ino_ctime_duration_clone_ts
 	// m_exe_ino_ctime_duration_pidns_start
 	// m_vmsize_kb
@@ -94,19 +109,19 @@ libsinsp::state::static_struct::field_infos sinsp_threadinfo::static_fields() co
 	// m_vmswap_kb
 	// m_pfmajor
 	// m_pfminor
-	define_static_field(ret, this, m_vtid, "vtid");
-	define_static_field(ret, this, m_vpid, "vpid");
-	define_static_field(ret, this, m_vpgid, "vpgid");
-	define_static_field(ret, this, m_pgid, "pgid");
-	define_static_field(ret, this, m_pidns_init_start_ts, "pidns_init_start_ts");
-	define_static_field(ret, this, m_root, "root");
-	define_static_field(ret, this, m_tty, "tty");
+	DEFINE_STATIC_FIELD(ret, self, m_vtid, "vtid");
+	DEFINE_STATIC_FIELD(ret, self, m_vpid, "vpid");
+	DEFINE_STATIC_FIELD(ret, self, m_vpgid, "vpgid");
+	DEFINE_STATIC_FIELD(ret, self, m_pgid, "pgid");
+	DEFINE_STATIC_FIELD(ret, self, m_pidns_init_start_ts, "pidns_init_start_ts");
+	DEFINE_STATIC_FIELD(ret, self, m_root, "root");
+	DEFINE_STATIC_FIELD(ret, self, m_tty, "tty");
 	// m_category
 	// m_clone_ts
 	// m_lastexec_ts
 	// m_latency
-	define_static_field(ret, this, m_main_fdtable, "file_descriptors", true);
-	define_static_field(ret, this, m_cwd, "cwd", true);
+	DEFINE_STATIC_FIELD_READONLY(ret, self, m_main_fdtable, "file_descriptors");
+	DEFINE_STATIC_FIELD_READONLY(ret, self, m_cwd, "cwd");
 	// m_parent_loop_detected
 	return ret;
 }

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -584,6 +584,12 @@ public:
 
 	void set_exepath(std::string&& exepath);
 
+	/*!
+	  \brief A static version of static_fields()
+	  \return The group of field infos available.
+	 */
+	static static_struct::field_infos get_static_fields();
+
 private:
 	sinsp_threadinfo* get_cwd_root();
 	bool set_env_from_proc();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR makes `define_static_field` constexpr static and allows to directly the field offset. It introduces `OFFSETOF_STATIC_FIELD`, `DEFINE_STATIC_FIELD_READONLY` and `DEFINE_STATIC_FIELD` macros to hide the complexity behind extracting the field type and offset needed for `define_static_field`. This foundation is used to define two additional static methods an additional static method `sinsp_threadinfo::get_static_fields()` that can be used for the global initialization of `s_threadinfo_static_fields` in `threadinfo.cpp`. This is useful to avoid instantiating a `sinsp_threadinfo` object to initialize `s_threadinfo_static_fields`, a preliminary step needed before isolating the `sinsp_thread_manager` dependencies and passing them directly to its constructor. Moreover, to align the fdinfo implementation, this PR adds the static method `sinsp_fdinfo::get_static_fields()` to the fdinfo implementation.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
