### PR TITLE
chore!: drop remaining `evt.dir` refs in default output fmt and tests

### DIFF
--- a/test/e2e/tests/test_event_generator/test_file_writes.py
+++ b/test/e2e/tests/test_event_generator/test_file_writes.py
@@ -68,7 +68,6 @@ def test_file_writes(sinsp, run_containers: dict, expected_arg: str):
         {
             "evt.args": SinspField.regex_field(expected_arg),
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": SinspField.regex_field(r'^(?:open|openat|openat2)$'),

--- a/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_make_binary_dirs.py
@@ -27,7 +27,6 @@ def test_make_binary_dirs(sinsp, run_containers: dict):
         {
             "evt.args": "res=0 dirfd=-100(AT_FDCWD) path=/bin/directory-created-by-event-generator mode=1ED",
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "mkdirat",
@@ -37,7 +36,6 @@ def test_make_binary_dirs(sinsp, run_containers: dict):
         {
             "evt.args": "res=-21(EISDIR) dirfd=-100(AT_FDCWD) name=/bin/directory-created-by-event-generator flags=0",
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "unlinkat",
@@ -47,7 +45,6 @@ def test_make_binary_dirs(sinsp, run_containers: dict):
         {
             "evt.args": "res=0 dirfd=-100(AT_FDCWD) name=/bin/directory-created-by-event-generator flags=512(AT_REMOVEDIR)",
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "unlinkat",

--- a/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
+++ b/test/e2e/tests/test_event_generator/test_modify_binary_dirs.py
@@ -27,7 +27,6 @@ def test_modify_binary_dirs(sinsp, run_containers: dict):
         {
             "evt.args": "res=0 olddirfd=-100(AT_FDCWD) oldpath=/bin/true newdirfd=-100(AT_FDCWD) newpath=/bin/true.event-generator",
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "renameat",
@@ -37,7 +36,6 @@ def test_modify_binary_dirs(sinsp, run_containers: dict):
         {
             "evt.args": "res=0 olddirfd=-100(AT_FDCWD) oldpath=/bin/true.event-generator newdirfd=-100(AT_FDCWD) newpath=/bin/true",
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "renameat",

--- a/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
+++ b/test/e2e/tests/test_event_generator/test_non_sudo_setuid.py
@@ -26,13 +26,11 @@ def test_non_sudo_setuid(sinsp, run_containers):
     expected_events = [
         {
             "evt.args": "res=0 uid=2(<NA>)",
-            "evt.dir": "<",
             "evt.type": "setuid",
             "proc.name": "child",
         },
         {
             "evt.args": "res=-1(EPERM) uid=0(<NA>)",
-            "evt.dir": "<",
             "evt.type": "setuid",
             "proc.name": "child",
         },

--- a/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
+++ b/test/e2e/tests/test_event_generator/test_read_sensitive_file.py
@@ -57,7 +57,6 @@ def test_read_sensitive_file(sinsp, run_containers: dict, expected_process: str)
         {
             "evt.args": SinspField.regex_field(r'fd=3\(<f>/etc/shadow\) dirfd=-100\(AT_FDCWD\) name=/etc/shadow flags=69633\(O_RDONLY|O_CLOEXEC\|FD_LOWER_LAYER\) mode=0 dev=\W+ ino=\d+'),
             "evt.cpu": SinspField.numeric_field(),
-            "evt.dir": "<",
             "evt.num": SinspField.numeric_field(),
             "evt.time": SinspField.numeric_field(),
             "evt.type": "openat",

--- a/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
+++ b/test/e2e/tests/test_event_generator/test_run_shell_untrusted.py
@@ -8,7 +8,7 @@ containers = [{
     'generator': event_generator.container_spec('syscall.RunShellUntrusted')
 }]
 
-sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
+sinsp_filters = ["-f", "evt.type in (execve, execveat)"]
 sinsp_examples = [
     sinsp_example for sinsp_example in sinsp.generate_specs(args=sinsp_filters)
 ]

--- a/test/e2e/tests/test_event_generator/test_system_user_interactive.py
+++ b/test/e2e/tests/test_event_generator/test_system_user_interactive.py
@@ -3,7 +3,7 @@ from sinspqa import sinsp, event_generator
 from sinspqa.sinsp import assert_events, SinspField
 from sinspqa.docker import get_container_id
 
-sinsp_filters = ["-f", "evt.type in (execve, execveat) and evt.dir=<"]
+sinsp_filters = ["-f", "evt.type in (execve, execveat)"]
 
 containers = [{
     'generator': event_generator.container_spec('syscall.SystemUserInteractive')

--- a/test/e2e/tests/test_network/test_network.py
+++ b/test/e2e/tests/test_network/test_network.py
@@ -48,12 +48,10 @@ def expected_events(origin: dict, destination: dict) -> list:
             "proc.exe": "nginx: master proces",
         }, {
             "evt.args": f"res=0 fd=3(<4t>{origin['ip']}->{destination['ip']})",
-            "evt.dir": "<",
             "evt.type": "close",
             "proc.name": "curl",
         }, {
             "evt.args": f"res=0 fd=3(<4t>{origin['ip']}->{destination['ip']})",
-            "evt.dir": "<",
             "evt.type": "close",
             "proc.name": "nginx",
         }

--- a/test/libsinsp_e2e/ipv6.cpp
+++ b/test/libsinsp_e2e/ipv6.cpp
@@ -59,7 +59,7 @@ protected:
 		std::string filter =
 		        "evt.type in (socket, connect, recvfrom, sendto, close, accept, connect, bind, "
 		        "read, "
-		        "write, poll) and evt.dir=< and fd.type!=file and fd.type!=unix and fd.type!=file "
+		        "write, poll) and fd.type!=file and fd.type!=unix and fd.type!=file "
 		        "and "
 		        "fd.type!=pipe";
 		if(extra_filter) {
@@ -73,8 +73,7 @@ protected:
 	void check_ipv6_filterchecks(sinsp_evt* evt) {
 		std::string full_output;
 		std::string full =
-		        "*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type "
-		        "%evt.info";
+		        "*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.type %evt.info";
 		sinsp_evt_formatter(m_inspector.get(), full, m_filterlist).tostring(evt, &full_output);
 
 		verify_filtercheck(evt, "*%fd.type", "ipv6", full_output);
@@ -387,8 +386,7 @@ TEST_F(ipv6_filtercheck_test, test_ipv6_client) {
 
 		        std::string full_output;
 		        std::string full =
-		                "*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.dir "
-		                "%evt.type "
+		                "*%evt.num %evt.outputtime %evt.cpu %proc.name (%thread.tid) %evt.type "
 		                "%evt.info";
 		        sinsp_evt_formatter(m_inspector.get(), full, m_filterlist)
 		                .tostring(evt, &full_output);

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -287,7 +287,7 @@ void print_table_entries(sinsp& inspector) {
 #define EVENT_HEADER                        \
 	"%evt.num %evt.time cat=%evt.category " \
 	"proc=%proc.name(%proc.pid.%thread.tid) "
-#define EVENT_TRAILER "%evt.dir %evt.type %evt.args"
+#define EVENT_TRAILER "%evt.type %evt.args"
 
 #define EVENT_DEFAULTS EVENT_HEADER EVENT_TRAILER
 #define PROCESS_DEFAULTS \
@@ -703,8 +703,8 @@ static void print_perftest_table_data(const uint64_t num_events_diff,
 //
 // Sample filters:
 //   "evt.category=process or evt.category=net"
-//   "evt.dir=< and (evt.category=net or (evt.type=execveat or evt.type=execve or evt.type=clone or
-//   evt.type=fork or evt.type=vfork))"
+//   "evt.category=net or (evt.type=execveat or evt.type=execve or evt.type=clone or evt.type=fork
+//   or evt.type=vfork)"
 //
 int main(int argc, char** argv) {
 	sinsp inspector;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -110,7 +110,7 @@ class sinsp_usergroup_manager;
   \brief The default way an event is converted to string by the library
 */
 #define DEFAULT_OUTPUT_STR \
-	"*%evt.num %evt.time %evt.cpu %proc.name (%thread.tid) %evt.dir %evt.type %evt.args"
+	"*%evt.num %evt.time %evt.cpu %proc.name (%thread.tid) %evt.type %evt.args"
 
 /**
  * @brief Possible platforms to use with plugins


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR drops remaining references to the deprecated `evt.dir` filtercheck. Specifically, it drops them from tests and the default output format. Notice that this latter one is a breaking change from the UX perspective.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
chore!: drop remaining `evt.dir` refs in default output fmt and tests
```
