### PR TITLE
fix: honor `BPF_ITERATOR_SUPPORT` and ensure BPF iterator global state is cleaned 

### DIFF
--- a/driver/modern_bpf/helpers/base/maps_getters.h
+++ b/driver/modern_bpf/helpers/base/maps_getters.h
@@ -183,19 +183,27 @@ static __always_inline uint16_t maps__get_ppm_sc(uint16_t syscall_id) {
 
 /*=============================== ITER AUXILIARY MAP ===========================*/
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 static __always_inline struct auxiliary_map *maps__get_iter_auxiliary_map() {
 	uint32_t key = 0;
 	return bpf_map_lookup_elem(&iter_auxiliary_map, &key);
 }
 
+#endif /* BPF_ITERATOR_SUPPORT */
+
 /*=============================== ITER AUXILIARY MAP ===========================*/
 
 /*=============================== ITER COUNTERS MAP ===========================*/
+
+#ifdef BPF_ITERATOR_SUPPORT
 
 static __always_inline struct iter_counters *maps__get_iter_counters() {
 	uint32_t key = 0;
 	return bpf_map_lookup_elem(&iter_counters_map, &key);
 }
+
+#endif /* BPF_ITERATOR_SUPPORT */
 
 /*=============================== ITER COUNTERS MAP ===========================*/
 

--- a/driver/modern_bpf/helpers/base/stats.h
+++ b/driver/modern_bpf/helpers/base/stats.h
@@ -101,6 +101,8 @@ static __always_inline void compute_event_types_stats(uint16_t event_type,
 	}
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 static __always_inline void account_iter_event_processed(const uint16_t event_type,
                                                          struct iter_counters *counters) {
 	if(!counters) {
@@ -182,3 +184,5 @@ static __always_inline void account_iter_event_drop(const uint16_t event_type,
 		break;
 	}
 }
+
+#endif /* BPF_ITERATOR_SUPPORT */

--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -68,9 +68,11 @@ static __always_inline struct auxiliary_map *auxmap__get() {
 	return maps__get_auxiliary_map();
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
 static __always_inline struct auxiliary_map *auxmap_iter__get() {
 	return maps__get_iter_auxiliary_map();
 }
+#endif /* BPF_ITERATOR_SUPPORT */
 
 /////////////////////////////////
 // STORE EVENT HEADER INTO THE AUXILIARY MAP
@@ -101,6 +103,8 @@ static __always_inline void auxmap__preload_event_header(struct auxiliary_map *a
 	auxmap->event_type = event_type;
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 /**
  * @brief Push the iterator event header inside the auxiliary map.
  *
@@ -128,6 +132,8 @@ static __always_inline void auxmap_iter__preload_event_header(struct auxiliary_m
 	auxmap->event_type = event_type;
 }
 
+#endif /* BPF_ITERATOR_SUPPORT */
+
 /**
  * @brief Finalize the event header writing the overall event len.
  *
@@ -138,6 +144,8 @@ static __always_inline void auxmap__finalize_event_header(struct auxiliary_map *
 	hdr->len = auxmap->payload_pos;
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 /**
  * @brief Finalize the iterator event header writing the overall event len.
  *
@@ -146,6 +154,8 @@ static __always_inline void auxmap__finalize_event_header(struct auxiliary_map *
 static __always_inline void auxmap_iter__finalize_event_header(struct auxiliary_map *auxmap) {
 	auxmap__finalize_event_header(auxmap);
 }
+
+#endif /* BPF_ITERATOR_SUPPORT */
 
 /////////////////////////////////
 // COPY EVENT FROM AUXMAP TO RINGBUF/SEQ FILE
@@ -190,6 +200,8 @@ static __always_inline void auxmap__submit_event(struct auxiliary_map *auxmap) {
 		compute_event_types_stats(auxmap->event_type, counter);
 	}
 }
+
+#ifdef BPF_ITERATOR_SUPPORT
 
 /**
  * @brief Copy the entire event from the auxiliary map to the seq file.
@@ -246,6 +258,8 @@ static __always_inline int auxmap_iter__submit_event(struct auxiliary_map *auxma
 	account_iter_event_processed(evt_type, counters);
 	return 0;
 }
+
+#endif /* BPF_ITERATOR_SUPPORT */
 
 /////////////////////////////////
 // STORE EVENT PARAMS INTO THE AUXILIARY MAP

--- a/driver/modern_bpf/maps/maps.h
+++ b/driver/modern_bpf/maps/maps.h
@@ -145,6 +145,8 @@ struct {
 	__type(value, struct capture_settings);
 } capture_settings __weak SEC(".maps");
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 /**
  * @brief Global iterator auxiliary map where the iterator event is temporally saved before being
  * pushed to userspace.
@@ -166,6 +168,8 @@ struct {
 	__type(key, uint32_t);
 	__type(value, struct iter_counters);
 } iter_counters_map __weak SEC(".maps");
+
+#endif /* BPF_ITERATOR_SUPPORT */
 
 /* These maps have one entry for each CPU.
  *

--- a/userspace/libpman/src/configuration.c
+++ b/userspace/libpman/src/configuration.c
@@ -90,6 +90,14 @@ void pman_clear_state() {
 	}
 	g_state.log_buf = NULL;
 	g_state.log_buf_size = 0;
+
+#ifdef BPF_ITERATOR_SUPPORT
+
+	/* BPF iterators section */
+	g_state.is_tasks_dumping_supported = false;
+	g_state.is_task_files_dumping_supported = false;
+
+#endif /* BPF_ITERATOR_SUPPORT */
 }
 
 int pman_init_state(falcosecurity_log_fn log_fn,

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -274,4 +274,12 @@ void pman_close_probe() {
 	if(g_state.rb_manager) {
 		ring_buffer__free(g_state.rb_manager);
 	}
+
+#ifdef BPF_ITERATOR_SUPPORT
+
+	/* BPF iterators section */
+	g_state.is_tasks_dumping_supported = false;
+	g_state.is_task_files_dumping_supported = false;
+
+#endif /* BPF_ITERATOR_SUPPORT */
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR compiles out some maps and helpers (that are specifically related to BPF iterators support) if `BPF_ITERATOR_SUPPORT` is not defined. Moreover, it ensures that both `pman_clear_state()` and `pman_close_probe()` correctly clear the global state related to BPF iterators.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
