### PR TITLE
feat(userspace/libsinsp/examples): add -c and -A options in example

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -147,27 +147,27 @@ static void select_engine(const char* select) {
 #ifndef _WIN32
 // Parse CLI options.
 void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
-	static struct option long_options[] = {{"help", no_argument, 0, 'h'},
-	                                       {"filter", required_argument, 0, 'f'},
-	                                       {"json", no_argument, 0, 'j'},
-	                                       {"all-threads", no_argument, 0, 'a'},
-	                                       {"bpf", required_argument, 0, 'b'},
-	                                       {"modern_bpf", no_argument, 0, 'm'},
-	                                       {"kmod", no_argument, 0, 'k'},
-	                                       {"scap_file", required_argument, 0, 's'},
-	                                       {"plugin", required_argument, 0, 'p'},
-	                                       {"buffer_dim", required_argument, 0, 'd'},
-	                                       {"output-fields", required_argument, 0, 'o'},
-	                                       {"exclude-users", no_argument, 0, 'E'},
-	                                       {"num-events", required_argument, 0, 'n'},
-	                                       {"ppm-sc-modifies-state", no_argument, 0, 'z'},
-	                                       {"ppm-sc-repair-state", no_argument, 0, 'x'},
-	                                       {"remove-io-sc-state", no_argument, 0, 'q'},
-	                                       {"enable-glogger", no_argument, 0, 'g'},
-	                                       {"raw", no_argument, 0, 'r'},
-	                                       {"gvisor", optional_argument, 0, 'G'},
-	                                       {"perftest", no_argument, 0, 't'},
-	                                       {0, 0, 0, 0}};
+	static struct option long_options[] = {{"help", no_argument, nullptr, 'h'},
+	                                       {"filter", required_argument, nullptr, 'f'},
+	                                       {"json", no_argument, nullptr, 'j'},
+	                                       {"all-threads", no_argument, nullptr, 'a'},
+	                                       {"bpf", required_argument, nullptr, 'b'},
+	                                       {"modern_bpf", no_argument, nullptr, 'm'},
+	                                       {"kmod", no_argument, nullptr, 'k'},
+	                                       {"scap_file", required_argument, nullptr, 's'},
+	                                       {"plugin", required_argument, nullptr, 'p'},
+	                                       {"buffer_dim", required_argument, nullptr, 'd'},
+	                                       {"output-fields", required_argument, nullptr, 'o'},
+	                                       {"exclude-users", no_argument, nullptr, 'E'},
+	                                       {"num-events", required_argument, nullptr, 'n'},
+	                                       {"ppm-sc-modifies-state", no_argument, nullptr, 'z'},
+	                                       {"ppm-sc-repair-state", no_argument, nullptr, 'x'},
+	                                       {"remove-io-sc-state", no_argument, nullptr, 'q'},
+	                                       {"enable-glogger", no_argument, nullptr, 'g'},
+	                                       {"raw", no_argument, nullptr, 'r'},
+	                                       {"gvisor", optional_argument, nullptr, 'G'},
+	                                       {"perftest", no_argument, nullptr, 't'},
+	                                       {nullptr, 0, nullptr, 0}};
 
 	bool format_set = false;
 	int op;
@@ -246,7 +246,7 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 			break;
 		}
 		case 'd':
-			buffer_bytes_dim = strtoul(optarg, NULL, 10);
+			buffer_bytes_dim = strtoul(optarg, nullptr, 10);
 			break;
 		case 'o':
 			default_output = optarg;
@@ -404,7 +404,7 @@ static bool insert_module() {
 		return true;
 
 	char* driver_path = getenv("KERNEL_MODULE");
-	if(driver_path == NULL || *driver_path == '\0') {
+	if(driver_path == nullptr || *driver_path == '\0') {
 		// We don't have a path set, assuming the kernel module is already there
 		return true;
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds two new CLI options for the modern eBPF probe in `sinsp-example`:
- `-c <num>, --cpus-for-each-buffer <num>` - allowing to select the number of CPUs for each ring buffer
- `-A, --all-cpus` - allowing to allocate ring buffers for all available CPUs (not only online ones)

Moreover, it replaces `NULL`/`0` pointers values with `nullptr`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
