### PR TITLE
fix(ci): download custom container plugin from workflow.

### DIFF
--- a/.github/workflows/reusable_e2e_tests.yaml
+++ b/.github/workflows/reusable_e2e_tests.yaml
@@ -3,8 +3,8 @@ name: Run libs e2e tests python framework
 on:
   workflow_call:
     inputs:
-      custom_container_plugin:
-        description: 'use a custom container plugin; path or empty'
+      container_plugin_artifact_name:
+        description: 'use a previously built custom container plugin; artifact name to be downloaded, or empty'
         type: string
         required: false
         default: ''
@@ -86,10 +86,12 @@ jobs:
           make -j$(nproc) sinsp-example driver bpf container_plugin
           sudo -E make e2e-install-deps
 
-      - name: Use custom container plugin
-        if: inputs.custom_container_plugin != ''
-        run: |
-          mv ${{ inputs.custom_container_plugin }} build/test/e2e/container_plugin-prefix/src/container_plugin/
+      - name: Download overriding custom container plugin
+        if: inputs.container_plugin_artifact_name != ''
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.container_plugin_artifact_name }}
+          path: build/test/e2e/container_plugin-prefix/src/container_plugin/
 
       - name: Run tests - docker 🧪
         if: inputs.test-docker


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since we cannot have multi-steps action when invoking a reusable workflow, download the container plugin artifact upon override instead of moving: we don't expect to receive a path but an artifact name now.
This means that the [container plugin CI](https://github.com/falcosecurity/plugins/blob/main/.github/workflows/container-ci.yaml#L154) will become:
```
  libs-tests:
    needs: [build-linux]
    uses: falcosecurity/libs/.github/workflows/reusable_e2e_tests.yaml@master
    with:
      container_plugin_artifact_name: libcontainer-amd64
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
