### PR TITLE
fix(driver): cast rets and fds to 32 bits before sending them in dup*

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -7340,24 +7340,20 @@ FILLER(sys_splice_e, true) {
 }
 
 FILLER(sys_dup_e, true) {
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	return bpf_push_s64_to_ring(data, oldfd);
 }
 
 FILLER(sys_dup_x, true) {
-	unsigned long val;
-	unsigned long retval;
-	unsigned long res;
-
-	retval = bpf_syscall_get_retval(data->ctx);
-	res = bpf_push_s64_to_ring(data, retval);
+	/* Parameter 1: res (type: PT_FD) */
+	int64_t retval = (int64_t)(int32_t)bpf_syscall_get_retval(data->ctx);
+	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
-	/*
-	 * oldfd
-	 */
-	val = bpf_syscall_get_argument(data, 0);
-	return bpf_push_s64_to_ring(data, val);
+
+	/* Parameter 2: oldfd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)bpf_syscall_get_argument(data, 0);
+	return bpf_push_s64_to_ring(data, oldfd);
 }
 
 FILLER(sys_dup2_e, true) {
@@ -7368,7 +7364,7 @@ FILLER(sys_dup2_e, true) {
 
 FILLER(sys_dup2_x, true) {
 	/* Parameter 1: res (type: PT_FD) */
-	unsigned long retval = bpf_syscall_get_retval(data->ctx);
+	int64_t retval = (int64_t)(int32_t)bpf_syscall_get_retval(data->ctx);
 	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 
@@ -7390,7 +7386,7 @@ FILLER(sys_dup3_e, true) {
 
 FILLER(sys_dup3_x, true) {
 	/* Parameter 1: res (type: PT_FD) */
-	unsigned long retval = bpf_syscall_get_retval(data->ctx);
+	int64_t retval = (int64_t)(int32_t)bpf_syscall_get_retval(data->ctx);
 	int res = bpf_push_s64_to_ring(data, retval);
 	CHECK_RES(res);
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup.bpf.c
@@ -21,9 +21,9 @@ int BPF_PROG(dup_e, struct pt_regs *regs, long id) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	/* Parameter 1: fd (type: PT_FD) */
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
@@ -47,12 +47,12 @@ int BPF_PROG(dup_x, struct pt_regs *regs, long ret) {
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
-	/* Parameter 1: res (type: PT_FD)*/
-	ringbuf__store_s64(&ringbuf, ret);
+	/* Parameter 1: res (type: PT_FD) */
+	ringbuf__store_s64(&ringbuf, (int64_t)(int32_t)ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
-	int32_t oldfd = (int32_t)extract__syscall_argument(regs, 0);
-	ringbuf__store_s64(&ringbuf, (int64_t)oldfd);
+	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);
+	ringbuf__store_s64(&ringbuf, oldfd);
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup2.bpf.c
@@ -48,7 +48,7 @@ int BPF_PROG(dup2_x, struct pt_regs *regs, long ret) {
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)(int32_t)ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
 	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/dup3.bpf.c
@@ -48,7 +48,7 @@ int BPF_PROG(dup3_x, struct pt_regs *regs, long ret) {
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 
 	/* Parameter 1: res (type: PT_FD) */
-	ringbuf__store_s64(&ringbuf, ret);
+	ringbuf__store_s64(&ringbuf, (int64_t)(int32_t)ret);
 
 	/* Parameter 2: oldfd (type: PT_FD) */
 	int64_t oldfd = (int64_t)(int32_t)extract__syscall_argument(regs, 0);

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6919,36 +6919,34 @@ int f_sys_epoll_wait_x(struct event_filler_arguments *args) {
 }
 
 int f_sys_dup_e(struct event_filler_arguments *args) {
-	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t old_fd;
+	int res;
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 1: fd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	old_fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, old_fd, 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
 }
 
 int f_sys_dup_x(struct event_filler_arguments *args) {
+	int64_t retval;
 	int res;
 	unsigned long val;
-	int32_t fd = 0;
+	int64_t old_fd;
 
-	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
+	/* Parameter 1: res (type: PT_FD) */
+	retval = (int64_t)(int32_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
 	CHECK_RES(res);
 
-	/*
-	 * oldfd
-	 */
+	/* Parameter 2: oldfd (type: PT_FD) */
 	syscall_get_arguments_deprecated(args, 0, 1, &val);
-	fd = (int32_t)val;
-	res = val_to_ring(args, (int64_t)fd, 0, false, 0);
+	old_fd = (int64_t)(int32_t)val;
+	res = val_to_ring(args, old_fd, 0, false, 0);
 	CHECK_RES(res);
 
 	return add_sentinel(args);
@@ -6969,12 +6967,13 @@ int f_sys_dup2_e(struct event_filler_arguments *args) {
 }
 
 int f_sys_dup2_x(struct event_filler_arguments *args) {
+	int64_t retval;
 	int res;
 	unsigned long val;
 	int64_t fd;
 
 	/* Parameter 1: res (type: PT_FD) */
-	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
+	retval = (int64_t)(int32_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
 	CHECK_RES(res);
 
@@ -7008,12 +7007,13 @@ int f_sys_dup3_e(struct event_filler_arguments *args) {
 }
 
 int f_sys_dup3_x(struct event_filler_arguments *args) {
+	int64_t retval;
 	int res;
 	unsigned long val;
 	int64_t fd;
 
 	/* Parameter 1: res (type: PT_FD) */
-	int64_t retval = (int64_t)syscall_get_return_value(current, args->regs);
+	retval = (int64_t)(int32_t)syscall_get_return_value(current, args->regs);
 	res = val_to_ring(args, retval, 0, false, 0);
 	CHECK_RES(res);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR completes the work in 3385c69812b426e679e7e90809fe80ff45c164f0 by aligning the `dup2`'s and `dup3`'s fillers returned values handling to the other file descriptors handling. Moreover, it also aligns the dup's fillers file descriptors handling.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
