### PR TITLE
cleanup(libsinsp): read/write static table fields using lambdas

### DIFF
--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -143,26 +143,12 @@ const char* sinsp_fdinfo::get_typestring() const {
 sinsp_fdinfo::sinsp_fdinfo(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& dyn_fields):
         extensible_struct(dyn_fields) {}
 
-#if defined(__clang__)
-__attribute__((no_sanitize("undefined")))
-#endif
-libsinsp::state::static_field_infos
-sinsp_fdinfo::get_static_fields() {
+libsinsp::state::static_field_infos sinsp_fdinfo::get_static_fields() {
 	using self = sinsp_fdinfo;
 
 	libsinsp::state::static_field_infos ret;
-
-	// the m_type is weird because it's a C-defined non-scoped enum, meaning that it
-	// should be represented by default as an integer of word-size (e.g. uint32_t in
-	// most cases). However, the state and plugin API only supports integers, and so
-	// we need to do some smart casting. Our enemy is the platform/compiler dependent
-	// integer size with which the enum could be represented, plus the endianess
-	// of the targeted architecture
-	auto is_big_endian = htonl(12) == 12;  // the chosen number does not matter
-	size_t type_byte_offset = is_big_endian ? (sizeof(scap_fd_type) - 1) : 0;
 	libsinsp::state::define_static_field<uint8_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_type) + type_byte_offset,
 	        "type",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -201,7 +187,6 @@ sinsp_fdinfo::get_static_fields() {
 	                    "socket_ipv4_l4_proto");
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip),
 	        "socket_ipv6_src_ip_low",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -213,7 +198,6 @@ sinsp_fdinfo::get_static_fields() {
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip) + 8,
 	        "socket_ipv6_src_ip_high",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -225,7 +209,6 @@ sinsp_fdinfo::get_static_fields() {
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip),
 	        "socket_ipv6_dest_ip_low",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -237,7 +220,6 @@ sinsp_fdinfo::get_static_fields() {
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip) + 8,
 	        "socket_ipv6_dest_ip_high",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -261,7 +243,6 @@ sinsp_fdinfo::get_static_fields() {
 	                    "socket_ipv4_server_l4_proto");
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip),
 	        "socket_ipv6_server_ip_low",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -273,7 +254,6 @@ sinsp_fdinfo::get_static_fields() {
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip) + 8,
 	        "socket_ipv6_server_ip_high",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -24,6 +24,18 @@ limitations under the License.
 #include <libsinsp/sinsp_int.h>
 #include <libscap/scap-int.h>
 
+static libsinsp::state::borrowed_state_data get_ipv6_addr_low(const ipv6addr& a) {
+	uint64_t addr;
+	memcpy(&addr, &a.m_b[0], sizeof(uint64_t));
+	return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_UINT64>(addr);
+};
+
+static libsinsp::state::borrowed_state_data get_ipv6_addr_high(const ipv6addr& a) {
+	uint64_t addr;
+	memcpy(&addr, &a.m_b[2], sizeof(uint64_t));
+	return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_UINT64>(addr);
+};
+
 char sinsp_fdinfo::get_typechar() const {
 	switch(m_type) {
 	case SCAP_FD_FILE_V2:
@@ -142,7 +154,13 @@ sinsp_fdinfo::get_static_fields() {
 	libsinsp::state::define_static_field<uint8_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_type) + type_byte_offset,
-	        "type");
+	        "type",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        auto type = static_cast<uint8_t>(c->m_type);
+		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_UINT8, uint8_t>(
+		                type);
+	        });
 
 	// the rest fo the fields are more trivial to expose
 	DEFINE_STATIC_FIELD(ret, self, m_openflags, "open_flags");
@@ -169,19 +187,35 @@ sinsp_fdinfo::get_static_fields() {
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip),
-	        "socket_ipv6_src_ip_low");
+	        "socket_ipv6_src_ip_low",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_sip);
+	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_sip) + 8,
-	        "socket_ipv6_src_ip_high");
+	        "socket_ipv6_src_ip_high",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_sip);
+	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip),
-	        "socket_ipv6_dest_ip_low");
+	        "socket_ipv6_dest_ip_low",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_dip);
+	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6info.m_fields.m_dip) + 8,
-	        "socket_ipv6_dest_ip_high");
+	        "socket_ipv6_dest_ip_high",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_dip);
+	        });
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_sport, "socket_ipv6_src_port");
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_dport, "socket_ipv6_dst_port");
 	DEFINE_STATIC_FIELD(ret,
@@ -197,11 +231,19 @@ sinsp_fdinfo::get_static_fields() {
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip),
-	        "socket_ipv6_server_ip_low");
+	        "socket_ipv6_server_ip_low",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6serverinfo.m_ip);
+	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_sockinfo.m_ipv6serverinfo.m_ip) + 8,
-	        "socket_ipv6_server_ip_high");
+	        "socket_ipv6_server_ip_high",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6serverinfo.m_ip);
+	        });
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6serverinfo.m_port, "socket_ipv6_server_port");
 	DEFINE_STATIC_FIELD(ret,
 	                    self,

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -36,6 +36,15 @@ static libsinsp::state::borrowed_state_data get_ipv6_addr_high(const ipv6addr& a
 	return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_UINT64>(addr);
 };
 
+static void set_ipv6_addr_low(ipv6addr& a, const libsinsp::state::borrowed_state_data& state_data) {
+	memcpy(&a.m_b[0], &state_data.data().u64, sizeof(uint64_t));
+};
+
+static void set_ipv6_addr_high(ipv6addr& a,
+                               const libsinsp::state::borrowed_state_data& state_data) {
+	memcpy(&a.m_b[2], &state_data.data().u64, sizeof(uint64_t));
+};
+
 char sinsp_fdinfo::get_typechar() const {
 	switch(m_type) {
 	case SCAP_FD_FILE_V2:
@@ -160,6 +169,12 @@ sinsp_fdinfo::get_static_fields() {
 		        auto type = static_cast<uint8_t>(c->m_type);
 		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_UINT8, uint8_t>(
 		                type);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        uint8_t type;
+		        auto c = static_cast<self*>(in);
+		        in_data.copy_to<SS_PLUGIN_ST_UINT8, uint8_t>(type);
+		        c->m_type = static_cast<scap_fd_type>(type);
 	        });
 
 	// the rest fo the fields are more trivial to expose
@@ -191,6 +206,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_sip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_sip, in_data);
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
@@ -199,6 +218,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_sip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_sip, in_data);
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
@@ -207,6 +230,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_dip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_low(c->m_sockinfo.m_ipv6info.m_fields.m_dip, in_data);
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
@@ -215,6 +242,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_dip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_high(c->m_sockinfo.m_ipv6info.m_fields.m_dip, in_data);
 	        });
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_sport, "socket_ipv6_src_port");
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6info.m_fields.m_dport, "socket_ipv6_dst_port");
@@ -235,6 +266,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_low(c->m_sockinfo.m_ipv6serverinfo.m_ip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_low(c->m_sockinfo.m_ipv6serverinfo.m_ip, in_data);
 	        });
 	libsinsp::state::define_static_field<uint64_t>(
 	        ret,
@@ -243,6 +278,10 @@ sinsp_fdinfo::get_static_fields() {
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
 		        return get_ipv6_addr_high(c->m_sockinfo.m_ipv6serverinfo.m_ip);
+	        },
+	        [](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {
+		        auto c = static_cast<self*>(in);
+		        set_ipv6_addr_high(c->m_sockinfo.m_ipv6serverinfo.m_ip, in_data);
 	        });
 	DEFINE_STATIC_FIELD(ret, self, m_sockinfo.m_ipv6serverinfo.m_port, "socket_ipv6_server_port");
 	DEFINE_STATIC_FIELD(ret,

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -162,30 +162,10 @@ private:
 	}
 
 protected:
-	struct writer {
-		extensible_struct* self;
-		const static_field_accessor* acc;
-		const borrowed_state_data& in;
-
-		template<typename T>
-		void operator()() const {
-			T val{};
-			in.copy_to<type_id_of<T>()>(val);
-			*reinterpret_cast<T*>(reinterpret_cast<char*>(self) + acc->info().offset()) =
-			        std::move(val);
-		}
-	};
-
 	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
 		if(auto static_acc = dynamic_cast<const static_field_accessor*>(&a)) {
-			if(!static_acc->info().valid()) {
-				throw sinsp_exception("can't set invalid field in static struct");
-			}
-			if(static_acc->info().readonly()) {
-				throw sinsp_exception("can't set a read-only static struct field: " +
-				                      static_acc->info().name());
-			}
-			return dispatch_lambda(a.type_id(), writer{this, static_acc, in});
+			static_acc->info().write(this, 0, in);
+			return;
 		}
 
 		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
@@ -217,6 +197,7 @@ using static_field_infos = std::unordered_map<std::string, static_field_info>;
  * @param offset Field's memory offset in instances of the class/struct.
  * @param name Display name of the field.
  * @param reader Function to read the field's value from an instance of the class/struct.
+ * @param writer Function to write the field's value in an instance of the class/struct.
  * @param readonly Read-only field annotation.
  */
 template<typename T>
@@ -224,6 +205,7 @@ constexpr static const static_field_info& define_static_field(static_field_infos
                                                               const size_t offset,
                                                               const std::string& name,
                                                               accessor::reader_fn reader,
+                                                              accessor::writer_fn writer,
                                                               const bool readonly = false) {
 	const auto& it = fields.find(name);
 	if(it != fields.end()) {
@@ -231,7 +213,8 @@ constexpr static const static_field_info& define_static_field(static_field_infos
 	}
 
 	// todo(jasondellaluce): add extra safety boundary checks here
-	fields.insert({name, static_field_info(name, offset, type_id_of<T>(), readonly, reader)});
+	fields.insert(
+	        {name, static_field_info(name, offset, type_id_of<T>(), readonly, reader, writer)});
 	return fields.at(name);
 }
 

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -141,48 +141,33 @@ private:
 	std::shared_ptr<dynamic_field_infos> m_dynamic_fields;
 	// end of dynamic_struct interface
 
-protected:
-	[[nodiscard]] const void* raw_read_field(const accessor& a) const override {
+	struct reader {
+		const extensible_struct* self;
+		const static_field_accessor* acc;
+
+		template<typename T>
+		borrowed_state_data operator()() const {
+			const T* ptr = reinterpret_cast<const T*>(reinterpret_cast<const char*>(self) +
+			                                          acc->info().offset());
+
+			return borrowed_state_data::from<type_id_of<T>(), T>(*ptr);
+		}
+	};
+
+	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const override {
 		if(auto static_acc = dynamic_cast<const static_field_accessor*>(&a)) {
 			if(!static_acc->info().valid()) {
 				throw sinsp_exception("can't get invalid field in static struct");
 			}
-			return reinterpret_cast<const char*>(this) + static_acc->info().offset();
+			return dispatch_lambda(a.type_id(), reader{this, static_acc});
 		}
 
 		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
 			_check_defsptr(dynamic_acc->info(), false);
-			auto ptr = _access_dynamic_field_for_read(dynamic_acc->info().index());
-			if(ptr) {
-				switch(a.type_id()) {
-				case SS_PLUGIN_ST_INT8:
-					return &ptr->m_data.s8;
-				case SS_PLUGIN_ST_INT16:
-					return &ptr->m_data.s16;
-				case SS_PLUGIN_ST_INT32:
-					return &ptr->m_data.s32;
-				case SS_PLUGIN_ST_INT64:
-					return &ptr->m_data.s64;
-				case SS_PLUGIN_ST_UINT8:
-					return &ptr->m_data.u8;
-				case SS_PLUGIN_ST_UINT16:
-					return &ptr->m_data.u16;
-				case SS_PLUGIN_ST_UINT32:
-					return &ptr->m_data.u32;
-				case SS_PLUGIN_ST_UINT64:
-					return &ptr->m_data.u64;
-				case SS_PLUGIN_ST_STRING:
-					return &ptr->m_str;
-				case SS_PLUGIN_ST_TABLE:
-					return &ptr->m_data.table;
-				case SS_PLUGIN_ST_BOOL:
-					return &ptr->m_data.b;
-				default:
-					throw sinsp_exception("can't convert plugin state type to typeinfo: " +
-					                      std::to_string(a.type_id()));
-				}
+			if(auto ptr = _access_dynamic_field_for_read(dynamic_acc->info().index())) {
+				return borrowed_state_data(ptr->m_data);
 			}
-			return nullptr;
+			return {};
 		}
 
 #ifdef _MSC_VER
@@ -192,6 +177,7 @@ protected:
 #endif
 	}
 
+protected:
 	struct writer {
 		extensible_struct* self;
 		const accessor* acc;

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -194,7 +194,6 @@ using static_field_infos = std::unordered_map<std::string, static_field_info>;
  *
  * @tparam T Type of the field.
  * @param fields Fields group to which to add the new field.
- * @param offset Field's memory offset in instances of the class/struct.
  * @param name Display name of the field.
  * @param reader Function to read the field's value from an instance of the class/struct.
  * @param writer Function to write the field's value in an instance of the class/struct.
@@ -202,7 +201,6 @@ using static_field_infos = std::unordered_map<std::string, static_field_info>;
  */
 template<typename T>
 constexpr static const static_field_info& define_static_field(static_field_infos& fields,
-                                                              const size_t offset,
                                                               const std::string& name,
                                                               accessor::reader_fn reader,
                                                               accessor::writer_fn writer,
@@ -212,9 +210,7 @@ constexpr static const static_field_info& define_static_field(static_field_infos
 		throw sinsp_exception("multiple definitions of static field in struct: " + name);
 	}
 
-	// todo(jasondellaluce): add extra safety boundary checks here
-	fields.insert(
-	        {name, static_field_info(name, offset, type_id_of<T>(), readonly, reader, writer)});
+	fields.insert({name, static_field_info(name, type_id_of<T>(), readonly, reader, writer)});
 	return fields.at(name);
 }
 

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -75,6 +75,10 @@ public:
 		return m_reader(obj, index);
 	}
 
+	inline void write(void* obj, size_t index, const borrowed_state_data& data) const {
+		m_writer(obj, index, data);
+	}
+
 	/**
 	 * @brief Returns a strongly-typed accessor for the given field,
 	 * that can be used to reading and writing the field's value in
@@ -86,12 +90,14 @@ public:
 	                         size_t o,
 	                         ss_plugin_state_type t,
 	                         bool r,
-	                         accessor::reader_fn reader):
+	                         accessor::reader_fn reader,
+	                         accessor::writer_fn writer):
 	        m_readonly(r),
 	        m_offset(o),
 	        m_name(n),
 	        m_type_id(t),
-	        m_reader(reader) {}
+	        m_reader(reader),
+	        m_writer(writer) {}
 
 private:
 	bool m_readonly;
@@ -99,6 +105,7 @@ private:
 	std::string m_name;
 	ss_plugin_state_type m_type_id;
 	accessor::reader_fn m_reader;
+	accessor::writer_fn m_writer;
 };
 
 /**
@@ -154,15 +161,29 @@ inline accessor::ptr static_field_info::new_accessor() const {
 		                c->container_field);                                                   \
 	}
 
+#define WRITER_LAMBDA(container_type, container_field, field_type)                                \
+	[](void* in, size_t, const libsinsp::state::borrowed_state_data& in_data) {                   \
+		auto* c = static_cast<container_type*>(in);                                               \
+		in_data.copy_to<libsinsp::state::type_id_of<field_type>(), decltype(c->container_field)>( \
+		        c->container_field);                                                              \
+	}
+
+#define READONLY_WRITER_LAMBDA(name)                                                  \
+	[](void*, size_t, const libsinsp::state::borrowed_state_data&) {                  \
+		throw sinsp_exception("attempt to write to read-only static struct field: " + \
+		                      std::string(name));                                     \
+	}
+
 // DEFINE_STATIC_FIELD macro is a wrapper around static_struct::define_static_field helping to
 // extract the field type and field offset.
-#define DEFINE_STATIC_FIELD(field_infos, container_type, container_field, name) \
-	libsinsp::state::define_static_field<                                       \
-	        decltype(static_cast<container_type*>(0)->container_field)>(        \
-	        field_infos,                                                        \
-	        OFFSETOF_STATIC_FIELD(container_type, container_field),             \
-	        name,                                                               \
-	        READER_LAMBDA(container_type, container_field, decltype(c->container_field)));
+#define DEFINE_STATIC_FIELD(field_infos, container_type, container_field, name)           \
+	libsinsp::state::define_static_field<                                                 \
+	        decltype(static_cast<container_type*>(0)->container_field)>(                  \
+	        field_infos,                                                                  \
+	        OFFSETOF_STATIC_FIELD(container_type, container_field),                       \
+	        name,                                                                         \
+	        READER_LAMBDA(container_type, container_field, decltype(c->container_field)), \
+	        WRITER_LAMBDA(container_type, container_field, decltype(c->container_field)));
 
 // DEFINE_STATIC_FIELD_READONLY macro is a wrapper around static_struct::define_static_field helping
 // to extract the field type and field offset. The defined field is set to guarantee read-only
@@ -174,4 +195,5 @@ inline accessor::ptr static_field_info::new_accessor() const {
 	        OFFSETOF_STATIC_FIELD(container_type, container_field),                       \
 	        name,                                                                         \
 	        READER_LAMBDA(container_type, container_field, decltype(c->container_field)), \
+	        READONLY_WRITER_LAMBDA(name),                                                 \
 	        true);

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -185,16 +185,7 @@ public:
 template<typename KeyType>
 class built_in_table : public table<KeyType> {
 public:
-	inline built_in_table(const std::string& name):
-	        table<KeyType>::table(),
-	        m_this_ptr(this),
-	        m_name(name) {}
-
-	/**
-	 * @brief Returns a pointer to the area of memory in which this table
-	 * object is allocated. Here for convenience as required in other code parts.
-	 */
-	inline const base_table* const& table_ptr() const { return m_this_ptr; }
+	inline built_in_table(const std::string& name): table<KeyType>::table(), m_name(name) {}
 
 	const char* name() const override { return m_name.c_str(); }
 
@@ -335,7 +326,6 @@ public:
 	                               const ss_plugin_state_data* in) override;
 
 private:
-	const base_table* m_this_ptr;
 	std::string m_name;
 	std::vector<ss_plugin_table_fieldinfo> m_field_list;
 	std::unordered_map<std::string, const accessor*> m_field_accessors;

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -196,18 +196,6 @@ public:
 	 */
 	inline const base_table* const& table_ptr() const { return m_this_ptr; }
 
-	/**
-	 * @brief Returns the offset of m_this_ptr. Here for convenience as required in other code
-	 * parts.
-	 */
-#if defined(__clang__)
-	__attribute__((no_sanitize("undefined")))
-#endif
-	static size_t
-	table_ptr_offset() {
-		return OFFSETOF_STATIC_FIELD(built_in_table<KeyType>, m_this_ptr);
-	}
-
 	const char* name() const override { return m_name.c_str(); }
 
 	/**

--- a/userspace/libsinsp/state/table_adapters.h
+++ b/userspace/libsinsp/state/table_adapters.h
@@ -74,22 +74,23 @@ public:
 		throw sinsp_exception(std::string("field ") + name + " not found");
 	}
 
-protected:
-	[[nodiscard]] const void* raw_read_field(const accessor& a) const override {
+	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const override {
 		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
+
 		if(acc->index() == 0) {
 			if(acc->type_id() == type_id_of<Tfirst>()) {
-				return &m_value->first;
+				return borrowed_state_data::from<type_id_of<Tfirst>()>(m_value->first);
 			}
 		} else {
 			if(acc->type_id() == type_id_of<Tsecond>()) {
-				return &m_value->second;
+				return borrowed_state_data::from<type_id_of<Tsecond>()>(m_value->second);
 			}
 		}
 		throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 		                      std::string(type_name(a.type_id())));
 	}
 
+protected:
 	void raw_write_field(const accessor& a, const void* in) override {
 		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
 		if(acc->index() == 0) {
@@ -151,8 +152,7 @@ public:
 		throw sinsp_exception(std::string("field ") + name + " not found");
 	}
 
-protected:
-	const void* raw_read_field(const accessor& a) const override {
+	borrowed_state_data raw_read_field(const accessor& a) const override {
 		if(a.type_id() != type_id_of<T>()) {
 			throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +
 			                      std::string(type_name(a.type_id())));
@@ -162,9 +162,10 @@ protected:
 			throw sinsp_exception(
 			        "invalid field info passed to value_table_entry_adapter::read_field");
 		}
-		return m_value;
+		return borrowed_state_data::from<type_id_of<T>()>(*m_value);
 	}
 
+protected:
 	void raw_write_field(const accessor& a, const void* in) override {
 		if(a.type_id() != type_id_of<T>()) {
 			throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +

--- a/userspace/libsinsp/state/table_adapters.h
+++ b/userspace/libsinsp/state/table_adapters.h
@@ -90,22 +90,21 @@ public:
 		                      std::string(type_name(a.type_id())));
 	}
 
-protected:
-	void raw_write_field(const accessor& a, const void* in) override {
+	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
 		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
 		if(acc->index() == 0) {
 			if(a.type_id() != type_id_of<Tfirst>()) {
 				throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 				                      std::string(type_name(a.type_id())));
 			}
-			m_value->first = *static_cast<const Tfirst*>(in);
+			in.copy_to<type_id_of<Tfirst>(), Tfirst>(m_value->first);
 			return;
 		} else {
 			if(a.type_id() != type_id_of<Tsecond>()) {
 				throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 				                      std::string(type_name(a.type_id())));
 			}
-			m_value->second = *static_cast<const Tsecond*>(in);
+			in.copy_to<type_id_of<Tsecond>(), Tsecond>(m_value->second);
 			return;
 		}
 	}
@@ -166,7 +165,7 @@ public:
 	}
 
 protected:
-	void raw_write_field(const accessor& a, const void* in) override {
+	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
 		if(a.type_id() != type_id_of<T>()) {
 			throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +
 			                      std::string(type_name(a.type_id())));
@@ -176,7 +175,7 @@ protected:
 			throw sinsp_exception(
 			        "invalid field info passed to value_table_entry_adapter::write_field");
 		}
-		*m_value = *static_cast<const T*>(in);
+		in.copy_to<type_id_of<T>(), T>(*m_value);
 	}
 
 private:

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -26,6 +26,8 @@ namespace libsinsp::state {
 
 class accessor {
 public:
+	using reader_fn = borrowed_state_data (*)(const void*, size_t);
+
 	template<typename T>
 	class typed_ref {
 	public:

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -27,6 +27,7 @@ namespace libsinsp::state {
 class accessor {
 public:
 	using reader_fn = borrowed_state_data (*)(const void*, size_t);
+	using writer_fn = void (*)(void*, size_t, const borrowed_state_data&);
 
 	template<typename T>
 	class typed_ref {

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #pragma once
 
+#include <libsinsp/state/borrowed_state_data.h>
 #include <libsinsp/state/type_info.h>
 #include <memory>
 
@@ -114,11 +115,9 @@ public:
 
 	template<typename T>
 	T read_field(const accessor::typed_ref<T>& a) const {
-		auto out = static_cast<const T*>(this->raw_read_field(a));
-		if(out == nullptr) {
-			return {};
-		}
-		return *out;
+		T val{};
+		this->raw_read_field(a).template borrow_to<libsinsp::state::type_id_of<T>(), T>(val);
+		return val;
 	}
 
 	template<typename T, typename Val = T>
@@ -150,19 +149,20 @@ public:
 		write_field(a.as_ref(), in);
 	}
 
+	[[nodiscard]] virtual borrowed_state_data raw_read_field(const accessor& a) const = 0;
+
 protected:
-	[[nodiscard]] virtual const void* raw_read_field(const accessor& a) const = 0;
 	virtual void raw_write_field(const accessor& a, const void* in) = 0;
 };
 
 template<>
 inline void table_entry::read_field(const accessor::typed_ref<std::string>& a,
                                     const char*& out) const {
-	auto out_ptr = static_cast<const std::string*>(this->raw_read_field(a));
-	if(out_ptr) {
-		out = out_ptr->c_str();
-	} else {
+	const auto val = this->raw_read_field(a);
+	if(val.data().str == nullptr) {
 		out = "";
+	} else {
+		out = val.data().str;
 	}
 }
 

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -137,11 +137,9 @@ public:
 
 	template<typename T, typename Val = T>
 	void write_field(const accessor::typed_ref<T>& a, const Val& in) {
-		// TODO: we could use a direct assignment of const char* to strings
-		//       but we'd have to handle it deep down in each individual
-		//       implementation of raw_write_field
-		T in_val = in;
-		this->raw_write_field(a, &in_val);
+		borrowed_state_data in_val =
+		        borrowed_state_data::from<libsinsp::state::type_id_of<T>(), Val>(in);
+		this->raw_write_field(a, in_val);
 	}
 
 	template<typename T, typename Val = T>
@@ -150,9 +148,7 @@ public:
 	}
 
 	[[nodiscard]] virtual borrowed_state_data raw_read_field(const accessor& a) const = 0;
-
-protected:
-	virtual void raw_write_field(const accessor& a, const void* in) = 0;
+	virtual void raw_write_field(const accessor& a, const borrowed_state_data& in) = 0;
 };
 
 template<>

--- a/userspace/libsinsp/test/plugins.ut.cpp
+++ b/userspace/libsinsp/test/plugins.ut.cpp
@@ -900,7 +900,6 @@ TEST_F(sinsp_with_test_input, plugin_subtables) {
 	auto field = table->static_fields()->find("file_descriptors");
 	ASSERT_NE(field, table->static_fields()->end());
 	ASSERT_EQ(field->second.readonly(), true);
-	ASSERT_EQ(field->second.valid(), true);
 	ASSERT_EQ(field->second.name(), "file_descriptors");
 	ASSERT_EQ(field->second.type_id(), SS_PLUGIN_ST_TABLE);
 
@@ -931,7 +930,6 @@ TEST_F(sinsp_with_test_input, plugin_subtables) {
 	auto sfield = subtable->static_fields()->find("pid");
 	ASSERT_NE(sfield, subtable->static_fields()->end());
 	ASSERT_EQ(sfield->second.readonly(), false);
-	ASSERT_EQ(sfield->second.valid(), true);
 	ASSERT_EQ(sfield->second.name(), "pid");
 	ASSERT_EQ(sfield->second.type_id(), SS_PLUGIN_ST_INT64);
 	auto sfieldacc = sfield->second.new_accessor().into<int64_t>();
@@ -1011,7 +1009,6 @@ TEST_F(sinsp_with_test_input, plugin_subtables_array) {
 	auto field = table->static_fields()->find("env");
 	ASSERT_NE(field, table->static_fields()->end());
 	ASSERT_EQ(field->second.readonly(), true);
-	ASSERT_EQ(field->second.valid(), true);
 	ASSERT_EQ(field->second.name(), "env");
 	ASSERT_EQ(field->second.type_id(), SS_PLUGIN_ST_TABLE);
 
@@ -1115,7 +1112,6 @@ TEST_F(sinsp_with_test_input, plugin_subtables_array_pair) {
 	auto field = table->static_fields()->find("cgroups");
 	ASSERT_NE(field, table->static_fields()->end());
 	ASSERT_EQ(field->second.readonly(), true);
-	ASSERT_EQ(field->second.valid(), true);
 	ASSERT_EQ(field->second.name(), "cgroups");
 	ASSERT_EQ(field->second.type_id(), SS_PLUGIN_ST_TABLE);
 

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -467,7 +467,6 @@ TEST(thread_manager, fdtable_access) {
 	auto field = table->static_fields()->find("file_descriptors");
 	ASSERT_NE(field, table->static_fields()->end());
 	ASSERT_EQ(field->second.readonly(), true);
-	ASSERT_EQ(field->second.valid(), true);
 	ASSERT_EQ(field->second.name(), "file_descriptors");
 	ASSERT_EQ(field->second.type_id(), SS_PLUGIN_ST_TABLE);
 
@@ -502,7 +501,6 @@ TEST(thread_manager, fdtable_access) {
 	auto sfield = subtable->static_fields()->find("pid");
 	ASSERT_NE(sfield, subtable->static_fields()->end());
 	ASSERT_EQ(sfield->second.readonly(), false);
-	ASSERT_EQ(sfield->second.valid(), true);
 	ASSERT_EQ(sfield->second.name(), "pid");
 	ASSERT_EQ(sfield->second.type_id(), SS_PLUGIN_ST_INT64);
 
@@ -613,7 +611,6 @@ TEST(thread_manager, env_vars_access) {
 	auto field = table->static_fields()->find("env");
 	ASSERT_NE(field, table->static_fields()->end());
 	EXPECT_EQ(field->second.readonly(), true);
-	EXPECT_EQ(field->second.valid(), true);
 	EXPECT_EQ(field->second.name(), "env");
 	EXPECT_EQ(field->second.type_id(), SS_PLUGIN_ST_TABLE);
 

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -24,6 +24,12 @@ limitations under the License.
 #include <cstring>
 #include <string>
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer) && !defined(__SANITIZE_ADDRESS__)  // for clang
+#define __SANITIZE_ADDRESS__                                            // GCC already sets this
+#endif
+#endif
+
 TEST(static_struct, defs_and_access) {
 	struct err_multidef_struct : public libsinsp::state::extensible_struct {
 #if defined(__clang__)
@@ -137,13 +143,18 @@ TEST(static_struct, defs_and_access) {
 	ASSERT_EQ(cstr, s.get_str().c_str());
 	ASSERT_ANY_THROW(s.write_field(acc_str, cstr));  // readonly
 
+#if !defined(__SANITIZE_ADDRESS__)
 	// illegal access from an accessor created from different definition list
 	// note: this should supposedly be checked for and throw an exception,
 	// but for now we have no elegant way to do it efficiently.
 	// todo(jasondellaluce): find a good way to check for this
+	//
+	// Note: With clang, ASAN actually catches this and aborts, so don't check
+	// this with ASAN enabled (even if GCC lets this through)
 	auto acc_num2 =
 	        sample_struct2::get_static_fields().find("num")->second.new_accessor().into<uint32_t>();
 	ASSERT_NO_THROW(s.read_field(acc_num2));
+#endif
 }
 
 TEST(dynamic_struct, defs_and_access) {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -39,7 +39,7 @@ sinsp_threadinfo::sinsp_threadinfo(const std::shared_ptr<ctor_params>& params):
         extensible_struct(params->thread_manager_dyn_fields),
         m_params{params},
         m_fdtable{params->fdtable_factory.create()},
-        m_main_fdtable(m_fdtable.table_ptr()),
+        m_main_fdtable(&m_fdtable),
         m_args_table_adapter("args", m_args),
         m_env_table_adapter("env", m_env),
         m_cgroups_table_adapter("cgroups", m_cgroups) {
@@ -68,8 +68,9 @@ libsinsp::state::static_field_infos sinsp_threadinfo::get_static_fields() {
 	        "args",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
-		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
-		                c->m_args_table_adapter.table_ptr());
+		        return libsinsp::state::borrowed_state_data::
+		                from<SS_PLUGIN_ST_TABLE, const libsinsp::state::base_table*>(
+		                        &c->m_args_table_adapter);
 	        },
 	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
 		        throw sinsp_exception("attempt to write to read-only static struct field: args");
@@ -80,8 +81,9 @@ libsinsp::state::static_field_infos sinsp_threadinfo::get_static_fields() {
 	        "env",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
-		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
-		                c->m_env_table_adapter.table_ptr());
+		        return libsinsp::state::borrowed_state_data::
+		                from<SS_PLUGIN_ST_TABLE, const libsinsp::state::base_table*>(
+		                        &c->m_env_table_adapter);
 	        },
 	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
 		        throw sinsp_exception("attempt to write to read-only static struct field: env");
@@ -92,8 +94,9 @@ libsinsp::state::static_field_infos sinsp_threadinfo::get_static_fields() {
 	        "cgroups",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
-		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
-		                c->m_cgroups_table_adapter.table_ptr());
+		        return libsinsp::state::borrowed_state_data::
+		                from<SS_PLUGIN_ST_TABLE, const libsinsp::state::base_table*>(
+		                        &c->m_cgroups_table_adapter);
 	        },
 	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
 		        throw sinsp_exception("attempt to write to read-only static struct field: cgroups");

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -46,11 +46,7 @@ sinsp_threadinfo::sinsp_threadinfo(const std::shared_ptr<ctor_params>& params):
 	init();
 }
 
-#if defined(__clang__)
-__attribute__((no_sanitize("undefined")))
-#endif
-libsinsp::state::static_field_infos
-sinsp_threadinfo::get_static_fields() {
+libsinsp::state::static_field_infos sinsp_threadinfo::get_static_fields() {
 	using self = sinsp_threadinfo;
 
 	libsinsp::state::static_field_infos ret;
@@ -67,10 +63,8 @@ sinsp_threadinfo::get_static_fields() {
 	DEFINE_STATIC_FIELD(ret, self, m_exe_upper_layer, "exe_upper_layer");
 	DEFINE_STATIC_FIELD(ret, self, m_exe_lower_layer, "exe_lower_layer");
 	DEFINE_STATIC_FIELD(ret, self, m_exe_from_memfd, "exe_from_memfd");
-	const auto table_ptr_offset = libsinsp::state::extensible_table<uint64_t>::table_ptr_offset();
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_args_table_adapter) + table_ptr_offset,
 	        "args",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -83,7 +77,6 @@ sinsp_threadinfo::get_static_fields() {
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_env_table_adapter) + table_ptr_offset,
 	        "env",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);
@@ -96,7 +89,6 @@ sinsp_threadinfo::get_static_fields() {
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
-	        OFFSETOF_STATIC_FIELD(self, m_cgroups_table_adapter) + table_ptr_offset,
 	        "cgroups",
 	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
 		        auto c = static_cast<const self*>(in);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -77,6 +77,9 @@ sinsp_threadinfo::get_static_fields() {
 		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
 		                c->m_args_table_adapter.table_ptr());
 	        },
+	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
+		        throw sinsp_exception("attempt to write to read-only static struct field: args");
+	        },
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
@@ -87,6 +90,9 @@ sinsp_threadinfo::get_static_fields() {
 		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
 		                c->m_env_table_adapter.table_ptr());
 	        },
+	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
+		        throw sinsp_exception("attempt to write to read-only static struct field: env");
+	        },
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
@@ -96,6 +102,9 @@ sinsp_threadinfo::get_static_fields() {
 		        auto c = static_cast<const self*>(in);
 		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
 		                c->m_cgroups_table_adapter.table_ptr());
+	        },
+	        [](void*, size_t, const libsinsp::state::borrowed_state_data&) {
+		        throw sinsp_exception("attempt to write to read-only static struct field: cgroups");
 	        },
 	        true);
 	DEFINE_STATIC_FIELD(ret, self, m_flags, "flags");

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -72,16 +72,31 @@ sinsp_threadinfo::get_static_fields() {
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_args_table_adapter) + table_ptr_offset,
 	        "args",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
+		                c->m_args_table_adapter.table_ptr());
+	        },
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_env_table_adapter) + table_ptr_offset,
 	        "env",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
+		                c->m_env_table_adapter.table_ptr());
+	        },
 	        true);
 	libsinsp::state::define_static_field<libsinsp::state::base_table*>(
 	        ret,
 	        OFFSETOF_STATIC_FIELD(self, m_cgroups_table_adapter) + table_ptr_offset,
 	        "cgroups",
+	        [](const void* in, size_t) -> libsinsp::state::borrowed_state_data {
+		        auto c = static_cast<const self*>(in);
+		        return libsinsp::state::borrowed_state_data::from<SS_PLUGIN_ST_TABLE>(
+		                c->m_cgroups_table_adapter.table_ptr());
+	        },
 	        true);
 	DEFINE_STATIC_FIELD(ret, self, m_flags, "flags");
 	DEFINE_STATIC_FIELD(ret, self, m_fdlimit, "fd_limit");

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -496,8 +496,7 @@ public:
 	inline void update_main_fdtable() {
 		auto fdtable = get_fd_table();
 		m_main_fdtable =
-		        !fdtable ? nullptr
-		                 : static_cast<const libsinsp::state::base_table*>(fdtable->table_ptr());
+		        !fdtable ? nullptr : static_cast<const libsinsp::state::base_table*>(fdtable);
 	}
 
 	void set_exepath(std::string&& exepath);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR replaces memcpy from/to an offset within the entry with a pair of lambdas. This makes reads/writes go through C++ assignments so it enables conversions and custom read/write accessors (e.g. taking a lock or doing atomic ops).

A subsequent PR will convert dynamic tables and STL tables to the same model, and then we'll do another (final) round of cleanups.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I'm not 100% a fan of the macro-based approach, but I left it in for two reasons:
1. It's already here
2. I did manage to get a full template-based macro-free solution but honestly I don't know if it's any more readable, especially for non trivial cases (like accessing nested fields).

We can discuss this in a separate PR.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
