### PR TITLE
fix: fix heap buffer overflow while reading sockaddr in connect parser

### DIFF
--- a/test/libscap/test_suites/engines/savefile/converter.cpp
+++ b/test/libscap/test_suites/engines/savefile/converter.cpp
@@ -2577,8 +2577,10 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_no_enter) {
 	constexpr char tuple[] = "tuple";
 	constexpr int64_t fd = 25;
 
-	// Defaulted
-	constexpr uint8_t addr = PPM_AF_UNSPEC;
+	// Set to empty.
+	constexpr auto addr = empty_value<scap_const_sized_buffer>();
+
+	SCAP_EMPTY_PARAMS_SET(empty_params_set, 3);
 
 	assert_single_conversion_success(
 	        CONVERSION_PASS,
@@ -2589,14 +2591,15 @@ TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_no_enter) {
 	                               res,
 	                               scap_const_sized_buffer{tuple, sizeof(tuple)},
 	                               fd),
-	        create_safe_scap_event(ts,
-	                               tid,
-	                               PPME_SOCKET_CONNECT_X,
-	                               4,
-	                               res,
-	                               scap_const_sized_buffer{tuple, sizeof(tuple)},
-	                               fd,
-	                               scap_const_sized_buffer{&addr, sizeof(addr)}));
+	        create_safe_scap_event_with_empty_params(ts,
+	                                                 tid,
+	                                                 PPME_SOCKET_CONNECT_X,
+	                                                 &empty_params_set,
+	                                                 4,
+	                                                 res,
+	                                                 scap_const_sized_buffer{tuple, sizeof(tuple)},
+	                                                 fd,
+	                                                 addr));
 }
 
 TEST_F(convert_event_test, PPME_SOCKET_CONNECT_X_3_to_4_params_with_enter) {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2345,28 +2345,6 @@ void sinsp_parser::fill_client_socket_info_from_addr(sinsp_evt &evt,
 		}
 		break;
 	}
-	case PPM_AF_UNSPEC: {
-		switch(fdinfo->m_type) {
-		case SCAP_FD_IPV4_SOCK:
-			sockinfo.m_ipv4info.m_fields.m_dip = 0;
-			sockinfo.m_ipv4info.m_fields.m_dport = 0;
-			break;
-		case SCAP_FD_IPV6_SOCK:
-			sockinfo.m_ipv6info.m_fields.m_dip = ipv6addr::empty_address;
-			sockinfo.m_ipv6info.m_fields.m_dport = 0;
-			break;
-		default:
-			break;
-		}
-		sinsp_utils::sockinfo_to_str(&sockinfo,
-		                             fdinfo->m_type,
-		                             &evt.get_paramstr_storage()[0],
-		                             static_cast<uint32_t>(evt.get_paramstr_storage().size()),
-		                             can_resolve_hostname_and_port);
-
-		fdinfo->m_name = &evt.get_paramstr_storage()[0];
-		return;
-	}
 	default: {
 		// Add the friendly name to the fd info.
 		const char *parstr;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

/area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The current scap converter implementation push a 1-byte parameter value set to `PPM_AF_UNSPEC` as default `PT_SOCKADDR` value. This custom logic was introduced in `51c1ee3f4f19e5e13bbabcf00e4e6179e4c31bb4` and was intended to fix some regressions related to connect enter events parsing. Recently, connect enter event parsing custom logic was dropped, and the enter event is only used in the exit event parsing logic to implement TOCTOU mitigation. To the current implementation, the custom default value for sockaddrs is not useful anymore, and can be safely dropped. Dropping it, contextually fixes an heap buffer overflow issue due to missing checks in the sockaddr size.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The commit introducing the custom logic was introduced in https://github.com/falcosecurity/libs/issues/260.

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
