### PR TITLE
fix(userspace/libpman): fix modern bpf engine hot-reload.

### DIFF
--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -98,9 +98,18 @@ int pman_prepare_progs_before_loading() {
 			return errno;
 		}
 
+		event_prog_t old_prog = progs[0];
 		// Always move the selected program to index 0 to be easily accessed by maps.c
 		// If no programs are skipped, the following line expands to progs[0] = progs[0];
 		progs[0] = progs[chosen_idx];
+
+		// To be able to reload the probe, we need to still reference the old
+		// program to set its autoload to false.
+		// Ie: in case of:
+		// * open()
+		// * close()
+		// * open()
+		progs[chosen_idx] = old_prog;
 	}
 	return 0;
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libpman

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

In #2255  i forgot to manage the hot-reload case; basically, in case `bpf_loop` was **not supported**, we put as first prog the `_old` one, the one that is not using `bpf_loop`.
BUT, we lost track of the other prog (the one using `bpf_loop`) that, upon an hot-reload, needs to be disabled (`bpf_program__set_autoload(p, false)`) once again, otherwise we would try to load it and fail.
This PR addresses the issue by storing the 0-indexed prog in `chosen_idx` to keep track of it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
