### PR TITLE
feat(userspace/libsinsp)!: defer sinsp evt params null-encoding logic

### DIFF
--- a/test/libsinsp_e2e/forking.cpp
+++ b/test/libsinsp_e2e/forking.cpp
@@ -767,7 +767,7 @@ TEST_F(sys_call_test, forking_main_thread_exit) {
 		} else if(param.m_evt->get_type() == PPME_PROCEXIT_1_E && param.m_evt->get_tid() == cpid) {
 			++callnum;
 		} else if(param.m_evt->get_type() == PPME_SYSCALL_READ_E) {
-			if(memcmp(&fd, param.m_evt->get_param(0)->m_val, sizeof(fd)) == 0) {
+			if(memcmp(&fd, param.m_evt->get_param(0)->data(), sizeof(fd)) == 0) {
 				EXPECT_EQ("<f>/etc/passwd", param.m_evt->get_param_value_str("fd"));
 				++callnum;
 			}

--- a/test/libsinsp_e2e/fs.cpp
+++ b/test/libsinsp_e2e/fs.cpp
@@ -1248,8 +1248,8 @@ TEST_F(sys_call_test, large_read_write) {
 			if(callnum == 1) {
 				const sinsp_evt_param* p = e->get_param_by_name("data");
 
-				EXPECT_EQ(p->m_len, SNAPLEN_MAX);
-				EXPECT_EQ(0, memcmp(buf.data(), p->m_val, SNAPLEN_MAX));
+				EXPECT_EQ(p->len(), SNAPLEN_MAX);
+				EXPECT_EQ(0, memcmp(buf.data(), p->data(), SNAPLEN_MAX));
 
 				callnum++;
 			}
@@ -1262,8 +1262,8 @@ TEST_F(sys_call_test, large_read_write) {
 			if(callnum == 3) {
 				const sinsp_evt_param* p = e->get_param_by_name("data");
 
-				EXPECT_EQ(p->m_len, SNAPLEN_MAX);
-				EXPECT_EQ(0, memcmp(buf.data(), p->m_val, SNAPLEN_MAX));
+				EXPECT_EQ(p->len(), SNAPLEN_MAX);
+				EXPECT_EQ(0, memcmp(buf.data(), p->data(), SNAPLEN_MAX));
 
 				callnum++;
 			}
@@ -1360,11 +1360,11 @@ TEST_F(sys_call_test, large_readv_writev) {
 					// The driver doesn't have the correct behavior for accumulating
 					// readv/writev, and it uses a single page as a temporary storage area
 					//
-					EXPECT_EQ(p->m_len, max_kmod_buf);
-					EXPECT_EQ(0, memcmp(buf, p->m_val, max_kmod_buf));
+					EXPECT_EQ(p->len(), max_kmod_buf);
+					EXPECT_EQ(0, memcmp(buf, p->data(), max_kmod_buf));
 				} else {
-					EXPECT_EQ(p->m_len, SNAPLEN_MAX);
-					EXPECT_EQ(0, memcmp(buf, p->m_val, SNAPLEN_MAX));
+					EXPECT_EQ(p->len(), SNAPLEN_MAX);
+					EXPECT_EQ(0, memcmp(buf, p->data(), SNAPLEN_MAX));
 				}
 				EXPECT_EQ(fd, std::stoll(e->get_param_value_str("fd", false)));
 
@@ -1379,11 +1379,11 @@ TEST_F(sys_call_test, large_readv_writev) {
 			if(callnum == 3) {
 				const sinsp_evt_param* p = e->get_param_by_name("data");
 				if(event_capture::s_engine_string == KMOD_ENGINE) {
-					EXPECT_EQ(p->m_len, max_kmod_buf);
-					EXPECT_EQ(0, memcmp(buf, p->m_val, max_kmod_buf));
+					EXPECT_EQ(p->len(), max_kmod_buf);
+					EXPECT_EQ(0, memcmp(buf, p->data(), max_kmod_buf));
 				} else {
-					EXPECT_EQ(p->m_len, SNAPLEN_MAX);
-					EXPECT_EQ(0, memcmp(buf, p->m_val, SNAPLEN_MAX));
+					EXPECT_EQ(p->len(), SNAPLEN_MAX);
+					EXPECT_EQ(0, memcmp(buf, p->data(), SNAPLEN_MAX));
 				}
 				EXPECT_EQ(fd, std::stoll(e->get_param_value_str("fd", false)));
 
@@ -1443,14 +1443,14 @@ TEST_F(sys_call_test, large_open) {
 			const sinsp_evt_param* p = e->get_param_by_name("name");
 
 			if(event_capture::s_engine_string == KMOD_ENGINE) {
-				EXPECT_EQ(p->m_len, PPM_MAX_ARG_SIZE);
-				EXPECT_EQ(buf.substr(0, PPM_MAX_ARG_SIZE - 1), std::string(p->m_val));
+				EXPECT_EQ(p->len(), PPM_MAX_ARG_SIZE);
+				EXPECT_EQ(buf.substr(0, PPM_MAX_ARG_SIZE - 1), std::string(p->data()));
 			} else if(event_capture::s_engine_string == BPF_ENGINE) {
-				EXPECT_EQ(p->m_len, SNAPLEN_MAX);
-				EXPECT_EQ(buf.substr(0, SNAPLEN_MAX - 1), std::string(p->m_val));
+				EXPECT_EQ(p->len(), SNAPLEN_MAX);
+				EXPECT_EQ(buf.substr(0, SNAPLEN_MAX - 1), std::string(p->data()));
 			} else if(event_capture::s_engine_string == MODERN_BPF_ENGINE) {
-				EXPECT_EQ(p->m_len, PATH_MAX);
-				EXPECT_EQ(buf.substr(0, PATH_MAX - 1), std::string(p->m_val));
+				EXPECT_EQ(p->len(), PATH_MAX);
+				EXPECT_EQ(buf.substr(0, PATH_MAX - 1), std::string(p->data()));
 			}
 
 			callnum++;

--- a/test/libsinsp_e2e/sys_call_test.cpp
+++ b/test/libsinsp_e2e/sys_call_test.cpp
@@ -960,25 +960,25 @@ TEST_F(sys_call_test, quotactl_ok) {
 				EXPECT_EQ("/dev/loop0", e->get_param_value_str("special"));
 				EXPECT_EQ(mydqblk.dqb_bhardlimit,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_bhardlimit")->m_val));
+				                  e->get_param_by_name("dqb_bhardlimit")->data()));
 				EXPECT_EQ(mydqblk.dqb_bsoftlimit,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_bsoftlimit")->m_val));
+				                  e->get_param_by_name("dqb_bsoftlimit")->data()));
 				EXPECT_EQ(mydqblk.dqb_curspace,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_curspace")->m_val));
+				                  e->get_param_by_name("dqb_curspace")->data()));
 				EXPECT_EQ(mydqblk.dqb_ihardlimit,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_ihardlimit")->m_val));
+				                  e->get_param_by_name("dqb_ihardlimit")->data()));
 				EXPECT_EQ(mydqblk.dqb_isoftlimit,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_isoftlimit")->m_val));
+				                  e->get_param_by_name("dqb_isoftlimit")->data()));
 				EXPECT_EQ(mydqblk.dqb_btime,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_btime")->m_val));
+				                  e->get_param_by_name("dqb_btime")->data()));
 				EXPECT_EQ(mydqblk.dqb_itime,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqb_itime")->m_val));
+				                  e->get_param_by_name("dqb_itime")->data()));
 				EXPECT_EQ("Q_GETQUOTA", e->get_param_value_str("cmd"));
 				EXPECT_EQ("USRQUOTA", e->get_param_value_str("type"));
 				EXPECT_EQ("0", e->get_param_value_str("id"));
@@ -988,10 +988,10 @@ TEST_F(sys_call_test, quotactl_ok) {
 				EXPECT_EQ("/dev/loop0", e->get_param_value_str("special"));
 				EXPECT_EQ(mydqinfo.dqi_bgrace,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqi_bgrace")->m_val));
+				                  e->get_param_by_name("dqi_bgrace")->data()));
 				EXPECT_EQ(mydqinfo.dqi_igrace,
 				          *reinterpret_cast<const uint64_t*>(
-				                  e->get_param_by_name("dqi_igrace")->m_val));
+				                  e->get_param_by_name("dqi_igrace")->data()));
 				EXPECT_EQ("Q_GETINFO", e->get_param_value_str("cmd"));
 				EXPECT_EQ("USRQUOTA", e->get_param_value_str("type"));
 				break;
@@ -1355,9 +1355,9 @@ TEST_F(sys_call_test, sendmsg_recvmsg_SCM_RIGHTS) {
 		sinsp_evt* e = param.m_evt;
 		if(e->get_num_params() >= 5) {
 			auto parinfo = e->get_param(4);
-			if(parinfo->m_len > sizeof(cmsghdr)) {
+			if(parinfo->len() > sizeof(cmsghdr)) {
 				cmsghdr cmsg = {};
-				memcpy(&cmsg, parinfo->m_val, sizeof(cmsghdr));
+				memcpy(&cmsg, parinfo->data(), sizeof(cmsghdr));
 				if(cmsg.cmsg_type == SCM_RIGHTS) {
 					++callnum;
 				}

--- a/test/libsinsp_e2e/udp_client_server.cpp
+++ b/test/libsinsp_e2e/udp_client_server.cpp
@@ -481,7 +481,7 @@ TEST_F(sys_call_test, udp_client_server) {
 		std::string dst_port;
 
 		if(type == PPME_SOCKET_RECVFROM_E) {
-			memcpy(&fd_server_socket, e->get_param(0)->m_val, sizeof(fd_server_socket));
+			memcpy(&fd_server_socket, e->get_param(0)->data(), sizeof(fd_server_socket));
 		}
 		switch(state) {
 		case 0:

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -937,7 +937,8 @@ void raw_dump(sinsp& inspector, sinsp_evt* ev) {
 		const sinsp_evt_param* p = ev->get_param(i);
 		const struct ppm_param_info* pi = ev->get_param_info(i);
 		cout << ' ' << i << ':' << pi->name << '=';
-		hexdump((const unsigned char*)p->m_val, p->m_len);
+		const auto [data, data_len] = p->data_and_len_with_legacy_null_encoding();
+		hexdump(reinterpret_cast<const unsigned char*>(data), data_len);
 	}
 
 	cout << endl;

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -214,7 +214,7 @@ public:
 
 	inline int64_t get_pid() const { return m_pid; }
 
-	inline void set_unix_info(uint8_t* packed_data) {
+	inline void set_unix_info(const uint8_t* packed_data) {
 		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_source, packed_data + 1, sizeof(uint64_t));
 		memcpy(&m_sockinfo.m_unixinfo.m_fields.m_dest, packed_data + 9, sizeof(uint64_t));
 	}

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -152,7 +152,7 @@ private:
 	                                                   uint16_t tdport,
 	                                                   bool overwrite_dest = true);
 	static inline void fill_client_socket_info(sinsp_evt& evt,
-	                                           uint8_t* packed_data,
+	                                           const uint8_t* packed_data,
 	                                           bool overwrite_dest,
 	                                           bool can_resolve_hostname_and_port);
 	inline void add_socket(sinsp_evt& evt,

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -923,8 +923,9 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt) const {
 	}
 
 	string ret = "";
-	auto datalen = evt->get_param(1)->m_len;
-	auto data = (const uint8_t*)evt->get_param(1)->m_val;
+	const auto data_param = evt->get_param(1);
+	const auto data = data_param->data();
+	const auto data_len = data_param->len();
 	if(m_state && m_handle->api.event_to_string) {
 		ss_plugin_event_input input;
 		input.evt = (const ss_plugin_event*)evt->get_scap_evt();
@@ -934,16 +935,16 @@ std::string sinsp_plugin::event_to_string(sinsp_evt* evt) const {
 	}
 	if(ret.empty()) {
 		ret += "datalen=";
-		ret += std::to_string(datalen);
+		ret += std::to_string(data_len);
 		ret += " data=";
-		for(size_t i = 0; i < std::min(datalen, uint32_t(50)); ++i) {
+		for(size_t i = 0; i < std::min(data_len, uint32_t(50)); ++i) {
 			if(!std::isprint(data[i])) {
 				ret += "<binary>";
 				return ret;
 			}
 		}
-		ret.append((char*)data, std::min(datalen, uint32_t(50)));
-		if(datalen > 50) {
+		ret.append((char*)data, std::min(data_len, uint32_t(50)));
+		if(data_len > 50) {
 			ret += "...";
 		}
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -107,7 +107,7 @@ uint8_t *sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt,
 	}
 
 	uint32_t j = 0;
-	const char *payload = parinfo->m_val;
+	const char *payload = parinfo->data();
 	uint16_t nfds = *(uint16_t *)payload;
 	uint32_t pos = 2;
 	sinsp_threadinfo *tinfo = evt->get_thread_info();

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -276,14 +276,18 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 			m_val.u32 = 0;
 		}
 		RETURN_EXTRACT_VAR(m_val.u32);
-	case TYPE_ASYNCTYPE:
+	case TYPE_ASYNCTYPE: {
 		if(!libsinsp::events::is_metaevent((ppm_event_code)evt->get_type())) {
 			return NULL;
 		}
-		if(evt->get_type() == PPME_ASYNCEVENT_E) {
-			RETURN_EXTRACT_CSTR(evt->get_param(1)->m_val);
+		if(evt->get_type() != PPME_ASYNCEVENT_E) {
+			RETURN_EXTRACT_CSTR(evt->get_name());
 		}
-		RETURN_EXTRACT_CSTR(evt->get_name());
+		const auto name_param = evt->get_param(1);
+		const auto [data, _] = name_param->data_and_len_with_legacy_null_encoding();
+		RETURN_EXTRACT_CSTR(data);
+	}
+
 	case TYPE_HOSTNAME:
 		minfo = m_inspector->get_machine_info();
 		if(!minfo) {

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -131,7 +131,7 @@ TEST_F(sinsp_with_test_input, bytebuf_empty_param) {
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.data"),
 	          "NULL");  // "NULL" is the string representation output of the empty buffer
 	ASSERT_TRUE(evt->get_param(1));
-	ASSERT_EQ(evt->get_param(1)->m_len, 0);
+	ASSERT_EQ(evt->get_param(1)->len(), 0);
 }
 
 /* Assert that empty (`PT_SOCKADDR`, `PT_SOCKTUPLE`, `PT_FDLIST`) params are NOT converted to `<NA>`
@@ -152,7 +152,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param) {
 	sockaddr_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SOCKET_CONNECT_E, 2, fd, sockaddr_param);
 	param = evt->get_param(1);
-	ASSERT_EQ(param->m_len, 0);
+	ASSERT_EQ(param->len(), 0);
 
 	/* `PPME_SOCKET_CONNECT_X` is a simple event that uses a `PT_SOCKTUPLE` */
 	scap_const_sized_buffer socktuple_param;
@@ -167,7 +167,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param) {
 	                           fd,
 	                           sockaddr_param);
 	param = evt->get_param(1);
-	ASSERT_EQ(param->m_len, 0);
+	ASSERT_EQ(param->len(), 0);
 
 	/* `PPME_SYSCALL_POLL_X` is a simple event that uses a `PT_FDLIST` */
 	scap_const_sized_buffer fdlist_param;
@@ -175,7 +175,7 @@ TEST_F(sinsp_with_test_input, sockaddr_empty_param) {
 	fdlist_param.size = 0;
 	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_POLL_X, 2, res, fdlist_param);
 	param = evt->get_param(1);
-	ASSERT_EQ(param->m_len, 0);
+	ASSERT_EQ(param->len(), 0);
 }
 
 TEST_F(sinsp_with_test_input, filename_toctou) {

--- a/userspace/libsinsp/test/parsers/parse_recvmsg.cpp
+++ b/userspace/libsinsp/test/parsers/parse_recvmsg.cpp
@@ -59,7 +59,7 @@ TEST_F(sinsp_with_test_input, RECVMSG_success) {
 	ASSERT_EQ(evt->get_param_value_str("data"), data);
 
 	// Check that msgcontrol is empty.
-	ASSERT_EQ(evt->get_param_by_name("msgcontrol")->m_len, 0);
+	ASSERT_EQ(evt->get_param_by_name("msgcontrol")->len(), 0);
 
 	// Check that fd value is as expected.
 	ASSERT_EQ(evt->get_param_by_name("fd")->as<int64_t>(), sock_params.fd);

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -737,7 +737,7 @@ std::string sinsp_utils::concatenate_paths(std::string_view path1, std::string_v
 	return std::string(fullpath);
 }
 
-bool sinsp_utils::is_ipv4_mapped_ipv6(uint8_t* paddr) {
+bool sinsp_utils::is_ipv4_mapped_ipv6(const uint8_t* paddr) {
 	if(paddr[0] == 0 && paddr[1] == 0 && paddr[2] == 0 && paddr[3] == 0 && paddr[4] == 0 &&
 	   paddr[5] == 0 && paddr[6] == 0 && paddr[7] == 0 && paddr[8] == 0 && paddr[9] == 0 &&
 	   ((paddr[10] == 0xff && paddr[11] == 0xff) ||  // A real IPv4 address

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -120,7 +120,7 @@ public:
 	//
 	// Determines if an IPv6 address is IPv4-mapped
 	//
-	static bool is_ipv4_mapped_ipv6(uint8_t* paddr);
+	static bool is_ipv4_mapped_ipv6(const uint8_t* paddr);
 
 	//
 	// Given a string, scan the event list and find the longest argument that the input string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In the previous implementation, some specific parameter configurations (empty or containing '(NULL)', with the type being equal to `PT_CHARBUF`, `PT_FSPATH` or `PT_FSRELPATH`) were patched at loading time with the following configuration:
- data: "<NA>"
- len: 5 This made empty parameters indistinguishable from non-empty parameters.

The new implementation loads the parameters and keeps them untouched: in this way, it is possible to inspect their original data and lengths.

Since majority of the userspace space implementation still relies on the aforementioned particular "null" encoding, a couple of new methods (i.e. `sinsp_evt_param::used_legacy_null_encoding()` and `sinsp_evt_param::data_and_len_with_legacy_null_encoding()`), helping to check or simulate the old behaviour, are provided. Moreover, parameter conversion methods (e.g.
`sinsp_evt_param::as<T>()`), still return the legacy encoded version.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: defer sinsp evt params null-encoding logic
```
