### PR TITLE
fix(test/drivers): ignore `SO_REUSEPORT` setsockopt syscall error

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -287,16 +287,17 @@ void event_test::client_reuse_address_port(int32_t socketfd) {
 	                             sizeof(option_value)),
 	                     NOT_EQUAL,
 	                     -1);
-	assert_syscall_state(SYSCALL_SUCCESS,
-	                     "setsockopt (client port)",
-	                     syscall(__NR_setsockopt,
-	                             socketfd,
-	                             SOL_SOCKET,
-	                             SO_REUSEPORT,
-	                             &option_value,
-	                             sizeof(option_value)),
-	                     NOT_EQUAL,
-	                     -1);
+
+	// Commit https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=5b0af621c3f6
+	// restricts SO_REUSEPORT socket option to inet sockets: this means that the following call is
+	// going to fail on unix sockets, and we have no way to prevent it. For this reason, simply
+	// ignore its return value and hope any subsequent call to bind is going to succeed.
+	syscall(__NR_setsockopt,
+	        socketfd,
+	        SOL_SOCKET,
+	        SO_REUSEPORT,
+	        &option_value,
+	        sizeof(option_value));
 }
 
 void event_test::server_reuse_address_port(int32_t socketfd) {
@@ -312,16 +313,17 @@ void event_test::server_reuse_address_port(int32_t socketfd) {
 	                             sizeof(option_value)),
 	                     NOT_EQUAL,
 	                     -1);
-	assert_syscall_state(SYSCALL_SUCCESS,
-	                     "setsockopt (server port)",
-	                     syscall(__NR_setsockopt,
-	                             socketfd,
-	                             SOL_SOCKET,
-	                             SO_REUSEPORT,
-	                             &option_value,
-	                             sizeof(option_value)),
-	                     NOT_EQUAL,
-	                     -1);
+
+	// Commit https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=5b0af621c3f6
+	// restricts SO_REUSEPORT socket option to inet sockets: this means that the following call is
+	// going to fail on unix sockets, and we have no way to prevent it. For this reason, simply
+	// ignore its return value and hope any subsequent call to bind is going to succeed.
+	syscall(__NR_setsockopt,
+	        socketfd,
+	        SOL_SOCKET,
+	        SO_REUSEPORT,
+	        &option_value,
+	        sizeof(option_value));
 }
 
 void event_test::client_fill_sockaddr_in(sockaddr_in* sockaddr,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Commit https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=5b0af621c3f6 restricts `SO_REUSEPORT` socket option to inet sockets: this means that calls to `setsockopt`, setting `SO_REUSEPORT` on unix sockets, are not permitted anymore and will fail on any kernel version backporting the change. For this reason, in `event_test::client_reuse_address_port()` and `event_test::server_reuse_address_port()`,  still perform the call (to account for socket belonging to inet families) but ignore its return value and hope any subsequent call to bind is going to succeed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
