### PR TITLE
feat(userspace/libsinsp)!: move server ports accounting in thread mgr

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -986,7 +986,9 @@ void sinsp::on_new_entry_from_proc(void* context,
 		}
 
 		const auto added_fdinfo =
-		        sinsp_tinfo->add_fd_from_scap(*fdinfo, m_hostname_and_port_resolution_enabled);
+		        m_thread_manager->add_thread_fd_from_scap(*sinsp_tinfo,
+		                                                  *fdinfo,
+		                                                  m_hostname_and_port_resolution_enabled);
 		if(m_filter != nullptr && m_mode.is_capture()) {
 			// in case the inspector is configured with an internal filter, we can
 			// filter-out thread infos (and their fd infos) to not dump them in

--- a/userspace/libsinsp/thread_manager.h
+++ b/userspace/libsinsp/thread_manager.h
@@ -78,7 +78,6 @@ public:
 	  @throws a sinsp_exception containing the error string is thrown in case
 	   of failure.
 	*/
-
 	const threadinfo_map_t::ptr_t& get_thread_ref(int64_t tid,
 	                                              bool query_os_if_not_found = false,
 	                                              bool lookup_only = true,
@@ -207,6 +206,22 @@ public:
 	constexpr static auto s_containers_table_field_user = "user";
 	constexpr static auto s_containers_table_field_ip = "ip";
 	constexpr static auto s_container_id_field_name = "container_id";
+
+	/*!
+	  \brief Account the file descriptor for the provided thread.
+
+	  \param tinfo The thread the provided fd must be accounted to.
+	  \param fdinfo The file descriptor the provided thread must be accounted for.
+	  \param resolve_hostname_and_port A flag indicating if, in case of socket file descriptors, the
+	    hostname and port must be resolved.
+
+	  \return the \ref sinsp_fdinfo object containing full file descriptor information.
+
+	  \note tinfo must be a reference to a thread that is already present in the thread table.
+	*/
+	sinsp_fdinfo* add_thread_fd_from_scap(sinsp_threadinfo& tinfo,
+	                                      const scap_fdinfo& fdinfo,
+	                                      bool resolve_hostname_and_port);
 
 private:
 	inline void clear_thread_pointers(sinsp_threadinfo& threadinfo);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -241,14 +241,6 @@ sinsp_fdinfo* sinsp_threadinfo::add_fd_from_scap(const scap_fdinfo& fdi,
 		newfdi->m_sockinfo.m_ipv4serverinfo.m_l4proto = fdi.info.ipv4serverinfo.l4proto;
 		newfdi->m_name = ipv4serveraddr_to_string(newfdi->m_sockinfo.m_ipv4serverinfo,
 		                                          resolve_hostname_and_port);
-
-		//
-		// We keep note of all the host bound server ports.
-		// We'll need them later when patching connections direction.
-		//
-		m_inspector->m_thread_manager->m_server_ports.insert(
-		        newfdi->m_sockinfo.m_ipv4serverinfo.m_port);
-
 		break;
 	case SCAP_FD_IPV6_SOCK:
 		if(sinsp_utils::is_ipv4_mapped_ipv6((uint8_t*)&fdi.info.ipv6info.sip) &&
@@ -291,14 +283,6 @@ sinsp_fdinfo* sinsp_threadinfo::add_fd_from_scap(const scap_fdinfo& fdi,
 		newfdi->m_sockinfo.m_ipv6serverinfo.m_l4proto = fdi.info.ipv6serverinfo.l4proto;
 		newfdi->m_name = ipv6serveraddr_to_string(newfdi->m_sockinfo.m_ipv6serverinfo,
 		                                          resolve_hostname_and_port);
-
-		//
-		// We keep note of all the host bound server ports.
-		// We'll need them later when patching connections direction.
-		//
-		m_inspector->m_thread_manager->m_server_ports.insert(
-		        newfdi->m_sockinfo.m_ipv6serverinfo.m_port);
-
 		break;
 	case SCAP_FD_UNIX_SOCK:
 		newfdi->m_sockinfo.m_unixinfo.m_fields.m_source = fdi.info.unix_socket_info.source;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/2343.
It moves bound server ports accounting from `sinsp_threadinfo::add_fd_from_scap()` method to a new `sinsp_thread_manager::add_thread_fd_from_scap()` API.
Notice that this changes the `sinsp_threadinfo::add_fd_from_scap()` method semantic.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: move server ports accounting in thread mgr
```
