### PR TITLE
fix(userspace/libsinsp): fixed `flt_cast` impl for big endian systems.

### DIFF
--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -583,9 +583,25 @@ bool flt_compare_ipv6net(cmpop op, const ipv6addr* operand1, const ipv6net* oper
 // flt_cast takes a pointer to memory, dereferences it as fromT type and casts it
 // to a compatible toT type
 template<class fromT, class toT>
-static inline toT flt_cast(const void* ptr) {
-	fromT val;
-	memcpy(&val, ptr, sizeof(fromT));
+static inline toT flt_cast(const void* ptr, uint32_t len) {
+	fromT val{};
+	/*
+	 * In big endian systems, we need to
+	 * make sure that we copy the right bytes
+	 * when len > sizeof(fromT).
+	 * This is an edge case that should only happen
+	 * for `evt.rawarg.*` fields.
+	 */
+	uint8_t shift = 0;
+#ifdef __s390x__
+	// NOTE: c++20 has `constexpr (std::endian::native == std::endian::big)`
+	// that would be much better.
+	// To avoid perf hit, only compile this on s390x (our only big-endian supported arch).
+	if(len > sizeof(fromT)) {
+		shift = len - sizeof(fromT);
+	}
+#endif
+	memcpy(&val, (uint8_t*)ptr + shift, sizeof(fromT));
 
 	return static_cast<toT>(val);
 }
@@ -607,56 +623,56 @@ bool flt_compare(cmpop op,
 	switch(type) {
 	case PT_INT8:
 		return flt_compare_numeric<int64_t>(op,
-		                                    flt_cast<int8_t, int64_t>(operand1),
-		                                    flt_cast<int8_t, int64_t>(operand2));
+		                                    flt_cast<int8_t, int64_t>(operand1, op1_len),
+		                                    flt_cast<int8_t, int64_t>(operand2, op2_len));
 	case PT_INT16:
 		return flt_compare_numeric<int64_t>(op,
-		                                    flt_cast<int16_t, int64_t>(operand1),
-		                                    flt_cast<int16_t, int64_t>(operand2));
+		                                    flt_cast<int16_t, int64_t>(operand1, op1_len),
+		                                    flt_cast<int16_t, int64_t>(operand2, op2_len));
 	case PT_INT32:
 		return flt_compare_numeric<int64_t>(op,
-		                                    flt_cast<int32_t, int64_t>(operand1),
-		                                    flt_cast<int32_t, int64_t>(operand2));
+		                                    flt_cast<int32_t, int64_t>(operand1, op1_len),
+		                                    flt_cast<int32_t, int64_t>(operand2, op2_len));
 	case PT_INT64:
 	case PT_FD:
 	case PT_PID:
 	case PT_ERRNO:
 		return flt_compare_numeric<int64_t>(op,
-		                                    flt_cast<int64_t, int64_t>(operand1),
-		                                    flt_cast<int64_t, int64_t>(operand2));
+		                                    flt_cast<int64_t, int64_t>(operand1, op1_len),
+		                                    flt_cast<int64_t, int64_t>(operand2, op2_len));
 	case PT_FLAGS8:
 	case PT_ENUMFLAGS8:
 	case PT_UINT8:
 	case PT_SIGTYPE:
 		return flt_compare_numeric<uint64_t>(op,
-		                                     flt_cast<uint8_t, uint64_t>(operand1),
-		                                     flt_cast<uint8_t, uint64_t>(operand2));
+		                                     flt_cast<uint8_t, uint64_t>(operand1, op1_len),
+		                                     flt_cast<uint8_t, uint64_t>(operand2, op2_len));
 	case PT_FLAGS16:
 	case PT_UINT16:
 	case PT_ENUMFLAGS16:
 	case PT_PORT:
 	case PT_SYSCALLID:
 		return flt_compare_numeric<uint64_t>(op,
-		                                     flt_cast<uint16_t, uint64_t>(operand1),
-		                                     flt_cast<uint16_t, uint64_t>(operand2));
+		                                     flt_cast<uint16_t, uint64_t>(operand1, op1_len),
+		                                     flt_cast<uint16_t, uint64_t>(operand2, op2_len));
 	case PT_UINT32:
 	case PT_FLAGS32:
 	case PT_ENUMFLAGS32:
 	case PT_MODE:
 		return flt_compare_numeric<uint64_t>(op,
-		                                     flt_cast<uint32_t, uint64_t>(operand1),
-		                                     flt_cast<uint32_t, uint64_t>(operand2));
+		                                     flt_cast<uint32_t, uint64_t>(operand1, op1_len),
+		                                     flt_cast<uint32_t, uint64_t>(operand2, op2_len));
 	case PT_BOOL:
 		return flt_compare_bool(op,
-		                        flt_cast<uint32_t, uint64_t>(operand1),
-		                        flt_cast<uint32_t, uint64_t>(operand2));
+		                        flt_cast<uint32_t, uint64_t>(operand1, op1_len),
+		                        flt_cast<uint32_t, uint64_t>(operand2, op2_len));
 	case PT_IPV4ADDR:
 		if(op2_len != sizeof(struct in_addr)) {
 			return op == CO_NE;
 		}
 		return flt_compare_ipv4addr(op,
-		                            flt_cast<uint32_t, uint64_t>(operand1),
-		                            flt_cast<uint32_t, uint64_t>(operand2));
+		                            flt_cast<uint32_t, uint64_t>(operand1, op1_len),
+		                            flt_cast<uint32_t, uint64_t>(operand2, op2_len));
 	case PT_IPV4NET:
 		if(op2_len != sizeof(ipv4net)) {
 			return op == CO_NE;
@@ -706,8 +722,8 @@ bool flt_compare(cmpop op,
 	case PT_RELTIME:
 	case PT_ABSTIME:
 		return flt_compare_numeric<uint64_t>(op,
-		                                     flt_cast<uint64_t, uint64_t>(operand1),
-		                                     flt_cast<uint64_t, uint64_t>(operand2));
+		                                     flt_cast<uint64_t, uint64_t>(operand1, op1_len),
+		                                     flt_cast<uint64_t, uint64_t>(operand2, op2_len));
 	case PT_CHARBUF:
 	case PT_FSPATH:
 	case PT_FSRELPATH:
@@ -716,8 +732,8 @@ bool flt_compare(cmpop op,
 		return flt_compare_buffer(op, (char*)operand1, (char*)operand2, op1_len, op2_len);
 	case PT_DOUBLE:
 		return flt_compare_numeric<double>(op,
-		                                   flt_cast<double, double>(operand1),
-		                                   flt_cast<double, double>(operand2));
+		                                   flt_cast<double, double>(operand1, op1_len),
+		                                   flt_cast<double, double>(operand2, op2_len));
 	default:
 		ASSERT(false);
 		return false;

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -255,6 +255,29 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_madness) {
 	// UINT64_MAX is FFFFFFFFFFFFFFFF
 	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.addr"), "FFFFFFFFFFFFFFFF");
 	ASSERT_ANY_THROW(eval_filter(evt, "evt.rawarg.addr > 0"));  // PT_SOCKADDR is not comparable
+
+	/*
+	 * Now test the bugged case where `find_longest_matching_evt_param` returns a size,
+	 * but then real event has a size that is bigger than that.
+	 * In this case, `find_longest_matching_evt_param` will find `size` param
+	 * from PPME_SYSCALL_READ_E, that is {"size", PT_UINT32, PF_DEC},
+	 * but then we call evt.rawarg.size on a PPME_SYSCALL_SPLICE_E,
+	 * whose `size` param is 64bit: {"size", PT_UINT64, PF_DEC}.
+	 */
+	// [PPME_SYSCALL_SPLICE_E] = {"splice", EC_IO_OTHER | EC_SYSCALL, EF_USES_FD, 4, {
+	//	{"fd_in", PT_FD, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"size", PT_UINT64, PF_DEC}, {
+	//		"flags", PT_FLAGS32, PF_HEX, splice_flags}}}
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_SPLICE_E,
+	                           4,
+	                           (int64_t)-1,
+	                           (int64_t)-1,
+	                           (uint64_t)512,
+	                           (uint32_t)0);
+	// Size is PF_DEC, 512 is 512
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.size"), "512");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.size < 515"));
 }
 
 TEST_F(sinsp_with_test_input, EVT_FILTER_thread_proc_info) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Edge case of the edge case here :rofl: 
Basically, `flt_cast` did not work well on big-endian systems when it was called on a source void pointer whose size was bigger than the requested type size.
This only happens for `evt.rawarg.*` filterchecks, since we do not know in advance which event we will need to extract, and thus the size of the parameter we need to extract. See https://github.com/falcosecurity/libs/issues/2333#issuecomment-2786734362 for a more formal explanation.

The second commit contains another fix, once again related to `evt.rawarg.*` fields, is to avoid copying past end of data.
Consider this scenario:
```
evt.rawarg.flags < 200
```
Let's say that:
* `200` gets compiled as uint16_t as the [`find_longest_matching_evt_param`](https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/sinsp_filtercheck_event.cpp#L480) returns a PTFLAGS16 type
* then, when we evaluated `evt.rawarg.flags` on the real event, we find it is a PTFLAGS32
* thus, when we reach `flt_compare`, we now expect to be able to memcpy 4B from both values, but the former one (ie: 200) was stored in 2B

The commit fixes this scenario.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2333 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
