### PR TITLE
fix(driver): cast fds to 32 bits before sending them in dup2 and dup3

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -7233,64 +7233,50 @@ FILLER(sys_dup_x, true) {
 }
 
 FILLER(sys_dup2_e, true) {
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	return bpf_push_s64_to_ring(data, oldfd);
 }
 
 FILLER(sys_dup2_x, true) {
-	unsigned long val;
-	unsigned long retval;
-	unsigned long res;
-
-	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, retval);
-	CHECK_RES(res);
-	/*
-	 * oldfd
-	 */
-	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, val);
+	/* Parameter 1: res (type: PT_FD) */
+	unsigned long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
-	/*
-	 * newfd
-	 */
-	val = bpf_syscall_get_argument(data, 1);
-	return bpf_push_s64_to_ring(data, val);
+	/* Parameter 2: oldfd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	res = bpf_push_s64_to_ring(data, oldfd);
+	CHECK_RES(res);
+
+	/* Parameter 3: newfd (type: PT_FD) */
+	int64_t newfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 1);
+	return bpf_push_s64_to_ring(data, newfd);
 }
 
 FILLER(sys_dup3_e, true) {
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	return bpf_push_s64_to_ring(data, oldfd);
 }
 
 FILLER(sys_dup3_x, true) {
-	unsigned long val;
-	unsigned long retval;
-	unsigned long res;
-
-	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, retval);
-	CHECK_RES(res);
-	/*
-	 * oldfd
-	 */
-	val = bpf_syscall_get_argument(data, 0);
-	res = bpf_push_s64_to_ring(data, val);
+	/* Parameter 1: res (type: PT_FD) */
+	unsigned long retval = bpf_syscall_get_retval(data->ctx);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
-	/*
-	 * newfd
-	 */
-	val = bpf_syscall_get_argument(data, 1);
-	res = bpf_push_s64_to_ring(data, val);
+	/* Parameter 2: oldfd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	res = bpf_push_s64_to_ring(data, oldfd);
 	CHECK_RES(res);
 
-	/*
-	 * flags
-	 */
+	/* Parameter 3: newfd (type: PT_FD) */
+	int64_t newfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 1);
+	res = bpf_push_s64_to_ring(data, newfd);
+	CHECK_RES(res);
+
+	/* Parameter 4: flags (type: PT_FLAGS32) */
 	int flags = bpf_syscall_get_argument(data, 2);
 	return bpf_push_u32_to_ring(data, dup3_flags_to_scap(flags));
 }

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -21,9 +21,9 @@ int BPF_PROG(dup2_e, struct pt_regs *regs, long id) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -47,16 +47,16 @@ int BPF_PROG(dup2_x, struct pt_regs *regs, long ret) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: res (type: PT_FD)*/
+	/* Parameter 1: res (type: PT_FD) */
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
-	int32_t newfd = (int32_t)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
+	int64_t newfd = (int64_t)(int32_t)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, newfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -21,9 +21,9 @@ int BPF_PROG(dup3_e, struct pt_regs *regs, long id) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -47,16 +47,16 @@ int BPF_PROG(dup3_x, struct pt_regs *regs, long ret) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: res (type: PT_FD)*/
+	/* Parameter 1: res (type: PT_FD) */
 	ringbuf__store_s64(&ringbuf, ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/* Parameter 3: newfd (type: PT_FD) */
-	int32_t newfd = (int32_t)extract__syscall_argument(regs, 1);
-	ringbuf__store_s64(&ringbuf, (int64_t)newfd);
+	int64_t newfd = (int64_t)(int32_t)extract__syscall_argument(regs, 1);
+	ringbuf__store_s64(&ringbuf, newfd);
 
 	/* Parameter 4: flags (type: PT_FLAGS32) */
 	int32_t flags = extract__syscall_argument(regs, 2);

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6841,16 +6841,14 @@ int f_sys_dup_x(struct event_filler_arguments *args) {
 }
 
 int f_sys_dup2_e(struct event_filler_arguments *args) {
-	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t oldfd;
+	int res;
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 1: fd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	oldfd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, oldfd, 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
@@ -6859,42 +6857,37 @@ int f_sys_dup2_e(struct event_filler_arguments *args) {
 int f_sys_dup2_x(struct event_filler_arguments *args) {
 	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t fd;
 
+	/* Parameter 1: res (type: PT_FD) */
 	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 2: oldfd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, fd, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * newfd
-	 */
+	/* Parameter 3: newfd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 1, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int32_t)fd, 0, false, 0);
+	fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, fd, 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
 }
 
 int f_sys_dup3_e(struct event_filler_arguments *args) {
-	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t fd;
+	int res;
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 1: fd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, fd, 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
@@ -6903,31 +6896,26 @@ int f_sys_dup3_e(struct event_filler_arguments *args) {
 int f_sys_dup3_x(struct event_filler_arguments *args) {
 	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t fd;
 
+	/* Parameter 1: res (type: PT_FD) */
 	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 2: oldfd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, fd, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * newfd
-	 */
+	/* Parameter 3: newfd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 1, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, fd, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * flags
-	 */
+	/* Parameter 4: flags (type: PT_FLAGS32) */
 	syscall_get_arguments_deprecated(args, 2, 1, &val);
 	res = val_to_ring(args, dup3_flags_to_scap((int)val), 0, false, 0);
 	CHECK_RES(res);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR aligns `dup2` and `dup3` fillers implementations to other fillers implementation by casting syscalls' file descriptor parameters to `int32_t` before sending them.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
