### PR TITLE
refactor(userspace/libsinsp): remove timestamp saving custom logic

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -141,12 +141,6 @@ void sinsp_parser::process_event(sinsp_evt &evt, sinsp_parser_verdict &verdict) 
 		parse_fspath_related_exit(evt);
 		parse_open_openat_creat_exit(evt);
 		break;
-	case PPME_SYSCALL_SELECT_E:
-	case PPME_SYSCALL_POLL_X:
-	case PPME_SYSCALL_PPOLL_X:
-	case PPME_SYSCALL_EPOLLWAIT_X:
-		parse_select_poll_ppoll_epollwait(evt);
-		break;
 	case PPME_SYSCALL_UNSHARE_X:
 	case PPME_SYSCALL_SETNS_X:
 		parse_unshare_setns_exit(evt);
@@ -3687,22 +3681,6 @@ void sinsp_parser::parse_prlimit_exit(sinsp_evt &evt) const {
 		}
 		main_thread->m_fdlimit = newcur;
 	}
-}
-
-void sinsp_parser::parse_select_poll_ppoll_epollwait(sinsp_evt &evt) {
-	if(evt.get_tinfo() == nullptr) {
-		return;
-	}
-
-	if(evt.get_tinfo()->get_last_event_data() == nullptr) {
-		evt.get_tinfo()->set_last_event_data(reserve_event_buffer());
-		if(evt.get_tinfo()->get_last_event_data() == nullptr) {
-			throw sinsp_exception(
-			        "cannot reserve event buffer in "
-			        "sinsp_parser::parse_select_poll_ppoll_epollwait.");
-		}
-	}
-	*(uint64_t *)evt.get_tinfo()->get_last_event_data() = evt.get_ts();
 }
 
 void sinsp_parser::parse_fcntl_exit(sinsp_evt &evt) const {

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -115,7 +115,6 @@ private:
 	void parse_single_param_fd_exit(sinsp_evt& evt, scap_fd_type type) const;
 	void parse_getrlimit_setrlimit_exit(sinsp_evt& evt) const;
 	void parse_prlimit_exit(sinsp_evt& evt) const;
-	void parse_select_poll_ppoll_epollwait(sinsp_evt& evt);
 	void parse_fcntl_exit(sinsp_evt& evt) const;
 	static void parse_prctl_exit_event(sinsp_evt& evt);
 	static void parse_context_switch(sinsp_evt& evt);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes unused timestamp saving custom logic in parser for `PPME_SYSCALL_SELECT_E`, `PPME_SYSCALL_POLL_X`, `PPME_SYSCALL_PPOLL_X` and `PPME_SYSCALL_EPOLLWAIT_X` events.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
