### PR TITLE
sync(0.22.2): fix(userspace/libsinsp): correct fallback for arg-less proc.* fields

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -836,10 +836,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.apid", val, NULL);
 		} catch(...) {
-			if(val == "proc.apid") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.apid")) - 1;
 		}
 
 		return res;
@@ -852,10 +850,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.aname", val, NULL);
 		} catch(...) {
-			if(val == "proc.aname") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.aname")) - 1;
 		}
 
 		return res;
@@ -868,10 +864,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.aexepath", val, NULL);
 		} catch(...) {
-			if(val == "proc.aexepath") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.aexepath")) - 1;
 		}
 
 		return res;
@@ -887,10 +881,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.aexe", val, NULL);
 		} catch(...) {
-			if(val == "proc.aexe") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.aexe")) - 1;
 		}
 
 		return res;
@@ -903,10 +895,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.acmdline", val, NULL);
 		} catch(...) {
-			if(val == "proc.acmdline") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.acmdline")) - 1;
 		}
 
 		return res;
@@ -919,10 +909,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.aargs", val, NULL);
 		} catch(...) {
-			if(val == "proc.aargs") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.aargs")) - 1;
 		}
 
 		return res;
@@ -935,10 +923,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.env", val, NULL);
 		} catch(...) {
-			if(val == "proc.env") {
-				m_argname.clear();
-				res = (int32_t)val.size();
-			}
+			m_argname.clear();
+			res = static_cast<int32_t>(std::size("proc.env")) - 1;
 		}
 
 		return res;
@@ -951,10 +937,8 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.args", val, NULL);
 		} catch(...) {
-			if(val == "proc.args") {
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.args")) - 1;
 		}
 
 		return res;
@@ -967,11 +951,9 @@ int32_t sinsp_filter_check_thread::parse_field_name(std::string_view val,
 		try {
 			res = extract_arg("proc.aenv", val, NULL);
 		} catch(...) {
-			if(val == "proc.aenv") {
-				m_argname.clear();
-				m_argid = -1;
-				res = (int32_t)val.size();
-			}
+			m_argname.clear();
+			m_argid = -1;
+			res = static_cast<int32_t>(std::size("proc.aenv")) - 1;
 		}
 
 		return res;


### PR DESCRIPTION
Parsing of ARG_ALLOWED fields in output formatting (e.g., `proc_args=%proc.args`) was broken because the `val ==` check always returned false. This fix drops the unnecessary checks so that `argid = -1` is set /, `argname` is cleared where appropriate, and correctly sets field-name length using `std::size(...)-1`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

/kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.22.2

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
