### PR TITLE
feat(savefile): added empty parameter support for PPME_SYSCALL_FCHDIR_X

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -6395,22 +6395,29 @@ TEST_F(convert_event_test, PPME_SYSCALL_FCHDIR_E_store) {
 	assert_event_storage_presence(evt);
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_FCHDIR_X_to_2_params_no_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_FCHDIR_X_1_to_2_params_no_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
 	constexpr int64_t res = -1;
 
-	// Defaulted to 0
-	constexpr int64_t fd = 0;
+	// Set to empty.
+	constexpr auto fd = empty_value<int64_t>();
 
-	assert_single_conversion_success(
-	        CONVERSION_COMPLETED,
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_FCHDIR_X, 1, res),
-	        create_safe_scap_event(ts, tid, PPME_SYSCALL_FCHDIR_X, 2, res, fd));
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1);
+
+	assert_single_conversion_success(CONVERSION_COMPLETED,
+	                                 create_safe_scap_event(ts, tid, PPME_SYSCALL_FCHDIR_X, 1, res),
+	                                 create_safe_scap_event_with_empty_params(ts,
+	                                                                          tid,
+	                                                                          PPME_SYSCALL_FCHDIR_X,
+	                                                                          &empty_params_set,
+	                                                                          2,
+	                                                                          res,
+	                                                                          fd));
 }
 
-TEST_F(convert_event_test, PPME_SYSCALL_FCHDIR_X_to_2_params_with_enter) {
+TEST_F(convert_event_test, PPME_SYSCALL_FCHDIR_X_1_to_2_params_with_enter) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 

--- a/userspace/libscap/engine/savefile/converter/table.cpp
+++ b/userspace/libscap/engine/savefile/converter/table.cpp
@@ -844,7 +844,9 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
         /*====================== FCHDIR ======================*/
         {conversion_key{PPME_SYSCALL_FCHDIR_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_FCHDIR_X, 1},
-         conversion_info().action(C_ACTION_ADD_PARAMS).instrs({{C_INSTR_FROM_ENTER, 0}})},
+         conversion_info()
+                 .action(C_ACTION_ADD_PARAMS)
+                 .instrs({{C_INSTR_FROM_ENTER, 0, CIF_FALLBACK_TO_EMPTY}})},
         /*====================== GETDENTS ======================*/
         {conversion_key{PPME_SYSCALL_GETDENTS_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_GETDENTS_X, 1},


### PR DESCRIPTION
Support for empty parameters was added with https://github.com/falcosecurity/libs/pull/2550.

This update adds empty parameter support for `PPME_SYSCALL_FCHDIR_X`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds support for empty parameters in case of PPME_SYSCALL_FCHDIR_X.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
