### PR TITLE
perf(userspace/libscap): rewrite `/proc/<pid>/status` parsing logic

### DIFF
--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -248,45 +248,73 @@ static void parse_procfs_proc_pid_status_line(
         const size_t line_len,
         struct scap_threadinfo* tinfo,
         struct parse_procfs_proc_pid_status_counters* counters) {
-	if(BEGIN_WITH_LITERAL(line, line_len, "Tgid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_tgid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "Uid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_uid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "Gid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_gid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "CapInh:")) {
-		counters->caps_nfound++;
-		parse_procfs_proc_pid_status_cap_inh_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "CapPrm:")) {
-		counters->caps_nfound++;
-		parse_procfs_proc_pid_status_cap_prm_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "CapEff:")) {
-		counters->caps_nfound++;
-		parse_procfs_proc_pid_status_cap_eff_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "PPid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_ppid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "VmSize:")) {
-		counters->vm_nfound++;
-		parse_procfs_proc_pid_status_vmsize_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "VmRSS:")) {
-		counters->vm_nfound++;
-		parse_procfs_proc_pid_status_vmrss_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "VmSwap:")) {
-		counters->vm_nfound++;
-		parse_procfs_proc_pid_status_vmswap_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "NSpid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_nspid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "NSpgid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_nspgid_line(line, tinfo);
-	} else if(BEGIN_WITH_LITERAL(line, line_len, "NStgid:")) {
-		counters->pidinfo_nfound++;
-		parse_procfs_proc_pid_status_nstgid_line(line, tinfo);
+	const char first_char = *line;
+	// note: the following switch case logic helps to avoid much of the comparisons in two ways:
+	// - if the first letter doesn't match any of the case, all other comparisons are skipped
+	// - if the first letter matches, only few comparisons are performed.
+	switch(first_char) {
+	case 'T':
+		if(BEGIN_WITH_LITERAL(line, line_len, "Tgid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_tgid_line(line, tinfo);
+		}
+		break;
+	case 'U':
+		if(BEGIN_WITH_LITERAL(line, line_len, "Uid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_uid_line(line, tinfo);
+		}
+		break;
+	case 'G':
+		if(BEGIN_WITH_LITERAL(line, line_len, "Gid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_gid_line(line, tinfo);
+		}
+		break;
+	case 'C':
+		if(BEGIN_WITH_LITERAL(line, line_len, "CapInh:")) {
+			counters->caps_nfound++;
+			parse_procfs_proc_pid_status_cap_inh_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "CapPrm:")) {
+			counters->caps_nfound++;
+			parse_procfs_proc_pid_status_cap_prm_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "CapEff:")) {
+			counters->caps_nfound++;
+			parse_procfs_proc_pid_status_cap_eff_line(line, tinfo);
+		}
+		break;
+	case 'P':
+		if(BEGIN_WITH_LITERAL(line, line_len, "PPid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_ppid_line(line, tinfo);
+		}
+		break;
+	case 'V':
+		if(BEGIN_WITH_LITERAL(line, line_len, "VmSize:")) {
+			counters->vm_nfound++;
+			parse_procfs_proc_pid_status_vmsize_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "VmRSS:")) {
+			counters->vm_nfound++;
+			parse_procfs_proc_pid_status_vmrss_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "VmSwap:")) {
+			counters->vm_nfound++;
+			parse_procfs_proc_pid_status_vmswap_line(line, tinfo);
+		}
+		break;
+	case 'N':
+		if(BEGIN_WITH_LITERAL(line, line_len, "NSpid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_nspid_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "NSpgid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_nspgid_line(line, tinfo);
+		} else if(BEGIN_WITH_LITERAL(line, line_len, "NStgid:")) {
+			counters->pidinfo_nfound++;
+			parse_procfs_proc_pid_status_nstgid_line(line, tinfo);
+		}
+		break;
+	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR refactors the `/proc/<pid>/status` parsing logic to achieve better performance. The previous logic used 1 single `fopen()` to open the `/proc/<pid>/status` file, and 1 `fgets()` for each single line in the file; then, each line was matched against a set of prefixes using `strstr()` and, for each match, `sscanf()` was used to parse the line content.

The new parsing logic, introduced in the first commit, introduces the following optimizations:
- use `open()` and `read()` to avoid `fopen()` and `fgets()` allocation, buffering and lock acquisition overheads
- try to read the entire file content with a single `read()`, reducing the overhead of issuing ~30 `fread()` (30 is approximately the position of the last interesting row in the `/proc/<pid>/status` file, which is the `VmSwap: ...` line for the current logic). In the extremely unlikely case in which the file content is bigger than the stack-allocated buffer of 4096 bytes, the unprocessed content (the last truncated line) is shifted at the beginning of the buffer, and a new read is attempted (this practically never happens in common scenarios, as the file content typically never exceeds 2kB)
- avoid the overhead of `strstr()` (which searches for a match at any position in the line) with a simple prefix check leveraging `memcmp()`
- avoid the overhead of `sscanf()` by skipping the already checked prefix and by parsing numbers with simpler calls to `strtoull()`

The second commit replaces if-else big chain in `parse_procfs_proc_pid_status_line()` with a switch lookup table. This allows to avoid wasting too much resources in memory comparisons. The switch case logic helps to avoid much of the comparisons in two ways:
- if the first letter doesn't match any of the case, all other comparisons are skipped
- if the first letter matches, only few comparisons are performed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
