### PR TITLE
fix(build): disable clang/ASAN check for offsetof hack

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -127,7 +127,11 @@ libsinsp::state::static_struct::field_infos sinsp_fdinfo::static_fields() const 
 	return get_static_fields();
 }
 
-libsinsp::state::static_struct::field_infos sinsp_fdinfo::get_static_fields() {
+#if defined(__clang__)
+__attribute__((no_sanitize("undefined")))
+#endif
+libsinsp::state::static_struct::field_infos
+sinsp_fdinfo::get_static_fields() {
 	using self = sinsp_fdinfo;
 
 	libsinsp::state::static_struct::field_infos ret;

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -237,7 +237,11 @@ public:
 	 * @brief Returns the offset of m_this_ptr. Here for convenience as required in other code
 	 * parts.
 	 */
-	static size_t table_ptr_offset() {
+#if defined(__clang__)
+	__attribute__((no_sanitize("undefined")))
+#endif
+	static size_t
+	table_ptr_offset() {
 		return OFFSETOF_STATIC_FIELD(built_in_table<KeyType>, m_this_ptr);
 	}
 

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -31,7 +31,11 @@ TEST(typeinfo, basic_tests) {
 
 TEST(static_struct, defs_and_access) {
 	struct err_multidef_struct : public libsinsp::state::static_struct {
-		libsinsp::state::static_struct::field_infos static_fields() const override {
+#if defined(__clang__)
+		__attribute__((no_sanitize("undefined")))
+#endif
+		libsinsp::state::static_struct::field_infos
+		static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
 			DEFINE_STATIC_FIELD(ret, err_multidef_struct, m_num, "num");
 			DEFINE_STATIC_FIELD(ret, err_multidef_struct, m_num, "num");
@@ -43,7 +47,11 @@ TEST(static_struct, defs_and_access) {
 
 	class sample_struct : public libsinsp::state::static_struct {
 	public:
-		libsinsp::state::static_struct::field_infos static_fields() const override {
+#if defined(__clang__)
+		__attribute__((no_sanitize("undefined")))
+#endif
+		libsinsp::state::static_struct::field_infos
+		static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
 			DEFINE_STATIC_FIELD(ret, sample_struct, m_num, "num");
 			DEFINE_STATIC_FIELD_READONLY(ret, sample_struct, m_str, "str");
@@ -62,7 +70,11 @@ TEST(static_struct, defs_and_access) {
 
 	struct sample_struct2 : public libsinsp::state::static_struct {
 	public:
-		libsinsp::state::static_struct::field_infos static_fields() const override {
+#if defined(__clang__)
+		__attribute__((no_sanitize("undefined")))
+#endif
+		libsinsp::state::static_struct::field_infos
+		static_fields() const override {
 			libsinsp::state::static_struct::field_infos ret;
 			DEFINE_STATIC_FIELD(ret, sample_struct2, m_num, "num");
 			return ret;

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -50,7 +50,11 @@ libsinsp::state::static_struct::field_infos sinsp_threadinfo::static_fields() co
 	return get_static_fields();
 }
 
-libsinsp::state::static_struct::field_infos sinsp_threadinfo::get_static_fields() {
+#if defined(__clang__)
+__attribute__((no_sanitize("undefined")))
+#endif
+libsinsp::state::static_struct::field_infos
+sinsp_threadinfo::get_static_fields() {
 	using self = sinsp_threadinfo;
 
 	libsinsp::state::static_struct::field_infos ret;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Using &nullptr->field to get the offset trips ASAN but only when built with clang (gcc builds do not complain). Piling hacks on top of other hacks, disable ASAN in places where OFFSETOF_STATIC_FIELD is involved.

The series tracked in https://github.com/falcosecurity/libs/issues/2802 fixes it eventually (by removing the need to calculate offsets in the first place), but in order to get there, we need working clang/ASAN builds.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
