### PR TITLE
ci(worflows/release-body): fix latest release fetching

### DIFF
--- a/.github/workflows/release-body.yml
+++ b/.github/workflows/release-body.yml
@@ -12,16 +12,26 @@ jobs:
   release-settings:
     runs-on: ubuntu-latest
     outputs:
-      is_latest: ${{ steps.get_settings.outputs.is_latest }}
-      is_driver: ${{ steps.get_settings.outputs.is_driver }}
+      is_latest_drivers: ${{ steps.get_settings.outputs.is_latest_drivers }}
+      is_latest_libs: ${{ steps.get_settings.outputs.is_latest_libs }}
     steps:
-      - name: Get latest release
-        uses: rez0n/actions-github-release@27a57820ee808f8fd940c8a9d1f7188f854aa2b5 # v2.0
-        id: latest_release
+      - name: Get latest drivers release
+        uses: ekoops/actions-github-release@667c095dfa9c26dc09bef7647fed6941254b286a # 0.1.0
+        id: latest_drivers_release
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           type: "stable"
+          filter: '^.*\+driver$' # Only include drivers releases.
+
+      - name: Get latest libs release
+        uses: ekoops/actions-github-release@667c095dfa9c26dc09bef7647fed6941254b286a # 0.1.0
+        id: latest_libs_release
+        env:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          type: "stable"
+          filter: '^.*(?<!\+driver)$' # Exclude drivers releases.
 
       - name: Get settings for this release
         id: get_settings
@@ -41,18 +51,26 @@ jobs:
 
           is_prerelease = '-' in tag_name
 
+          latest_drivers_release = '${{ steps.latest_drivers_release.outputs.release }}'
+          latest_libs_release = '${{ steps.latest_libs_release.outputs.release }}'
           # Safeguard: you need to both set "latest" in GH and not have suffixes to overwrite latest
-          is_latest = '${{ steps.latest_release.outputs.release }}' == tag_name and not is_prerelease
+          is_latest_drivers = tag_name == latest_drivers_release and not is_prerelease
+          is_latest_libs = tag_name == latest_libs_release and not is_prerelease
 
-          is_driver = "+driver" in tag_name
+          # Print useful info for debugging purposes.
+          print(f'tag name: {tag_name}')
+          print(f'latest drivers release: {latest_drivers_release}')
+          print(f'latest libs release: {latest_libs_release}')
+          print(f'is latest drivers release: {is_latest_drivers}')
+          print(f'is latest libs release: {is_latest_drivers}')
 
           with open(os.environ['GITHUB_OUTPUT'], 'a') as ofp:
-            print(f'is_latest={is_latest}'.lower(), file=ofp)
-            print(f'is_driver={is_driver}'.lower(), file=ofp)
+            print(f'is_latest_drivers={is_latest_drivers}'.lower(), file=ofp)
+            print(f'is_latest_libs={is_latest_libs}'.lower(), file=ofp)
 
   release-body-libs:
     needs: [release-settings]
-    if: ${{ needs.release-settings.outputs.is_latest == 'true' && needs.release-settings.outputs.is_driver == 'false' }} # only for latest releases and not driver ones
+    if: ${{ needs.release-settings.outputs.is_latest_libs == 'true' }} # Only for latest libs releases.
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -106,15 +124,15 @@ jobs:
 
   kernel-tests-release:
     needs: [release-settings]
-    if: ${{ needs.release-settings.outputs.is_latest == 'true' && needs.release-settings.outputs.is_driver == 'true' }} # only for latest driver releases
+    if: ${{ needs.release-settings.outputs.is_latest_drivers == 'true' }} # Only for latest drivers releases.
     uses: ./.github/workflows/reusable_kernel_tests.yaml
     with:
       libsversion: ${{ github.event.release.tag_name }}
     secrets: inherit
 
-  release-body-driver:
+  release-body-drivers:
     needs: [release-settings, kernel-tests-release]
-    if: ${{ needs.release-settings.outputs.is_latest == 'true' && needs.release-settings.outputs.is_driver == 'true' }} # only for latest driver releases
+    if: ${{ needs.release-settings.outputs.is_latest_drivers == 'true' }} # Only for latest drivers releases.
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

/area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

At the same time, there are two latest releases:
- the latest libs release
- the latest drivers release
 
This PR accounts for this distinction while generating release body for published releases.
The need raised because I realized that the release body of the `0.22.0` libs release was not updated by this run: https://github.com/falcosecurity/libs/actions/runs/18587421906 . The reason was that the `rez0n/actions-github-release` Github Action retrieved `9.0.0+driver` as latest release (indeed, the latest driver release, but not the latest libs release), letting `is_latest` latest to be set to false (https://github.com/falcosecurity/libs/actions/runs/18587421906/job/52994393705#step:4:17) and preventing the execution of `release-body-libs` job.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
