### PR TITLE
fix(plugin): fix extract offsets handling

### DIFF
--- a/userspace/libsinsp/filter_cache.h
+++ b/userspace/libsinsp/filter_cache.h
@@ -37,10 +37,7 @@ struct extract_value_t {
 /**
  * @brief Represents a field offset extracted when evaluating a filter
  */
-struct extract_offset_t {
-	uint32_t start = UINT32_MAX;
-	uint32_t length = UINT32_MAX;
-};
+using extract_offset_t = ss_plugin_extract_value_offsets;
 
 /**
  * @brief Represents a cache value storage for value extraction in filters

--- a/userspace/libsinsp/plugin_filtercheck.cpp
+++ b/userspace/libsinsp/plugin_filtercheck.cpp
@@ -170,10 +170,16 @@ bool sinsp_filter_check_plugin::extract_nocache(sinsp_evt* evt,
 	efield.arg_present = m_arg_present;
 	efield.ftype = type;
 	efield.flist = m_info->m_fields[m_field_id].m_flags & EPF_IS_LIST;
-	ss_plugin_extract_value_offsets eoffset = {nullptr, nullptr};
+
+	if(offsets) {
+		if(offsets->size() < num_fields) {
+			offsets->resize(num_fields, {UINT32_MAX, UINT32_MAX});
+		}
+	}
+
 	ss_plugin_extract_value_offsets* eoptr = nullptr;
 	if(offsets) {
-		eoptr = &eoffset;
+		eoptr = offsets->data();
 	}
 	if(!m_eplugin->extract_fields_and_offsets(evt, num_fields, &efield, eoptr) ||
 	   efield.res_len == 0) {
@@ -214,10 +220,6 @@ bool sinsp_filter_check_plugin::extract_nocache(sinsp_evt* evt,
 			break;
 		}
 		values.push_back(res);
-
-		if(offsets && eoffset.start && eoffset.length) {
-			offsets->emplace_back(extract_offset_t{eoffset.start[i], eoffset.length[i]});
-		}
 	}
 
 	return true;

--- a/userspace/libsinsp/test/plugins/plugin_extract.cpp
+++ b/userspace/libsinsp/test/plugins/plugin_extract.cpp
@@ -141,8 +141,8 @@ ss_plugin_rc plugin_extract_fields(ss_plugin_t* s,
 			in->fields[i].res.str = &ps->strptr;
 			in->fields[i].res_len = 1;
 			if(in->value_offsets) {
-				in->value_offsets[i].start = &res_start;
-				in->value_offsets[i].length = &res_length;
+				in->value_offsets[i].start = res_start;
+				in->value_offsets[i].length = res_length;
 			}
 		} break;
 		default:

--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -371,11 +371,12 @@ typedef struct ss_plugin_field_extract_input {
 	// Vtable for controlling a state table for read operations.
 	ss_plugin_table_reader_vtable_ext* table_reader_ext;
 
-	// An array of ss_plugin_extract_value_offsets structs. The start
-	// and length in each entry should be set to nullptr, and as with
-	// the "fields" member, memory pointers set as output must be
-	// allocated by the plugin and must not be deallocated or modified
-	// until the next extract_fields() call.
+	// An optional array of ss_plugin_extract_value_offsets structs, capable
+	// of holding (at least) num_fields elements.
+	// If set, the plugin is then expected to fill it with the offsets and lengths
+	// of the extracted values. The offsets are counted starting from the beginning
+	// of the event (including the header), and the lengths are the number of bytes
+	// that the extracted value occupies in the event data.
 	// This member is optional, and might be ignored by extractors.
 	ss_plugin_extract_value_offsets* value_offsets;
 } ss_plugin_field_extract_input;

--- a/userspace/plugin/plugin_types.h
+++ b/userspace/plugin/plugin_types.h
@@ -130,16 +130,16 @@ typedef struct ss_plugin_byte_buffer {
 
 // Used in extract_fields_and_offsets to receive field value offsets
 // along with field data.
-// Extraction functions that support offsets should be set these to an
-// array of zero-indexed start offsets and lengths of each returned
-// value in the event or log data. {0, 0} can be used to indicate that
-// there are no valid offsets, e.g. if the value was generated or
-// computed from other data.
+// Extraction functions that support offsets should set these to
+// the zero-indexed start offset and length of each returned value
+// in the event or log data, counting from the start of the event
+// header. {0, 0} can be used to indicate that there are no valid offsets,
+// e.g. if the value was generated or computed from other data.
 // Extraction functions might not support offsets. In order to detect
 // this, callers should initialize the start and length to nullptr.
 typedef struct ss_plugin_extract_value_offsets {
-	uint32_t* start;
-	uint32_t* length;
+	uint32_t start;
+	uint32_t length;
 } ss_plugin_extract_value_offsets;
 
 // Used in extract_fields functions below to receive a field/arg


### PR DESCRIPTION
The docs (and a unit test) specified `value_offsets` to be an array of `ss_plugin_extract_value_offsets` structs, while the code in plugin_filtercheck.cpp expected it to be a struct of arrays. Things worked out only because we never extract multiple fields in one go (at least in libsinsp itself).

Make `value_offsets` an actual array of structs allocated by the caller (not the plugin). Since the plugin needs to rely on the size of the array now, make sure it's large enough (at least num_fields in size).

Additionally, clarify that the offsets are counted from the start of the event buffer (including the header).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

/kind design

/kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I'm submitting two PRs for the same issue. This one is the cleaner fix that breaks the plugin API (might be considered acceptable as it hasn't been out too long) and would be my preference, but if we consider the API set in stone already, let's move forward with the other one.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
