### PR TITLE
feat(userspace/libsinsp)!: remove `sinsp::build_fdinfo()`

### DIFF
--- a/test/libsinsp_e2e/threadinfo.cpp
+++ b/test/libsinsp_e2e/threadinfo.cpp
@@ -47,7 +47,8 @@ static void run_test(test_type ttype,
                      std::vector<std::string>& vals,
                      std::vector<std::string>& expected,
                      std::string expectedrem) {
-	sinsp_threadinfo ti(nullptr);
+	const sinsp inspector;
+	sinsp_threadinfo ti{inspector.get_fdinfo_factory()};
 	struct iovec* iov;
 	int iovcnt;
 	std::string rem;

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -26,8 +26,9 @@ limitations under the License.
 
 static const auto s_fdtable_static_fields = sinsp_fdinfo().static_fields();
 
-sinsp_fdtable::sinsp_fdtable(sinsp* inspector):
-        built_in_table("file_descriptors", &s_fdtable_static_fields) {
+sinsp_fdtable::sinsp_fdtable(const sinsp_fdinfo_factory& fdinfo_factory, sinsp* inspector):
+        built_in_table("file_descriptors", &s_fdtable_static_fields),
+        m_fdinfo_factory{fdinfo_factory} {
 	m_tid = 0;
 	m_inspector = inspector;
 	if(m_inspector != nullptr) {
@@ -211,7 +212,7 @@ sinsp_fdinfo* sinsp_fdtable::add(int64_t fd, std::unique_ptr<sinsp_fdinfo> fdinf
 }
 
 std::unique_ptr<libsinsp::state::table_entry> sinsp_fdtable::new_entry() const {
-	return m_inspector->build_fdinfo();
+	return m_fdinfo_factory.create();
 };
 
 std::shared_ptr<libsinsp::state::table_entry> sinsp_fdtable::get_entry(const int64_t& key) {

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <libsinsp/state/table.h>
 #include <libsinsp/fdinfo.h>
+#include <libsinsp/sinsp_fdinfo_factory.h>
 
 // Forward declare sinsp_stats_v2 to avoid including metrics_collector.h here.
 struct sinsp_stats_v2;
@@ -33,9 +34,7 @@ public:
 
 	typedef std::function<bool(int64_t, const sinsp_fdinfo&)> fdtable_const_visitor_t;
 
-	sinsp_fdtable(sinsp* inspector);
-
-	inline std::unique_ptr<sinsp_fdinfo> new_fdinfo() const { return sinsp_fdinfo{}.clone(); }
+	sinsp_fdtable(const sinsp_fdinfo_factory& fdinfo_factory, sinsp* inspector);
 
 	sinsp_fdinfo* find(int64_t fd);
 
@@ -115,6 +114,8 @@ private:
 	std::shared_ptr<sinsp_fdinfo> m_last_accessed_fdinfo;
 	uint64_t m_tid;
 	std::shared_ptr<sinsp_fdinfo> m_nullptr_ret;  // needed for returning a reference
+
+	const sinsp_fdinfo_factory& m_fdinfo_factory;
 
 	inline void lookup_device(sinsp_fdinfo& fdi) const;
 	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -146,6 +146,8 @@ sinsp::sinsp(bool with_metrics):
         m_evt(this),
         m_lastevent_ts(0),
         m_host_root(scap_get_host_root()),
+        m_fdtable_dyn_fields{std::make_shared<libsinsp::state::dynamic_struct::field_infos>()},
+        m_fdinfo_factory{this, &m_external_event_processor, m_fdtable_dyn_fields},
         m_async_events_queue(DEFAULT_ASYNC_EVENT_QUEUE_SIZE),
         m_inited(false) {
 	++instance_count;
@@ -154,7 +156,8 @@ sinsp::sinsp(bool with_metrics):
 	m_parser = NULL;
 	m_is_dumping = false;
 	m_parser_tmp_evt = sinsp_evt{this};
-	m_thread_manager = std::make_shared<sinsp_thread_manager>(this);
+	m_thread_manager =
+	        std::make_shared<sinsp_thread_manager>(m_fdinfo_factory, this, m_fdtable_dyn_fields);
 	m_usergroup_manager = std::make_shared<sinsp_usergroup_manager>(this);
 	m_max_fdtable_size = MAX_FD_TABLE_SIZE;
 	m_usergroups_purging_scan_time_ns = DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S * ONE_SECOND_IN_NS;
@@ -200,7 +203,7 @@ sinsp::sinsp(bool with_metrics):
 	        m_network_interfaces,
 	        m_hostname_and_port_resolution_enabled,
 	        sinsp_threadinfo_factory{this, m_thread_manager, &m_external_event_processor},
-	        sinsp_fdinfo_factory{this, m_thread_manager, &m_external_event_processor},
+	        m_fdinfo_factory,
 	        m_input_plugin,
 	        m_plugin_manager,
 	        m_thread_manager,
@@ -1895,7 +1898,7 @@ bool sinsp_thread_manager::remove_inactive_threads() {
 }
 
 std::unique_ptr<sinsp_threadinfo> libsinsp::event_processor::build_threadinfo(sinsp* inspector) {
-	return std::make_unique<sinsp_threadinfo>(inspector);
+	return std::make_unique<sinsp_threadinfo>(inspector->get_fdinfo_factory(), inspector);
 }
 
 std::unique_ptr<sinsp_fdinfo> libsinsp::event_processor::build_fdinfo(sinsp* inspector) {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -481,13 +481,6 @@ public:
 		return ret;
 	}
 
-	inline std::unique_ptr<sinsp_fdinfo> build_fdinfo() {
-		auto ret = m_external_event_processor ? m_external_event_processor->build_fdinfo(this)
-		                                      : m_thread_manager->new_fdinfo();
-		m_thread_manager->set_fdinfo_shared_dynamic_fields(*ret);
-		return ret;
-	}
-
 	/*!
 	  \brief registers external event processor.
 	  After this, callbacks on libsinsp::event_processor will happen at
@@ -972,7 +965,16 @@ private:
 
 	std::shared_ptr<sinsp_thread_pool> m_thread_pool;
 
+	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> m_fdtable_dyn_fields;
+	const sinsp_fdinfo_factory m_fdinfo_factory;
+
 public:
+	std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> get_fdtable_dyn_fields() const {
+		return m_fdtable_dyn_fields;
+	}
+
+	const sinsp_fdinfo_factory& get_fdinfo_factory() const { return m_fdinfo_factory; }
+
 	std::shared_ptr<sinsp_thread_manager> m_thread_manager;
 	std::shared_ptr<sinsp_usergroup_manager> m_usergroup_manager;
 

--- a/userspace/libsinsp/sinsp_external_processor.h
+++ b/userspace/libsinsp/sinsp_external_processor.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include <libsinsp/event.h>
+
 /**
  * This api defines a relationship between libsinsp and an external event processor.
  * Such external processors should derive from event_processor and register themselves with

--- a/userspace/libsinsp/sinsp_fdinfo_factory.h
+++ b/userspace/libsinsp/sinsp_fdinfo_factory.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <libsinsp/threadinfo.h>
 #include <libsinsp/sinsp_external_processor.h>
 
 /*!
@@ -7,26 +6,27 @@
 */
 class sinsp_fdinfo_factory {
 	sinsp* m_sinsp;
-	std::shared_ptr<sinsp_thread_manager> m_thread_manager;
 	libsinsp::event_processor** m_external_event_processor;
+	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& m_dyn_fields;
 
 	libsinsp::event_processor* get_external_event_processor() const {
 		return *m_external_event_processor;
 	}
 
 public:
-	sinsp_fdinfo_factory(sinsp* sinsp,
-	                     const std::shared_ptr<sinsp_thread_manager>& thread_manager,
-	                     libsinsp::event_processor** external_event_processor):
+	sinsp_fdinfo_factory(
+	        sinsp* sinsp,
+	        libsinsp::event_processor** external_event_processor,
+	        const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields):
 	        m_sinsp{sinsp},
-	        m_thread_manager{thread_manager},
-	        m_external_event_processor{external_event_processor} {}
+	        m_external_event_processor{external_event_processor},
+	        m_dyn_fields{dyn_fields} {}
 
 	std::unique_ptr<sinsp_fdinfo> create() const {
 		const auto external_event_processor = get_external_event_processor();
-		auto ret = external_event_processor ? external_event_processor->build_fdinfo(m_sinsp)
-		                                    : m_thread_manager->new_fdinfo();
-		m_thread_manager->set_fdinfo_shared_dynamic_fields(*ret);
-		return ret;
+		auto fdinfo = external_event_processor ? external_event_processor->build_fdinfo(m_sinsp)
+		                                       : std::make_unique<sinsp_fdinfo>();
+		fdinfo->set_dynamic_fields(m_dyn_fields);
+		return fdinfo;
 	}
 };

--- a/userspace/libsinsp/test/classes/sinsp_threadinfo.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_threadinfo.cpp
@@ -19,7 +19,9 @@ limitations under the License.
 #include <helpers/threads_helpers.h>
 
 TEST(sinsp_threadinfo, get_main_thread) {
-	auto tinfo = std::make_shared<sinsp_threadinfo>();
+	const sinsp inspector;
+	const auto fdinfo_factory = inspector.get_fdinfo_factory();
+	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -39,7 +41,7 @@ TEST(sinsp_threadinfo, get_main_thread) {
 	tinfo->m_tginfo = tginfo;
 	ASSERT_EQ(tinfo->get_main_thread(), nullptr);
 
-	auto main_tinfo = std::make_shared<sinsp_threadinfo>();
+	auto main_tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	main_tinfo->m_tid = 23;
 	main_tinfo->m_pid = 23;
 
@@ -53,7 +55,9 @@ TEST(sinsp_threadinfo, get_main_thread) {
 }
 
 TEST(sinsp_threadinfo, get_num_threads) {
-	auto tinfo = std::make_shared<sinsp_threadinfo>();
+	const sinsp inspector;
+	const auto fdinfo_factory = inspector.get_fdinfo_factory();
+	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tinfo->m_tid = 25;
 	tinfo->m_pid = 23;
 
@@ -67,7 +71,7 @@ TEST(sinsp_threadinfo, get_num_threads) {
 	ASSERT_EQ(tinfo->get_num_threads(), 1);
 	ASSERT_EQ(tinfo->get_num_not_leader_threads(), 1);
 
-	auto main_tinfo = std::make_shared<sinsp_threadinfo>();
+	auto main_tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	main_tinfo->m_tid = 23;
 	main_tinfo->m_pid = 23;
 
@@ -130,7 +134,8 @@ TEST_F(sinsp_with_test_input, THRD_INFO_assign_children_to_a_nullptr) {
 }
 
 TEST(sinsp_threadinfo, set_exepath) {
-	auto tinfo = std::make_shared<sinsp_threadinfo>();
+	const sinsp inspector;
+	auto tinfo = std::make_shared<sinsp_threadinfo>(inspector.get_fdinfo_factory());
 
 	{
 		// Nothing changes

--- a/userspace/libsinsp/test/classes/thread_group_info.cpp
+++ b/userspace/libsinsp/test/classes/thread_group_info.cpp
@@ -21,13 +21,15 @@ limitations under the License.
 /*=============================== THREAD-GROUP-INFO ===========================*/
 
 TEST(thread_group_info, create_thread_group_info) {
-	std::shared_ptr<sinsp_threadinfo> tinfo = std::make_shared<sinsp_threadinfo>();
+	const sinsp inspector;
+	const auto fdinfo_factory = inspector.get_fdinfo_factory();
+	std::shared_ptr<sinsp_threadinfo> tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tinfo.reset();
 
 	/* This will throw an exception since tinfo is expired */
 	EXPECT_THROW(thread_group_info(34, true, tinfo), sinsp_exception);
 
-	tinfo = std::make_shared<sinsp_threadinfo>();
+	tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -51,7 +53,9 @@ TEST(thread_group_info, create_thread_group_info) {
 }
 
 TEST(thread_group_info, populate_thread_group_info) {
-	auto tinfo = std::make_shared<sinsp_threadinfo>();
+	const sinsp inspector;
+	const auto fdinfo_factory = inspector.get_fdinfo_factory();
+	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -64,12 +68,12 @@ TEST(thread_group_info, populate_thread_group_info) {
 	tginfo.decrement_thread_count();
 	EXPECT_EQ(tginfo.get_thread_count(), 2);
 
-	auto tinfo1 = std::make_shared<sinsp_threadinfo>();
+	auto tinfo1 = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tginfo.add_thread_to_group(tinfo1, true);
 	ASSERT_EQ(tginfo.get_first_thread(), tinfo1.get());
 	EXPECT_EQ(tginfo.get_thread_count(), 3);
 
-	auto tinfo2 = std::make_shared<sinsp_threadinfo>();
+	auto tinfo2 = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
 	tginfo.add_thread_to_group(tinfo2, false);
 	ASSERT_EQ(tginfo.get_first_thread(), tinfo1.get());
 	ASSERT_EQ(tginfo.get_thread_list().back().lock().get(), tinfo2.get());

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -46,11 +46,13 @@ static void copy_ipv6_address(uint32_t* dest, uint32_t* src) {
 ///////////////////////////////////////////////////////////////////////////////
 
 sinsp_threadinfo::sinsp_threadinfo(
+        const sinsp_fdinfo_factory& fdinfo_factory,
         sinsp* inspector,
         const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields):
         table_entry(dyn_fields),
         m_inspector(inspector),
-        m_fdtable(inspector),
+        m_fdinfo_factory{fdinfo_factory},
+        m_fdtable{fdinfo_factory, inspector},
         m_main_fdtable(m_fdtable.table_ptr()),
         m_args_table_adapter("args", m_args),
         m_env_table_adapter("env", m_env),
@@ -199,7 +201,7 @@ void sinsp_threadinfo::fix_sockets_coming_from_proc() {
 }
 
 void sinsp_threadinfo::add_fd_from_scap(scap_fdinfo* fdi) {
-	auto newfdi = m_inspector->build_fdinfo();
+	auto newfdi = m_fdinfo_factory.create();
 	bool do_add = true;
 
 	newfdi->m_type = fdi->type;
@@ -1327,10 +1329,14 @@ static const auto s_threadinfo_static_fields = sinsp_threadinfo().static_fields(
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_thread_manager implementation
 ///////////////////////////////////////////////////////////////////////////////
-sinsp_thread_manager::sinsp_thread_manager(sinsp* inspector):
+sinsp_thread_manager::sinsp_thread_manager(
+        const sinsp_fdinfo_factory& fdinfo_factory,
+        sinsp* inspector,
+        const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& fdtable_dyn_fields):
         built_in_table(s_thread_table_name, &s_threadinfo_static_fields),
+        m_fdinfo_factory{fdinfo_factory},
         m_max_thread_table_size(m_thread_table_default_size),
-        m_fdtable_dyn_fields(std::make_shared<libsinsp::state::dynamic_struct::field_infos>()) {
+        m_fdtable_dyn_fields{fdtable_dyn_fields} {
 	m_inspector = inspector;
 	if(m_inspector != nullptr) {
 		m_sinsp_stats_v2 = m_inspector->get_sinsp_stats_v2();
@@ -1429,12 +1435,12 @@ void sinsp_thread_manager::create_thread_dependencies(
 }
 
 std::unique_ptr<sinsp_threadinfo> sinsp_thread_manager::new_threadinfo() const {
-	auto tinfo = new sinsp_threadinfo(m_inspector, dynamic_fields());
+	auto tinfo = new sinsp_threadinfo(m_fdinfo_factory, m_inspector, dynamic_fields());
 	return std::unique_ptr<sinsp_threadinfo>(tinfo);
 }
 
 std::unique_ptr<sinsp_fdinfo> sinsp_thread_manager::new_fdinfo() const {
-	return sinsp_fdtable(m_inspector).new_fdinfo();
+	return std::make_unique<sinsp_fdinfo>();
 }
 
 /* Can be called when:

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -65,7 +65,8 @@ struct erase_fd_params {
 */
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry {
 public:
-	sinsp_threadinfo(sinsp* inspector = nullptr,
+	sinsp_threadinfo(const sinsp_fdinfo_factory& fdinfo_factory,
+	                 sinsp* inspector = nullptr,
 	                 const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
 	                         dyn_fields = nullptr);
 	virtual ~sinsp_threadinfo();
@@ -603,6 +604,7 @@ private:
 	// Parameters that can't be accessed directly because they could be in the
 	// parent thread info
 	//
+	const sinsp_fdinfo_factory& m_fdinfo_factory;
 	sinsp_fdtable m_fdtable;  // The fd table of this thread
 	const libsinsp::state::base_table*
 	        m_main_fdtable;     // Points to the base fd table of the current main thread
@@ -696,7 +698,10 @@ protected:
 class SINSP_PUBLIC sinsp_thread_manager : public libsinsp::state::built_in_table<int64_t>,
                                           public libsinsp::state::sinsp_table_owner {
 public:
-	sinsp_thread_manager(sinsp* inspector);
+	sinsp_thread_manager(const sinsp_fdinfo_factory& fdinfo_factory,
+	                     sinsp* inspector,
+	                     const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
+	                             fdtable_dyn_fields);
 	void clear();
 
 	std::unique_ptr<sinsp_threadinfo> new_threadinfo() const;
@@ -869,6 +874,7 @@ private:
 	inline void clear_thread_pointers(sinsp_threadinfo& threadinfo);
 	void free_dump_fdinfos(std::vector<scap_fdinfo*>* fdinfos_to_free);
 
+	const sinsp_fdinfo_factory& m_fdinfo_factory;
 	sinsp* m_inspector;
 	std::shared_ptr<sinsp_stats_v2> m_sinsp_stats_v2;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes inspector's `sinsp::build_fdinfo()` exposed method and forces the other components (i.e.: `sinsp_threadinfo`, `sinsp_thread_manager`, etc...) to use the fdinfo factory to create a new `sinsp_fdinfo` object.

Moreover, it removes the dependency of `sinsp_fdinfo_factory` from `sinsp_thread_manager`.

Together, these changes reduces the number of dependencies of components that want to create a new fdinfo. This step is needed to get rid of the `sinsp` pointer in `fdtable`, `sinsp_thread_manager` and `sinsp_threadinfo`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: remove `sinsp::build_fdinfo()`
```
