### PR TITLE
Fix race condition in auxmap due to eBPF preemption

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -88,8 +88,25 @@ static __always_inline struct auxiliary_map *auxmap_iter__get() {
  * @param auxmap pointer to the auxmap in which we are writing our event header.
  * @param event_type This is the type of the event that we are writing into the map.
  */
-static __always_inline void auxmap__preload_event_header(struct auxiliary_map *auxmap,
+
+ /*
+ * Protect the per-CPU auxmap from concurrent access.
+ * Even though eBPF programs are expected to run on a single CPU,
+ * they can be preempted, leading to possible interleaving on the same CPU.
+ *
+ * If contention is detected, we drop the event to avoid corrupting
+ * the auxmap buffer.
+ */
+static __always_inline bool auxmap__preload_event_header(struct auxiliary_map *auxmap,
                                                          uint16_t event_type) {
+	if (__sync_lock_test_and_set(&auxmap->busy, 1)) {
+		struct counter_map *counter = maps__get_counter_map();
+		if(counter) {
+			counter->n_preemption_drops++;
+		}
+		/* auxmap is busy, drop this event */
+		return false;
+	}
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)auxmap->data;
 	uint8_t nparams = maps__get_event_num_params(event_type);
 	hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
@@ -99,6 +116,7 @@ static __always_inline void auxmap__preload_event_header(struct auxiliary_map *a
 	auxmap->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	auxmap->lengths_pos = sizeof(struct ppm_evt_hdr);
 	auxmap->event_type = event_type;
+	return true;
 }
 
 /**
@@ -114,9 +132,18 @@ static __always_inline void auxmap__preload_event_header(struct auxiliary_map *a
  * the thread id of the task the iterator event is related to.
  * @param event_type This is the type of the iterator event that we are writing into the map.
  */
-static __always_inline void auxmap_iter__preload_event_header(struct auxiliary_map *auxmap,
+ /* Same protection as auxmap__preload_event_header for iterator events */
+static __always_inline bool auxmap_iter__preload_event_header(struct auxiliary_map *auxmap,
                                                               uint64_t tgid_pid,
                                                               uint16_t event_type) {
+	if (__sync_lock_test_and_set(&auxmap->busy, 1)) {
+		struct counter_map *counter = maps__get_counter_map();
+		if(counter) {
+			counter->n_preemption_drops++;
+		}
+		/* auxmap is busy, drop this event */
+		return false;
+	}
 	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)auxmap->data;
 	uint8_t nparams = maps__get_event_num_params(event_type);
 	hdr->ts = 0;  // The timestamp field is currently not used.
@@ -126,6 +153,7 @@ static __always_inline void auxmap_iter__preload_event_header(struct auxiliary_m
 	auxmap->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	auxmap->lengths_pos = sizeof(struct ppm_evt_hdr);
 	auxmap->event_type = event_type;
+	return true;
 }
 
 /**
@@ -164,11 +192,14 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 		/* This should never happen in tail-called exit programs because we check it in `sys_exit`
 		 * dispatcher. It can happen in TOCTOU mitigation programs. */
 		bpf_printk("FAILURE: unable to obtain the ring buffer");
+		/* Release auxmap lock acquired during preload */
+		__sync_lock_release(&auxmap->busy);
 		return;
 	}
 
 	struct counter_map *counter = maps__get_counter_map();
 	if(!counter) {
+		__sync_lock_release(&auxmap->busy);
 		return;
 	}
 
@@ -178,6 +209,7 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 
 	if(auxmap->payload_pos > MAX_EVENT_SIZE) {
 		counter->n_drops_max_event_size++;
+		__sync_lock_release(&auxmap->busy);
 		return;
 	}
 
@@ -189,6 +221,7 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 		counter->n_drops_buffer++;
 		compute_event_types_stats(auxmap->event_type, counter);
 	}
+	__sync_lock_release(&auxmap->busy);
 }
 
 /**
@@ -212,11 +245,13 @@ static __always_inline int auxmap_iter__submit_event(struct auxiliary_map *auxma
                                                      struct seq_file *seq) {
 	struct iter_counters *counters = maps__get_iter_counters();
 	if(!counters) {
+		__sync_lock_release(&auxmap->busy);
 		return 0;
 	}
 
 	if(auxmap->payload_pos > MAX_ITER_EVENT_SIZE) {
 		counters->n_drops_max_event_size++;
+		__sync_lock_release(&auxmap->busy);
 		return 0;
 	}
 
@@ -233,6 +268,7 @@ static __always_inline int auxmap_iter__submit_event(struct auxiliary_map *auxma
 	 * object, and no error is surfaced to userspace. */
 	if(seq_count == 0 && auxmap->payload_pos >= seq_size) {
 		account_iter_event_drop(evt_type, counters);
+		__sync_lock_release(&auxmap->busy);
 		return 0;
 	}
 
@@ -240,10 +276,12 @@ static __always_inline int auxmap_iter__submit_event(struct auxiliary_map *auxma
 	 * from previous objects (`seq_count > 0`) and the remaining space is insufficient.
 	 * Return 1 so the kernel flushes the buffer and re-presents the current object. */
 	if(bpf_seq_write(seq, auxmap->data, auxmap->payload_pos) < 0) {
+		__sync_lock_release(&auxmap->busy);
 		return 1;
 	}
 
 	account_iter_event_processed(evt_type, counters);
+	__sync_lock_release(&auxmap->busy);
 	return 0;
 }
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exec.bpf.c
@@ -81,7 +81,10 @@ int BPF_PROG(sched_p_exec, struct task_struct *p, pid_t old_pid, struct linux_bi
 	if(!auxmap) {
 		return 0;
 	}
-	auxmap__preload_event_header(auxmap, PPME_SYSCALL_EXECVE_19_X);
+	/* Drop event if auxmap is busy to avoid data corruption */
+	if (!auxmap__preload_event_header(auxmap, PPME_SYSCALL_EXECVE_19_X)) {
+		return 0;
+	}
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_exit.bpf.c
@@ -152,8 +152,10 @@ int BPF_PROG(sched_proc_exit, struct task_struct *task) {
 	if(!auxmap) {
 		return 0;
 	}
-
-	auxmap__preload_event_header(auxmap, PPME_PROCEXIT_1_E);
+	/* Drop event if auxmap is busy to avoid data corruption */
+	if (!auxmap__preload_event_header(auxmap, PPME_PROCEXIT_1_E)) {
+		return 0;
+	}
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
+++ b/driver/modern_bpf/programs/attached/events/sched_process_fork.bpf.c
@@ -61,7 +61,10 @@ int BPF_PROG(sched_p_fork, struct task_struct *parent, struct task_struct *child
 	if(!auxmap) {
 		return 0;
 	}
-	auxmap__preload_event_header(auxmap, PPME_SYSCALL_CLONE_20_X);
+	/* Drop event if auxmap is busy to avoid data corruption */
+	if (!auxmap__preload_event_header(auxmap, PPME_SYSCALL_CLONE_20_X)) {
+		return 0;
+	}
 
 	/*=============================== COLLECT PARAMETERS  ===========================*/
 

--- a/driver/modern_bpf/shared_definitions/struct_definitions.h
+++ b/driver/modern_bpf/shared_definitions/struct_definitions.h
@@ -47,6 +47,7 @@ struct auxiliary_map {
 	uint64_t payload_pos;             /* position of the first empty byte in the `data` buf. */
 	uint8_t lengths_pos; /* position the first empty slot into the lengths array of the event. */
 	uint16_t event_type; /* event type we want to send to userspace */
+	volatile __u32 busy; /* Per-CPU guard to prevent concurrent writes due to eBPF preemption */
 };
 
 /* These per-cpu maps are used to carry the number of drops and
@@ -75,6 +76,7 @@ struct counter_map {
 	uint64_t n_drops_buffer_close_exit;
 	uint64_t n_drops_buffer_proc_exit;
 	uint64_t n_drops_max_event_size; /* Number of drops due to an excessive event size (>64KB). */
+	uint64_t n_preemption_drops; /* Number of events dropped due to auxmap contention (preemption) */
 };
 
 /**


### PR DESCRIPTION
/kind bug
/area driver-modern-bpf

## What this PR does / why we need it

This PR fixes a race condition in the per-CPU auxmap used by modern eBPF programs.

Although eBPF programs run on a single CPU at a time, they can be preempted in modern kernels. This can lead to interleaving of multiple programs on the same CPU, causing concurrent writes to the auxmap and resulting in corrupted events.

To prevent this, a per-CPU guard (`busy`) is introduced in `struct auxiliary_map`. The guard is acquired before writing begins and released after the event is submitted.

If contention is detected, the event is safely dropped to avoid corruption. A new counter `n_preemption_drops` is added to track such cases.

## Which issue(s) this PR fixes

Fixes #2719

## Special notes for your reviewer

- Ensures correctness under eBPF preemption scenarios
- Prevents malformed events caused by concurrent writes
- Minimal and safe change with no impact on existing logic, only preventing concurrent auxmap access
- All call sites updated to handle early drop

## Does this PR introduce a user-facing change?

```release-note
fix: prevent race condition in auxmap under eBPF preemption by introducing a per-CPU guard
```