### PR TITLE
fix(driver): fixed build of old bpf probe against linux 6.15-rc1.

### DIFF
--- a/driver/bpf/configure/KERNFS_NODE_PARENT/test.c
+++ b/driver/bpf/configure/KERNFS_NODE_PARENT/test.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+
+Copyright (C) 2025 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+/*
+ * Check that kernfs_node's field `parent` exists.
+ * See 6.15 kernel commit it is named __parent:
+ * https://github.com/torvalds/linux/commit/633488947ef66b194377411322dc9e12aab79b65
+ */
+
+#include "../../quirks.h"
+#include "../../ppm_events_public.h"
+#include "../../types.h"
+
+// struct kernfs_node declaration
+#include <linux/kernfs.h>
+
+BPF_PROBE("signal/", signal_deliver, signal_deliver_args) {
+	struct kernfs_node *parent;
+	struct kernfs_node node;
+
+	parent = node.parent;
+	return 0;
+}
+
+char __license[] __bpf_section("license") = "Dual MIT/GPL";

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1819,7 +1819,11 @@ static __always_inline int __bpf_append_cgroup(struct css_set *cgroups,
 	for(int k = 0; k < MAX_CGROUP_PATHS; ++k) {
 		if(kn) {
 			cgroup_path[k] = (char *)_READ(kn->name);
+#ifdef HAS_KERNFS_NODE_PARENT
 			kn = _READ(kn->parent);
+#else
+			kn = _READ(kn->__parent);
+#endif
 		} else {
 			cgroup_path[k] = NULL;
 		}

--- a/driver/modern_bpf/definitions/struct_flavors.h
+++ b/driver/modern_bpf/definitions/struct_flavors.h
@@ -59,6 +59,10 @@ struct inode___v6_11 {
 	uint32_t i_ctime_nsec;
 };
 
+struct kernfs_node___v6_15 {
+	struct kernfs_node *__parent;
+};
+
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop
 #endif

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -1296,7 +1296,12 @@ static __always_inline uint16_t store_cgroup_subsys(struct auxiliary_map *auxmap
 		}
 		path_components++;
 		BPF_CORE_READ_INTO(&cgroup_path_pointers[k], kn, name);
-		BPF_CORE_READ_INTO(&kn, kn, parent);
+		if(bpf_core_field_exists(kn->parent)) {
+			BPF_CORE_READ_INTO(&kn, kn, parent);
+		} else {
+			struct kernfs_node___v6_15 *kn_v6_15 = (void *)kn;
+			BPF_CORE_READ_INTO(&kn, kn_v6_15, __parent);
+		}
 	}
 
 	/* Reconstruct the path in reverse, using previously collected pointers.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-bpf
/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Linux 6.15-rc1 changed a field name in https://github.com/torvalds/linux/commit/633488947ef66b194377411322dc9e12aab79b65#diff-778d4f53e80041bbe5133320016dbc6603495e37f800d264765ac0ff012d279e
Properly update our bpf probe to build once again. Also, fixed modern ebpf probe to run on that kernel.

Holding until 6.15-rc6/7 as always.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver): fixed build of old bpf probe against linux 6.15-rc1.
```
