### PR TITLE
fix(userspace/libsinsp): avoid clearing host users and groups tables every minute

### DIFF
--- a/userspace/libsinsp/settings.h
+++ b/userspace/libsinsp/settings.h
@@ -30,11 +30,6 @@ limitations under the License.
 #define MAX_FD_TABLE_SIZE 4096
 
 //
-// How often the users/groups tables are scanned for deleted users/groups
-//
-#define DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S 60
-
-//
 // Default snaplen
 //
 #define DEFAULT_SNAPLEN 80

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -204,7 +204,6 @@ sinsp::sinsp(bool with_metrics):
 	// Add thread manager table to state tables registry.
 	m_table_registry->add_table(m_thread_manager.get());
 	m_usergroup_manager = std::make_shared<sinsp_usergroup_manager>(this, m_timestamper);
-	m_usergroups_purging_scan_time_ns = DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S * ONE_SECOND_IN_NS;
 	m_filter = nullptr;
 	m_machine_info = nullptr;
 	m_agent_info = nullptr;
@@ -1398,10 +1397,6 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 
 			m_next_stats_print_time_ns = ts - (ts % ONE_SECOND_IN_NS) + ONE_SECOND_IN_NS;
 		}
-	}
-
-	if(m_auto_usergroups_purging && !is_offline()) {
-		m_usergroup_manager->clear_host_users_groups();
 	}
 
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -347,21 +347,6 @@ public:
 	}
 
 	/*!
-	 * \brief Enables or disables an automatic routine that periodically purges
-	 * users and groups infos from the internal state. If disabled, the client
-	 * is responsible of manually-handling the lifetime of users and groups.
-	 */
-	void set_auto_usergroups_purging(bool enabled) { m_auto_usergroups_purging = enabled; }
-
-	/*!
-	 * \brief Sets the interval (in seconds) at which the automatic
-	 * users and groups purging routine runs (if enabled).
-	 */
-	inline void set_auto_usergroups_purging_interval_s(uint32_t val) {
-		m_usergroups_purging_scan_time_ns = (uint64_t)val * ONE_SECOND_IN_NS;
-	}
-
-	/*!
 	 * \brief Enables or disables an automatic routine that periodically logs
 	 * the current capture stats.
 	 */
@@ -976,12 +961,6 @@ public:
 	bool m_auto_threads_purging = true;
 	uint64_t m_thread_timeout_ns = (uint64_t)1800 * ONE_SECOND_IN_NS;
 	uint64_t m_threads_purging_scan_time_ns = (uint64_t)1200 * ONE_SECOND_IN_NS;
-
-	//
-	// Users/groups limits
-	//
-	bool m_auto_usergroups_purging = true;
-	uint64_t m_usergroups_purging_scan_time_ns;
 
 	//
 	// How to render the data buffers

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -172,32 +172,6 @@ void sinsp_usergroup_manager::delete_container(const std::string &container_id) 
 	m_grouplist.erase(container_id);
 }
 
-bool sinsp_usergroup_manager::clear_host_users_groups() {
-	if(!m_import_users) {
-		return false;
-	}
-
-	bool res = false;
-
-	const uint64_t last_event_ts = m_timestamper.get_cached_ts();
-	if(m_last_flush_time_ns == 0) {
-		m_last_flush_time_ns = last_event_ts - m_inspector->m_usergroups_purging_scan_time_ns +
-		                       60 * ONE_SECOND_IN_NS;
-	}
-
-	if(last_event_ts > m_last_flush_time_ns + m_inspector->m_usergroups_purging_scan_time_ns) {
-		res = true;
-
-		m_last_flush_time_ns = last_event_ts;
-
-		// Clear everything, so that new threadinfos incoming will update
-		// user and group informations
-		m_userlist[""].clear();
-		m_grouplist[""].clear();
-	}
-	return res;
-}
-
 scap_userinfo *sinsp_usergroup_manager::userinfo_map_insert(userinfo_map &map,
                                                             uint32_t uid,
                                                             uint32_t gid,

--- a/userspace/libsinsp/user.h
+++ b/userspace/libsinsp/user.h
@@ -49,19 +49,15 @@ class ns_helper;
  * * on PPME_{USER,GROUP}_ADDED, the new user/group is stored in the
  * m_{user,group}_list<container_id>, if not present.
  *
- * * Host users and groups lists are cleared once every DEFAULT_DELETED_USERS_GROUPS_SCAN_TIME_S (1
- * min by default), see sinsp::m_usergroups_purging_scan_time_ns. Then, the users and groups will be
- * refreshed as explained above, every time a threadinfo is created. This is needed to fetch deleted
- * users/groups, or overwritten ones. Note: PPME_USER_DELETED_E is never sent for host users; we
+ * PPME_USER_DELETED_E is never sent for host users; we
  * miss the mechanism to undestand when an user is removed (without calling scap_get_userlist and
  * comparing to the already stored one; but that is an heavy operation).
  * * Containers users and groups gets bulk deleted once the container is cleaned up and
  *      PPME_{USER,GROUP}_DELETED_E event is sent for each of them.
  *
- * * Each threadinfo stores internally its user and group informations.
- *      This is needed to avoid that eg: a threadinfo spawns on uid 1000 "foo".
- *      Then, uid 1000 is deleted, and a new uid 1000 is created, named "bar".
- *      We need to be able to tell that the threadinfo user is still "foo".
+ * * Each threadinfo stores internally its uid and gid informations that, together
+ * with the container_id written by the container plugin, will be used as keys to access
+ * user/group metadata cache tables.
  */
 class sinsp_usergroup_manager {
 public:
@@ -137,8 +133,6 @@ public:
 
 	bool rm_user(const std::string &container_id, uint32_t uid, bool notify = false);
 	bool rm_group(const std::string &container_id, uint32_t gid, bool notify = false);
-
-	bool clear_host_users_groups();
 
 	void delete_container(const std::string &container_id);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Since we now do not store users and groups full info inside each threadinfo, we would lose users and groups info for host processes after 1 minute.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
