### PR TITLE
feat(userspace/libsinsp)!: filter out `PPME_SYSCALL_OPEN_E` events

### DIFF
--- a/test/libsinsp_e2e/fs.cpp
+++ b/test/libsinsp_e2e/fs.cpp
@@ -1268,9 +1268,7 @@ TEST_F(sys_call_test, large_open) {
 		sinsp_evt* e = param.m_evt;
 		std::string name(e->get_name());
 
-		if(name.find("open") != std::string::npos && e->get_direction() == SCAP_ED_IN) {
-			callnum++;
-		} else if(name.find("open") != std::string::npos && e->get_direction() == SCAP_ED_OUT) {
+		if(name.find("open") != std::string::npos && e->get_direction() == SCAP_ED_OUT) {
 			const sinsp_evt_param* p = e->get_param_by_name("name");
 
 			if(event_capture::s_engine_string == KMOD_ENGINE) {
@@ -1289,5 +1287,5 @@ TEST_F(sys_call_test, large_open) {
 	};
 
 	ASSERT_NO_FATAL_FAILURE({ event_capture::run(test, callback, filter); });
-	EXPECT_EQ(2, callnum);
+	EXPECT_EQ(1, callnum);  // open exit event.
 }

--- a/test/libsinsp_e2e/paths.cpp
+++ b/test/libsinsp_e2e/paths.cpp
@@ -67,13 +67,13 @@ public:
 
 		switch(m_callnum) {
 		case 0:
-			if(type == PPME_SYSCALL_OPEN_E || type == PPME_SYSCALL_OPENAT_2_E) {
+			if(type == PPME_SYSCALL_OPEN_X || type == PPME_SYSCALL_OPENAT_2_E) {
 				m_callnum++;
 			}
 
 			break;
 		case 1:
-			if(type == PPME_SYSCALL_OPEN_X || type == PPME_SYSCALL_OPENAT_2_X) {
+			if(type == PPME_SYSCALL_OPENAT_2_X) {
 				EXPECT_EQ(e->get_param_value_str("name", false), m_filename);
 				EXPECT_EQ(m_scwd, pinfo->get_cwd());
 				EXPECT_EQ(m_scat, e->get_param_value_str("fd"));

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -100,6 +100,17 @@ struct sinsp_evt_filter {
 	}
 
 	~sinsp_evt_filter() {
+		// Some syscall enter events are still used by the parser for different purposes. At this
+		// point, these events have been already used, and can safely be dropped.
+		switch(evt->get_type()) {
+			// Enter events for TOCTOU mitigation.
+		case PPME_SYSCALL_OPEN_E:
+			evt->set_filtered_out(true);
+			return;
+		default:
+			break;
+		}
+
 		//
 		// With some state-changing events like clone, execve and open, we do the
 		// filtering after having updated the state

--- a/userspace/libsinsp/test/events_evt.ut.cpp
+++ b/userspace/libsinsp/test/events_evt.ut.cpp
@@ -102,20 +102,13 @@ TEST_F(sinsp_with_test_input, event_res) {
 
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
-	                           PPME_SYSCALL_OPEN_E,
-	                           3,
-	                           "/tmp/the_file.txt",
-	                           0,
-	                           0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
 	                           PPME_SYSCALL_OPEN_X,
 	                           6,
 	                           (int64_t)123,
 	                           "/tmp/the_file.txt",
-	                           0,
-	                           0,
-	                           0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
 	                           (uint64_t)0);
 
 	EXPECT_EQ(get_field_as_string(evt, "evt.res"), "SUCCESS");
@@ -124,20 +117,13 @@ TEST_F(sinsp_with_test_input, event_res) {
 
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
-	                           PPME_SYSCALL_OPEN_E,
-	                           3,
-	                           "/tmp/the_file.txt",
-	                           0,
-	                           0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
 	                           PPME_SYSCALL_OPEN_X,
 	                           6,
 	                           (int64_t)-SE_EACCES,
 	                           "/tmp/the_file.txt",
-	                           0,
-	                           0,
-	                           0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
 	                           (uint64_t)0);
 
 	EXPECT_EQ(get_field_as_string(evt, "evt.res"), "EACCES");
@@ -164,17 +150,16 @@ TEST_F(sinsp_with_test_input, event_hostname) {
 
 	/* Toy event example from a previous test. */
 	int64_t dirfd = 3;
-	const char *file_to_run = "/tmp/file_to_run";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
+	auto *file_to_run = "/tmp/file_to_run";
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
 	                           PPME_SYSCALL_OPEN_X,
 	                           6,
 	                           dirfd,
 	                           file_to_run,
-	                           0,
-	                           0,
-	                           0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
 	                           (uint64_t)0);
 
 	/* Assert correct custom hostname. */

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -55,27 +55,19 @@ TEST_F(sinsp_with_test_input, file_open) {
 	add_default_init_thread();
 
 	open_inspector();
-	sinsp_evt* evt = NULL;
 
 	// since adding and reading events happens on a single thread they can be interleaved.
 	// tests may need to change if that will not be the case anymore
-	add_event_advance_ts(increasing_ts(),
-	                     1,
-	                     PPME_SYSCALL_OPEN_E,
-	                     3,
-	                     "/tmp/the_file",
-	                     (uint32_t)PPM_O_RDWR,
-	                     (uint32_t)0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           (uint64_t)3,
-	                           "/tmp/the_file",
-	                           (uint32_t)PPM_O_RDWR,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	const auto evt = add_event_advance_ts(increasing_ts(),
+	                                      1,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (uint64_t)3,
+	                                      "/tmp/the_file",
+	                                      (uint32_t)PPM_O_RDWR,
+	                                      (uint32_t)0,
+	                                      (uint32_t)5,
+	                                      (uint64_t)123);
 
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
@@ -91,13 +83,6 @@ TEST_F(sinsp_with_test_input, dup_dup2_dup3) {
 
 	int64_t fd = 3, res = 1, oldfd = 3, newfd = 123;
 
-	add_event_advance_ts(increasing_ts(),
-	                     1,
-	                     PPME_SYSCALL_OPEN_E,
-	                     3,
-	                     "/tmp/test",
-	                     (uint32_t)(PPM_O_TRUNC | PPM_O_CREAT | PPM_O_WRONLY),
-	                     (uint32_t)0666);
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
@@ -169,7 +154,6 @@ TEST_F(sinsp_with_test_input, path_too_long) {
 	add_default_init_thread();
 
 	open_inspector();
-	sinsp_evt* evt = NULL;
 
 	std::stringstream long_path_ss;
 	long_path_ss << "/";
@@ -184,23 +168,16 @@ TEST_F(sinsp_with_test_input, path_too_long) {
 	std::string long_path = long_path_ss.str();
 	int64_t fd = 3, mountfd = 5;
 
-	add_event_advance_ts(increasing_ts(),
-	                     1,
-	                     PPME_SYSCALL_OPEN_E,
-	                     3,
-	                     long_path.c_str(),
-	                     (uint32_t)PPM_O_RDWR,
-	                     (uint32_t)0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           long_path.c_str(),
-	                           (uint32_t)PPM_O_RDWR,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                fd,
+	                                long_path.c_str(),
+	                                (uint32_t)PPM_O_RDWR,
+	                                (uint32_t)0,
+	                                (uint32_t)5,
+	                                (uint64_t)123);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/DIR_TOO_LONG/FILENAME_TOO_LONG");
 	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/DIR_TOO_LONG");
 	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "FILENAME_TOO_LONG");
@@ -694,7 +671,6 @@ TEST_F(sinsp_with_test_input, signalfd4) {
 TEST_F(sinsp_with_test_input, fchmod) {
 	add_default_init_thread();
 	open_inspector();
-	sinsp_evt* evt = NULL;
 	const char* path = "/tmp/test";
 	int64_t fd = 3;
 	int32_t flags = PPM_O_RDWR;
@@ -705,17 +681,16 @@ TEST_F(sinsp_with_test_input, fchmod) {
 	int64_t res = 0;
 
 	// We need to open a fd first so fchmod can act on it
-	evt = add_event_advance_ts(increasing_ts(), 3, PPME_SYSCALL_OPEN_E, 3, path, flags, mode);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           path,
-	                           flags,
-	                           mode,
-	                           dev,
-	                           ino);
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                fd,
+	                                path,
+	                                flags,
+	                                mode,
+	                                dev,
+	                                ino);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "3");
 
@@ -727,7 +702,6 @@ TEST_F(sinsp_with_test_input, fchmod) {
 TEST_F(sinsp_with_test_input, fchown) {
 	add_default_init_thread();
 	open_inspector();
-	sinsp_evt* evt = NULL;
 	const char* path = "/tmp/test";
 	int64_t fd = 3;
 	int32_t flags = PPM_O_RDWR;
@@ -740,17 +714,16 @@ TEST_F(sinsp_with_test_input, fchown) {
 	uint32_t gid = 0;
 
 	// We need to open a fd first so fchown can act on it
-	evt = add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, path, flags, mode);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           path,
-	                           flags,
-	                           mode,
-	                           dev,
-	                           ino);
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                fd,
+	                                path,
+	                                flags,
+	                                mode,
+	                                dev,
+	                                ino);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/test");
 	ASSERT_EQ(get_field_as_string(evt, "fd.num"), "3");
 
@@ -779,27 +752,16 @@ TEST_F(sinsp_with_test_input, test_fdtypes) {
 	add_default_init_thread();
 
 	open_inspector();
-	sinsp_evt* evt = NULL;
-
-	// since adding and reading events happens on a single thread they can be interleaved.
-	// tests may need to change if that will not be the case anymore
-	add_event_advance_ts(increasing_ts(),
-	                     1,
-	                     PPME_SYSCALL_OPEN_E,
-	                     3,
-	                     "/tmp/the_file",
-	                     (uint32_t)PPM_O_RDWR,
-	                     (uint32_t)0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           (uint64_t)1,
-	                           "/tmp/the_file",
-	                           (uint32_t)PPM_O_RDWR,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                (uint64_t)1,
+	                                "/tmp/the_file",
+	                                (uint32_t)PPM_O_RDWR,
+	                                (uint32_t)0,
+	                                (uint32_t)5,
+	                                (uint64_t)123);
 
 	ASSERT_EQ(evt->get_type(), PPME_SYSCALL_OPEN_X);
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");

--- a/userspace/libsinsp/test/events_fspath.ut.cpp
+++ b/userspace/libsinsp/test/events_fspath.ut.cpp
@@ -98,18 +98,16 @@ protected:
 	}
 
 	void inject_open_event() {
-		sinsp_evt *evt =
-		        add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, path, flags, mode);
-		evt = add_event_advance_ts(increasing_ts(),
-		                           1,
-		                           PPME_SYSCALL_OPEN_X,
-		                           6,
-		                           fd,
-		                           path,
-		                           open_flags,
-		                           mode,
-		                           dev,
-		                           ino);
+		const auto evt = add_event_advance_ts(increasing_ts(),
+		                                      1,
+		                                      PPME_SYSCALL_OPEN_X,
+		                                      6,
+		                                      fd,
+		                                      path,
+		                                      open_flags,
+		                                      mode,
+		                                      dev,
+		                                      ino);
 		ASSERT_STREQ(get_field_as_string(evt, "fd.name").c_str(), path);
 	}
 
@@ -340,7 +338,6 @@ TEST_F(fspath, unlinkat_2) {
 }
 
 TEST_F(fspath, open) {
-	test_enter(PPME_SYSCALL_OPEN_E, 3, name, open_flags, mode);
 	test_exit_path(resolved_name,
 	               name,
 	               PPME_SYSCALL_OPEN_X,

--- a/userspace/libsinsp/test/events_param.ut.cpp
+++ b/userspace/libsinsp/test/events_param.ut.cpp
@@ -194,7 +194,13 @@ TEST_F(sinsp_with_test_input, filename_toctou) {
 
 	int64_t fd = 1, dirfd = 3;
 
-	add_event(increasing_ts(), 3, PPME_SYSCALL_OPEN_E, 3, "/tmp/the_file", 0, 0);
+	add_event(increasing_ts(),
+	          3,
+	          PPME_SYSCALL_OPEN_E,
+	          3,
+	          "/tmp/the_file",
+	          (uint32_t)0,
+	          (uint32_t)0);
 	evt = add_event_advance_ts(increasing_ts(),
 	                           3,
 	                           PPME_SYSCALL_OPEN_X,
@@ -328,7 +334,13 @@ TEST_F(sinsp_with_test_input, enter_event_retrieval) {
 		std::string test_context =
 		        std::string("open with filename ") + test_utils::describe_string(enter_filename);
 
-		add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, NULL, 0, 0);
+		add_filtered_event_advance_ts(increasing_ts(),
+		                              1,
+		                              PPME_SYSCALL_OPEN_E,
+		                              3,
+		                              NULL,
+		                              (uint32_t)0,
+		                              (uint32_t)0);
 		evt = add_event_advance_ts(increasing_ts(),
 		                           1,
 		                           PPME_SYSCALL_OPEN_X,

--- a/userspace/libsinsp/test/events_proc.ut.cpp
+++ b/userspace/libsinsp/test/events_proc.ut.cpp
@@ -38,8 +38,7 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *file_to_run = "/tmp/file_to_run";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
+	auto *file_to_run = "/tmp/file_to_run";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
@@ -125,17 +124,16 @@ TEST_F(sinsp_with_test_input, execveat_relative_path) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *directory = "/tmp/dir";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
+	auto *directory = "/tmp/dir";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
 	                     6,
 	                     dirfd,
 	                     directory,
-	                     0,
-	                     0,
-	                     0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
 	                     (uint64_t)0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
@@ -210,17 +208,16 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *directory = "/tmp/dir";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
+	auto *directory = "/tmp/dir";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
 	                     6,
 	                     dirfd,
 	                     directory,
-	                     0,
-	                     0,
-	                     0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
 	                     (uint64_t)0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
@@ -361,17 +358,16 @@ TEST_F(sinsp_with_test_input, execveat_empty_path_flag_s390) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *file_to_run = "/tmp/s390x/file_to_run";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
+	auto *file_to_run = "/tmp/s390x/file_to_run";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
 	                     6,
 	                     dirfd,
 	                     file_to_run,
-	                     0,
-	                     0,
-	                     0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
 	                     (uint64_t)0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
@@ -446,17 +442,16 @@ TEST_F(sinsp_with_test_input, execveat_relative_path_s390) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *directory = "/tmp/s390x/dir";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
+	auto *directory = "/tmp/s390x/dir";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
 	                     6,
 	                     dirfd,
 	                     directory,
-	                     0,
-	                     0,
-	                     0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
 	                     (uint64_t)0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
@@ -595,17 +590,16 @@ TEST_F(sinsp_with_test_input, execveat_invalid_path_s390) {
 	 * we want to run with the `execveat`,
 	 */
 	int64_t dirfd = 3;
-	const char *directory = "/tmp/s390/dir";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, directory, 0, 0);
+	auto *directory = "/tmp/s390/dir";
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,
 	                     6,
 	                     dirfd,
 	                     directory,
-	                     0,
-	                     0,
-	                     0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
 	                     (uint64_t)0);
 
 	/* Now we call the `execveat_e` event,`sinsp` will store this enter
@@ -907,13 +901,6 @@ TEST_F(sinsp_with_test_input, chdir_fchdir) {
 
 	// generate a fd associated with the directory we wish to change to
 	int64_t dirfd = 3, test_errno = 0;
-	add_event_advance_ts(increasing_ts(),
-	                     1,
-	                     PPME_SYSCALL_OPEN_E,
-	                     3,
-	                     "/tmp/target-directory-fd",
-	                     0,
-	                     0);
 	add_event_advance_ts(increasing_ts(),
 	                     1,
 	                     PPME_SYSCALL_OPEN_X,

--- a/userspace/libsinsp/test/filter_op_numeric_compare.ut.cpp
+++ b/userspace/libsinsp/test/filter_op_numeric_compare.ut.cpp
@@ -53,13 +53,6 @@ TEST_F(sinsp_with_test_input, signed_int_compare) {
 
 	evt = add_event_advance_ts(increasing_ts(),
 	                           1,
-	                           PPME_SYSCALL_OPEN_E,
-	                           3,
-	                           "/tmp/the_file",
-	                           PPM_O_NONE,
-	                           0666);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
 	                           PPME_SYSCALL_OPEN_X,
 	                           6,
 	                           (int64_t)(-1),

--- a/userspace/libsinsp/test/filter_transformer.ut.cpp
+++ b/userspace/libsinsp/test/filter_transformer.ut.cpp
@@ -346,21 +346,18 @@ TEST_F(sinsp_with_test_input, basename_transformer) {
 	add_default_init_thread();
 	open_inspector();
 
-	sinsp_evt* evt;
-
 	int64_t dirfd = 3;
-	const char* file_to_run = "/tmp/file_to_run";
-	add_event_advance_ts(increasing_ts(), 1, PPME_SYSCALL_OPEN_E, 3, file_to_run, 0, 0);
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           dirfd,
-	                           file_to_run,
-	                           0,
-	                           0,
-	                           0,
-	                           (uint64_t)0);
+	auto* file_to_run = "/tmp/file_to_run";
+	const auto evt = add_event_advance_ts(increasing_ts(),
+	                                      1,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      dirfd,
+	                                      file_to_run,
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0);
 
 	EXPECT_TRUE(eval_filter(evt, "basename(fd.name) = file_to_run"));
 	EXPECT_FALSE(eval_filter(evt, "basename(fd.name) = /tmp/file_to_run"));

--- a/userspace/libsinsp/test/filterchecks/evt.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt.cpp
@@ -26,29 +26,16 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_is_open_create) {
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
 
-	// In the enter event we don't send the `PPM_O_F_CREATED`
-	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
+	const auto evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      fd,
 	                                      path.c_str(),
-	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                      (uint32_t)0);
-	ASSERT_EQ(get_field_as_string(evt, "evt.is_open_create"), "false");
-
-	// The `fdinfo` is not populated in the enter event
-	ASSERT_FALSE(evt->get_fd_info());
-
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           path.c_str(),
-	                           (uint32_t)PPM_O_RDWR | PPM_O_CREAT | PPM_O_F_CREATED,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT | PPM_O_F_CREATED,
+	                                      (uint32_t)0,
+	                                      (uint32_t)5,
+	                                      (uint64_t)123);
 	ASSERT_EQ(get_field_as_string(evt, "evt.is_open_create"), "true");
 	ASSERT_TRUE(evt->get_fd_info());
 
@@ -63,28 +50,16 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_is_lower_layer) {
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
 
-	// In the enter event we don't send the `PPM_O_F_CREATED`
-	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
+	const auto evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      fd,
 	                                      path.c_str(),
-	                                      (uint32_t)PPM_O_RDONLY,
-	                                      (uint32_t)0);
-
-	// The `fdinfo` is not populated in the enter event
-	ASSERT_FALSE(evt->get_fd_info());
-
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           path.c_str(),
-	                           (uint32_t)PPM_O_RDONLY | PPM_FD_LOWER_LAYER,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	                                      (uint32_t)PPM_O_RDONLY | PPM_FD_LOWER_LAYER,
+	                                      (uint32_t)0,
+	                                      (uint32_t)5,
+	                                      (uint64_t)123);
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_lower_layer"), "true");
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_upper_layer"), "false");
 	ASSERT_TRUE(evt->get_fd_info());
@@ -101,28 +76,16 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_is_upper_layer) {
 	std::string path = "/home/file.txt";
 	int64_t fd = 3;
 
-	// In the enter event we don't send the `PPM_O_F_CREATED`
-	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
+	const auto evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      fd,
 	                                      path.c_str(),
-	                                      (uint32_t)PPM_O_RDONLY,
-	                                      (uint32_t)0);
-
-	// The `fdinfo` is not populated in the enter event
-	ASSERT_FALSE(evt->get_fd_info());
-
-	evt = add_event_advance_ts(increasing_ts(),
-	                           1,
-	                           PPME_SYSCALL_OPEN_X,
-	                           6,
-	                           fd,
-	                           path.c_str(),
-	                           (uint32_t)PPM_O_RDONLY | PPM_FD_UPPER_LAYER,
-	                           (uint32_t)0,
-	                           (uint32_t)5,
-	                           (uint64_t)123);
+	                                      (uint32_t)PPM_O_RDONLY | PPM_FD_UPPER_LAYER,
+	                                      (uint32_t)0,
+	                                      (uint32_t)5,
+	                                      (uint64_t)123);
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_lower_layer"), "false");
 	ASSERT_EQ(get_field_as_string(evt, "fd.is_upper_layer"), "true");
 	ASSERT_TRUE(evt->get_fd_info());

--- a/userspace/libsinsp/test/filterchecks/evt/rawarg.cpp
+++ b/userspace/libsinsp/test/filterchecks/evt/rawarg.cpp
@@ -125,11 +125,14 @@ TEST_F(sinsp_with_test_input, EVT_FILTER_rawarg_str) {
 	// In the enter event we don't send the `PPM_O_F_CREATED`
 	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (int64_t)0,
 	                                      path.c_str(),
 	                                      (uint32_t)0,
-	                                      (uint32_t)0);
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.rawarg.name"), path);
 }
 

--- a/userspace/libsinsp/test/filterchecks/fd.cpp
+++ b/userspace/libsinsp/test/filterchecks/fd.cpp
@@ -23,39 +23,17 @@ TEST_F(sinsp_with_test_input, FD_FILTER_extract_from_null_type_filename) {
 
 	open_inspector();
 
-	std::string path = "/home/file.txt";
-	int64_t dirfd = 4;
+	const std::string path = "/home/file.txt";
 
-	auto evt = add_event_advance_ts(increasing_ts(),
-	                                INIT_TID,
-	                                PPME_SYSCALL_OPEN_E,
-	                                3,
-	                                path.c_str(),
-	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                (uint32_t)0);
-	ASSERT_FALSE(field_has_value(evt, "fd.filename"));
-
-	evt = add_event_advance_ts(increasing_ts(),
-	                           INIT_TID,
-	                           PPME_SYSCALL_OPENAT_2_E,
-	                           4,
-	                           dirfd,
-	                           path.c_str(),
-	                           0,
-	                           0);
-	ASSERT_FALSE(field_has_value(evt, "fd.filename"));
-
-	evt = add_event_advance_ts(increasing_ts(),
-	                           INIT_TID,
-	                           PPME_SYSCALL_OPENAT2_E,
-	                           5,
-	                           dirfd,
-	                           path.c_str(),
-	                           0,
-	                           0,
-	                           0);
-	ASSERT_FALSE(field_has_value(evt, "fd.filename"));
-
-	evt = add_event_advance_ts(increasing_ts(), INIT_TID, PPME_SYSCALL_CREAT_E, 2, path.c_str(), 0);
+	const auto evt = add_event_advance_ts(increasing_ts(),
+	                                      INIT_TID,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (int64_t)-1,
+	                                      path.c_str(),
+	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0);
 	ASSERT_FALSE(field_has_value(evt, "fd.filename"));
 }

--- a/userspace/libsinsp/test/filterchecks/static.cpp
+++ b/userspace/libsinsp/test/filterchecks/static.cpp
@@ -50,13 +50,16 @@ TEST_F(sinsp_with_test_input, STATIC_FILTER_suggested_output) {
 	open_inspector();
 
 	std::string path = "/home/file.txt";
-	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
+	const auto evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (int64_t)0,
 	                                      path.c_str(),
 	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                      (uint32_t)0);
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "static.example", *pl_flist), "example_value");
 }
 
@@ -73,11 +76,14 @@ TEST_F(sinsp_with_test_input, STATIC_FILTER_filter) {
 	std::string path = "/home/file.txt";
 	sinsp_evt* evt = add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (int64_t)3,
 	                                      path.c_str(),
 	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                      (uint32_t)0);
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0);
 	ASSERT_NE(evt, nullptr);
 	ASSERT_EQ(get_field_as_string(evt, "static.example", *pl_flist), "example_value");
 }
@@ -96,9 +102,12 @@ TEST_F(sinsp_with_test_input, STATIC_FILTER_filter_wrong) {
 	// Exception thrown because no event matches the required filter
 	ASSERT_ANY_THROW(add_event_advance_ts(increasing_ts(),
 	                                      1,
-	                                      PPME_SYSCALL_OPEN_E,
-	                                      3,
+	                                      PPME_SYSCALL_OPEN_X,
+	                                      6,
+	                                      (int64_t)3,
 	                                      path.c_str(),
 	                                      (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                      (uint32_t)0));
+	                                      (uint32_t)0,
+	                                      (uint32_t)0,
+	                                      (uint64_t)0));
 }

--- a/userspace/libsinsp/test/filterchecks/user.cpp
+++ b/userspace/libsinsp/test/filterchecks/user.cpp
@@ -34,11 +34,14 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry) {
 
 	auto evt = add_event_advance_ts(increasing_ts(),
 	                                INIT_TID,
-	                                PPME_SYSCALL_OPEN_E,
-	                                3,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                (int64_t)3,
 	                                path.c_str(),
 	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                (uint32_t)0);
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "1000");
 	ASSERT_EQ(get_field_as_string(evt, "user.loginuid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "foo");
@@ -85,11 +88,14 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_default_user_entry) {
 
 	auto evt = add_event_advance_ts(increasing_ts(),
 	                                INIT_TID,
-	                                PPME_SYSCALL_OPEN_E,
-	                                3,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                (int64_t)3,
 	                                path.c_str(),
 	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                (uint32_t)0);
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
 
 	// For non-existent entries whose uid is 0, "root" and "/root"
 	// are automatically filled by threadinfo::get_user() method.
@@ -113,11 +119,14 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_existent_user_entry_witho
 
 	auto evt = add_event_advance_ts(increasing_ts(),
 	                                INIT_TID,
-	                                PPME_SYSCALL_OPEN_E,
-	                                3,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                (int64_t)3,
 	                                path.c_str(),
 	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                (uint32_t)0);
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "");
 	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "");
@@ -138,11 +147,14 @@ TEST_F(sinsp_with_test_input, USER_FILTER_extract_from_loaded_user_entry) {
 
 	auto evt = add_event_advance_ts(increasing_ts(),
 	                                INIT_TID,
-	                                PPME_SYSCALL_OPEN_E,
-	                                3,
+	                                PPME_SYSCALL_OPEN_X,
+	                                6,
+	                                (int64_t)3,
 	                                path.c_str(),
 	                                (uint32_t)PPM_O_RDWR | PPM_O_CREAT,
-	                                (uint32_t)0);
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "user.uid"), "0");
 	ASSERT_EQ(get_field_as_string(evt, "user.name"), "root");
 	ASSERT_EQ(get_field_as_string(evt, "user.homedir"), "/root");

--- a/userspace/libsinsp/test/plugins/metrics.cpp
+++ b/userspace/libsinsp/test/plugins/metrics.cpp
@@ -58,8 +58,8 @@ const char* plugin_get_parse_event_sources() {
 
 uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s) {
 	static uint16_t types[] = {
-	        PPME_SYSCALL_OPEN_E,
-	        // PPME_SYSCALL_OPEN_X,
+	        // PPME_SYSCALL_OPEN_E,
+	        PPME_SYSCALL_OPEN_X,
 	};
 	*num_types = sizeof(types) / sizeof(uint16_t);
 	return &types[0];

--- a/userspace/libsinsp/test/plugins/routines.cpp
+++ b/userspace/libsinsp/test/plugins/routines.cpp
@@ -58,7 +58,7 @@ static const char* plugin_get_parse_event_sources() {
 
 static uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s) {
 	static uint16_t types[] = {
-	        PPME_SYSCALL_OPEN_E,
+	        PPME_SYSCALL_OPEN_X,
 	};
 	*num_types = sizeof(types) / sizeof(uint16_t);
 	return &types[0];

--- a/userspace/libsinsp/test/plugins/syscall_subtables.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_subtables.cpp
@@ -64,7 +64,7 @@ const char* plugin_get_parse_event_sources() {
 }
 
 uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s) {
-	static uint16_t types[] = {PPME_SYSCALL_OPEN_E};
+	static uint16_t types[] = {PPME_SYSCALL_OPEN_X};
 	*num_types = sizeof(types) / sizeof(uint16_t);
 	return &types[0];
 }

--- a/userspace/libsinsp/test/plugins/syscall_subtables_array.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_subtables_array.cpp
@@ -61,7 +61,7 @@ const char* plugin_get_parse_event_sources() {
 }
 
 uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s) {
-	static uint16_t types[] = {PPME_SYSCALL_OPEN_E};
+	static uint16_t types[] = {PPME_SYSCALL_OPEN_X};
 	*num_types = sizeof(types) / sizeof(uint16_t);
 	return &types[0];
 }

--- a/userspace/libsinsp/test/plugins/syscall_subtables_array_pair.cpp
+++ b/userspace/libsinsp/test/plugins/syscall_subtables_array_pair.cpp
@@ -62,7 +62,7 @@ const char* plugin_get_parse_event_sources() {
 }
 
 uint16_t* plugin_get_parse_event_types(uint32_t* num_types, ss_plugin_t* s) {
-	static uint16_t types[] = {PPME_SYSCALL_OPEN_E};
+	static uint16_t types[] = {PPME_SYSCALL_OPEN_X};
 	*num_types = sizeof(types) / sizeof(uint16_t);
 	return &types[0];
 }

--- a/userspace/libsinsp/test/sinsp_with_test_input.h
+++ b/userspace/libsinsp/test/sinsp_with_test_input.h
@@ -248,6 +248,10 @@ protected:
 	_add_event_advance_ts(ts, tid, code, n, ##__VA_ARGS__); \
 	_check_event_params(__FILE__, __LINE__, code, n, ##__VA_ARGS__)
 
+#define add_filtered_event_advance_ts(ts, tid, code, n, ...)         \
+	_add_filtered_event_advance_ts(ts, tid, code, n, ##__VA_ARGS__); \
+	_check_event_params(__FILE__, __LINE__, code, n, ##__VA_ARGS__)
+
 #define add_event_advance_ts_with_empty_params(ts, tid, code, empty_params_set, n, ...)         \
 	_add_event_advance_ts_with_empty_params(ts, tid, code, empty_params_set, n, ##__VA_ARGS__); \
 	_check_event_params(__FILE__, __LINE__, code, n, ##__VA_ARGS__)
@@ -267,6 +271,11 @@ protected:
 	                                 ppm_event_code event_type,
 	                                 uint32_t n,
 	                                 ...);
+	void _add_filtered_event_advance_ts(uint64_t ts,
+	                                    uint64_t tid,
+	                                    ppm_event_code event_type,
+	                                    uint32_t n,
+	                                    ...);
 	sinsp_evt* _add_event_advance_ts_with_empty_params(
 	        uint64_t ts,
 	        uint64_t tid,
@@ -280,6 +289,12 @@ protected:
 	                                  const scap_empty_params_set* empty_params_set,
 	                                  uint32_t n,
 	                                  va_list args);
+	void add_filtered_event_advance_ts_v(uint64_t ts,
+	                                     uint64_t tid,
+	                                     ppm_event_code event_type,
+	                                     const scap_empty_params_set* empty_params_set,
+	                                     uint32_t n,
+	                                     va_list args);
 	scap_evt* create_event_v(uint64_t ts,
 	                         uint64_t tid,
 	                         ppm_event_code event_type,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

As `PPME_SYSCALL_OPEN_E` events are just generated to let the parser implement TOCTOU mitigation for the `open` system call, they are now an internal sinsp details and should not be exposed to sinsp users, in alignment with what is done for all the other system call enter events.

For this reason, this PR filters out `PPME_SYSCALL_OPEN_E` events after the sinsp parser (and possibly parser plugins), used them. Moreover, it updates the tests to reflect this new logic, and adds some new unit tests helpers to properly state that the events are filtered out.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
feat(userspace/libsinsp)!: filter out `PPME_SYSCALL_OPEN_E` events
```
