### PR TITLE
fix(userspace/libsinsp): partially fix filterchecks for empty params

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -740,7 +740,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_PRLIMIT_X_5_to_7_params_no_enter) {
 	constexpr auto pid = empty_value<int64_t>();
 	constexpr auto resource = empty_value<uint8_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(5, 6);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 5, 6);
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -971,8 +971,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_EXECVE_19_X_18_to_30_params_no_enter) {
 	constexpr auto pgid = empty_value<int64_t>();
 	constexpr auto gid = empty_value<uint32_t>();
 
-	const auto empty_params_set =
-	        SCAP_EMPTY_PARAMS_SET(18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
 
 	assert_full_conversion(create_safe_scap_event(ts,
 	                                              tid_hdr,
@@ -1861,7 +1860,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESUID_X_1_to_4_params_no_enter) {
 	constexpr auto euid = empty_value<uint32_t>();
 	constexpr auto suid = empty_value<uint32_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(1, 2, 3);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1, 2, 3);
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -1921,7 +1920,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETUID_X_to_2_params_no_enter) {
 	// Set to empty.
 	constexpr auto uid = empty_value<uint32_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(1);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1);
 
 	assert_single_conversion_success(CONVERSION_COMPLETED,
 	                                 create_safe_scap_event(ts, tid, PPME_SYSCALL_SETUID_X, 1, res),
@@ -3551,7 +3550,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_PTRACE_X_0_to_3_params) {
 	constexpr auto addr = empty_value<scap_const_sized_buffer>();
 	constexpr auto data = empty_value<scap_const_sized_buffer>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(0, 1, 2);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 0, 1, 2);
 
 	assert_single_conversion_success(CONVERSION_CONTINUE,
 	                                 create_safe_scap_event(ts, tid, PPME_SYSCALL_PTRACE_X, 0),
@@ -3576,7 +3575,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_PTRACE_X_0_to_5_params_no_enter) {
 	constexpr auto pid = empty_value<int64_t>();
 	constexpr auto request = empty_value<uint16_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(0, 1, 2, 3, 4);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 0, 1, 2, 3, 4);
 
 	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_SYSCALL_PTRACE_X, 0),
 	                       create_safe_scap_event_with_empty_params(ts,
@@ -3603,7 +3602,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_PTRACE_X_0_to_5_params_with_enter) {
 	constexpr auto addr = empty_value<scap_const_sized_buffer>();
 	constexpr auto data = empty_value<scap_const_sized_buffer>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(0, 1, 2);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 0, 1, 2);
 
 	// After the first conversion we should have the storage
 	const auto evt = create_safe_scap_event(ts, tid, PPME_SYSCALL_PTRACE_E, 2, request, pid);
@@ -3635,7 +3634,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_PTRACE_X_3_to_5_params_no_enter) {
 	constexpr auto pid = empty_value<int64_t>();
 	constexpr auto request = empty_value<uint16_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(3, 4);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 3, 4);
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -3964,7 +3963,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_MKDIR_2_X_2_to_3_params_no_enter) {
 	// Set to empty values
 	constexpr auto mode = empty_value<uint32_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(2);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 2);
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,
@@ -4029,7 +4028,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_RMDIR_X_1_to_2_X_2_no_enter) {
 	// Set to empty values
 	constexpr auto path = empty_value<scap_const_sized_buffer>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(1);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1);
 
 	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_SYSCALL_RMDIR_X, 1, res),
 	                       create_safe_scap_event_with_empty_params(ts,
@@ -5136,7 +5135,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETGID_X_1_to_2_params_no_enter) {
 	// Set to empty.
 	constexpr auto gid = empty_value<uint32_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(1);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1);
 
 	assert_single_conversion_success(CONVERSION_COMPLETED,
 	                                 create_safe_scap_event(ts, tid, PPME_SYSCALL_SETGID_X, 1, res),
@@ -5195,7 +5194,7 @@ TEST_F(convert_event_test, PPME_SYSCALL_SETRESGID_X_1_to_4_params_no_enter) {
 	constexpr auto egid = empty_value<uint32_t>();
 	constexpr auto sgid = empty_value<uint32_t>();
 
-	const auto empty_params_set = SCAP_EMPTY_PARAMS_SET(1, 2, 3);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1, 2, 3);
 
 	assert_single_conversion_success(
 	        CONVERSION_COMPLETED,

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -850,13 +850,13 @@ typedef uint64_t scap_empty_params_set;
 void scap_empty_params_set_init(scap_empty_params_set* set, int n, ...);
 int scap_empty_params_set_is_set(const scap_empty_params_set* set, int index);
 
-#define SCAP_EMPTY_PARAMS_SET(...)                                          \
-	({                                                                      \
-		scap_empty_params_set set = 0;                                      \
-		const int VA_ARGS_NUM = sizeof((int[]){__VA_ARGS__}) / sizeof(int); \
-		scap_empty_params_set_init(&set, VA_ARGS_NUM, __VA_ARGS__);         \
-		set;                                                                \
-	})
+#define SCAP_EMPTY_PARAMS_SET(set_name, ...)                                 \
+	scap_empty_params_set set_name = 0;                                      \
+	{ /* New scope to hide the following temporary variables. */             \
+		const int VA_ARGS_INT_ARR[] = {__VA_ARGS__};                         \
+		const int VA_ARGS_NUM = sizeof(VA_ARGS_INT_ARR) / sizeof(const int); \
+		scap_empty_params_set_init(&set_name, VA_ARGS_NUM, __VA_ARGS__);     \
+	}
 
 /*!
   \brief Create an event from the parameters given as arguments.

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -727,7 +727,28 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	param_info = param->get_info();
 
 	if(param->empty()) {
-		snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "NULL");
+		// Ideally, we should always <NA>, but this would break compatibility, so keep pushing NULL
+		// for parameters that could already be empty before the scap-converter introduced the
+		// notion of "empty parameters" for all types.
+		// TODO(ekoops): consistently send the same value.
+		switch(param_info->type) {
+		case PT_BYTEBUF:
+		case PT_CHARBUF:
+		case PT_SOCKTUPLE:
+		case PT_FDLIST:
+		case PT_FSPATH:
+		case PT_CHARBUFARRAY:
+		case PT_CHARBUF_PAIR_ARRAY:
+		case PT_FSRELPATH:
+		case PT_DYN: {
+			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "NULL");
+			break;
+		}
+		default: {
+			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "<NA>");
+			break;
+		}
+		}
 		*resolved_str = &m_resolved_paramstr_storage[0];
 		return &m_paramstr_storage[0];
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1692,7 +1692,7 @@ bool sinsp_filter_check_event::compare_nocache(sinsp_evt* evt) {
 		// class does not support multi-valued extraction
 		uint8_t* extracted_val = extract_single(evt, &len, sanitize_strings);
 
-		if(extracted_val == NULL) {
+		if(extracted_val == NULL || len == 0) {
 			return false;
 		}
 

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -78,6 +78,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	ast_exprs.ut.cpp
 	test_utils.cpp
 	sinsp_with_test_input.cpp
+	filter_eval_test.cpp
 	events_evt.ut.cpp
 	events_file.ut.cpp
 	events_fspath.ut.cpp

--- a/userspace/libsinsp/test/filter_eval_test.cpp
+++ b/userspace/libsinsp/test/filter_eval_test.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <filter_eval_test.h>
+
+TEST_P(filter_eval_test, execve_empty_params) {
+	const auto tc = GetParam();
+
+	add_default_init_thread();
+
+	open_inspector();
+
+	// Use execve event type as it contains a multitude of parameters (specifically, in the range
+	// 18-29) that can be set to empty by the scap-converter.
+	const auto evt = generate_execve_exit_event_with_empty_params(1, "/bin/test-exe", "test-exe");
+
+	const auto filter_str = tc.filter_str.c_str();
+
+	switch(tc.expected_result) {
+	case filter_eval_test_case::EXPECT_TRUE: {
+		EXPECT_TRUE(eval_filter(evt, filter_str));
+		break;
+	}
+	case filter_eval_test_case::EXPECT_FALSE: {
+		EXPECT_FALSE(eval_filter(evt, filter_str));
+		break;
+	}
+	case filter_eval_test_case::EXPECT_THROW: {
+		EXPECT_ANY_THROW(eval_filter(evt, filter_str));
+		break;
+	}
+	default:
+		ASSERT(false);
+		break;
+	}
+}
+
+/* On windows, the previous TEST_P definition would generate a synthetic failing test.
+ * The correct solution, would be adding GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST here, but
+ * this macro generates an error for some reason. Just add a dummy test case to fix the issue. */
+INSTANTIATE_TEST_CASE_P(dummy,
+                        filter_eval_test,
+                        testing::ValuesIn(std::vector<filter_eval_test_case>{
+                                {"dummy", "proc.pid exists", filter_eval_test_case::EXPECT_TRUE}}),
+                        filter_eval_test::test_case_name_gen);

--- a/userspace/libsinsp/test/filter_eval_test.h
+++ b/userspace/libsinsp/test/filter_eval_test.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <sinsp_with_test_input.h>
+
+/*!
+  \brief Test case for the filter_eval_test fixture.
+*/
+struct filter_eval_test_case {
+	enum expected_filter_result : uint8_t { EXPECT_TRUE, EXPECT_FALSE, EXPECT_THROW };
+
+	std::string name;
+	std::string filter_str;
+	expected_filter_result expected_result;
+
+	std::string expected_result_to_string() const {
+		switch(expected_result) {
+		case EXPECT_TRUE:
+			return "true";
+		case EXPECT_FALSE:
+			return "false";
+		case EXPECT_THROW:
+			return "throw";
+		default:
+			ASSERT(false);
+			throw std::runtime_error("unexpected filter result: " +
+			                         std::to_string(expected_result));
+		}
+	}
+
+	friend std::ostream& operator<<(std::ostream& os, const filter_eval_test_case& tc) {
+		return os << "(filter=" << tc.filter_str
+		          << ", expected_result=" << tc.expected_result_to_string() << ")";
+	}
+};
+
+/*!
+  \brief Fixture allowing to evaluate filters on events and test the outcomes.
+*/
+class filter_eval_test : public testing::WithParamInterface<filter_eval_test_case>,
+                         public sinsp_with_test_input {
+public:
+	static std::string test_case_name_gen(const testing::TestParamInfo<ParamType>& info) {
+		return info.param.name;
+	}
+};

--- a/userspace/libsinsp/test/filterchecks/evt/arg.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt/arg.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <helpers/threads_helpers.h>
+#include <filter_eval_test.h>
+
+const auto arg_eq_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_eq_NA",
+         "evt.arg.flags = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_UINT64_eq_NA",
+         "evt.arg.cap_inheritable = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_ABSTIME_eq_NA",
+         "evt.arg.exe_ino_ctime = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_UID_eq_NA",
+         "evt.arg.uid = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_eq_NA",
+         "evt.arg.trusted_exepath = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_PID_eq_NA",
+         "evt.arg.pgid = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_GID_eq_NA",
+         "evt.arg.gid = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+});
+
+const auto arg_tolower_eq_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_eq_NA",
+         "tolower(evt.arg.flags) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_UINT64_eq_NA",
+         "tolower(evt.arg.cap_inheritable) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_ABSTIME_eq_NA",
+         "tolower(evt.arg.exe_ino_ctime) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_UID_eq_NA",
+         "tolower(evt.arg.uid) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_eq_NA",
+         "tolower(evt.arg.trusted_exepath) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_PID_eq_NA",
+         "tolower(evt.arg.pgid) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_GID_eq_NA",
+         "tolower(evt.arg.gid) = <na>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+});
+
+INSTANTIATE_TEST_CASE_P(arg_eq_op,
+                        filter_eval_test,
+                        arg_eq_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(arg_tolower_eq_op,
+                        filter_eval_test,
+                        arg_tolower_eq_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_arg_empty_params) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	// Use execve event type as it contains a multitude of parameters (specifically, in the range
+	// 18-29) that can be set to empty by the scap-converter.
+	const auto evt = generate_execve_exit_event_with_empty_params(1, "/bin/test-exe", "test-exe");
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.flags"), "<NA>");            // PT_FLAGS32
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.cap_inheritable"), "<NA>");  // PT_UINT64
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.exe_ino_ctime"), "<NA>");    // PT_ABSTIME
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.uid"), "<NA>");              // PT_UID
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.trusted_exepath"), "<NA>");  // PT_FSPATH
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.pgid"), "<NA>");             // PT_PID
+	ASSERT_EQ(get_field_as_string(evt, "evt.arg.gid"), "<NA>");              // PT_GID
+}

--- a/userspace/libsinsp/test/filterchecks/evt/rawarg.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt/rawarg.cpp
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2025 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <helpers/threads_helpers.h>
+#include <filter_eval_test.h>
+
+// Test that for rawarg.X we are correctly retrieving the correct field type/format.
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_madness) {
+	add_default_init_thread();
+	open_inspector();
+
+	// [PPME_SYSCALL_EPOLL_CREATE_E] = {"epoll_create", EC_WAIT | EC_SYSCALL, EF_CREATES_FD |
+	// EF_MODIFIES_STATE, 1, { {"size", PT_INT32, PF_DEC} } },
+	sinsp_evt* evt =
+	        add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_EPOLL_CREATE_E, 1, (int32_t)-22);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.size"), "-22");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.size < -20"));
+
+	// [PPME_SYSCALL_SIGNALFD4_X] = {"signalfd4", EC_SIGNAL | EC_SYSCALL, EF_CREATES_FD |
+	// EF_MODIFIES_STATE, 2, {{"res", PT_FD, PF_DEC}, {"flags", PT_FLAGS16, PF_HEX, file_flags}}},
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_SIGNALFD4_X,
+	                           4,
+	                           (int64_t)-1,
+	                           (uint16_t)512,
+	                           (int64_t)9,
+	                           (uint32_t)0);
+	// 512 in hex is 200
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.flags"), "200");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.flags < 515"));
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.fd"), "9");
+
+	// [PPME_SYSCALL_TIMERFD_CREATE_E] = {"timerfd_create",EC_TIME | EC_SYSCALL,EF_CREATES_FD |
+	// EF_MODIFIES_STATE,2,{{"clockid", PT_UINT8, PF_DEC},{"flags", PT_UINT8, PF_HEX}}},
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_TIMERFD_CREATE_E,
+	                           2,
+	                           (uint8_t)-1,
+	                           (uint8_t)255);
+	// 255 in hex is FF
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.flags"), "FF");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.flags <= 255"));
+
+	// [PPME_SYSCALL_BRK_4_E] = {"brk", EC_MEMORY | EC_SYSCALL, EF_NONE, 1, {{"addr", PT_UINT64,
+	// PF_HEX}}}
+	uint64_t addr = UINT64_MAX;
+	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_BRK_4_E, 1, addr);
+	// UINT64_MAX is FFFFFFFFFFFFFFFF
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.addr"), "FFFFFFFFFFFFFFFF");
+	ASSERT_ANY_THROW(eval_filter(evt, "evt.rawarg.addr > 0"));  // PT_SOCKADDR is not comparable
+
+	/*
+	 * Now test the bugged case where `find_longest_matching_evt_param` returns a size,
+	 * but then real event has a size that is bigger than that.
+	 * In this case, `find_longest_matching_evt_param` will find `size` param
+	 * from PPME_SYSCALL_READ_E, that is {"size", PT_UINT32, PF_DEC},
+	 * but then we call evt.rawarg.size on a PPME_SYSCALL_SPLICE_E,
+	 * whose `size` param is 64bit: {"size", PT_UINT64, PF_DEC}.
+	 */
+	// [PPME_SYSCALL_SPLICE_E] = {"splice", EC_IO_OTHER | EC_SYSCALL, EF_USES_FD, 4, {
+	//	{"fd_in", PT_FD, PF_DEC}, {"fd_out", PT_FD, PF_DEC}, {"size", PT_UINT64, PF_DEC}, {
+	//		"flags", PT_FLAGS32, PF_HEX, splice_flags}}}
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_SPLICE_E,
+	                           4,
+	                           (int64_t)-1,
+	                           (int64_t)-1,
+	                           (uint64_t)512,
+	                           (uint32_t)0);
+	// Size is PF_DEC, 512 is 512
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.size"), "512");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.size < 515"));
+
+	evt = generate_execve_exit_event_with_default_params(1, "/bin/test-exe", "test-exe");
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.uid = 0"));   // PT_UID
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.pgid = 0"));  // PT_PID
+	ASSERT_TRUE(eval_filter(evt, "evt.rawarg.gid = 0"));   // PT_GID
+
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__) && !defined(__APPLE__)
+	evt = generate_connect_events();
+	ASSERT_ANY_THROW(eval_filter(evt, "evt.rawarg.addr > 0"));   // PT_SOCKADDR is not comparable
+	ASSERT_ANY_THROW(eval_filter(evt, "evt.rawarg.tuple > 0"));  // PT_TUPLE is not comparable
+#endif
+}
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_int) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	sinsp_evt* evt =
+	        add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_SETUID_E, 1, (uint32_t)1000);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.uid"), "1000");
+}
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_str) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	std::string path = "/home/file.txt";
+
+	// In the enter event we don't send the `PPM_O_F_CREATED`
+	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
+	                                      1,
+	                                      PPME_SYSCALL_OPEN_E,
+	                                      3,
+	                                      path.c_str(),
+	                                      (uint32_t)0,
+	                                      (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.name"), path);
+}
+
+const auto rawarg_eq_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_eq_0", "evt.rawarg.flags = 0", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UINT64_eq_0", "evt.rawarg.cap_inheritable = 0", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_ABSTIME_eq_0", "evt.rawarg.exe_ino_ctime = 0", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UID_eq_0", "evt.rawarg.uid = 0", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_FSPATH_eq_NA",
+         "evt.rawarg.trusted_exepath = <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false? Actually,
+                                               // trusted_exepath is set to <NA>.
+        {"PT_PID_eq_0", "evt.rawarg.pgid = 0", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_GID_eq_0", "evt.rawarg.gid = 0", filter_eval_test_case::EXPECT_FALSE},
+});
+
+const auto rawarg_contains_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_contains_str",
+         "evt.rawarg.flags contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UINT64_contains_str",
+         "evt.rawarg.cap_inheritable contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_ABSTIME_contains_str",
+         "evt.rawarg.exe_ino_ctime contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UID_contains_str",
+         "evt.rawarg.uid contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_FSPATH_contains_str",
+         "evt.rawarg.trusted_exepath contains 'str'",
+         filter_eval_test_case::EXPECT_FALSE},  // Should this always return false?
+        {"PT_FSPATH_contains_NA",
+         "evt.rawarg.trusted_exepath contains <NA>",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_contains_empty",
+         "evt.rawarg.trusted_exepath contains ''",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_PID_contains_str",
+         "evt.rawarg.pgid contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_GID_contains_str",
+         "evt.rawarg.gid contains 'str'",
+         filter_eval_test_case::EXPECT_THROW},
+});
+
+const auto rawarg_exists_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_exists", "evt.rawarg.flags exists", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UINT64_exists",
+         "evt.rawarg.cap_inheritable exists",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_ABSTIME_exists",
+         "evt.rawarg.exe_ino_ctime exists",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UID_exists", "evt.rawarg.uid exists", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_FSPATH_exists",
+         "evt.rawarg.trusted_exepath exists",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false? Actually,
+                                               // trusted_exepath is set to <NA>, so it exists
+        {"PT_PID_exists", "evt.rawarg.pgid exists", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_GID_exists", "evt.rawarg.gid exists", filter_eval_test_case::EXPECT_FALSE},
+});
+
+const auto rawarg_glob_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_glob_path",
+         "evt.rawarg.flags glob '/path/*'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UINT64_glob_path",
+         "evt.rawarg.cap_inheritable glob '/path/*'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_ABSTIME_glob_path",
+         "evt.rawarg.exe_ino_ctime glob '/path/*'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UID_glob_path", "evt.rawarg.uid glob '/path/*'", filter_eval_test_case::EXPECT_THROW},
+        {"PT_FSPATH_glob_path",
+         "evt.rawarg.trusted_exepath glob '/path/*'",
+         filter_eval_test_case::EXPECT_FALSE},  // Should this always return false?
+        {"PT_FSPATH_glob_NA",
+         "evt.rawarg.trusted_exepath glob '<NA>'",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_glob_empty",
+         "evt.rawarg.trusted_exepath glob ''",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_PID_glob_path", "evt.rawarg.pgid glob '/path/*'", filter_eval_test_case::EXPECT_THROW},
+        {"PT_GID_glob_path", "evt.rawarg.gid glob '/path/*'", filter_eval_test_case::EXPECT_THROW},
+});
+
+const auto rawarg_pmatch_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_pmatch_path",
+         "evt.rawarg.flags pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UINT64_pmatch_path",
+         "evt.rawarg.cap_inheritable pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_ABSTIME_pmatch_path",
+         "evt.rawarg.exe_ino_ctime pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UID_pmatch_path",
+         "evt.rawarg.uid pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_FSPATH_pmatch_NA",
+         "evt.rawarg.trusted_exepath pmatch (<NA>)",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_pmatch_empty_str",
+         "evt.rawarg.trusted_exepath pmatch ('')",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_pmatch_empty",
+         "evt.rawarg.trusted_exepath pmatch ()",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_PID_pmatch_path",
+         "evt.rawarg.pgid pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_GID_pmatch_path",
+         "evt.rawarg.gid pmatch (/path)",
+         filter_eval_test_case::EXPECT_THROW},
+});
+
+const auto rawarg_regex_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_regex", "evt.rawarg.flags regex '[0-9]+'", filter_eval_test_case::EXPECT_THROW},
+        {"PT_UINT64_regex",
+         "evt.rawarg.cap_inheritable regex '[0-9]+'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_ABSTIME_regex",
+         "evt.rawarg.exe_ino_ctime regex '[0-9]+'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UID_regex", "evt.rawarg.uid regex '[0-9]+'", filter_eval_test_case::EXPECT_THROW},
+        {"PT_FSPATH_regex_NA",
+         "evt.rawarg.trusted_exepath regex '<NA>'",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_regex_everything",
+         "evt.rawarg.trusted_exepath regex '.*'",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_regex_empty_str",
+         "evt.rawarg.trusted_exepath regex ''",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_PID_regex", "evt.rawarg.pgid regex '[0-9]+'", filter_eval_test_case::EXPECT_THROW},
+        {"PT_GID_regex", "evt.rawarg.gid regex '[0-9]+'", filter_eval_test_case::EXPECT_THROW},
+});
+
+const auto rawarg_startswith_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_startswith_0",
+         "evt.rawarg.flags startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UINT64_startswith_0",
+         "evt.rawarg.cap_inheritable startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_ABSTIME_startswith_0",
+         "evt.rawarg.exe_ino_ctime startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_UID_startswith_0",
+         "evt.rawarg.uid startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_FSPATH_startswith_NA",
+         "evt.rawarg.trusted_exepath startswith '<NA>'",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_startswith_empty_str",
+         "evt.rawarg.trusted_exepath startswith ''",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_PID_startswith_0",
+         "evt.rawarg.pgid startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+        {"PT_GID_startswith_0",
+         "evt.rawarg.gid startswith 0'",
+         filter_eval_test_case::EXPECT_THROW},
+});
+
+const auto rawarg_in_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_in_set_with_0", "evt.rawarg.flags in (0)", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UINT64_in_set_with_0",
+         "evt.rawarg.cap_inheritable in (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_ABSTIME_in_set_with_0",
+         "evt.rawarg.exe_ino_ctime in (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UID_in_set_with_0", "evt.rawarg.uid in (0)", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_FSPATH_in_set_with_NA",
+         "evt.rawarg.trusted_exepath in ('<NA>')",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_in_set_with_empty_str",
+         "evt.rawarg.trusted_exepath in ('')",
+         filter_eval_test_case::EXPECT_FALSE},  // Should this always return false?
+        {"PT_FSPATH_in_empty_set",
+         "evt.rawarg.trusted_exepath in ()",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_PID_in_set_with_0", "evt.rawarg.pgid in (0)", filter_eval_test_case::EXPECT_FALSE},
+        {"PT_GID_in_set_with_0", "evt.rawarg.gid in (0)", filter_eval_test_case::EXPECT_FALSE},
+});
+
+const auto rawarg_intersects_op_test_cases = testing::ValuesIn(std::vector<filter_eval_test_case>{
+        {"PT_FLAGS_intersects_set_with_0",
+         "evt.rawarg.flags intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UINT64_intersects_set_with_0",
+         "evt.rawarg.cap_inheritable intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_ABSTIME_intersects_set_with_0",
+         "evt.rawarg.exe_ino_ctime intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_UID_intersects_set_with_0",
+         "evt.rawarg.uid intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_FSPATH_intersects_set_with_NA",
+         "evt.rawarg.trusted_exepath intersects ('<NA>')",
+         filter_eval_test_case::EXPECT_TRUE},  // Should this always return false?
+        {"PT_FSPATH_intersects_set_with_empty_str",
+         "evt.rawarg.trusted_exepath intersects ('')",
+         filter_eval_test_case::EXPECT_FALSE},  // Should this always return false?
+        {"PT_FSPATH_intersects_empty_set",
+         "evt.rawarg.trusted_exepath intersects ()",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_PID_intersects_set_with_0",
+         "evt.rawarg.pgid intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+        {"PT_GID_intersects_set_with_0",
+         "evt.rawarg.gid intersects (0)",
+         filter_eval_test_case::EXPECT_FALSE},
+});
+
+INSTANTIATE_TEST_CASE_P(rawarg_eq_op,
+                        filter_eval_test,
+                        rawarg_eq_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_contains_op,
+                        filter_eval_test,
+                        rawarg_contains_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_exists_op,
+                        filter_eval_test,
+                        rawarg_exists_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_glob_op,
+                        filter_eval_test,
+                        rawarg_glob_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_pmatch_op,
+                        filter_eval_test,
+                        rawarg_pmatch_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_regex_op,
+                        filter_eval_test,
+                        rawarg_regex_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_startswith_op,
+                        filter_eval_test,
+                        rawarg_startswith_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_in_op,
+                        filter_eval_test,
+                        rawarg_in_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+INSTANTIATE_TEST_CASE_P(rawarg_intersects_op,
+                        filter_eval_test,
+                        rawarg_intersects_op_test_cases,
+                        filter_eval_test::test_case_name_gen);
+
+TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_empty_params) {
+	add_default_init_thread();
+
+	open_inspector();
+
+	// Use execve event type as it contains a multitude of parameters (specifically, in the range
+	// 18-29) that can be set to empty by the scap-converter.
+	const auto evt = generate_execve_exit_event_with_empty_params(1, "/bin/test-exe", "test-exe");
+
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.flags"), "0");               // PT_FLAGS32
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.cap_inheritable"), "0");     // PT_UINT64
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.exe_ino_ctime"), "0");       // PT_ABSTIME
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.uid"), "0");                 // PT_UID
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.trusted_exepath"), "<NA>");  // PT_FSPATH
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.pgid"), "0");                // PT_PID
+	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.gid"), "0");                 // PT_GID
+}

--- a/userspace/libsinsp/test/sinsp_with_test_input.cpp
+++ b/userspace/libsinsp/test/sinsp_with_test_input.cpp
@@ -408,6 +408,49 @@ sinsp_evt* sinsp_with_test_input::generate_execve_exit_event_with_default_params
 	);
 }
 
+sinsp_evt* sinsp_with_test_input::generate_execve_exit_event_with_empty_params(
+        const int64_t pid,
+        const std::string& file_to_run,
+        const std::string& comm) {
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29);
+	return add_event_advance_ts_with_empty_params(
+	        increasing_ts(),
+	        1,
+	        PPME_SYSCALL_EXECVE_19_X,
+	        &empty_params_set,
+	        30,
+	        (int64_t)0,                             /* res */
+	        file_to_run.c_str(),                    /* exe */
+	        scap_const_sized_buffer{nullptr, 0},    /* args */
+	        (uint64_t)pid,                          /* tid */
+	        (uint64_t)pid,                          /* pid */
+	        (uint64_t)pid,                          /* ptid */
+	        "",                                     /* cwd */
+	        (uint64_t)0,                            /* fdlimit */
+	        (uint64_t)0,                            /* pgft_maj */
+	        (uint64_t)0,                            /* pgft_min */
+	        0,                                      /* vm_size */
+	        0,                                      /* vm_rss */
+	        0,                                      /* vm_swap */
+	        comm.c_str(),                           /* comm */
+	        empty_value<scap_const_sized_buffer>(), /* cgroups */
+	        empty_value<scap_const_sized_buffer>(), /* env */
+	        0,                                      /* tty */
+	        (uint64_t)0,                            /* vpgid */
+	        empty_value<uint32_t>(),                /* loginuid */
+	        empty_value<uint32_t>(),                /* flags */
+	        empty_value<uint64_t>(),                /* cap_inheritable */
+	        empty_value<uint64_t>(),                /* cap_permitted */
+	        empty_value<uint64_t>(),                /* cap_effective */
+	        empty_value<uint64_t>(),                /* exe_ino */
+	        empty_value<uint64_t>(),                /* exe_ino_ctime */
+	        empty_value<uint64_t>(),                /* exe_ino_mtime */
+	        empty_value<uint32_t>(),                /* uid */
+	        empty_value<scap_const_sized_buffer>(), /* trusted_exepath */
+	        empty_value<int64_t>(),                 /* pgid */
+	        empty_value<uint32_t>());               /* gid */
+}
+
 void sinsp_with_test_input::remove_thread(int64_t tid_to_remove, int64_t reaper_tid) {
 	generate_proc_exit_event(tid_to_remove, reaper_tid);
 	// Generate a random event on init to trigger the removal after proc exit

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -333,6 +333,10 @@ protected:
 	sinsp_evt* generate_execve_exit_event_with_default_params(int64_t pid,
 	                                                          const std::string& file_to_run,
 	                                                          const std::string& comm);
+	// Generate a PPME_SYSCALL_EXECVE_19_X event with empty parameters in the range 18-29.
+	sinsp_evt* generate_execve_exit_event_with_empty_params(int64_t pid,
+	                                                        const std::string& file_to_run,
+	                                                        const std::string& comm);
 
 	void remove_thread(int64_t tid_to_remove, int64_t reaper_tid);
 	sinsp_evt* generate_proc_exit_event(int64_t tid_to_remove, int64_t reaper_tid);
@@ -434,6 +438,12 @@ protected:
 
 	sinsp_evt* next_event();
 
+	// Return an empty value for the type T.
+	template<typename T>
+	constexpr static T empty_value() {
+		return static_cast<T>(0);
+	}
+
 	scap_test_input_data m_test_data;
 	std::vector<scap_evt*> m_events;
 	std::vector<scap_evt*> m_async_events;
@@ -446,3 +456,13 @@ protected:
 	uint64_t m_test_timestamp = 1566230400000000000;
 	uint64_t m_last_recorded_timestamp = 0;
 };
+
+template<>
+constexpr scap_const_sized_buffer sinsp_with_test_input::empty_value() {
+	return {nullptr, 0};
+}
+
+template<>
+constexpr char* sinsp_with_test_input::empty_value() {
+	return nullptr;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces two fixes:
- turns `NULL` into `<NA>` upon string conversion for parameters that couldn't be empty before the introduction of the notion of "empty parameters" in the scap-converter
- fixes the `exists` operator implementation  for `evt.rawarg` by flagging zero-length parameters as non-existing

Moreover, it introduces a bunch of unit tests for `evt.arg.*` and `evt.rawarg.*`, and moves some of the old ones to new locations. Tests are annotated in order to reflect the expectation of a future good implementation.

Finally, it replaces the `SCAP_EMPTY_PARAMS_SET` definition using a GCC extension with a new one working on Windows.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
