### PR TITLE
refactor(userspace/libsinsp/sinsp_filtercheck_*): replace `RETURN_EXTRACT_*` macros with methods

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -265,6 +265,15 @@ protected:
 		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str.c_str()));
 	}
 
+	// Helper that must be used while extracting a single value. It returns a pointer to `val` and
+	// sets `*len` to `sizeof(val)`.
+	template<typename T,
+	         std::enable_if_t<std::is_trivially_copyable_v<T> && !std::is_pointer_v<T>, int> = 0>
+	static uint8_t* extract_single_val(T& val, uint32_t* len) {
+		*len = sizeof(val);
+		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(&val));
+	}
+
 private:
 	//
 	// Instead of populating the filter check values with const values extracted at

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -265,6 +265,16 @@ protected:
 		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str.c_str()));
 	}
 
+	// Helper that must be used while extracting a single C string value. It returns `str` and sets
+	// `*len` to `strlen(str)`. Returns nullptr if `str` is nullptr, leaving `*len` unset.
+	static uint8_t* extract_single_cstring(const char* str, uint32_t* len) {
+		if(str == nullptr) {
+			return nullptr;
+		}
+		*len = strlen(str);
+		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str));
+	}
+
 	// Helper that must be used while extracting a single value. It returns a pointer to `val` and
 	// sets `*len` to `sizeof(val)`.
 	template<typename T,

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -31,12 +31,6 @@ extern sinsp_evttables g_infotables;
 
 #define UESTORAGE_INITIAL_BUFSIZE 256
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)           \
 	do {                                 \
 		if((x)) {                        \
@@ -803,7 +797,7 @@ inline uint8_t* sinsp_filter_check_event::extract_buflen(sinsp_evt* evt, uint32_
 		m_val.s64 = evt->get_syscall_return_value();
 
 		if(m_val.s64 >= 0) {
-			RETURN_EXTRACT_VAR(m_val.s64);
+			return extract_single_val(m_val.s64, len);
 		}
 	}
 
@@ -844,7 +838,7 @@ uint8_t* sinsp_filter_check_event::extract_error_count(sinsp_evt* evt, uint32_t*
 	if(evt->get_syscall_return_value() < 0) {
 		m_val.u32 = 1;
 	}
-	RETURN_EXTRACT_VAR(m_val.u32);
+	return extract_single_val(m_val.u32, len);
 }
 
 uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
@@ -860,7 +854,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		// Hardcoded value to 0 for now to avoid breaking changes.
 		// TODO(irozzo): get rid of this once the deprecated fields are removed.
 		m_val.u64 = 0;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	}
 	case TYPE_LATENCY_HUMAN: {
 		// Hardcoded value to "0ns" for now to avoid breaking changes.
@@ -888,7 +882,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_val.u64 = tts;
 		}
 
-		RETURN_EXTRACT_VAR(m_tsdelta);
+		return extract_single_val(m_tsdelta, len);
 	}
 	case TYPE_RUNTIME_TIME_OUTPUT_FORMAT: {
 		char timebuffer[100];
@@ -992,7 +986,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_val.u32 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_SYSCALL_TYPE: {
 		const auto etype = static_cast<ppm_event_code>(evt->get_scap_evt()->type);
@@ -1121,7 +1115,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_CPU:
 		m_val.u16 = evt->get_cpuid();
-		RETURN_EXTRACT_VAR(m_val.u16);
+		return extract_single_val(m_val.u16, len);
 	case TYPE_ARGRAW:
 		return extract_argraw(evt, len, m_argname.c_str());
 		break;
@@ -1214,7 +1208,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 
 		m_val.s64 = evt->get_syscall_return_value();
-		RETURN_EXTRACT_VAR(m_val.s64);
+		return extract_single_val(m_val.s64, len);
 	case TYPE_RESSTR: {
 		if(!evt->has_return_value()) {
 			return NULL;
@@ -1242,7 +1236,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 	}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_ISIO_READ: {
 		ppm_event_flags eflags = evt->get_info_flags();
 		if(eflags & EF_READS_FROM_FD) {
@@ -1251,7 +1245,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_val.u32 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	}
 	case TYPE_ISIO_WRITE: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1261,7 +1255,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_val.u32 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	}
 	case TYPE_IODIR: {
 		ppm_event_flags eflags = evt->get_info_flags();
@@ -1284,7 +1278,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 	}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_ISSYSLOG: {
 		m_val.u32 = 0;
 
@@ -1297,11 +1291,11 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			}
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	}
 	case TYPE_COUNT:
 		m_val.u32 = 1;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_FAILED:
 	case TYPE_COUNT_ERROR:
 		return extract_error_count(evt, len);
@@ -1377,7 +1371,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 	case TYPE_COUNT_EXIT:
 		if(PPME_IS_EXIT(evt->get_type())) {
 			m_val.u32 = 1;
-			RETURN_EXTRACT_VAR(m_val.u32);
+			return extract_single_val(m_val.u32, len);
 		} else {
 			return NULL;
 		}
@@ -1385,7 +1379,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 	case TYPE_COUNT_THREADINFO: {
 		m_val.u32 = 0;
 		if(evt->get_type() != PPME_PROCINFO_E) {
-			RETURN_EXTRACT_VAR(m_val.u32);
+			return extract_single_val(m_val.u32, len);
 		}
 
 		if(m_field_id == TYPE_COUNT_THREADINFO) {
@@ -1396,7 +1390,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 				m_val.u32 = 1;
 			}
 		}
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	}
 	case TYPE_ABSPATH:
 		return extract_abspath(evt, len, sanitize_strings);
@@ -1531,7 +1525,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			m_val.u32 = (mode_bits & is_exec_mask) ? 1 : 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	}
 
 	break;

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -31,14 +31,6 @@ extern sinsp_evttables g_infotables;
 
 #define UESTORAGE_INITIAL_BUFSIZE 256
 
-#define RETURN_EXTRACT_CSTR(x)           \
-	do {                                 \
-		if((x)) {                        \
-			*len = strlen((char*)((x))); \
-		}                                \
-		return (uint8_t*)((x));          \
-	} while(0)
-
 static inline bool str_match_start(std::string_view val, size_t len, const char* m) {
 	return val.compare(0, len, m) == 0;
 }
@@ -936,11 +928,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 	}
 	case TYPE_DIR:
-		if(PPME_IS_ENTER(evt->get_type())) {
-			RETURN_EXTRACT_CSTR(">");
-		} else {
-			RETURN_EXTRACT_CSTR("<");
-		}
+		return extract_single_cstring(PPME_IS_ENTER(evt->get_type()) ? ">" : "<", len);
 	case TYPE_TYPE: {
 		// TODO(ekoops): from each case, remove the following const_casts once the method signature
 		//   is updated to return a pointer to a const buffer.
@@ -975,7 +963,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 		}
 
-		RETURN_EXTRACT_CSTR(evt_name);
+		return extract_single_cstring(evt_name, len);
 	} break;
 	case TYPE_TYPE_IS: {
 		uint16_t etype = evt->get_scap_evt()->type;
@@ -1016,7 +1004,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			evt_name = const_cast<char*>(evt->get_name());
 		}
 
-		RETURN_EXTRACT_CSTR(evt_name);
+		return extract_single_cstring(evt_name, len);
 	} break;
 	case TYPE_CATEGORY:
 		sinsp_evt::category cat;
@@ -1139,9 +1127,9 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 
 		if(resolved_argstr != NULL && resolved_argstr[0] != 0) {
-			RETURN_EXTRACT_CSTR(resolved_argstr);
+			return extract_single_cstring(resolved_argstr, len);
 		} else {
-			RETURN_EXTRACT_CSTR(argstr);
+			return extract_single_cstring(argstr, len);
 		}
 	} break;
 	case TYPE_INFO: {
@@ -1152,7 +1140,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 	case TYPE_ARGS: {
 		if(evt->get_type() == PPME_GENERIC_X) {
 			// Don't print the arguments for generic events: they have only internal use.
-			RETURN_EXTRACT_CSTR("");
+			return extract_single_cstring("", len);
 		}
 
 		const char* resolved_argstr = NULL;
@@ -1216,7 +1204,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 
 		int64_t res = evt->get_syscall_return_value();
 		if(res >= 0) {
-			RETURN_EXTRACT_CSTR("SUCCESS");
+			return extract_single_cstring("SUCCESS", len);
 		}
 
 		// todo!: we should check if a failed syscall can return something that is not an errno.

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -24,12 +24,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)   \
-	do {                        \
-		*len = sizeof((x));     \
-		return (uint8_t *)&(x); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)            \
 	do {                                  \
 		if((x)) {                         \
@@ -497,7 +491,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 	// TYPE_FDNUM doesn't need fdinfo
 	//
 	if(m_field_id == TYPE_FDNUM) {
-		RETURN_EXTRACT_VAR(m_tinfo->m_lastevent_fd);
+		return extract_single_val(m_tinfo->m_lastevent_fd, len);
 	}
 
 	std::string container_id;
@@ -611,9 +605,9 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		scap_fd_type evt_type = m_fdinfo->m_type;
 		if(evt_type == SCAP_FD_IPV4_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip, len);
 		} else if(evt_type == SCAP_FD_IPV6_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip, len);
 		}
 	} break;
 	case TYPE_CLIENTIP_NAME: {
@@ -655,13 +649,13 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		scap_fd_type evt_type = m_fdinfo->m_type;
 		if(evt_type == SCAP_FD_IPV4_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip, len);
 		} else if(evt_type == SCAP_FD_IPV4_SERVSOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip, len);
 		} else if(evt_type == SCAP_FD_IPV6_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip, len);
 		} else if(evt_type == SCAP_FD_IPV6_SERVSOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip, len);
 		}
 	} break;
 	case TYPE_SERVERIP_NAME: {
@@ -738,29 +732,37 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			if(is_local) {
 				if(m_field_id == TYPE_LIP || m_field_id == TYPE_LNET) {
 					if(evt_type == SCAP_FD_IPV4_SOCK) {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip,
+						                          len);
 					} else {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip,
+						                          len);
 					}
 				} else {
 					if(evt_type == SCAP_FD_IPV4_SOCK) {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip,
+						                          len);
 					} else {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip,
+						                          len);
 					}
 				}
 			} else {
 				if(m_field_id == TYPE_LIP || m_field_id == TYPE_LNET) {
 					if(evt_type == SCAP_FD_IPV4_SOCK) {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dip,
+						                          len);
 					} else {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dip,
+						                          len);
 					}
 				} else {
 					if(evt_type == SCAP_FD_IPV4_SOCK) {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip,
+						                          len);
 					} else {
-						RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip);
+						return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sip,
+						                          len);
 					}
 				}
 			}
@@ -839,9 +841,9 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		if(evt_type == SCAP_FD_IPV4_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport, len);
 		} else if(evt_type == SCAP_FD_IPV6_SOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport, len);
 		}
 	} break;
 	case TYPE_CLIENTPROTO: {
@@ -880,17 +882,17 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 				return NULL;
 			}
 
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport, len);
 		} else if(evt_type == SCAP_FD_IPV4_SERVSOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_port);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4serverinfo.m_port, len);
 		} else if(evt_type == SCAP_FD_IPV6_SOCK) {
 			if(m_fdinfo->is_role_none()) {
 				return NULL;
 			}
 
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport, len);
 		} else if(evt_type == SCAP_FD_IPV6_SERVSOCK) {
-			RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_port);
+			return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6serverinfo.m_port, len);
 		} else {
 			return NULL;
 		}
@@ -967,29 +969,37 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(is_local) {
 			if(m_field_id == TYPE_LPORT || m_field_id == TYPE_LPROTO) {
 				if(evt_type == SCAP_FD_IPV4_SOCK) {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport,
+					                          len);
 				} else {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport,
+					                          len);
 				}
 			} else {
 				if(evt_type == SCAP_FD_IPV4_SOCK) {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport,
+					                          len);
 				} else {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport,
+					                          len);
 				}
 			}
 		} else {
 			if(m_field_id == TYPE_LPORT || m_field_id == TYPE_LPROTO) {
 				if(evt_type == SCAP_FD_IPV4_SOCK) {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_dport,
+					                          len);
 				} else {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_dport,
+					                          len);
 				}
 			} else {
 				if(evt_type == SCAP_FD_IPV4_SOCK) {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sport,
+					                          len);
 				} else {
-					RETURN_EXTRACT_VAR(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport);
+					return extract_single_val(m_fdinfo->m_sockinfo.m_ipv6info.m_fields.m_sport,
+					                          len);
 				}
 			}
 		}
@@ -1110,7 +1120,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			m_val.u32 = false;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_SOCKFAMILY: {
 		if(m_fdinfo == NULL) {
@@ -1143,7 +1153,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		m_val.u32 = m_fdinfo->is_socket_connected();
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_NAME_CHANGED: {
 		if(m_fdinfo == NULL) {
@@ -1152,7 +1162,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		m_val.u32 = evt->fdinfo_name_changed();
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_DEV: {
 		if(m_fdinfo == NULL) {
@@ -1161,7 +1171,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		m_val.u32 = m_fdinfo->get_device();
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_DEV_MAJOR: {
 		if(m_fdinfo == NULL) {
@@ -1170,7 +1180,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		m_val.u32 = m_fdinfo->get_device_major();
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_DEV_MINOR: {
 		if(m_fdinfo == NULL) {
@@ -1179,7 +1189,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 
 		m_val.u32 = m_fdinfo->get_device_minor();
 
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_INO: {
 		if(m_fdinfo == NULL) {
@@ -1187,7 +1197,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_val.u64 = m_fdinfo->get_ino();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	} break;
 	case TYPE_FDNAMERAW: {
 		if(m_fdinfo == NULL) {
@@ -1206,7 +1216,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_val.u32 = m_fdinfo->is_overlay_upper();
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	case TYPE_FDLOWER: {
 		if(m_fdinfo == NULL) {
@@ -1214,7 +1224,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		}
 
 		m_val.u32 = m_fdinfo->is_overlay_lower();
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	} break;
 	default:
 		ASSERT(false);

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -24,14 +24,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_CSTR(x)            \
-	do {                                  \
-		if((x)) {                         \
-			*len = strlen((char *)((x))); \
-		}                                 \
-		return (uint8_t *)((x));          \
-	} while(0)
-
 static inline bool str_match_start(std::string_view val, size_t len, const char *m) {
 	return val.compare(0, len, m) == 0;
 }
@@ -521,8 +513,8 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 		if(m_fdinfo == NULL) {
 			return NULL;
 		} else {
-			uint8_t *typestr = (uint8_t *)m_fdinfo->get_typestring();
-			RETURN_EXTRACT_CSTR(typestr);
+			const char *typestr = m_fdinfo->get_typestring();
+			return extract_single_cstring(typestr, len);
 		}
 		break;
 	case TYPE_DIRECTORY:

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -24,12 +24,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 #define RETURN_EXTRACT_CSTR(x)           \
 	do {                                 \
 		if((x)) {                        \
@@ -223,25 +217,25 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_strstorage, len, sanitize_strings);
 	case TYPE_RAWTS:
 		m_val.u64 = evt->get_ts();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_RAWTS_S:
 		m_val.u64 = evt->get_ts() / ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_RAWTS_NS:
 		m_val.u64 = evt->get_ts() % ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_RELTS:
 		m_val.u64 = evt->get_ts() - m_inspector->m_firstevent_ts;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_RELTS_S:
 		m_val.u64 = (evt->get_ts() - m_inspector->m_firstevent_ts) / ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_RELTS_NS:
 		m_val.u64 = (evt->get_ts() - m_inspector->m_firstevent_ts) % ONE_SECOND_IN_NS;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_NUMBER:
 		m_val.u64 = evt->get_num();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_PLUGINNAME:
 	case TYPE_PLUGININFO: {
 		const auto& plugin = m_inspector->get_plugin_manager()->plugin_by_evt(evt);
@@ -269,7 +263,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		} else {
 			m_val.u32 = 0;
 		}
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_ASYNCTYPE: {
 		if(!libsinsp::events::is_metaevent((ppm_event_code)evt->get_type())) {
 			return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -24,14 +24,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_CSTR(x)           \
-	do {                                 \
-		if((x)) {                        \
-			*len = strlen((char*)((x))); \
-		}                                \
-		return (uint8_t*)((x));          \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_gen_event_fields[] = {
         {PT_UINT64, EPF_NONE, PF_ID, "evt.num", "Event Number", "event number."},
         {PT_CHARBUF,
@@ -256,7 +248,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		   evt->get_source_name() == sinsp_no_event_source_name) {
 			return NULL;
 		}
-		RETURN_EXTRACT_CSTR(evt->get_source_name());
+		return extract_single_cstring(evt->get_source_name(), len);
 	case TYPE_ISASYNC:
 		if(libsinsp::events::is_metaevent((ppm_event_code)evt->get_type())) {
 			m_val.u32 = 1;
@@ -269,11 +261,11 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		if(evt->get_type() != PPME_ASYNCEVENT_E) {
-			RETURN_EXTRACT_CSTR(evt->get_name());
+			return extract_single_cstring(evt->get_name(), len);
 		}
 		const auto name_param = evt->get_param(1);
 		const auto [data, _] = name_param->data_and_len_with_legacy_null_encoding();
-		RETURN_EXTRACT_CSTR(data);
+		return extract_single_cstring(data, len);
 	}
 
 	case TYPE_HOSTNAME:
@@ -281,7 +273,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		if(!minfo) {
 			return NULL;
 		}
-		RETURN_EXTRACT_CSTR(minfo->hostname);
+		return extract_single_cstring(minfo->hostname, len);
 	default:
 		ASSERT(false);
 		return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_group.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_group.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_group_fields[] = {
         {PT_UINT32, EPF_NONE, PF_ID, "group.gid", "Group ID", "group ID."},
         {PT_CHARBUF, EPF_NONE, PF_NA, "group.name", "Group Name", "group name."},
@@ -62,7 +56,7 @@ uint8_t* sinsp_filter_check_group::extract_single(sinsp_evt* evt,
 	switch(m_field_id) {
 	case TYPE_GID:
 		m_gid = tinfo->m_gid;
-		RETURN_EXTRACT_VAR(m_gid);
+		return extract_single_val(m_gid, len);
 	case TYPE_NAME: {
 		auto container_id = m_inspector->m_plugin_tables.get_container_id(*tinfo);
 		auto group = m_inspector->m_usergroup_manager->get_group(container_id, tinfo->m_gid);

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 #define RETURN_EXTRACT_PTR(x) \
 	do {                      \
 		*len = sizeof(*(x));  \
@@ -1056,7 +1050,7 @@ uint8_t* sinsp_filter_check_thread::extract_thread_cpu(sinsp_evt* evt,
 
 		tinfo->write_field(m_thread_dyn_field_accessor, tcpu);
 
-		RETURN_EXTRACT_VAR(m_val.d);
+		return extract_single_val(m_val.d, len);
 	}
 
 	return NULL;
@@ -1087,16 +1081,16 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(!should_extract_xid(m_val.s64)) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(m_val.s64);
+		return extract_single_val(m_val.s64, len);
 	case TYPE_PID:
 		if(!should_extract_xid(tinfo->m_pid)) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_pid);
+		return extract_single_val(tinfo->m_pid, len);
 	case TYPE_SID:
-		RETURN_EXTRACT_VAR(tinfo->m_sid);
+		return extract_single_val(tinfo->m_sid, len);
 	case TYPE_VPGID:
-		RETURN_EXTRACT_VAR(tinfo->m_vpgid);
+		return extract_single_val(tinfo->m_vpgid, len);
 	case TYPE_SID_NAME:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
@@ -1140,7 +1134,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		        true);
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_TTY:
-		RETURN_EXTRACT_VAR(tinfo->m_tty);
+		return extract_single_val(tinfo->m_tty, len);
 	case TYPE_NAME:
 		m_tstr = tinfo->get_comm();
 		return extract_single_string(m_tstr, len, sanitize_strings);
@@ -1283,22 +1277,22 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_NTHREADS: {
 		m_val.u64 = tinfo->get_num_threads();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	} break;
 	case TYPE_NCHILDS: {
 		m_val.u64 = tinfo->get_num_not_leader_threads();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	} break;
 	case TYPE_ISMAINTHREAD:
 		m_val.u32 = (uint32_t)tinfo->is_main_thread();
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_EXECTIME: {
 		if(const auto etype = evt->get_type(); etype == PPME_SCHEDSWITCH_6_E) {
 			m_val.u64 = extract_exectime(evt);
 		} else {
 			m_val.u64 = 0;
 		}
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	}
 	case TYPE_TOTEXECTIME: {
 		if(const auto etype = evt->get_type(); etype == PPME_SCHEDSWITCH_6_E) {
@@ -1314,7 +1308,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			tinfo->read_field(m_thread_dyn_field_accessor, ptot);
 			m_val.u64 += ptot;
 			tinfo->write_field(m_thread_dyn_field_accessor, m_val.u64);
-			RETURN_EXTRACT_VAR(m_val.u64);
+			return extract_single_val(m_val.u64, len);
 		} else {
 			return NULL;
 		}
@@ -1328,7 +1322,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(!should_extract_xid(mt->m_pid)) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(mt->m_pid);
+		return extract_single_val(mt->m_pid, len);
 	}
 	case TYPE_PNAME: {
 		sinsp_threadinfo* ptinfo = m_inspector->m_thread_manager->get_ancestor_process(*tinfo);
@@ -1389,7 +1383,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(!should_extract_xid(mt->m_pid)) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(mt->m_pid);
+		return extract_single_val(mt->m_pid, len);
 	}
 	case TYPE_ANAME: {
 		if(m_argid == -1) {
@@ -1529,7 +1523,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(tinfo->m_clone_ts != 0) {
 			m_val.s64 = evt->get_ts() - tinfo->m_clone_ts;
 			ASSERT(m_val.s64 > 0);
-			RETURN_EXTRACT_VAR(m_val.s64);
+			return extract_single_val(m_val.s64, len);
 		} else {
 			return NULL;
 		}
@@ -1543,27 +1537,27 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(ptinfo->m_clone_ts != 0) {
 			m_val.s64 = evt->get_ts() - ptinfo->m_clone_ts;
 			ASSERT(m_val.s64 > 0);
-			RETURN_EXTRACT_VAR(m_val.s64);
+			return extract_single_val(m_val.s64, len);
 		}
 	}
 	case TYPE_FDOPENCOUNT:
 		m_val.u64 = tinfo->get_fd_opencount();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_FDLIMIT:
 		m_val.s64 = tinfo->get_fd_limit();
-		RETURN_EXTRACT_VAR(m_val.s64);
+		return extract_single_val(m_val.s64, len);
 	case TYPE_FDUSAGE:
 		m_val.d = tinfo->get_fd_usage_pct_d();
-		RETURN_EXTRACT_VAR(m_val.d);
+		return extract_single_val(m_val.d, len);
 	case TYPE_VMSIZE:
 		m_val.u64 = tinfo->m_vmsize_kb;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_VMRSS:
 		m_val.u64 = tinfo->m_vmrss_kb;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_VMSWAP:
 		m_val.u64 = tinfo->m_vmswap_kb;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_THREAD_VMSIZE:
 		if(tinfo->is_main_thread()) {
 			m_val.u64 = tinfo->m_vmsize_kb;
@@ -1571,7 +1565,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			m_val.u64 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_THREAD_VMRSS:
 		if(tinfo->is_main_thread()) {
 			m_val.u64 = tinfo->m_vmrss_kb;
@@ -1579,7 +1573,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			m_val.u64 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_THREAD_VMSIZE_B:
 		if(tinfo->is_main_thread()) {
 			m_val.u64 = static_cast<uint64_t>(tinfo->m_vmsize_kb) * 1024ULL;
@@ -1587,7 +1581,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			m_val.u64 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_THREAD_VMRSS_B:
 		if(tinfo->is_main_thread()) {
 			m_val.u64 = static_cast<uint64_t>(tinfo->m_vmrss_kb) * 1024ULL;
@@ -1595,13 +1589,13 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 			m_val.u64 = 0;
 		}
 
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_PFMAJOR:
 		m_val.u64 = tinfo->m_pfmajor;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_PFMINOR:
 		m_val.u64 = tinfo->m_pfminor;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_CGROUPS: {
 		m_tstr.clear();
 		auto cgroups = tinfo->cgroups();
@@ -1635,14 +1629,14 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		}
 
 		m_val.u64 = tinfo->m_vtid;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_VPID:
 		if(tinfo->m_vpid == -1) {
 			return NULL;
 		}
 
 		m_val.u64 = tinfo->m_vpid;
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	case TYPE_THREAD_CPU: {
 		return extract_thread_cpu(evt, len, tinfo, true, true);
 	}
@@ -1657,22 +1651,22 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_IS_EXE_WRITABLE:
 		m_val.u32 = tinfo->m_exe_writable;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_IS_EXE_UPPER_LAYER:
 		m_val.u32 = tinfo->m_exe_upper_layer;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_IS_EXE_LOWER_LAYER:
 		m_val.u32 = tinfo->m_exe_lower_layer;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_IS_EXE_FROM_MEMFD:
 		m_val.u32 = tinfo->m_exe_from_memfd;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_IS_SID_LEADER:
 		m_val.u32 = tinfo->m_sid == tinfo->m_vpid;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_IS_VPGID_LEADER:
 		m_val.u32 = tinfo->m_vpgid == tinfo->m_vpid;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_CAP_PERMITTED:
 		m_tstr = sinsp_utils::caps_to_string(tinfo->m_cap_permitted);
 		return extract_single_string(m_tstr, len, sanitize_strings);
@@ -1684,7 +1678,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_CMDNARGS: {
 		m_val.u64 = (uint32_t)tinfo->m_args.size();
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	}
 	case TYPE_CMDLENARGS: {
 		m_val.u64 = 0;
@@ -1694,14 +1688,14 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		for(j = 0; j < nargs; j++) {
 			m_val.u64 += tinfo->m_args[j].length();
 		}
-		RETURN_EXTRACT_VAR(m_val.u64);
+		return extract_single_val(m_val.u64, len);
 	}
 	case TYPE_PVPID: {
 		sinsp_threadinfo* ptinfo =
 		        m_inspector->m_thread_manager->find_thread(tinfo->m_ptid, true).get();
 
 		if(ptinfo != NULL) {
-			RETURN_EXTRACT_VAR(ptinfo->m_vpid);
+			return extract_single_val(ptinfo->m_vpid, len);
 		} else {
 			return NULL;
 		}
@@ -1711,43 +1705,43 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		if(tinfo->m_exe_ino == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_exe_ino);
+		return extract_single_val(tinfo->m_exe_ino, len);
 	case TYPE_EXE_INO_CTIME:
 		if(tinfo->m_exe_ino_ctime == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_exe_ino_ctime);
+		return extract_single_val(tinfo->m_exe_ino_ctime, len);
 	case TYPE_EXE_INO_MTIME:
 		if(tinfo->m_exe_ino_mtime == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_exe_ino_mtime);
+		return extract_single_val(tinfo->m_exe_ino_mtime, len);
 	case TYPE_EXE_INO_CTIME_DURATION_CLONE_TS:
 		if(tinfo->m_exe_ino_ctime_duration_clone_ts == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_exe_ino_ctime_duration_clone_ts);
+		return extract_single_val(tinfo->m_exe_ino_ctime_duration_clone_ts, len);
 	case TYPE_EXE_INO_CTIME_DURATION_PIDNS_START:
 		if(tinfo->m_exe_ino_ctime_duration_pidns_start == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_exe_ino_ctime_duration_pidns_start);
+		return extract_single_val(tinfo->m_exe_ino_ctime_duration_pidns_start, len);
 	case TYPE_PIDNS_INIT_START_TS:
 		if(tinfo->m_pidns_init_start_ts == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_pidns_init_start_ts);
+		return extract_single_val(tinfo->m_pidns_init_start_ts, len);
 	case TYPE_PID_CLONE_TS:
 		if(tinfo->m_clone_ts == 0) {
 			return NULL;
 		}
-		RETURN_EXTRACT_VAR(tinfo->m_clone_ts);
+		return extract_single_val(tinfo->m_clone_ts, len);
 	case TYPE_PPID_CLONE_TS: {
 		sinsp_threadinfo* ptinfo =
 		        m_inspector->m_thread_manager->find_thread(tinfo->m_ptid, true).get();
 
 		if(ptinfo != NULL) {
-			RETURN_EXTRACT_VAR(ptinfo->m_clone_ts);
+			return extract_single_val(ptinfo->m_clone_ts, len);
 		} else {
 			return NULL;
 		}
@@ -1797,7 +1791,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	}
 	case TYPE_PGID:
-		RETURN_EXTRACT_VAR(tinfo->m_pgid);
+		return extract_single_val(tinfo->m_pgid, len);
 	case TYPE_PGID_NAME:
 		m_tstr = m_inspector->m_thread_manager->get_ancestor_field_as_string(
 		        tinfo,
@@ -1818,7 +1812,7 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		return extract_single_string(m_tstr, len, sanitize_strings);
 	case TYPE_IS_PGID_LEADER:
 		m_val.u32 = tinfo->m_pgid == tinfo->m_pid;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	default:
 		ASSERT(false);
 		return NULL;

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_PTR(x) \
-	do {                      \
-		*len = sizeof(*(x));  \
-		return (uint8_t*)(x); \
-	} while(0)
-
 static inline bool str_match_start(std::string_view val, size_t len, const char* m) {
 	return val.compare(0, len, m) == 0;
 }
@@ -1517,7 +1511,10 @@ uint8_t* sinsp_filter_check_thread::extract_single(sinsp_evt* evt,
 		// Then check all its parents to see if they are shells
 		m_inspector->m_thread_manager->traverse_parent_state(*mt, check_thread_for_shell);
 
-		RETURN_EXTRACT_PTR(res);
+		if(res == nullptr) {
+			return nullptr;
+		}
+		return extract_single_val(*res, len);
 	}
 	case TYPE_DURATION: {
 		if(tinfo->m_clone_ts != 0) {

--- a/userspace/libsinsp/sinsp_filtercheck_user.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_user.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_user_fields[] = {
         {PT_UINT32, EPF_NONE, PF_ID, "user.uid", "User ID", "user ID."},
         {PT_CHARBUF, EPF_NONE, PF_NA, "user.name", "User Name", "user name."},
@@ -104,7 +98,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 	switch(m_field_id) {
 	case TYPE_UID:
 		m_val.u32 = tinfo->m_uid;
-		RETURN_EXTRACT_VAR(m_val.u32);
+		return extract_single_val(m_val.u32, len);
 	case TYPE_NAME:
 		if(user) {
 			m_strval = user->name;
@@ -135,7 +129,7 @@ uint8_t* sinsp_filter_check_user::extract_single(sinsp_evt* evt,
 		if(tinfo->m_loginuid < UINT32_MAX) {
 			m_val.s64 = (int64_t)tinfo->m_loginuid;
 		}
-		RETURN_EXTRACT_VAR(m_val.s64);
+		return extract_single_val(m_val.s64, len);
 	case TYPE_LOGINNAME:
 		if(loginuser) {
 			m_strval = loginuser->name;

--- a/userspace/libsinsp/sinsp_filtercheck_utils.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_utils.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 
 using namespace std;
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_utils_fields[] = {
         {PT_UINT64, EPF_NONE, PF_ID, "util.cnt", "Counter", "incremental counter."},
 };
@@ -56,7 +50,7 @@ uint8_t* sinsp_filter_check_utils::extract_single(sinsp_evt* evt,
 	switch(m_field_id) {
 	case TYPE_CNT:
 		m_cnt++;
-		RETURN_EXTRACT_VAR(m_cnt);
+		return extract_single_val(m_cnt, len);
 	default:
 		ASSERT(false);
 		break;

--- a/userspace/libsinsp/test/filterchecks/mock.cpp
+++ b/userspace/libsinsp/test/filterchecks/mock.cpp
@@ -22,12 +22,6 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include <test_utils.h>
 
-#define RETURN_EXTRACT_VAR(x)  \
-	do {                       \
-		*len = sizeof((x));    \
-		return (uint8_t*)&(x); \
-	} while(0)
-
 static const filtercheck_field_info sinsp_filter_check_mock_fields[] = {
         {PT_INT64, EPF_NONE, PF_ID, "test.int64", "", ""},
         {PT_CHARBUF, EPF_NONE, PF_NA, "test.charbuf", "", ""},
@@ -94,7 +88,7 @@ protected:
 		switch(m_field_id) {
 		case TYPE_INT64:
 			m_u64_val = 1;
-			RETURN_EXTRACT_VAR(m_u64_val);
+			return extract_single_val(m_u64_val, len);
 		case TYPE_CHARBUF:
 			m_str_val = "charbuf";
 			return extract_single_string(m_str_val, len, sanitize_strings);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR replaces `RETURN_EXTRACT_{CSTR,VAR,PTR}` macros with equivalent `sinsp_filter_check::extract_single_{cstring,val}` methods. These methods are defined as protected `static`. Notice that they are implicitly `inline`. `extract_single_val()` is a templated method that is constrained to be instantiated only for trivially-copyable, non-pointer types. There is no need to introduce a third method for `RETURN_EXTRACT_PTR(x)`: after a non-NULL check on `x`, it is possible to replace the macro with a call to extract_single_val(*x).

Notice that `extract_single_cstring()` doesn't supported sanitization yet. This is not a regression, as the current macro doesn't support it as well. Sanitization for C strings will be addressed in a subsequent PR.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
