### PR TITLE
feat(userspace/libsinsp)!: remove `sinsp::build_threadinfo()`

### DIFF
--- a/test/libsinsp_e2e/thread_state.cpp
+++ b/test/libsinsp_e2e/thread_state.cpp
@@ -31,11 +31,12 @@ using namespace std;
 class thread_state_test : public ::testing::Test {
 protected:
 	virtual void SetUp() {
+		const auto& threadinfo_factory = m_inspector.get_threadinfo_factory();
 		// Each entry in the vector has a parent of the previous
 		// entry. The first entry has a parent of 1.
 		for(int64_t pid = 100, i = 0; i < m_max; pid++, i++) {
 			int64_t ppid = (i == 0 ? 1 : m_threads[i - 1]->m_tid);
-			std::unique_ptr<sinsp_threadinfo> thr = m_inspector.build_threadinfo();
+			std::unique_ptr<sinsp_threadinfo> thr = threadinfo_factory.create();
 			thr->init();
 			thr->m_tid = pid;
 			thr->m_ptid = ppid;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -47,7 +47,6 @@ limitations under the License.
 #include <libsinsp/capture_stats_source.h>
 #include <libsinsp/dumper.h>
 #include <libsinsp/event.h>
-#include <libsinsp/fdinfo.h>
 #include <libsinsp/filter.h>
 #include <libsinsp/ifinfo.h>
 #include <libsinsp/eventformatter.h>
@@ -74,6 +73,8 @@ limitations under the License.
 #include <libsinsp/tuples.h>
 #include <libsinsp/utils.h>
 #include <libsinsp/sinsp_mode.h>
+#include <libsinsp/sinsp_threadinfo_factory.h>
+#include <libsinsp/sinsp_fdinfo_factory.h>
 
 #include <list>
 #include <map>
@@ -473,13 +474,6 @@ public:
 	                                              int32_t* rc) const override;
 
 	libsinsp::event_processor* m_external_event_processor;
-
-	inline std::unique_ptr<sinsp_threadinfo> build_threadinfo() {
-		auto ret = m_external_event_processor ? m_external_event_processor->build_threadinfo(this)
-		                                      : m_thread_manager->new_threadinfo();
-		m_thread_manager->set_tinfo_shared_dynamic_fields(*ret);
-		return ret;
-	}
 
 	/*!
 	  \brief registers external event processor.
@@ -976,15 +970,24 @@ private:
 	//
 	std::string m_input_plugin_open_params;
 
+	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> m_thread_manager_dyn_fields;
 	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> m_fdtable_dyn_fields;
 	const sinsp_fdinfo_factory m_fdinfo_factory;
+	const sinsp_threadinfo_factory m_threadinfo_factory;
 
 public:
+	std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> get_thread_manager_dyn_fields()
+	        const {
+		return m_thread_manager_dyn_fields;
+	}
+
 	std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> get_fdtable_dyn_fields() const {
 		return m_fdtable_dyn_fields;
 	}
 
 	const sinsp_fdinfo_factory& get_fdinfo_factory() const { return m_fdinfo_factory; }
+
+	const sinsp_threadinfo_factory& get_threadinfo_factory() const { return m_threadinfo_factory; }
 
 	std::shared_ptr<sinsp_thread_manager> m_thread_manager;
 	std::shared_ptr<sinsp_usergroup_manager> m_usergroup_manager;

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -20,8 +20,9 @@ limitations under the License.
 
 TEST(sinsp_thread_manager, remove_non_existing_thread) {
 	sinsp m_inspector;
-	sinsp_thread_manager manager(m_inspector.get_fdinfo_factory(),
+	sinsp_thread_manager manager(m_inspector.get_threadinfo_factory(),
 	                             &m_inspector,
+	                             m_inspector.get_thread_manager_dyn_fields(),
 	                             m_inspector.get_fdtable_dyn_fields());
 
 	int64_t unknown_tid = 100;
@@ -33,8 +34,9 @@ TEST(sinsp_thread_manager, remove_non_existing_thread) {
 TEST(sinsp_thread_manager, thread_group_manager) {
 	sinsp m_inspector;
 	const auto fdinfo_factory = m_inspector.get_fdinfo_factory();
-	sinsp_thread_manager manager(fdinfo_factory,
+	sinsp_thread_manager manager(m_inspector.get_threadinfo_factory(),
 	                             &m_inspector,
+	                             m_inspector.get_thread_manager_dyn_fields(),
 	                             m_inspector.get_fdtable_dyn_fields());
 
 	/* We don't have thread group info here */
@@ -185,8 +187,9 @@ TEST_F(sinsp_with_test_input, THRD_MANAGER_create_thread_dependencies_invalid_pa
 
 TEST(sinsp_thread_manager, THRD_MANAGER_find_new_reaper_nullptr) {
 	sinsp m_inspector;
-	sinsp_thread_manager manager(m_inspector.get_fdinfo_factory(),
+	sinsp_thread_manager manager(m_inspector.get_threadinfo_factory(),
 	                             &m_inspector,
+	                             m_inspector.get_thread_manager_dyn_fields(),
 	                             m_inspector.get_fdtable_dyn_fields());
 	EXPECT_THROW(manager.find_new_reaper(nullptr), sinsp_exception);
 }

--- a/userspace/libsinsp/thread_manager.h
+++ b/userspace/libsinsp/thread_manager.h
@@ -23,13 +23,15 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <set>
+
+#include <libscap/scap_savefile_api.h>
 #include <libsinsp/fdtable.h>
 #include <libsinsp/state/table.h>
 #include <libsinsp/event.h>
 #include <libsinsp/plugin.h>
 #include <libsinsp/threadinfo.h>
 #include <libsinsp/thread_group_info.h>
-#include <libscap/scap_savefile_api.h>
+#include <libsinsp/sinsp_threadinfo_factory.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // This class manages the thread table
@@ -37,15 +39,13 @@ limitations under the License.
 class SINSP_PUBLIC sinsp_thread_manager : public libsinsp::state::built_in_table<int64_t>,
                                           public libsinsp::state::sinsp_table_owner {
 public:
-	sinsp_thread_manager(const sinsp_fdinfo_factory& fdinfo_factory,
+	sinsp_thread_manager(const sinsp_threadinfo_factory& threadinfo_factory,
 	                     sinsp* inspector,
+	                     const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
+	                             thread_manager_dyn_fields,
 	                     const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
 	                             fdtable_dyn_fields);
 	void clear();
-
-	std::unique_ptr<sinsp_threadinfo> new_threadinfo() const;
-
-	void set_tinfo_shared_dynamic_fields(sinsp_threadinfo& tinfo) const;
 
 	const threadinfo_map_t::ptr_t& add_thread(std::unique_ptr<sinsp_threadinfo> threadinfo,
 	                                          bool from_scap_proctable);
@@ -212,7 +212,7 @@ private:
 	inline void clear_thread_pointers(sinsp_threadinfo& threadinfo);
 	void free_dump_fdinfos(std::vector<scap_fdinfo*>* fdinfos_to_free);
 
-	const sinsp_fdinfo_factory& m_fdinfo_factory;
+	const sinsp_threadinfo_factory& m_threadinfo_factory;
 	sinsp* m_inspector;
 	std::shared_ptr<sinsp_stats_v2> m_sinsp_stats_v2;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes inspector's `sinsp::build_threadinfo()` exposed method and force the other components (i.e.: `sinsp_thread_manager`, `sinsp`, `sinsp_parser`, etc...) to use the threadinfo factory to create a new `sinsp_threadinfo` object.

Moreover, it extracts the thread manager's dynamic fields initialization from thread manager, and passes them to its constructor from sinsp: this allows to control the dynamic fields in a single place and inject them both on the thread manager and on the threadinfo factory.

Together, these changes reduces the number of dependencies of components that want to create a new threadinfo. This step is needed to get rid of the `sinsp` pointer in `sinsp_thread_manager`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

This is a step forward towards https://github.com/falcosecurity/libs/pull/2311#discussion_r1999376633 . Once this is merged, we can isolate `sinsp_fdinfo` and `sinsp_fdtable` from sinsp, and remove the mentioned repeated code.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: remove `sinsp::build_threadinfo()`
```
