### PR TITLE
feat!: don't reserve any byte for empty parameters values

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -219,10 +219,11 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
                                            uint32_t len) {
 	char* prfmt;
 
-	ASSERT(rawval != NULL);
-
 	switch(ptype) {
 	case PT_INT8:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo8;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -241,6 +242,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		         *(int8_t*)rawval);
 		return m_getpropertystr_storage.data();
 	case PT_INT16:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo16;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -259,6 +263,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 		         rawval_cast<int16_t>(rawval));
 		return m_getpropertystr_storage.data();
 	case PT_INT32:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo32;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -280,6 +287,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 	case PT_PID:
 	case PT_ERRNO:
 	case PT_FD:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo64;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -302,6 +312,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 	case PT_UINT8:
 	case PT_FLAGS8:
 	case PT_ENUMFLAGS8:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo8;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -323,6 +336,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 	case PT_UINT16:
 	case PT_FLAGS16:
 	case PT_ENUMFLAGS16:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo16;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -345,6 +361,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 	case PT_ENUMFLAGS32:
 	case PT_UID:
 	case PT_GID:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo32;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {
@@ -365,6 +384,9 @@ char* sinsp_filter_check::rawval_to_string(uint8_t* rawval,
 	case PT_UINT64:
 	case PT_RELTIME:
 	case PT_ABSTIME:
+		if(len == 0) {
+			return (char*)"0";
+		}
 		if(print_format == PF_OCT) {
 			prfmt = (char*)"%" PRIo64;
 		} else if(print_format == PF_DEC || print_format == PF_ID) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In the current implementation, an empty parameter is encoded using the following conventions:
- its length, in the event lengths array, is set to 0
- its value, in the event values list, is encoded using a zeroed buffer of N bytes, where N depends on the formal parameter type (e.g.: 2 bytes for `PT_UINT16` parameters).

This PR makes the declared length and the actual parameter value length consistent by avoiding any value buffer reservation in the event buffer for an empty parameter value.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat!: don't reserve any byte for empty parameters values
```
