### PR TITLE
fix(modern_bpf): skip syscall -1

### DIFF
--- a/driver/modern_bpf/helpers/interfaces/toctou_mitigation.h
+++ b/driver/modern_bpf/helpers/interfaces/toctou_mitigation.h
@@ -54,6 +54,14 @@ static __always_inline int toctou_mitigation__64bit_should_drop(uint32_t syscall
 	uint32_t socketcall_syscall_id = -1;
 #endif
 
+	/* syscall_id == -1 means "no syscall" (e.g. cancelled by ptrace/seccomp).
+	 * Bail out early to avoid accidentally matching the socketcall_syscall_id
+	 * sentinel value.
+	 */
+	if(syscall_id == (uint32_t)-1) {
+		return 1;
+	}
+
 	// Convert the socketcall id into the network syscall id.
 	// In this way the syscall will be treated exactly as the original one.
 	if(syscall_id == socketcall_syscall_id) {

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -179,6 +179,17 @@ int BPF_PROG(sys_exit, struct pt_regs *regs, long ret) {
 
 	uint32_t syscall_id = extract__syscall_id(regs);
 
+	/* On x86_64, orig_rax == -1 means "no syscall" (e.g. the syscall was
+	 * cancelled by ptrace/seccomp, or this is a signal-interrupted restart).
+	 * We must bail out early, otherwise syscall_id (0xFFFFFFFF) would
+	 * accidentally match the socketcall_syscall_id sentinel value of -1
+	 * and we'd enter the socketcall conversion path with garbage registers,
+	 * misrouting to arbitrary syscall handlers.
+	 */
+	if(syscall_id == (uint32_t)-1) {
+		return 0;
+	}
+
 	if(bpf_in_ia32_syscall()) {
 #if defined(__TARGET_ARCH_x86)
 		if(syscall_id == __NR_ia32_socketcall) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

syscall id -1 means the system call was interrupted or cancelled (e.g. by ptrace or a signal) and is not processed normally.

Unfortunately, we also picked -1 as the "syscall does not exist" value for socketcall on architectures that do not support it. This means that syscalls interrupted by signals were actually treated as socketcall and dispatched based on whatever happened to be in the registers.

This led to tons of bogus SOCKET_X (mostly, but not only) events being reported, filling the fd table with fds that would never get cleaned up (they never really existed so nobody closed them).

Combined with copying the fd table on creating a new process, this led to fd table size explosion (thousands of bogus fds copied to all children).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
