### PR TITLE
feat(userspace/libsinsp)!: drop unused `sinsp_dumper` APIs

### DIFF
--- a/userspace/libsinsp/dumper.cpp
+++ b/userspace/libsinsp/dumper.cpp
@@ -156,19 +156,6 @@ uint64_t sinsp_dumper::written_bytes() const {
 	return written_bytes;
 }
 
-uint64_t sinsp_dumper::next_write_position() const {
-	if(m_dumper == NULL) {
-		return 0;
-	}
-
-	int64_t position = scap_dump_ftell(m_dumper);
-	if(position == -1) {
-		throw sinsp_exception("error getting offset");
-	}
-
-	return position;
-}
-
 void sinsp_dumper::flush() {
 	if(m_dumper == NULL) {
 		throw sinsp_exception("dumper not opened yet");

--- a/userspace/libsinsp/dumper.h
+++ b/userspace/libsinsp/dumper.h
@@ -96,15 +96,6 @@ public:
 	uint64_t written_bytes() const;
 
 	/*!
-	  \brief Return the starting position for the next write into
-	          the file. (Under the covers, this uses gztell while
-	          written_bytes uses gzoffset, which represent different values).
-
-	  \return The starting position for the next write.
-	*/
-	uint64_t next_write_position() const;
-
-	/*!
 	  \brief Flush all pending output into the file.
 	*/
 	void flush();
@@ -115,8 +106,6 @@ public:
 	  \param evt Pointer to the event to dump.
 	*/
 	void dump(sinsp_evt* evt);
-
-	inline uint8_t* get_memory_dump_cur_buf() { return scap_get_memorydumper_curpos(m_dumper); }
 
 	inline void set_inspector(sinsp* inspector) { m_inspector = inspector; }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR drops unused `sinsp_dumper::get_memory_dump_cur_buf()` and `sinsp_dumper::next_write_position()` public APIs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: drop unused `sinsp_dumper` APIs
```
