### PR TITLE
fix(libsinsp): add FTR_STORAGE for plugin fields in unary check expressions

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -502,6 +502,14 @@ void sinsp_filter_compiler::visit(const libsinsp::filter::ast::unary_check_expr*
 	node_info.m_field = check->get_transformed_field_info();
 	check->m_cache_metrics = m_cache_factory->new_metrics(e->left.get(), node_info);
 	check->m_extract_cache = m_cache_factory->new_extract_cache(e->left.get(), node_info);
+
+	// if the extraction comes from a plugin-implemented field, then
+	// we need to add a storage transformer as the cache may end up storing a
+	// shallow copy of the value pointers that are not valid anymore.
+	if(check->get_field_info()->is_ptr_unstable() && check->m_extract_cache) {
+		check->add_transformer(filter_transformer_type::FTR_STORAGE);
+	}
+
 	node_info.m_compare_operator = check->m_cmpop;
 	check->m_compare_cache = m_cache_factory->new_compare_cache(e, node_info);
 

--- a/userspace/libsinsp/test/filter_compiler.ut.cpp
+++ b/userspace/libsinsp/test/filter_compiler.ut.cpp
@@ -843,6 +843,48 @@ TEST_F(sinsp_with_test_input, filter_cache_pointer_instability) {
 	EXPECT_FALSE(eval_filter(evt, "(evt.arg.ret = val(evt.arg.reaper_tid))"));
 }
 
+// Verify that a unary 'exists' check on a plugin field doesn't poison
+// the shared extract cache with unstable pointers for a later binary check.
+// Pattern: field_A exists AND field_B = "x" AND field_A = "y"
+// Without FTR_STORAGE on the unary check, the extract cache stores a shallow
+// pointer for field_A. When field_B is extracted from the same plugin, the
+// plugin's internal buffer is overwritten, making the cached pointer stale.
+// The final binary check on field_A hits the cache and reads garbage data.
+TEST_F(sinsp_with_test_input, filter_cache_unary_check_plugin_ptr_instability) {
+	sinsp_filter_check_list flist;
+
+	add_default_init_thread();
+	open_inspector();
+
+	// Register a plugin with extraction capabilities
+	std::string err;
+	plugin_api papi;
+	get_plugin_api_sample_syscall_extract(papi);
+	auto pl = m_inspector.register_plugin(&papi);
+	ASSERT_TRUE(pl->init("", err)) << err;
+	flist.add_filter_check(m_inspector.new_generic_filtercheck());
+	flist.add_filter_check(sinsp_plugin::new_filtercheck(pl));
+
+	auto ff = std::make_shared<sinsp_filter_factory>(&m_inspector, flist);
+	auto cf = std::make_shared<test_sinsp_filter_cache_factory>();
+	auto evt = generate_getcwd_failed_entry_event();
+
+	// Both sample.proc_name and sample.tick are string fields sharing the
+	// same internal storage in the test plugin. Extracting sample.tick after
+	// sample.proc_name overwrites the buffer, invalidating any cached pointer.
+	//
+	// Without FTR_STORAGE on the unary 'exists' check:
+	//   1. "sample.proc_name exists" caches a shallow pointer to "init"
+	//   2. "sample.tick = \"false\"" extracts tick, overwriting the buffer
+	//   3. "sample.proc_name = \"init\"" cache hit → reads stale data → FALSE
+	// With FTR_STORAGE, step 1 deep-copies the value, so step 3 succeeds.
+	ASSERT_TRUE(eval_filter(
+	        evt,
+	        "sample.proc_name exists and sample.tick = \"false\" and sample.proc_name = \"init\"",
+	        ff,
+	        cf));
+}
+
 TEST_F(sinsp_with_test_input, filter_regex_operator_evaluation) {
 	// Basic case just to assert that the basic setup works
 	add_default_init_thread();


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

/area libsinsp

**Any specific area of the project related to this PR?**

libsinsp — filter compiler

**What this PR does / why we need it**:

The `unary_check_expr` visitor in the filter compiler installs an extract cache for plugin fields but does not add the `FTR_STORAGE` transformer to stabilize pointers. Plugin fields have `EPF_NO_PTR_STABILITY`, meaning their extracted value pointers point into the plugin's internal buffer and become invalid when the same plugin extracts another field.

The `binary_check_expr` visitor already correctly handles this by checking `is_ptr_unstable()` and adding `FTR_STORAGE` when a cache is present ([filter.cpp:548-553](https://github.com/falcosecurity/libs/blob/master/userspace/libsinsp/filter.cpp#L548-L553)). This PR mirrors that logic in the unary check path.

Without this fix, the following filter pattern produces incorrect results:

```
plugin_field_A exists AND plugin_field_B = "x" AND plugin_field_A = "y"
```

1. `plugin_field_A exists` (unary) — caches a shallow pointer (no FTR_STORAGE)
2. `plugin_field_B = "x"` (binary) — overwrites the plugin's internal buffer
3. `plugin_field_A = "y"` (binary) — cache hit returns stale pointer → wrong result

This commonly manifests in Falco when rules use `exists` on container/k8s plugin fields in conditions and also reference the same plugin fields in exceptions.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/libs/issues/2934

**Special notes for your reviewer**:

- The fix is a 4-line addition mirroring existing logic from the binary check path
- The test demonstrates the bug by using two string fields (`sample.proc_name` and `sample.tick`) that share the same internal storage in the test plugin — extracting one overwrites the other's cached pointer
- The test was verified to fail before the fix and pass after
- Bug was introduced in [`f319ef8b4`](https://github.com/falcosecurity/libs/commit/f319ef8b4140b15532eb11240914f7ef3be7b59b) (Jun 2024), affects libs >= 0.18.0, Falco >= 0.39.0

**Does this PR introduce a user-facing change?**:
Yes, previously incorrectly evaluated conditions will evaluate correctly now

```release-note
fix(libsinsp): add FTR_STORAGE transformer for plugin fields in unary check expressions to prevent stale extract cache data
```
