### PR TITLE
refactor(userspace/libsinsp): isolate fdtable and fdinfo from `sinsp`

### DIFF
--- a/test/libsinsp_e2e/threadinfo.cpp
+++ b/test/libsinsp_e2e/threadinfo.cpp
@@ -48,7 +48,7 @@ static void run_test(test_type ttype,
                      std::vector<std::string>& expected,
                      std::string expectedrem) {
 	const sinsp inspector;
-	sinsp_threadinfo ti{inspector.get_fdinfo_factory()};
+	const auto ti = inspector.get_threadinfo_factory().create();
 	struct iovec* iov;
 	int iovcnt;
 	std::string rem;
@@ -57,31 +57,31 @@ static void run_test(test_type ttype,
 	for(auto& val : vals) {
 		switch(ttype) {
 		case TEST_ARGS:
-			ti.m_args.push_back(val.c_str());
+			ti->m_args.push_back(val.c_str());
 			break;
 		case TEST_ENV:
-			ti.m_env.push_back(val.c_str());
+			ti->m_env.push_back(val.c_str());
 			break;
 		case TEST_CGROUPS:
 			size_t pos = val.find("=");
 			ASSERT_NE(pos, std::string::npos);
-			auto cgroups = ti.cgroups();
+			auto cgroups = ti->cgroups();
 			cgroups.emplace_back(val.substr(0, pos), val.substr(pos + 1));
-			ti.set_cgroups(cgroups);
+			ti->set_cgroups(cgroups);
 			break;
 		}
 	}
 
 	switch(ttype) {
 	case TEST_ARGS:
-		ti.args_to_iovec(&iov, &iovcnt, rem);
+		ti->args_to_iovec(&iov, &iovcnt, rem);
 		break;
 	case TEST_ENV:
-		ti.env_to_iovec(&iov, &iovcnt, rem);
+		ti->env_to_iovec(&iov, &iovcnt, rem);
 		break;
 	case TEST_CGROUPS:
-		cg = ti.cgroups();
-		ti.cgroups_to_iovec(&iov, &iovcnt, rem, cg);
+		cg = ti->cgroups();
+		ti->cgroups_to_iovec(&iov, &iovcnt, rem, cg);
 		break;
 	};
 

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -55,7 +55,6 @@ limitations under the License.
 #define CHAR_FD_MEMFD 'm'
 #define CHAR_FD_PIDFD 'P'
 
-class sinsp;
 class sinsp_threadinfo;
 
 /** @defgroup state State management

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -73,8 +73,9 @@ limitations under the License.
 #include <libsinsp/tuples.h>
 #include <libsinsp/utils.h>
 #include <libsinsp/sinsp_mode.h>
-#include <libsinsp/sinsp_threadinfo_factory.h>
 #include <libsinsp/sinsp_fdinfo_factory.h>
+#include <libsinsp/sinsp_fdtable_factory.h>
+#include <libsinsp/sinsp_threadinfo_factory.h>
 
 #include <list>
 #include <map>
@@ -973,6 +974,7 @@ private:
 	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> m_thread_manager_dyn_fields;
 	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> m_fdtable_dyn_fields;
 	const sinsp_fdinfo_factory m_fdinfo_factory;
+	const sinsp_fdtable_factory m_fdtable_factory;
 	const sinsp_threadinfo_factory m_threadinfo_factory;
 
 public:
@@ -986,6 +988,8 @@ public:
 	}
 
 	const sinsp_fdinfo_factory& get_fdinfo_factory() const { return m_fdinfo_factory; }
+
+	const sinsp_fdtable_factory& get_fdtable_factory() const { return m_fdtable_factory; }
 
 	const sinsp_threadinfo_factory& get_threadinfo_factory() const { return m_threadinfo_factory; }
 
@@ -1015,7 +1019,7 @@ public:
 	//
 	// Some thread table limits
 	//
-	uint32_t m_max_fdtable_size;
+	static constexpr uint32_t s_max_fdtable_size = MAX_FD_TABLE_SIZE;
 	bool m_auto_threads_purging = true;
 	uint64_t m_thread_timeout_ns = (uint64_t)1800 * ONE_SECOND_IN_NS;
 	uint64_t m_threads_purging_scan_time_ns = (uint64_t)1200 * ONE_SECOND_IN_NS;

--- a/userspace/libsinsp/sinsp_fdtable_factory.h
+++ b/userspace/libsinsp/sinsp_fdtable_factory.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+#include <libsinsp/sinsp_mode.h>
+#include <libsinsp/sinsp_fdinfo_factory.h>
+#include <libsinsp/fdtable.h>
+
+struct sinsp_stats_v2;
+
+/*!
+  \brief Factory hiding sinsp_fdtable creation details.
+*/
+class sinsp_fdtable_factory {
+	const sinsp_mode& m_sinsp_mode;
+	const uint32_t m_max_table_size;
+	const sinsp_fdinfo_factory& m_fdinfo_factory;
+	const std::shared_ptr<const sinsp_plugin>& m_input_plugin;
+	const std::shared_ptr<sinsp_stats_v2> m_sinsp_stats_v2;
+	scap_platform* const* m_scap_platform;
+
+public:
+	sinsp_fdtable_factory(const sinsp_mode& sinsp_mode,
+	                      const uint32_t max_table_size,
+	                      const sinsp_fdinfo_factory& fdinfo_factory,
+	                      const std::shared_ptr<const sinsp_plugin>& input_plugin,
+	                      const std::shared_ptr<sinsp_stats_v2>& sinsp_stats_v2,
+	                      scap_platform* const* scap_platform):
+	        m_sinsp_mode{sinsp_mode},
+	        m_max_table_size{max_table_size},
+	        m_fdinfo_factory{fdinfo_factory},
+	        m_input_plugin{input_plugin},
+	        m_sinsp_stats_v2{sinsp_stats_v2},
+	        m_scap_platform{scap_platform} {}
+
+	sinsp_fdtable create() const {
+		return sinsp_fdtable{m_sinsp_mode,
+		                     m_max_table_size,
+		                     m_fdinfo_factory,
+		                     m_input_plugin,
+		                     m_sinsp_stats_v2,
+		                     m_scap_platform};
+	}
+};

--- a/userspace/libsinsp/sinsp_threadinfo_factory.h
+++ b/userspace/libsinsp/sinsp_threadinfo_factory.h
@@ -29,6 +29,7 @@ class sinsp_threadinfo_factory {
 	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&m_thread_manager_dyn_fields,
 	        m_fdtable_dyn_fields;
 	const sinsp_fdinfo_factory& m_fdinfo_factory;
+	const sinsp_fdtable_factory& m_fdtable_factory;
 
 	libsinsp::event_processor* get_external_event_processor() const {
 		return *m_external_event_processor;
@@ -41,18 +42,21 @@ public:
 	        const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
 	                thread_manager_dyn_fields,
 	        const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& fdtable_dyn_fields,
-	        const sinsp_fdinfo_factory& fdinfo_factory):
+	        const sinsp_fdinfo_factory& fdinfo_factory,
+	        const sinsp_fdtable_factory& fdtable_factory):
 	        m_sinsp{sinsp},
 	        m_external_event_processor{external_event_processor},
 	        m_thread_manager_dyn_fields{thread_manager_dyn_fields},
 	        m_fdtable_dyn_fields{fdtable_dyn_fields},
-	        m_fdinfo_factory{fdinfo_factory} {}
+	        m_fdinfo_factory{fdinfo_factory},
+	        m_fdtable_factory{fdtable_factory} {}
 	std::unique_ptr<sinsp_threadinfo> create() const {
 		const auto external_event_processor = get_external_event_processor();
 		std::unique_ptr<sinsp_threadinfo> tinfo =
 		        external_event_processor
 		                ? external_event_processor->build_threadinfo(m_sinsp)
 		                : std::make_unique<sinsp_threadinfo>(m_fdinfo_factory,
+		                                                     m_fdtable_factory,
 		                                                     m_sinsp,
 		                                                     m_thread_manager_dyn_fields);
 		if(tinfo->dynamic_fields() == nullptr) {
@@ -60,5 +64,12 @@ public:
 		}
 		tinfo->get_fdtable().set_dynamic_fields(m_fdtable_dyn_fields);
 		return tinfo;
+	}
+
+	std::shared_ptr<sinsp_threadinfo> create_shared() const {
+		// create_shared is currently used in contexts not handled by any external event processor,
+		// nor by any component needing dynamic fields to be initialized: for these reasons, for the
+		// moment, it is just a simplified (shared) version of what `create` does.
+		return std::make_shared<sinsp_threadinfo>(m_fdinfo_factory, m_fdtable_factory);
 	}
 };

--- a/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_thread_manager.cpp
@@ -33,8 +33,8 @@ TEST(sinsp_thread_manager, remove_non_existing_thread) {
 
 TEST(sinsp_thread_manager, thread_group_manager) {
 	sinsp m_inspector;
-	const auto fdinfo_factory = m_inspector.get_fdinfo_factory();
-	sinsp_thread_manager manager(m_inspector.get_threadinfo_factory(),
+	const auto& threadinfo_factory = m_inspector.get_threadinfo_factory();
+	sinsp_thread_manager manager(threadinfo_factory,
 	                             &m_inspector,
 	                             m_inspector.get_thread_manager_dyn_fields(),
 	                             m_inspector.get_fdtable_dyn_fields());
@@ -42,7 +42,7 @@ TEST(sinsp_thread_manager, thread_group_manager) {
 	/* We don't have thread group info here */
 	ASSERT_FALSE(manager.get_thread_group_info(8).get());
 
-	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto tinfo = threadinfo_factory.create_shared();
 	tinfo->m_pid = 12;
 	auto tginfo = std::make_shared<thread_group_info>(tinfo->m_pid, false, tinfo);
 
@@ -64,7 +64,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_null_pointer) {
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo.reset();
 
 	/* The thread info is nullptr */
@@ -78,7 +78,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_invalid_tinfo) {
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	const auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo->m_tid = 4;
 	tinfo->m_pid = -1;
 	tinfo->m_ptid = 1;
@@ -95,7 +95,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_tginfo_already_there) {
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo->m_tid = 4;
 	tinfo->m_pid = 4;
 	tinfo->m_ptid = 1;
@@ -115,7 +115,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_new_tginfo) {
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	const auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo->m_tid = 51000;
 	tinfo->m_pid = 51000;
 	tinfo->m_ptid = 51001; /* we won't find it in the table, so we will default to 0 */
@@ -135,8 +135,8 @@ TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo) {
 	data.thread_count = 0;
 	m_inspector.open_test_input(&data, SINSP_MODE_TEST);
 
-	const auto fdinfo_factory = m_inspector.get_fdinfo_factory();
-	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto& threadinfo_factory = m_inspector.get_threadinfo_factory();
+	const auto tinfo = threadinfo_factory.create_shared();
 	tinfo->m_tid = 51000;
 	tinfo->m_pid = 51003;
 	tinfo->m_ptid = 51004; /* we won't find it in the table, so we will default to 1 */
@@ -146,7 +146,7 @@ TEST(sinsp_thread_manager, create_thread_dependencies_use_existing_tginfo) {
 		m_inspector.m_thread_manager->set_thread_group_info(tinfo->m_pid, tginfo);
 	}
 
-	auto other_tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto other_tinfo = threadinfo_factory.create_shared();
 	other_tinfo->m_tid = 51003;
 	other_tinfo->m_pid = 51003;
 	other_tinfo->m_ptid = 51004;
@@ -159,7 +159,7 @@ TEST_F(sinsp_with_test_input, THRD_MANAGER_create_thread_dependencies_valid_pare
 	DEFAULT_TREE
 
 	/* new thread will be a child of p6_t1 */
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo->m_tid = 51000;
 	tinfo->m_pid = 51003;
 	tinfo->m_ptid = p6_t1_tid;
@@ -174,7 +174,7 @@ TEST_F(sinsp_with_test_input, THRD_MANAGER_create_thread_dependencies_invalid_pa
 	DEFAULT_TREE
 
 	/* new thread will be a child of p6_t1 */
-	auto tinfo = std::make_shared<sinsp_threadinfo>(m_inspector.get_fdinfo_factory());
+	auto tinfo = m_inspector.get_threadinfo_factory().create_shared();
 	tinfo->m_tid = 51000;
 	tinfo->m_pid = 51003;
 	tinfo->m_ptid = 8000;

--- a/userspace/libsinsp/test/classes/sinsp_threadinfo.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_threadinfo.cpp
@@ -20,8 +20,8 @@ limitations under the License.
 
 TEST(sinsp_threadinfo, get_main_thread) {
 	const sinsp inspector;
-	const auto fdinfo_factory = inspector.get_fdinfo_factory();
-	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto& threadinfo_factory = inspector.get_threadinfo_factory();
+	const auto tinfo = threadinfo_factory.create_shared();
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -41,7 +41,7 @@ TEST(sinsp_threadinfo, get_main_thread) {
 	tinfo->m_tginfo = tginfo;
 	ASSERT_EQ(tinfo->get_main_thread(), nullptr);
 
-	auto main_tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto main_tinfo = threadinfo_factory.create_shared();
 	main_tinfo->m_tid = 23;
 	main_tinfo->m_pid = 23;
 
@@ -56,8 +56,8 @@ TEST(sinsp_threadinfo, get_main_thread) {
 
 TEST(sinsp_threadinfo, get_num_threads) {
 	const sinsp inspector;
-	const auto fdinfo_factory = inspector.get_fdinfo_factory();
-	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto& threadinfo_factory = inspector.get_threadinfo_factory();
+	const auto tinfo = threadinfo_factory.create_shared();
 	tinfo->m_tid = 25;
 	tinfo->m_pid = 23;
 
@@ -71,7 +71,7 @@ TEST(sinsp_threadinfo, get_num_threads) {
 	ASSERT_EQ(tinfo->get_num_threads(), 1);
 	ASSERT_EQ(tinfo->get_num_not_leader_threads(), 1);
 
-	auto main_tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto main_tinfo = threadinfo_factory.create_shared();
 	main_tinfo->m_tid = 23;
 	main_tinfo->m_pid = 23;
 
@@ -135,7 +135,7 @@ TEST_F(sinsp_with_test_input, THRD_INFO_assign_children_to_a_nullptr) {
 
 TEST(sinsp_threadinfo, set_exepath) {
 	const sinsp inspector;
-	auto tinfo = std::make_shared<sinsp_threadinfo>(inspector.get_fdinfo_factory());
+	const auto tinfo = inspector.get_threadinfo_factory().create_shared();
 
 	{
 		// Nothing changes

--- a/userspace/libsinsp/test/classes/thread_group_info.cpp
+++ b/userspace/libsinsp/test/classes/thread_group_info.cpp
@@ -22,14 +22,14 @@ limitations under the License.
 
 TEST(thread_group_info, create_thread_group_info) {
 	const sinsp inspector;
-	const auto fdinfo_factory = inspector.get_fdinfo_factory();
-	std::shared_ptr<sinsp_threadinfo> tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto& threadinfo_factory = inspector.get_threadinfo_factory();
+	auto tinfo = threadinfo_factory.create_shared();
 	tinfo.reset();
 
 	/* This will throw an exception since tinfo is expired */
 	EXPECT_THROW(thread_group_info(34, true, tinfo), sinsp_exception);
 
-	tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	tinfo = threadinfo_factory.create_shared();
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -54,8 +54,8 @@ TEST(thread_group_info, create_thread_group_info) {
 
 TEST(thread_group_info, populate_thread_group_info) {
 	const sinsp inspector;
-	const auto fdinfo_factory = inspector.get_fdinfo_factory();
-	auto tinfo = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto& threadinfo_factory = inspector.get_threadinfo_factory();
+	const auto tinfo = threadinfo_factory.create_shared();
 	tinfo->m_tid = 23;
 	tinfo->m_pid = 23;
 
@@ -68,12 +68,12 @@ TEST(thread_group_info, populate_thread_group_info) {
 	tginfo.decrement_thread_count();
 	EXPECT_EQ(tginfo.get_thread_count(), 2);
 
-	auto tinfo1 = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto tinfo1 = threadinfo_factory.create_shared();
 	tginfo.add_thread_to_group(tinfo1, true);
 	ASSERT_EQ(tginfo.get_first_thread(), tinfo1.get());
 	EXPECT_EQ(tginfo.get_thread_count(), 3);
 
-	auto tinfo2 = std::make_shared<sinsp_threadinfo>(fdinfo_factory);
+	const auto tinfo2 = threadinfo_factory.create_shared();
 	tginfo.add_thread_to_group(tinfo2, false);
 	ASSERT_EQ(tginfo.get_first_thread(), tinfo1.get());
 	ASSERT_EQ(tginfo.get_thread_list().back().lock().get(), tinfo2.get());

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -40,12 +40,13 @@ static void copy_ipv6_address(uint32_t* dest, uint32_t* src) {
 
 sinsp_threadinfo::sinsp_threadinfo(
         const sinsp_fdinfo_factory& fdinfo_factory,
+        const sinsp_fdtable_factory& fdtable_factory,
         sinsp* inspector,
         const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields):
         table_entry(dyn_fields),
         m_inspector(inspector),
         m_fdinfo_factory{fdinfo_factory},
-        m_fdtable{fdinfo_factory, inspector},
+        m_fdtable{fdtable_factory.create()},
         m_main_fdtable(m_fdtable.table_ptr()),
         m_args_table_adapter("args", m_args),
         m_env_table_adapter("env", m_env),

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -31,6 +31,7 @@ struct iovec {
 
 #include <functional>
 #include <memory>
+#include <sinsp_fdtable_factory.h>
 #include <libsinsp/fdtable.h>
 #include <libsinsp/thread_group_info.h>
 #include <libsinsp/state/table.h>
@@ -64,6 +65,7 @@ struct erase_fd_params {
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry {
 public:
 	sinsp_threadinfo(const sinsp_fdinfo_factory& fdinfo_factory,
+	                 const sinsp_fdtable_factory& fdtable_factory,
 	                 sinsp* inspector = nullptr,
 	                 const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
 	                         dyn_fields = nullptr);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR isolates fdtable and fdinfo components from `sinsp`. Moreover, it centralizes the `threadinfo` creation details under `sinsp_threadinfo_factory`. As different APIs require a threadinfo shared pointer, a new `sinsp_threadinfo_factory::created_shared` method has been added and used throughout the codebase.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
