### PR TITLE
chore(userspace/libsinsp): drop useless assert from logger::add_callback_log()

### DIFF
--- a/userspace/libsinsp/logger.cpp
+++ b/userspace/libsinsp/logger.cpp
@@ -98,14 +98,7 @@ void sinsp_logger::add_encoded_severity() {
 }
 
 void sinsp_logger::add_callback_log(const sinsp_logger_callback callback) {
-	const sinsp_logger_callback old_cb = m_callback.exchange(callback);
-
-	ASSERT(old_cb == nullptr);
-
-	// For release builds, the compiler doesn't see that old_cb is used,
-	// so do something that will satisfy the compiler
-	static_cast<void>(old_cb);
-
+	m_callback = callback;
 	m_flags |= sinsp_logger::OT_CALLBACK;
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

I don't see the point of that assert. Also that is breaking tests in https://github.com/falcosecurity/falco/pull/3507.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
