### PR TITLE
feat(userspace/libsinsp)!: isolate `sinsp_threadinfo` from `sinsp`

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -163,6 +163,7 @@ sinsp::sinsp(bool with_metrics):
                 m_network_interfaces,
                 m_fdinfo_factory,
                 m_fdtable_factory,
+                m_usergroup_manager,
                 m_external_event_processor,
                 m_thread_manager_dyn_fields,
                 m_fdtable_dyn_fields,
@@ -180,6 +181,8 @@ sinsp::sinsp(bool with_metrics):
 	                                                          this,
 	                                                          m_thread_manager_dyn_fields,
 	                                                          m_fdtable_dyn_fields);
+	sinsp_threadinfo_factory::set_thread_manager_attorney::set(m_threadinfo_factory,
+	                                                           &m_thread_manager);
 	// Add thread manager table to state tables registry.
 	m_table_registry->add_table(m_thread_manager.get());
 	m_usergroup_manager = std::make_shared<sinsp_usergroup_manager>(this);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -158,12 +158,15 @@ sinsp::sinsp(bool with_metrics):
                                            m_sinsp_stats_v2,
                                            m_platform})},
         m_fdtable_factory{m_fdtable_ctor_params},
-        m_threadinfo_factory{this,
-                             m_external_event_processor,
-                             m_thread_manager_dyn_fields,
-                             m_fdtable_dyn_fields,
-                             m_fdinfo_factory,
-                             m_fdtable_factory},
+        m_threadinfo_factory{
+                this,
+                m_network_interfaces,
+                m_fdinfo_factory,
+                m_fdtable_factory,
+                m_external_event_processor,
+                m_thread_manager_dyn_fields,
+                m_fdtable_dyn_fields,
+        },
         m_table_registry{std::make_shared<libsinsp::state::table_registry>()},
         m_async_events_queue(DEFAULT_ASYNC_EVENT_QUEUE_SIZE),
         m_inited(false) {
@@ -1969,10 +1972,8 @@ bool sinsp_thread_manager::remove_inactive_threads() {
 }
 
 std::unique_ptr<sinsp_threadinfo> libsinsp::event_processor::build_threadinfo(sinsp* inspector) {
-	return std::make_unique<sinsp_threadinfo>(inspector->get_fdinfo_factory(),
-	                                          inspector->get_fdtable_factory(),
-	                                          inspector,
-	                                          inspector->get_thread_manager_dyn_fields());
+	return sinsp_threadinfo_factory::create_unique_attorney::create(
+	        inspector->get_threadinfo_factory());
 }
 
 std::unique_ptr<sinsp_fdinfo> libsinsp::event_processor::build_fdinfo(sinsp* inspector) {

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -980,7 +980,10 @@ private:
 	const sinsp_fdinfo_factory m_fdinfo_factory;
 	const std::shared_ptr<sinsp_fdtable::ctor_params> m_fdtable_ctor_params;
 	const sinsp_fdtable_factory m_fdtable_factory;
-	const sinsp_threadinfo_factory m_threadinfo_factory;
+	// TODO(ekoops): restore constness once we find a way to remove the circular dependency
+	//   between `sinsp_thread_manager` and `sinsp_threadinfo_factory` without providing the
+	//   additional `sinsp_threadinfo_factory::set_thread_manager method`.
+	sinsp_threadinfo_factory m_threadinfo_factory;
 	// A registry that manages the state tables of this inspector.
 	std::shared_ptr<libsinsp::state::table_registry> m_table_registry;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -980,10 +980,9 @@ private:
 	const sinsp_fdinfo_factory m_fdinfo_factory;
 	const std::shared_ptr<sinsp_fdtable::ctor_params> m_fdtable_ctor_params;
 	const sinsp_fdtable_factory m_fdtable_factory;
-	// TODO(ekoops): restore constness once we find a way to remove the circular dependency
-	//   between `sinsp_thread_manager` and `sinsp_threadinfo_factory` without providing the
-	//   additional `sinsp_threadinfo_factory::set_thread_manager method`.
-	sinsp_threadinfo_factory m_threadinfo_factory;
+	// Parameter shared with each single sinsp_threadinfo instance.
+	const std::shared_ptr<sinsp_threadinfo::ctor_params> m_threadinfo_ctor_params;
+	const sinsp_threadinfo_factory m_threadinfo_factory;
 	// A registry that manages the state tables of this inspector.
 	std::shared_ptr<libsinsp::state::table_registry> m_table_registry;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -587,7 +587,7 @@ public:
 	/*!
 	  \brief Returns true if truncated environments should be loaded from /proc
 	*/
-	inline bool large_envs_enabled() const {
+	bool large_envs_enabled() const {
 		return (is_live() || is_syscall_plugin()) && m_large_envs_enabled;
 	}
 
@@ -996,10 +996,6 @@ public:
 	std::shared_ptr<libsinsp::state::dynamic_struct::field_infos> get_fdtable_dyn_fields() const {
 		return m_fdtable_dyn_fields;
 	}
-
-	const sinsp_fdinfo_factory& get_fdinfo_factory() const { return m_fdinfo_factory; }
-
-	const sinsp_fdtable_factory& get_fdtable_factory() const { return m_fdtable_factory; }
 
 	const sinsp_threadinfo_factory& get_threadinfo_factory() const { return m_threadinfo_factory; }
 

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -39,13 +39,15 @@ static void copy_ipv6_address(uint32_t (&dest)[4], const uint32_t (&src)[4]) {
 }
 
 sinsp_threadinfo::sinsp_threadinfo(
+        const sinsp_network_interfaces& network_interfaces,
         const sinsp_fdinfo_factory& fdinfo_factory,
         const sinsp_fdtable_factory& fdtable_factory,
         sinsp* inspector,
         const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& dyn_fields):
         table_entry(dyn_fields),
-        m_inspector(inspector),
+        m_network_interfaces{network_interfaces},
         m_fdinfo_factory{fdinfo_factory},
+        m_inspector(inspector),
         m_fdtable{fdtable_factory.create()},
         m_main_fdtable(m_fdtable.table_ptr()),
         m_args_table_adapter("args", m_args),
@@ -230,7 +232,7 @@ sinsp_fdinfo* sinsp_threadinfo::add_fd_from_scap(const scap_fdinfo& fdi,
 		if(fdi.info.ipv4info.l4proto == SCAP_L4_TCP) {
 			newfdi->m_flags |= sinsp_fdinfo::FLAGS_SOCKET_CONNECTED;
 		}
-		m_inspector->get_ifaddr_list().update_fd(*newfdi);
+		m_network_interfaces.update_fd(*newfdi);
 		newfdi->m_name =
 		        ipv4tuple_to_string(newfdi->m_sockinfo.m_ipv4info, resolve_hostname_and_port);
 		break;
@@ -258,7 +260,7 @@ sinsp_fdinfo* sinsp_threadinfo::add_fd_from_scap(const scap_fdinfo& fdi,
 			if(fdi.info.ipv6info.l4proto == SCAP_L4_TCP) {
 				newfdi->m_flags |= sinsp_fdinfo::FLAGS_SOCKET_CONNECTED;
 			}
-			m_inspector->get_ifaddr_list().update_fd(*newfdi);
+			m_network_interfaces.update_fd(*newfdi);
 			newfdi->m_name =
 			        ipv4tuple_to_string(newfdi->m_sockinfo.m_ipv4info, resolve_hostname_and_port);
 		} else {

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -37,6 +37,7 @@ struct iovec {
 #include <libsinsp/state/table.h>
 #include <libsinsp/state/table_adapters.h>
 #include <libsinsp/event.h>
+#include <libsinsp/ifinfo.h>
 #include <libscap/scap_savefile_api.h>
 
 // Forward declare sinsp_thread_manager to avoid cyclic dependency.
@@ -67,7 +68,8 @@ struct erase_fd_params {
 */
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry {
 public:
-	sinsp_threadinfo(const sinsp_fdinfo_factory& fdinfo_factory,
+	sinsp_threadinfo(const sinsp_network_interfaces& network_interfaces,
+	                 const sinsp_fdinfo_factory& fdinfo_factory,
 	                 const sinsp_fdtable_factory& fdtable_factory,
 	                 sinsp* inspector = nullptr,
 	                 const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>&
@@ -627,11 +629,14 @@ private:
 	                  uint32_t& alen,
 	                  std::string& rem) const;
 
+	// The following fields are externally provided and access to them is expected to be read-only.
+	const sinsp_network_interfaces& m_network_interfaces;
+	const sinsp_fdinfo_factory& m_fdinfo_factory;
+
 	//
 	// Parameters that can't be accessed directly because they could be in the
 	// parent thread info
 	//
-	const sinsp_fdinfo_factory& m_fdinfo_factory;
 	sinsp_fdtable m_fdtable;  // The fd table of this thread
 	const libsinsp::state::base_table*
 	        m_main_fdtable;     // Points to the base fd table of the current main thread


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/2343.
It removes `sinsp_threadinfo` dependency on `sinsp` by selectively providing each single dependency the component needs.

In order to avoid code duplication in the event processor, this PR adds `sinsp_thread_info::create_unique_attorney` `sinsp_threadinfo_factory`'s inner classes following the attorney-client idiom (this helps to limit access to `sinsp_threadinfo_factory` private methods).

Moreover, this PR also removes some related and unused sinsp APIs: `sinsp::get_fdinfo_factory()` and `sinsp::get_fdtable_factory()`.

Finally, it changes the `sinsp_threadinfo` constructor to accept the dependencies.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: isolate immutable `sinsp_threadinfo` deps
feat(userspace/libsinsp)!: isolate mutable `sinsp_threadinfo` deps
feat(userspace/libsinsp)!: remove unused `sinsp` public APIs
```
