### PR TITLE
ci: introduce bpfvalidator for modern bpf probe

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -39,7 +39,7 @@ jobs:
   # This job run all engine tests and scap-open
   test-scap:
     name: test-scap-${{ matrix.arch }} 😆 (bundled_deps)
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
     needs: paths-filter
     strategy:
       matrix:
@@ -101,6 +101,14 @@ jobs:
         run: |
           cd build
           sudo ./test/libscap/libscap_test
+
+      - name: Validate scap-open with modern bpf
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        uses: Andreagit97/bpfvalidator@v0.2.0
+        with:
+          cmd: "$GITHUB_WORKSPACE/build/libscap/examples/01-open/scap-open --modern_bpf --num_events 10"
+          kernels: "v5.10.237,v5.15.184,v6.1.140,v6.6.92,v6.12.30,v6.15"
+          kvm: ${{ matrix.arch == 'amd64' }}
 
   test-drivers:
     name: test-drivers-${{ matrix.arch }} 😇 (bundled_deps)


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

/area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

First attempt to integrate [bpfvalidator](https://github.com/Andreagit97/bpfvalidator) to test modern ebpf driver

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
