### PR TITLE
fix(driver/modern_bpf): remove retval from ttm kprobe signatures

### DIFF
--- a/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_connect.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_connect.bpf.c
@@ -68,7 +68,7 @@ int connect_e(struct sys_enter_connect_args* ctx) {
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/
 
-static __always_inline int ia32_common_handler(struct pt_regs* regs, long int retval) {
+static __always_inline int ia32_common_handler(struct pt_regs* regs) {
 	if(toctou_mitigation__ia32_should_drop(__NR_ia32_connect, -1)) {
 		return 0;
 	}
@@ -88,13 +88,13 @@ static __always_inline int ia32_common_handler(struct pt_regs* regs, long int re
 }
 
 SEC("kprobe/__ia32_compat_sys_connect")
-int BPF_KPROBE(ia32_compat_connect_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_compat_connect_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 SEC("kprobe/__ia32_sys_connect")
-int BPF_KPROBE(ia32_connect_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_connect_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/

--- a/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_creat.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_creat.bpf.c
@@ -64,7 +64,7 @@ int creat_e(struct sys_enter_creat_args* ctx) {
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/
 
-static __always_inline int ia32_common_handler(struct pt_regs* regs, long int retval) {
+static __always_inline int ia32_common_handler(struct pt_regs* regs) {
 	if(toctou_mitigation__ia32_should_drop(__NR_ia32_creat, -1)) {
 		return 0;
 	}
@@ -84,13 +84,13 @@ static __always_inline int ia32_common_handler(struct pt_regs* regs, long int re
 }
 
 SEC("kprobe/__ia32_compat_sys_creat")
-int BPF_KPROBE(ia32_compat_creat_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_compat_creat_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 SEC("kprobe/__ia32_sys_creat")
-int BPF_KPROBE(ia32_creat_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_creat_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/

--- a/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_open.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_open.bpf.c
@@ -71,7 +71,7 @@ int open_e(struct sys_enter_open_args* ctx) {
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/
 
-static __always_inline int ia32_common_handler(struct pt_regs* regs, long int retval) {
+static __always_inline int ia32_common_handler(struct pt_regs* regs) {
 	if(toctou_mitigation__ia32_should_drop(__NR_ia32_open, -1)) {
 		return 0;
 	}
@@ -91,13 +91,13 @@ static __always_inline int ia32_common_handler(struct pt_regs* regs, long int re
 }
 
 SEC("kprobe/__ia32_compat_sys_open")
-int BPF_KPROBE(ia32_compat_open_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_compat_open_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 SEC("kprobe/__ia32_sys_open")
-int BPF_KPROBE(ia32_open_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_open_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/

--- a/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_openat.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_openat.bpf.c
@@ -80,7 +80,7 @@ int openat_e(struct sys_enter_openat_args* ctx) {
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/
 
-static __always_inline int ia32_common_handler(struct pt_regs* regs, long int retval) {
+static __always_inline int ia32_common_handler(struct pt_regs* regs) {
 	if(toctou_mitigation__ia32_should_drop(__NR_ia32_openat, -1)) {
 		return 0;
 	}
@@ -101,13 +101,13 @@ static __always_inline int ia32_common_handler(struct pt_regs* regs, long int re
 }
 
 SEC("kprobe/__ia32_compat_sys_openat")
-int BPF_KPROBE(ia32_compat_openat_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_compat_openat_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 SEC("kprobe/__ia32_sys_openat")
-int BPF_KPROBE(ia32_openat_e, struct pt_regs* regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_openat_e, struct pt_regs* regs) {
+	return ia32_common_handler(regs);
 }
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/

--- a/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_openat2.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/toctou_mitigation/sys_enter_openat2.bpf.c
@@ -85,7 +85,7 @@ int openat2_e(struct sys_enter_openat2_args *ctx) {
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/
 
-static __always_inline int ia32_common_handler(struct pt_regs *regs, long int retval) {
+static __always_inline int ia32_common_handler(struct pt_regs *regs) {
 	if(toctou_mitigation__ia32_should_drop(__NR_ia32_openat2, -1)) {
 		return 0;
 	}
@@ -105,13 +105,13 @@ static __always_inline int ia32_common_handler(struct pt_regs *regs, long int re
 }
 
 SEC("kprobe/__ia32_compat_sys_openat2")
-int BPF_KPROBE(ia32_compat_openat2_e, struct pt_regs *regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_compat_openat2_e, struct pt_regs *regs) {
+	return ia32_common_handler(regs);
 }
 
 SEC("kprobe/__ia32_sys_openat2")
-int BPF_KPROBE(ia32_openat2_e, struct pt_regs *regs, long int retval) {
-	return ia32_common_handler(regs, retval);
+int BPF_KPROBE(ia32_openat2_e, struct pt_regs *regs) {
+	return ia32_common_handler(regs);
 }
 
 /*=============================== IA-32 SUPPORT (KPROBE-BASED) ===========================*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Kprobe programs attached to system call symbols have access to a single parameter containing the register state, so they don't have access to any `retval` parameter. This PR removes it from ia-32 TOCTOU mitigation kprobe signatures.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
