### PR TITLE
fix(plugin): Use UTF-8 paths on Windows

### DIFF
--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -2323,11 +2323,18 @@ struct ppm_proc_info {
 	uint64_t stime;
 };
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
 struct ppm_proclist_info {
 	int64_t n_entries;
 	int64_t max_entries;
 	struct ppm_proc_info entries[];
 };
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 enum syscall_flags {
 	UF_NONE = 0,

--- a/userspace/libsinsp/examples/CMakeLists.txt
+++ b/userspace/libsinsp/examples/CMakeLists.txt
@@ -19,7 +19,9 @@ include(jsoncpp)
 set(sources util.cpp platform.cpp test.cpp)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	set(sources ${sources} perftest.cpp)
+	list(APPEND sources perftest.cpp)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+	list(APPEND sources sinsp-example.manifest)
 endif()
 
 add_executable(sinsp-example ${sources})

--- a/userspace/libsinsp/examples/sinsp-example.manifest
+++ b/userspace/libsinsp/examples/sinsp-example.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="FalcoSecurity.SinspExample" version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -734,6 +734,8 @@ public:
 	// Create and register a plugin from a shared library pointed
 	// to by filepath, and add it to the inspector.
 	// The created sinsp_plugin is returned.
+	// filepath must be encoded as UTF-8 on Windows.
+
 	std::shared_ptr<sinsp_plugin> register_plugin(const std::string& filepath);
 
 	// Create and register a plugin given a custom API vtable.

--- a/userspace/plugin/plugin_loader.c
+++ b/userspace/plugin/plugin_loader.c
@@ -71,7 +71,29 @@ plugin_handle_t* plugin_load(const char* path, char* err) {
 
 	// open dynamic library
 #ifdef _WIN32
-	ret->handle = LoadLibrary(path);
+	// Using LoadLibraryW ensures that we have a valid path independent
+	// of the system or application code page.
+	int wpath_len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+	if(wpath_len <= 0) {
+		free(ret);
+		strlcpy(err, "unable to decode plugin path", PLUGIN_MAX_ERRLEN);
+		return NULL;
+	}
+
+	WCHAR* wpath = malloc(wpath_len * sizeof(WCHAR));
+	if(!wpath) {
+		free(ret);
+		strlcpy(err, "unable to allocate memory for plugin path", PLUGIN_MAX_ERRLEN);
+		return NULL;
+	}
+	if(MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wpath, wpath_len) <= 0) {
+		free(ret);
+		free(wpath);
+		strlcpy(err, "unable to decode plugin path", PLUGIN_MAX_ERRLEN);
+		return NULL;
+	}
+	ret->handle = LoadLibraryW(wpath);
+	free(wpath);
 	if(ret->handle == NULL) {
 		DWORD flg = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
 		            FORMAT_MESSAGE_IGNORE_INSERTS;

--- a/userspace/plugin/plugin_loader.h
+++ b/userspace/plugin/plugin_loader.h
@@ -72,6 +72,8 @@ plugin_handle_t* plugin_load_api(const plugin_api* api, char* err);
     \brief Loads a dynamic library from the given path and returns a
     plugin_handle_t* representing the loaded plugin. In case of error,
     returns NULL and fills the err string up to PLUGIN_MAX_ERRLEN chars.
+
+    The path must be encoded as UTF-8 on Windows.
 */
 plugin_handle_t* plugin_load(const char* path, char* err);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This ensures that we can load plugins on Windows independent of the system code page. It adds a requirement that plugin paths on Windows be encoded as UTF-8.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
