### PR TITLE
feat!: drop scap files' enter events not eligible for scap conversion

### DIFF
--- a/userspace/libscap/engine/savefile/converter/README.md
+++ b/userspace/libscap/engine/savefile/converter/README.md
@@ -1,0 +1,39 @@
+# scap converter
+
+The scap converter is a `savefile` engine's component mainly aiming to convert event with old layouts and types to their
+latest versions.
+
+Once an event, with a specific type and a specific number of parameters, is read from a scap file, it is checked against
+a set of static conversion eligibility rules: these rules allow the converter to determine if the event is eligible for
+conversion, if it must be allowed to proceed towards upper layers or must be dropped.
+
+Static conversion eligibility rules are evaluated using a top-down approach. They leverage the following definitions:
+
+- an event having `EF_TMP_CONVERTER_MANAGED` among its flag is considered to be managed by the scap converter
+- an event having `EF_OLD_VERSION` among its flag is considered an old event version
+
+The following is the set of rules:
+
+1. event not managed by the converter don't need any conversion; moreover
+    1. new event versions are allowed to proceed towards upper layers
+    2. old enter event versions are always dropped
+    3. (validity check) exit events cannot be old without being managed by the converter
+2. enter events always need a conversion
+3. old exit event versions, or new exit event versions with a number of expected parameters (as specified in the event
+   schema) different from their actual number of parameters, always need a conversion
+4. all the other combinations don't need any conversion
+
+Events eligible for conversion are checked against the conversion table defined in `table.cpp`. The conversion table is
+indexed by `(event type, event parameters number)` keys, and contains declarative instructions about how to act of a
+matching
+event. Possible conversion instructions are:
+
+- store the event for later retrieval - used for augmenting exit events with information coming from enter events
+- change the event type
+- push a new empty parameter (i.e.: a zero-length parameter)
+- push a new default parameter (i.e.: the default value associated with the parameter type)
+- take a parameter from the corresponding retrieved enter events, if present, or push an empty one as a fallback
+- and so on...
+
+After each conversion, the static conversion eligibility rules are always re-checked to determine what do to with the
+new event. A static maximum number of conversion prevent the conversion engine to enter an infinite loop of conversions. 

--- a/userspace/libscap/engine/savefile/converter/converter.h
+++ b/userspace/libscap/engine/savefile/converter/converter.h
@@ -38,7 +38,7 @@ conversion_result scap_convert_event(struct scap_convert_buffer* buf,
                                      char* error);
 void scap_convert_free_buffer(struct scap_convert_buffer* buf);
 
-bool is_conversion_needed(scap_evt* evt_to_convert);
+conversion_result test_event_convertibility(const scap_evt* evt_to_convert, char* error);
 
 // Only for testing purposes
 scap_evt* scap_retrieve_evt_from_converter_storage(struct scap_convert_buffer* buf, uint64_t tid);

--- a/userspace/libscap/engine/savefile/converter/results.h
+++ b/userspace/libscap/engine/savefile/converter/results.h
@@ -22,4 +22,5 @@ typedef enum conversion_result {
 	CONVERSION_CONTINUE,
 	CONVERSION_COMPLETED,
 	CONVERSION_SKIP,
+	CONVERSION_DROP
 } conversion_result;

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1388,11 +1388,10 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 			restart_capture();
 			res = SCAP_TIMEOUT;
 		} else if(res == SCAP_FILTERED_EVENT) {
-			// This will happen if SCAP has filtered the event in userspace (tid suppression).
-			// A valid event was read from the driver, but we are choosing to not report it to
-			// the client at the client's request.
-			// However, we still need to return here so that the client doesn't time out the
-			// request.
+			// This will happen if SCAP has filtered the event in userspace (tid suppression or scap
+			// converter internal dropping logic). A valid event was read from the driver, but we
+			// are choosing to not report it to the client at the client's request. However, we
+			// still need to return here so that the client doesn't time out the request.
 			if(m_external_event_processor) {
 				m_external_event_processor->process_event(nullptr, libsinsp::EVENT_RETURN_FILTERED);
 			}

--- a/userspace/libsinsp/test/scap_files/scap_file_test.h
+++ b/userspace/libsinsp/test/scap_files/scap_file_test.h
@@ -51,6 +51,9 @@ protected:
 			if(ret == SCAP_EOF) {
 				break;
 			}
+			if(ret == SCAP_FILTERED_EVENT) {
+				continue;
+			}
 			if(ret != SCAP_SUCCESS) {
 				throw std::runtime_error("Error reading event. scap_code: " + std::to_string(ret) +
 				                         ", " + m_inspector->getlasterr());
@@ -74,6 +77,9 @@ protected:
 			ret = m_inspector->next(&evt);
 			if(ret == SCAP_EOF) {
 				break;
+			}
+			if(ret == SCAP_FILTERED_EVENT) {
+				continue;
 			}
 			if(ret != SCAP_SUCCESS) {
 				throw std::runtime_error("Error reading event. scap_code: " + std::to_string(ret) +
@@ -127,6 +133,9 @@ protected:
 			ret = m_inspector->next(&evt);
 			if(ret == SCAP_EOF) {
 				break;
+			}
+			if(ret == SCAP_FILTERED_EVENT) {
+				continue;
 			}
 			if(ret != SCAP_SUCCESS) {
 				throw std::runtime_error("Error reading event. scap_code: " + std::to_string(ret) +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR drops scap files' enter events not eligible for scap conversion. Moreover, it formalizes the conversion eligiblity rules both in code and in a separate `README.md` file.

Conversion eligibility rules are used to determine if an event is eligible for conversion, if it must be allowed to proceed towards upper layers or must be dropped. Moreover, after each conversion, these rules are always re-checked, to determine what to do with the new event.

Static conversion eligibility rules are evaluated using a top-down approach. They leverage the following definitions:

- an event having `EF_TMP_CONVERTER_MANAGED` among its flag is considered to be managed by the scap converter
- an event having `EF_OLD_VERSION` among its flag is considered an old event version

The following is the set of rules:

1. event not managed by the converter don't need any conversion; moreover
   1. new event versions are allowed to proceed towards upper layers
   2. old enter event versions are always dropped
   3. (validity check) exit events cannot be old without being managed by the converter
2. enter events always need a conversion
3. old exit event versions, or new exit event versions with a number of expected parameters (as specified in the event schema) different from their actual number of parameters, always need a conversion
4. all the other combinations don't need any conversion

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat!: drop scap files' enter events not eligible for scap conversion
```
