### PR TITLE
fix!: make `sinsp_utils::concatenate_paths()` UTF-8-aware

### DIFF
--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -25,7 +25,7 @@ TEST(sinsp_utils_test, concatenate_paths) {
 	// https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap04.html#tag_04_11
 
 	// PLEASE NOTE:
-	// * current impl does not support unicode.
+	// * current impl supports UTF-8 encoding.
 	// * current impl does not sanitize path1
 	// * current impl expects path1 to end with '/'
 	// * current impl skips path1 altogether if path2 is absolute
@@ -188,7 +188,7 @@ TEST(sinsp_utils_test, concatenate_paths) {
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG", res);
 
-	/* No unicode support
+	// Valid UTF-8 multibyte characters pass through unchanged.
 	path1 = "/root/";
 	path2 = "../😉";
 	res = sinsp_utils::concatenate_paths(path1, path2);
@@ -204,10 +204,78 @@ TEST(sinsp_utils_test, concatenate_paths) {
 	res = sinsp_utils::concatenate_paths(path1, path2);
 	EXPECT_EQ("/АБВЙЛж", res);
 
-	path1 = "/root";
+	// Invalid UTF-8 bytes are replaced with U+FFFD (EF BF BD).
+	path1 = "/root/";
+	path2 = "../\xFF\xFE/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD\xEF\xBF\xBD/test", res);
+
+	// Mix of valid UTF-8 (é = C3 A9) and an invalid byte (FF).
+	path1 = "/root/";
+	path2 = "../\xC3\xA9\xFF/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xC3\xA9\xEF\xBF\xBD/test", res);
+
+	// C1 control character encoded as valid-but-non-printable UTF-8 (U+0085, NEL = C2 85) is
+	// replaced.
+	path1 = "/root/";
+	path2 = "../\xC2\x85/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD/test", res);
+
+	// Non-printable ASCII control characters are replaced with U+FFFD.
+	path1 = "/root/";
+	path2 = "../\x01\x1F/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD\xEF\xBF\xBD/test", res);
+
+	// Unicode non-characters are replaced with U+FFFD.
+	// U+FDD0 (EF B7 90) - non-character in the range U+FDD0..U+FDEF.
+	path1 = "/root/";
+	path2 = "../\xEF\xB7\x90/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD/test", res);
+
+	// U+FFFF (EF BF BF) - non-character U+FFFF.
+	path1 = "/root/";
+	path2 = "../\xEF\xBF\xBF/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD/test", res);
+
+	// U+1FFFE (F0 9F BF BE) - end-of-plane non-character in plane 1.
+	path1 = "/root/";
+	path2 = "../\xF0\x9F\xBF\xBE/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD/test", res);
+
+	// Maximal-subpart: 3-byte lead (E1) + valid first continuation (80) + bad second continuation
+	// (2F = '/'). The maximal subpart is 2 bytes, so the pair is replaced with one U+FFFD.
+	path1 = "/root/";
+	path2 = "../\xE1\x80/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD/test", res);
+
+	// Maximal-subpart: surrogate bytes (ED A0 80). The first continuation A0 is outside the valid
+	// range 80-9F for lead ED, so the maximal subpart is just ED, and the entire sequence is
+	// replaced with three individual U+FFFDs.
+	path1 = "/root/";
+	path2 = "../\xED\xA0\x80/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD/test", res);
+
+	// Maximal-subpart: overlong 3-byte (E0 9F BF). The first continuation 9F is outside the valid
+	// range A0-BF for lead E0, so the maximal subpart is just E0, and the entire sequence is
+	// replaced with three individual U+FFFDs.
+	path1 = "/root/";
+	path2 = "../\xE0\x9F\xBF/test";
+	res = sinsp_utils::concatenate_paths(path1, path2);
+	EXPECT_EQ("/\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD/test", res);
+
+	// todo(ekoops): path1 and Windows-style path2... What to do here?
+	/* path1 = "/root";
 	path2 = "c:/hello/world/";
 	res = sinsp_utils::concatenate_paths(path1, path2);
-	EXPECT_EQ("/root/c:/hello/world", res); */
+	EXPECT_EQ("/rootc:/hello/world", res); */
 }
 
 TEST(sinsp_utils_test, sinsp_split) {

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -594,20 +594,119 @@ static inline void rewind_to_parent_path(const char* targetbase,
 	(*pc) += delta;
 }
 
+// Returns a nonzero integer describing the UTF-8 sequence starting at `p`:
+// - if > 0, indicates a valid and printable UTF-8 sequence; the returned value is the sequence
+//   length (in range [1; 4]).
+// - if < 0, indicates an invalid byte, a broken sequence, or a valid-but-non-printable sequence;
+//   the absolute value is the number of bytes to consume (in range [1; 4]).
+//
+// Broken sequences follow the maximal subpart substitution algorithm (Unicode Standard §3.9, U+FFFD
+// Substitution of Maximal Subparts): each continuation byte that falls within the valid range for
+// its position extends the consumed subpart; the first byte that is out of range (or absent)
+// truncates it. For example:
+// - sequence: 3-byte lead + valid first continuation + bad second continuation; consumed: 2 bytes;
+//   return value: -2
+// - sequence: 3-byte lead + bad first continuation; consumed 1 byte; return value: -1
+//
+// Valid-but-non-printable sequences (C1 controls U+0080..U+009F, Unicode non-characters) are
+// consumed in full (e.g. -2 for U+0085 = C2 85, -3 for U+FDD0 = EF B7 90).
+// `p_end` is the exclusive upper bound of the source buffer.
+static inline int utf8_seq_len(const unsigned char* p, const unsigned char* p_end) {
+	const unsigned char c = p[0];
+	if(c < 0x80) {
+		// ASCII: printable range is 0x20 (space) to 0x7E (tilde); reject control chars and DEL.
+		return c >= 0x20 && c != 0x7F ? 1 : -1;
+	}
+	if(c < 0xC2) {
+		// 0x80-0xBF: orphan continuation byte.
+		// 0xC0-0xC1: would encode U+0000..U+007F (overlong 2-byte).
+		return -1;
+	}
+	if(c < 0xE0) {
+		// 2-byte: 110xxxxx 10xxxxxx. Need 1 continuation byte.
+		if(p + 1 >= p_end || (p[1] & 0xC0) != 0x80) {
+			return -1;
+		}
+		const unsigned int cp =
+		        static_cast<unsigned int>(c & 0x1F) << 6 | static_cast<unsigned int>(p[1] & 0x3F);
+		// Reject C1 control characters (U+0080..U+009F) (non-printable).
+		return cp > 0x9F ? 2 : -2;
+	}
+	if(c < 0xF0) {
+		// 3-byte: 1110xxxx 10xxxxxx 10xxxxxx.
+		// Enforce lead-byte-specific valid ranges for the first continuation byte: 0xE0 requires
+		// 0xA0-0xBF (to structurally exclude overlongs), 0xED requires 0x80-0x9F (to structurally
+		// exclude surrogates). When the first continuation is out of range, only the lead byte is
+		// the maximal subpart (-1); when the second continuation is bad, the lead plus the valid
+		// first continuation form the maximal subpart (-2).
+		const unsigned char lo2 = c == 0xE0 ? 0xA0u : 0x80u;
+		const unsigned char hi2 = c == 0xED ? 0x9Fu : 0xBFu;
+		if(p + 1 >= p_end || p[1] < lo2 || p[1] > hi2) {
+			return -1;  // Maximal subpart: lead byte only.
+		}
+		if(p + 2 >= p_end || (p[2] & 0xC0) != 0x80) {
+			return -2;  // Maximal subpart: lead + first continuation.
+		}
+		const unsigned int cp = static_cast<unsigned int>(c & 0x0F) << 12 |
+		                        static_cast<unsigned int>(p[1] & 0x3F) << 6 |
+		                        static_cast<unsigned int>(p[2] & 0x3F);
+		// Overlongs and surrogates are structurally excluded by the narrow ranges above.
+		// Reject Unicode non-characters (U+FDD0-U+FDEF, U+FFFE-U+FFFF).
+		if((cp >= 0xFDD0 && cp <= 0xFDEF) || cp >= 0xFFFE) {
+			return -3;
+		}
+		return 3;
+	}
+	if(c <= 0xF4) {
+		// 4-byte: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx.
+		// Enforce lead-byte-specific valid ranges for the first continuation byte: 0xF0 requires
+		// 0x90-0xBF (to structurally exclude overlongs), 0xF4 requires 0x80-0x8F (to structurally
+		// exclude > U+10FFFF). 0xF5-0xFF are never valid and fall through to the catch-all below.
+		// Maximal subpart grows by one byte for each valid continuation position consumed.
+		const unsigned char lo2 = c == 0xF0 ? 0x90u : 0x80u;
+		const unsigned char hi2 = c == 0xF4 ? 0x8Fu : 0xBFu;
+		if(p + 1 >= p_end || p[1] < lo2 || p[1] > hi2) {
+			return -1;  // Maximal subpart: lead byte only.
+		}
+		if(p + 2 >= p_end || (p[2] & 0xC0) != 0x80) {
+			return -2;  // Maximal subpart: lead + first continuation.
+		}
+		if(p + 3 >= p_end || (p[3] & 0xC0) != 0x80) {
+			return -3;  // Maximal subpart: lead + first + second continuation.
+		}
+		const unsigned int cp = static_cast<unsigned int>(c & 0x07) << 18 |
+		                        static_cast<unsigned int>(p[1] & 0x3F) << 12 |
+		                        static_cast<unsigned int>(p[2] & 0x3F) << 6 |
+		                        static_cast<unsigned int>(p[3] & 0x3F);
+		// Overlongs and out-of-range values are structurally excluded by the narrow ranges above.
+		// Reject end-of-plane non-characters (U+xFFFE, U+xFFFF for planes 1-16).
+		if((cp & 0xFFFF) >= 0xFFFE) {
+			return -4;
+		}
+		return 4;
+	}
+
+	// 0xF5-0xFF: never valid in UTF-8.
+	return -1;
+}
+
 //
 // Args:
 //  - target: the string where we are supposed to start copying
 //  - targetbase: the base of the path, i.e. the furthest we can go back when
 //                following parent directories
+//  - target_end: exclusive end of the output buffer (target + buffer_size)
 //  - path: the path to copy
+//  - path_end: exclusive end of the source buffer (path + path_len)
 //
 static inline void copy_and_sanitize_path(char* target,
                                           char* targetbase,
+                                          char* target_end,
                                           const char* path,
+                                          const char* path_end,
                                           char separator) {
 	char* tc = target;
 	const char* pc = path;
-	g_invalidchar ic;
 	const bool empty_base = target == targetbase;
 
 	while(true) {
@@ -625,15 +724,31 @@ static inline void copy_and_sanitize_path(char* target,
 			return;
 		}
 
-		if(ic(*pc)) {
-			//
-			// Invalid char, substitute with a '.'
-			//
-			*tc = '.';
-			tc++;
-			pc++;
+		if(const int seq_len = utf8_seq_len(reinterpret_cast<const unsigned char*>(pc),
+		                                    reinterpret_cast<const unsigned char*>(path_end));
+		   seq_len > 1) {
+			// Valid multibyte printable UTF-8 sequence. Copy all bytes as-is.
+			if(tc + seq_len >= target_end) {
+				*tc = 0;
+				return;
+			}
+			memcpy(tc, pc, static_cast<size_t>(seq_len));
+			tc += seq_len;
+			pc += seq_len;
+		} else if(seq_len < 0) {
+			// Invalid, broken, or valid-but-non-printable UTF-8 sequence `-seq_len` long. Replace
+			// with `U+FFFD` (EF BF BD) and advance by the number of bytes that form the sequence
+			// (i.e.: `-seq_len`).
+			if(tc + 3 >= target_end) {
+				*tc = 0;
+				return;
+			}
+			memcpy(tc, "\xEF\xBF\xBD", 3);
+			tc += 3;
+			pc += -seq_len;
 		} else {
-			//
+			// Printable ASCII (`seqlen == 1`). Apply path-aware logic.
+
 			// If path begins with '.' or '.' is the first char after a '/'
 			//
 			if(*pc == '.' && (tc == targetbase || *(tc - 1) == separator)) {
@@ -667,6 +782,10 @@ static inline void copy_and_sanitize_path(char* target,
 				// Otherwise, we leave the string intact.
 				//
 				else {
+					if(tc + 1 >= target_end) {
+						*tc = 0;
+						return;
+					}
 					*tc = *pc;
 					pc++;
 					tc++;
@@ -684,6 +803,10 @@ static inline void copy_and_sanitize_path(char* target,
 				   (tc == targetbase && !empty_base)) {
 					pc++;
 				} else {
+					if(tc + 1 >= target_end) {
+						*tc = 0;
+						return;
+					}
 					*tc = *pc;
 					tc++;
 					pc++;
@@ -692,6 +815,10 @@ static inline void copy_and_sanitize_path(char* target,
 				//
 				// Normal char, copy it
 				//
+				if(tc + 1 >= target_end) {
+					*tc = 0;
+					return;
+				}
 				*tc = *pc;
 				tc++;
 				pc++;
@@ -712,18 +839,24 @@ static inline bool concatenate_paths_(char* target,
                                       uint32_t len1,
                                       const char* path2,
                                       uint32_t len2) {
+	// note: this is a loose check, as `len2` doesn't account any replacement character (3 bytes
+	// long) that would replace any `path2`'s UTF-8 invalid, broken or non-printable sequence
+	// (1-to-4 bytes long) during sanitization. Keep this loose and truncate the final string in
+	// case it becomes longer than `targetlen` during sanitization.
 	if(targetlen < (len1 + len2 + 1)) {
 		strlcpy(target, "/DIR_TOO_LONG/FILENAME_TOO_LONG", targetlen);
 		return false;
 	}
 
+	char* target_end = target + targetlen;
+	const char* path2_end = path2 + len2;
 	if(len2 != 0 && path2[0] != '/') {
 		memcpy(target, path1, len1);
-		copy_and_sanitize_path(target + len1, target, path2, '/');
+		copy_and_sanitize_path(target + len1, target, target_end, path2, path2_end, '/');
 		return true;
 	} else {
 		target[0] = 0;
-		copy_and_sanitize_path(target, target, path2, '/');
+		copy_and_sanitize_path(target, target, target_end, path2, path2_end, '/');
 		return false;
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The current implementation of `sinsp_utils::concatenate_paths()` just left untouched printable ASCII character and replaces anything else with `.`s. Besides `.` being a valid character, the implementation unreasonably replaces any valid UTF-8 sequence (or part of it) with dots as well.

This PR makes `sinsp_utils::concatenate_paths()` UTF-8-aware, by leaving untouched UTF-8 printable sequences. Invalid bytes or non-printable UTF-8 sequences are replaced with UTF-8 replacement characters (i.e.: `U+FFFD`).

The following points describe how replacement takes place.
1) A single invalid byte is replaced with a single replacement character.
2) A single non-printable ASCII character is replaced with a single replacement character.
3) A broken sequence is handled through the maximal subpart substitution algorithm (Unicode Standard §3.9, U+FFFD Substitution of Maximal Subparts). A maximal subpart in a sequence is computed as follows:
    - each continuation byte that falls within the valid range for its position extends the consumed subpart;
    - the first byte that is out of range (or absent) truncates it. 4) A valid-but-non-printable UTF-8 multibyte sequence is replaced with a single replacement character.

The implementation takes inspiration from Rust's `std::string::String::from_utf8_lossy()` standard library API, but replacement is also applied for valid-but-non-printable UTF-8 sequences (including non-printable ASCII characters).

Notice that this PR requires a follow-up patch fixing other incompatible sanitization strategy, like the one applied in `sanitize_string` (`userspace/libsinsp/utils.h`).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: invalid or non-printable UTF-8 sequences are now replaced with the `U+FFFD` replacement characters
```
