### PR TITLE
fix(driver): replace usage of `pgprot_val()` as lvalue

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1164,7 +1164,7 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma) {
 
 			pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
-			pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+			vma->vm_page_prot = __pgprot(pgprot_val(PAGE_SHARED) | _PAGE_ENC);
 			ret = remap_pfn_range(vma, useraddr, pfn, PAGE_SIZE, vma->vm_page_prot);
 			if(ret < 0) {
 				pr_err("remap_pfn_range failed (1)\n");
@@ -1202,7 +1202,7 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma) {
 			while(mlength > 0) {
 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
-				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+				vma->vm_page_prot = __pgprot(pgprot_val(PAGE_SHARED) | _PAGE_ENC);
 				ret = remap_pfn_range(vma, useraddr, pfn, PAGE_SIZE, vma->vm_page_prot);
 				if(ret < 0) {
 					pr_err("remap_pfn_range failed (1)\n");
@@ -1225,7 +1225,7 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma) {
 			while(mlength > 0) {
 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
 
-				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+				vma->vm_page_prot = __pgprot(pgprot_val(PAGE_SHARED) | _PAGE_ENC);
 				ret = remap_pfn_range(vma, useraddr, pfn, PAGE_SIZE, vma->vm_page_prot);
 				if(ret < 0) {
 					pr_err("remap_pfn_range failed (1)\n");


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bb2598c0d31bca8e57662b7d203e1876cd7f455f replaced `pgprot_val()` macro definition on s390x with an inline function definition: this means that `pgprot_val()` cannot be used as an lvalue anymore.

This PR changes approach and directly assigns the value returned by `__pgprot()`, which is supported on all architectures.

Notice that `pgprot_val()` can still be used as an rvalue.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2936 

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
