### PR TITLE
fix: fix scap converter `PT_UID` parameters default value

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -1653,10 +1653,10 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_to_4_params_no_enter) {
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t ruid = 0;
-	constexpr uint32_t euid = 0;
-	constexpr uint32_t suid = 0;
+	// Defaulted.
+	constexpr uint32_t ruid = std::numeric_limits<uint32_t>::max();
+	constexpr uint32_t euid = std::numeric_limits<uint32_t>::max();
+	constexpr uint32_t suid = std::numeric_limits<uint32_t>::max();
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -1705,8 +1705,8 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETUID_X_to_2_params_no_enter) {
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t uid = 0;
+	// Defaulted.
+	constexpr uint32_t uid = std::numeric_limits<uint32_t>::max();
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -135,6 +135,11 @@ private:
 	static void parse_capset_exit(sinsp_evt& evt);
 	static void parse_unshare_setns_exit(sinsp_evt& evt);
 
+	// Set the event thread user to the user corresponding to the provided effective user id. This
+	// is no-op if there is no thread associated with the provided event or the effective user id is
+	// invalid.
+	void set_evt_thread_user(sinsp_evt& evt, uint32_t euid) const;
+
 	static inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo& fdinfo,
 	                                                   uint32_t tsip,
 	                                                   uint16_t tsport,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the scap converter `PT_UID` parameters default value by setting it to `UINT32_MAX`. Moreover, it fixes scap converter tests and sinsp parser code to correctly account for the default value.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
