### PR TITLE
feat(userspace/libsinsp/example): Allow running under Windows

### DIFF
--- a/.github/install-deps.sh
+++ b/.github/install-deps.sh
@@ -60,3 +60,11 @@ wget -P "/usr/include" "https://raw.githubusercontent.com/troydhanson/uthash/v1.
 echo "=== Downloading BS_thread_pool.h (4.1.0) ==="
 
 wget -P "/usr/include" "https://github.com/bshoshany/thread-pool/raw/v4.1.0/include/BS_thread_pool.hpp"
+
+# === cxxopts ===
+if [ ! -f "/usr/include/cxxopts.hpp" ]; then
+    echo "=== Downloading cxxopts.hpp (3.3.1) ==="
+    wget -P "/usr/include" "https://raw.githubusercontent.com/jarro2783/cxxopts/refs/tags/v3.3.1/include/cxxopts.hpp"
+else
+    echo "=== cxxopts.hpp already exists, skipping download ==="
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Install deps ⛓️
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install c-ares re2 tbb jq jsoncpp openssl uthash
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install c-ares re2 tbb jq jsoncpp openssl uthash cxxopts
 
       - name: Build 🏗️
         run: |
@@ -248,7 +248,7 @@ jobs:
       - name: Install deps ⛓️
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends ca-certificates build-essential clang-14 llvm-14 git pkg-config autoconf automake libtool libelf-dev libcap-dev linux-headers-$(uname -r)
+          sudo apt install -y --no-install-recommends ca-certificates build-essential clang-14 llvm-14 git pkg-config autoconf automake libtool libelf-dev libcap-dev libcxxopts-dev linux-headers-$(uname -r)
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
           sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
           sudo update-alternatives --install /usr/bin/llc llc /usr/bin/llc-14 90

--- a/cmake/modules/cxxopts.cmake
+++ b/cmake/modules/cxxopts.cmake
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2026 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+#
+# cxxopts (https://github.com/jarro2783/cxxopts)
+#
+
+option(USE_BUNDLED_CXXOPTS "Enable building of the bundled cxxopts" ${USE_BUNDLED_DEPS})
+
+if(CXXOPTS_INCLUDE_DIR)
+	# we already have cxxopts
+elseif(NOT USE_BUNDLED_CXXOPTS)
+	find_package(cxxopts CONFIG)
+	if(CXXOPTS_INCLUDE_DIR)
+		get_target_property(CXXOPTS_INCLUDE_DIR cxxopts::cxxopts INTERFACE_INCLUDE_DIRECTORIES)
+	else()
+		# Was it manually installed?
+		find_path(CXXOPTS_INCLUDE_DIR cxxopts.hpp)
+		if(CXXOPTS_INCLUDE_DIR)
+			message(STATUS "Found cxxopts: include: ${CXXOPTS_INCLUDE_DIR}")
+		else()
+			message(FATAL_ERROR "Couldn't find system cxxopts")
+		endif()
+	endif()
+else()
+	set(CXXOPTS_SRC "${PROJECT_BINARY_DIR}/cxxopts-prefix/src/cxxopts/")
+	set(CXXOPTS_INCLUDE_DIR "${CXXOPTS_SRC}/include")
+
+	message(STATUS "Using bundled cxxopts in ${CXXOPTS_SRC}")
+
+	ExternalProject_Add(
+		cxxopts
+		URL "https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.3.1.tar.gz"
+		URL_HASH "SHA256=3bfc70542c521d4b55a46429d808178916a579b28d048bd8c727ee76c39e2072"
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""
+		INSTALL_COMMAND ""
+	)
+endif()
+
+if(NOT TARGET cxxopts)
+	add_custom_target(cxxopts)
+endif()

--- a/cmake/modules/libsinsp.cmake
+++ b/cmake/modules/libsinsp.cmake
@@ -35,6 +35,7 @@ if(NOT HAVE_LIBSINSP)
 	include(jsoncpp)
 	include(valijson)
 	include(re2)
+	include(cxxopts)
 
 	if(ENABLE_THREAD_POOL AND NOT EMSCRIPTEN)
 		include(bs_threadpool)

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -13,6 +13,7 @@
 # the License.
 #
 
+include(cxxopts)
 include(jsoncpp)
 
 set(sources util.cpp test.cpp)
@@ -23,6 +24,7 @@ endif()
 
 add_executable(sinsp-example ${sources})
 
+target_include_directories(sinsp-example PRIVATE "${CXXOPTS_INCLUDE_DIR}")
 target_link_libraries(sinsp-example sinsp "${JSONCPP_LIB}")
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
Change command line option parsing from getopt_long to cxxopts, which lets us run on Windows.

Initial conversion was done using Claude Sonnet 4.5, then cleaned up manually.

cxxopts.cmake was copied from the Falco repository and updated to version 3.1.1.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This switches command line option parsing in sinsp-example to cxxopts, which supports Windows.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
