### PR TITLE
fix(userspace/libsinsp)!: make `strcpy_sanitized()` UTF-8 aware

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -469,34 +469,84 @@ uint32_t binary_buffer_to_string(char *dst,
 	return k;
 }
 
-static uint32_t strcpy_sanitized(char *dest, const char *src, uint32_t dstsize) {
-	volatile char *tmp = (volatile char *)dest;
-	uint32_t j = 0;
-	g_invalidchar ic;
+// `dst` and `src` must both be non-empty.
+static void strcpy_sanitized(std::vector<char> &dst, const std::string_view src) {
+	auto *dst_ptr = reinterpret_cast<unsigned char *>(&dst[0]);
+	const auto dst_size = dst.size();
+	ASSERT(dst_size > 0);
 
-	while(j < dstsize) {
-		if(!ic(*src)) {
-			*tmp = *src;
-			tmp++;
-			j++;
+	const auto *src_ptr = reinterpret_cast<const unsigned char *>(src.data());
+	const size_t src_size = src.size();
+	ASSERT(src_size > 0);
+
+	auto *capped_src_end = src_ptr + std::min(src_size, dst_size);
+
+	// Find the first sequence in source needing replacement. For valid strings, this is the only
+	// pass that runs (no replacement needed), and the flow immediately returns after copying the
+	// maximum allowed amount of bytes.
+	auto *scan_src_ptr = utf8_first_invalid_seq(src_ptr, capped_src_end);
+	if(scan_src_ptr == capped_src_end) {
+		size_t bytes_to_copy;
+		if(src_size < dst_size) {
+			bytes_to_copy = src_size;
+		} else {
+			// The source string must be truncated (`src_size >= dst_size`). Find the boundary of
+			// the last valid UTF-8 sequence in source (a valid UTF-8 sequence is guaranteed to
+			// exist, given `src_size > 0`).
+			auto *scan_ptr = capped_src_end - 1;
+			while(utf8_seq_len(scan_ptr, capped_src_end) < 0) {
+				scan_ptr--;
+			}
+			const auto last_valid_seq_off = capped_src_end - scan_ptr;
+			bytes_to_copy = dst_size - last_valid_seq_off;
 		}
-
-		if(*src == 0) {
-			*tmp = 0;
-			return j + 1;
-		}
-
-		src++;
+		memcpy(dst_ptr, src_ptr, bytes_to_copy);
+		dst_ptr[bytes_to_copy] = 0;
+		return;
 	}
 
-	//
-	// In case there wasn't enough space, null-terminate the destination
-	//
-	if(dstsize) {
-		dest[dstsize - 1] = 0;
-	}
+	// Copy the valid prefix (note: can be empty) in one shot.
+	size_t bytes_to_copy = scan_src_ptr - src_ptr;
+	memcpy(dst_ptr, src_ptr, bytes_to_copy);
 
-	return dstsize;
+	// Process the remainder. The assumption here is that, at the beginning of each iteration, there
+	// is an invalid sequence in source that should result into a single replacement character into
+	// destination: this requires at least 3 bytes for the replacement character. Moreover, the
+	// destination must be NUL terminated, so the destination must have at least 4 bytes (i.e.:
+	// `dst_left_bytes >= 4`).
+	auto *scan_dst_ptr = dst_ptr + bytes_to_copy;
+	size_t dst_left_bytes = dst_size - bytes_to_copy;
+	while(scan_src_ptr < capped_src_end && dst_left_bytes >= 4) {
+		// Replace the invalid sequence at the beginning of each iteration with the replacement
+		// character.
+		const int seq_len = utf8_seq_len(scan_src_ptr, capped_src_end);
+		ASSERT(seq_len < 0);
+		memcpy(scan_dst_ptr, "\xEF\xBF\xBD", 3);
+		scan_dst_ptr += 3;
+		dst_left_bytes -= 3;
+		scan_src_ptr += -seq_len;
+
+		// Find the next valid block of UTF-8 characters to copy. Its size must not be greater than
+		// `min(src_left_bytes, dst_left_bytes - 1)`. (-1 accounts for the NUL terminator).
+		const size_t src_left_bytes = capped_src_end - scan_src_ptr;
+		const auto *end_ptr = scan_src_ptr + std::min(dst_left_bytes - 1, src_left_bytes);
+		const auto *next_invalid = utf8_first_invalid_seq(scan_src_ptr, end_ptr);
+		bytes_to_copy = next_invalid - scan_src_ptr;
+		if(bytes_to_copy > 0) {
+			memcpy(scan_dst_ptr, scan_src_ptr, bytes_to_copy);
+			scan_dst_ptr += bytes_to_copy;
+			dst_left_bytes -= bytes_to_copy;
+		}
+		scan_src_ptr = next_invalid;
+
+		// `utf8_first_invalid_seq` could have stopped before the end of source due to the cap to
+		// `dst_left_bytes - 1`. In this case, the following UTF-8 sequence could still be valid,
+		// but there is no space left in the destination, so break.
+		if(scan_src_ptr < capped_src_end && utf8_seq_len(scan_src_ptr, capped_src_end) > 0) {
+			break;
+		}
+	}
+	*scan_dst_ptr = 0;
 }
 
 int sinsp_evt::render_fd_json(Json::Value *ret,
@@ -882,7 +932,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			m_paramstr_storage.resize(path.length() + 1);
 		}
 
-		strcpy_sanitized(&m_paramstr_storage[0], path.data(), path.length() + 1);
+		strcpy_sanitized(m_paramstr_storage, path);
 
 		sinsp_threadinfo *tinfo = get_thread_info();
 
@@ -898,10 +948,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 					m_resolved_paramstr_storage[0] = 0;
 				} else {
 					std::string concatenated_path = sinsp_utils::concatenate_paths(cwd, path);
-					strcpy_sanitized(&m_resolved_paramstr_storage[0],
-					                 concatenated_path.data(),
-					                 std::min(concatenated_path.size() + 1,
-					                          m_resolved_paramstr_storage.size()));
+					strcpy_sanitized(m_resolved_paramstr_storage, concatenated_path);
 				}
 			}
 		} else {
@@ -1341,9 +1388,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				user_info = m_inspector->m_usergroup_manager->get_user(container_id, val);
 			}
 			if(user_info != NULL && user_info->name[0] != 0) {
-				strcpy_sanitized(&m_resolved_paramstr_storage[0],
-				                 user_info->name,
-				                 (uint32_t)m_resolved_paramstr_storage.size());
+				strcpy_sanitized(m_resolved_paramstr_storage, user_info->name);
 			} else {
 				snprintf(&m_resolved_paramstr_storage[0],
 				         m_resolved_paramstr_storage.size(),
@@ -1371,9 +1416,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				group_info = m_inspector->m_usergroup_manager->get_group(container_id, val);
 			}
 			if(group_info != NULL && group_info->name[0] != 0) {
-				strcpy_sanitized(&m_resolved_paramstr_storage[0],
-				                 group_info->name,
-				                 (uint32_t)m_resolved_paramstr_storage.size());
+				strcpy_sanitized(m_resolved_paramstr_storage, group_info->name);
 			} else {
 				snprintf(&m_resolved_paramstr_storage[0],
 				         m_resolved_paramstr_storage.size(),

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -306,6 +306,31 @@ inline const unsigned char* skip_8_byte_printable_ascii_blocks(const unsigned ch
 	return ptr;
 }
 
+// Returns a pointer to the first invalid UTF-8 sequence of bytes between `ptr` and `end_ptr`. In
+// this context, an invalid sequence is an invalid byte, a broken sequence (e.g.: wrong continuation
+// byte) or a valid-but-non-printable sequence. If the input is a valid printable UTF-8 string, it
+// returns `end_ptr`; otherwise, the returned pointer is guaranteed to be in the range [ptr;
+// end_ptr).
+inline const unsigned char* utf8_first_invalid_seq(const unsigned char* ptr,
+                                                   const unsigned char* end_ptr) {
+	while(ptr < end_ptr) {
+		// If `ptr` is 8-byte aligned, try to fast-skip 8-byte printable ASCII blocks.
+		if((reinterpret_cast<uintptr_t>(ptr) & 7u) == 0u) {
+			ptr = skip_8_byte_printable_ascii_blocks(ptr, end_ptr);
+			if(ptr >= end_ptr) {
+				return end_ptr;
+			}
+		}
+		// Check if the next sequence is invalid (i.e.: `seq_len` is negative).
+		const int seq_len = utf8_seq_len(ptr, end_ptr);
+		if(seq_len < 0) {
+			return ptr;
+		}
+		ptr += seq_len;
+	}
+	return end_ptr;
+}
+
 inline void sanitize_string(std::string& str) {
 	const auto* const str_ptr = reinterpret_cast<const unsigned char*>(str.data());
 	const auto str_len = str.size();
@@ -313,25 +338,8 @@ inline void sanitize_string(std::string& str) {
 
 	// First pass (note: this must be FAST).
 	// Find the first sequence needing replacement. For valid strings, this is the only pass that
-	// runs (no replacement needed).
-	auto* scan_ptr = str_ptr;
-	while(scan_ptr < str_end_ptr) {
-		// If `scan_ptr` is 8-byte aligned, try to fast-skip 8-byte printable ASCII blocks.
-		if((reinterpret_cast<uintptr_t>(scan_ptr) & 7u) == 0u) {
-			scan_ptr = skip_8_byte_printable_ascii_blocks(scan_ptr, str_end_ptr);
-			if(scan_ptr >= str_end_ptr) {
-				break;
-			}
-		}
-		// Check if the next sequence needs to be replaced (i.e.: `seq_len` is negative).
-		const int seq_len = utf8_seq_len(scan_ptr, str_end_ptr);
-		if(seq_len < 0) {
-			break;
-		}
-		scan_ptr += seq_len;
-	}
-
-	// String is already valid, return.
+	// runs (no replacement needed), and the flow immediately returns after it.
+	auto* scan_ptr = utf8_first_invalid_seq(str_ptr, str_end_ptr);
 	if(scan_ptr == str_end_ptr) {
 		return;
 	}

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -174,15 +174,6 @@ public:
 // little STL thing to sanitize strings
 ///////////////////////////////////////////////////////////////////////////////
 
-struct g_invalidchar {
-	bool operator()(char c) const {
-		unsigned char uc = static_cast<unsigned char>(c);
-		// Exclude all non-printable characters and control characters while
-		// including a wide range of languages (emojis, cyrillic, chinese etc)
-		return (!(isprint(uc)));
-	}
-};
-
 // Returns a nonzero integer describing the UTF-8 sequence starting at `p`:
 // - if > 0, indicates a valid and printable UTF-8 sequence; the returned value is the sequence
 //   length (in range [1; 4]).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The current implementation of `strcpy_sanitized()` just copies any non-printable ASCII character from the source string. This is inconsistent with the `concatenate_paths()` and `sanitize_string()` behaviour, that correctly replaces any UTF-8 invalid sequence with the UTF-8 replacement character. This PR makes `strcpy_sanitized()` consistent by implementing the same logic.

The logic is implemented in two passes:
1) The source string is scanned in order to find the first sequence needing replacement. This is the only pass that runs in case the string is only composed of valid UTF-8 printable characters, and the flow immediately returns after copying the maximum allowed amount of bytes. Notice that, in case the source string must be truncated (the destination buffer is smaller than the source one), the implementation takes care of truncating it at a valid UTF-8 sequence boundary.
2) Every invalid sequence is replaced with the replacement character, and valid blocks of characters are copied in a single shot from source to destination.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix!: additional invalid or non-printable UTF-8 sequences are now replaced with the `U+FFFD` replacement characters
```
