### PR TITLE
feat(userspace/libscap): add capability to push empty parameters to scap-converter

### DIFF
--- a/test/libscap/test_suites/engines/savefile/convert_event_test.h
+++ b/test/libscap/test_suites/engines/savefile/convert_event_test.h
@@ -26,7 +26,41 @@ safe_scap_evt_t new_safe_scap_evt(scap_evt *evt) {
 class convert_event_test : public testing::Test {
 	static constexpr uint16_t safe_margin = 100;
 
+	static void set_empty_parameters(const safe_scap_evt_t &expected_evt,
+	                                 const std::set<uint32_t> &expected_empty_param_indexes) {
+		if(expected_empty_param_indexes.empty()) {
+			return;
+		}
+
+		const auto evt = expected_evt.get();
+
+		uint16_t params_offset = sizeof(scap_evt) + evt->nparams * sizeof(uint16_t);
+		constexpr uint64_t zero = 0;
+		for(size_t i = 0; i < expected_evt->nparams; i++) {
+			const auto len_offset = sizeof(scap_evt) + i * sizeof(uint16_t);
+			// Get original length value.
+			uint16_t len;
+			memcpy(&len, reinterpret_cast<char *>(evt) + len_offset, sizeof(uint16_t));
+
+			if(expected_empty_param_indexes.find(i) == expected_empty_param_indexes.end()) {
+				params_offset += len;
+				continue;
+			}
+
+			// Set the parameter length and value to zero.
+			memcpy(reinterpret_cast<char *>(evt) + len_offset, &zero, sizeof(uint16_t));
+			memcpy(reinterpret_cast<char *>(evt) + params_offset, &zero, len);
+			params_offset += len;
+		}
+	}
+
 protected:
+	// Return an empty value for the type T.
+	template<typename T>
+	constexpr static T empty_value() {
+		return static_cast<T>(0);
+	}
+
 	virtual void SetUp() {
 		m_converter_buf = scap_convert_alloc_buffer();
 		ASSERT_NE(m_converter_buf, nullptr);
@@ -34,11 +68,11 @@ protected:
 
 	virtual void TearDown() { scap_convert_free_buffer(m_converter_buf); }
 
-	safe_scap_evt_t create_safe_scap_event(uint64_t ts,
-	                                       uint64_t tid,
-	                                       ppm_event_code event_type,
-	                                       uint32_t n,
-	                                       ...) {
+	static safe_scap_evt_t create_safe_scap_event(uint64_t ts,
+	                                              uint64_t tid,
+	                                              ppm_event_code event_type,
+	                                              uint32_t n,
+	                                              ...) {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		va_list args;
 		va_start(args, n);
@@ -49,10 +83,13 @@ protected:
 		}
 		return new_safe_scap_evt(evt);
 	}
+
 	// The expected result can be either CONVERSION_CONTINUE or CONVERSION_COMPLETED
-	void assert_single_conversion_success(enum conversion_result expected_res,
-	                                      safe_scap_evt_t evt_to_convert,
-	                                      safe_scap_evt_t expected_evt) {
+	void assert_single_conversion_success(
+	        const conversion_result expected_res,
+	        const safe_scap_evt_t &evt_to_convert,
+	        const safe_scap_evt_t &expected_evt,
+	        const std::set<uint32_t> &expected_empty_param_indexes = {}) const {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, expected_evt->len));
@@ -60,6 +97,9 @@ protected:
 		ASSERT_EQ(scap_convert_event(m_converter_buf, storage.get(), evt_to_convert.get(), error),
 		          expected_res)
 		        << "Different conversion results: " << error;
+
+		set_empty_parameters(expected_evt, expected_empty_param_indexes);
+
 		if(!scap_compare_events(storage.get(), expected_evt.get(), error)) {
 			printf("\nExpected event:\n");
 			scap_print_event(expected_evt.get(), PRINT_FULL);
@@ -68,7 +108,8 @@ protected:
 			FAIL() << error;
 		}
 	}
-	void assert_single_conversion_failure(safe_scap_evt_t evt_to_convert) {
+
+	void assert_single_conversion_failure(const safe_scap_evt_t &evt_to_convert) const {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, evt_to_convert->len));
@@ -77,7 +118,7 @@ protected:
 		          CONVERSION_ERROR)
 		        << "The conversion is not failed: " << error;
 	}
-	void assert_single_conversion_skip(safe_scap_evt_t evt_to_convert) {
+	void assert_single_conversion_skip(const safe_scap_evt_t &evt_to_convert) const {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, evt_to_convert->len));
@@ -86,7 +127,9 @@ protected:
 		          CONVERSION_SKIP)
 		        << "The conversion is not skipped: " << error;
 	}
-	void assert_full_conversion(safe_scap_evt_t evt_to_convert, safe_scap_evt_t expected_evt) {
+	void assert_full_conversion(const safe_scap_evt_t &evt_to_convert,
+	                            const safe_scap_evt_t &expected_evt,
+	                            const std::set<uint32_t> &expected_empty_param_indexes = {}) const {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		// Here we need to allocate more space than the expected event because in the middle we
 		// could have larger events. We could also use `MAX_EVENT_SIZE` but probably it will just
@@ -124,6 +167,9 @@ protected:
 		default:
 			break;
 		}
+
+		set_empty_parameters(expected_evt, expected_empty_param_indexes);
+
 		if(!scap_compare_events(new_evt.get(), expected_evt.get(), error)) {
 			printf("\nExpected event:\n");
 			scap_print_event(expected_evt.get(), PRINT_FULL);
@@ -132,7 +178,7 @@ protected:
 			FAIL() << error;
 		}
 	}
-	void assert_event_storage_presence(safe_scap_evt_t expected_evt) {
+	void assert_event_storage_presence(const safe_scap_evt_t &expected_evt) const {
 		char error[SCAP_LASTERR_SIZE] = {'\0'};
 		int64_t tid = expected_evt.get()->tid;
 		auto event = scap_retrieve_evt_from_converter_storage(m_converter_buf, tid);

--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -1647,24 +1647,27 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_E_store) {
 	assert_event_storage_presence(evt);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_to_4_params_no_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_1_to_4_params_no_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t res = 89;
 
-	// Defaulted.
-	constexpr uint32_t ruid = std::numeric_limits<uint32_t>::max();
-	constexpr uint32_t euid = std::numeric_limits<uint32_t>::max();
-	constexpr uint32_t suid = std::numeric_limits<uint32_t>::max();
+	// Set to empty.
+	constexpr auto ruid = empty_value<uint32_t>();
+	constexpr auto euid = empty_value<uint32_t>();
+	constexpr auto suid = empty_value<uint32_t>();
+
+	const std::set<uint32_t> expected_empty_param_indexes{1, 2, 3};
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESUID_X, 1, res),
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESUID_X, 4, res, ruid, euid, suid));
+	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESUID_X, 4, res, ruid, euid, suid),
+	        expected_empty_param_indexes);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_to_4_params_with_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_1_to_4_params_with_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
@@ -1673,7 +1676,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_to_4_params_with_enter) {
 	constexpr uint32_t euid = 43;
 	constexpr uint32_t suid = 44;
 
-	// After the first conversion we should have the storage
+	// After the first conversion we should have the storage.
 	const auto evt = create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESUID_E, 3, ruid, euid, suid);
 	assert_single_conversion_skip(evt);
 	assert_event_storage_presence(evt);
@@ -1705,13 +1708,16 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETUID_X_to_2_params_no_enter) {
 
 	constexpr int64_t res = 89;
 
-	// Defaulted.
-	constexpr uint32_t uid = std::numeric_limits<uint32_t>::max();
+	// Set to empty.
+	constexpr auto uid = empty_value<uint32_t>();
+
+	const std::set<uint32_t> expected_empty_param_indexes{1};
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETUID_X, 1, res),
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETUID_X, 2, res, uid));
+	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETUID_X, 2, res, uid),
+	        expected_empty_param_indexes);
 }
 
 TEST_F(convert_event_test, PPME_SYSCALL_SETUID_X_to_2_params_with_enter) {

--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -916,7 +916,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_E_store) {
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t fd = 25;
-	struct sockaddr_in sockaddr = {};
+	sockaddr_in sockaddr = {};
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons(1234);
 	sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -943,7 +943,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_no_enter) {
 	constexpr uint8_t addr = PPM_AF_UNSPEC;
 
 	assert_single_conversion_success(
-	        conversion_result::CONVERSION_COMPLETED,
+	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts,
 	                               tid,
 	                               PPME_SOCKET_CONNECT_X,
@@ -966,7 +966,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_with_enter) {
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t fd = 25;
-	struct sockaddr_in sockaddr = {};
+	sockaddr_in sockaddr = {};
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons(1234);
 	sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -984,7 +984,7 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_with_enter) {
 	assert_event_storage_presence(evt);
 
 	assert_single_conversion_success(
-	        conversion_result::CONVERSION_COMPLETED,
+	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts,
 	                               tid,
 	                               PPME_SOCKET_CONNECT_X,
@@ -4779,22 +4779,25 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETGID_E_store) {
 	assert_event_storage_presence(evt);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_to_3_params_no_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_1_to_2_params_no_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t gid = 0;
+	// Set to empty.
+	constexpr auto gid = empty_value<uint32_t>();
+
+	const std::set<uint32_t> expected_empty_param_indexes{1};
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETGID_X, 1, res),
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETGID_X, 2, res, gid));
+	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETGID_X, 2, res, gid),
+	        expected_empty_param_indexes);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_to_3_params_with_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_1_to_2_params_with_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
@@ -4829,24 +4832,27 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_E_store) {
 	assert_event_storage_presence(evt);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_to_4_params_no_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_1_to_4_params_no_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t res = 89;
 
-	// Defaulted to 0
-	constexpr uint32_t rgid = 0;
-	constexpr uint32_t egid = 0;
-	constexpr uint32_t sgid = 0;
+	// Set to empty.
+	constexpr auto rgid = empty_value<uint32_t>();
+	constexpr auto egid = empty_value<uint32_t>();
+	constexpr auto sgid = empty_value<uint32_t>();
+
+	const std::set<uint32_t> expected_empty_param_indexes{1, 2, 3};
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
 	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESGID_X, 1, res),
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESGID_X, 4, res, rgid, egid, sgid));
+	        create_safe_scap_event(ts, tid, PPME_SYSCALL_SETRESGID_X, 4, res, rgid, egid, sgid),
+	        expected_empty_param_indexes);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_to_4_params_with_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_1_to_4_params_with_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 

--- a/userspace/libscap/engine/savefile/converter/converter.cpp
+++ b/userspace/libscap/engine/savefile/converter/converter.cpp
@@ -183,6 +183,7 @@ static uint8_t get_default_value_size_bytes_from_type(const ppm_param_type t) {
 static uint64_t get_default_value_from_type(const ppm_param_type t) {
 	switch(t) {
 	case PT_UID:
+	case PT_GID:
 		return std::numeric_limits<uint32_t>::max();
 	case PT_SOCKADDR:
 		return PPM_AF_UNSPEC;

--- a/userspace/libscap/engine/savefile/converter/table.cpp
+++ b/userspace/libscap/engine/savefile/converter/table.cpp
@@ -439,7 +439,9 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
         /*====================== SETGID ======================*/
         {conversion_key{PPME_SYSCALL_SETGID_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_SETGID_X, 1},
-         conversion_info().action(C_ACTION_ADD_PARAMS).instrs({{C_INSTR_FROM_ENTER, 0}})},
+         conversion_info()
+                 .action(C_ACTION_ADD_PARAMS)
+                 .instrs({{C_INSTR_FROM_ENTER, 0, CIF_FALLBACK_TO_EMPTY}})},
         /*====================== SETPGID ======================*/
         {conversion_key{PPME_SYSCALL_SETPGID_E, 2}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_SETPGID_E, 2}, conversion_info().action(C_ACTION_STORE)},
@@ -485,9 +487,9 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
         {conversion_key{PPME_SYSCALL_SETRESGID_X, 1},
          conversion_info()
                  .action(C_ACTION_ADD_PARAMS)
-                 .instrs({{C_INSTR_FROM_ENTER, 0},
-                          {C_INSTR_FROM_ENTER, 1},
-                          {C_INSTR_FROM_ENTER, 2}})},
+                 .instrs({{C_INSTR_FROM_ENTER, 0, CIF_FALLBACK_TO_EMPTY},
+                          {C_INSTR_FROM_ENTER, 1, CIF_FALLBACK_TO_EMPTY},
+                          {C_INSTR_FROM_ENTER, 2, CIF_FALLBACK_TO_EMPTY}})},
         /*====================== ACCEPT4 ======================*/
         {conversion_key{PPME_SOCKET_ACCEPT4_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SOCKET_ACCEPT4_X, 3},

--- a/userspace/libscap/engine/savefile/converter/table.cpp
+++ b/userspace/libscap/engine/savefile/converter/table.cpp
@@ -184,13 +184,15 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
         {conversion_key{PPME_SYSCALL_SETRESUID_X, 1},
          conversion_info()
                  .action(C_ACTION_ADD_PARAMS)
-                 .instrs({{C_INSTR_FROM_ENTER, 0},
-                          {C_INSTR_FROM_ENTER, 1},
-                          {C_INSTR_FROM_ENTER, 2}})},
+                 .instrs({{C_INSTR_FROM_ENTER, 0, CIF_FALLBACK_TO_EMPTY},
+                          {C_INSTR_FROM_ENTER, 1, CIF_FALLBACK_TO_EMPTY},
+                          {C_INSTR_FROM_ENTER, 2, CIF_FALLBACK_TO_EMPTY}})},
         /*====================== SETUID ======================*/
         {conversion_key{PPME_SYSCALL_SETUID_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_SETUID_X, 1},
-         conversion_info().action(C_ACTION_ADD_PARAMS).instrs({{C_INSTR_FROM_ENTER, 0}})},
+         conversion_info()
+                 .action(C_ACTION_ADD_PARAMS)
+                 .instrs({{C_INSTR_FROM_ENTER, 0, CIF_FALLBACK_TO_EMPTY}})},
         /*====================== RECV ======================*/
         {conversion_key{PPME_SOCKET_RECV_E, 2}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SOCKET_RECV_X, 2},

--- a/userspace/libscap/engine/savefile/converter/types.h
+++ b/userspace/libscap/engine/savefile/converter/types.h
@@ -20,11 +20,21 @@ limitations under the License.
 #include <vector>
 #include <cstdint>
 
-enum conversion_instruction_flags {
+enum conversion_instruction_code {
 	C_NO_INSTR = 0,        // This should be never called
 	C_INSTR_FROM_OLD,      // Take the parameter from the old event
 	C_INSTR_FROM_ENTER,    // Take the parameter from the enter event
 	C_INSTR_FROM_DEFAULT,  // Generate the default parameter
+	C_INSTR_FROM_EMPTY,    // Generate the empty parameter
+};
+
+// TODO(ekoops): remove CIF_FALLBACK_TO_EMPTY and fallback to empty by default once sinsp is able to
+//   handle empty parameters for all the EF_TMP_CONVERTER_MANAGED entries in the converter table.
+enum conversion_instruction_flags {
+	CIF_NO_FLAGS = 0,
+	CIF_FALLBACK_TO_EMPTY,  // C_INSTR_FROM_ENTER-only flag: fallback to the empty value instead of
+	                        // the default one if for some reason the converter is not able to
+	                        // obtain the parameter.
 };
 
 // Conversion actions
@@ -37,8 +47,9 @@ enum conversion_action {
 };
 
 struct conversion_instruction {
-	uint8_t flags = 0;
+	conversion_instruction_code code = C_NO_INSTR;
 	uint8_t param_num = 0;
+	conversion_instruction_flags flags = CIF_NO_FLAGS;
 };
 
 struct conversion_key {

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -726,7 +726,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	const sinsp_evt_param *param = get_param(id);
 	param_info = param->get_info();
 
-	if(param->m_len == 0) {
+	if(param->empty()) {
 		snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "NULL");
 		*resolved_str = &m_resolved_paramstr_storage[0];
 		return &m_paramstr_storage[0];

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -98,6 +98,11 @@ public:
 		return get_event_param_as<T>(*this);
 	}
 
+	/*!
+	 * @return true if the length is equal to zero.
+	 */
+	bool empty() const { return m_len == 0; }
+
 	const struct ppm_param_info* get_info() const;
 
 	// Throws a sinsp_exception detailing why the requested_len is incorrect.
@@ -132,7 +137,7 @@ inline T get_event_param_as(const sinsp_evt_param& param) {
 
 template<>
 inline std::string_view get_event_param_as<std::string_view>(const sinsp_evt_param& param) {
-	if(param.m_len == 0) {
+	if(param.empty()) {
 		return {};
 	}
 
@@ -149,7 +154,7 @@ inline std::string_view get_event_param_as<std::string_view>(const sinsp_evt_par
 
 template<>
 inline std::string get_event_param_as<std::string>(const sinsp_evt_param& param) {
-	if(param.m_len == 0) {
+	if(param.empty()) {
 		return "";
 	}
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4196,6 +4196,19 @@ void sinsp_parser::set_evt_thread_user(sinsp_evt &evt, const sinsp_evt_param &eu
 	ti->set_user(euid_param.as<uint32_t>(), must_notify_thread_user_update());
 }
 
+void sinsp_parser::set_evt_thread_group(sinsp_evt &evt, const sinsp_evt_param &egid_param) const {
+	if(egid_param.empty()) {
+		return;
+	}
+
+	sinsp_threadinfo *ti = evt.get_thread_info();
+	if(ti == nullptr) {
+		return;
+	}
+
+	ti->set_group(egid_param.as<uint32_t>(), must_notify_thread_group_update());
+}
+
 void sinsp_parser::parse_setresuid_exit(sinsp_evt &evt) const {
 	if(evt.get_syscall_return_value() != 0) {
 		return;
@@ -4213,39 +4226,19 @@ void sinsp_parser::parse_setreuid_exit(sinsp_evt &evt) const {
 }
 
 void sinsp_parser::parse_setresgid_exit(sinsp_evt &evt) const {
-	//
-	// Extract the return value
-	//
-	const int64_t retval = evt.get_syscall_return_value();
-
-	if(retval == 0) {
-		uint32_t new_egid = evt.get_param(2)->as<uint32_t>();
-
-		if(new_egid < std::numeric_limits<uint32_t>::max()) {
-			sinsp_threadinfo *ti = evt.get_thread_info();
-			if(ti) {
-				ti->set_group(new_egid, must_notify_thread_group_update());
-			}
-		}
+	if(evt.get_syscall_return_value() != 0) {
+		return;
 	}
+
+	set_evt_thread_group(evt, *evt.get_param(2));
 }
 
 void sinsp_parser::parse_setregid_exit(sinsp_evt &evt) const {
-	//
-	// Extract the return value
-	//
-	const int64_t retval = evt.get_syscall_return_value();
-
-	if(retval == 0) {
-		uint32_t new_egid = evt.get_param(2)->as<uint32_t>();
-
-		if(new_egid < std::numeric_limits<uint32_t>::max()) {
-			sinsp_threadinfo *ti = evt.get_thread_info();
-			if(ti) {
-				ti->set_group(new_egid, must_notify_thread_group_update());
-			}
-		}
+	if(evt.get_syscall_return_value() != 0) {
+		return;
 	}
+
+	set_evt_thread_group(evt, *evt.get_param(2));
 }
 
 void sinsp_parser::parse_setuid_exit(sinsp_evt &evt) const {
@@ -4257,18 +4250,11 @@ void sinsp_parser::parse_setuid_exit(sinsp_evt &evt) const {
 }
 
 void sinsp_parser::parse_setgid_exit(sinsp_evt &evt) const {
-	//
-	// Extract the return value
-	//
-	const int64_t retval = evt.get_syscall_return_value();
-
-	if(retval == 0 && evt.get_num_params() > 1) {
-		uint32_t new_egid = evt.get_param(1)->as<uint32_t>();
-		sinsp_threadinfo *ti = evt.get_thread_info();
-		if(ti) {
-			ti->set_group(new_egid, must_notify_thread_group_update());
-		}
+	if(evt.get_syscall_return_value() != 0) {
+		return;
 	}
+
+	set_evt_thread_group(evt, *evt.get_param(1));
 }
 
 void sinsp_parser::parse_user_evt(sinsp_evt &evt) const {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2630,7 +2630,7 @@ void sinsp_parser::parse_bind_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 	}
 
 	parinfo = evt.get_param(1);
-	if(parinfo->m_len == 0) {
+	if(parinfo->empty()) {
 		//
 		// No address, there's nothing we can really do with this.
 		//
@@ -2713,7 +2713,7 @@ void sinsp_parser::parse_connect_enter(sinsp_evt &evt) const {
 	auto &sockinfo = fdinfo->m_sockinfo;
 
 	const sinsp_evt_param *addr_param = evt.get_param(1);
-	if(addr_param->m_len == 0) {
+	if(addr_param->empty()) {
 		// Address can be nullptr:
 		// sk is a TCP fastopen active socket and
 		// TCP_FASTOPEN_CONNECT sockopt is set and
@@ -2917,7 +2917,7 @@ void sinsp_parser::parse_connect_exit(sinsp_evt &evt, sinsp_parser_verdict &verd
 	}
 
 	const sinsp_evt_param *tuple_param = evt.get_param(1);
-	if(tuple_param->m_len == 0) {
+	if(tuple_param->empty()) {
 		// Address can be nullptr:
 		// sk is a TCP fastopen active socket and
 		// TCP_FASTOPEN_CONNECT sockopt is set and
@@ -2960,7 +2960,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt &evt, sinsp_parser_verdict &verdi
 
 	// Extract the address.
 	const sinsp_evt_param *parinfo = evt.get_param(1);
-	if(parinfo->m_len == 0) {
+	if(parinfo->empty()) {
 		// No address, there's nothing we can really do with this.
 		// This happens for socket types that we don't support, so we have the assertion
 		// to make sure that this is not a type of socket that we support.
@@ -3339,7 +3339,7 @@ bool sinsp_parser::update_fd(sinsp_evt &evt, const sinsp_evt_param &parinfo) con
 	uint8_t *packed_data = (uint8_t *)parinfo.m_val;
 	uint8_t family = *packed_data;
 
-	if(parinfo.m_len == 0) {
+	if(parinfo.empty()) {
 		return false;
 	}
 
@@ -4183,8 +4183,8 @@ void sinsp_parser::parse_brk_mmap_mmap2_munmap__exit(sinsp_evt &evt) {
 	evt.get_tinfo()->m_vmswap_kb = evt.get_param(3)->as<uint32_t>();
 }
 
-void sinsp_parser::set_evt_thread_user(sinsp_evt &evt, const uint32_t euid) const {
-	if(euid == std::numeric_limits<uint32_t>::max()) {
+void sinsp_parser::set_evt_thread_user(sinsp_evt &evt, const sinsp_evt_param &euid_param) const {
+	if(euid_param.empty()) {
 		return;
 	}
 
@@ -4193,7 +4193,7 @@ void sinsp_parser::set_evt_thread_user(sinsp_evt &evt, const uint32_t euid) cons
 		return;
 	}
 
-	ti->set_user(euid, must_notify_thread_user_update());
+	ti->set_user(euid_param.as<uint32_t>(), must_notify_thread_user_update());
 }
 
 void sinsp_parser::parse_setresuid_exit(sinsp_evt &evt) const {
@@ -4201,7 +4201,7 @@ void sinsp_parser::parse_setresuid_exit(sinsp_evt &evt) const {
 		return;
 	}
 
-	set_evt_thread_user(evt, evt.get_param(2)->as<uint32_t>());
+	set_evt_thread_user(evt, *evt.get_param(2));
 }
 
 void sinsp_parser::parse_setreuid_exit(sinsp_evt &evt) const {
@@ -4209,7 +4209,7 @@ void sinsp_parser::parse_setreuid_exit(sinsp_evt &evt) const {
 		return;
 	}
 
-	set_evt_thread_user(evt, evt.get_param(2)->as<uint32_t>());
+	set_evt_thread_user(evt, *evt.get_param(2));
 }
 
 void sinsp_parser::parse_setresgid_exit(sinsp_evt &evt) const {
@@ -4253,7 +4253,7 @@ void sinsp_parser::parse_setuid_exit(sinsp_evt &evt) const {
 		return;
 	}
 
-	set_evt_thread_user(evt, evt.get_param(1)->as<uint32_t>());
+	set_evt_thread_user(evt, *evt.get_param(1));
 }
 
 void sinsp_parser::parse_setgid_exit(sinsp_evt &evt) const {

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -135,10 +135,10 @@ private:
 	static void parse_capset_exit(sinsp_evt& evt);
 	static void parse_unshare_setns_exit(sinsp_evt& evt);
 
-	// Set the event thread user to the user corresponding to the provided effective user id. This
-	// is no-op if there is no thread associated with the provided event or the effective user id is
-	// invalid.
-	void set_evt_thread_user(sinsp_evt& evt, uint32_t euid) const;
+	// Set the event thread user to the user corresponding to the effective user id taken from the
+	// provided parameter. This is no-op if there is no thread associated with the provided event
+	// or the provided parameter is empty.
+	void set_evt_thread_user(sinsp_evt& evt, const sinsp_evt_param& euid_param) const;
 
 	static inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo& fdinfo,
 	                                                   uint32_t tsip,

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -140,6 +140,11 @@ private:
 	// or the provided parameter is empty.
 	void set_evt_thread_user(sinsp_evt& evt, const sinsp_evt_param& euid_param) const;
 
+	// Set the event thread group to the group corresponding to the effective group id taken from
+	// the provided parameter. This is no-op if there is no thread associated with the provided
+	// event or the provided parameter is empty.
+	void set_evt_thread_group(sinsp_evt& evt, const sinsp_evt_param& egid_param) const;
+
 	static inline bool update_ipv4_addresses_and_ports(sinsp_fdinfo& fdinfo,
 	                                                   uint32_t tsip,
 	                                                   uint16_t tsport,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR enables the scap converter to push empty parameters in place of default parameters. This is motivated by the fact that we need a way to distinguish between valid parameter values (that can be read and used by the userspace code) and invalid parameter values (that must not be accessed and so, used) regardless of their parameter type. 

This PR adds `C_INSTR_FROM_EMPTY` converter instruction code and `CIF_FALLBACK_TO_EMPTY` conversion flag, and uses them to push empty parameters for all `PT_UID` and `PT_GID` handled by the scap converter table.

In order to keep compatibility with old scap files, an empty parameters has a parameter length set to 0, but it still have `len` bytes set to 0 as parameter value, where `len` is determined from the parameter type. E.g.: a `PT_UINT64` parameter will have the length set to 0 and its value will occupy 8 bytes, all set to 0.

Contextually, this PR introduces the notion of conversion flags and particularly, the `CIF_FALLBACK_TO_EMPTY` flag: by default, if a `C_INSTR_FROM_ENTER` instruction is encountered, and for some reason the converter is not able to obtain a parameter from the enter event, it pushes a default parameter; if `CIF_FALLBACK_TO_EMPTY` is specified, it will fallback to an empty parameter.
This flag is a temporary solution to avoid handling all the new empty parameters in place of default ones in a single shot.

Finally, this PR adapts user space code to handle possible empty `PT_UID` and `PT_GID` parameters.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
