### PR TITLE
fix(userspace/libscap): avoid field access to possibly NULL struct

### DIFF
--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -300,7 +300,7 @@ int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf,
 				        "could not fit event param %d size %zu for event with type %d in %zu bytes",
 				        i,
 				        param.size,
-				        event->type,
+				        event_type,
 				        len_size);
 			}
 			if(scap_buffer_can_fit(event_buf, len)) {
@@ -316,7 +316,7 @@ int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf,
 				        "could not fit event param %d size %zu for event with type %d in %zu bytes",
 				        i,
 				        param.size,
-				        event->type,
+				        event_type,
 				        len_size);
 			}
 			if(scap_buffer_can_fit(event_buf, len)) {
@@ -330,7 +330,7 @@ int32_t scap_event_encode_params_v(const struct scap_sized_buffer event_buf,
 			                      "unexpected param %d length %zu for event with type %d",
 			                      i,
 			                      len_size,
-			                      event->type);
+			                      event_type);
 		}
 
 		if(scap_buffer_can_fit(event_buf, len + param.size) && param.size != 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes invalid field access to a possibly NULL scap event. It fixes it by avoiding the access to the event field and using instead the `event_type` function parameter.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
