### PR TITLE
fix(userspace/libsinsp): fix `sinsp_evt::extract_typechar()` logic

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1057,7 +1057,7 @@ or GPL2.txt for full copies of the license.
 #define PPME_DIRECTION_FLAG 1
 #define PPME_IS_ENTER(x) ((x & PPME_DIRECTION_FLAG) == 0)
 #define PPME_IS_EXIT(x) (x & PPME_DIRECTION_FLAG)
-#define PPME_MAKE_ENTER(x) (x & (~1))
+#define PPME_MAKE_EXIT(x) (x | 1)
 
 /*
  * Event category to classify events in generic categories

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -689,17 +689,15 @@ public:
 	inline std::vector<sinsp_evt_param>& get_params() { return m_params; }
 
 	inline char extract_typechar() {
-		switch(PPME_MAKE_ENTER(get_type())) {
-		case PPME_SYSCALL_OPENAT_E:
-		case PPME_SYSCALL_OPENAT_2_E:
-		case PPME_SYSCALL_OPENAT2_E:
-		case PPME_SYSCALL_CREAT_E:
+		switch(PPME_MAKE_EXIT(get_type())) {
+		case PPME_SYSCALL_OPENAT_X:
+		case PPME_SYSCALL_OPENAT_2_X:
+		case PPME_SYSCALL_OPENAT2_X:
+		case PPME_SYSCALL_CREAT_X:
 			return CHAR_FD_FILE;
-		case PPME_SOCKET_ACCEPT_E:
-		case PPME_SOCKET_ACCEPT_5_E:
-		case PPME_SOCKET_ACCEPT4_E:
-		case PPME_SOCKET_ACCEPT4_5_E:
-		case PPME_SOCKET_ACCEPT4_6_E:
+		case PPME_SOCKET_SOCKET_X:
+		case PPME_SOCKET_ACCEPT_5_X:
+		case PPME_SOCKET_ACCEPT4_6_X:
 			//
 			// Note, this is not accurate, because it always
 			// returns IPv4 even if this could be IPv6 or unix.
@@ -707,6 +705,20 @@ public:
 			// real event parsing here would be a pain.
 			//
 			return CHAR_FD_IPV4_SOCK;
+		case PPME_SYSCALL_PIPE_X:
+		case PPME_SYSCALL_PIPE2_X:
+			return CHAR_FD_FIFO;
+		case PPME_SYSCALL_EVENTFD_X:
+		case PPME_SYSCALL_EVENTFD2_X:
+			return CHAR_FD_EVENT;
+		case PPME_SYSCALL_SIGNALFD_X:
+		case PPME_SYSCALL_SIGNALFD4_X:
+			return CHAR_FD_SIGNAL;
+		case PPME_SYSCALL_TIMERFD_CREATE_X:
+			return CHAR_FD_TIMERFD;
+		case PPME_SYSCALL_INOTIFY_INIT_X:
+		case PPME_SYSCALL_INOTIFY_INIT1_X:
+			return CHAR_FD_INOTIFY;
 		default:
 			return 'o';
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the type char evaluation by re-introducing the previously-removed switch cases for `pipe`, `pipe2`, `eventfd`, `eventfd2`, `signalfd`, `signalfd4`, `timerfd_create`, `inotify_init` and `inotify_init1`.
Contextually, it removes `PPME_SOCKET_ACCEPT_E`, `PPME_SOCKET_ACCEPT_5_E` `PPME_SOCKET_ACCEPT4_5_E` switch cases, as these event types are converted in scap into their latest variants, before reaching sinsp.
Finally, it makes the logic based on exit event types instead of enter events types.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
