### PR TITLE
fix(libsinsp): prevent integer overflow in thread memory calculations

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -1588,7 +1588,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_THREAD_VMSIZE_B:
 		if(tinfo->is_main_thread()) {
-			m_val.u64 = tinfo->m_vmsize_kb * 1024;
+			m_val.u64 = static_cast<uint64_t>(tinfo->m_vmsize_kb) * 1024ULL;
 		} else {
 			m_val.u64 = 0;
 		}
@@ -1596,7 +1596,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_VAR(m_val.u64);
 	case TYPE_THREAD_VMRSS_B:
 		if(tinfo->is_main_thread()) {
-			m_val.u64 = tinfo->m_vmrss_kb * 1024;
+			m_val.u64 = static_cast<uint64_t>(tinfo->m_vmrss_kb) * 1024ULL;
 		} else {
 			m_val.u64 = 0;
 		}


### PR DESCRIPTION
/kind bug

/area libsinsp

**What this PR does / why we need it**:

This PR fixes integer overflow issues in thread memory calculations
for VMSIZE and VMRSS fields in libsinsp.

Previously, multiplication of memory values (in KB) by 1024 was performed
using 32-bit arithmetic. For processes with memory usage greater than 4GB,
this caused integer overflow, resulting in incorrect values being assigned
to uint64_t fields.

This could lead to inaccurate memory reporting and potential inconsistencies
in rule evaluation.


**Which issue(s) this PR fixes**:

Fixes #2875
Fixes #2876


**Special notes for your reviewer**:

Both issues originate from the same root cause: integer overflow due to
implicit 32-bit arithmetic during KB to bytes conversion.

This PR applies a consistent fix by explicitly promoting operands to
uint64_t before multiplication. The change is minimal, safe, and does not
alter existing logic beyond fixing the overflow condition.


**Does this PR introduce a user-facing change?**:

```release-note
fix: prevent integer overflow in thread memory calculations (VMSIZE, VMRSS)
```