### PR TITLE
fix!: create thread dependencies after scanning procfs

### DIFF
--- a/test/libsinsp_e2e/thread_state.cpp
+++ b/test/libsinsp_e2e/thread_state.cpp
@@ -42,7 +42,7 @@ protected:
 			thr->m_tid = pid;
 			thr->m_ptid = ppid;
 
-			thread_manager->add_thread(std::move(thr), false);
+			thread_manager->add_thread(std::move(thr), true);
 			sinsp_threadinfo* tinfo = thread_manager->find_thread(pid, true).get();
 
 			m_threads.push_back(tinfo);

--- a/userspace/libscap/scap_proc_util.c
+++ b/userspace/libscap/scap_proc_util.c
@@ -30,6 +30,7 @@ int32_t scap_proc_scan_vtable(char *error,
 	uint32_t res = SCAP_SUCCESS;
 	uint64_t i;
 
+	proclist->m_callbacks.m_refresh_start_cb(proclist->m_callbacks.m_callback_context);
 	for(i = 0; i < n_tinfos; i++) {
 		// we need a copy because tinfos is const
 		// note: we drop the copy, so we lose the filtering information (tinfo->filtered_out)
@@ -70,6 +71,7 @@ int32_t scap_proc_scan_vtable(char *error,
 			                                      NULL);
 		}
 	}
+	proclist->m_callbacks.m_refresh_end_cb(proclist->m_callbacks.m_callback_context);
 
 	return SCAP_SUCCESS;
 }

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1012,7 +1012,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt &evt,
 	/*=============================== ADD THREAD TO THE TABLE ===========================*/
 
 	/* Until we use the shared pointer we need it here, after we can move it at the end */
-	auto new_child = m_thread_manager->add_thread(std::move(child_tinfo), false);
+	auto new_child = m_thread_manager->add_thread(std::move(child_tinfo), true);
 	if(!new_child) {
 		// note: we expect the thread manager to log a warning already
 		return;
@@ -1377,7 +1377,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &
 	/*=============================== CREATE NEW THREAD-INFO ===========================*/
 
 	/* Add the new thread to the table */
-	auto new_child = m_thread_manager->add_thread(std::move(child_tinfo), false);
+	auto new_child = m_thread_manager->add_thread(std::move(child_tinfo), true);
 	if(!new_child) {
 		// note: we expect the thread manager to log a warning already
 		evt.set_tinfo(nullptr);

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -374,9 +374,6 @@ void sinsp::init() {
 
 	import_user_list();
 
-	/* Create parent/child dependencies */
-	m_thread_manager->create_thread_dependencies_after_proc_scan();
-
 	//
 	// Scan the list to fix the direction of the sockets
 	//
@@ -742,14 +739,14 @@ void sinsp::open_test_input(scap_test_input_data* data, sinsp_mode_t mode) {
 	scap_platform* platform;
 	switch(mode) {
 	case SINSP_MODE_TEST:
-		platform = scap_test_input_alloc_platform({default_refresh_start_end_callback,
-		                                           default_refresh_start_end_callback,
+		platform = scap_test_input_alloc_platform({::on_proc_table_refresh_start,
+		                                           ::on_proc_table_refresh_end,
 		                                           ::on_new_entry_from_proc,
 		                                           this});
 		break;
 	case SINSP_MODE_LIVE:
-		platform = scap_linux_alloc_platform({default_refresh_start_end_callback,
-		                                      default_refresh_start_end_callback,
+		platform = scap_linux_alloc_platform({::on_proc_table_refresh_start,
+		                                      ::on_proc_table_refresh_end,
 		                                      ::on_new_entry_from_proc,
 		                                      this});
 		break;
@@ -910,6 +907,12 @@ void sinsp::on_new_entry_from_proc(void* context,
                                    int64_t tid,
                                    scap_threadinfo* tinfo,
                                    scap_fdinfo* fdinfo) {
+	// If we end up adding a thread to the thread table, we must create thread dependencies
+	// depending on the fact we are in the context of a full procfs scan or not. Indeed, if we are
+	// in a full procfs scan, we will create all thread dependencies in one shot after we finish it.
+	// In all the other cases (single thread/file fetching), we must create them here.
+	bool must_create_thread_dependencies = !m_is_full_procfs_scan_in_progress;
+
 	//
 	// Retrieve machine information if we don't have it yet
 	//
@@ -949,10 +952,12 @@ void sinsp::on_new_entry_from_proc(void* context,
 		if(is_nodriver()) {
 			auto existing_tinfo = find_thread(tid, true);
 			if(existing_tinfo == nullptr || newti->m_clone_ts > existing_tinfo->m_clone_ts) {
-				sinsp_tinfo = m_thread_manager->add_thread(std::move(newti), true);
+				sinsp_tinfo = m_thread_manager->add_thread(std::move(newti),
+				                                           must_create_thread_dependencies);
 			}
 		} else {
-			sinsp_tinfo = m_thread_manager->add_thread(std::move(newti), true);
+			sinsp_tinfo =
+			        m_thread_manager->add_thread(std::move(newti), must_create_thread_dependencies);
 		}
 		if(sinsp_tinfo) {
 			// in case the inspector is configured with an internal filter,
@@ -1048,7 +1053,8 @@ void sinsp::on_new_entry_from_proc(void* context,
 			                               tinfo->pid,
 			                               tinfo->gid,
 			                               must_notify_thread_user_update());
-			sinsp_tinfo = m_thread_manager->add_thread(std::move(newti), true);
+			sinsp_tinfo =
+			        m_thread_manager->add_thread(std::move(newti), must_create_thread_dependencies);
 			if(sinsp_tinfo == nullptr) {
 				ASSERT(false);
 				return;
@@ -1108,11 +1114,14 @@ void sinsp::on_new_entry_from_proc(void* context,
 }
 
 void sinsp::on_proc_table_refresh_start() {
+	m_is_full_procfs_scan_in_progress = true;
 	m_suppress.initialize();
 }
 
 void sinsp::on_proc_table_refresh_end() {
+	m_is_full_procfs_scan_in_progress = false;
 	m_suppress.finalize();
+	m_thread_manager->create_thread_dependencies_after_proc_scan();
 }
 
 int32_t on_new_entry_from_proc(void* context,

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -900,6 +900,8 @@ private:
 
 	std::shared_ptr<sinsp_thread_pool> m_thread_pool;
 
+	bool m_is_full_procfs_scan_in_progress = false;
+
 	//
 	// The ID of the plugin to use as event input, or zero
 	// if no source plugin should be used as source

--- a/userspace/libsinsp/thread_manager.cpp
+++ b/userspace/libsinsp/thread_manager.cpp
@@ -230,14 +230,9 @@ void sinsp_thread_manager::create_thread_dependencies(
 	parent_thread->add_child(tinfo);
 }
 
-/* Can be called when:
- * 1. We crafted a new event to create in clone parsers. (`from_scap_proctable==false`)
- * 2. We are doing a proc scan with a callback or without. (`from_scap_proctable==true`)
- * 3. We are trying to obtain thread info from /proc through `get_thread_ref`
- */
 const std::shared_ptr<sinsp_threadinfo>& sinsp_thread_manager::add_thread(
         std::unique_ptr<sinsp_threadinfo> threadinfo,
-        bool from_scap_proctable) {
+        const bool must_create_thread_dependencies) {
 	/* We have no more space */
 	if(m_threadtable.size() >= m_max_thread_table_size && threadinfo->m_pid != m_sinsp_pid) {
 		if(m_sinsp_stats_v2 != nullptr) {
@@ -258,7 +253,7 @@ const std::shared_ptr<sinsp_threadinfo>& sinsp_thread_manager::add_thread(
 
 	auto tinfo_shared_ptr = std::shared_ptr<sinsp_threadinfo>(std::move(threadinfo));
 
-	if(!from_scap_proctable) {
+	if(must_create_thread_dependencies) {
 		create_thread_dependencies(tinfo_shared_ptr);
 	}
 
@@ -988,7 +983,7 @@ const threadinfo_map_t::ptr_t& sinsp_thread_manager::get_thread(const int64_t ti
 		//
 		// Done. Add the new thread to the list.
 		//
-		add_thread(std::move(newti), false);
+		add_thread(std::move(newti), true);
 		return find_thread(tid, lookup_only);
 	}
 

--- a/userspace/libsinsp/thread_manager.h
+++ b/userspace/libsinsp/thread_manager.h
@@ -62,7 +62,7 @@ public:
 	void clear();
 
 	const threadinfo_map_t::ptr_t& add_thread(std::unique_ptr<sinsp_threadinfo> threadinfo,
-	                                          bool from_scap_proctable);
+	                                          bool must_create_thread_dependencies);
 
 	sinsp_threadinfo* find_new_reaper(sinsp_threadinfo*);
 	void remove_thread(int64_t tid);
@@ -193,7 +193,7 @@ public:
 		}
 		entry.release();
 		tinfo->m_tid = key;
-		return add_thread(std::unique_ptr<sinsp_threadinfo>(tinfo), false);
+		return add_thread(std::unique_ptr<sinsp_threadinfo>(tinfo), true);
 	}
 
 	bool erase_entry(const int64_t& key) override {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The current implementation just creates thread dependencies during the first full procfs scan by calling
`sinsp_thread_manager::create_thread_dependencies_after_proc_scan()`. This PR also calls it at the end of a full procfs scan other the first one. Moreover, it patches `sinsp::on_new_entry_from_proc()` to create thread dependencies in case it is not called in the context of a full procfs scan. Notice that I changed the meaning of `sinsp_thread_manger::add_thread()` second parameter: its meaning is indeed flipped now.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
chore!: flip `sinsp_thread_manager::add_thread()` second argument meaning
```
