### PR TITLE
feat(userspace/libsinsp)! use `timestamper` in usergroup mgr

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -191,7 +191,7 @@ sinsp::sinsp(bool with_metrics):
 	                                                          m_fdtable_dyn_fields);
 	// Add thread manager table to state tables registry.
 	m_table_registry->add_table(m_thread_manager.get());
-	m_usergroup_manager = std::make_shared<sinsp_usergroup_manager>(this);
+	m_usergroup_manager = std::make_shared<sinsp_usergroup_manager>(this, m_timestamper);
 	m_usergroups_purging_scan_time_ns = DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S * ONE_SECOND_IN_NS;
 	m_filter = NULL;
 	m_machine_info = NULL;

--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -32,9 +32,9 @@ class usergroup_manager_test : public sinsp_with_test_input {
 };
 
 TEST_F(usergroup_manager_test, add_rm) {
-	std::string container_id{""};
-
-	sinsp_usergroup_manager mgr(&m_inspector);
+	const std::string container_id{""};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
 	// no data so far
 	ASSERT_EQ(mgr.get_user(container_id, 0), nullptr);
 	ASSERT_EQ(mgr.get_group(container_id, 0), nullptr);
@@ -82,9 +82,9 @@ TEST_F(usergroup_manager_test, add_rm) {
 // note(jasondellaluce): emscripten has issues with getpwuid
 #if !defined(__EMSCRIPTEN__)
 TEST_F(usergroup_manager_test, system_lookup) {
-	std::string container_id{""};
-
-	sinsp_usergroup_manager mgr(&m_inspector);
+	const std::string container_id{""};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
 
 	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
 	auto* user = mgr.get_user(container_id, 0);
@@ -118,9 +118,9 @@ TEST_F(usergroup_manager_test, system_lookup) {
 #endif
 
 TEST_F(usergroup_manager_test, add_no_import_users) {
-	std::string container_id{""};
-
-	sinsp_usergroup_manager mgr(&m_inspector);
+	const std::string container_id{""};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
 	mgr.m_import_users = false;
 
 	auto* added_usr = mgr.add_user(container_id, -1, 37, 15, "test", "/test", "/bin/test");
@@ -184,9 +184,9 @@ protected:
 };
 
 TEST_F(usergroup_manager_host_root_test, host_root_lookup) {
-	std::string container_id{""};
-
-	sinsp_usergroup_manager mgr(&m_inspector);
+	const std::string container_id{""};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
 
 	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
 	auto* user = mgr.get_user(container_id, 0);
@@ -205,9 +205,9 @@ TEST_F(usergroup_manager_host_root_test, host_root_lookup) {
 }
 
 TEST_F(usergroup_manager_host_root_test, nss_user_lookup) {
-	std::string container_id;  // empty container_id means host
-
-	sinsp_usergroup_manager mgr(&m_inspector);
+	const std::string container_id;  // empty container_id means host
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
 	mgr.add_user(container_id, -1, 0, 0, {}, {}, {});
 	mgr.add_user(container_id, -1, 65534, 0, {}, {}, {});
 

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -65,7 +65,7 @@ class ns_helper;
  */
 class sinsp_usergroup_manager {
 public:
-	explicit sinsp_usergroup_manager(sinsp *inspector);
+	explicit sinsp_usergroup_manager(sinsp *inspector, const timestamper &timestamper);
 	~sinsp_usergroup_manager() = default;
 
 	void dump_users_groups(sinsp_dumper &dumper);
@@ -197,6 +197,7 @@ private:
 	std::unordered_map<std::string, groupinfo_map> m_grouplist;
 	uint64_t m_last_flush_time_ns;
 	sinsp *m_inspector;
+	const timestamper &m_timestamper;
 
 	// User and group used as a fallback when m_import_users is disabled
 	scap_userinfo m_fallback_user;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR is part of a series https://github.com/falcosecurity/libs/issues/2343.
It replaces `sinsp::get_lastevent_ts()` and `sinsp::get_new_ts()` accesses in `sinsp_usergroup_manager` with accesses to `timestamper` APIs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)! use `timestamper` in usergroup mgr
```
