### PR TITLE
fix(userspace/libsinsp): fix extraction of the directory value

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -582,7 +582,14 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			sanitize_string(m_tstr);
 		}
 
-		if(m_fdinfo != NULL && m_fdinfo->is_file()) {
+		// It is possible that `m_fdinfo` is still NULL, but `m_tstr` is
+		// set to a value which requires postprocessing. This can happen,
+		// e.g., when a syscall operation fails and therefore the syscall's
+		// parsing in `parsers.cpp` leaves `m_fdinfo` as NULL. In this case,
+		// `extract_fd()` leaves `m_fdinfo` as NULL, which leads
+		// `extract_fdname_from_event()` to set the value of `m_tstr`
+		// instead. This value will also require postprocessing.
+		if(m_fdinfo == NULL || m_fdinfo->is_file()) {
 			size_t pos = m_tstr.rfind('/');
 			if(pos != string::npos && pos != 0) {
 				if(pos < m_tstr.size() - 1) {


### PR DESCRIPTION
Extracting the value of a directory is broken and in some cases the extraction returns also the filename. This will also impact Falco's rule parsing because rules that depend on the correct value do no longer work.

This fix makes sure that the code to strip off the leading filename is run in all cases when the resulting string contains also the filename.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

There has been an issue with Falco 0.40.0+ of not being able to correctly handle rules that depend on the value of `fd.directory`. In particular, when extracting the value for a `directory` field, the returned value contains also the filename while prior Falco 0.39.2 the value contains only the expected value i.e. the directory name.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/falco/issues/3679

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace/libsinsp): fix extraction of the directory value
```
