### PR TITLE
table_input_adapter

### DIFF
--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 add_executable(sinsp-example ${sources})
 
-target_link_libraries(sinsp-example sinsp)
+target_link_libraries(sinsp-example sinsp "${JSONCPP_LIB}")
 
 if(EMSCRIPTEN)
 	target_compile_options(sinsp-example PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")

--- a/userspace/libsinsp/state/type_info.h
+++ b/userspace/libsinsp/state/type_info.h
@@ -44,6 +44,8 @@ public:
 		                      std::string(typeid(T).name()));
 	}
 
+	static typeinfo from(ss_plugin_state_type state_type);
+
 	inline typeinfo() = delete;
 	inline ~typeinfo() = default;
 	inline typeinfo(typeinfo&&) = default;
@@ -178,6 +180,36 @@ inline typeinfo typeinfo::of<libsinsp::state::base_table*>() {
 template<>
 inline typeinfo typeinfo::of<const libsinsp::state::base_table*>() {
 	return _build<const libsinsp::state::base_table*>("table", SS_PLUGIN_ST_TABLE);
+}
+
+inline typeinfo typeinfo::from(ss_plugin_state_type state_type) {
+	switch(state_type) {
+	case SS_PLUGIN_ST_INT8:
+		return typeinfo::of<int8_t>();
+	case SS_PLUGIN_ST_INT16:
+		return typeinfo::of<int16_t>();
+	case SS_PLUGIN_ST_INT32:
+		return typeinfo::of<int32_t>();
+	case SS_PLUGIN_ST_INT64:
+		return typeinfo::of<int64_t>();
+	case SS_PLUGIN_ST_UINT8:
+		return typeinfo::of<uint8_t>();
+	case SS_PLUGIN_ST_UINT16:
+		return typeinfo::of<uint16_t>();
+	case SS_PLUGIN_ST_UINT32:
+		return typeinfo::of<uint32_t>();
+	case SS_PLUGIN_ST_UINT64:
+		return typeinfo::of<uint64_t>();
+	case SS_PLUGIN_ST_STRING:
+		return typeinfo::of<std::string>();
+	case SS_PLUGIN_ST_TABLE:
+		return typeinfo::of<libsinsp::state::base_table*>();
+	case SS_PLUGIN_ST_BOOL:
+		return typeinfo::of<bool>();
+	default:
+		throw sinsp_exception("state::typeinfo::of invoked for unsupported state_type: " +
+		                      std::to_string(state_type));
+	}
 }
 
 };  // namespace state


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Introduce `table_input_adapter` to be able to access sub-tables.
Update sinsp-example `-T` switch to be able to print the contents of the available tables.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
