### PR TITLE
fix(userspace/libscap/savefile): revert enter event freeing logic

### DIFF
--- a/userspace/libscap/engine/savefile/converter/converter.cpp
+++ b/userspace/libscap/engine/savefile/converter/converter.cpp
@@ -366,6 +366,8 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 	PRINT_EVENT(new_evt, PRINT_HEADER);
 
 	scap_evt *tmp_evt = NULL;
+	// If this is true at the end of the for loop we will free its memory.
+	bool used_enter_event = false;
 
 	// We iterate over the instructions
 	for(size_t i = 0; i < ci.m_instrs.size(); i++, param_to_populate++) {
@@ -400,6 +402,7 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 				        get_direction_char((ppm_event_code)tmp_evt->type));
 				return CONVERSION_ERROR;
 			}
+			used_enter_event = true;
 			break;
 
 		case C_INSTR_FROM_OLD:
@@ -439,7 +442,7 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 		}
 	}
 
-	if(PPME_IS_EXIT(evt_to_convert->type)) {
+	if(used_enter_event) {
 		// We can free the enter event for this thread because we don't need it anymore.
 		clear_evt(evt_storage, evt_to_convert->tid);
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Commit 72a6d4f39aef6a8c75c6dc0053af452e08d22fa4 changed the logic governing when enter events are freed. Specifically, enter events were freed after having performed a conversion (not a skipped conversion) involving an exit event. With this configuration, the following conversion would not work:

```c++
{conversion_key{EXAMPLE_E, 1},
  conversion_info().action(C_ACTION_STORE)},
{conversion_key{EXAMPLE_X, 4},
  conversion_info().action(C_ACTION_ADD_PARAMS)
    .instrs({{C_INSTR_FROM_DEFAULT, 0}})},
{conversion_key{EXAMPLE_X, 5},
  conversion_info().action(C_ACTION_ADD_PARAMS)
    .instrs({{C_INSTR_FROM_ENTER, 0}})}
```

The reason why it would not work, is that the converter would free the stored enter event upon execution of the second conversion, and would not find it upon execution of the third one.

This PR reverts only the logic applied to free the enter event, which means freeing it only if it is used by a `C_INSTR_FROM_ENTER` instruction.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I'm not 100% sure this is the right way to fix this issue, any help validating this approach would be appreciated.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
