### PR TITLE
feat(userspace/libsinsp)!: make `sinsp_parser::reset()` const

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -771,7 +771,7 @@ bool sinsp_parser::retrieve_enter_event(sinsp_evt &enter_evt, sinsp_evt &exit_ev
 
 void sinsp_parser::parse_clone_exit_caller(sinsp_evt &evt,
                                            sinsp_parser_verdict &verdict,
-                                           int64_t child_tid) {
+                                           const int64_t child_tid) const {
 	uint16_t etype = evt.get_type();
 	int64_t caller_tid = evt.get_tid();
 
@@ -1265,7 +1265,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt &evt,
 	/*=============================== ADD THREAD TO THE TABLE ===========================*/
 }
 
-void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &verdict) {
+void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &verdict) const {
 	uint16_t etype = evt.get_type();
 	int64_t child_tid = evt.get_tid();
 
@@ -1752,7 +1752,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &
 	/*=============================== CREATE NEW THREAD-INFO ===========================*/
 }
 
-void sinsp_parser::parse_clone_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict) {
+void sinsp_parser::parse_clone_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict) const {
 	int64_t childtid = evt.get_syscall_return_value();
 	/* Please note that if the child is in a namespace different from the init one
 	 * we should never use this `childtid` otherwise we will use a thread id referred to
@@ -3699,7 +3699,7 @@ inline void sinsp_parser::process_recvmsg_ancillary_data(sinsp_evt &evt,
 }
 #endif  // _WIN32
 
-void sinsp_parser::parse_rw_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict) {
+void sinsp_parser::parse_rw_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict) const {
 	const sinsp_evt_param *parinfo;
 	int64_t retval;
 	int64_t tid = evt.get_tid();

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -37,6 +37,7 @@ public:
 	sinsp_parser(const sinsp_mode& mode,
 	             const scap_machine_info* const& machine_info,
 	             const std::vector<std::string>& event_sources,
+	             size_t syscall_event_source_idx,
 	             const sinsp_network_interfaces& network_interfaces,
 	             const bool& hostname_and_port_resolution_enabled,
 	             const sinsp_threadinfo_factory& threadinfo_factory,
@@ -58,7 +59,7 @@ public:
 	void process_event(sinsp_evt& evt, sinsp_parser_verdict& verdict);
 	void event_cleanup(sinsp_evt& evt);
 
-	bool reset(sinsp_evt& evt, sinsp_parser_verdict& verdict);
+	bool reset(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
 
 	//
 	// Get the enter event matching the last received event
@@ -203,6 +204,7 @@ private:
 	const sinsp_mode& m_sinsp_mode;
 	const scap_machine_info* const& m_machine_info;
 	const std::vector<std::string>& m_event_sources;
+	const size_t m_syscall_event_source_idx;
 	const sinsp_network_interfaces& m_network_interfaces;
 	const bool& m_hostname_and_port_resolution_enabled;
 	const sinsp_threadinfo_factory m_threadinfo_factory;
@@ -223,7 +225,4 @@ private:
 	bool m_track_connection_status = false;
 
 	std::stack<uint8_t*> m_tmp_events_buffer;
-
-	// caches the index of the "syscall" event source
-	size_t m_syscall_event_source_idx;
 };

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -83,9 +83,11 @@ private:
 	//
 	// Parsers
 	//
-	void parse_clone_exit_child(sinsp_evt& evt, sinsp_parser_verdict& verdict);
-	void parse_clone_exit_caller(sinsp_evt& evt, sinsp_parser_verdict& verdict, int64_t child_tid);
-	void parse_clone_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict);
+	void parse_clone_exit_child(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
+	void parse_clone_exit_caller(sinsp_evt& evt,
+	                             sinsp_parser_verdict& verdict,
+	                             int64_t child_tid) const;
+	void parse_clone_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
 	void parse_execve_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
 	void parse_open_openat_creat_exit(sinsp_evt& evt) const;
 	static void parse_fchmod_fchown_exit(sinsp_evt& evt);
@@ -102,7 +104,7 @@ private:
 	void parse_pidfd_open_exit(sinsp_evt& evt) const;
 	void parse_pidfd_getfd_exit(sinsp_evt& evt) const;
 	void parse_fspath_related_exit(sinsp_evt& evt) const;
-	inline void parse_rw_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict);
+	inline void parse_rw_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
 	void parse_sendfile_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;
 	void parse_eventfd_exit(sinsp_evt& evt) const;
 	void parse_bind_exit(sinsp_evt& evt, sinsp_parser_verdict& verdict) const;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -235,15 +235,16 @@ sinsp::sinsp(bool with_metrics):
 
 	m_replay_scap_evt = nullptr;
 
-	// the "syscall" event source is implemented by sinsp itself
-	// and is always present
 	m_plugin_parsers.clear();
+	// The "syscall" event source is implemented by sinsp itself and is always present at index 0.
+	constexpr size_t syscall_event_source_idx = 0;
 	m_event_sources.push_back(sinsp_syscall_event_source_name);
 	m_plugin_manager = std::make_shared<sinsp_plugin_manager>(m_event_sources);
 
 	m_parser = std::make_unique<sinsp_parser>(m_mode,
 	                                          m_machine_info,
 	                                          m_event_sources,
+	                                          syscall_event_source_idx,
 	                                          m_network_interfaces,
 	                                          m_hostname_and_port_resolution_enabled,
 	                                          m_threadinfo_factory,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR makes `sinsp_parser::reset()` const by removing from `sinsp_parser` the logic for obtaining the syscall event source index and providing it directly from sinsp. Moreover, it makes some other `sinsp_parser` methods const.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: make `sinsp_parser::reset()` const
feat(userspace/libsinsp)!: make some `sinsp_parser` methods const
```
