### PR TITLE
fix(libscap): report unsupported configure settings as SCAP_NOT_SUPPORTED

### DIFF
--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -905,12 +905,7 @@ static int32_t configure(struct scap_engine_handle engine,
 	case SCAP_STATSD_PORT:
 		return scap_kmod_set_statsd_port(engine, arg1);
 	default: {
-		return scap_errprintf(HANDLE(engine)->m_lasterr,
-		                      0,
-		                      "Unsupported setting %d (args %lu, %lu)",
-		                      setting,
-		                      arg1,
-		                      arg2);
+		return scap_err_unsupported_setting(HANDLE(engine)->m_lasterr, setting, arg1, arg2);
 	}
 	}
 }

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -125,13 +125,7 @@ static int32_t scap_modern_bpf__configure(struct scap_engine_handle engine,
 		pman_set_statsd_port(arg1);
 		break;
 	default: {
-		struct modern_bpf_engine* handle = engine.m_handle;
-		return scap_errprintf(handle->m_lasterr,
-		                      0,
-		                      "Unsupported setting %d (args %lu, %lu)",
-		                      setting,
-		                      arg1,
-		                      arg2);
+		return scap_err_unsupported_setting(HANDLE(engine)->m_lasterr, setting, arg1, arg2);
 	}
 	}
 

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -282,9 +282,8 @@ int32_t scap_stop_capture(scap_t* handle) {
 		return handle->m_vtable->stop_capture(handle->m_engine);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
 	ASSERT(false);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 //
@@ -299,9 +298,8 @@ int32_t scap_start_capture(scap_t* handle) {
 		return handle->m_vtable->start_capture(handle->m_engine);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
 	ASSERT(false);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_stop_dropping_mode(scap_t* handle) {
@@ -313,9 +311,8 @@ int32_t scap_stop_dropping_mode(scap_t* handle) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
 	ASSERT(false);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio) {
@@ -344,9 +341,8 @@ int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio) {
 		                                   1);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
 	ASSERT(false);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen) {
@@ -358,8 +354,7 @@ int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int64_t scap_get_readfile_offset(scap_t* handle) {
@@ -393,8 +388,7 @@ int32_t scap_set_ppm_sc(scap_t* handle, ppm_sc_code ppm_sc, bool enabled) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_PPM_SC_MASK, op, ppm_sc);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_set_dropfailed(scap_t* handle, bool enabled) {
@@ -406,8 +400,7 @@ int32_t scap_set_dropfailed(scap_t* handle, bool enabled) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DROP_FAILED, enabled, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle) {
@@ -419,8 +412,7 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle) {
@@ -432,8 +424,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 const char* scap_get_host_root() {
@@ -471,8 +462,7 @@ int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret) {
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 bool scap_check_current_engine(scap_t* handle, const char* engine_name) {
@@ -494,8 +484,7 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 		                                   range_end);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port) {
@@ -507,8 +496,7 @@ int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port) {
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
 	}
 
-	scap_err_opnotsup(handle->m_lasterr);
-	return SCAP_FAILURE;
+	return scap_err_opnotsup(handle->m_lasterr);
 }
 
 uint64_t scap_get_driver_api_version(scap_t* handle) {

--- a/userspace/libscap/strerror.h
+++ b/userspace/libscap/strerror.h
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include <stdint.h>
 
+#include <libscap/scap_const.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,6 +38,14 @@ int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...)
 	((void)sizeof(printf(__VA_ARGS__)), scap_errprintf_unchecked(BUF, ERRNUM, __VA_ARGS__))
 int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...);
 #endif
+
+static inline int32_t scap_err_unsupported_setting(char* lasterr,
+                                                   int setting,
+                                                   unsigned long arg1,
+                                                   unsigned long arg2) {
+	(void)scap_errprintf(lasterr, 0, "Unsupported setting %d (args %lu, %lu)", setting, arg1, arg2);
+	return SCAP_NOT_SUPPORTED;
+}
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/strerror.h
+++ b/userspace/libscap/strerror.h
@@ -39,6 +39,11 @@ int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...)
 int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...);
 #endif
 
+static inline int32_t scap_err_opnotsup(char* error) {
+	(void)scap_errprintf(error, 0, "operation not supported");
+	return SCAP_NOT_SUPPORTED;
+}
+
 static inline int32_t scap_err_unsupported_setting(char* lasterr,
                                                    int setting,
                                                    unsigned long arg1,
@@ -50,5 +55,3 @@ static inline int32_t scap_err_unsupported_setting(char* lasterr,
 #ifdef __cplusplus
 };
 #endif
-
-#define scap_err_opnotsup(error) scap_errprintf(error, 0, "operation not supported")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libscap

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:
Engines used scap_errprintf() in configure() defaults, which always yields SCAP_FAILURE.
Add scap_err_unsupported_setting() and use it from all engines.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
