### PR TITLE
fix(libscap): add missing fd locations for dup exit events

### DIFF
--- a/userspace/libscap/scap_event.c
+++ b/userspace/libscap/scap_event.c
@@ -610,6 +610,9 @@ int get_exit_event_fd_location(ppm_event_code etype) {
 	case PPME_SYSCALL_FLOCK_X:
 	case PPME_SYSCALL_COPY_FILE_RANGE_X:
 	case PPME_SYSCALL_FCNTL_X:
+	case PPME_SYSCALL_DUP_1_X:
+	case PPME_SYSCALL_DUP2_X:
+	case PPME_SYSCALL_DUP3_X:
 		location = 1;
 		break;
 	case PPME_SYSCALL_READ_X:


### PR DESCRIPTION
The function extracting `fd` parameter's location from the exit event is missing information for the dup syscalls.

Add location of the `fd` parameter in the exit event for all dup syscalls.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The function that extracts file descriptors from exit events is missing offset for the fd argument in various versions of the dup syscall exit event. This update makes it possible to set event's fd information basing on the information available in the exit event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

There is no need to pump up the driver version, all required information is already available in the current events. We simply utilize better what is already available.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
