### PR TITLE
fix(userspace/libsinsp): sinsp_filter_check_user::extract_single return-stack-address

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -99,9 +99,9 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 	if(m_field_id == TYPE_NAME &&
 	   (evt->get_type() == PPME_CONTAINER_JSON_E || evt->get_type() == PPME_CONTAINER_JSON_2_E ||
 	    is_container_asyncevent)) {
-		auto user = tinfo->get_container_user();
-		if(!user.empty()) {
-			RETURN_EXTRACT_STRING(user);
+		m_strval = tinfo->get_container_user();
+		if(!m_strval.empty()) {
+			RETURN_EXTRACT_STRING(m_strval);
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

Address the following warning (we build with `-Werror`...):
```
/__w/libs/libs/userspace/libsinsp/sinsp_filtercheck_user.cpp:104:26: warning: address of stack memory associated with local variable 'user' returned [-Wreturn-stack-address]
  104 |                         RETURN_EXTRACT_STRING(user);
      |                                               ^~~~
/__w/libs/libs/userspace/libsinsp/sinsp_filtercheck_user.cpp:34:21: note: expanded from macro 'RETURN_EXTRACT_STRING'
   34 |                 return (uint8_t*)(x).c_str(); \
      |                                   ^
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
