### PR TITLE
fix(userspace/libscap): re-add interruption resiliency to reads

### DIFF
--- a/userspace/libscap/linux/read_helpers.h
+++ b/userspace/libscap/linux/read_helpers.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+#include <unistd.h>
+#include <asm-generic/errno-base.h>
+#include <errno.h>
+#include <libscap/scap_assert.h>
+
+// Strive to read exactly `count` bytes from `fd` into `buff`. Read fewer bytes if an error other
+// than `EINTR` occurs or EOF is reached before reading them. The return value has the same semantic
+// of the `read()` system call return value.
+// note: `noinline` is needed in order to avoid GCC from messing out with `buff` boundaries and
+// telling that the underlying read operation could overflow.
+// note: `unused` is needed in order to avoid GCC to complain about source files including this
+// header while not using this function.
+static ssize_t __attribute__((noinline, unused)) read_exact(const int fd,
+                                                            void *buff,
+                                                            const size_t count) {
+	size_t total_read_bytes = 0;
+	while(1) {
+		const ssize_t read_bytes =
+		        read(fd, (char *)buff + total_read_bytes, count - total_read_bytes);
+		if(read_bytes == -1) {
+			// Re-attempt read upon signal.
+			if(errno == EINTR) {
+				continue;
+			}
+			return read_bytes;
+		}
+
+		if(read_bytes == 0) {
+			return total_read_bytes;
+		}
+
+		total_read_bytes += read_bytes;
+		if(total_read_bytes == count) {
+			return count;
+		}
+	}
+
+	// Unreachable.
+	ASSERT(false);
+	return total_read_bytes;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR attempts to address an issue identified in https://github.com/falcosecurity/libs/pull/2798#discussion_r2708288534.
Upon signal reception, `read()` operation can return -1 and set `errno` to `EINTR`, or read fewer bytes then the specified one. This patch adds an helper `read_exact()` that strives to read exactly `N` bytes from an fd into a provided buffer: specifically, the helper re-attempts to read if the read operation didn't fill the buffer or returned -1 while setting `errno` to `EINTR`.

Besides introducing the helper, it uses it in differently places or corrects the pre-existing logic to do something similar.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
