### PR TITLE
chore!: replace unusable `SCAPEVENT_X` usage with `SCAPEVENT_E`

### DIFF
--- a/driver/bpf/fillers.h
+++ b/driver/bpf/fillers.h
@@ -5419,11 +5419,6 @@ FILLER(sys_symlinkat_x, true) {
 	return res;
 }
 
-FILLER(sys_scapevent_e, false) {
-	bpf_printk("f_sys_scapevent_e should never be called\n");
-	return PPM_FAILURE_BUG;
-}
-
 FILLER(cpu_hotplug_e, false) {
 	int res;
 

--- a/driver/event_stats.h
+++ b/driver/event_stats.h
@@ -12,6 +12,6 @@ or GPL2.txt for full copies of the license.
 /* These numbers must be updated when we add new events in the event table */
 #define SYSCALL_EVENTS_NUM 382
 #define TRACEPOINT_EVENTS_NUM 6
-#define METAEVENTS_NUM 19
+#define METAEVENTS_NUM 18
 #define PLUGIN_EVENTS_NUM 1
-#define UNKNOWN_EVENTS_NUM 22
+#define UNKNOWN_EVENTS_NUM 23

--- a/driver/event_table.c
+++ b/driver/event_table.c
@@ -1350,7 +1350,7 @@ const struct ppm_event_info g_event_info[] = {
                               2,
                               {{"event_type", PT_UINT32, PF_DEC},
                                {"event_data", PT_UINT64, PF_DEC}}},
-        [PPME_SCAPEVENT_X] = {"scapevent", EC_INTERNAL | EC_METAEVENT, EF_UNUSED, 0},
+        [PPME_SCAPEVENT_X] = {"NA", EC_UNKNOWN, EF_UNUSED, 0},
         [PPME_SYSCALL_SETUID_E] = {"setuid",
                                    EC_USER | EC_SYSCALL,
                                    EF_OLD_VERSION | EF_MODIFIES_STATE | EF_CONVERTER_MANAGED,

--- a/driver/fillers_table.c
+++ b/driver/fillers_table.c
@@ -116,7 +116,6 @@ const struct ppm_event_entry g_ppm_events[PPM_EVENT_MAX] = {
         [PPME_SYSCALL_QUOTACTL_X] = {FILLER_REF(sys_quotactl_x)},
         [PPME_SYSCALL_SETRESUID_X] = {FILLER_REF(sys_setresuid_x)},
         [PPME_SYSCALL_SETRESGID_X] = {FILLER_REF(sys_setresgid_x)},
-        [PPME_SCAPEVENT_E] = {FILLER_REF(sys_scapevent_e)},
         [PPME_SYSCALL_SETUID_X] = {FILLER_REF(sys_setuid_x)},
         [PPME_SYSCALL_SETGID_X] = {FILLER_REF(sys_setgid_x)},
         [PPME_SYSCALL_GETUID_X] = {FILLER_REF(sys_autofill), 1, APT_REG, {{AF_ID_RETVAL}}},

--- a/driver/main.c
+++ b/driver/main.c
@@ -1735,7 +1735,7 @@ static int record_event_consumer(struct ppm_consumer_t *consumer,
 
 	if(event_datap->category == PPMC_CONTEXT_SWITCH &&
 	   event_datap->event_info.context_data.sched_prev != NULL) {
-		if(event_type != PPME_SCAPEVENT_E && event_type != PPME_CPU_HOTPLUG_E) {
+		if(event_type != PPME_CPU_HOTPLUG_E) {
 			ASSERT(event_datap->event_info.context_data.sched_prev != NULL);
 			ASSERT(event_datap->event_info.context_data.sched_next != NULL);
 			ring_info->n_context_switches++;

--- a/driver/modern_bpf/definitions/events_dimensions.h
+++ b/driver/modern_bpf/definitions/events_dimensions.h
@@ -64,7 +64,6 @@
 #define SETRESUID_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) * 3 + PARAM_LEN * 4
 #define SETRESGID_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) * 3 + PARAM_LEN * 4
 #define SCAPEVENT_E_SIZE HEADER_LEN + sizeof(uint32_t) + sizeof(uint64_t) + PARAM_LEN * 2
-#define SCAPEVENT_X_SIZE HEADER_LEN
 #define SETUID_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 #define SETGID_X_SIZE HEADER_LEN + sizeof(int64_t) + sizeof(uint32_t) + PARAM_LEN * 2
 #define GETUID_X_SIZE HEADER_LEN + sizeof(uint32_t) + PARAM_LEN

--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -6631,24 +6631,6 @@ int f_sys_quotactl_x(struct event_filler_arguments *args) {
 	return add_sentinel(args);
 }
 
-int f_sys_scapevent_e(struct event_filler_arguments *args) {
-	int res;
-
-	/*
-	 * event_type
-	 */
-	res = val_to_ring(args, (unsigned long)args->sched_prev, 0, false, 0);
-	CHECK_RES(res);
-
-	/*
-	 * event_data
-	 */
-	res = val_to_ring(args, (unsigned long)args->sched_next, 0, false, 0);
-	CHECK_RES(res);
-
-	return add_sentinel(args);
-}
-
 int f_sys_getresuid_and_gid_x(struct event_filler_arguments *args) {
 	int res;
 	unsigned long val, len;

--- a/driver/ppm_fillers.h
+++ b/driver/ppm_fillers.h
@@ -79,7 +79,6 @@ or GPL2.txt for full copies of the license.
 	FN(sys_procexit_e)                   \
 	FN(sys_sendfile_x)                   \
 	FN(sys_quotactl_x)                   \
-	FN(sys_scapevent_e)                  \
 	FN(sys_getresuid_and_gid_x)          \
 	FN(sys_signaldeliver_e)              \
 	FN(sys_pagefault_e)                  \

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -683,8 +683,8 @@ TEST_F(sinsp_with_test_input, plugin_syscall_async) {
 	while(rc == SCAP_SUCCESS && cycles < max_cycles && count < max_count) {
 		cycles++;
 		rc = m_inspector.next(&evt);
-		/* The no driver engine sends only `PPME_SCAPEVENT_X` events */
-		if(rc == SCAP_TIMEOUT || evt->get_type() == PPME_SCAPEVENT_X) {
+		/* The no driver engine sends only `PPME_SCAPEVENT_E` events */
+		if(rc == SCAP_TIMEOUT || evt->get_type() == PPME_SCAPEVENT_E) {
 			// wait a bit so that the plugin can fire the async event
 			std::this_thread::sleep_for(std::chrono::nanoseconds(period_ns));
 			rc = SCAP_SUCCESS;

--- a/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
@@ -251,6 +251,7 @@ const libsinsp::events::set<ppm_event_code> expected_unknown_event_set = {
         PPME_TRACER_X,        PPME_CPU_HOTPLUG_X,
         PPME_PROCINFO_X,      PPME_SIGNALDELIVER_X,
         PPME_CONTAINER_X,     PPME_ASYNCEVENT_X,
+        PPME_SCAPEVENT_X,
 };
 
 /// todo(@Andreagit97): here we miss static sets for io, proc, net groups


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

/area driver-bpf

/area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

/area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

/version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR performs 3 major tasks:
- drops dead `PPME_SCAPEVENT_E` fillers and code
- replaces unusable `SCAPEVENT_X` events with `SCAPEVENT_E` events
- marks `PPME_SCAPEVENT_X` with `EC_UNKNOWN` and sets its name to `NA`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Not bumping the driver schema version is currently a practice we are following as we will bump it in a single shot once we are done with the https://github.com/falcosecurity/libs/pull/2068 proposal.

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
chore(driver)!: drop dead `PPME_SCAPEVENT_E` fillers and code
chore!: mark `PPME_SCAPEVENT_X` with `EC_UNKNOWN` and set name to `NA`
```
