### PR TITLE
fix(driver): fix building scap driver against clang+LTO enabled kernel

### DIFF
--- a/driver/configure/Makefile.inc.in
+++ b/driver/configure/Makefile.inc.in
@@ -1,9 +1,9 @@
 MODULE_MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Run the module build.sh (wrapper for make) script with an empty environment,
-# but pass PATH, KERNELDIR and eventually (if set) CC and KBUILD_MODPOST_WARN.
+# but pass PATH, KERNELDIR and eventually (if set) CC, LD and KBUILD_MODPOST_WARN.
 # The latter ones are used by driverkit build templates.
-HAS_@CONFIGURE_MODULE@ := $(shell env -i CC="$(CC)" KBUILD_MODPOST_WARN="$(KBUILD_MODPOST_WARN)" PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
+HAS_@CONFIGURE_MODULE@ := $(shell env -i CC="$(CC)" LD="$(LD)" KBUILD_MODPOST_WARN="$(KBUILD_MODPOST_WARN)" PATH="$(PATH)" KERNELDIR="$(KERNELDIR)" sh $(MODULE_MAKEFILE_DIR)/build.sh ; echo $$?)
 
 ifeq ($(HAS_@CONFIGURE_MODULE@),0)
 $(info [configure-kmod] Setting HAS_@CONFIGURE_MODULE@ flag)

--- a/driver/configure/build.sh
+++ b/driver/configure/build.sh
@@ -10,4 +10,4 @@
 SCRIPT=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname ${SCRIPT})
 
-make CC="${CC}" -C ${SCRIPT_DIR} > ${SCRIPT_DIR}/build.log 2>&1
+make CC="${CC}" LD="${LD}" -C ${SCRIPT_DIR} > ${SCRIPT_DIR}/build.log 2>&1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No

**What this PR does / why we need it**:
Properly use an injected LD which is necessary for linking the scap module against an LTO-built kernel. Otherwise the kmod configuration tests do not compile, incorrectly signal failure to the build which will then fail with the same incorrect message as in https://github.com/draios/sysdig/issues/2151. Originally reported downstream at https://bugs.gentoo.org/968857

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
