### PR TITLE
fix(driver): fix driver Makefile for Linux 6.13 support

### DIFF
--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -29,7 +29,15 @@ install: all
 
 else
 
-KERNELDIR 	?= $(CURDIR)
+KERNELRELEASE ?= $(shell uname -r)
+KERNEL_VERSION_MAJOR := $(shell echo $(KERNELRELEASE) | cut -d. -f1)
+KERNEL_VERSION_MINOR := $(shell echo $(KERNELRELEASE) | cut -d. -f2)
+
+ifeq ($(shell [ $(KERNEL_VERSION_MAJOR) -gt 6 -o \( $(KERNEL_VERSION_MAJOR) -eq 6 -a $(KERNEL_VERSION_MINOR) -ge 13 \) ] && echo y),y)
+KERNELDIR ?= $(srctree)
+else
+KERNELDIR ?= $(CURDIR)
+endif
 #
 # Get the path of the module sources
 #


### PR DESCRIPTION
In Linux 6.13 there has been a change regarding how kernel modules get built when using the M= option. In partiucular, when building a module (M=) the working directory changed from the kernel directory to the external module directory.
See commit 13b25489b6f8bd kbuild: change working directory to external module directory with M=.

This causes compile time errors when compiling the driver against kernels >= 6.13.

This update requires changes in the driver's Makefile.

Fixes #2277

/kind bug
/area driver-kmod