### PR TITLE
test(drivers/syscall_exit/execveat_x): fix `comm` assertion

### DIFF
--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -1132,6 +1132,31 @@ void event_test::assert_charbuf_param(int param_num, const char* param) {
 	        << VALUE_NOT_CORRECT << m_current_param << std::endl;
 }
 
+void event_test::assert_charbuf_param_any_of(const int param_num,
+                                             const std::vector<const char*>& candidates) {
+	assert_param_boundaries(param_num);
+	ASSERT_GT(candidates.size(), 0);
+	const auto& [param_value, param_size] = m_event_params[m_current_param];
+	for(const auto& candidate : candidates) {
+		// 'strlen()' does not include the terminating null byte while drivers adds it.
+		if(const auto candidate_size = strlen(candidate) + 1; param_size != candidate_size) {
+			continue;
+		}
+		if(!strncmp(param_value, candidate, param_size)) {
+			return;
+		}
+	}
+
+	// The parameter didn't match any of the provided candidates. Fail with a useful error message.
+	std::ostringstream oss;
+	oss << VALUE_NOT_CORRECT << m_current_param << ", value = \"" << param_value
+	    << "\". It must be equal to any of the provided candidates:\n";
+	for(const auto& value : candidates) {
+		oss << "- \"" << std::string{value} << "\"\n";
+	}
+	FAIL() << oss.str();
+}
+
 void event_test::assert_charbuf_array_param(int param_num, const char** param) {
 	assert_param_boundaries(param_num);
 	uint16_t total_len = 0;

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -567,6 +567,8 @@ public:
 	 */
 	void assert_charbuf_param(int param_num, const char* param);
 
+	void assert_charbuf_param_any_of(int param_num, const std::vector<const char*>& candidates);
+
 	/**
 	 * @brief Assert that the parameter is a `charbuf` array and
 	 * compare element per element the array with the one passed as a parameter `param`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`SyscallExit.execveatX_execve_exit_comm_equal_to_fd` test asserts the `comm` parameter value among the others. For kernel versions lower than 6.14, if the `AT_EMPTY_PATH` flag is specified while invoking execveat, the comm value is expected to be set to the dirfd numeric value. Starting from 6.14 (https://github.com/torvalds/linux/commit/543841d1806029889c2f69f040e88b247aba8e22), this strange behaviour has been fixed, and the exact same execveat
invocation results in the comm value to be correctly set to the dentry's filename value. For this reason, this PR patches the test code to account for both scenarios while testing for the `comm` parameter to match the expectation.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
