### PR TITLE
chore(driver/modern_bpf): limit `bpf_loop` helper to 16 iterations.

### DIFF
--- a/driver/modern_bpf/helpers/base/shared_size.h
+++ b/driver/modern_bpf/helpers/base/shared_size.h
@@ -26,6 +26,9 @@
 /* Maximum number of `iovec` structures that we can analyze. */
 #define MAX_IOVCNT 32
 
+/* Maximum number of supported sendmmsg/recvmmsg loops with bpf_loop helper */
+#define MAX_SENDMMSG_RECVMMSG_SIZE 16
+
 /* Maximum number of `pollfd` structures that we can analyze. */
 #define MAX_POLLFD 16
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -161,7 +161,7 @@ int BPF_PROG(recvmmsg_x, struct pt_regs *regs, long ret) {
 	        .args = args,
 	};
 
-	uint32_t nr_loops = ret < 1024 ? ret : 1024;
+	uint32_t nr_loops = ret < MAX_SENDMMSG_RECVMMSG_SIZE ? ret : MAX_SENDMMSG_RECVMMSG_SIZE;
 	bpf_loop(nr_loops, handle_exit, &data, 0);
 
 	return 0;

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
@@ -147,7 +147,7 @@ int BPF_PROG(sendmmsg_x, struct pt_regs *regs, long ret) {
 	        .args = args,
 	};
 
-	uint32_t nr_loops = ret < 1024 ? ret : 1024;
+	uint32_t nr_loops = ret < MAX_SENDMMSG_RECVMMSG_SIZE ? ret : MAX_SENDMMSG_RECVMMSG_SIZE;
 	bpf_loop(nr_loops, handle_exit, &data, 0);
 
 	return 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area driver-modern-bpf

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

We noticed that on some kernels, it seems like `bpf_loop` `sendmmsg/recvmmsg` programs are slowing down the machine (possibly some kernel bugs?), leading to issues with multiple programs.
Limit `bpf_loop` iterations to 16 instead of 1024 to mitigate the issue (that will need proper investigation).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
