### PR TITLE
fix(.github): validate artifact PR number in workflow_run comment wor…

### DIFF
--- a/.github/workflows/create-comment-kernel-testing.yml
+++ b/.github/workflows/create-comment-kernel-testing.yml
@@ -58,6 +58,21 @@ jobs:
               process.exit();
             }
             var issue_number = Number(fs.readFileSync('./NR'));
+
+            // Validate artifact PR number against the workflow_run context
+            // to prevent artifact poisoning (cross-issue comment injection).
+            const head_sha = context.payload.workflow_run.head_sha;
+            const {data: associated_prs} = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: head_sha,
+            });
+            const valid_pr_numbers = associated_prs.map(pr => pr.number);
+            if (!valid_pr_numbers.includes(issue_number)) {
+              core.setFailed(`Artifact PR number ${issue_number} does not match any PR for commit ${head_sha}. Aborting to prevent artifact poisoning.`);
+              return;
+            }
+
             var comment_body = fs.readFileSync('./COMMENT');
 
             // Get the existing comments.

--- a/.github/workflows/create-comment-perf.yml
+++ b/.github/workflows/create-comment-perf.yml
@@ -58,6 +58,21 @@ jobs:
               process.exit();
             }
             var issue_number = Number(fs.readFileSync('./NR'));
+
+            // Validate artifact PR number against the workflow_run context
+            // to prevent artifact poisoning (cross-issue comment injection).
+            const head_sha = context.payload.workflow_run.head_sha;
+            const {data: associated_prs} = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: head_sha,
+            });
+            const valid_pr_numbers = associated_prs.map(pr => pr.number);
+            if (!valid_pr_numbers.includes(issue_number)) {
+              core.setFailed(`Artifact PR number ${issue_number} does not match any PR for commit ${head_sha}. Aborting to prevent artifact poisoning.`);
+              return;
+            }
+
             var comment_body = fs.readFileSync('./COMMENT');
 
             // Get the existing comments.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

/area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The create-comment workflows download artifacts produced by `pull_request` workflows (which execute attacker-controlled fork code) and use the artifact's NR file as the target issue/PR number for posting bot comments.

Without validation, an attacker can craft a fork PR whose CI artifact sets NR to any issue/PR number in the repository, causing github-actions[bot] to post arbitrary comments on unrelated issues.

Validate the artifact's NR against the PRs actually associated with the `workflow_run`'s head commit using the `listPullRequestsAssociatedWithCommit` API. If the numbers don't match, the workflow fails immediately.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
