### PR TITLE
refactor: clean parser's reset logic

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -364,15 +364,7 @@ static bool can_query_os_for_thread_info(const uint16_t evt_type) {
 	         is_schedswitch_event(evt_type) || is_procexit_event(evt_type));
 }
 
-//
-// Called before starting the parsing.
-// Returns false in case of issues resetting the state.
-//
-bool sinsp_parser::reset(sinsp_evt &evt) const {
-	uint16_t etype = evt.get_type();
-	// Before anything can happen, the event needs to be initialized.
-	evt.init();
-
+void sinsp_parser::set_event_source(sinsp_evt &evt) const {
 	uint32_t plugin_id = 0;
 	if(evt.get_type() == PPME_PLUGINEVENT_E || evt.get_type() == PPME_ASYNCEVENT_E) {
 		// Note: async events can potentially encode a non-zero plugin ID to indicate that they've
@@ -399,7 +391,18 @@ bool sinsp_parser::reset(sinsp_evt &evt) const {
 		                            ? sinsp_syscall_event_source_name
 		                            : sinsp_no_event_source_name);
 	}
+}
 
+//
+// Called before starting the parsing.
+// Returns false in case of issues resetting the state.
+//
+bool sinsp_parser::reset(sinsp_evt &evt) const {
+	uint16_t etype = evt.get_type();
+	// Before anything can happen, the event needs to be initialized.
+	evt.init();
+
+	set_event_source(evt);
 	evt.set_fdinfo_ref(nullptr);
 	evt.set_fd_info(nullptr);
 	evt.set_errorcode(0);

--- a/userspace/libsinsp/parsers.h
+++ b/userspace/libsinsp/parsers.h
@@ -79,6 +79,7 @@ private:
 	// Helpers
 	//
 	inline void store_event(sinsp_evt& evt);
+	inline void set_event_source(sinsp_evt& evt) const;
 
 	//
 	// Parsers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR cleans parser's reset logic by moving the `sendmmsg`/`recvmmsg` exit event fd extraction logic into scap `get_exit_event_fd_location()`. Moreover, it extracts the `sinsp_parser::reset()`'s event source setting logic into a separate `sinsp_parser::set_event_source()` helper.

EDIT: see https://github.com/falcosecurity/libs/pull/2664#issuecomment-3360112478

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
