### PR TITLE
fix(driver/modern_bpf): fix iovec size eval for emulated ia32 syscalls

### DIFF
--- a/test/libsinsp_e2e/sys_call_test.cpp
+++ b/test/libsinsp_e2e/sys_call_test.cpp
@@ -1821,7 +1821,7 @@ TEST_F(sys_call_test32, fs_preadv) {
 				EXPECT_EQ(987654321, std::stoll(e->get_param_value_str("pos")));
 				EXPECT_EQ(15, std::stoll(e->get_param_value_str("size")));
 				callnum++;
-			} else {
+			} else if(callnum == 2) {
 				EXPECT_EQ(fd, std::stoll(e->get_param_value_str("fd", false)));
 				EXPECT_EQ(10, std::stoll(e->get_param_value_str("pos")));
 				EXPECT_EQ(15, std::stoll(e->get_param_value_str("size")));
@@ -1831,10 +1831,16 @@ TEST_F(sys_call_test32, fs_preadv) {
 			if(callnum == 1) {
 				pwrite1_res = std::stoi(e->get_param_value_str("res", false));
 				EXPECT_EQ("aaaaabbbbbccccc", e->get_param_value_str("data"));
+				EXPECT_EQ(fd, std::stoll(e->get_param_value_str("fd", false)));
+				EXPECT_EQ(987654321, std::stoll(e->get_param_value_str("pos")));
+				EXPECT_EQ(15, std::stoll(e->get_param_value_str("size")));
 				callnum++;
-			} else {
+			} else if(callnum == 3) {
 				pwrite2_res = std::stoi(e->get_param_value_str("res", false));
 				EXPECT_EQ("aaaaabbbbbccccc", e->get_param_value_str("data"));
+				EXPECT_EQ(fd, std::stoll(e->get_param_value_str("fd", false)));
+				EXPECT_EQ(10, std::stoll(e->get_param_value_str("pos")));
+				EXPECT_EQ(15, std::stoll(e->get_param_value_str("size")));
 				callnum++;
 			}
 		} else if(type == PPME_SYSCALL_PREADV_E) {
@@ -1842,15 +1848,22 @@ TEST_F(sys_call_test32, fs_preadv) {
 				EXPECT_EQ(fd1, std::stoll(e->get_param_value_str("fd", false)));
 				EXPECT_EQ(987654321, std::stoll(e->get_param_value_str("pos")));
 				callnum++;
-			} else {
+			} else if(callnum == 6) {
 				EXPECT_EQ(fd1, std::stoll(e->get_param_value_str("fd", false)));
 				EXPECT_EQ(10, std::stoll(e->get_param_value_str("pos")));
 				callnum++;
 			}
 		} else if(type == PPME_SYSCALL_PREADV_X) {
-			if(callnum == 3) {
+			if(callnum == 5) {
 				EXPECT_EQ(15, std::stoi(e->get_param_value_str("res", false)));
-				EXPECT_EQ("aaaaabbbbb", e->get_param_value_str("data"));
+				EXPECT_EQ("aaaaabbbbbccccc", e->get_param_value_str("data"));
+				EXPECT_EQ(15, std::stoll(e->get_param_value_str("size")));
+				EXPECT_EQ(fd1, std::stoll(e->get_param_value_str("fd", false)));
+				EXPECT_EQ(987654321, std::stoll(e->get_param_value_str("pos")));
+				callnum++;
+			} else if(callnum == 7) {
+				EXPECT_EQ(30, std::stoi(e->get_param_value_str("res", false)));
+				EXPECT_EQ("aaaaabbbbbccccc...............", e->get_param_value_str("data"));
 				EXPECT_EQ(30, std::stoll(e->get_param_value_str("size")));
 				EXPECT_EQ(fd1, std::stoll(e->get_param_value_str("fd", false)));
 				EXPECT_EQ(10, std::stoll(e->get_param_value_str("pos")));
@@ -1860,7 +1873,7 @@ TEST_F(sys_call_test32, fs_preadv) {
 	};
 
 	ASSERT_NO_FATAL_FAILURE({ event_capture::run(test, callback, filter); });
-	EXPECT_EQ(6, callnum);
+	EXPECT_EQ(8, callnum);
 	if(pwritev64_succeeded) {
 		EXPECT_EQ(15, pwrite1_res);
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

While computing the cumulative iovecs length, the current modern probe implementation doesn't take into account the fact that a program can be triggered upon the execution of a emulated ia-32 system call. This PR takes it into account by using `compat_iovec` in place of `iovec` in ia-32 emulation contexts.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
