### PR TITLE
chore: include cxxopts only when building sinsp-example

### DIFF
--- a/cmake/modules/cxxopts.cmake
+++ b/cmake/modules/cxxopts.cmake
@@ -35,8 +35,9 @@ elseif(NOT USE_BUNDLED_CXXOPTS)
 		endif()
 	endif()
 else()
-	set(CXXOPTS_SRC "${PROJECT_BINARY_DIR}/cxxopts-prefix/src/cxxopts/")
+	set(CXXOPTS_SRC "${CMAKE_CURRENT_BINARY_DIR}/cxxopts-prefix/src/cxxopts/")
 	set(CXXOPTS_INCLUDE_DIR "${CXXOPTS_SRC}/include")
+	file(MAKE_DIRECTORY "${CXXOPTS_INCLUDE_DIR}") # needed to make target_include_directories() work
 
 	message(STATUS "Using bundled cxxopts in ${CXXOPTS_SRC}")
 

--- a/cmake/modules/libsinsp.cmake
+++ b/cmake/modules/libsinsp.cmake
@@ -35,7 +35,6 @@ if(NOT HAVE_LIBSINSP)
 	include(jsoncpp)
 	include(valijson)
 	include(re2)
-	include(cxxopts)
 
 	if(ENABLE_THREAD_POOL AND NOT EMSCRIPTEN)
 		include(bs_threadpool)

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 add_executable(sinsp-example ${sources})
 
+add_dependencies(sinsp-example cxxopts)
 target_include_directories(sinsp-example PRIVATE "${CXXOPTS_INCLUDE_DIR}")
 target_link_libraries(sinsp-example sinsp "${JSONCPP_LIB}")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR avoids including `cxxopts` when not needed. Moreover, it fixes bundle-deps build by declaring sinsp-example dependency on cxxopts.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
