### PR TITLE
fix(userspace/libsinsp): do not throw an error while reading container's plugin IP or USER

### DIFF
--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -448,8 +448,14 @@ std::string sinsp_threadinfo::get_container_user() {
 		if(table != nullptr) {
 			auto fld = table->get_field<std::string>(
 			        sinsp_thread_manager::s_containers_table_field_user);
-			auto e = table->get_entry(container_id.c_str());
-			e.read_field(fld, user);
+			try {
+				auto e = table->get_entry(container_id);
+				e.read_field(fld, user);
+			} catch(...) {
+				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
+				                          "Failed to read user from container %s",
+				                          container_id.c_str());
+			}
 		}
 	}
 	return user;
@@ -465,8 +471,14 @@ std::string sinsp_threadinfo::get_container_ip() {
 		if(table != nullptr) {
 			auto fld = table->get_field<std::string>(
 			        sinsp_thread_manager::s_containers_table_field_ip);
-			auto e = table->get_entry(container_id.c_str());
-			e.read_field(fld, ip);
+			try {
+				auto e = table->get_entry(container_id);
+				e.read_field(fld, ip);
+			} catch(...) {
+				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
+				                          "Failed to read ip from container %s",
+				                          container_id.c_str());
+			}
 		}
 	}
 	return ip;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

It might happen that a threadinfo has a container_id attached, but the plugin already removed the container from its cache.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
