### PR TITLE
fix(driver): fix driver and bpf makefile for linux 6.13.

### DIFF
--- a/driver/Makefile.in
+++ b/driver/Makefile.in
@@ -29,7 +29,7 @@ install: all
 
 else
 
-KERNELDIR 	?= $(CURDIR)
+KERNELDIR 	?= $(realpath $(objtree))
 #
 # Get the path of the module sources
 #

--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -28,7 +28,7 @@ clean:
 
 else
 
-KERNELDIR 	?= $(CURDIR)
+KERNELDIR 	?= $(realpath $(objtree))
 #
 # Get the path of the module sources
 #


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod
/area driver-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since https://github.com/torvalds/linux/commit/13b25489b6f8bd73ed65f07928f7c27a481f1820, our driver and bpf makefile were a bit off.
Quoting the commit message:
> Currently, Kbuild always operates in the output directory of the kernel,
even when building external modules.

...

> The command for building external modules maintains backward
compatibility, but Makefiles that rely on working in the kernel
directory may break. In such cases, $(objtree) and $(srctree) should
be used to refer to the output and source directories of the kernel.

Thus, to retain old behavior, we should definitely use `$(objtree)`

`objtree` is also part of the documentation: https://github.com/torvalds/linux/commit/13b25489b6f8bd73ed65f07928f7c27a481f1820#diff-5a02662444aaba282ed85bc93267c9f07095fa0a882ce5717275ecda46e4a137R462
> $(objtree)
>
>  $(objtree) refers to the root of the kernel object tree. It is ``.`` when
>  building the kernel, but it is different when building external modules.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2277 

Supersedes #2301 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): fix driver and bpf makefile for linux 6.13.
```
