### PR TITLE
fix(libsinsp): use reentrant fget*ent functions

### DIFF
--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -95,6 +95,12 @@ add_library(
 	state/table.cpp
 )
 
+# On non-glibc platforms (e.g. musl), fgetpwent_r/fgetgrent_r are not available. Provide
+# from-scratch implementations.
+if(MUSL_OPTIMIZED_BUILD)
+	target_sources(sinsp PRIVATE fgetpwent_r.cpp)
+endif()
+
 if(NOT WIN32
    AND NOT APPLE
    AND NOT EMSCRIPTEN

--- a/userspace/libsinsp/fgetpwent_r.cpp
+++ b/userspace/libsinsp/fgetpwent_r.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+//
+// From-scratch implementations of fgetpwent_r() and fgetgrent_r() for
+// platforms that lack them (e.g. musl).  These parse /etc/passwd and
+// /etc/group line-by-line into caller-owned storage, with no global
+// or thread-local state.
+//
+// This file is only compiled on non-glibc builds (see CMakeLists.txt).
+//
+
+#include <libsinsp/fgetpwent_r.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+
+// Find the next colon (or end-of-string) in s, return the length of the field.
+static size_t field_len(const char *s) {
+	const char *p = s;
+	while(*p && *p != ':') {
+		p++;
+	}
+	return static_cast<size_t>(p - s);
+}
+
+#ifdef HAVE_PWD_H
+// Parse one line of /etc/passwd: name:passwd:uid:gid:gecos:dir:shell
+int fgetpwent_r(FILE *f, struct passwd *pwd, char *buf, size_t buflen, struct passwd **result) {
+	*result = nullptr;
+
+	if(!fgets(buf, static_cast<int>(buflen), f)) {
+		return errno ? errno : ENOENT;
+	}
+
+	// Strip trailing newline
+	size_t line_len = strlen(buf);
+	if(line_len > 0 && buf[line_len - 1] == '\n') {
+		buf[--line_len] = '\0';
+	}
+
+	// Parse 7 colon-separated fields
+	const char *fields[7];
+	size_t lengths[7];
+	const char *p = buf;
+	for(int i = 0; i < 7; i++) {
+		fields[i] = p;
+		lengths[i] = field_len(p);
+		p += lengths[i];
+		if(*p == ':') {
+			p++;
+		} else if(i < 6) {
+			return ENOENT;  // malformed line
+		}
+	}
+
+	// Null-terminate each field in-place by overwriting ':' separators
+	char *w = buf;
+	for(int i = 0; i < 7; i++) {
+		w += lengths[i];
+		if(i < 6) {
+			*w++ = '\0';
+		}
+	}
+
+	pwd->pw_name = const_cast<char *>(fields[0]);
+	pwd->pw_passwd = const_cast<char *>(fields[1]);
+	pwd->pw_uid = static_cast<uid_t>(strtoul(fields[2], nullptr, 10));
+	pwd->pw_gid = static_cast<gid_t>(strtoul(fields[3], nullptr, 10));
+	pwd->pw_gecos = const_cast<char *>(fields[4]);
+	pwd->pw_dir = const_cast<char *>(fields[5]);
+	pwd->pw_shell = const_cast<char *>(fields[6]);
+
+	*result = pwd;
+	return 0;
+}
+#endif
+
+#ifdef HAVE_GRP_H
+// Parse one line of /etc/group: name:passwd:gid:member1,member2,...
+int fgetgrent_r(FILE *f, struct group *grp, char *buf, size_t buflen, struct group **result) {
+	*result = nullptr;
+
+	if(!fgets(buf, static_cast<int>(buflen), f)) {
+		return errno ? errno : ENOENT;
+	}
+
+	size_t line_len = strlen(buf);
+	if(line_len > 0 && buf[line_len - 1] == '\n') {
+		buf[--line_len] = '\0';
+	}
+
+	// Parse 4 colon-separated fields
+	const char *fields[4];
+	size_t lengths[4];
+	const char *p = buf;
+	for(int i = 0; i < 4; i++) {
+		fields[i] = p;
+		lengths[i] = field_len(p);
+		p += lengths[i];
+		if(*p == ':') {
+			p++;
+		} else if(i < 3) {
+			return ENOENT;  // malformed line
+		}
+	}
+
+	// Null-terminate each field in-place
+	char *w = buf;
+	for(int i = 0; i < 4; i++) {
+		w += lengths[i];
+		if(i < 3) {
+			*w++ = '\0';
+		}
+	}
+
+	grp->gr_name = const_cast<char *>(fields[0]);
+	grp->gr_passwd = const_cast<char *>(fields[1]);
+	grp->gr_gid = static_cast<gid_t>(strtoul(fields[2], nullptr, 10));
+
+	// Parse comma-separated member list from fields[3].
+	const char *members = fields[3];
+	size_t members_len = lengths[3];
+
+	// Count members
+	size_t nmem = 0;
+	if(members_len > 0) {
+		nmem = 1;
+		for(size_t i = 0; i < members_len; i++) {
+			if(members[i] == ',') {
+				nmem++;
+			}
+		}
+	}
+
+	// Place the char** pointer array after the parsed line data, aligned.
+	char *after_line = const_cast<char *>(fields[3]) + members_len + 1;
+	uintptr_t align_off = reinterpret_cast<uintptr_t>(after_line) % alignof(char *);
+	if(align_off) {
+		after_line += alignof(char *) - align_off;
+	}
+	char *end = buf + buflen;
+	size_t ptrs_size = (nmem + 1) * sizeof(char *);
+	if(after_line + ptrs_size > end) {
+		return ERANGE;
+	}
+
+	grp->gr_mem = reinterpret_cast<char **>(after_line);
+
+	// Split member list by replacing ',' with '\0'
+	if(nmem > 0) {
+		char *m = const_cast<char *>(fields[3]);
+		size_t idx = 0;
+		grp->gr_mem[idx++] = m;
+		for(size_t i = 0; i < members_len; i++) {
+			if(m[i] == ',') {
+				m[i] = '\0';
+				if(idx < nmem) {
+					grp->gr_mem[idx++] = &m[i + 1];
+				}
+			}
+		}
+	}
+	grp->gr_mem[nmem] = nullptr;
+
+	*result = grp;
+	return 0;
+}
+#endif

--- a/userspace/libsinsp/fgetpwent_r.h
+++ b/userspace/libsinsp/fgetpwent_r.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+#pragma once
+
+// On glibc, fgetpwent_r() and fgetgrent_r() are provided by the system.
+// On other platforms (e.g. musl), we provide from-scratch implementations
+// that parse /etc/passwd and /etc/group line-by-line into caller-owned storage.
+//
+// This header ensures that fgetpwent_r / fgetgrent_r are always available
+// when HAVE_FGET__ENT is defined.
+
+#ifdef HAVE_PWD_H
+#include <pwd.h>
+#endif
+
+#ifdef HAVE_GRP_H
+#include <grp.h>
+#endif
+
+#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
+
+#if defined(MUSL_OPTIMIZED) || defined(_DEFAULT_SOURCE) || defined(_SVID_SOURCE)
+#ifndef HAVE_FGET__ENT
+#define HAVE_FGET__ENT
+#endif
+#endif
+
+#if defined(__GLIBC__) && defined(HAVE_FGET__ENT)
+#ifndef HAVE_FGET__ENT_R
+#define HAVE_FGET__ENT_R
+#endif
+#endif
+
+#if defined(HAVE_FGET__ENT) && !defined(HAVE_FGET__ENT_R)
+
+#include <cstdio>
+
+#ifdef HAVE_PWD_H
+int fgetpwent_r(FILE *f, struct passwd *pwd, char *buf, size_t buflen, struct passwd **result);
+#endif
+
+#ifdef HAVE_GRP_H
+int fgetgrent_r(FILE *f, struct group *grp, char *buf, size_t buflen, struct group **result);
+#endif
+
+#define HAVE_FGET__ENT_R
+#endif
+
+#endif  // HAVE_PWD_H || HAVE_GRP_H

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <libsinsp/utils.h>
 #include <libsinsp/logger.h>
 #include <libsinsp/sinsp.h>
+#include <libsinsp/fgetpwent_r.h>
 #include <libscap/strl.h>
 #include <sys/types.h>
 
@@ -32,26 +33,23 @@ limitations under the License.
 #include <grp.h>
 #endif
 
-#if defined(HAVE_PWD_H) || defined(HAVE_GRP_H)
-
-// See fgetpwent() / fgetgrent() feature test macros:
-// https://man7.org/linux/man-pages/man3/fgetpwent.3.html
-// https://man7.org/linux/man-pages/man3/fgetgrent.3.html
-#if defined(MUSL_OPTIMIZED) || defined(_DEFAULT_SOURCE) || defined(_SVID_SOURCE)
-#define HAVE_FGET__ENT
-#endif
-
-#endif
-
 #ifdef HAVE_PWD_H
-static struct passwd *__getpwuid(uint32_t uid, const std::string &host_root) {
+static struct passwd *__getpwuid(uint32_t uid,
+                                 const std::string &host_root,
+                                 struct passwd *pwd,
+                                 char *buf,
+                                 size_t buflen) {
 	if(uid == (uint32_t)-1) {
 		return nullptr;
 	}
 	if(host_root.empty()) {
 		// When we don't have any host root set,
 		// leverage NSS (see man nsswitch.conf)
-		return getpwuid(uid);
+		struct passwd *result = nullptr;
+		if(getpwuid_r(uid, pwd, buf, buflen, &result) == 0) {
+			return result;
+		}
+		return nullptr;
 	}
 
 	// If we have a host root and we can use fgetpwent,
@@ -60,31 +58,43 @@ static struct passwd *__getpwuid(uint32_t uid, const std::string &host_root) {
 	static std::string filename(host_root + "/etc/passwd");
 
 	auto f = fopen(filename.c_str(), "r");
-	if(f) {
-		struct passwd *p = nullptr;
-		while((p = fgetpwent(f))) {
-			if(uid == p->pw_uid) {
-				break;
-			}
-		}
-
-		fclose(f);
-		return p;
+	if(!f) {
+		return nullptr;
 	}
+
+	struct passwd *p = nullptr;
+	while(!feof(f)) {
+		if(fgetpwent_r(f, pwd, buf, buflen, &p) != 0 || !p) {
+			continue;  // skip malformed lines
+		}
+		if(uid == p->pw_uid) {
+			fclose(f);
+			return p;
+		}
+	}
+	fclose(f);
 #endif
 	return nullptr;
 }
 #endif
 
 #ifdef HAVE_GRP_H
-static struct group *__getgrgid(uint32_t gid, const std::string &host_root) {
+static struct group *__getgrgid(uint32_t gid,
+                                const std::string &host_root,
+                                struct group *grp,
+                                char *buf,
+                                size_t buflen) {
 	if(gid == (uint32_t)-1) {
 		return nullptr;
 	}
 	if(host_root.empty()) {
 		// When we don't have any host root set,
 		// leverage NSS (see man nsswitch.conf)
-		return getgrgid(gid);
+		struct group *result = nullptr;
+		if(getgrgid_r(gid, grp, buf, buflen, &result) == 0) {
+			return result;
+		}
+		return nullptr;
 	}
 
 	// If we have a host root and we can use fgetgrent,
@@ -93,17 +103,21 @@ static struct group *__getgrgid(uint32_t gid, const std::string &host_root) {
 	static std::string filename(host_root + "/etc/group");
 
 	auto f = fopen(filename.c_str(), "r");
-	if(f) {
-		struct group *p = nullptr;
-		while((p = fgetgrent(f))) {
-			if(gid == p->gr_gid) {
-				break;
-			}
-		}
-
-		fclose(f);
-		return p;
+	if(!f) {
+		return nullptr;
 	}
+
+	struct group *p = nullptr;
+	while(!feof(f)) {
+		if(fgetgrent_r(f, grp, buf, buflen, &p) != 0 || !p) {
+			continue;  // skip malformed lines
+		}
+		if(gid == p->gr_gid) {
+			fclose(f);
+			return p;
+		}
+	}
+	fclose(f);
 #endif
 	return NULL;
 }
@@ -288,7 +302,9 @@ scap_userinfo *sinsp_usergroup_manager::add_host_user(uint32_t uid,
 	} else {
 #ifdef HAVE_PWD_H
 		// On Host, try to load info from db
-		auto *p = __getpwuid(uid, m_host_root);
+		struct passwd pwd_entry;
+		char pwd_buf[4096];
+		auto *p = __getpwuid(uid, m_host_root, &pwd_entry, pwd_buf, sizeof(pwd_buf));
 		if(p) {
 			retval = userinfo_map_insert(m_userlist[""],
 			                             p->pw_uid,
@@ -326,7 +342,13 @@ scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &co
 	auto pwd_file = fopen(path.c_str(), "r");
 	if(pwd_file) {
 		auto &userlist = m_userlist[container_id];
-		while(auto p = fgetpwent(pwd_file)) {
+		struct passwd pwd_entry;
+		char pwd_buf[4096];
+		struct passwd *p = nullptr;
+		while(!feof(pwd_file)) {
+			if(fgetpwent_r(pwd_file, &pwd_entry, pwd_buf, sizeof(pwd_buf), &p) != 0 || !p) {
+				continue;  // skip malformed lines
+			}
 			// Here we cache all container users
 			auto *usr = userinfo_map_insert(userlist,
 			                                p->pw_uid,
@@ -415,7 +437,9 @@ scap_groupinfo *sinsp_usergroup_manager::add_host_group(uint32_t gid,
 	} else {
 #ifdef HAVE_GRP_H
 		// On Host, try to load info from db
-		auto *g = __getgrgid(gid, m_host_root);
+		struct group grp_entry;
+		char grp_buf[4096];
+		auto *g = __getgrgid(gid, m_host_root, &grp_entry, grp_buf, sizeof(grp_buf));
 		if(g) {
 			gr = groupinfo_map_insert(m_grouplist[""], g->gr_gid, g->gr_name);
 		}
@@ -448,7 +472,13 @@ scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &
 	auto group_file = fopen(path.c_str(), "r");
 	if(group_file) {
 		auto &grouplist = m_grouplist[container_id];
-		while(auto g = fgetgrent(group_file)) {
+		struct group grp_entry;
+		char grp_buf[4096];
+		struct group *g = nullptr;
+		while(!feof(group_file)) {
+			if(fgetgrent_r(group_file, &grp_entry, grp_buf, sizeof(grp_buf), &g) != 0 || !g) {
+				continue;  // skip malformed lines
+			}
 			// Here we cache all container groups
 			auto *gr = groupinfo_map_insert(grouplist, g->gr_gid, g->gr_name);
 


### PR DESCRIPTION
If we don't have them (on musl), provide our own implementations

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The fget*ent are not thread safe, so if two threads (sinsp or otherwise) are calling them at the same time, we can end up with heap corruption and funny crashes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Musl doesn't have the reentrant variants of fget*ent_r, so provide our own implementation in that case (courtesy of an LLM).

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
