### PR TITLE
fix(cmake): Fix zlib PIC build flag handling

### DIFF
--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -70,7 +70,7 @@ else()
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
-				CONFIGURE_COMMAND CFLAGS=${ZLIB_CFLAGS} ./configure --prefix=${ZLIB_SRC}
+				CONFIGURE_COMMAND env "CFLAGS=${ZLIB_CFLAGS}" ./configure --prefix=${ZLIB_SRC}
 								  ${ZLIB_CONFIGURE_FLAGS}
 				BUILD_COMMAND make
 				BUILD_IN_SOURCE 1

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -27,7 +27,23 @@ elseif(NOT USE_BUNDLED_ZLIB)
 	endif()
 else()
 	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
-	set(ZLIB_INCLUDE "${ZLIB_SRC}/include")
+	set(ZLIB_INCLUDE "${ZLIB_SRC}")
+	set(ZLIB_HEADERS "")
+	list(
+		APPEND
+		ZLIB_HEADERS
+		"${ZLIB_INCLUDE}/crc32.h"
+		"${ZLIB_INCLUDE}/deflate.h"
+		"${ZLIB_INCLUDE}/gzguts.h"
+		"${ZLIB_INCLUDE}/inffast.h"
+		"${ZLIB_INCLUDE}/inffixed.h"
+		"${ZLIB_INCLUDE}/inflate.h"
+		"${ZLIB_INCLUDE}/inftrees.h"
+		"${ZLIB_INCLUDE}/trees.h"
+		"${ZLIB_INCLUDE}/zconf.h"
+		"${ZLIB_INCLUDE}/zlib.h"
+		"${ZLIB_INCLUDE}/zutil.h"
+	)
 	if(NOT TARGET zlib)
 		# Match both release and relwithdebinfo builds
 		if(CMAKE_BUILD_TYPE MATCHES "[R,r]el*")
@@ -35,26 +51,31 @@ else()
 		else()
 			set(ZLIB_CFLAGS "-g")
 		endif()
+		if(ENABLE_PIC)
+			set(ZLIB_CFLAGS "${ZLIB_CFLAGS} -fPIC")
+		endif()
 
 		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
 		if(NOT WIN32)
 			if(BUILD_SHARED_LIBS)
 				set(ZLIB_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+				set(ZLIB_CONFIGURE_FLAGS)
 			else()
 				set(ZLIB_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+				set(ZLIB_CONFIGURE_FLAGS "--static")
 			endif()
-			set(ZLIB_LIB "${ZLIB_SRC}/lib/libz${ZLIB_LIB_SUFFIX}")
+			set(ZLIB_LIB "${ZLIB_SRC}/libz${ZLIB_LIB_SUFFIX}")
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
-				CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-						-DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
-						-DCMAKE_C_FLAGS=${ZLIB_CFLAGS}
-						-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-						-DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_PIC}
+				CONFIGURE_COMMAND env "CFLAGS=${ZLIB_CFLAGS}" ./configure --prefix=${ZLIB_SRC}
+								  ${ZLIB_CONFIGURE_FLAGS}
+				BUILD_COMMAND make
+				BUILD_IN_SOURCE 1
 				BUILD_BYPRODUCTS ${ZLIB_LIB}
+				INSTALL_COMMAND ""
 			)
 			install(
 				FILES "${ZLIB_LIB}"
@@ -62,7 +83,7 @@ else()
 				COMPONENT "libs-deps"
 			)
 			install(
-				FILES ${ZLIB_INCLUDE}
+				FILES ${ZLIB_HEADERS}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)
@@ -94,7 +115,7 @@ else()
 				COMPONENT "libs-deps"
 			)
 			install(
-				DIRECTORY ${ZLIB_INCLUDE}
+				FILES ${ZLIB_HEADERS}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -27,23 +27,7 @@ elseif(NOT USE_BUNDLED_ZLIB)
 	endif()
 else()
 	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
-	set(ZLIB_INCLUDE "${ZLIB_SRC}")
-	set(ZLIB_HEADERS "")
-	list(
-		APPEND
-		ZLIB_HEADERS
-		"${ZLIB_INCLUDE}/crc32.h"
-		"${ZLIB_INCLUDE}/deflate.h"
-		"${ZLIB_INCLUDE}/gzguts.h"
-		"${ZLIB_INCLUDE}/inffast.h"
-		"${ZLIB_INCLUDE}/inffixed.h"
-		"${ZLIB_INCLUDE}/inflate.h"
-		"${ZLIB_INCLUDE}/inftrees.h"
-		"${ZLIB_INCLUDE}/trees.h"
-		"${ZLIB_INCLUDE}/zconf.h"
-		"${ZLIB_INCLUDE}/zlib.h"
-		"${ZLIB_INCLUDE}/zutil.h"
-	)
+	set(ZLIB_INCLUDE "${ZLIB_SRC}/include")
 	if(NOT TARGET zlib)
 		# Match both release and relwithdebinfo builds
 		if(CMAKE_BUILD_TYPE MATCHES "[R,r]el*")
@@ -51,31 +35,26 @@ else()
 		else()
 			set(ZLIB_CFLAGS "-g")
 		endif()
-		if(ENABLE_PIC)
-			set(ZLIB_CFLAGS "${ZLIB_CFLAGS} -fPIC")
-		endif()
 
 		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
 		if(NOT WIN32)
 			if(BUILD_SHARED_LIBS)
 				set(ZLIB_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-				set(ZLIB_CONFIGURE_FLAGS)
 			else()
 				set(ZLIB_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
-				set(ZLIB_CONFIGURE_FLAGS "--static")
 			endif()
-			set(ZLIB_LIB "${ZLIB_SRC}/libz${ZLIB_LIB_SUFFIX}")
+			set(ZLIB_LIB "${ZLIB_SRC}/lib/libz${ZLIB_LIB_SUFFIX}")
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
-				CONFIGURE_COMMAND env "CFLAGS=${ZLIB_CFLAGS}" ./configure --prefix=${ZLIB_SRC}
-								  ${ZLIB_CONFIGURE_FLAGS}
-				BUILD_COMMAND make
-				BUILD_IN_SOURCE 1
+				CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+						-DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
+						-DCMAKE_C_FLAGS=${ZLIB_CFLAGS}
+						-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+						-DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_PIC}
 				BUILD_BYPRODUCTS ${ZLIB_LIB}
-				INSTALL_COMMAND ""
 			)
 			install(
 				FILES "${ZLIB_LIB}"
@@ -83,7 +62,7 @@ else()
 				COMPONENT "libs-deps"
 			)
 			install(
-				FILES ${ZLIB_HEADERS}
+				FILES ${ZLIB_INCLUDE}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)
@@ -115,7 +94,7 @@ else()
 				COMPONENT "libs-deps"
 			)
 			install(
-				FILES ${ZLIB_HEADERS}
+				DIRECTORY ${ZLIB_INCLUDE}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area build

**Does this PR require a change in the driver versions?**

N/A


**What this PR does / why we need it**:

Fixes CFLAG qoting with bundled `zlib` dep so the command doesn't error if more than one CFLAG is defined.

Before, adding `-DENABLE_PIC` broke `zlib` dep builds (key flags are `-DUSE_BUNDLED_DEPS=ON -DENABLE_PIC=ON`):

> cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_LIBSCAP_GVISOR=OFF -DENABLE_PIC=ON -DCREATE_TEST_TARGETS=OFF -DBUILD_LIBSCAP_MODERN_BPF=ON -DMODERN_BPF_DEBUG_MODE=ON scap ..

> [ 26%] Built target elf
> [ 26%] Performing configure step for 'zlib'
> /bin/sh: line 1: CFLAGS=-O3 -fPIC: command not found
> make[3]: *** [libscap/CMakeFiles/zlib.dir/build.make:92: zlib-prefix/src/zlib-stamp/zlib-configure] Error 127
> make[2]: *** [CMakeFiles/Makefile2:823: libscap/CMakeFiles/zlib.dir/all] Error 2
> make[1]: *** [CMakeFiles/Makefile2:910: libscap/CMakeFiles/scap.dir/rule] Error 2
> make: *** [Makefile:286: scap] Error 2

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes

```release-note
fix(cmake): Properly quote zlib CFLAGs
```
