### PR TITLE
fix(userspace/libsinsp)!: make filtered evts handling consistent

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1537,20 +1537,11 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 	// Finally set output evt;
 	// From now on, any return must have the correct output being set.
 	*puevt = evt;
-	if(evt->is_filtered_out()) {
-		ppm_event_category cat = evt->get_category();
-
-		// Skip the event, unless we're in internal events
-		// mode and the category of this event is internal.
-		if(!(m_isinternal_events_enabled && (cat & EC_INTERNAL))) {
-			return SCAP_FILTERED_EVENT;
-		}
-	}
 
 	//
 	// Run the analysis engine
 	//
-	if(m_external_event_processor) {
+	if(m_external_event_processor && !evt->is_filtered_out()) {
 		m_external_event_processor->process_event(evt, libsinsp::EVENT_RETURN_NONE);
 	}
 
@@ -1563,6 +1554,16 @@ int32_t sinsp::next(sinsp_evt** puevt) {
 	if(evt->get_tinfo() && evt->get_type() != PPME_SCHEDSWITCH_6_E) {
 		evt->get_tinfo()->m_prevevent_ts = evt->get_tinfo()->m_lastevent_ts;
 		evt->get_tinfo()->m_lastevent_ts = m_timestamper.get_cached_ts();
+	}
+
+	if(evt->is_filtered_out()) {
+		ppm_event_category cat = evt->get_category();
+
+		// Skip the event, unless we're in internal events
+		// mode and the category of this event is internal.
+		if(!(m_isinternal_events_enabled && (cat & EC_INTERNAL))) {
+			return SCAP_FILTERED_EVENT;
+		}
 	}
 
 	//


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The current implementation of `sinsp::next()` returns early if the event is chosen to be filtered out by the `sinsp_evt_filter`. This introduces some inconsistencies for filtered events:
- filtered events are not involved in the parser cleanup procedure (i.e.: `m_parser->event_cleanup(*evt)` is not called on them) and this turns into a potential memory leak
- filtered events do not update the "last event seen by this thread" timestamp (i.e.: `sinsp_threadinfo::m_lastevent_ts`)

This PR addresses these inconsistencies/issues by moving the early-return logic (1) after the code triggering the parser's event cleanup procedure and (2) after updating the "last event seen" timestamp on the event thread.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
