### PR TITLE
fix: fix scap converter `PT_GID` parameters default value

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -916,7 +916,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_E_store) {
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t fd = 25;
-	struct sockaddr_in sockaddr = {};
+	sockaddr_in sockaddr = {};
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons(1234);
 	sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -939,11 +939,11 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_no_enter) {
 	constexpr char tuple[] = "tuple";
 	constexpr int64_t fd = 25;
 
-	// Defaulted
+	// Defaulted.
 	constexpr uint8_t addr = PPM_AF_UNSPEC;
 
 	assert_single_conversion_success(
-	        conversion_result::CONVERSION_COMPLETED,
+	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts,
 	                               tid,
 	                               PPME_SOCKET_CONNECT_X,
@@ -966,7 +966,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_with_enter) {
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t fd = 25;
-	struct sockaddr_in sockaddr = {};
+	sockaddr_in sockaddr = {};
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons(1234);
 	sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -984,7 +984,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_with_enter) {
 	assert_event_storage_presence(evt);
 
 	assert_single_conversion_success(
-	        conversion_result::CONVERSION_COMPLETED,
+	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts,
 	                               tid,
 	                               PPME_SOCKET_CONNECT_X,
@@ -4779,8 +4779,8 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_to_3_params_no_enter) {
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t gid = 0;
+	// Defaulted.
+	constexpr uint32_t gid = std::numeric_limits<uint32_t>::max();
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -4829,10 +4829,10 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_to_4_params_no_enter) {
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t rgid = 0;
-	constexpr uint32_t egid = 0;
-	constexpr uint32_t sgid = 0;
+	// Defaulted.
+	constexpr uint32_t rgid = std::numeric_limits<uint32_t>::max();
+	constexpr uint32_t egid = std::numeric_limits<uint32_t>::max();
+	constexpr uint32_t sgid = std::numeric_limits<uint32_t>::max();
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,

--- a/userspace/libscap/engine/savefile/converter/converter.cpp
+++ b/userspace/libscap/engine/savefile/converter/converter.cpp
@@ -183,6 +183,7 @@ static uint8_t get_size_bytes_from_type(const ppm_param_type t) {
 static uint64_t get_default_value_from_type(const ppm_param_type t) {
 	switch(t) {
 	case PT_UID:
+	case PT_GID:
 		return std::numeric_limits<uint32_t>::max();
 	case PT_SOCKADDR:
 		return PPM_AF_UNSPEC;

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -139,6 +139,10 @@ private:
 	// is no-op if there is no thread associated with the provided event or the effective user id is
 	// invalid.
 	void set_evt_thread_user(sinsp_evt& evt, uint32_t euid) const;
+	// Set the event thread group to the group corresponding to the provided effective group id.
+	// This is no-op if there is no thread associated with the provided event or the effective group
+	// id is invalid.
+	void set_evt_thread_group(sinsp_evt& evt, uint32_t egid) const;
 
 	static inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo& fdinfo,
 	                                                   uint32_t tsip,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the scap converter `PT_GID` parameters default value by setting it to `UINT32_MAX`. Moreover, it fixes scap converter tests and sinsp parser code to correctly account for the default value.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
