### PR TITLE
fix(testing): adjust gvisor testing for execve

### DIFF
--- a/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
+++ b/test/libscap/test_suites/engines/gvisor/gvisor_parsers.cpp
@@ -163,7 +163,7 @@ TEST(gvisor_parsers, parse_execve_x) {
 
 	scap_sized_buffer decoded_params[PPM_MAX_EVENT_PARAMS];
 	uint32_t n = scap_event_decode_params(res.scap_events[0], decoded_params);
-	EXPECT_EQ(n, 27);
+	EXPECT_EQ(n, 30);
 	EXPECT_STREQ(static_cast<const char *>(decoded_params[1].buf), "/usr/bin/ls");  // exe
 	EXPECT_STREQ(static_cast<const char *>(decoded_params[2].buf), "a");  // args[0] must be argv[1]
 	EXPECT_STREQ(static_cast<const char *>(decoded_params[6].buf), "/root");  // cwd
@@ -190,7 +190,7 @@ TEST(gvisor_parsers, parse_execve_x) {
 	EXPECT_EQ(res.scap_events.size(), 1);
 
 	n = scap_event_decode_params(res.scap_events[0], decoded_params);
-	EXPECT_EQ(n, 27);
+	EXPECT_EQ(n, 30);
 	EXPECT_STREQ(static_cast<const char *>(decoded_params[1].buf), "/usr/bin/ls");  // exe
 	EXPECT_EQ(strlen(static_cast<const char *>(decoded_params[2].buf)),
 	          0);  // there must be no args


### PR DESCRIPTION
https://github.com/falcosecurity/libs/pull/2544 implements conversion of the exceve_x event which increases the number of parameters to 30.

Adjust the number of expected parameters from 27 to 30 for execve_x events with the gvisor engine.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

One of the gvisor engine tests needs adjustment because the number of expected arguments has been increased for the execve_x event from 27 to 30.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
