### PR TITLE
fix(test/drivers): avoid using invalid pid numbers

### DIFF
--- a/test/drivers/helpers/proc_parsing.cpp
+++ b/test/drivers/helpers/proc_parsing.cpp
@@ -149,3 +149,35 @@ bool get_proc_info(pid_t pid, proc_info* info) {
 
 	return true;
 }
+
+pid_t get_proc_max_pid() {
+	static pid_t maxpid = -1;
+
+	if(maxpid == -1) {
+		char path_to_read[MAX_PATH];
+
+		/*
+		 * Gather the maximum PID value on the system
+		 */
+		snprintf(path_to_read, sizeof(path_to_read), "/proc/sys/kernel/pid_max");
+		FILE* pidmax = fopen(path_to_read, "r");
+		if(pidmax == NULL) {
+			std::cerr << "'fopen /proc/sys/kernel/pid_max' must not fail: (" << errno << "), "
+			          << strerror(errno) << std::endl;
+			/*
+			 * If reading fails once, we don't try again
+			 */
+			maxpid = 0;
+			return 0;
+		}
+		if(fscanf(pidmax, "%d", &maxpid) != 1) {
+			std::cerr << "'fscanf /proc/sys/kernel/pid_max' must not fail: (" << errno << "), "
+			          << strerror(errno) << std::endl;
+			fclose(pidmax);
+			maxpid = 0;
+			return 0;
+		}
+		fclose(pidmax);
+	}
+	return maxpid;
+}

--- a/test/drivers/helpers/proc_parsing.h
+++ b/test/drivers/helpers/proc_parsing.h
@@ -27,3 +27,4 @@ struct proc_info {
 };
 
 bool get_proc_info(pid_t pid, proc_info* info);
+pid_t get_proc_max_pid();

--- a/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/clone3_x.cpp
@@ -256,14 +256,23 @@ TEST(SyscallExit, clone3X_create_child_with_2_threads) {
 
 	evt_test->enable_capture();
 
+	/* Get the maximum pid value from the proc filesystem in order
+	 * to prevent failures in systems where the pid has a low maximum
+	 * value (e.g. 32768).
+	 */
+	pid_t maxpid = get_proc_max_pid();
+	if(maxpid == 0) {
+		FAIL() << "Unable to get maximum pid info from proc" << std::endl;
+	}
+
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
 	/* Here we create a child process that will have:
 	 * - a leader thread with `tid` equal to `p1_t1`
 	 * - a second thread with `tid` equal to `p1_t2`.
 	 */
-	pid_t p1_t1 = 61001;
-	pid_t p1_t2 = 61004;
+	pid_t p1_t1 = 61001 % maxpid;
+	pid_t p1_t2 = 61004 % maxpid;
 
 	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
@@ -363,12 +372,21 @@ TEST(SyscallExit, clone3X_child_clone_parent_flag) {
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
+	/* Get the maximum pid value from the proc filesystem in order
+	 * to prevent failures in systems where the pid has a low maximum
+	 * value (e.g. 32768).
+	 */
+	pid_t maxpid = get_proc_max_pid();
+	if(maxpid == 0) {
+		FAIL() << "Unable to get maximum pid info from proc" << std::endl;
+	}
+
 	/* Here we create a child process that will have:
 	 * - a leader thread with `tid` equal to `p1_t1`
 	 * - a child process with `tid` equal to `p2_t1`
 	 */
-	pid_t p1_t1 = 61024;
-	pid_t p2_t1 = 60128;
+	pid_t p1_t1 = 61024 % maxpid;
+	pid_t p2_t1 = 60128 % maxpid;
 
 	clone_args cl_args_parent = {};
 	cl_args_parent.set_tid = (uint64_t)&p1_t1;
@@ -475,8 +493,17 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_child) {
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
+	/* Get the maximum pid value from the proc filesystem in order
+	 * to prevent failures in systems where the pid has a low maximum
+	 * value (e.g. 32768).
+	 */
+	pid_t maxpid = get_proc_max_pid();
+	if(maxpid == 0) {
+		FAIL() << "Unable to get maximum pid info from proc" << std::endl;
+	}
+
 	/* Here we create a child process in a new namespace. */
-	pid_t p1_t1[2] = {1, 61032};
+	pid_t p1_t1[2] = {1, 61032 % maxpid};
 
 	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;
@@ -558,8 +585,17 @@ TEST(SyscallExit, clone3X_child_new_namespace_from_caller) {
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
+	/* Get the maximum pid value from the proc filesystem in order
+	 * to prevent failures in systems where the pid has a low maximum
+	 * value (e.g. 32768).
+	 */
+	pid_t maxpid = get_proc_max_pid();
+	if(maxpid == 0) {
+		FAIL() << "Unable to get maximum pid info from proc" << std::endl;
+	}
+
 	/* Here we create a child process in a new namespace. */
-	pid_t p1_t1[2] = {1, 61032};
+	pid_t p1_t1[2] = {1, 61032 % maxpid};
 
 	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;
@@ -634,13 +670,22 @@ TEST(SyscallExit, clone3X_child_new_namespace_create_thread) {
 
 	/*=============================== TRIGGER SYSCALL  ===========================*/
 
+	/* Get the maximum pid value from the proc filesystem in order
+	 * to prevent failures in systems where the pid has a low maximum
+	 * value (e.g. 32768).
+	 */
+	pid_t maxpid = get_proc_max_pid();
+	if(maxpid == 0) {
+		FAIL() << "Unable to get maximum pid info from proc" << std::endl;
+	}
+
 	/* Here we create a child process in a new namespace.
 	 * The child process will have `tid` equal to `p1_t1`.
 	 * The child process will create a new thread with `tid` equal to `p1_t2`
 	 */
-	pid_t p1_t1[2] = {1, 61032};
+	pid_t p1_t1[2] = {1, 61032 % maxpid};
 	/* Please note that a process can have the same pid number in different namespaces */
-	pid_t p1_t2[2] = {61036, 61036};
+	pid_t p1_t2[2] = {61036 % maxpid, 61036 % maxpid};
 
 	clone_args cl_args = {};
 	cl_args.set_tid = (uint64_t)&p1_t1;


### PR DESCRIPTION
In some systems the maximum value of pid is limited to a low value such as e.g. 32768. Some of the driver tests are currently using values that exceed this limit in certain systems. This leads to failing driver tests due to an error in properly setting up the test case.

Fit the value of the pid within the boudaries by reading the system's maximum allowed pid value from
`/proc/sys/kernel/pid_max` and running modulos operator.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR will fix the problems with the driver tests when using a system such as SLES15 SP6 which limits the maximum value of the pid to a value which is lower than the values used in the driver tests.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2413

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
