### PR TITLE
fix(userspace/libpman): avoid closing fds returned by `bpf_{program,map}__fd()`

### DIFF
--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -186,18 +186,18 @@ static int bpf_prog_fd_or_default(const struct bpf_program *prog) {
 }
 
 static void pman_save_attached_progs() {
-	g_state.attached_progs_fds[0] = bpf_program__fd(g_state.skel->progs.sys_exit);
-	g_state.attached_progs_fds[1] = bpf_program__fd(g_state.skel->progs.sched_proc_exit);
-	g_state.attached_progs_fds[2] = bpf_program__fd(g_state.skel->progs.sched_switch);
-	g_state.attached_progs_fds[3] = bpf_program__fd(g_state.skel->progs.sched_p_exec);
+	g_state.attached_progs_fds[0] = bpf_prog_fd_or_default(g_state.skel->progs.sys_exit);
+	g_state.attached_progs_fds[1] = bpf_prog_fd_or_default(g_state.skel->progs.sched_proc_exit);
+	g_state.attached_progs_fds[2] = bpf_prog_fd_or_default(g_state.skel->progs.sched_switch);
+	g_state.attached_progs_fds[3] = bpf_prog_fd_or_default(g_state.skel->progs.sched_p_exec);
 #ifdef CAPTURE_SCHED_PROC_FORK
-	g_state.attached_progs_fds[4] = bpf_program__fd(g_state.skel->progs.sched_p_fork);
+	g_state.attached_progs_fds[4] = bpf_prog_fd_or_default(g_state.skel->progs.sched_p_fork);
 #endif
 #ifdef CAPTURE_PAGE_FAULTS
-	g_state.attached_progs_fds[5] = bpf_program__fd(g_state.skel->progs.pf_user);
-	g_state.attached_progs_fds[6] = bpf_program__fd(g_state.skel->progs.pf_kernel);
+	g_state.attached_progs_fds[5] = bpf_prog_fd_or_default(g_state.skel->progs.pf_user);
+	g_state.attached_progs_fds[6] = bpf_prog_fd_or_default(g_state.skel->progs.pf_kernel);
 #endif
-	g_state.attached_progs_fds[7] = bpf_program__fd(g_state.skel->progs.signal_deliver);
+	g_state.attached_progs_fds[7] = bpf_prog_fd_or_default(g_state.skel->progs.signal_deliver);
 	g_state.attached_progs_fds[8] = bpf_prog_fd_or_default(g_state.skel->progs.connect_e);
 	g_state.attached_progs_fds[9] =
 	        bpf_prog_fd_or_default(g_state.skel->progs.ia32_compat_connect_e);

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -250,10 +250,7 @@ void pman_close_probe() {
 	}
 
 	for(int i = 0; i < MODERN_BPF_PROG_ATTACHED_MAX; i++) {
-		if(g_state.attached_progs_fds[i] != -1) {
-			close(g_state.attached_progs_fds[i]);
-			g_state.attached_progs_fds[i] = -1;
-		}
+		g_state.attached_progs_fds[i] = -1;
 	}
 
 	if(g_state.cons_pos) {

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -235,10 +235,8 @@ void pman_fill_ia32_to_64_table() {
 /*=============================== BPF_MAP_TYPE_PROG_ARRAY ===============================*/
 
 static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog_name, int key) {
-	struct bpf_program* bpf_prog = NULL;
-	int bpf_prog_fd = -1;
-
-	bpf_prog = bpf_object__find_program_by_name(g_state.skel->obj, bpf_prog_name);
+	struct bpf_program* bpf_prog =
+	        bpf_object__find_program_by_name(g_state.skel->obj, bpf_prog_name);
 	if(!bpf_prog) {
 		pman_print_msgf(FALCOSECURITY_LOG_SEV_DEBUG,
 		                "unable to find BPF program '%s'",
@@ -252,26 +250,21 @@ static int add_bpf_program_to_tail_table(int tail_table_fd, const char* bpf_prog
 		return 0;
 	}
 
-	int last_errno = EINVAL;
-
-	bpf_prog_fd = bpf_program__fd(bpf_prog);
+	int last_errno;
+	const int bpf_prog_fd = bpf_program__fd(bpf_prog);
 	if(bpf_prog_fd < 0) {
 		last_errno = errno;
 		pman_print_errorf("unable to get the fd for BPF program '%s'", bpf_prog_name);
-		goto clean_add_program_to_tail_table;
+		return last_errno;
 	}
 
 	if(bpf_map_update_elem(tail_table_fd, &key, &bpf_prog_fd, BPF_ANY)) {
 		last_errno = errno;
 		pman_print_errorf("unable to update the tail table with BPF program '%s'", bpf_prog_name);
-		goto clean_add_program_to_tail_table;
+		return last_errno;
 	}
 
 	return 0;
-
-clean_add_program_to_tail_table:
-	close(bpf_prog_fd);
-	return last_errno;
 }
 
 int pman_fill_syscalls_tail_table() {

--- a/userspace/libpman/src/maps.c
+++ b/userspace/libpman/src/maps.c
@@ -275,11 +275,9 @@ clean_add_program_to_tail_table:
 }
 
 int pman_fill_syscalls_tail_table() {
-	int last_errno = EINVAL;
-
 	const int syscall_exit_tail_table_fd = bpf_map__fd(g_state.skel->maps.syscall_exit_tail_table);
 	if(syscall_exit_tail_table_fd < 0) {
-		last_errno = errno;
+		const int last_errno = errno;
 		pman_print_errorf("unable to get the syscall exit tail table");
 		return last_errno;
 	}
@@ -307,21 +305,17 @@ int pman_fill_syscalls_tail_table() {
 		}
 
 		if(add_bpf_program_to_tail_table(syscall_exit_tail_table_fd, exit_prog->name, syscall_id)) {
-			last_errno = errno;
-			close(syscall_exit_tail_table_fd);
-			return last_errno;
+			return errno;
 		}
 	}
 	return 0;
 }
 
 int pman_fill_syscall_exit_extra_tail_table() {
-	int last_errno = EINVAL;
-
-	int extra_sys_exit_tail_table_fd =
+	const int extra_sys_exit_tail_table_fd =
 	        bpf_map__fd(g_state.skel->maps.syscall_exit_extra_tail_table);
 	if(extra_sys_exit_tail_table_fd < 0) {
-		last_errno = errno;
+		const int last_errno = errno;
 		pman_print_errorf("unable to get the extra sys exit tail table");
 		return last_errno;
 	}
@@ -329,16 +323,13 @@ int pman_fill_syscall_exit_extra_tail_table() {
 	const char* tail_prog_name = NULL;
 	for(int j = 0; j < SYS_EXIT_EXTRA_CODE_MAX; j++) {
 		tail_prog_name = sys_exit_extra_event_names[j];
-
 		if(!tail_prog_name) {
 			pman_print_errorf("unknown entry in the extra sys exit tail table");
 			return EINVAL;
 		}
 
 		if(add_bpf_program_to_tail_table(extra_sys_exit_tail_table_fd, tail_prog_name, j)) {
-			last_errno = errno;
-			close(extra_sys_exit_tail_table_fd);
-			return last_errno;
+			return errno;
 		}
 	}
 	return 0;
@@ -349,32 +340,35 @@ int pman_fill_syscall_exit_extra_tail_table() {
 /*=============================== BPF_MAP_TYPE_ARRAY ===============================*/
 
 int pman_fill_interesting_syscalls_table_64bit() {
-	int fd = bpf_map__fd(g_state.skel->maps.interesting_syscalls_table_64bit);
+	const int fd = bpf_map__fd(g_state.skel->maps.interesting_syscalls_table_64bit);
 	for(uint32_t i = 0; i < SYSCALL_TABLE_SIZE; i++) {
 		const bool interesting = false;
 		if(bpf_map_update_elem(fd, &i, &interesting, BPF_ANY) < 0) {
+			const int last_errno = errno;
 			pman_print_errorf("unable to initialize interesting syscall table at index %d!", i);
-			return errno;
+			return last_errno;
 		}
 	}
 	return 0;
 }
 
 int pman_mark_single_64bit_syscall(int syscall_id, bool interesting) {
-	int fd = bpf_map__fd(g_state.skel->maps.interesting_syscalls_table_64bit);
+	const int fd = bpf_map__fd(g_state.skel->maps.interesting_syscalls_table_64bit);
 	if(bpf_map_update_elem(fd, &syscall_id, &interesting, BPF_ANY) < 0) {
+		const int last_errno = errno;
 		pman_print_errorf("unable to set interesting syscall at index %d as %d!",
 		                  syscall_id,
 		                  interesting);
-		return errno;
+		return last_errno;
 	}
 	return 0;
 }
 
 static int size_auxiliary_maps(const struct bpf_probe* probe, const uint32_t max_entries) {
 	if(bpf_map__set_max_entries(probe->maps.auxiliary_maps, max_entries)) {
+		const int last_errno = errno;
 		pman_print_errorf("unable to set max entries for 'auxiliary_maps' to %d", max_entries);
-		return errno;
+		return last_errno;
 	}
 	return 0;
 }

--- a/userspace/libpman/src/ringbuffer.c
+++ b/userspace/libpman/src/ringbuffer.c
@@ -140,7 +140,7 @@ int pman_finalize_ringbuf_array_after_loading() {
 	int last_errno = EINVAL;
 	bool success = false;
 
-	int ringbuf_array_fd = -1;
+	int ringbuf_array_fd;
 
 	int *ringbufs_fds = (int *)malloc(g_state.n_required_buffers * sizeof(int));
 	if(ringbufs_fds == NULL) {
@@ -247,7 +247,6 @@ clean_percpu_ring_buffers:
 		return 0;
 	}
 
-	close(ringbuf_array_fd);
 	if(g_state.rb_manager) {
 		ring_buffer__free(g_state.rb_manager);
 	}

--- a/userspace/libpman/src/stats.c
+++ b/userspace/libpman/src/stats.c
@@ -131,7 +131,7 @@ int pman_get_scap_stats(struct scap_stats *stats) {
 		return EINVAL;
 	}
 
-	int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
+	const int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
 	if(counter_maps_fd < 0) {
 		const int last_errno = errno;
 		pman_print_errorf("unable to get counter maps");
@@ -149,9 +149,11 @@ int pman_get_scap_stats(struct scap_stats *stats) {
 	 */
 	for(int index = 0; index < g_state.n_possible_cpus; index++) {
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0) {
+			const int last_errno = errno;
 			pman_print_errorf("unable to get the counter map for CPU %d", index);
-			goto clean_print_stats;
+			return last_errno;
 		}
+
 		stats->n_evts += cnt_map.n_evts;
 		stats->n_drops_buffer += cnt_map.n_drops_buffer;
 		stats->n_drops_buffer_clone_fork_exit += cnt_map.n_drops_buffer_clone_fork_exit;
@@ -168,10 +170,6 @@ int pman_get_scap_stats(struct scap_stats *stats) {
 		stats->n_drops += (cnt_map.n_drops_buffer + cnt_map.n_drops_max_event_size);
 	}
 	return 0;
-
-clean_print_stats:
-	close(counter_maps_fd);
-	return errno;
 }
 
 // Initializes global v2 metrics. Returns 0 on success, -1 otherwise.
@@ -519,27 +517,24 @@ struct metrics_v2 *pman_get_metrics_v2(uint32_t flags, uint32_t *nstats, int32_t
 }
 
 int pman_get_n_tracepoint_hit(long *n_events_per_cpu) {
-	struct counter_map cnt_map;
-
-	int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
+	const int counter_maps_fd = bpf_map__fd(g_state.skel->maps.counter_maps);
 	if(counter_maps_fd < 0) {
+		const int last_errno = errno;
 		pman_print_errorf("unable to get counter maps");
-		return errno;
+		return last_errno;
 	}
 
 	/* We always take statistics from all the CPUs, even if some of them are not online.
 	 * If the CPU is not online the counter map will be empty.
 	 */
+	struct counter_map cnt_map;
 	for(int index = 0; index < g_state.n_possible_cpus; index++) {
 		if(bpf_map_lookup_elem(counter_maps_fd, &index, &cnt_map) < 0) {
+			const int last_errno = errno;
 			pman_print_errorf("unbale to get the counter map for CPU %d", index);
-			goto clean_print_stats;
+			return last_errno;
 		}
 		n_events_per_cpu[index] = cnt_map.n_evts;
 	}
 	return 0;
-
-clean_print_stats:
-	close(counter_maps_fd);
-	return errno;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

/area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`bpf_{program,map}__fd()` is just a getter retrieving the file descriptor stored by libbpf in the `bpf_{program,map}` object: it is libbpf duty, upon skeleton destruction, to close it. This PR honors this contract by removing any call to `close()` on file descriptor returned by `bpf_{program,map}__fd()`.

Moreover, this PR replaces remaining calls to `bpf_program__fd()` in `pman_save_attached_progs()` with calls to the `bpf_prog_fd_or_default()` wrapper. This ensures that entries in `g_state.attached_progs_fds` are set to `-1` if the corresponding program fds cannot be retrieved (i.e.: programs are not attached). `-1` is later used by `collect_libbpf_stats()` to avoid collecting stats for non-attached programs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
