### PR TITLE
test/drivers: correct s390x socketcall handling for accept

### DIFF
--- a/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/socketcall_x.cpp
@@ -486,17 +486,18 @@ TEST(SyscallExit, socketcall_acceptX_INET) {
 	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
 
 #ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	/* Parameter 6: flags (type: PT_FLAGS32) */
-	/* Right now `flags` are not supported so we will catch always `0` */
-	evt_test->assert_numeric_param(6, (uint32_t)0);
-#endif
+	/* Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
+	   However, The kmod/bpf can correctly handle accept also on s390x (see also above) */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine()) {
+		evt_test->assert_num_params_pushed(5);
+	} else {
+		/* accept4 is used */
+		/* Parameter 6: flags (type: PT_FLAGS32) */
+		/* Right now `flags` are not supported so we will catch always `0` */
+		evt_test->assert_numeric_param(6, (uint32_t)0);
 
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-#ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	evt_test->assert_num_params_pushed(6);
+		evt_test->assert_num_params_pushed(6);
+	}
 #else
 	evt_test->assert_num_params_pushed(5);
 #endif
@@ -585,18 +586,21 @@ TEST(SyscallExit, socketcall_acceptX_INET6) {
 	/* Parameter 5: queuemax (type: PT_UINT32) */
 	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
 
-#ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	/* Parameter 6: flags (type: PT_FLAGS32) */
-	/* Right now `flags` are not supported so we will catch always `0` */
-	evt_test->assert_numeric_param(6, (uint32_t)0);
-#endif
-
 	/*=============================== ASSERT PARAMETERS  ===========================*/
 
 #ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	evt_test->assert_num_params_pushed(6);
+	/* Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
+	   However, The kmod/bpf can correctly handle accept also on s390x (see also above) */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine()) {
+		evt_test->assert_num_params_pushed(5);
+	} else {
+		/* accept4 is used */
+		/* Parameter 6: flags (type: PT_FLAGS32) */
+		/* Right now `flags` are not supported so we will catch always `0` */
+		evt_test->assert_numeric_param(6, (uint32_t)0);
+
+		evt_test->assert_num_params_pushed(6);
+	}
 #else
 	evt_test->assert_num_params_pushed(5);
 #endif
@@ -684,17 +688,18 @@ TEST(SyscallExit, socketcall_acceptX_UNIX) {
 	evt_test->assert_numeric_param(5, (uint32_t)QUEUE_LENGTH);
 
 #ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	/* Parameter 6: flags (type: PT_FLAGS32) */
-	/* Right now `flags` are not supported so we will catch always `0` */
-	evt_test->assert_numeric_param(6, (uint32_t)0);
-#endif
+	/* Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
+	   However, The kmod/bpf can correctly handle accept also on s390x (see also above) */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine()) {
+		evt_test->assert_num_params_pushed(5);
+	} else {
+		/* accept4 is used */
+		/* Parameter 6: flags (type: PT_FLAGS32) */
+		/* Right now `flags` are not supported so we will catch always `0` */
+		evt_test->assert_numeric_param(6, (uint32_t)0);
 
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-#ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	evt_test->assert_num_params_pushed(6);
+		evt_test->assert_num_params_pushed(6);
+	}
 #else
 	evt_test->assert_num_params_pushed(5);
 #endif
@@ -763,17 +768,18 @@ TEST(SyscallExit, socketcall_acceptX_failure) {
 	evt_test->assert_numeric_param(5, (uint32_t)0);
 
 #ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	/* Parameter 6: flags (type: PT_FLAGS32) */
-	/* Right now `flags` are not supported so we will catch always `0` */
-	evt_test->assert_numeric_param(6, (uint32_t)0);
-#endif
+	/* Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
+	   However, The kmod/bpf can correctly handle accept also on s390x (see also above) */
+	if(evt_test->is_kmod_engine() || evt_test->is_bpf_engine()) {
+		evt_test->assert_num_params_pushed(5);
+	} else {
+		/* accept4 is used */
+		/* Parameter 6: flags (type: PT_FLAGS32) */
+		/* Right now `flags` are not supported so we will catch always `0` */
+		evt_test->assert_numeric_param(6, (uint32_t)0);
 
-	/*=============================== ASSERT PARAMETERS  ===========================*/
-
-#ifdef __s390x__
-	// Under s390x we use accept4 instead of accept, and we collect the flags parameter for it.
-	evt_test->assert_num_params_pushed(6);
+		evt_test->assert_num_params_pushed(6);
+	}
 #else
 	evt_test->assert_num_params_pushed(5);
 #endif

--- a/test/libsinsp_e2e/fs.cpp
+++ b/test/libsinsp_e2e/fs.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cassert>
+#include <climits>
 #include <iostream>
 #include <list>
 #include <mutex>

--- a/test/libsinsp_e2e/sys_call_test.cpp
+++ b/test/libsinsp_e2e/sys_call_test.cpp
@@ -51,6 +51,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cassert>
+#include <climits>
 #include <list>
 #include <numeric>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

/kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR corrects socketcall handling for accept. Because there is no direct accept syscall on s390x, there is special handling for the modern BPF driver necessary. Other drivers can handle accept via socketcall. The handling needs to be revised with the recent changes on the exit events.

**Which issue(s) this PR fixes**:

Fix driver tests.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
