### PR TITLE
cleanup(modern_bpf): r/w ro ebpf maps best practices

### DIFF
--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -89,8 +89,12 @@ static __always_inline uint8_t maps__64bit_sampling_syscall_table(uint32_t sysca
 
 /*=============================== SYSCALL-64 INTERESTING TABLE ===========================*/
 
-static __always_inline bool maps__64bit_interesting_syscall(uint32_t syscall_id) {
-	return g_64bit_interesting_syscalls_table[syscall_id & (SYSCALL_TABLE_SIZE - 1)];
+static __always_inline bool maps__interesting_syscall_64bit(uint32_t syscall_id) {
+	bool *ret = bpf_map_lookup_elem(&interesting_syscalls_table_64bit, &syscall_id);
+	if(ret == NULL) {
+		return false;
+	}
+	return *ret;
 }
 
 /*=============================== SYSCALL-64 INTERESTING TABLE ===========================*/

--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -17,44 +17,99 @@
 
 /*=============================== SETTINGS ===========================*/
 
+static __always_inline struct capture_settings *maps__get_capture_settings() {
+	uint32_t key = 0;
+	return bpf_map_lookup_elem(&capture_settings, &key);
+}
+
 static __always_inline uint64_t maps__get_boot_time() {
-	return g_settings.boot_time;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->boot_time;
 }
 
 static __always_inline uint32_t maps__get_snaplen() {
-	return g_settings.snaplen;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->snaplen;
 }
 
 static __always_inline bool maps__get_dropping_mode() {
-	return g_settings.dropping_mode;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->dropping_mode;
 }
 
 static __always_inline uint32_t maps__get_sampling_ratio() {
-	return g_settings.sampling_ratio;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->sampling_ratio;
 }
 
 static __always_inline bool maps__get_drop_failed() {
-	return g_settings.drop_failed;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->drop_failed;
 }
 
 static __always_inline bool maps__get_do_dynamic_snaplen() {
-	return g_settings.do_dynamic_snaplen;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->do_dynamic_snaplen;
 }
 
 static __always_inline uint16_t maps__get_fullcapture_port_range_start() {
-	return g_settings.fullcapture_port_range_start;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->fullcapture_port_range_start;
 }
 
 static __always_inline uint16_t maps__get_fullcapture_port_range_end() {
-	return g_settings.fullcapture_port_range_end;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->fullcapture_port_range_end;
 }
 
 static __always_inline uint16_t maps__get_statsd_port() {
-	return g_settings.statsd_port;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->statsd_port;
 }
 
 static __always_inline int32_t maps__get_scap_tid() {
-	return g_settings.scap_tid;
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return 0;
+	}
+
+	return settings->scap_tid;
 }
 
 /*=============================== SETTINGS ===========================*/

--- a/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
+++ b/driver/modern_bpf/helpers/interfaces/syscalls_dispatcher.h
@@ -14,7 +14,7 @@
 #include <helpers/extract/extract_from_kernel.h>
 
 static __always_inline bool syscalls_dispatcher__64bit_interesting_syscall(uint32_t syscall_id) {
-	return maps__64bit_interesting_syscall(syscall_id);
+	return maps__interesting_syscall_64bit(syscall_id);
 }
 
 static __always_inline long convert_network_syscalls(struct pt_regs *regs) {

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -66,12 +66,6 @@ __weak const volatile uint32_t g_ia32_to_64_table[SYSCALL_TABLE_SIZE];
 /*=============================== BPF GLOBAL VARIABLES ===============================*/
 
 /**
- * @brief Global capture settings shared between userspace and
- * bpf programs.
- */
-__weak struct capture_settings g_settings;
-
-/**
  * @brief Variable used only kernel side to understand when we need to send
  * `DROP_E` and `DROP_X` events
  */
@@ -137,6 +131,17 @@ struct {
 	__type(key, uint32_t);
 	__type(value, bool);
 } interesting_syscalls_table_64bit __weak SEC(".maps");
+
+/**
+ * @brief Global capture settings shared between userspace and
+ * bpf programs.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, uint32_t);
+	__type(value, struct capture_settings);
+} capture_settings __weak SEC(".maps");
 
 /* These maps have one entry for each CPU.
  *

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -48,12 +48,6 @@ __weak const volatile uint64_t probe_api_ver = PPM_API_CURRENT_VERSION;
 __weak const volatile uint64_t probe_schema_var = PPM_SCHEMA_CURRENT_VERSION;
 
 /**
- * @brief Given the syscall id on 64-bit-architectures returns if
- * the syscall must be filtered out according to the simple consumer logic.
- */
-__weak bool g_64bit_interesting_syscalls_table[SYSCALL_TABLE_SIZE];
-
-/**
  * @brief Given the syscall id on 64-bit-architectures returns:
  * - `UF_NEVER_DROP` if the syscall must not be dropped in the sampling logic.
  * - `UF_ALWAYS_DROP` if the syscall must always be dropped in the sampling logic.
@@ -132,6 +126,17 @@ struct {
 /*=============================== BPF_MAP_TYPE_PROG_ARRAY ===============================*/
 
 /*=============================== BPF_MAP_TYPE_ARRAY ===============================*/
+
+/**
+ * @brief This table is used to keep track of which syscalls must be filtered out
+ * according to the simple consumer logic.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, SYSCALL_TABLE_SIZE);
+	__type(key, uint32_t);
+	__type(value, bool);
+} interesting_syscalls_table_64bit __weak SEC(".maps");
 
 /* These maps have one entry for each CPU.
  *

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -47,10 +47,6 @@ __weak const volatile uint64_t probe_api_ver = PPM_API_CURRENT_VERSION;
  */
 __weak const volatile uint64_t probe_schema_var = PPM_SCHEMA_CURRENT_VERSION;
 
-/*=============================== BPF READ-ONLY GLOBAL VARIABLES ===============================*/
-
-/*=============================== BPF GLOBAL VARIABLES ===============================*/
-
 /**
  * @brief Given the syscall id on 64-bit-architectures returns if
  * the syscall must be filtered out according to the simple consumer logic.
@@ -63,13 +59,17 @@ __weak bool g_64bit_interesting_syscalls_table[SYSCALL_TABLE_SIZE];
  * - `UF_ALWAYS_DROP` if the syscall must always be dropped in the sampling logic.
  * - `UF_NONE` if we drop the syscall depends on the sampling ratio.
  */
-__weak uint8_t g_64bit_sampling_syscall_table[SYSCALL_TABLE_SIZE];
+__weak const volatile uint8_t g_64bit_sampling_syscall_table[SYSCALL_TABLE_SIZE];
 
 /**
  * @brief Given the syscall id on 32-bit x86 arch returns
  * its x64 value. Used to support ia32 syscall emulation.
  */
-__weak uint32_t g_ia32_to_64_table[SYSCALL_TABLE_SIZE];
+__weak const volatile uint32_t g_ia32_to_64_table[SYSCALL_TABLE_SIZE];
+
+/*=============================== BPF READ-ONLY GLOBAL VARIABLES ===============================*/
+
+/*=============================== BPF GLOBAL VARIABLES ===============================*/
 
 /**
  * @brief Global capture settings shared between userspace and

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/socket.bpf.c
@@ -76,7 +76,7 @@ int BPF_PROG(socket_x, struct pt_regs *regs, long ret) {
 	/* Just called once by our scap process */
 	if(ret >= 0 && maps__get_socket_file_ops() == NULL) {
 		struct task_struct *task = get_current_task();
-		/* Please note that in `g_settings.scap_tid` scap will put its virtual tid
+		/* Please note that in `settings.scap_tid` scap will put its virtual tid
 		 * if it is running inside a container. If we want to extract the same information
 		 * in the kernel we need to extract the virtual tid of the task.
 		 */

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -461,8 +461,9 @@ int pman_finalize_maps_after_loading(void);
  * @param syscall_id syscall system id.
  * @param interesting true if the syscall must be marked as interesting.
  *
+ * @return `0` on success, `errno` in case of error.
  */
-void pman_mark_single_64bit_syscall(int syscall_id, bool interesting);
+int pman_mark_single_64bit_syscall(int syscall_id, bool interesting);
 
 #ifdef __cplusplus
 }

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -115,49 +115,63 @@ int pman_update_capture_settings(struct capture_settings* settings) {
 
 void pman_set_snaplen(uint32_t desired_snaplen) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.snaplen = desired_snaplen;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_boot_time(uint64_t boot_time) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.boot_time = boot_time;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_dropping_mode(bool value) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.dropping_mode = value;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_sampling_ratio(uint32_t value) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.sampling_ratio = value;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_drop_failed(bool drop_failed) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.drop_failed = drop_failed;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_do_dynamic_snaplen(bool do_dynamic_snaplen) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.do_dynamic_snaplen = do_dynamic_snaplen;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_fullcapture_port_range(uint16_t range_start, uint16_t range_end) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.fullcapture_port_range_start = range_start;
 	settings.fullcapture_port_range_end = range_end;
 	pman_update_capture_settings(&settings);
@@ -165,14 +179,18 @@ void pman_set_fullcapture_port_range(uint16_t range_start, uint16_t range_end) {
 
 void pman_set_statsd_port(uint16_t statsd_port) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.statsd_port = statsd_port;
 	pman_update_capture_settings(&settings);
 }
 
 void pman_set_scap_tid(int32_t scap_tid) {
 	struct capture_settings settings;
-	pman_get_capture_settings(&settings);
+	if(pman_get_capture_settings(&settings) != 0) {
+		return;
+	}
 	settings.scap_tid = scap_tid;
 	pman_update_capture_settings(&settings);
 }
@@ -196,28 +214,6 @@ void pman_fill_syscall_sampling_table() {
 			continue;
 		}
 	}
-}
-
-int pman_init_settings_map() {
-	char error_message[MAX_ERROR_MESSAGE_LEN];
-	struct capture_settings settings = {};
-	uint32_t key = 0;
-	int fd = bpf_map__fd(g_state.skel->maps.capture_settings);
-	if(fd <= 0) {
-		snprintf(error_message, MAX_ERROR_MESSAGE_LEN, "unable to get capture_settings map!");
-		pman_print_error((const char*)error_message);
-		return errno;
-	}
-
-	if(bpf_map_update_elem(fd, &key, &settings, BPF_ANY)) {
-		snprintf(error_message,
-		         MAX_ERROR_MESSAGE_LEN,
-		         "unable to initialize capture_settings map!");
-		pman_print_error((const char*)error_message);
-		return errno;
-	}
-
-	return 0;
 }
 
 void pman_fill_ia32_to_64_table() {
@@ -452,7 +448,8 @@ int pman_prepare_maps_before_loading() {
 
 int pman_finalize_maps_after_loading() {
 	int err;
-	err = pman_init_settings_map();
+	struct capture_settings settings = {};
+	err = pman_update_capture_settings(&settings);
 	if(err != 0) {
 		return err;
 	}

--- a/userspace/libpman/src/sc_set.c
+++ b/userspace/libpman/src/sc_set.c
@@ -52,11 +52,11 @@ int pman_enforce_sc_set(bool *sc_set) {
 		}
 
 		if(!sc_set[sc]) {
-			pman_mark_single_64bit_syscall(syscall_id, false);
+			ret = ret ?: pman_mark_single_64bit_syscall(syscall_id, false);
 		} else {
 			sys_enter = true;
 			sys_exit = true;
-			pman_mark_single_64bit_syscall(syscall_id, true);
+			ret = ret ?: pman_mark_single_64bit_syscall(syscall_id, true);
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area driver-modern-bpf

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

No

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Our ebpf probe is saving many things, including the interesting syscall set, into the `.bss` section which is set by libbpf as mmapable. It is a best practice not to include security sensitive settings in an mmapable fd, so we are separating these, plus the general ebpf probe settings into their own maps; in addition, we are setting variables that are never written to read-only (by using `.rodata`).

Credits to @mouadk for looking at the maps permissions and suggesting this improvement!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
cleanup(modern_bpf): r/w ro ebpf maps best practices
```
