### PR TITLE
fix(userspace/libscap): push default param as evt result in converter

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -4008,14 +4008,16 @@ TEST_F(convert_event_test, PPME_SOCKET_SENDMMSG_X_0_to_5_params) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
+	// Set to default.
+	constexpr int64_t res = 0;
+
 	// Set to empty.
-	constexpr auto res = empty_value<int64_t>();
 	constexpr auto fd = empty_value<int64_t>();
 	constexpr auto size = empty_value<uint32_t>();
 	constexpr auto data = empty_value<scap_const_sized_buffer>();
 	constexpr auto tuple = empty_value<scap_const_sized_buffer>();
 
-	SCAP_EMPTY_PARAMS_SET(empty_params_set, 0, 1, 2, 3, 4);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1, 2, 3, 4);
 	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_SOCKET_SENDMMSG_X, 0),
 	                       create_safe_scap_event_with_empty_params(ts,
 	                                                                tid,
@@ -4201,15 +4203,17 @@ TEST_F(convert_event_test, PPME_SOCKET_RECVMMSG_X_0_to_6_params) {
 	constexpr uint64_t ts = 12;
 	constexpr int64_t tid = 25;
 
+	// Set to default.
+	constexpr int64_t res = 0;
+
 	// Set to empty.
-	constexpr auto res = empty_value<int64_t>();
 	constexpr auto fd = empty_value<int64_t>();
 	constexpr auto size = empty_value<uint32_t>();
 	constexpr auto data = empty_value<scap_const_sized_buffer>();
 	constexpr auto tuple = empty_value<scap_const_sized_buffer>();
 	constexpr auto msgcontrol = empty_value<scap_const_sized_buffer>();
 
-	SCAP_EMPTY_PARAMS_SET(empty_params_set, 0, 1, 2, 3, 4, 5);
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 1, 2, 3, 4, 5);
 	assert_full_conversion(create_safe_scap_event(ts, tid, PPME_SOCKET_RECVMMSG_X, 0),
 	                       create_safe_scap_event_with_empty_params(ts,
 	                                                                tid,

--- a/userspace/libscap/engine/savefile/converter/table.cpp
+++ b/userspace/libscap/engine/savefile/converter/table.cpp
@@ -677,11 +677,11 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
          conversion_info()
                  .action(C_ACTION_ADD_PARAMS)
                  .instrs({
-                         {C_INSTR_FROM_EMPTY, 0},  // res
-                         {C_INSTR_FROM_EMPTY, 0},  // fd
-                         {C_INSTR_FROM_EMPTY, 0},  // size
-                         {C_INSTR_FROM_EMPTY, 0},  // data
-                         {C_INSTR_FROM_EMPTY, 0},  // tuple
+                         {C_INSTR_FROM_DEFAULT, 0},  // res // note: never push an empty result
+                         {C_INSTR_FROM_EMPTY, 0},    // fd
+                         {C_INSTR_FROM_EMPTY, 0},    // size
+                         {C_INSTR_FROM_EMPTY, 0},    // data
+                         {C_INSTR_FROM_EMPTY, 0},    // tuple
                  })},
         /*====================== RECVMSG ======================*/
         {conversion_key{PPME_SOCKET_RECVMSG_E, 1}, conversion_info().action(C_ACTION_STORE)},
@@ -694,12 +694,12 @@ const std::unordered_map<conversion_key, conversion_info> g_conversion_table = {
          conversion_info()
                  .action(C_ACTION_ADD_PARAMS)
                  .instrs({
-                         {C_INSTR_FROM_EMPTY, 0},  // res
-                         {C_INSTR_FROM_EMPTY, 0},  // fd
-                         {C_INSTR_FROM_EMPTY, 0},  // size
-                         {C_INSTR_FROM_EMPTY, 0},  // data
-                         {C_INSTR_FROM_EMPTY, 0},  // tuple
-                         {C_INSTR_FROM_EMPTY, 0},  // msgcontrol
+                         {C_INSTR_FROM_DEFAULT, 0},  // res // note: never push an empty result
+                         {C_INSTR_FROM_EMPTY, 0},    // fd
+                         {C_INSTR_FROM_EMPTY, 0},    // size
+                         {C_INSTR_FROM_EMPTY, 0},    // data
+                         {C_INSTR_FROM_EMPTY, 0},    // tuple
+                         {C_INSTR_FROM_EMPTY, 0},    // msgcontrol
                  })},
         /*====================== CREAT ======================*/
         {conversion_key{PPME_SYSCALL_CREAT_E, 0},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

sinsp expects the event result to be populated if present, so push zero instead of an empty parameter to not break sinsp assumptions.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
