### PR TITLE
fix(userspace)!: honor sanitization request while extracting strings

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -252,6 +252,13 @@ protected:
 
 	inline void check_rhs_field_type_consistency() const;
 
+	// Helper that must be used while extracting a single string value. It returns a pointer to the
+	// first character of `str` and sets `*len` to the string length.
+	static uint8_t* extract_single_string(std::string& str, uint32_t* len) {
+		*len = str.size();
+		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str.c_str()));
+	}
+
 private:
 	//
 	// Instead of populating the filter check values with const values extracted at

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -253,8 +253,14 @@ protected:
 	inline void check_rhs_field_type_consistency() const;
 
 	// Helper that must be used while extracting a single string value. It returns a pointer to the
-	// first character of `str` and sets `*len` to the string length.
-	static uint8_t* extract_single_string(std::string& str, uint32_t* len) {
+	// first character of `str` and sets `*len` to the string length. If `must_sanitize` is true, it
+	// sanitizes `str` first.
+	static uint8_t* extract_single_string(std::string& str,
+	                                      uint32_t* len,
+	                                      const bool must_sanitize) {
+		if(must_sanitize) {
+			sanitize_string(str);
+		}
 		*len = str.size();
 		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str.c_str()));
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -37,12 +37,6 @@ extern sinsp_evttables g_infotables;
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)           \
 	do {                                 \
 		if((x)) {                        \
@@ -713,7 +707,7 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 			//
 			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string>());
 
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 		}
 	} else if(etype == PPME_SYSCALL_LINKAT_2_X) {
 		if(m_argid == 0 || m_argid == 1) {
@@ -796,7 +790,7 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 
 	m_strstorage = sinsp_utils::concatenate_paths(sdir, path);
 
-	RETURN_EXTRACT_STRING(m_strstorage);
+	return extract_single_string(m_strstorage, len);
 }
 
 inline uint8_t* sinsp_filter_check_event::extract_buflen(sinsp_evt* evt, uint32_t* len) {
@@ -870,7 +864,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		// Hardcoded value to "0ns" for now to avoid breaking changes.
 		// TODO(irozzo): get rid of this once the deprecated fields are removed.
 		m_strstorage = "0ns";
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	}
 	case TYPE_DELTA:
 	case TYPE_DELTA_S:
@@ -900,13 +894,13 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		switch(m_inspector->get_time_output_mode()) {
 		case 'h':
 			sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, true);
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 
 		case 'a':
 			m_strstorage += to_string(evt->get_ts() / ONE_SECOND_IN_NS);
 			m_strstorage += ".";
 			m_strstorage += to_string(evt->get_ts() % ONE_SECOND_IN_NS);
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 
 		case 'r':
 			m_strstorage +=
@@ -917,11 +911,11 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			         "%09llu",
 			         (evt->get_ts() - m_inspector->m_firstevent_ts) % ONE_SECOND_IN_NS);
 			m_strstorage += string(timebuffer);
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 
 		case 'd': {
 			m_strstorage = "0.000000000";
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 		}
 
 		case 'D':
@@ -942,7 +936,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_tsdelta = (tts - m_val.u64) % ONE_SECOND_IN_NS;
 
 			m_val.u64 = tts;
-			RETURN_EXTRACT_STRING(m_strstorage);
+			return extract_single_string(m_strstorage, len);
 		}
 	}
 	case TYPE_DIR:
@@ -1122,7 +1116,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			break;
 		}
 
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_CPU:
 		m_val.u16 = evt->get_cpuid();
 		RETURN_EXTRACT_VAR(m_val.u16);
@@ -1191,7 +1185,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		if(!m_strstorage.empty()) {
 			m_strstorage.pop_back();
 		}
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	} break;
 	case TYPE_BUFFER: {
 		if(m_is_compare) {
@@ -1235,7 +1229,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		//
 		// m_strstorage = sinsp_utils::errno_to_str((int32_t)res);
 		m_strstorage = evt->get_param_value_str(0, true);
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	} break;
 	case TYPE_ISIO: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1277,7 +1271,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	}
 	case TYPE_ISWAIT: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1556,7 +1550,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 						vector<string> subelements = sinsp_split(e, ':');
 						ASSERT(subelements.size() == 2);
 						m_strstorage = trim(subelements[1]);
-						RETURN_EXTRACT_STRING(m_strstorage);
+						return extract_single_string(m_strstorage, len);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_ID) {
 					if(e.substr(0, sizeof("ID") - 1) == "ID") {
@@ -1566,14 +1560,14 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 						if(m_strstorage.length() > 12) {
 							m_strstorage = m_strstorage.substr(0, 12);
 						}
-						RETURN_EXTRACT_STRING(m_strstorage);
+						return extract_single_string(m_strstorage, len);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_NAME) {
 					if(e.substr(0, sizeof("name") - 1) == "name") {
 						vector<string> subelements = sinsp_split(e, ':');
 						ASSERT(subelements.size() == 2);
 						m_strstorage = trim(subelements[1]);
-						RETURN_EXTRACT_STRING(m_strstorage);
+						return extract_single_string(m_strstorage, len);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_IMAGE) {
 					if(e.substr(0, sizeof("Image") - 1) == "Image") {
@@ -1587,7 +1581,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 							m_strstorage = e.substr(e.find(":") + 1);
 						}
 						m_strstorage = trim(m_strstorage);
-						RETURN_EXTRACT_STRING(m_strstorage);
+						return extract_single_string(m_strstorage, len);
 					}
 				}
 			}

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -667,7 +667,9 @@ uint8_t* sinsp_filter_check_event::extract_argraw(sinsp_evt* evt,
 	return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data));
 }
 
-uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len) {
+uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt,
+                                                   uint32_t* len,
+                                                   const bool sanitize_strings) {
 	std::string spath;
 
 	if(evt->get_tinfo() == nullptr) {
@@ -707,7 +709,7 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 			//
 			m_strstorage = sinsp_utils::concatenate_paths("", evt->get_param(3)->as<std::string>());
 
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 		}
 	} else if(etype == PPME_SYSCALL_LINKAT_2_X) {
 		if(m_argid == 0 || m_argid == 1) {
@@ -790,7 +792,7 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 
 	m_strstorage = sinsp_utils::concatenate_paths(sdir, path);
 
-	return extract_single_string(m_strstorage, len);
+	return extract_single_string(m_strstorage, len, sanitize_strings);
 }
 
 inline uint8_t* sinsp_filter_check_event::extract_buflen(sinsp_evt* evt, uint32_t* len) {
@@ -864,7 +866,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		// Hardcoded value to "0ns" for now to avoid breaking changes.
 		// TODO(irozzo): get rid of this once the deprecated fields are removed.
 		m_strstorage = "0ns";
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	}
 	case TYPE_DELTA:
 	case TYPE_DELTA_S:
@@ -894,13 +896,13 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		switch(m_inspector->get_time_output_mode()) {
 		case 'h':
 			sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, true);
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 
 		case 'a':
 			m_strstorage += to_string(evt->get_ts() / ONE_SECOND_IN_NS);
 			m_strstorage += ".";
 			m_strstorage += to_string(evt->get_ts() % ONE_SECOND_IN_NS);
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 
 		case 'r':
 			m_strstorage +=
@@ -911,11 +913,11 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			         "%09llu",
 			         (evt->get_ts() - m_inspector->m_firstevent_ts) % ONE_SECOND_IN_NS);
 			m_strstorage += string(timebuffer);
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 
 		case 'd': {
 			m_strstorage = "0.000000000";
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 		}
 
 		case 'D':
@@ -936,7 +938,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_tsdelta = (tts - m_val.u64) % ONE_SECOND_IN_NS;
 
 			m_val.u64 = tts;
-			return extract_single_string(m_strstorage, len);
+			return extract_single_string(m_strstorage, len, sanitize_strings);
 		}
 	}
 	case TYPE_DIR:
@@ -1116,7 +1118,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			break;
 		}
 
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_CPU:
 		m_val.u16 = evt->get_cpuid();
 		RETURN_EXTRACT_VAR(m_val.u16);
@@ -1185,7 +1187,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		if(!m_strstorage.empty()) {
 			m_strstorage.pop_back();
 		}
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	} break;
 	case TYPE_BUFFER: {
 		if(m_is_compare) {
@@ -1229,7 +1231,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		//
 		// m_strstorage = sinsp_utils::errno_to_str((int32_t)res);
 		m_strstorage = evt->get_param_value_str(0, true);
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	} break;
 	case TYPE_ISIO: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1271,7 +1273,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	}
 	case TYPE_ISWAIT: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1397,7 +1399,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_VAR(m_val.u32);
 	}
 	case TYPE_ABSPATH:
-		return extract_abspath(evt, len);
+		return extract_abspath(evt, len, sanitize_strings);
 	case TYPE_BUFLEN_IN:
 		if(evt->get_fd_info() && evt->get_category() == EC_IO_READ) {
 			return extract_buflen(evt, len);
@@ -1550,7 +1552,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 						vector<string> subelements = sinsp_split(e, ':');
 						ASSERT(subelements.size() == 2);
 						m_strstorage = trim(subelements[1]);
-						return extract_single_string(m_strstorage, len);
+						return extract_single_string(m_strstorage, len, sanitize_strings);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_ID) {
 					if(e.substr(0, sizeof("ID") - 1) == "ID") {
@@ -1560,14 +1562,14 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 						if(m_strstorage.length() > 12) {
 							m_strstorage = m_strstorage.substr(0, 12);
 						}
-						return extract_single_string(m_strstorage, len);
+						return extract_single_string(m_strstorage, len, sanitize_strings);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_NAME) {
 					if(e.substr(0, sizeof("name") - 1) == "name") {
 						vector<string> subelements = sinsp_split(e, ':');
 						ASSERT(subelements.size() == 2);
 						m_strstorage = trim(subelements[1]);
-						return extract_single_string(m_strstorage, len);
+						return extract_single_string(m_strstorage, len, sanitize_strings);
 					}
 				} else if(m_field_id == TYPE_INFRA_DOCKER_CONTAINER_IMAGE) {
 					if(e.substr(0, sizeof("Image") - 1) == "Image") {
@@ -1581,7 +1583,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 							m_strstorage = e.substr(e.find(":") + 1);
 						}
 						m_strstorage = trim(m_strstorage);
-						return extract_single_string(m_strstorage, len);
+						return extract_single_string(m_strstorage, len, sanitize_strings);
 					}
 				}
 			}

--- a/userspace/libsinsp/sinsp_filtercheck_event.h
+++ b/userspace/libsinsp/sinsp_filtercheck_event.h
@@ -108,7 +108,7 @@ private:
 	int32_t extract_arg(std::string_view fldname, std::string_view val, const ppm_param_info**);
 	int32_t extract_type(std::string_view fldname, std::string_view val, const ppm_param_info**);
 	uint8_t* extract_error_count(sinsp_evt* evt, uint32_t* len);
-	uint8_t* extract_abspath(sinsp_evt* evt, uint32_t* len);
+	uint8_t* extract_abspath(sinsp_evt* evt, uint32_t* len, bool sanitize_strings);
 	inline uint8_t* extract_buflen(sinsp_evt* evt, uint32_t* len);
 	uint8_t* extract_argraw(sinsp_evt* evt, uint32_t* len, const char* argname);
 

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -534,7 +534,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(sanitize_strings) {
 			sanitize_string(m_tstr);
 		}
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 		break;
 	case TYPE_FDTYPES:
 	case TYPE_FDTYPE:
@@ -584,7 +584,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = container_id + ':' + m_tstr;
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_FILENAME: {
 		if(m_fdinfo == NULL) {
@@ -609,7 +609,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = "/";
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_FDTYPECHAR:
 		*len = 1;
@@ -661,7 +661,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		if(!m_tstr.empty()) {
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 	} break;
 	case TYPE_SNET:
@@ -718,7 +718,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		if(!m_tstr.empty()) {
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 	} break;
 	case TYPE_LNET:
@@ -842,7 +842,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			}
 
 			if(!m_tstr.empty()) {
-				return extract_single_string(m_tstr, len);
+				return extract_single_string(m_tstr, len, sanitize_strings);
 			}
 		}
 	}
@@ -887,7 +887,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			                        m_inspector->is_hostname_and_port_resolution_enabled());
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_SERVERPORT: {
 		if(m_fdinfo == NULL) {
@@ -954,7 +954,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			                        m_inspector->is_hostname_and_port_resolution_enabled());
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_LPORT:
 	case TYPE_RPORT: {
@@ -1080,7 +1080,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		m_tstr = port_to_string(nport,
 		                        this->m_fdinfo->get_l4proto(),
 		                        m_inspector->is_hostname_and_port_resolution_enabled());
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 
 	case TYPE_L4PROTO: {
@@ -1108,7 +1108,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			break;
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_IS_SERVER: {
 		if(m_fdinfo == NULL) {
@@ -1141,10 +1141,10 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(m_fdinfo->m_type == SCAP_FD_IPV4_SOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
 		   m_fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SERVSOCK) {
 			m_tstr = "ip";
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		} else if(m_fdinfo->m_type == SCAP_FD_UNIX_SOCK) {
 			m_tstr = "unix";
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		} else {
 			return NULL;
 		}
@@ -1155,7 +1155,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_tstr = to_string(m_tinfo->m_tid) + to_string(m_tinfo->m_lastevent_fd);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_IS_CONNECTED: {
 		if(m_fdinfo == NULL) {
@@ -1219,7 +1219,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = m_fdinfo->m_name_raw;
 		}
 		remove_duplicate_path_separators(m_tstr);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	} break;
 	case TYPE_FDUPPER: {
 		if(m_fdinfo == NULL) {

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -369,9 +369,7 @@ int32_t sinsp_filter_check_fd::parse_field_name(std::string_view val,
 	return sinsp_filter_check::parse_field_name(val, alloc_state, needed_for_filtering);
 }
 
-bool sinsp_filter_check_fd::extract_fdname_from_event(sinsp_evt *evt,
-                                                      bool sanitize_strings,
-                                                      bool fd_nameraw) {
+bool sinsp_filter_check_fd::extract_fdname_from_event(sinsp_evt *evt, bool fd_nameraw) {
 	const char *resolved_argstr;
 	uint16_t etype = evt->get_type();
 
@@ -427,19 +425,10 @@ bool sinsp_filter_check_fd::extract_fdname_from_event(sinsp_evt *evt,
 			m_tstr = sinsp_utils::concatenate_paths(sdir, name);  // here we'd like a string
 		}
 
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
-		}
-
 		return true;
 	}
 	case PPME_SYSCALL_OPEN_BY_HANDLE_AT_X: {
 		m_tstr = evt->get_param(3)->as<std::string>();
-
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
-		}
-
 		return true;
 	}
 	default:
@@ -519,7 +508,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 	case TYPE_FDNAME:
 	case TYPE_CONTAINERNAME:
 		if(m_fdinfo == NULL) {
-			if(!extract_fdname_from_event(evt, sanitize_strings)) {
+			if(!extract_fdname_from_event(evt)) {
 				return NULL;
 			}
 		} else {
@@ -531,9 +520,6 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = container_id + ':' + m_tstr;
 		}
 
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
-		}
 		return extract_single_string(m_tstr, len, sanitize_strings);
 		break;
 	case TYPE_FDTYPES:
@@ -548,17 +534,13 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 	case TYPE_DIRECTORY:
 	case TYPE_CONTAINERDIRECTORY: {
 		if(m_fdinfo == NULL) {
-			if(!extract_fdname_from_event(evt, sanitize_strings)) {
+			if(!extract_fdname_from_event(evt)) {
 				return NULL;
 			}
 		} else if(!(m_fdinfo->is_file() || m_fdinfo->is_directory())) {
 			return NULL;
 		} else {
 			m_tstr = m_fdinfo->m_name;
-		}
-
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
 		}
 
 		// It is possible that `m_fdinfo` is still NULL, but `m_tstr` is
@@ -596,9 +578,6 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_tstr = m_fdinfo->m_name;
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
-		}
 
 		size_t pos = m_tstr.rfind('/');
 		if(pos != string::npos) {
@@ -1212,7 +1191,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 	} break;
 	case TYPE_FDNAMERAW: {
 		if(m_fdinfo == NULL) {
-			if(!extract_fdname_from_event(evt, sanitize_strings, true)) {
+			if(!extract_fdname_from_event(evt, true)) {
 				return NULL;
 			}
 		} else {

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -30,12 +30,6 @@ using namespace std;
 		return (uint8_t *)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)       \
-	do {                               \
-		*len = (x).size();             \
-		return (uint8_t *)(x).c_str(); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)            \
 	do {                                  \
 		if((x)) {                         \
@@ -540,7 +534,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(sanitize_strings) {
 			sanitize_string(m_tstr);
 		}
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 		break;
 	case TYPE_FDTYPES:
 	case TYPE_FDTYPE:
@@ -590,7 +584,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = container_id + ':' + m_tstr;
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_FILENAME: {
 		if(m_fdinfo == NULL) {
@@ -615,7 +609,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = "/";
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_FDTYPECHAR:
 		*len = 1;
@@ -667,7 +661,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		if(!m_tstr.empty()) {
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 	} break;
 	case TYPE_SNET:
@@ -724,7 +718,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		if(!m_tstr.empty()) {
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 	} break;
 	case TYPE_LNET:
@@ -848,7 +842,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			}
 
 			if(!m_tstr.empty()) {
-				RETURN_EXTRACT_STRING(m_tstr);
+				return extract_single_string(m_tstr, len);
 			}
 		}
 	}
@@ -893,7 +887,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			                        m_inspector->is_hostname_and_port_resolution_enabled());
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_SERVERPORT: {
 		if(m_fdinfo == NULL) {
@@ -960,7 +954,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			                        m_inspector->is_hostname_and_port_resolution_enabled());
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_LPORT:
 	case TYPE_RPORT: {
@@ -1086,7 +1080,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		m_tstr = port_to_string(nport,
 		                        this->m_fdinfo->get_l4proto(),
 		                        m_inspector->is_hostname_and_port_resolution_enabled());
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 
 	case TYPE_L4PROTO: {
@@ -1114,7 +1108,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			break;
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_IS_SERVER: {
 		if(m_fdinfo == NULL) {
@@ -1147,10 +1141,10 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(m_fdinfo->m_type == SCAP_FD_IPV4_SOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
 		   m_fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK || m_fdinfo->m_type == SCAP_FD_IPV6_SERVSOCK) {
 			m_tstr = "ip";
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		} else if(m_fdinfo->m_type == SCAP_FD_UNIX_SOCK) {
 			m_tstr = "unix";
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		} else {
 			return NULL;
 		}
@@ -1161,7 +1155,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_tstr = to_string(m_tinfo->m_tid) + to_string(m_tinfo->m_lastevent_fd);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_IS_CONNECTED: {
 		if(m_fdinfo == NULL) {
@@ -1225,7 +1219,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_tstr = m_fdinfo->m_name_raw;
 		}
 		remove_duplicate_path_separators(m_tstr);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	} break;
 	case TYPE_FDUPPER: {
 		if(m_fdinfo == NULL) {

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -89,7 +89,7 @@ protected:
 
 private:
 	int32_t extract_arg(std::string_view fldname, std::string_view val);
-	bool extract_fdname_from_event(sinsp_evt* evt, bool sanitize_strings, bool fd_nameraw = false);
+	bool extract_fdname_from_event(sinsp_evt* evt, bool fd_nameraw = false);
 	bool extract_fd(sinsp_evt* evt);
 
 	bool compare_ip(sinsp_evt* evt);

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_STRING(x)       \
-	do {                               \
-		*len = (x).size();             \
-		return (uint8_t *)(x).c_str(); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_fdlist_fields[] = {
         {PT_CHARBUF,
          EPF_NONE,
@@ -236,7 +230,7 @@ uint8_t *sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt,
 			m_strval = m_strval.substr(0, m_strval.size() - 1);
 		}
 
-		RETURN_EXTRACT_STRING(m_strval);
+		return extract_single_string(m_strval, len);
 	} else {
 		return NULL;
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -230,7 +230,7 @@ uint8_t *sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt,
 			m_strval = m_strval.substr(0, m_strval.size() - 1);
 		}
 
-		return extract_single_string(m_strval, len);
+		return extract_single_string(m_strval, len, sanitize_strings);
 	} else {
 		return NULL;
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -25,12 +25,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_fspath_fields[] = {
         {PT_CHARBUF,
          EPF_NONE,
@@ -411,7 +405,7 @@ uint8_t* sinsp_filter_check_fspath::extract_single(sinsp_evt* evt,
 		}
 	}
 
-	RETURN_EXTRACT_STRING(m_tstr);
+	return extract_single_string(m_tstr, len);
 }
 
 bool sinsp_filter_check_fspath::extract_fspath(sinsp_evt* evt,

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -405,7 +405,7 @@ uint8_t* sinsp_filter_check_fspath::extract_single(sinsp_evt* evt,
 		}
 	}
 
-	return extract_single_string(m_tstr, len);
+	return extract_single_string(m_tstr, len, sanitize_strings);
 }
 
 bool sinsp_filter_check_fspath::extract_fspath(sinsp_evt* evt,

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -208,19 +208,19 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		} else {
 			sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, true);
 		}
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_TIME_S:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, false);
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_TIME_ISO8601:
 		sinsp_utils::ts_to_iso_8601(evt->get_ts(), &m_strstorage);
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_DATETIME:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, true, true);
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_DATETIME_S:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, true, false);
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_RAWTS:
 		m_val.u64 = evt->get_ts();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -255,7 +255,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 			m_strstorage = plugin->event_to_string(evt);
 		}
 
-		return extract_single_string(m_strstorage, len);
+		return extract_single_string(m_strstorage, len, sanitize_strings);
 	}
 	case TYPE_SOURCE:
 		if(evt->get_source_idx() == sinsp_no_event_source_idx ||

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -30,12 +30,6 @@ using namespace std;
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)           \
 	do {                                 \
 		if((x)) {                        \
@@ -214,19 +208,19 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		} else {
 			sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, true);
 		}
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_TIME_S:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, false, false);
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_TIME_ISO8601:
 		sinsp_utils::ts_to_iso_8601(evt->get_ts(), &m_strstorage);
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_DATETIME:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, true, true);
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_DATETIME_S:
 		sinsp_utils::ts_to_string(evt->get_ts(), &m_strstorage, true, false);
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	case TYPE_RAWTS:
 		m_val.u64 = evt->get_ts();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -261,7 +255,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 			m_strstorage = plugin->event_to_string(evt);
 		}
 
-		RETURN_EXTRACT_STRING(m_strstorage);
+		return extract_single_string(m_strstorage, len);
 	}
 	case TYPE_SOURCE:
 		if(evt->get_source_idx() == sinsp_no_event_source_idx ||

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -28,12 +28,6 @@ using namespace std;
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_group_fields[] = {
         {PT_UINT32, EPF_NONE, PF_ID, "group.gid", "Group ID", "group ID."},
         {PT_CHARBUF, EPF_NONE, PF_NA, "group.name", "Group Name", "group name."},
@@ -79,7 +73,7 @@ uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt* evt,
 		} else {
 			m_name = "<NA>";
 		}
-		RETURN_EXTRACT_STRING(m_name);
+		return extract_single_string(m_name, len);
 	}
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -73,7 +73,7 @@ uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt* evt,
 		} else {
 			m_name = "<NA>";
 		}
-		return extract_single_string(m_name, len);
+		return extract_single_string(m_name, len, sanitize_strings);
 	}
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -1261,9 +1261,6 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 	}
 	case TYPE_CMDLINE: {
 		sinsp_threadinfo::populate_cmdline(m_tstr, tinfo);
-		if(sanitize_strings) {
-			sanitize_string(m_tstr);
-		}
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_EXELINE: {

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -34,12 +34,6 @@ using namespace std;
 		return (uint8_t*)(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 static inline bool str_match_start(std::string_view val, size_t len, const char* m) {
 	return val.compare(0, len, m) == 0;
 }
@@ -1109,53 +1103,53 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_SID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_SID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_VPGID_NAME:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_VPGID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_VPGID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); },
 		        true);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_TTY:
 		RETURN_EXTRACT_VAR(tinfo->m_tty);
 	case TYPE_NAME:
 		m_tstr = tinfo->get_comm();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_EXE:
 		m_tstr = tinfo->get_exe();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_EXEPATH:
 		m_tstr = tinfo->get_exepath();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_ARGS: {
 		m_tstr.clear();
 
@@ -1167,7 +1161,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			sinsp_threadinfo::populate_args(m_tstr, tinfo);
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_AARGS: {
 		m_tstr.clear();
@@ -1190,7 +1184,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
@@ -1199,7 +1193,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_args(m_tstr, mt);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_ENV: {
 		m_tstr.clear();
@@ -1207,10 +1201,10 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		// proc.env[ENV_NAME] use case: returns matched env variable value
 		if(!m_argname.empty()) {
 			m_tstr = tinfo->get_env(m_argname);
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		} else {
 			m_tstr = tinfo->concatenate_all_env();
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 	}
 	case TYPE_AENV: {
@@ -1219,7 +1213,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		// in case of proc.aenv without [ENV_NAME] return proc.env; same applies for proc.aenv[0]
 		if(m_argname.empty() && m_argid < 1) {
 			m_tstr = tinfo->concatenate_all_env();
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 
 		// get current tinfo / init for subsequent parent lineage traversal
@@ -1229,7 +1223,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		} else {
 			mt = tinfo->get_main_thread();
 			if(mt == NULL) {
-				RETURN_EXTRACT_STRING(m_tstr);
+				return extract_single_string(m_tstr, len);
 			}
 		}
 
@@ -1249,7 +1243,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 					break;
 				}
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		} else if(m_argid > 0) {
 			// start parent lineage traversal
 			for(int32_t j = 0; j < m_argid; j++) {
@@ -1261,13 +1255,16 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 
 			// parent tinfo specified found; extract env
 			m_tstr = mt->concatenate_all_env();
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_CMDLINE: {
 		sinsp_threadinfo::populate_cmdline(m_tstr, tinfo);
-		RETURN_EXTRACT_STRING(m_tstr);
+		if(sanitize_strings) {
+			sanitize_string(m_tstr);
+		}
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_EXELINE: {
 		m_tstr = tinfo->get_exe() + " ";
@@ -1282,11 +1279,11 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			}
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_CWD:
 		m_tstr = tinfo->get_cwd();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_NTHREADS: {
 		m_val.u64 = tinfo->get_num_threads();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -1343,7 +1340,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_comm();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_PCMDLINE: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1352,7 +1349,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_cmdline(m_tstr, ptinfo);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_ACMDLINE: {
 		if(m_argid == -1) {
@@ -1374,7 +1371,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1382,7 +1379,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_cmdline(m_tstr, mt);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_APID: {
 		sinsp_threadinfo* mt =
@@ -1415,7 +1412,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1423,7 +1420,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_comm();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_PEXE: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1432,7 +1429,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_exe();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_AEXE: {
 		if(m_argid == -1) {
@@ -1452,7 +1449,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1460,7 +1457,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_exe();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_PEXEPATH: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1469,7 +1466,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_exepath();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_AEXEPATH: {
 		if(m_argid == -1) {
@@ -1489,7 +1486,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1497,7 +1494,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_exepath();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_LOGINSHELLID: {
 		sinsp_threadinfo* mt = NULL;
@@ -1628,11 +1625,11 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			}
 		}
 
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_CGROUP:
 		if(tinfo->get_cgroup(m_argname, m_tstr)) {
-			RETURN_EXTRACT_STRING(m_tstr);
+			return extract_single_string(m_tstr, len);
 		}
 		return NULL;
 	case TYPE_VTID:
@@ -1660,7 +1657,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 	}
 	case TYPE_NAMETID:
 		m_tstr = tinfo->get_comm() + to_string(evt->get_tid());
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_IS_EXE_WRITABLE:
 		m_val.u32 = tinfo->m_exe_writable;
 		RETURN_EXTRACT_VAR(m_val.u32);
@@ -1681,13 +1678,13 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_VAR(m_val.u32);
 	case TYPE_CAP_PERMITTED:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_permitted);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_CAP_INHERITABLE:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_inheritable);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_CAP_EFFECTIVE:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_effective);
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_CMDNARGS: {
 		m_val.u64 = (uint32_t)tinfo->m_args.size();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -1778,7 +1775,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		m_tstr = fdinfo->get_typestring();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_FD_STDIN_NAME:
 	case TYPE_FD_STDOUT_NAME:
@@ -1800,7 +1797,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		m_tstr = fdinfo->m_name.c_str();
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	}
 	case TYPE_PGID:
 		RETURN_EXTRACT_VAR(tinfo->m_pgid);
@@ -1809,19 +1806,19 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); });
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_PGID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); });
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_PGID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); });
-		RETURN_EXTRACT_STRING(m_tstr);
+		return extract_single_string(m_tstr, len);
 	case TYPE_IS_PGID_LEADER:
 		m_val.u32 = tinfo->m_pgid == tinfo->m_pid;
 		RETURN_EXTRACT_VAR(m_val.u32);

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -1103,53 +1103,53 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_SID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_SID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_sid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_VPGID_NAME:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_VPGID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_VPGID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_vpgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); },
 		        true);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_TTY:
 		RETURN_EXTRACT_VAR(tinfo->m_tty);
 	case TYPE_NAME:
 		m_tstr = tinfo->get_comm();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_EXE:
 		m_tstr = tinfo->get_exe();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_EXEPATH:
 		m_tstr = tinfo->get_exepath();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_ARGS: {
 		m_tstr.clear();
 
@@ -1161,7 +1161,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			sinsp_threadinfo::populate_args(m_tstr, tinfo);
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_AARGS: {
 		m_tstr.clear();
@@ -1184,7 +1184,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
@@ -1193,7 +1193,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_args(m_tstr, mt);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_ENV: {
 		m_tstr.clear();
@@ -1201,10 +1201,10 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		// proc.env[ENV_NAME] use case: returns matched env variable value
 		if(!m_argname.empty()) {
 			m_tstr = tinfo->get_env(m_argname);
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		} else {
 			m_tstr = tinfo->concatenate_all_env();
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 	}
 	case TYPE_AENV: {
@@ -1213,7 +1213,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		// in case of proc.aenv without [ENV_NAME] return proc.env; same applies for proc.aenv[0]
 		if(m_argname.empty() && m_argid < 1) {
 			m_tstr = tinfo->concatenate_all_env();
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 
 		// get current tinfo / init for subsequent parent lineage traversal
@@ -1223,7 +1223,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		} else {
 			mt = tinfo->get_main_thread();
 			if(mt == NULL) {
-				return extract_single_string(m_tstr, len);
+				return extract_single_string(m_tstr, len, sanitize_strings);
 			}
 		}
 
@@ -1243,7 +1243,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 					break;
 				}
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		} else if(m_argid > 0) {
 			// start parent lineage traversal
 			for(int32_t j = 0; j < m_argid; j++) {
@@ -1255,16 +1255,16 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 
 			// parent tinfo specified found; extract env
 			m_tstr = mt->concatenate_all_env();
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_CMDLINE: {
 		sinsp_threadinfo::populate_cmdline(m_tstr, tinfo);
 		if(sanitize_strings) {
 			sanitize_string(m_tstr);
 		}
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_EXELINE: {
 		m_tstr = tinfo->get_exe() + " ";
@@ -1279,11 +1279,11 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			}
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_CWD:
 		m_tstr = tinfo->get_cwd();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_NTHREADS: {
 		m_val.u64 = tinfo->get_num_threads();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -1340,7 +1340,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_comm();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_PCMDLINE: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1349,7 +1349,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_cmdline(m_tstr, ptinfo);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_ACMDLINE: {
 		if(m_argid == -1) {
@@ -1371,7 +1371,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1379,7 +1379,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		sinsp_threadinfo::populate_cmdline(m_tstr, mt);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_APID: {
 		sinsp_threadinfo* mt =
@@ -1412,7 +1412,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1420,7 +1420,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_comm();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_PEXE: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1429,7 +1429,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_exe();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_AEXE: {
 		if(m_argid == -1) {
@@ -1449,7 +1449,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1457,7 +1457,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_exe();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_PEXEPATH: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1466,7 +1466,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = ptinfo->get_exepath();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_AEXEPATH: {
 		if(m_argid == -1) {
@@ -1486,7 +1486,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			if(m_tstr.empty()) {
 				return NULL;
 			}
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 		sinsp_threadinfo* mt = m_inspector->m_thread_manager->get_ancestor_process(*tinfo, m_argid);
 		if(!mt) {
@@ -1494,7 +1494,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_tstr = mt->get_exepath();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_LOGINSHELLID: {
 		sinsp_threadinfo* mt = NULL;
@@ -1625,11 +1625,11 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			}
 		}
 
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_CGROUP:
 		if(tinfo->get_cgroup(m_argname, m_tstr)) {
-			return extract_single_string(m_tstr, len);
+			return extract_single_string(m_tstr, len, sanitize_strings);
 		}
 		return NULL;
 	case TYPE_VTID:
@@ -1657,7 +1657,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 	}
 	case TYPE_NAMETID:
 		m_tstr = tinfo->get_comm() + to_string(evt->get_tid());
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_IS_EXE_WRITABLE:
 		m_val.u32 = tinfo->m_exe_writable;
 		RETURN_EXTRACT_VAR(m_val.u32);
@@ -1678,13 +1678,13 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		RETURN_EXTRACT_VAR(m_val.u32);
 	case TYPE_CAP_PERMITTED:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_permitted);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_CAP_INHERITABLE:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_inheritable);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_CAP_EFFECTIVE:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_effective);
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_CMDNARGS: {
 		m_val.u64 = (uint32_t)tinfo->m_args.size();
 		RETURN_EXTRACT_VAR(m_val.u64);
@@ -1775,7 +1775,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		m_tstr = fdinfo->get_typestring();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_FD_STDIN_NAME:
 	case TYPE_FD_STDOUT_NAME:
@@ -1797,7 +1797,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		m_tstr = fdinfo->m_name.c_str();
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_PGID:
 		RETURN_EXTRACT_VAR(tinfo->m_pgid);
@@ -1806,19 +1806,19 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_comm(); });
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_PGID_EXE:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exe(); });
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_PGID_EXEPATH:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
 		        [](sinsp_threadinfo* t) { return t->m_pgid; },
 		        [](sinsp_threadinfo* t) { return t->get_exepath(); });
-		return extract_single_string(m_tstr, len);
+		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_IS_PGID_LEADER:
 		m_val.u32 = tinfo->m_pgid == tinfo->m_pid;
 		RETURN_EXTRACT_VAR(m_val.u32);

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -94,7 +94,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 	   (evt->get_type() == PPME_CONTAINER_JSON_2_E || is_container_asyncevent)) {
 		m_strval = m_inspector->m_plugin_tables.get_container_user(*tinfo);
 		if(!m_strval.empty()) {
-			return extract_single_string(m_strval, len);
+			return extract_single_string(m_strval, len, sanitize_strings);
 		}
 	}
 
@@ -113,7 +113,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		return extract_single_string(m_strval, len);
+		return extract_single_string(m_strval, len, sanitize_strings);
 	case TYPE_HOMEDIR:
 		if(user) {
 			m_strval = user->homedir;
@@ -122,14 +122,14 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		return extract_single_string(m_strval, len);
+		return extract_single_string(m_strval, len, sanitize_strings);
 	case TYPE_SHELL:
 		if(user) {
 			m_strval = user->shell;
 		} else {
 			m_strval = "<NA>";
 		}
-		return extract_single_string(m_strval, len);
+		return extract_single_string(m_strval, len, sanitize_strings);
 	case TYPE_LOGINUID:
 		m_val.s64 = (int64_t)-1;
 		if(tinfo->m_loginuid < UINT32_MAX) {
@@ -144,7 +144,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		return extract_single_string(m_strval, len);
+		return extract_single_string(m_strval, len, sanitize_strings);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -28,12 +28,6 @@ using namespace std;
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_user_fields[] = {
         {PT_UINT32, EPF_NONE, PF_ID, "user.uid", "User ID", "user ID."},
         {PT_CHARBUF, EPF_NONE, PF_NA, "user.name", "User Name", "user name."},
@@ -100,7 +94,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 	   (evt->get_type() == PPME_CONTAINER_JSON_2_E || is_container_asyncevent)) {
 		m_strval = m_inspector->m_plugin_tables.get_container_user(*tinfo);
 		if(!m_strval.empty()) {
-			RETURN_EXTRACT_STRING(m_strval);
+			return extract_single_string(m_strval, len);
 		}
 	}
 
@@ -119,7 +113,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		RETURN_EXTRACT_STRING(m_strval);
+		return extract_single_string(m_strval, len);
 	case TYPE_HOMEDIR:
 		if(user) {
 			m_strval = user->homedir;
@@ -128,14 +122,14 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		RETURN_EXTRACT_STRING(m_strval);
+		return extract_single_string(m_strval, len);
 	case TYPE_SHELL:
 		if(user) {
 			m_strval = user->shell;
 		} else {
 			m_strval = "<NA>";
 		}
-		RETURN_EXTRACT_STRING(m_strval);
+		return extract_single_string(m_strval, len);
 	case TYPE_LOGINUID:
 		m_val.s64 = (int64_t)-1;
 		if(tinfo->m_loginuid < UINT32_MAX) {
@@ -150,7 +144,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		} else {
 			m_strval = "<NA>";
 		}
-		RETURN_EXTRACT_STRING(m_strval);
+		return extract_single_string(m_strval, len);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -28,12 +28,6 @@ limitations under the License.
 		return (uint8_t*)&(x); \
 	} while(0)
 
-#define RETURN_EXTRACT_STRING(x)      \
-	do {                              \
-		*len = (x).size();            \
-		return (uint8_t*)(x).c_str(); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_mock_fields[] = {
         {PT_INT64, EPF_NONE, PF_ID, "test.int64", "", ""},
         {PT_CHARBUF, EPF_NONE, PF_NA, "test.charbuf", "", ""},
@@ -103,16 +97,16 @@ protected:
 			RETURN_EXTRACT_VAR(m_u64_val);
 		case TYPE_CHARBUF:
 			m_str_val = "charbuf";
-			RETURN_EXTRACT_STRING(m_str_val);
+			return extract_single_string(m_str_val, len);
 		case TYPE_BYTEBUF:
 			m_str_val = "bytebuf";
-			RETURN_EXTRACT_STRING(m_str_val);
+			return extract_single_string(m_str_val, len);
 		case TYPE_MORE_THAN_256:
 			m_str_val = std::string(257, 'a');
-			RETURN_EXTRACT_STRING(m_str_val);
+			return extract_single_string(m_str_val, len);
 		case TYPE_BASE64:
 			m_str_val = "Y2hhcmJ1Zg==";  // base64("charbuf")
-			RETURN_EXTRACT_STRING(m_str_val);
+			return extract_single_string(m_str_val, len);
 		default:
 			throw std::runtime_error("unknown field id: " + std::to_string(m_field_id));
 			break;

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -97,16 +97,16 @@ protected:
 			RETURN_EXTRACT_VAR(m_u64_val);
 		case TYPE_CHARBUF:
 			m_str_val = "charbuf";
-			return extract_single_string(m_str_val, len);
+			return extract_single_string(m_str_val, len, sanitize_strings);
 		case TYPE_BYTEBUF:
 			m_str_val = "bytebuf";
-			return extract_single_string(m_str_val, len);
+			return extract_single_string(m_str_val, len, sanitize_strings);
 		case TYPE_MORE_THAN_256:
 			m_str_val = std::string(257, 'a');
-			return extract_single_string(m_str_val, len);
+			return extract_single_string(m_str_val, len, sanitize_strings);
 		case TYPE_BASE64:
 			m_str_val = "Y2hhcmJ1Zg==";  // base64("charbuf")
-			return extract_single_string(m_str_val, len);
+			return extract_single_string(m_str_val, len, sanitize_strings);
 		default:
 			throw std::runtime_error("unknown field id: " + std::to_string(m_field_id));
 			break;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR honors the `sanitize_strings` boolean flag passed to `extract_single()` by ensuring `sanitize_string()` is called for each string extraction where its value is set to true. Moreover, it replaces `RETURN_EXTRACT_STRING()` macro calls with calls to a new protected `static` and `__always_inline` `extract_single_string()` method of the `sinsp_filter_check` class.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(userspace)!: honor sanitization request while extracting strings
```
