### PR TITLE
fix(ci): fix valijson installation with newest cmake versions.

### DIFF
--- a/.github/install-deps.sh
+++ b/.github/install-deps.sh
@@ -37,6 +37,7 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -Dvalijson_BUILD_TESTS=OFF \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     ../
 
 make install -j


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Github updates its linux runners with a newer cmake version (3.22.x) that dropped support for cmake<3.5:
```
/home/runner/work/plugins/plugins/third_party/valijson-0.6 /home/runner/work/plugins/plugins/third_party
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```
Seen here: https://github.com/falcosecurity/plugins/actions/runs/14195814672/job/39770831134?pr=695 (but uses same CI as libs).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
