### PR TITLE
fix(test/e2e): properly flush remaining queue once sinsp process leaves.

### DIFF
--- a/test/e2e/tests/commons/sinspqa/sinsp.py
+++ b/test/e2e/tests/commons/sinspqa/sinsp.py
@@ -121,6 +121,10 @@ class SinspProcessStreamer(SinspStreamer):
             if (datetime.now() - start).total_seconds() > self.timeout:
                 break
 
+        # flush remaining queue
+        while not self.queue.empty():
+            yield self.queue.get(block=False)
+
 
 class SinspStreamerBuilder:
     def __init__(self):


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area tests

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Will fix `test_curl_nginx` spurious failures.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
