### PR TITLE
wip: chore(ci): download assets from latest driverkit release instead of release workflow

### DIFF
--- a/.github/workflows/latest-kernel.yml
+++ b/.github/workflows/latest-kernel.yml
@@ -61,11 +61,14 @@ jobs:
           name: driverkit_config.yaml
 
       - name: Download latest driverkit artifact
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
-          name: driverkit-amd64
-          workflow: release.yml
-          repo: falcosecurity/driverkit
+          fileName: driverkit_*_linux_amd64.tar.gz
+          latest: true
+          repository: falcosecurity/driverkit
+          tarBall: false
+          zipBall: false
+          extract: true
 
       - name: Test drivers build
         id: build
@@ -86,11 +89,14 @@ jobs:
           name: driverkit_config.yaml
 
       - name: Download latest driverkit artifact
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
         with:
-          name: driverkit-arm64
-          workflow: release.yml
-          repo: falcosecurity/driverkit
+          fileName:  driverkit_*_linux_arm64.tar.gz
+          latest: true
+          repository: falcosecurity/driverkit
+          tarBall: false
+          zipBall: false
+          extract: true
 
       - name: Test drivers build
         id: build


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
