### PR TITLE
fix(userspace/libsinsp): prevent infinite loop in ancillary data pars…

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3207,6 +3207,10 @@ static ppm_cmsghdr *ppm_cmsg_nxthdr(char const *msg_control,
 	}
 
 	size_t const cmsg_aligned_len = PPM_CMSG_ALIGN(cmsg_len);
+	// Guard against infinite loop: ensure we advance by at least sizeof(ppm_cmsghdr)
+	if(cmsg_aligned_len < sizeof(ppm_cmsghdr)) {
+		return nullptr;
+	}
 	cmsg = reinterpret_cast<ppm_cmsghdr *>(reinterpret_cast<char *>(cmsg) + cmsg_aligned_len);
 	if(reinterpret_cast<char *>(cmsg + 1) > msg_control + msg_controllen ||
 	   reinterpret_cast<char *>(cmsg) + cmsg_aligned_len > msg_control + msg_controllen) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Add validation in `ppm_cmsg_nxthdr` to ensure `cmsg_aligned_len` is at `least sizeof(ppm_cmsghdr)` after alignment calculation. 
This prevents an infinite loop when malformed ancillary data contains `cmsg_len = 0xFFFFFFFFFFFFFFFF`, which causes integer overflow in `PPM_CMSG_ALIGN` macro, resulting in `cmsg_aligned_len = 0` and preventing forward progress in the loop inside `rocess_recvmsg_ancillary_data`

**More details:**
I experienced a malfunctioning caused by an infinite tight loop when we process ancillary data from `recvmsg() / recvmmsg()`.

Look at [ppm_cmsg_nxthdr](https://github.com/draios/agent-libs/blob/519813872512e3f1bea4628b0aeb56d43fa6cbd6/userspace/libsinsp/parsers.cpp#L3649)

If a control message contains a broken `cmsg_len` value equal to `0xFFFFFFFFFFFFFFFF`, we hit an integer overflow during the alignment calculation. Because of this, the aligned length becomes 0

```
#define PPM_CMSG_ALIGN(len) (((len) + sizeof(size_t) - 1) & (size_t) ~(sizeof(size_t) - 1))
// On 64-bit systems with sizeof(size_t) = 8:
cmsg_aligned_len = ((0xFFFFFFFFFFFFFFFF + 7) & ~7)
                 = (0x0000000000000006 & 0xFFFFFFFFFFFFFFF8)  // Overflow!
                 = 0x0000000000000000
```

The addition `0xFFFFFFFFFFFFFFFF + 7` wraps around to `0x0000000000000006` due to integer overflow. After masking, the result is 0.

The infinite loop happens here:

[sinsp_parser::process_recvmsg_ancillary_data](https://github.com/draios/agent-libs/blob/519813872512e3f1bea4628b0aeb56d43fa6cbd6/userspace/libsinsp/parsers.cpp#L3691)


```
	for(ppm_cmsghdr *cmsg = PPM_CMSG_FIRSTHDR(msg_ctrl, msg_ctrllen); cmsg != nullptr;
	    cmsg = PPM_CMSG_NXTHDR(msg_ctrl, msg_ctrllen, cmsg)) <--- ALWAYS THE SAME{
		// Check for malformed control message buffer:
		if(reinterpret_cast<const char *>(cmsg) < msg_ctrl ||
		   reinterpret_cast<const char *>(cmsg) >= msg_ctrl + msg_ctrllen) {
			libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
			                          "Malformed ancillary data, skipping.");
			break;
		}
		int cmsg_type;
		PPM_CMSG_UNALIGNED_READ(cmsg, cmsg_type, cmsg_type);
		if(cmsg_type != SCM_RIGHTS) {
			continue; <-- CONTINUE FOR EVER
		}
```
When `cmsg_aligned_len = 0`, the pointer advancement soon before the for statement became

```
cmsg = reinterpret_cast<ppm_cmsghdr *>(reinterpret_cast<char *>(cmsg) + 0);
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
