### PR TITLE
update(event_processor)!: new build_threadinfo API

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -2005,9 +2005,9 @@ bool sinsp_thread_manager::remove_inactive_threads() {
 	return true;
 }
 
-std::unique_ptr<sinsp_threadinfo> libsinsp::event_processor::build_threadinfo(sinsp* inspector) {
-	return sinsp_threadinfo_factory::create_unique_attorney::create(
-	        inspector->get_threadinfo_factory());
+std::unique_ptr<sinsp_threadinfo> libsinsp::event_processor::build_threadinfo(
+        const std::shared_ptr<sinsp_threadinfo_ctor_params>& params) {
+	return std::make_unique<sinsp_threadinfo>(params);
 }
 
 std::unique_ptr<sinsp_fdinfo> libsinsp::event_processor::build_fdinfo(sinsp* inspector) {

--- a/userspace/libsinsp/sinsp_external_processor.h
+++ b/userspace/libsinsp/sinsp_external_processor.h
@@ -11,7 +11,8 @@
  */
 
 class sinsp;
-class threadinfo;
+class sinsp_threadinfo;
+class sinsp_threadinfo_ctor_params;
 
 namespace libsinsp {
 enum event_return {
@@ -45,7 +46,8 @@ public:
 	 * If this is overridden by the event processor, the processor MUST be registered
 	 * before the sinsp object is init-ed
 	 */
-	virtual std::unique_ptr<sinsp_threadinfo> build_threadinfo(sinsp* inspector);
+	virtual std::unique_ptr<sinsp_threadinfo> build_threadinfo(
+	        const std::shared_ptr<sinsp_threadinfo_ctor_params>& params);
 
 	/**
 	 * Some event processors allocate different fd info types with extra data.

--- a/userspace/libsinsp/sinsp_threadinfo_factory.h
+++ b/userspace/libsinsp/sinsp_threadinfo_factory.h
@@ -31,27 +31,7 @@ class sinsp_threadinfo_factory {
 	libsinsp::event_processor* const& m_external_event_processor;
 	const std::shared_ptr<libsinsp::state::dynamic_struct::field_infos>& m_fdtable_dyn_fields;
 
-	// `create_unique` is only provided in order to let an external event processor create a
-	// threadinfo without tracking all the needed dependencies and, at the same time, avoiding code
-	// repetition. The access is granted through the
-	// `sinsp_threadinfo_factory::create_unique_attorney` class (see its definition for more
-	// details).
-	std::unique_ptr<sinsp_threadinfo> create_unique() const {
-		return std::make_unique<sinsp_threadinfo>(m_params);
-	}
-
 public:
-	/*!
-	  \brief This class follows the attorney-client idiom to limit the access to
-	  `sinsp_threadinfo_factory::create_unique()` only to `libsinsp::event_processor`.
-	*/
-	class create_unique_attorney {
-		static std::unique_ptr<sinsp_threadinfo> create(sinsp_threadinfo_factory const& factory) {
-			return factory.create_unique();
-		}
-		friend libsinsp::event_processor;
-	};
-
 	sinsp_threadinfo_factory(sinsp* sinsp,
 	                         const std::shared_ptr<sinsp_threadinfo::ctor_params>& params,
 	                         libsinsp::event_processor* const& external_event_processor,
@@ -64,8 +44,8 @@ public:
 
 	std::unique_ptr<sinsp_threadinfo> create() const {
 		std::unique_ptr<sinsp_threadinfo> tinfo =
-		        m_external_event_processor ? m_external_event_processor->build_threadinfo(m_sinsp)
-		                                   : create_unique();
+		        m_external_event_processor ? m_external_event_processor->build_threadinfo(m_params)
+		                                   : std::make_unique<sinsp_threadinfo>(m_params);
 		if(tinfo->dynamic_fields() == nullptr) {
 			tinfo->set_dynamic_fields(m_params->thread_manager_dyn_fields);
 		}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -58,6 +58,25 @@ struct erase_fd_params {
  */
 
 /*!
+  \brief Container holding parameters to be provided to sinsp_threadinfo constructor.
+  An instance of this struct is meant to be shared among all sinsp_threadinfo instances.
+*/
+struct sinsp_threadinfo_ctor_params {
+	// The following fields are externally provided and access to them is expected to be
+	// read-only.
+	const sinsp_network_interfaces& network_interfaces;
+	const sinsp_fdinfo_factory& fdinfo_factory;
+	const sinsp_fdtable_factory& fdtable_factory;
+	const std::shared_ptr<libsinsp::state::table_entry::dynamic_struct::field_infos>&
+	        thread_manager_dyn_fields;
+
+	// The following fields are externally provided and expected to be populated/updated by the
+	// thread info.
+	std::shared_ptr<sinsp_thread_manager>& thread_manager;
+	std::shared_ptr<sinsp_usergroup_manager>& usergroup_manager;
+};
+
+/*!
   \brief Thread/process information class.
   This class contains the full state for a thread, and a bunch of functions to
   manipulate threads and retrieve thread information.
@@ -70,23 +89,7 @@ struct erase_fd_params {
 */
 class SINSP_PUBLIC sinsp_threadinfo : public libsinsp::state::table_entry {
 public:
-	/*!
-	  \brief Container holding parameters to be provided to sinsp_threadinfo constructor.
-	  An instance of this struct is meant to be shared among all sinsp_threadinfo instances.
-	*/
-	struct ctor_params {
-		// The following fields are externally provided and access to them is expected to be
-		// read-only.
-		const sinsp_network_interfaces& network_interfaces;
-		const sinsp_fdinfo_factory& fdinfo_factory;
-		const sinsp_fdtable_factory& fdtable_factory;
-		const std::shared_ptr<dynamic_struct::field_infos>& thread_manager_dyn_fields;
-
-		// The following fields are externally provided and expected to be populated/updated by the
-		// thread info.
-		std::shared_ptr<sinsp_thread_manager>& thread_manager;
-		std::shared_ptr<sinsp_usergroup_manager>& usergroup_manager;
-	};
+	using ctor_params = sinsp_threadinfo_ctor_params;
 
 	explicit sinsp_threadinfo(const std::shared_ptr<ctor_params>& params);
 	~sinsp_threadinfo() override;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
`event_processor::build_threadinfo` shall be aligned to the new `sinsp_threadinfo` constructor.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
sinsp_threadinfo ctor change references:
- https://github.com/falcosecurity/libs/commit/9c6d68a0ffd8196b569a6243e0d17342ea81dc3f#diff-42bb444cadccd57c45d52c21568207e3ab49d2d9cd8eb8df92faf4898aed9b3aR68
- https://github.com/falcosecurity/libs/commit/7ceeac9a34315320a9cb19a911f66210d883491e#diff-42bb444cadccd57c45d52c21568207e3ab49d2d9cd8eb8df92faf4898aed9b3aR92

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
