### PR TITLE
feat: add support for BPF iterators in multi-thread mode

### DIFF
--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -186,7 +186,7 @@ static __always_inline uint16_t maps__get_ppm_sc(uint16_t syscall_id) {
 #ifdef BPF_ITERATOR_SUPPORT
 
 static __always_inline struct auxiliary_map *maps__get_iter_auxiliary_map() {
-	uint32_t key = 0;
+	uint32_t key = max_iters_num == 1 ? 0 : (uint32_t)bpf_get_current_pid_tgid();
 	return bpf_map_lookup_elem(&iter_auxiliary_map, &key);
 }
 
@@ -199,7 +199,7 @@ static __always_inline struct auxiliary_map *maps__get_iter_auxiliary_map() {
 #ifdef BPF_ITERATOR_SUPPORT
 
 static __always_inline struct iter_counters *maps__get_iter_counters() {
-	uint32_t key = 0;
+	uint32_t key = max_iters_num == 1 ? 0 : (uint32_t)bpf_get_current_pid_tgid();
 	return bpf_map_lookup_elem(&iter_counters_map, &key);
 }
 

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -63,9 +63,17 @@ __weak const volatile uint32_t g_ia32_to_64_table[SYSCALL_TABLE_SIZE];
 
 /**
  * @brief Number of ring buffers. If set to zero, events will be pushed to the ring buffer
- * associated with the current CPU).
+ * associated with the current CPU.
  */
 __weak const volatile uint16_t ringbufs_num;
+
+/**
+ * @brief Maximum number of allowed iterator threads that can run concurrently. This must always be
+ * strictly positive. This directly affects iterator-related maps: if set to 1, `iter_auxiliary_map`
+ * and `iter_counters_map` will be array maps with a single entry; otherwise, they will be hash maps
+ * with an entry for each worker, indexed by the thread id of the corresponding worker.
+ */
+__weak const volatile uint8_t max_iters_num = 1;
 
 /*=============================== BPF READ-ONLY GLOBAL VARIABLES ===============================*/
 
@@ -151,32 +159,6 @@ struct {
 	__type(value, struct capture_settings);
 } capture_settings __weak SEC(".maps");
 
-#ifdef BPF_ITERATOR_SUPPORT
-
-/**
- * @brief Global iterator auxiliary map where the iterator event is temporally saved before being
- * pushed to userspace.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, uint32_t);
-	__type(value, struct auxiliary_map);
-} iter_auxiliary_map __weak SEC(".maps");
-
-/**
- * @brief Global iterator counters map accounting the number of dropped and processed iterator
- * events.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, uint32_t);
-	__type(value, struct iter_counters);
-} iter_counters_map __weak SEC(".maps");
-
-#endif /* BPF_ITERATOR_SUPPORT */
-
 /* These maps have one entry for each CPU.
  *
  * PLEASE NOTE:
@@ -236,3 +218,38 @@ struct {
 } ringbuf_maps __weak SEC(".maps");
 
 /*=============================== RINGBUF MAP ===============================*/
+
+#ifdef BPF_ITERATOR_SUPPORT
+/*=============================== BPF ITERATOR MAPS ===============================*/
+
+/* The type of these maps is patched during the preloading phase, and is linked to the maximum
+ * number of concurrent userspace iterators (see `max_iters_num`):
+ * - if there is at most a single iterator, these will be array maps with a single entry
+ * - otherwise, they will be hash maps with an entry for each iterator, indexed by the thread id of
+ * the iterator thread.
+ */
+
+/**
+ * @brief Auxiliary map holding scratch buffers where iterator events are temporally saved before
+ * being pushed to userspace.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, uint32_t);
+	__type(value, struct auxiliary_map);
+} iter_auxiliary_map __weak SEC(".maps");
+
+/**
+ * @brief Counters map accounting the number of dropped and processed iterator events.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, uint32_t);
+	__type(value, struct iter_counters);
+} iter_counters_map __weak SEC(".maps");
+
+/*=============================== BPF ITERATOR MAPS ===============================*/
+
+#endif /* BPF_ITERATOR_SUPPORT */

--- a/test/drivers/start_tests.cpp
+++ b/test/drivers/start_tests.cpp
@@ -158,6 +158,8 @@ int open_engine(int argc, char** argv) {
 		{
 			abort_if_already_configured(vtable);
 			vtable = &scap_modern_bpf_engine;
+			modern_bpf_params.buffers_num = DEFAULT_BUFFERS_NUM;
+			modern_bpf_params.iters_num = DEFAULT_ITERS_NUM;
 			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			oargs.engine_params = &modern_bpf_params;
 			std::cout << "* Configure modern BPF probe tests!" << std::endl;

--- a/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/modern_bpf.cpp
@@ -25,6 +25,7 @@ scap_t* open_modern_bpf_engine(char* error_buf,
                                int32_t* rc,
                                unsigned long buffer_dim,
                                double buffers_num,
+                               int iters_num,
                                bool online_only,
                                std::unordered_set<uint32_t> ppm_sc_set = {}) {
 	struct scap_open_args oargs {};
@@ -42,6 +43,7 @@ scap_t* open_modern_bpf_engine(char* error_buf,
 
 	struct scap_modern_bpf_engine_params modern_bpf_params = {
 	        .buffers_num = buffers_num,
+	        .iters_num = iters_num,
 	        .allocate_online_only = online_only,
 	        .buffer_bytes_dim = buffer_dim,
 	};
@@ -55,7 +57,7 @@ TEST(modern_bpf, open_engine) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* we want 1 ring buffer for each CPU */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, true);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, 1, true);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine: " << error_buffer << std::endl;
 	scap_close(h);
@@ -64,7 +66,7 @@ TEST(modern_bpf, open_engine) {
 TEST(modern_bpf, empty_buffer_dim) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 0, 1, true);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 0, 1, 1, true);
 	ASSERT_TRUE(!h || ret != SCAP_SUCCESS)
 	        << "the buffer dimension is 0, we should fail: " << error_buffer << std::endl;
 	/* In case of failure the `scap_close(h)` is already called in the vtable `init` method */
@@ -74,7 +76,7 @@ TEST(modern_bpf, wrong_buffer_dim) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* ring buffer dim is not a multiple of PAGE_SIZE */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 + 4 * 4096, 1, true);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 + 4 * 4096, 1, 1, true);
 	ASSERT_TRUE(!h || ret != SCAP_SUCCESS)
 	        << "the buffer dimension is not a multiple of the page size, we should fail: "
 	        << error_buffer << std::endl;
@@ -89,6 +91,7 @@ TEST(modern_bpf, not_enough_possible_CPUs) {
 	                                   &ret,
 	                                   4 * 4096,
 	                                   1.0 / (num_possible_CPUs + 1),
+	                                   1,
 	                                   false);
 	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater "
 	                                          "than the system possible CPUs, we should fail: "
@@ -101,8 +104,12 @@ TEST(modern_bpf, not_enough_online_CPUs) {
 
 	ssize_t num_online_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
 
-	scap_t* h =
-	        open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1.0 / (num_online_CPUs + 1), true);
+	scap_t* h = open_modern_bpf_engine(error_buffer,
+	                                   &ret,
+	                                   4 * 4096,
+	                                   1.0 / (num_online_CPUs + 1),
+	                                   1,
+	                                   true);
 	ASSERT_TRUE(!h || ret != SCAP_SUCCESS) << "the CPUs required for each ring buffer are greater "
 	                                          "than the system online CPUs, we should fail: "
 	                                       << error_buffer << std::endl;
@@ -111,7 +118,7 @@ TEST(modern_bpf, not_enough_online_CPUs) {
 TEST(modern_bpf, one_buffer_per_possible_CPU) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1, 1, false);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer
 	        << std::endl;
@@ -128,7 +135,7 @@ TEST(modern_bpf, one_buffer_per_possible_CPU) {
 TEST(modern_bpf, one_buffer_every_two_possible_CPUs) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0.5, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0.5, 1, false);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one ring buffer every 2 CPUs: "
 	        << error_buffer << std::endl;
@@ -150,7 +157,7 @@ TEST(modern_bpf, one_buffer_shared_between_all_possible_CPUs_with_special_value)
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* `0` is a special value that means one single shared ring buffer */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 0, 1, false);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -173,7 +180,8 @@ TEST(modern_bpf, one_buffer_shared_between_all_online_CPUs_with_explicit_CPUs_nu
 
 	ssize_t num_possible_CPUs = sysconf(_SC_NPROCESSORS_ONLN);
 
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1.0 / num_possible_CPUs, true);
+	scap_t* h =
+	        open_modern_bpf_engine(error_buffer, &ret, 4 * 4096, 1.0 / num_possible_CPUs, 1, true);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -189,7 +197,7 @@ TEST(modern_bpf, read_in_order_one_buffer_per_online_CPU) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 1, true);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 1, 1, true);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one ring buffer per CPU: " << error_buffer
 	        << std::endl;
@@ -202,7 +210,7 @@ TEST(modern_bpf, read_in_order_one_buffer_every_two_online_CPUs) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0.5, true);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0.5, 1, true);
 	ASSERT_FALSE(!h || ret != SCAP_SUCCESS)
 	        << "unable to open modern bpf engine with one ring buffer every 2 CPUs: "
 	        << error_buffer << std::endl;
@@ -215,7 +223,7 @@ TEST(modern_bpf, read_in_order_one_buffer_shared_between_all_possible_CPUs) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -228,7 +236,7 @@ TEST(modern_bpf, scap_stats_check) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -246,7 +254,7 @@ TEST(modern_bpf, double_scap_stats_call) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -268,7 +276,7 @@ TEST(modern_bpf, double_scap_stats_call) {
 TEST(modern_bpf, metrics_v2_check_per_CPU_stats) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -332,7 +340,7 @@ TEST(modern_bpf, metrics_v2_check_kernel_iter_stats) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -392,7 +400,7 @@ TEST(modern_bpf, metrics_v2_check_results) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -444,7 +452,7 @@ TEST(modern_bpf, metrics_v2_check_empty) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;
@@ -462,7 +470,7 @@ TEST(modern_bpf, double_metrics_v2_call) {
 	char error_buffer[FILENAME_MAX]{};
 	int ret = 0;
 	/* We use buffers of 1 MB to be sure that we don't have drops */
-	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, false);
+	scap_t* h = open_modern_bpf_engine(error_buffer, &ret, 1 * 1024 * 1024, 0, 1, false);
 	ASSERT_EQ(!h || ret != SCAP_SUCCESS, false)
 	        << "unable to open modern bpf engine with one single shared ring buffer: "
 	        << error_buffer << std::endl;

--- a/test/libsinsp_e2e/event_capture.cpp
+++ b/test/libsinsp_e2e/event_capture.cpp
@@ -212,7 +212,11 @@ void event_capture::open_engine(const std::string& engine_string,
 #endif
 #ifdef HAS_ENGINE_MODERN_BPF
 	else if(!engine_string.compare(MODERN_BPF_ENGINE)) {
-		m_inspector->open_modern_bpf(s_buffer_dim, DEFAULT_BUFFERS_NUM, true, events_sc_codes);
+		m_inspector->open_modern_bpf(s_buffer_dim,
+		                             DEFAULT_BUFFERS_NUM,
+		                             DEFAULT_ITERS_NUM,
+		                             true,
+		                             events_sc_codes);
 	}
 #endif
 	else {

--- a/userspace/libpman/include/libpman.h
+++ b/userspace/libpman/include/libpman.h
@@ -59,6 +59,8 @@ struct scap_stats;
  * - if buffers_num > 0 && buffers_num <= 1, 1 / buffers_num is the number of CPUs to which we want
  *   to associate a ring buffer.
  * - if buffers_num == 0, it means that 1 ring buffer is shared among all available CPUs
+ * @param iters_num the maximum number of iterator threads that will use `pman_fetch_*` APIs. It
+ * must be in the range [1; 255].
  * @param allocate_online_only if true, allocate ring buffers taking only into account online CPUs.
  *   This parameter is taken into account only if buffers_num >= 0 && buffers_num <= 1.
  * @return `0` on success, `-1` in case of error.
@@ -66,6 +68,7 @@ struct scap_stats;
 int pman_init_state(falcosecurity_log_fn log_fn,
                     unsigned long buf_bytes_dim,
                     double buffers_num,
+                    int iters_num,
                     bool allocate_online_only);
 
 /**
@@ -341,7 +344,7 @@ extern pman_ringbuf_t PMAN_INVALID_RING_BUFFER_HANDLE;
 
 /**
  * @brief Get the number of allocated ring buffer handles. The returned value determines the maximum
- * number of times that `scap_buffer_reserve_handle` can be called.
+ * number of times that `pman_reserve_ringbuf_handle` can be called.
  *
  * @return The number of allocated ring buffer handles.
  */

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -96,18 +96,34 @@ void pman_clear_state() {
 #ifdef BPF_ITERATOR_SUPPORT
 
 	/* BPF iterators section */
+	g_state.n_max_iters = 0;
+	__atomic_store_n(&g_state.n_encountered_iters, 0, __ATOMIC_SEQ_CST);
 	g_state.is_tasks_dumping_supported = false;
 	g_state.is_task_files_dumping_supported = false;
 
 #endif /* BPF_ITERATOR_SUPPORT */
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
+static int init_iter_state(const uint8_t iters_num) {
+	g_state.n_max_iters = iters_num;
+	__atomic_store_n(&g_state.n_encountered_iters, 0, __ATOMIC_SEQ_CST);
+	return 0;
+}
+#endif /* BPF_ITERATOR_SUPPORT */
+
 int pman_init_state(falcosecurity_log_fn log_fn,
                     unsigned long buf_bytes_dim,
                     double buffers_num,
+                    int iters_num,
                     bool allocate_online_only) {
 	if(buffers_num < 0) {
 		pman_print_errorf("buffers_num cannot be negative");
+		return -1;
+	}
+
+	if(iters_num < 1 || iters_num > UINT8_MAX) {
+		pman_print_errorf("iters_num cannot be less than 1 or greater than %u", UINT8_MAX);
 		return -1;
 	}
 
@@ -161,6 +177,14 @@ int pman_init_state(falcosecurity_log_fn log_fn,
 		g_state.n_required_buffers = (uint32_t)buffers_num;
 		/* The following disables cpus-to-ring-buffers mapping */
 		g_state.cpus_for_each_buffer = 0;
+
+#ifdef BPF_ITERATOR_SUPPORT
+		/* BPF iterators configuration section */
+		if(init_iter_state((uint8_t)iters_num)) {
+			return -1;
+		}
+#endif /* BPF_ITERATOR_SUPPORT */
+
 		return 0;
 	}
 
@@ -217,6 +241,13 @@ int pman_init_state(falcosecurity_log_fn log_fn,
 	if((g_state.n_interesting_cpus % g_state.cpus_for_each_buffer) != 0) {
 		g_state.n_required_buffers++;
 	}
+
+#ifdef BPF_ITERATOR_SUPPORT
+	/* BPF iterators configuration section */
+	if(init_iter_state((uint8_t)iters_num)) {
+		return -1;
+	}
+#endif /* BPF_ITERATOR_SUPPORT */
 
 	return 0;
 }

--- a/userspace/libpman/src/iterators.c
+++ b/userspace/libpman/src/iterators.c
@@ -16,6 +16,12 @@ limitations under the License.
 
 */
 
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <state.h>
+#include <bpf/libbpf.h>
+#include <netinet/in.h>
+
 #include <driver/ppm_events_public.h>
 #include <driver/ppm_param_helpers.h>
 #include <libpman.h>
@@ -23,10 +29,6 @@ limitations under the License.
 #include <libscap/strl.h>
 #include <libscap/scap_likely.h>
 #include <libscap/strerror.h>
-
-#include <state.h>
-#include <bpf/libbpf.h>
-#include <netinet/in.h>
 
 #ifdef BPF_ITERATOR_DEBUG
 
@@ -725,11 +727,73 @@ static int32_t fetch_evts(const int iter_fd,
 }
 
 struct prog_info {
-	struct bpf_link **link;
 	const struct bpf_program *prog;
 	const char *name;
 	enum evt_handler_selector selector;
 };
+
+// `prev` is the value of `g_state.n_encountered_iters` before being atomically incremented.
+static int32_t configure_iter_maps_impl(const uint32_t tid, const uint8_t prev, char *error) {
+	if(prev >= g_state.n_max_iters) {
+		return scap_errprintf(error,
+		                      0,
+		                      "no more free iterator map entries available for new thread with tid "
+		                      "%" PRIu32 ": try to increase the number of required iterators",
+		                      tid);
+	}
+
+	// In case of a single required iterator, both `iter_auxiliary_map` and `iter_counters_map` are
+	// `BPF_MAP_TYPE_ARRAY` maps: their single entry is already pre-allocated and zeroed by the
+	// kernel.
+	if(g_state.n_max_iters == 1) {
+		return SCAP_SUCCESS;
+	}
+
+	const int auxiliary_map_fd = bpf_map__fd(g_state.skel->maps.iter_auxiliary_map);
+	if(auxiliary_map_fd < 0) {
+		return scap_errprintf(error, errno, "failed to get `iter_auxiliary_map` fd");
+	}
+
+	const int counters_map_fd = bpf_map__fd(g_state.skel->maps.iter_counters_map);
+	if(counters_map_fd < 0) {
+		return scap_errprintf(error, errno, "failed to get `iter_counters_map` fd");
+	}
+
+	// Use pre-initialized zeroed static values to populate the map entries' ones.
+	static struct auxiliary_map zeroed_auxmap;
+	static struct iter_counters zeroed_counters;
+
+	if(bpf_map_update_elem(auxiliary_map_fd, &tid, &zeroed_auxmap, BPF_NOEXIST)) {
+		return scap_errprintf(error,
+		                      errno,
+		                      "failed to initialize `iter_auxiliary_map` entry for tid %" PRIu32,
+		                      tid);
+	}
+
+	if(bpf_map_update_elem(counters_map_fd, &tid, &zeroed_counters, BPF_NOEXIST)) {
+		const int last_errno = errno;
+		bpf_map_delete_elem(auxiliary_map_fd, &tid);
+		return scap_errprintf(error,
+		                      last_errno,
+		                      "failed to initialize `iter_counters_map` entry for tid %" PRIu32,
+		                      tid);
+	}
+
+	pman_print_msgf(FALCOSECURITY_LOG_SEV_DEBUG,
+	                "Reserved iterator map entries for new iterator thread with tid %" PRIu32,
+	                tid);
+	return SCAP_SUCCESS;
+}
+
+static int32_t configure_iter_maps(const uint32_t tid, char *error) {
+	// Atomically acquire and increment the counter, but decrement it if an error occurs.
+	const uint8_t prev = __atomic_fetch_add(&g_state.n_encountered_iters, 1, __ATOMIC_SEQ_CST);
+	const int32_t res = configure_iter_maps_impl(tid, prev, error);
+	if(res != SCAP_SUCCESS) {
+		__atomic_fetch_sub(&g_state.n_encountered_iters, 1, __ATOMIC_SEQ_CST);
+	}
+	return res;
+}
 
 static int32_t fetch(const struct prog_info *prog_info,
                      const struct scap_fetch_callbacks *callbacks,
@@ -748,17 +812,21 @@ static int32_t fetch(const struct prog_info *prog_info,
 		                      tid_filter);
 	}
 
-	// The program must not be already attached.
-	if(*prog_info->link) {
-		return scap_errprintf(error,
-		                      0,
-		                      "'%s' program is unexpectedly already attached",
-		                      prog_info->name);
-	}
-
 	errno = 0;
 	int32_t res = SCAP_SUCCESS;
+	struct bpf_link *link = NULL;
 	int iter_fd = -1;
+
+	// Ensure each caller thread has its entries in the iterator maps by leveraging a per-thread
+	// flag that becomes true once the corresponding map entries have been successfully configured.
+	static _Thread_local bool iter_maps_configured = false;
+	if(!iter_maps_configured) {
+		const uint32_t caller_tid = gettid();
+		if((res = configure_iter_maps(caller_tid, error)) != SCAP_SUCCESS) {
+			goto cleanup;
+		}
+		iter_maps_configured = true;
+	}
 
 	// Attach the program.
 	LIBBPF_OPTS(bpf_iter_attach_opts, opts);
@@ -768,14 +836,14 @@ static int32_t fetch(const struct prog_info *prog_info,
 	linfo.task.tid = tid_filter;  // If the tid is set to zero, no filtering logic is applied.
 	opts.link_info = &linfo;
 	opts.link_info_len = sizeof(linfo);
-	*prog_info->link = bpf_program__attach_iter(prog_info->prog, &opts);
-	if(!*prog_info->link) {
+	link = bpf_program__attach_iter(prog_info->prog, &opts);
+	if(!link) {
 		res = scap_errprintf(error, errno, "failed to attach the '%s' program", prog_info->name);
 		goto cleanup;
 	}
 
 	// Create the iter FD.
-	iter_fd = bpf_iter_create(bpf_link__fd(*prog_info->link));
+	iter_fd = bpf_iter_create(bpf_link__fd(link));
 	if(iter_fd < 0) {
 		res = scap_errprintf(error,
 		                     errno,
@@ -796,22 +864,19 @@ cleanup:
 	if(iter_fd >= 0 && close(iter_fd) < 0) {
 		pman_print_errorf("failed to close iter FD for `%s` program", prog_info->name);
 	}
-	if(*prog_info->link && bpf_link__destroy(*prog_info->link)) {
+	if(link && bpf_link__destroy(link)) {
 		pman_print_errorf("failed to detach the `%s` program", prog_info->name);
 	}
-	*prog_info->link = NULL;
 	return res;
 }
 
 static void fill_dump_task_prog_info(struct prog_info *info) {
-	info->link = &g_state.skel->links.dump_task;
 	info->prog = g_state.skel->progs.dump_task;
 	info->name = "dump_task";
 	info->selector = EHS_TASK;
 }
 
 static void fill_dump_task_file_prog_info(struct prog_info *info) {
-	info->link = &g_state.skel->links.dump_task_file;
 	info->prog = g_state.skel->progs.dump_task_file;
 	info->name = "dump_task_file";
 	info->selector = EHS_TASK_FILE;

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -281,6 +281,8 @@ void pman_close_probe() {
 #ifdef BPF_ITERATOR_SUPPORT
 
 	/* BPF iterators section */
+	g_state.n_max_iters = 0;
+	__atomic_store_n(&g_state.n_encountered_iters, 0, __ATOMIC_SEQ_CST);
 	g_state.is_tasks_dumping_supported = false;
 	g_state.is_task_files_dumping_supported = false;
 

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -80,6 +80,10 @@ static void set_ringbufs_num() {
 	        pman_is_cpus_to_ringbufs_mapping_disabled() ? g_state.n_required_buffers : 0;
 }
 
+static void set_max_iters_num(const uint8_t max_iters_num) {
+	g_state.skel->rodata->max_iters_num = max_iters_num;
+}
+
 /*=============================== BPF READ-ONLY GLOBAL VARIABLES ===============================*/
 
 /*=============================== BPF GLOBAL VARIABLES ===============================*/
@@ -397,6 +401,43 @@ static int size_counter_maps(const struct bpf_probe* probe, const uint32_t max_e
 
 /*=============================== BPF_MAP_TYPE_ARRAY ===============================*/
 
+/*=============================== BPF ITERATOR MAPS ===============================*/
+
+#ifdef BPF_ITERATOR_SUPPORT
+
+static int configure_iter_map(struct bpf_map* map, const uint32_t max_entries) {
+	// Set the type to `BPF_MAP_TYPE_ARRAY` or `BPF_MAP_TYPE_HASH` depending on the number of chosen
+	// max entries.
+	const enum bpf_map_type map_type = max_entries == 1 ? BPF_MAP_TYPE_ARRAY : BPF_MAP_TYPE_HASH;
+	if(bpf_map__set_type(map, map_type)) {
+		const int last_errno = errno;
+		const char* map_name = bpf_map__name(map);
+		pman_print_errorf("unable to set map type for '%s' to %d", map_name, map_type);
+		return last_errno;
+	}
+
+	if(bpf_map__set_max_entries(map, max_entries)) {
+		const int last_errno = errno;
+		const char* map_name = bpf_map__name(map);
+		pman_print_errorf("unable to set max entries for '%s' to %d", map_name, max_entries);
+		return last_errno;
+	}
+	return 0;
+}
+
+static int configure_iter_auxiliary_maps(const struct bpf_probe* probe,
+                                         const uint32_t max_entries) {
+	return configure_iter_map(probe->maps.iter_auxiliary_map, max_entries);
+}
+
+static int configure_iter_counters_maps(const struct bpf_probe* probe, const uint32_t max_entries) {
+	return configure_iter_map(probe->maps.iter_counters_map, max_entries);
+}
+
+#endif  // BPF_ITERATOR_SUPPORT
+
+/*=============================== BPF ITERATOR MAPS ===============================*/
+
 /* Here we split maps operations, before and after the loading phase.
  */
 
@@ -407,20 +448,38 @@ int pman_prepare_maps_before_loading() {
 	pman_fill_ia32_to_64_table();
 	pman_fill_syscall_sampling_table();
 	set_ringbufs_num();
+#ifdef BPF_ITERATOR_SUPPORT
+	set_max_iters_num(g_state.n_max_iters);
+#else
+	set_max_iters_num(1);
+#endif  // BPF_ITERATOR_SUPPORT
 
 	/* We need to set the entries number for every BPF_MAP_TYPE_ARRAY. The number of entries will be
 	 * always equal to the CPUs number, even if some of them are not online.
 	 */
 	int err = size_auxiliary_maps(g_state.skel, g_state.n_possible_cpus);
 	err = err ?: size_counter_maps(g_state.skel, g_state.n_possible_cpus);
+
+#ifdef BPF_ITERATOR_SUPPORT
+	/* We need to set the entries number for every map used by BPF iterator programs. The number of
+	 * entries will be always equal to the maximum number of allowed iterator threads, even if it
+	 * doesn't happen we manage to encounter all of them.
+	 */
+	err = err ?: configure_iter_auxiliary_maps(g_state.skel, g_state.n_max_iters);
+	err = err ?: configure_iter_counters_maps(g_state.skel, g_state.n_max_iters);
+#endif  // BPF_ITERATOR_SUPPORT
+
 	return err;
 }
 
 #ifdef BPF_ITERATOR_SUPPORT
 // Variant of `pman_prepare_maps_before_loading()` used for testing BPF iterator programs support.
 int iter_support_probing__prepare_maps_before_loading(struct iter_support_probing_ctx* ctx) {
+	set_max_iters_num(1);
 	int err = size_auxiliary_maps(ctx->probe, 1);
 	err = err ?: size_counter_maps(ctx->probe, 1);
+	err = err ?: configure_iter_auxiliary_maps(ctx->probe, 1);
+	err = err ?: configure_iter_counters_maps(ctx->probe, 1);
 	return err;
 }
 #endif  // BPF_ITERATOR_SUPPORT

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -78,7 +78,10 @@ struct internal_state {
 
 #ifdef BPF_ITERATOR_SUPPORT
 
-	/* BPF iterator section */
+	/* BPF iterators section */
+	uint8_t n_max_iters;         /* Maximum number of allowed iterator threads. */
+	uint8_t n_encountered_iters; /* Number of encountered iterator threads. Always <= `n_max_iters`.
+	                                Updated atomically. */
 	bool is_tasks_dumping_supported;      /* If true, use the corresponding BPF iterator program to
 	                                         gather tasks information */
 	bool is_task_files_dumping_supported; /* If true, use the corresponding BPF iterator program to

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -378,10 +378,36 @@ static void set_kernel_iter_counter(const uint32_t base_offset,
 // number of collected stats on success, -1 otherwise.
 static int collect_kernel_iter_counter_stats(const int counters_map_fd, const int base_offset) {
 	struct iter_counters counters = {};
-	const uint32_t key = 0;  // Just a single entry.
-	if(bpf_map_lookup_elem(counters_map_fd, &key, &counters) < 0) {
-		pman_print_errorf("unable to get BPF iterator programs counters");
-		return -1;
+	uint32_t key;
+	for(const uint32_t *prev = NULL; bpf_map_get_next_key(counters_map_fd, prev, &key) == 0;
+	    prev = &key) {
+		struct iter_counters entry = {};
+		if(bpf_map_lookup_elem(counters_map_fd, &key, &entry) < 0) {
+			pman_print_errorf("unable to get BPF iterator programs counters for tid %u", key);
+			return -1;
+		}
+
+		counters.n_evts_task += entry.n_evts_task;
+		counters.n_evts_task_file_pipe += entry.n_evts_task_file_pipe;
+		counters.n_evts_task_file_memfd += entry.n_evts_task_file_memfd;
+		counters.n_evts_task_file_regular += entry.n_evts_task_file_regular;
+		counters.n_evts_task_file_directory += entry.n_evts_task_file_directory;
+		counters.n_evts_task_file_socket_inet += entry.n_evts_task_file_socket_inet;
+		counters.n_evts_task_file_socket_inet6 += entry.n_evts_task_file_socket_inet6;
+		counters.n_evts_task_file_socket_unix += entry.n_evts_task_file_socket_unix;
+		counters.n_evts_task_file_socket_netlink += entry.n_evts_task_file_socket_netlink;
+		counters.n_evts_task_file_anon_inode += entry.n_evts_task_file_anon_inode;
+		counters.n_drops_max_event_size += entry.n_drops_max_event_size;
+		counters.n_drops_task += entry.n_drops_task;
+		counters.n_drops_task_file_pipe += entry.n_drops_task_file_pipe;
+		counters.n_drops_task_file_memfd += entry.n_drops_task_file_memfd;
+		counters.n_drops_task_file_regular += entry.n_drops_task_file_regular;
+		counters.n_drops_task_file_directory += entry.n_drops_task_file_directory;
+		counters.n_drops_task_file_socket_inet += entry.n_drops_task_file_socket_inet;
+		counters.n_drops_task_file_socket_inet6 += entry.n_drops_task_file_socket_inet6;
+		counters.n_drops_task_file_socket_unix += entry.n_drops_task_file_socket_unix;
+		counters.n_drops_task_file_socket_netlink += entry.n_drops_task_file_socket_netlink;
+		counters.n_drops_task_file_anon_inode += entry.n_drops_task_file_anon_inode;
 	}
 
 	set_kernel_iter_counter(base_offset, MODERN_BPF_ITER_N_EVTS_TASK, counters.n_evts_task);

--- a/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
+++ b/userspace/libscap/engine/modern_bpf/modern_bpf_public.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #define MODERN_BPF_ENGINE "modern_bpf"
 #define DEFAULT_BUFFERS_NUM 1
+#define DEFAULT_ITERS_NUM 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,6 +32,8 @@ struct scap_modern_bpf_engine_params {
 	                     ///<   number of CPUs to which we want to associate a ring buffer.
 	                     ///< - if buffers_num == 0, it means that 1 ring buffer is shared among all
 	                     ///<   available CPUs.
+	int iters_num;  ///< [EXPERIMENTAL] Determines the maximum number of allowed iterator threads.
+	                ///< It must be in the range [1; 255].
 	bool allocate_online_only;  ///< [EXPERIMENTAL] Allocate ring buffers only for online CPUs. The
 	                            ///< number of ring buffers allocated changes according to the
 	                            ///< `buffers_num` param. This parameter is taken into account only

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -297,6 +297,7 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs) {
 	if(pman_init_state(oargs->log_fn,
 	                   params->buffer_bytes_dim,
 	                   params->buffers_num,
+	                   params->iters_num,
 	                   params->allocate_online_only)) {
 		return scap_errprintf(handle->m_lasterr, 0, "unable to configure the libpman state.");
 	}

--- a/userspace/libscap/examples/01-open/scap_open.c
+++ b/userspace/libscap/examples/01-open/scap_open.c
@@ -50,6 +50,7 @@ using namespace std;
 #define BUFFER_OPTION "--buffer_dim"
 #define SIMPLE_SET_OPTION "--simple_set"
 #define BUFFERS_NUM_OPTION "--buffers_num"
+#define ITERS_NUM_OPTION "--iters_num"
 #define ALL_AVAILABLE_CPUS_MODE "--available_cpus"
 #define DROP_FAILED "--drop-failed"
 #define VERBOSE_OPTION "--verbose"
@@ -307,6 +308,10 @@ void print_help() {
 	       "`<buffers_num == 0` it means that 1 ring buffer is shared among all available CPUs. "
 	       "Default: 1.\n",
 	       BUFFERS_NUM_OPTION);
+	printf("'%s <iters_num>': determines the maximum number of allowed iterator threads. "
+	       "It must be in the range [1; 255]. Moreover, it must also be greater than or equal to "
+	       "`<buffers_num>` if this latter is greater than 1. Default: 1.\n",
+	       ITERS_NUM_OPTION);
 	printf("'%s': allocate ring buffers for all available CPUs. Default: allocate ring buffers for "
 	       "online CPUs only.\n",
 	       ALL_AVAILABLE_CPUS_MODE);
@@ -414,6 +419,7 @@ void parse_CLI_options(int argc, char** argv) {
 			vtable = &scap_modern_bpf_engine;
 			modern_bpf_params.buffer_bytes_dim = buffer_bytes_dim;
 			modern_bpf_params.buffers_num = DEFAULT_BUFFERS_NUM;
+			modern_bpf_params.iters_num = DEFAULT_ITERS_NUM;
 			modern_bpf_params.allocate_online_only = true;
 			oargs.engine_params = &modern_bpf_params;
 		}
@@ -475,9 +481,10 @@ void parse_CLI_options(int argc, char** argv) {
 				exit(EXIT_FAILURE);
 			}
 
-			char* err_ptr;
-			const double buffers_num = strtod(argv[++i], &err_ptr);
-			if(*err_ptr != '\0' || buffers_num < 0) {
+			const char* ptr = argv[++i];
+			char* endptr;
+			const double buffers_num = strtod(ptr, &endptr);
+			if(endptr == ptr || *endptr != '\0' || buffers_num < 0) {
 				printf("\nInvalid %s parameter. Must be greater than or equal to 0. Bye!\n",
 				       BUFFERS_NUM_OPTION);
 				exit(EXIT_FAILURE);
@@ -499,6 +506,33 @@ void parse_CLI_options(int argc, char** argv) {
 			}
 
 			modern_bpf_params.buffers_num = buffers_num;
+		}
+		/* This should be used only with the modern probe */
+		if(!strcmp(argv[i], ITERS_NUM_OPTION)) {
+			if(!(i + 1 < argc)) {
+				printf("\nYou need to specify also the number of iterators. Bye!\n");
+				exit(EXIT_FAILURE);
+			}
+
+			const char* ptr = argv[++i];
+			char* endptr;
+			const uint64_t iters_num = strtoull(ptr, &endptr, 10);
+			if(endptr == ptr || *endptr != '\0' || iters_num < 1 || iters_num > UINT8_MAX) {
+				printf("\nInvalid %s parameter. Must be in the range [1; 255]. Bye!\n",
+				       ITERS_NUM_OPTION);
+				exit(EXIT_FAILURE);
+			}
+
+			const double buffers_num = modern_bpf_params.buffers_num;
+			if(buffers_num > 1 && iters_num < buffers_num) {
+				printf("\nInvalid %s parameter. Must be greater than or equal to %g. Bye!\n",
+				       ITERS_NUM_OPTION,
+				       buffers_num);
+				exit(EXIT_FAILURE);
+			}
+
+			// Truncation never happens due to previous range check.
+			modern_bpf_params.iters_num = (int)iters_num;
 		}
 		/* This should be used only with the modern probe */
 		if(!strcmp(argv[i], ALL_AVAILABLE_CPUS_MODE)) {

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -85,9 +85,9 @@ static string filter_string = "";
 static string file_path = "";
 static unsigned long buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
 static double buffers_num = DEFAULT_BUFFERS_NUM;
+static double iters_num = DEFAULT_ITERS_NUM;
 static bool all_cpus = false;
 static uint64_t max_events = UINT64_MAX;
-static uint32_t num_processing_threads = 1;  // Number of threads for parallel event processing
 static std::shared_ptr<sinsp_plugin> plugin;
 static std::string open_params;  // for source plugins, its open params
 static std::unique_ptr<filter_check_list> filter_list;
@@ -500,13 +500,13 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 			" - if `<num> > 1`, number of requested ring buffers;\n"
 			" - if `<num> > 0 && <num> <= 1`, a ring buffer for every `1 / <num>` CPUs;\n"
 			" - if `<num> == 0`, one ring buffer shared among all CPUs.\n"
-			" Default when omitted: 1. Ignored when -P is specified.",
+			" Default when omitted: 1.",
 			cxxopts::value<double>())
-		("P,processing-threads",
-			"Number of parallel event processing threads with TGID-partitioned ring buffers.\n"
-			" Allocates <num> ring buffers with events routed by tgid, one thread per buffer.\n"
-			" When specified, overrides --buffers-num (-b).",
-			cxxopts::value<uint32_t>());
+		("iters-num",
+			"(modern eBPF probe only) Determines the maximum number of allowed iterator "
+			"threads. It must be in the range [1; 255]. Moreover, it must also be greater than or "
+			"equal to `<buffers-num>` if this latter is greater than 1. Default when omitted: 1.",
+			cxxopts::value<int>());
 	// clang-format on
 
 	add_platform_test_options(options);
@@ -618,6 +618,24 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 			buffers_num = bufs_num;
 		}
 
+		if(result.count("iters-num")) {
+			const auto iters = result["iters-num"].as<int>();
+			if(const auto max_u8 = std::numeric_limits<uint8_t>::max();
+			   iters < 1 || iters > max_u8) {
+				std::cerr << "Invalid iters-num option value. Must be in range [1; " << max_u8
+				          << "]" << std::endl;
+				exit(EXIT_FAILURE);
+			}
+
+			if(buffers_num > 1 && iters < buffers_num) {
+				std::cerr << "Invalid iters-num option value. Must be greater than or equal to "
+				          << static_cast<int>(buffers_num) << std::endl;
+				exit(EXIT_FAILURE);
+			}
+
+			iters_num = iters;
+		}
+
 		if(result.count("all-cpus")) {
 			all_cpus = true;
 		}
@@ -670,15 +688,6 @@ void parse_CLI_options(sinsp& inspector, int argc, char** argv) {
 				          << std::endl;
 				exit(EXIT_FAILURE);
 			}
-		}
-
-		if(result.count("processing-threads")) {
-			num_processing_threads = result["processing-threads"].as<uint32_t>();
-			if(num_processing_threads < 2) {
-				std::cerr << "Number of processing threads must be >= 2" << std::endl;
-				exit(EXIT_FAILURE);
-			}
-			buffers_num = static_cast<double>(num_processing_threads);
 		}
 
 		parse_platform_test_options(result);
@@ -756,7 +765,7 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 #endif
 #ifdef HAS_ENGINE_MODERN_BPF
 	else if(!engine_string.compare(MODERN_BPF_ENGINE)) {
-		inspector.open_modern_bpf(buffer_bytes_dim, buffers_num, !all_cpus, ppm_sc);
+		inspector.open_modern_bpf(buffer_bytes_dim, buffers_num, iters_num, !all_cpus, ppm_sc);
 	}
 #endif
 #ifdef HAS_ENGINE_SOURCE_PLUGIN
@@ -1080,6 +1089,9 @@ int main(int argc, char** argv) {
 	std::cout << "-- Start capture" << std::endl;
 
 	inspector.start_capture();
+
+	static uint32_t num_processing_threads =
+	        buffers_num <= 1 ? 1 : static_cast<uint32_t>(buffers_num);
 
 	initialize_formatter_vectors(inspector, num_processing_threads);
 

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -726,6 +726,7 @@ void sinsp::open_plugin(const std::string& plugin_name,
 
 void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim,
                             double buffers_num,
+                            int iters_num,
                             bool online_only,
                             const libsinsp::events::set<ppm_sc_code>& ppm_sc_of_interest) {
 #ifdef HAS_ENGINE_MODERN_BPF
@@ -738,6 +739,7 @@ void sinsp::open_modern_bpf(unsigned long driver_buffer_bytes_dim,
 	scap_modern_bpf_engine_params params;
 	params.buffer_bytes_dim = driver_buffer_bytes_dim;
 	params.buffers_num = buffers_num;
+	params.iters_num = iters_num;
 	params.allocate_online_only = online_only;
 	oargs.engine_params = &params;
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -161,6 +161,9 @@ public:
 	 *   as the (integer) number of CPUs to which a single buffer must be associated
 	 * - if `buffers_num` == 0, it means requiring 1 buffer shared among all available CPUs
 	 *
+	 * `iters_num` determines the maximum number of allowed iterator threads. It must be in the
+	 * range [1; 255].
+	 *
 	 * `online_only` is taken into account only if `buffers_num` >= 0 && `buffers_num` <= 1:
 	 * it allows to require allocation of buffers only for online CPUs and not for all
 	 * system-available CPUs.
@@ -168,6 +171,7 @@ public:
 	virtual void open_modern_bpf(
 	        unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM,
 	        double buffers_num = DEFAULT_BUFFERS_NUM,
+	        int iters_num = DEFAULT_ITERS_NUM,
 	        bool online_only = true,
 	        const libsinsp::events::set<ppm_sc_code>& ppm_sc_of_interest = {});
 	virtual void open_test_input(scap_test_input_data* data, sinsp_mode_t mode = SINSP_MODE_TEST);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR exstend BPF iterator logic to be useful in multi-thread mode. Specifically, BPF iterator maps have different shapes depending on the number of "maximum allowed iterator threads" (that is specified at probe initialization through a `iters_num` parameter):
- if there is at most a single iterator, these will be array maps with a single entry;
- otherwise, they will be hash maps with an entry for each iterator, indexed by the thread id of the iterator thread.

Before starting event fetching, the implementation checks if it is the first time that the calling thread uses one of the `pman_fetch_*` APIs and, if it is, initializes maps to take the new ecountered thread into account (specifically, this means that both `iter_auxiliary_map` and `iter_counters_map` are initialized).

Iterator maps initialization is done from userspace, and leverages thread local flags and atomic counters to ensure maps are not initialized twice for the same thread, and that no more than `iters_num` different threads will ever call `pman_fetch_*` APIs.

In multi-thread mode, iterator maps initialization is done by adding a new entry for each encountered new thread to each map. Entries' values are initialized leveraging zeroed values allocated in static memory.

In single-thread mode, the array map has simply a pre-initialized single entry, and no additional work is required when the single thread is encountered for the first time.

The whole design makes the switch between single- and multi-thread mode transparent to users, apart from the `iters_num` probe parameter: this must be evaluated in advance, and include any thread that will ever use any `fetch_*` API.

Each iterator metric is the result of the sum of the corresponding counters on each `iter_counters_map` entry.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
