### PR TITLE
fix(libsinsp/filter): support syscall.type in event code search

### DIFF
--- a/userspace/libsinsp/filter/ppm_codes.cpp
+++ b/userspace/libsinsp/filter/ppm_codes.cpp
@@ -149,7 +149,8 @@ struct ppm_code_visitor : public libsinsp::filter::ast::const_expr_visitor {
 				e->right->accept(this);
 				if(m_last_node_is_field_or_transformer) {
 					throw sinsp_exception(
-					        "right-hand field comparisons on `evt.type` checks are not supported "
+					        "right-hand field comparisons on `evt.type`/`syscall.type` checks are "
+					        "not supported "
 					        "by event code search");
 				}
 				if(e->op == "!=") {
@@ -208,7 +209,8 @@ struct ppm_code_visitor : public libsinsp::filter::ast::const_expr_visitor {
 	void visit(const libsinsp::filter::ast::field_expr* e) override {
 		m_last_node_has_codes = false;
 		m_last_node_is_field_or_transformer = true;
-		m_last_node_is_evttype_field = e->field == "evt.type" && e->arg.empty();
+		m_last_node_is_evttype_field =
+		        (e->field == "evt.type" || e->field == "syscall.type") && e->arg.empty();
 		m_last_node_codes = all_codes_set();
 		try_inversion(m_last_node_codes);
 	}
@@ -217,7 +219,8 @@ struct ppm_code_visitor : public libsinsp::filter::ast::const_expr_visitor {
 		e->value->accept(this);
 		if(m_last_node_is_evttype_field) {
 			throw sinsp_exception(
-			        "event code search does not support `evt.type` checks with transformers");
+			        "event code search does not support `evt.type`/`syscall.type` checks with "
+			        "transformers");
 		}
 		m_last_node_is_field_or_transformer = true;
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

When searching for `evt.type` comparisons in rules condition filters, we never considered the`syscall.type`. This is essentially wrong, as that field extract the same exact sets of values as `evt.type`, except for the fact that it returns NULL in case the event is not produced from a syscall. That means that it's extractable value set is a subset of the one of `evt.type`, thus meaning that it should be considered in the same way.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp/filter): support syscall.type in event code search
```
