### PR TITLE
fix(userspace/libscap): rewrite `/proc/pid/net/netlink` parsing logic

### DIFF
--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -645,7 +645,7 @@ static int32_t parse_ipv4_socket_table_line(const char *const line_start,
 	HASH_ADD_INT64((*sockets), ino, fdinfo);
 	if(uth_status != SCAP_SUCCESS) {
 		free(fdinfo);
-		return scap_errprintf(error, 0, "ipv4 socket allocation error");
+		return scap_errprintf(error, 0, "IPv4 socket allocation error");
 	}
 	return SCAP_SUCCESS;
 }
@@ -762,7 +762,7 @@ static int32_t parse_ipv6_socket_table_line(const char *const line_start,
 	HASH_ADD_INT64((*sockets), ino, fdinfo);
 	if(uth_status != SCAP_SUCCESS) {
 		free(fdinfo);
-		return scap_errprintf(error, 0, "ipv6 socket allocation error");
+		return scap_errprintf(error, 0, "IPv6 socket allocation error");
 	}
 	return SCAP_SUCCESS;
 }
@@ -1027,20 +1027,16 @@ static int32_t parse_procfs_proc_pid_socket_table_file(const char *filename,
 	return res;
 }
 
-int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets, char *error) {
+int32_t scap_fd_read_sockets_impl(char *procdir, struct scap_ns_socket_list *sockets, char *error) {
 	char filename[SCAP_MAX_PATH_SIZE];
 	char netroot[SCAP_MAX_PATH_SIZE];
 	char err_buf[SCAP_LASTERR_SIZE];
 
 	if(sockets->net_ns) {
-		//
-		// Namespace support, look in /proc/PID/net/
-		//
+		// Namespace support, look in /proc/PID/net/.
 		snprintf(netroot, sizeof(netroot), "%snet/", procdir);
 	} else {
-		//
-		// No namespace support, look in the base /proc
-		//
+		// No namespace support, look in the base /proc/net/.
 		snprintf(netroot, sizeof(netroot), "%s/proc/net/", scap_get_host_root());
 	}
 
@@ -1050,8 +1046,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_TCP,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv4 tcp sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv4 TCP sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%sudp", netroot);
@@ -1060,8 +1055,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_UDP,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv4 udp sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv4 UDP sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%sraw", netroot);
@@ -1070,8 +1064,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_RAW,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv4 raw sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv4 raw sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%sunix", netroot);
@@ -1080,8 +1073,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_NA,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read unix sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read unix sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%snetlink", netroot);
@@ -1090,8 +1082,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_NA,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read netlink sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read netlink sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%stcp6", netroot);
@@ -1105,8 +1096,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_TCP,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv6 tcp sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv6 TCP sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%sudp6", netroot);
@@ -1115,8 +1105,7 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_UDP,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv6 udp sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv6 UDP sockets: %s", err_buf);
 	}
 
 	snprintf(filename, sizeof(filename), "%sraw6", netroot);
@@ -1125,11 +1114,18 @@ int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets,
 	                                           SCAP_L4_RAW,
 	                                           &sockets->sockets,
 	                                           err_buf) == SCAP_FAILURE) {
-		scap_fd_free_table(&sockets->sockets);
-		return scap_errprintf(error, 0, "Could not read ipv6 raw sockets (%s)", err_buf);
+		return scap_errprintf(error, 0, "can't read IPv6 raw sockets: %s", err_buf);
 	}
 
 	return SCAP_SUCCESS;
+}
+
+int32_t scap_fd_read_sockets(char *procdir, struct scap_ns_socket_list *sockets, char *error) {
+	const int32_t res = scap_fd_read_sockets_impl(procdir, sockets, error);
+	if(res != SCAP_SUCCESS) {
+		scap_fd_free_table(&sockets->sockets);
+	}
+	return res;
 }
 
 char *decode_st_mode(struct stat *sb) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The previous logic used 1 single `fopen()` to open the `/proc/<pid>/net/netlink`/`/proc/net/netlink` files, and `fgets()` to read and each line; then each line was parsed using `strtok_r()`. The new parsing logic introduces the following optimizations:
- use `parse_procfs_proc_pid_socket_table_file()` for efficiently read the socket table file content and (this uses lighter `open()` and `read()` system calls, a stack-allocated for cache localicty and a sliding window logic for handling truncated lines)
- the single line parsing logic (implemented in `parse_netlink_socket_table_line()` uses lighter helper like `str_scan_u64()`, or `mem_skip_fields()` in place of `strtok_r()`

Moreover, this PR fixes fdinfo type by setting it to `SCAP_FD_NETLINK` instead of `SCAP_FD_UNIX_SOCK`, and initialize `fdinfo->ino` and creates a wrapper over `scap_fd_read_sockets()` to safely call `scap_fd_free_table()` on error.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
