### PR TITLE
fix(driver/bpf): fix `socket_x` and `socketpair_x` domain encoding

### DIFF
--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -1407,3 +1407,15 @@ static __always_inline pid_t bpf_push_pgid(struct filler_data *data, struct task
 }
 
 #endif
+
+/* Legacy-probe-specific replacement for `socket_family_to_scap` helper. As encoding the socket
+ * family using the `socket_family_to_scap` helper breaks the verifier on old kernel versions, just
+ * send `PPM_AF_UNSPEC` if the user-provided socket family is negative, and leave it as is
+ * otherwise. This solution relies on the fact that `AF_*` and corresponding `PPM_AF_*` macros map
+ * to the same values. */
+static __always_inline uint8_t bpf_socket_family_to_scap(int8_t family) {
+	if(family < 0) {
+		family = PPM_AF_UNSPEC;
+	}
+	return (uint8_t)family;
+}

--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -1336,8 +1336,8 @@ FILLER(sys_socketpair_x, true) {
 
 	/* Parameter 6: domain (type: PT_ENUMFLAGS32) */
 	/* why to send 32 bits if we need only 8 bits? */
-	uint8_t domain = (uint8_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_u32_to_ring(data, (uint32_t)socket_family_to_scap(domain));
+	int8_t domain = (int8_t)bpf_syscall_get_argument(data, 0);
+	res = bpf_push_u32_to_ring(data, (uint32_t)bpf_socket_family_to_scap(domain));
 	CHECK_RES(res);
 
 	/* Parameter 7: type (type: PT_UINT32) */
@@ -5357,8 +5357,8 @@ FILLER(sys_socket_x, true) {
 	}
 
 	/* Parameter 2: domain (type: PT_ENUMFLAGS32) */
-	uint8_t domain = (uint8_t)bpf_syscall_get_argument(data, 0);
-	res = bpf_push_u32_to_ring(data, (uint32_t)socket_family_to_scap(domain));
+	int8_t domain = (int8_t)bpf_syscall_get_argument(data, 0);
+	res = bpf_push_u32_to_ring(data, (uint32_t)bpf_socket_family_to_scap(domain));
 	CHECK_RES(res);
 
 	/* Parameter 3: type (type: PT_UINT32) */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR partially reverts changes introduced in commit dfdd45cc2c905a917331d91a3605815f98d99c2b (https://github.com/falcosecurity/libs/pull/2470) by replacing the usage of `socket_family_to_scap` helper with a calls to a new ad-hoc helper for the legacy bpf probe. To avoid breaking the verifier on old kernel version (i.e. `oraclelinux-4.14`), just convert user-provided negative socket family values to `PPM_AF_UNSPEC` and leave positive values as are. This simplified version relies on the fact that `AF_*` and corresponding `PPM_AF_*` macros map to the same values.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
