### PR TITLE
fix(userspace/libpman): avoid closing map fds in `pman_get_metrics_v2()` 

### DIFF
--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -39,6 +39,7 @@ typedef enum modern_bpf_kernel_counters_stats {
 	MODERN_BPF_MAX_KERNEL_COUNTERS_STATS
 } modern_bpf_kernel_counters_stats;
 
+#ifdef BPF_ITERATOR_SUPPORT
 typedef enum modern_bpf_kernel_iter_counters_stats {
 	MODERN_BPF_ITER_N_EVTS_TASK = 0,
 	MODERN_BPF_ITER_N_EVTS_TASK_FILE_PIPE,
@@ -63,6 +64,7 @@ typedef enum modern_bpf_kernel_iter_counters_stats {
 	MODERN_BPF_ITER_N_DROPS_TASK_FILE_ANON_INODE,
 	MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS
 } modern_bpf_kernel_iter_counters_stats;
+#endif /* BPF_ITERATOR_SUPPORT */
 
 typedef enum modern_bpf_libbpf_stats {
 	RUN_CNT = 0,
@@ -88,6 +90,7 @@ const char *const modern_bpf_kernel_counters_stats_names[] = {
         [MODERN_BPF_N_DROPS] = "n_drops",
 };
 
+#ifdef BPF_ITERATOR_SUPPORT
 const char *const modern_bpf_kernel_iter_counters_stats_names[] = {
         [MODERN_BPF_ITER_N_EVTS_TASK] = "n_evts_task",
         [MODERN_BPF_ITER_N_EVTS_TASK_FILE_PIPE] = "n_evts_task_file_pipe",
@@ -111,6 +114,7 @@ const char *const modern_bpf_kernel_iter_counters_stats_names[] = {
         [MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_NETLINK] = "n_drops_task_file_socket_netlink",
         [MODERN_BPF_ITER_N_DROPS_TASK_FILE_ANON_INODE] = "n_drops_task_file_anon_inode",
 };
+#endif /* BPF_ITERATOR_SUPPORT */
 
 const char *const modern_bpf_libbpf_stats_names[] = {
         [RUN_CNT] = ".run_cnt",          ///< `bpf_prog_info` run_cnt.
@@ -196,9 +200,11 @@ static int init_metrics_v2(const uint32_t flags) {
 
 	// Account for statistics related to BPF iterator programs.
 	uint32_t iter_stats = 0;
+#ifdef BPF_ITERATOR_SUPPORT
 	if(flags & METRICS_V2_KERNEL_ITER_COUNTERS) {
 		iter_stats = MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS;
 	}
+#endif /* BPF_ITERATOR_SUPPORT */
 
 	const uint32_t n_stats = MODERN_BPF_MAX_KERNEL_COUNTERS_STATS + per_cpu_stats +
 	                         (nprogs_attached * MODERN_BPF_MAX_LIBBPF_STATS) + iter_stats;
@@ -356,6 +362,8 @@ static int collect_libbpf_stats(const int base_offset) {
 	return collected_stats;
 }
 
+#ifdef BPF_ITERATOR_SUPPORT
+
 static void set_kernel_iter_counter(const uint32_t base_offset,
                                     const uint32_t stat_index,
                                     const uint64_t val) {
@@ -440,6 +448,8 @@ static int collect_kernel_iter_counter_stats(const int counters_map_fd, const in
 	return collected_stats;
 }
 
+#endif /* BPF_ITERATOR_SUPPORT */
+
 struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t *rc) {
 	*rc = SCAP_FAILURE;
 	*nstats = 0;
@@ -484,6 +494,7 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 		offset += collected_stats;
 	}
 
+#ifdef BPF_ITERATOR_SUPPORT
 	/* BPF ITERATOR PROGRAMS STATS */
 	if(flags & METRICS_V2_KERNEL_ITER_COUNTERS) {
 		const int counters_map_fd = bpf_map__fd(g_state.skel->maps.iter_counters_map);
@@ -499,6 +510,7 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 		}
 		offset += collected_stats;
 	}
+#endif /* BPF_ITERATOR_SUPPORT */
 
 	/* Update with the real number of stats collected */
 	*nstats = offset;

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -294,6 +294,68 @@ static int collect_kernel_counter_stats(const int counter_maps_fd, const bool co
 	return collected_stats;
 }
 
+// Collects stats for `METRICS_V2_LIBBPF_STATS`. `base_offset` is the first free position in the
+// global v2 metrics array to push libbpf stats to. Returns the strictly-positive number of
+// collected stats on success, -1 otherwise.
+static int collect_libbpf_stats(const int base_offset) {
+	int fd = 0;
+	int offset = base_offset;
+	for(int bpf_prog = 0; bpf_prog < MODERN_BPF_PROG_ATTACHED_MAX; bpf_prog++) {
+		fd = g_state.attached_progs_fds[bpf_prog];
+		if(fd < 0) {
+			/* landing here means prog was not attached */
+			continue;
+		}
+		struct bpf_prog_info info = {};
+		__u32 len = sizeof(info);
+		if(bpf_obj_get_info_by_fd(fd, &info, &len)) {
+			/* no info for that prog, it seems like a bug, but we can go on */
+			continue;
+		}
+
+		for(int stat = 0; stat < MODERN_BPF_MAX_LIBBPF_STATS; stat++) {
+			if(offset >= g_state.nstats) {
+				/* This should never happen, we are doing something wrong */
+				pman_print_errorf("no enough space for all the stats");
+				return -1;
+			}
+			g_state.stats[offset].type = METRIC_VALUE_TYPE_U64;
+			g_state.stats[offset].flags = METRICS_V2_LIBBPF_STATS;
+			strlcpy(g_state.stats[offset].name, info.name, METRIC_NAME_MAX);
+			strlcat(g_state.stats[offset].name,
+			        modern_bpf_libbpf_stats_names[stat],
+			        sizeof(g_state.stats[offset].name));
+			switch(stat) {
+			case RUN_CNT:
+				g_state.stats[offset].unit = METRIC_VALUE_UNIT_COUNT;
+				g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
+				g_state.stats[offset].value.u64 = info.run_cnt;
+				break;
+			case RUN_TIME_NS:
+				g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS_COUNT;
+				g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
+				g_state.stats[offset].value.u64 = info.run_time_ns;
+				break;
+			case AVG_TIME_NS:
+				g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS;
+				g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT;
+				g_state.stats[offset].value.u64 = 0;
+				if(info.run_cnt > 0) {
+					g_state.stats[offset].value.u64 = info.run_time_ns / info.run_cnt;
+				}
+				break;
+			default:
+				ASSERT(false);
+				break;
+			}
+			offset++;
+		}
+	}
+
+	const int collected_stats = offset - base_offset;
+	return collected_stats;
+}
+
 static void set_kernel_iter_counter(const uint32_t base_offset,
                                     const uint32_t stat_index,
                                     const uint64_t val) {
@@ -339,60 +401,12 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 	 * we can simulate perf comparisons between future LSM hooks and tracepoints by leveraging
 	 * syscall selection mechanisms `handle->curr_sc_set`.
 	 */
-	if((flags & METRICS_V2_LIBBPF_STATS)) {
-		int fd = 0;
-		for(int bpf_prog = 0; bpf_prog < MODERN_BPF_PROG_ATTACHED_MAX; bpf_prog++) {
-			fd = g_state.attached_progs_fds[bpf_prog];
-			if(fd < 0) {
-				/* landing here means prog was not attached */
-				continue;
-			}
-			struct bpf_prog_info info = {};
-			__u32 len = sizeof(info);
-			if((bpf_obj_get_info_by_fd(fd, &info, &len))) {
-				/* no info for that prog, it seems like a bug but we can go on */
-				continue;
-			}
-
-			for(int stat = 0; stat < MODERN_BPF_MAX_LIBBPF_STATS; stat++) {
-				if(offset >= g_state.nstats) {
-					/* This should never happen, we are doing something wrong */
-					pman_print_errorf("no enough space for all the stats");
-					return NULL;
-				}
-				g_state.stats[offset].type = METRIC_VALUE_TYPE_U64;
-				g_state.stats[offset].flags = METRICS_V2_LIBBPF_STATS;
-				strlcpy(g_state.stats[offset].name, info.name, METRIC_NAME_MAX);
-				strlcat(g_state.stats[offset].name,
-				        modern_bpf_libbpf_stats_names[stat],
-				        sizeof(g_state.stats[offset].name));
-				switch(stat) {
-				case RUN_CNT:
-					g_state.stats[offset].unit = METRIC_VALUE_UNIT_COUNT;
-					g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
-					g_state.stats[offset].value.u64 = info.run_cnt;
-					break;
-				case RUN_TIME_NS:
-					g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS_COUNT;
-					g_state.stats[offset].metric_type = METRIC_VALUE_METRIC_TYPE_MONOTONIC;
-					g_state.stats[offset].value.u64 = info.run_time_ns;
-					break;
-				case AVG_TIME_NS:
-					g_state.stats[offset].unit = METRIC_VALUE_UNIT_TIME_NS;
-					g_state.stats[offset].metric_type =
-					        METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT;
-					g_state.stats[offset].value.u64 = 0;
-					if(info.run_cnt > 0) {
-						g_state.stats[offset].value.u64 = info.run_time_ns / info.run_cnt;
-					}
-					break;
-				default:
-					ASSERT(false);
-					break;
-				}
-				offset++;
-			}
+	if(flags & METRICS_V2_LIBBPF_STATS) {
+		const int collected_stats = collect_libbpf_stats(offset);
+		if(collected_stats < 0) {
+			return NULL;
 		}
+		offset += collected_stats;
 	}
 
 	/* BPF ITERATOR PROGRAMS STATS */

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -221,6 +221,79 @@ static void set_u64_monotonic_kernel_counter(uint32_t pos, uint64_t val, uint32_
 	g_state.stats[pos].value.u64 = val;
 }
 
+// Collects stats for `METRICS_V2_KERNEL_COUNTERS` and `METRICS_V2_KERNEL_COUNTERS_PER_CPU` (if
+// provided). Returns the strictly-positive number of collected stats on success, -1 otherwise.
+static int collect_kernel_counter_stats(const int counter_maps_fd, const bool collect_per_cpu) {
+	for(uint32_t stat = 0; stat < MODERN_BPF_MAX_KERNEL_COUNTERS_STATS; stat++) {
+		set_u64_monotonic_kernel_counter(stat, 0, METRICS_V2_KERNEL_COUNTERS);
+		strlcpy(g_state.stats[stat].name,
+		        (char *)modern_bpf_kernel_counters_stats_names[stat],
+		        METRIC_NAME_MAX);
+	}
+	uint32_t collected_stats = MODERN_BPF_MAX_KERNEL_COUNTERS_STATS;
+
+	/* We always take statistics from all the CPUs, even if some of them are not online.
+	 * If the CPU is not online the counter map will be empty.
+	 */
+	struct counter_map cnt_map = {};
+	for(uint32_t index = 0; index < g_state.n_possible_cpus; index++) {
+		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0) {
+			pman_print_errorf("unable to get the counter map for CPU %d", index);
+			return -1;
+		}
+		g_state.stats[MODERN_BPF_N_EVTS].value.u64 += cnt_map.n_evts;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.u64 += cnt_map.n_drops_buffer;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_clone_fork_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_execve_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_ENTER].value.u64 +=
+		        cnt_map.n_drops_buffer_connect_enter;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_connect_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OPEN_ENTER].value.u64 +=
+		        cnt_map.n_drops_buffer_open_enter;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OPEN_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_open_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_DIR_FILE_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_dir_file_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OTHER_INTEREST_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_other_interest_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLOSE_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_close_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_BUFFER_PROC_EXIT].value.u64 +=
+		        cnt_map.n_drops_buffer_proc_exit;
+		g_state.stats[MODERN_BPF_N_DROPS_SCRATCH_MAP].value.u64 += cnt_map.n_drops_max_event_size;
+		g_state.stats[MODERN_BPF_N_DROPS].value.u64 +=
+		        (cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size);
+
+		if(!collect_per_cpu) {
+			continue;
+		}
+		// We set the num events for that CPU.
+		set_u64_monotonic_kernel_counter(collected_stats,
+		                                 cnt_map.n_evts,
+		                                 METRICS_V2_KERNEL_COUNTERS_PER_CPU);
+		snprintf(g_state.stats[collected_stats].name,
+		         METRIC_NAME_MAX,
+		         N_EVENTS_PER_CPU_PREFIX "%d",
+		         index);
+		collected_stats++;
+
+		// We set the drops for that CPU.
+		set_u64_monotonic_kernel_counter(collected_stats,
+		                                 cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size,
+		                                 METRICS_V2_KERNEL_COUNTERS_PER_CPU);
+		snprintf(g_state.stats[collected_stats].name,
+		         METRIC_NAME_MAX,
+		         N_DROPS_PER_CPU_PREFIX "%d",
+		         index);
+		collected_stats++;
+	}
+
+	return collected_stats;
+}
+
 static void set_kernel_iter_counter(const uint32_t base_offset,
                                     const uint32_t stat_index,
                                     const uint64_t val) {
@@ -244,81 +317,18 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 
 	/* KERNEL COUNTER STATS */
 	if(flags & METRICS_V2_KERNEL_COUNTERS) {
-		int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
+		const int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
 		if(counter_maps_fd < 0) {
 			pman_print_errorf("unable to get 'counter_maps' fd during kernel stats processing");
 			return NULL;
 		}
 
-		for(uint32_t stat = 0; stat < MODERN_BPF_MAX_KERNEL_COUNTERS_STATS; stat++) {
-			set_u64_monotonic_kernel_counter(stat, 0, METRICS_V2_KERNEL_COUNTERS);
-			strlcpy(g_state.stats[stat].name,
-			        (char *)modern_bpf_kernel_counters_stats_names[stat],
-			        METRIC_NAME_MAX);
+		const bool collect_per_cpu = flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU;
+		const int collected_stats = collect_kernel_counter_stats(counter_maps_fd, collect_per_cpu);
+		if(collected_stats < 0) {
+			return NULL;
 		}
-
-		/* We always take statistics from all the CPUs, even if some of them are not online.
-		 * If the CPU is not online the counter map will be empty.
-		 */
-		struct counter_map cnt_map = {};
-		uint32_t pos = MODERN_BPF_MAX_KERNEL_COUNTERS_STATS;
-		for(uint32_t index = 0; index < g_state.n_possible_cpus; index++) {
-			if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0) {
-				pman_print_errorf("unable to get the counter map for CPU %d", index);
-				close(counter_maps_fd);
-				return NULL;
-			}
-			g_state.stats[MODERN_BPF_N_EVTS].value.u64 += cnt_map.n_evts;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_TOTAL].value.u64 += cnt_map.n_drops_buffer;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLONE_FORK_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_clone_fork_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_EXECVE_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_execve_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_ENTER].value.u64 +=
-			        cnt_map.n_drops_buffer_connect_enter;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CONNECT_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_connect_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OPEN_ENTER].value.u64 +=
-			        cnt_map.n_drops_buffer_open_enter;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OPEN_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_open_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_DIR_FILE_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_dir_file_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_OTHER_INTEREST_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_other_interest_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_CLOSE_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_close_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_BUFFER_PROC_EXIT].value.u64 +=
-			        cnt_map.n_drops_buffer_proc_exit;
-			g_state.stats[MODERN_BPF_N_DROPS_SCRATCH_MAP].value.u64 +=
-			        cnt_map.n_drops_max_event_size;
-			g_state.stats[MODERN_BPF_N_DROPS].value.u64 +=
-			        (cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size);
-
-			if((flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU)) {
-				// We set the num events for that CPU.
-				set_u64_monotonic_kernel_counter(pos,
-				                                 cnt_map.n_evts,
-				                                 METRICS_V2_KERNEL_COUNTERS_PER_CPU);
-				snprintf(g_state.stats[pos].name,
-				         METRIC_NAME_MAX,
-				         N_EVENTS_PER_CPU_PREFIX "%d",
-				         index);
-				pos++;
-
-				// We set the drops for that CPU.
-				set_u64_monotonic_kernel_counter(
-				        pos,
-				        cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size,
-				        METRICS_V2_KERNEL_COUNTERS_PER_CPU);
-				snprintf(g_state.stats[pos].name,
-				         METRIC_NAME_MAX,
-				         N_DROPS_PER_CPU_PREFIX "%d",
-				         index);
-				pos++;
-			}
-		}
-		offset = pos;
+		offset = collected_stats;
 	}
 
 	/* LIBBPF STATS */

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -365,6 +365,81 @@ static void set_kernel_iter_counter(const uint32_t base_offset,
 	strlcpy(g_state.stats[stat_pos].name, stat_name, METRIC_NAME_MAX);
 }
 
+// Collects stats for `METRICS_V2_KERNEL_ITER_COUNTERS`. `base_offset` is the first free position in
+// the global v2 metrics array to push kernel iterator stats to. Returns the strictly-positive
+// number of collected stats on success, -1 otherwise.
+static int collect_kernel_iter_counter_stats(const int counters_map_fd, const int base_offset) {
+	struct iter_counters counters = {};
+	const uint32_t key = 0;  // Just a single entry.
+	if(bpf_map_lookup_elem(counters_map_fd, &key, &counters) < 0) {
+		pman_print_errorf("unable to get BPF iterator programs counters");
+		return -1;
+	}
+
+	set_kernel_iter_counter(base_offset, MODERN_BPF_ITER_N_EVTS_TASK, counters.n_evts_task);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_PIPE,
+	                        counters.n_evts_task_file_pipe);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_MEMFD,
+	                        counters.n_evts_task_file_memfd);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_REGULAR,
+	                        counters.n_evts_task_file_regular);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_DIRECTORY,
+	                        counters.n_evts_task_file_directory);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_INET,
+	                        counters.n_evts_task_file_socket_inet);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_INET6,
+	                        counters.n_evts_task_file_socket_inet6);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_UNIX,
+	                        counters.n_evts_task_file_socket_unix);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_NETLINK,
+	                        counters.n_evts_task_file_socket_netlink);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_ANON_INODE,
+	                        counters.n_evts_task_file_anon_inode);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_MAX_EVENT_SIZE,
+	                        counters.n_drops_max_event_size);
+	set_kernel_iter_counter(base_offset, MODERN_BPF_ITER_N_DROPS_TASK, counters.n_drops_task);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_PIPE,
+	                        counters.n_drops_task_file_pipe);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_MEMFD,
+	                        counters.n_drops_task_file_memfd);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_REGULAR,
+	                        counters.n_drops_task_file_regular);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_DIRECTORY,
+	                        counters.n_drops_task_file_directory);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_INET,
+	                        counters.n_drops_task_file_socket_inet);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_INET6,
+	                        counters.n_drops_task_file_socket_inet6);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_UNIX,
+	                        counters.n_drops_task_file_socket_unix);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_NETLINK,
+	                        counters.n_drops_task_file_socket_netlink);
+	set_kernel_iter_counter(base_offset,
+	                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_ANON_INODE,
+	                        counters.n_drops_task_file_anon_inode);
+
+	const int collected_stats = MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS;
+	return collected_stats;
+}
+
 struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t *rc) {
 	*rc = SCAP_FAILURE;
 	*nstats = 0;
@@ -411,81 +486,18 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 
 	/* BPF ITERATOR PROGRAMS STATS */
 	if(flags & METRICS_V2_KERNEL_ITER_COUNTERS) {
-		const int counters_maps_fd = bpf_map__fd(g_state.skel->maps.iter_counters_map);
-		if(counters_maps_fd < 0) {
+		const int counters_map_fd = bpf_map__fd(g_state.skel->maps.iter_counters_map);
+		if(counters_map_fd < 0) {
 			pman_print_errorf(
 			        "unable to get 'iter_counters_map' fd during kernel stats processing");
 			return NULL;
 		}
 
-		struct iter_counters counters = {};
-		const uint32_t key = 0;  // Just a single entry.
-		if(bpf_map_lookup_elem(counters_maps_fd, &key, &counters) < 0) {
-			pman_print_errorf("unable to get BPF iterator programs counters");
-			close(counters_maps_fd);
+		const int collected_stats = collect_kernel_iter_counter_stats(counters_map_fd, offset);
+		if(collected_stats < 0) {
 			return NULL;
 		}
-
-		set_kernel_iter_counter(offset, MODERN_BPF_ITER_N_EVTS_TASK, counters.n_evts_task);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_PIPE,
-		                        counters.n_evts_task_file_pipe);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_MEMFD,
-		                        counters.n_evts_task_file_memfd);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_REGULAR,
-		                        counters.n_evts_task_file_regular);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_DIRECTORY,
-		                        counters.n_evts_task_file_directory);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_INET,
-		                        counters.n_evts_task_file_socket_inet);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_INET6,
-		                        counters.n_evts_task_file_socket_inet6);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_UNIX,
-		                        counters.n_evts_task_file_socket_unix);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_SOCKET_NETLINK,
-		                        counters.n_evts_task_file_socket_netlink);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_EVTS_TASK_FILE_ANON_INODE,
-		                        counters.n_evts_task_file_anon_inode);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_MAX_EVENT_SIZE,
-		                        counters.n_drops_max_event_size);
-		set_kernel_iter_counter(offset, MODERN_BPF_ITER_N_DROPS_TASK, counters.n_drops_task);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_PIPE,
-		                        counters.n_drops_task_file_pipe);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_MEMFD,
-		                        counters.n_drops_task_file_memfd);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_REGULAR,
-		                        counters.n_drops_task_file_regular);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_DIRECTORY,
-		                        counters.n_drops_task_file_directory);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_INET,
-		                        counters.n_drops_task_file_socket_inet);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_INET6,
-		                        counters.n_drops_task_file_socket_inet6);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_UNIX,
-		                        counters.n_drops_task_file_socket_unix);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_SOCKET_NETLINK,
-		                        counters.n_drops_task_file_socket_netlink);
-		set_kernel_iter_counter(offset,
-		                        MODERN_BPF_ITER_N_DROPS_TASK_FILE_ANON_INODE,
-		                        counters.n_drops_task_file_anon_inode);
-		offset += MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS;
+		offset += collected_stats;
 	}
 
 	/* Update with the real number of stats collected */

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -170,6 +170,49 @@ clean_print_stats:
 	return errno;
 }
 
+// Initializes global v2 metrics. Returns 0 on success, -1 otherwise.
+static int init_metrics_v2(const uint32_t flags) {
+	if(g_state.stats) {
+		pman_print_errorf("bug: 'metrics_v2' array is already allocated");
+		return -1;
+	}
+
+	g_state.nstats = 0;
+
+	int nprogs_attached = 0;
+	for(int j = 0; j < MODERN_BPF_PROG_ATTACHED_MAX; j++) {
+		if(g_state.attached_progs_fds[j] != -1) {
+			nprogs_attached++;
+		}
+	}
+
+	uint32_t per_cpu_stats = 0;
+	if(flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU) {
+		// At the moment for each available CPU we want:
+		// - the number of events.
+		// - the number of drops.
+		per_cpu_stats = g_state.n_possible_cpus * 2;
+	}
+
+	// Account for statistics related to BPF iterator programs.
+	uint32_t iter_stats = 0;
+	if(flags & METRICS_V2_KERNEL_ITER_COUNTERS) {
+		iter_stats = MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS;
+	}
+
+	const uint32_t n_stats = MODERN_BPF_MAX_KERNEL_COUNTERS_STATS + per_cpu_stats +
+	                         (nprogs_attached * MODERN_BPF_MAX_LIBBPF_STATS) + iter_stats;
+	struct metrics_v2 *stats = (metrics_v2 *)calloc(n_stats, sizeof(metrics_v2));
+	if(!stats) {
+		pman_print_errorf("unable to allocate memory for 'metrics_v2' array");
+		return -1;
+	}
+
+	g_state.nstats = n_stats;
+	g_state.stats = stats;
+	return 0;
+}
+
 static void set_u64_monotonic_kernel_counter(uint32_t pos, uint64_t val, uint32_t metric_flag) {
 	g_state.stats[pos].type = METRIC_VALUE_TYPE_U64;
 	g_state.stats[pos].flags = metric_flag;
@@ -191,37 +234,9 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 	*rc = SCAP_FAILURE;
 	*nstats = 0;
 
-	// If it is the first time we call this function we populate the stats
-	if(g_state.stats == NULL) {
-		int nprogs_attached = 0;
-		for(int j = 0; j < MODERN_BPF_PROG_ATTACHED_MAX; j++) {
-			if(g_state.attached_progs_fds[j] != -1) {
-				nprogs_attached++;
-			}
-		}
-
-		uint32_t per_cpu_stats = 0;
-		if(flags & METRICS_V2_KERNEL_COUNTERS_PER_CPU) {
-			// At the moment for each available CPU we want:
-			// - the number of events.
-			// - the number of drops.
-			per_cpu_stats = g_state.n_possible_cpus * 2;
-		}
-
-		// Account for statistics related to BPF iterator programs.
-		uint32_t iter_stats = 0;
-		if(flags & METRICS_V2_KERNEL_ITER_COUNTERS) {
-			iter_stats = MODERN_BPF_MAX_KERNEL_ITER_COUNTERS_STATS;
-		}
-
-		g_state.nstats = MODERN_BPF_MAX_KERNEL_COUNTERS_STATS + per_cpu_stats +
-		                 (nprogs_attached * MODERN_BPF_MAX_LIBBPF_STATS) + iter_stats;
-		g_state.stats = (metrics_v2 *)calloc(g_state.nstats, sizeof(metrics_v2));
-		if(!g_state.stats) {
-			g_state.nstats = 0;
-			pman_print_errorf("unable to allocate memory for 'metrics_v2' array");
-			return NULL;
-		}
+	// If it is the first time we call this function we populate the stats.
+	if(g_state.stats == NULL && init_metrics_v2(flags) < 0) {
+		return NULL;
 	}
 
 	// offset in stats buffer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

/area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR avoids that `close()` is called on fd returned by `bpf_map__fd()` in `pman_get_metrics_v2()`: this libbpf helper doesn't request any new file descriptor to the OS, so the returned one must not be closed; closing them is a `libbpf` duty, and it performs it when the probe is destroyed.

Moreover, it cleans `pman_get_metrics_v2()` by extracting some helper functions dealing with the extracting of different stats, separately.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Better to go through it commit by commit.

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
