### PR TITLE
fix(libsinsp/modern_bpf): ancillary data improvements

### DIFF
--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -96,7 +96,10 @@ static __always_inline long handle_exit(uint32_t index, void *ctx) {
 	                              (struct sockaddr *)mmh.msg_hdr.msg_name);
 
 	/* Parameter 6: msg_control (type: PT_BYTEBUF) */
-	if(mmh.msg_hdr.msg_control != NULL) {
+	/* We are limited to UINT16_MAX bytes of control data due to the size parameter in
+	 * auxmap__store_bytebuf_param. */
+	if(mmh.msg_hdr.msg_control != NULL && mmh.msg_hdr.msg_controllen > 0 &&
+	   mmh.msg_hdr.msg_controllen <= 0xFFFF) {
 		auxmap__store_bytebuf_param(auxmap,
 		                            (unsigned long)mmh.msg_hdr.msg_control,
 		                            mmh.msg_hdr.msg_controllen,

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -87,7 +87,10 @@ int BPF_PROG(recvmsg_x, struct pt_regs *regs, long ret) {
 		auxmap__store_socktuple_param(auxmap, socket_fd, INBOUND, msghhdr.msg_name);
 
 		/* Parameter 5: msg_control (type: PT_BYTEBUF) */
-		if(msghhdr.msg_control != NULL) {
+		/* We are limited to UINT16_MAX bytes of control data due to the size parameter in
+		 * auxmap__store_bytebuf_param. */
+		if(msghhdr.msg_control != NULL && msghhdr.msg_controllen > 0 &&
+		   msghhdr.msg_controllen <= 0xFFFF) {
 			auxmap__store_bytebuf_param(auxmap,
 			                            (unsigned long)msghhdr.msg_control,
 			                            msghhdr.msg_controllen,

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3856,16 +3856,18 @@ void sinsp_parser::parse_rw_exit(sinsp_evt *evt) {
 			// accordingly via procfs scan.
 			//
 #ifndef _WIN32
-			int32_t cmparam = -1;
-			if(etype == PPME_SOCKET_RECVMSG_X && evt->get_num_params() >= 5) {
-				cmparam = 4;
-			} else if(etype == PPME_SOCKET_RECVMMSG_X && evt->get_num_params() >= 6) {
-				cmparam = 5;
-			}
+			if(evt->get_fd_info()->is_unix_socket()) {
+				int32_t cmparam = -1;
+				if(etype == PPME_SOCKET_RECVMSG_X && evt->get_num_params() >= 5) {
+					cmparam = 4;
+				} else if(etype == PPME_SOCKET_RECVMMSG_X && evt->get_num_params() >= 6) {
+					cmparam = 5;
+				}
 
-			if(cmparam != -1) {
-				parinfo = evt->get_param(cmparam);
-				process_recvmsg_ancillary_data(evt, parinfo);
+				if(cmparam != -1) {
+					parinfo = evt->get_param(cmparam);
+					process_recvmsg_ancillary_data(evt, parinfo);
+				}
 			}
 #endif
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3706,7 +3706,7 @@ inline void sinsp_parser::process_recvmsg_ancillary_data(sinsp_evt *evt,
 	    cmsg = PPM_CMSG_NXTHDR(msg_ctrl, msg_ctrllen, cmsg)) {
 		// Check for malformed control message buffer:
 		if(reinterpret_cast<const char *>(cmsg) < msg_ctrl ||
-		   reinterpret_cast<const char *>(cmsg) > msg_ctrl + msg_ctrllen) {
+		   reinterpret_cast<const char *>(cmsg) >= msg_ctrl + msg_ctrllen) {
 			libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
 			                          "Malformed ancillary data, skipping.");
 			break;

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3704,6 +3704,13 @@ inline void sinsp_parser::process_recvmsg_ancillary_data(sinsp_evt *evt,
 	size_t const msg_ctrllen = parinfo->m_len;
 	for(ppm_cmsghdr *cmsg = PPM_CMSG_FIRSTHDR(msg_ctrl, msg_ctrllen); cmsg != nullptr;
 	    cmsg = PPM_CMSG_NXTHDR(msg_ctrl, msg_ctrllen, cmsg)) {
+		// Check for malformed control message buffer:
+		if(reinterpret_cast<const char *>(cmsg) < msg_ctrl ||
+		   reinterpret_cast<const char *>(cmsg) > msg_ctrl + msg_ctrllen) {
+			libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
+			                          "Malformed ancillary data, skipping.");
+			break;
+		}
 		int cmsg_type;
 		PPM_CMSG_UNALIGNED_READ(cmsg, cmsg_type, cmsg_type);
 		if(cmsg_type != SCM_RIGHTS) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This change brings improvements in handling ancillary data retrieved by `recvmsg` and `recvmmsg`:
1. (modern_bpf) we explicitly limit stored ancillary data to buffers below 64k (due to maximum buffer length). Larger payloads are discarded.
2. (sinsp/parsers) additional check is added for ancillary data parsing for (rare) cases of malformed payloads.
3. (sinsp/parsers) ancillary data processing is now limited only to Unix sockets, since file descriptors processing only makes sense in this context.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
