### PR TITLE
fix(driver): compile support for s390 compat support conditionally

### DIFF
--- a/driver/configure/COMPAT_S390/test.c
+++ b/driver/configure/COMPAT_S390/test.c
@@ -1,0 +1,28 @@
+/*
+
+Copyright (C) 2026 The Falco Authors.
+
+This file is dual licensed under either the MIT or GPL 2. See MIT.txt
+or GPL2.txt for full copies of the license.
+
+*/
+
+#include <linux/module.h>
+#include <linux/sched.h>
+#include <linux/thread_info.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("the Falco authors");
+
+static int compat_s390_init(void) {
+#ifdef CONFIG_S390
+	unsigned long flags = task_thread_info(current)->flags & _TIF_31BIT;
+	(void)flags;
+#endif /* CONFIG_S390 */
+	return 0;
+}
+
+static void compat_s390_exit(void) {}
+
+module_init(compat_s390_init);
+module_exit(compat_s390_exit);

--- a/driver/main.c
+++ b/driver/main.c
@@ -1976,7 +1976,7 @@ static inline bool kmod_in_ia32_syscall(void) {
 #elif defined(CONFIG_ARM64)
 	if(unlikely(task_thread_info(current)->flags & _TIF_32BIT))
 		return true;
-#elif defined(CONFIG_S390)
+#elif defined(CONFIG_S390) && HAS_COMPAT_S390
 	if(unlikely(task_thread_info(current)->flags & _TIF_31BIT))
 		return true;
 #elif defined(CONFIG_PPC64)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

/area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

Commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8e0b986c59c67e08ada646249f834655a9e6da16
removed 31-bit code support for `s390` and any related macro, so this PR compiles out from kmod the check involving the usage of the dropped `_TIF_31BIT` macro if this is not available on the kernel against which we compile.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 10.0.0+driver

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
