### PR TITLE
fix(libscap): cgroupv2 path discovery with empty cgroup2 mountpoint

### DIFF
--- a/userspace/libscap/debug_log_helpers.h
+++ b/userspace/libscap/debug_log_helpers.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <libscap/scap_log.h>
 
+#include <stdarg.h>
 #include <stdio.h>
 
 #define scap_log(HANDLE, sev, ...) scap_log_impl(HANDLE->m_log_fn, sev, __VA_ARGS__)

--- a/userspace/libscap/linux/scap_cgroup.h
+++ b/userspace/libscap/linux/scap_cgroup.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <stdint.h>
 
 #include <libscap/scap_cgroup_set.h>
+#include <libscap/scap_log.h>
 
 #define FOR_EACH_SUBSYS(cgset, subsys)                                                           \
 	for(const char *subsys = (cgset)->path, *_end = (cgset)->path + (cgset)->len; subsys < _end; \
@@ -54,6 +55,8 @@ struct scap_cgroup_interface {
 	char m_self_v2[SCAP_MAX_PATH_SIZE];
 
 	bool m_in_cgroupns;
+
+	falcosecurity_log_fn m_log_fn;
 };
 
 int32_t scap_cgroup_interface_init(struct scap_cgroup_interface* cgi,

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -62,6 +62,7 @@ int32_t scap_linux_init_platform(struct scap_platform* platform,
 	linux_platform->m_proc_scan_timeout_ms = oargs->proc_scan_timeout_ms;
 	linux_platform->m_proc_scan_log_interval_ms = oargs->proc_scan_log_interval_ms;
 	linux_platform->m_log_fn = oargs->log_fn;
+	linux_platform->m_cgroups.m_log_fn = oargs->log_fn;
 
 	if(scap_os_get_machine_info(&platform->m_machine_info, lasterr) != SCAP_SUCCESS) {
 		return SCAP_FAILURE;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The cgroup v2 path detection logic breaks when a mountpoint of type `cgroup2` with no controllers is present. This issue has been observed on nodes of a RKE cluster (version 1.4.3).

```
[root@ip-172-31-58-203 /]# mount | grep "type cgroup2"
cgroup on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
none on /host/run/calico/cgroup type cgroup2 (rw,relatime,nsdelegate,memory_recursiveprot)
cgroup on /host/var/lib/docker/overlay2/eeb2a1f2ac65e8311bd2c3b3badeb3134968b81b0710a5d3ab9456b4d05d8cc7/merged/sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
none on /host/var/lib/docker/overlay2/eeb2a1f2ac65e8311bd2c3b3badeb3134968b81b0710a5d3ab9456b4d05d8cc7/merged/host/run/calico/cgroup type cgroup2 (rw,relatime,nsdelegate,memory_recursiveprot)
cgroup2 on /host/sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
none on /host/var/run/calico/cgroup type cgroup2 (rw,relatime,nsdelegate,memory_recursiveprot)
[root@ip-172-31-58-203 /]# ls -alh /host/var/run/calico/cgroup
total 0
```

This mount is created by a [calico init container](https://github.com/projectcalico/calico/pull/6078/).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
