### PR TITLE
fix(plugin): fix and clarify extract offsets docs/tests

### DIFF
--- a/userspace/plugin/plugin_api.h
+++ b/userspace/plugin/plugin_api.h
@@ -46,6 +46,15 @@ extern "C" {
 //
 #define PLUGIN_MAX_ERRLEN 1024
 
+// The offset in the event where a plugin event payload starts
+// Since the event payload is at a fixed offset, you can add this value
+// to the start of an extracted field within the payload to get the offset
+// from the start of the event.
+//
+// 26 bytes for the event header, plus 2*4 bytes for the parameter lengths,
+// plus 4 bytes for the plugin ID.
+#define PLUGIN_EVENT_PAYLOAD_OFFSET 38
+
 // Supported by the API but deprecated. Use the extended version ss_plugin_table_reader_vtable_ext
 // instead. todo(jasondellaluce): when/if major changes to v4, remove this and give this name to the
 // associated *_ext struct.
@@ -371,9 +380,13 @@ typedef struct ss_plugin_field_extract_input {
 	// Vtable for controlling a state table for read operations.
 	ss_plugin_table_reader_vtable_ext* table_reader_ext;
 
-	// An array of ss_plugin_extract_value_offsets structs. The start
-	// and length in each entry should be set to nullptr, and as with
-	// the "fields" member, memory pointers set as output must be
+	// An optional ss_plugin_extract_value_offsets struct. If set, the plugin
+	// is expected to allocate two arrays of size num_fields, one for
+	// the offsets and one for the lengths of the extracted values.
+	// The offsets are counted starting from the beginning of the event
+	// (including the header), and the lengths are the number of bytes
+	// that the extracted value occupies in the event data.
+	// As with the "fields" member, memory pointers set as output must be
 	// allocated by the plugin and must not be deallocated or modified
 	// until the next extract_fields() call.
 	// This member is optional, and might be ignored by extractors.

--- a/userspace/plugin/plugin_types.h
+++ b/userspace/plugin/plugin_types.h
@@ -130,11 +130,11 @@ typedef struct ss_plugin_byte_buffer {
 
 // Used in extract_fields_and_offsets to receive field value offsets
 // along with field data.
-// Extraction functions that support offsets should be set these to an
+// Extraction functions that support offsets should set these to an
 // array of zero-indexed start offsets and lengths of each returned
-// value in the event or log data. {0, 0} can be used to indicate that
-// there are no valid offsets, e.g. if the value was generated or
-// computed from other data.
+// value in the event or log data, counting from the start of the event
+// header. {0, 0} can be used to indicate that there are no valid offsets,
+// e.g. if the value was generated or computed from other data.
 // Extraction functions might not support offsets. In order to detect
 // this, callers should initialize the start and length to nullptr.
 typedef struct ss_plugin_extract_value_offsets {


### PR DESCRIPTION
The docs (and a unit test) specified `value_offsets` to be an array of `ss_plugin_extract_value_offsets` structs, while the code in plugin_filtercheck.cpp expected it to be a struct of arrays. Things worked out only because we never extract multiple fields in one go (at least in libsinsp itself).

Keep the plugin_filtercheck.cpp behavior and adapt the documentation and tests to match.

Additionally, clarify that the offsets are counted from the start of the event buffer (including the header).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

/kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I'm submitting two PRs for the same issue. This is the minimal, documentation-only, fix on the libs side that also fixes the test to actually implement the spec. It does force the plugin to maintain a bit more state (and more (re)allocations) but we do get to keep the API unchanged.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
