### PR TITLE
perf(libsinsp): sinsp_table_owner optimizations

### DIFF
--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <type_traits>
 #include <memory>
 #include <list>
+#include <vector>
 
 namespace libsinsp {
 namespace state {
@@ -422,17 +423,14 @@ public:
 	std::string m_last_owner_err;
 
 protected:
-	std::list<std::shared_ptr<libsinsp::state::table_entry>>
-	        m_accessed_entries;  // using lists for ptr stability
-	std::list<std::unique_ptr<libsinsp::state::table_entry>>
+	std::vector<std::shared_ptr<libsinsp::state::table_entry>> m_accessed_entries;
+	std::vector<std::unique_ptr<libsinsp::state::table_entry>>
 	        m_created_entries;  // entries created but not yet added to a table
 	std::list<libsinsp::state::table_accessor>
-	        m_ephemeral_tables;                        // note: lists have pointer stability
-	std::list<accessor::ptr> m_accessed_table_fields;  // note: lists have pointer stability
+	        m_ephemeral_tables;  // note: lists have pointer stability
+	std::vector<accessor::ptr> m_accessed_table_fields;
 
 	bool m_ephemeral_tables_clear = false;
-	bool m_accessed_entries_clear = false;
-	bool m_created_entries_clear = false;
 
 	inline void clear_ephemeral_tables() {
 		if(m_ephemeral_tables_clear) {
@@ -447,37 +445,14 @@ protected:
 	}
 
 	inline void clear_accessed_entries() {
-		if(m_accessed_entries_clear) {
-			// quick break-out that prevents us from looping over the
-			// whole list in the critical path
-			return;
-		}
-		for(auto& et : m_accessed_entries) {
-			if(et != nullptr) {
-				// if we get here, it means that the plugin did not
-				// release some of the entries it acquired
-				ASSERT(false);
-				et.reset();
-			};
-		}
-		m_accessed_entries_clear = true;
+		// In the normal case, the plugin released all entries already.
+		ASSERT(m_accessed_entries.empty());
+		m_accessed_entries.clear();  // safety net; keeps capacity
 	}
 
 	inline void clear_created_entries() {
-		if(m_created_entries_clear) {
-			// quick break-out that prevents us from looping over the
-			// whole list in the critical path
-			return;
-		}
-		for(auto& et : m_created_entries) {
-			if(et != nullptr) {
-				// if we get here, it means that the plugin created entries
-				// but did not add or destroy them
-				ASSERT(false);
-				et.reset();
-			};
-		}
-		m_created_entries_clear = true;
+		ASSERT(m_created_entries.empty());
+		m_created_entries.clear();  // safety net; keeps capacity
 	}
 
 public:
@@ -491,45 +466,45 @@ public:
 		return m_ephemeral_tables.emplace_back();
 	}
 
-	inline std::shared_ptr<libsinsp::state::table_entry>* store_accessed_entry(
-	        std::shared_ptr<libsinsp::state::table_entry> entry) {
-		m_accessed_entries_clear = false;
-		for(auto& et : m_accessed_entries) {
-			if(et == nullptr) {
-				et = std::move(entry);
-				return &et;
-			}
-		}
-		return &m_accessed_entries.emplace_back(std::move(entry));
+	// O(1) — push_back reuses existing capacity after the first few events
+	inline void store_accessed_entry(std::shared_ptr<libsinsp::state::table_entry> entry) {
+		m_accessed_entries.push_back(std::move(entry));
 	}
 
+	// O(n) scan to find the element, then O(1) swap-with-back + pop_back
+	// to make room for a new item at future add (with push_back)
 	inline void release_accessed_entry(libsinsp::state::table_entry* raw) {
-		for(auto& et : m_accessed_entries) {
-			if(et.get() == raw) {
-				et.reset();
+		for(size_t i = 0; i < m_accessed_entries.size(); i++) {
+			if(m_accessed_entries[i].get() == raw) {
+				if(i != m_accessed_entries.size() - 1) {
+					m_accessed_entries[i] = std::move(m_accessed_entries.back());
+				}
+				m_accessed_entries.pop_back();
 				return;
 			}
 		}
 	}
 
+	// O(1) — push_back reuses existing capacity
 	inline libsinsp::state::table_entry* add_created_entry(
 	        std::unique_ptr<libsinsp::state::table_entry> entry) {
-		m_created_entries_clear = false;
-		// Reuse empty slots to avoid unbounded growth
-		for(auto& et : m_created_entries) {
-			if(et == nullptr) {
-				et = std::move(entry);
-				return et.get();
-			}
-		}
-		return m_created_entries.emplace_back(std::move(entry)).get();
+		libsinsp::state::table_entry* raw = entry.get();
+		m_created_entries.push_back(std::move(entry));
+		return raw;
 	}
 
+	// O(n) scan to find the element, then O(1) swap-with-back + pop_back
+	// to make room for a new item at future add (with push_back)
 	inline std::unique_ptr<libsinsp::state::table_entry> extract_created_entry(
 	        libsinsp::state::table_entry* raw) {
-		for(auto& et : m_created_entries) {
-			if(et.get() == raw) {
-				return std::move(et);  // Move out, slot becomes nullptr (reusable)
+		for(size_t i = 0; i < m_created_entries.size(); i++) {
+			if(m_created_entries[i].get() == raw) {
+				auto result = std::move(m_created_entries[i]);
+				if(i != m_created_entries.size() - 1) {
+					m_created_entries[i] = std::move(m_created_entries.back());
+				}
+				m_created_entries.pop_back();
+				return result;
 			}
 		}
 		return nullptr;

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <functional>
 #include <type_traits>
 #include <memory>
-#include <list>
+#include <deque>
 #include <vector>
 
 namespace libsinsp {
@@ -426,23 +426,16 @@ protected:
 	std::vector<std::shared_ptr<libsinsp::state::table_entry>> m_accessed_entries;
 	std::vector<std::unique_ptr<libsinsp::state::table_entry>>
 	        m_created_entries;  // entries created but not yet added to a table
-	std::list<libsinsp::state::table_accessor>
-	        m_ephemeral_tables;  // note: lists have pointer stability
+
+	// we only ever append to the deque, so existing entries keep their addresses forever
+	// (a deque does not move an element once created, unless we erase some element in the middle,
+	// which we never do)
+	std::deque<libsinsp::state::table_accessor>
+	        m_ephemeral_tables;          // pool of reusable table_accessor slots
+	size_t m_ephemeral_tables_used = 0;  // number of slots in use (reset between events)
 	std::vector<accessor::ptr> m_accessed_table_fields;
 
-	bool m_ephemeral_tables_clear = false;
-
-	inline void clear_ephemeral_tables() {
-		if(m_ephemeral_tables_clear) {
-			// quick break-out that prevents us from looping over the
-			// whole list in the critical path, in case of no accessed table
-			return;
-		}
-		for(auto& et : m_ephemeral_tables) {
-			et.unset();
-		}
-		m_ephemeral_tables_clear = true;
-	}
+	inline void clear_ephemeral_tables() { m_ephemeral_tables_used = 0; }
 
 	inline void clear_accessed_entries() {
 		// In the normal case, the plugin released all entries already.
@@ -457,13 +450,14 @@ protected:
 
 public:
 	inline libsinsp::state::table_accessor& find_unset_ephemeral_table() {
-		m_ephemeral_tables_clear = false;
-		for(auto& et : m_ephemeral_tables) {
-			if(!et.is_set()) {
-				return et;
-			}
+		if(m_ephemeral_tables_used < m_ephemeral_tables.size()) {
+			// reuse an existing slot
+			return m_ephemeral_tables[m_ephemeral_tables_used++];
 		}
-		return m_ephemeral_tables.emplace_back();
+		// grow the pool — deque guarantees existing element pointers stay valid
+		m_ephemeral_tables.emplace_back();
+		m_ephemeral_tables_used++;
+		return m_ephemeral_tables.back();
 	}
 
 	// O(1) — push_back reuses existing capacity after the first few events


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This makes a (synthetic) benchmark based on real-world behavior of the container plugin 50x faster, mostly by making clear_ephemeral_tables O(1) instead of O(mg).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
