### PR TITLE
feat(userspace/libscap)!: add large payload support to scap converter

### DIFF
--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -1839,10 +1839,13 @@ const struct ppm_event_info g_event_info[] = {
         [PPME_CONTAINER_JSON_E] =
                 {"container",
                  EC_PROCESS | EC_METAEVENT,
-                 EF_MODIFIES_STATE | EF_OLD_VERSION,
+                 EF_MODIFIES_STATE | EF_OLD_VERSION | EF_TMP_CONVERTER_MANAGED,
                  1,
                  {{"json", PT_CHARBUF, PF_NA}}},  /// TODO: do we need SKIPPARSERESET flag?
-        [PPME_CONTAINER_JSON_X] = {"NA", EC_UNKNOWN, EF_UNUSED | EF_OLD_VERSION, 0},
+        [PPME_CONTAINER_JSON_X] = {"NA",
+                                   EC_UNKNOWN,
+                                   EF_UNUSED | EF_OLD_VERSION | EF_TMP_CONVERTER_MANAGED,
+                                   0},
         [PPME_SYSCALL_SETSID_E] = {"setsid", EC_PROCESS | EC_SYSCALL, EF_MODIFIES_STATE, 0},
         [PPME_SYSCALL_SETSID_X] = {"setsid",
                                    EC_PROCESS | EC_SYSCALL,

--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -6861,6 +6861,28 @@ TEST_F(convert_event_test, PPME_SYSCALL_ACCESS_X_2_to_3_params_with_enter) {
 }
 
 ////////////////////////////
+// CONTAINER
+////////////////////////////
+
+TEST_F(convert_event_test, PPME_CONTAINER_JSON_E_1_to_2_E_1) {
+	constexpr uint64_t ts = 12;
+	constexpr int64_t tid = 25;
+
+	constexpr char json[] = "{}";
+
+	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_CONTAINER_JSON_E, 1, json),
+	                       create_safe_scap_event(ts, tid, PPME_CONTAINER_JSON_2_E, 1, json));
+}
+
+TEST_F(convert_event_test, PPME_CONTAINER_JSON_X_0_to_2_X_0) {
+	constexpr uint64_t ts = 12;
+	constexpr int64_t tid = 25;
+
+	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_CONTAINER_JSON_X, 0),
+	                       create_safe_scap_event(ts, tid, PPME_CONTAINER_JSON_2_X, 0));
+}
+
+////////////////////////////
 // FCHDIR
 ////////////////////////////
 

--- a/userspace/libscap/engine/savefile/converter/table.cpp
+++ b/userspace/libscap/engine/savefile/converter/table.cpp
@@ -1010,6 +1010,19 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
         {conversion_key{PPME_SYSCALL_ACCESS_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_ACCESS_X, 2},
          conversion_info().action(C_ACTION_ADD_PARAMS).instrs({{C_INSTR_FROM_ENTER, 0}})},
+        /*====================== CONTAINER ======================*/
+        {conversion_key{PPME_CONTAINER_JSON_E, 1},
+         conversion_info()
+                 .desired_type(PPME_CONTAINER_JSON_2_E)
+                 .action(C_ACTION_CHANGE_TYPE)
+                 .instrs({
+                         {C_INSTR_FROM_OLD, 0},  // json
+                 })},
+        {conversion_key{PPME_CONTAINER_JSON_X, 0},
+         conversion_info()
+                 .desired_type(PPME_CONTAINER_JSON_2_X)
+                 .action(C_ACTION_CHANGE_TYPE)
+                 .instrs({})},
         /*====================== SETGID ======================*/
         {conversion_key{PPME_SYSCALL_SETGID_E, 1}, conversion_info().action(C_ACTION_STORE)},
         {conversion_key{PPME_SYSCALL_SETGID_X, 1},

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -410,8 +410,8 @@ bool sinsp_parser::reset(sinsp_evt &evt, sinsp_parser_verdict &verdict) const {
 	}
 
 	// todo(jasondellaluce): should we do this for all meta-events in general?
-	if(etype == PPME_CONTAINER_JSON_E || etype == PPME_CONTAINER_JSON_2_E ||
-	   etype == PPME_USER_ADDED_E || etype == PPME_USER_DELETED_E || etype == PPME_GROUP_ADDED_E ||
+	if(etype == PPME_CONTAINER_JSON_2_E || etype == PPME_USER_ADDED_E ||
+	   etype == PPME_USER_DELETED_E || etype == PPME_GROUP_ADDED_E ||
 	   etype == PPME_GROUP_DELETED_E || etype == PPME_PLUGINEVENT_E || etype == PPME_ASYNCEVENT_E) {
 		// Note: still managing container events cases. They might still be present in existing scap
 		// files, even if they are then parsed by the container plugin.

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -275,10 +275,10 @@ sinsp::~sinsp() {
 
 bool sinsp::is_initialstate_event(const scap_evt& pevent) {
 	const auto evt_type = pevent.type;
-	return evt_type == PPME_CONTAINER_E || evt_type == PPME_CONTAINER_JSON_E ||
-	       evt_type == PPME_CONTAINER_JSON_2_E || evt_type == PPME_USER_ADDED_E ||
-	       evt_type == PPME_USER_DELETED_E || evt_type == PPME_GROUP_ADDED_E ||
-	       evt_type == PPME_GROUP_DELETED_E || evt_type == PPME_ASYNCEVENT_E;
+	return evt_type == PPME_CONTAINER_E || evt_type == PPME_CONTAINER_JSON_2_E ||
+	       evt_type == PPME_USER_ADDED_E || evt_type == PPME_USER_DELETED_E ||
+	       evt_type == PPME_GROUP_ADDED_E || evt_type == PPME_GROUP_DELETED_E ||
+	       evt_type == PPME_ASYNCEVENT_E;
 }
 
 void sinsp::consume_initialstate_events() {

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -97,8 +97,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		}
 	}
 	if(m_field_id == TYPE_NAME &&
-	   (evt->get_type() == PPME_CONTAINER_JSON_E || evt->get_type() == PPME_CONTAINER_JSON_2_E ||
-	    is_container_asyncevent)) {
+	   (evt->get_type() == PPME_CONTAINER_JSON_2_E || is_container_asyncevent)) {
 		m_strval = tinfo->get_container_user();
 		if(!m_strval.empty()) {
 			RETURN_EXTRACT_STRING(m_strval);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for converting events that use different number of bytes to encode parameter lengths in the lengths array. Specifically, the scap converter is now able to perform conversions between events using 4 or 2 bytes as parameter length size (the 4 bytes version being the one used for large payload events). Contextually, this PR makes `PPME_CONTAINER_JSON_{E,X}` "scap converter"-managed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Not bumping the driver schema version is currently a practice we are following as we will bump it in a single shot once we are done with the https://github.com/falcosecurity/libs/pull/2068 proposal.

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat!: make `PPME_CONTAINER_JSON_{E,X}` "scap converter"-managed
```
