### PR TITLE
fix!: honor sanitization request in `extract_single_cstring()`

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -267,12 +267,39 @@ protected:
 
 	// Helper that must be used while extracting a single C string value. It returns `str` and sets
 	// `*len` to `strlen(str)`. Returns nullptr if `str` is nullptr, leaving `*len` unset.
-	static uint8_t* extract_single_cstring(const char* str, uint32_t* len) {
+	// If `must_sanitize` is true and the string contains invalid UTF-8 sequences, the sanitized
+	// copy is written into `storage` and a pointer to it is returned instead.
+	static uint8_t* extract_single_cstring(const char* str,
+	                                       uint32_t* len,
+	                                       const bool must_sanitize,
+	                                       std::string& storage) {
 		if(str == nullptr) {
 			return nullptr;
 		}
+
 		*len = strlen(str);
-		return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str));
+		if(!must_sanitize) {
+			return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(str));
+		}
+
+		// Check if the string needs sanitization.
+		const auto* const ptr = reinterpret_cast<const unsigned char*>(str);
+		const auto* const end_ptr = ptr + *len;
+		const auto* const first_invalid_ptr = utf8_first_invalid_seq(ptr, end_ptr);
+		// String already sanitized, return it.
+		if(first_invalid_ptr == end_ptr) {
+			return const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(ptr));
+		}
+
+		// String needs sanitization. Store the sanitized version in `storage` and returns a pointer
+		// to it.
+		const auto valid_prefix_len = static_cast<size_t>(first_invalid_ptr - ptr);
+		const std::string_view str_to_sanitize{str, *len};
+		storage.clear();  // Reset to empty while preserving allocated capacity.
+		storage.reserve(*len);
+		append_sanitized_string(storage, str_to_sanitize, valid_prefix_len);
+		*len = static_cast<uint32_t>(storage.size());
+		return reinterpret_cast<uint8_t*>(storage.data());
 	}
 
 	// Helper that must be used while extracting a single value. It returns a pointer to `val` and

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -928,7 +928,10 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 	}
 	case TYPE_DIR:
-		return extract_single_cstring(PPME_IS_ENTER(evt->get_type()) ? ">" : "<", len);
+		return extract_single_cstring(PPME_IS_ENTER(evt->get_type()) ? ">" : "<",
+		                              len,
+		                              sanitize_strings,
+		                              m_strstorage);
 	case TYPE_TYPE: {
 		// TODO(ekoops): from each case, remove the following const_casts once the method signature
 		//   is updated to return a pointer to a const buffer.
@@ -963,7 +966,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 		}
 
-		return extract_single_cstring(evt_name, len);
+		return extract_single_cstring(evt_name, len, sanitize_strings, m_strstorage);
 	} break;
 	case TYPE_TYPE_IS: {
 		uint16_t etype = evt->get_scap_evt()->type;
@@ -1004,7 +1007,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 			evt_name = const_cast<char*>(evt->get_name());
 		}
 
-		return extract_single_cstring(evt_name, len);
+		return extract_single_cstring(evt_name, len, sanitize_strings, m_strstorage);
 	} break;
 	case TYPE_CATEGORY:
 		sinsp_evt::category cat;
@@ -1127,9 +1130,9 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 		}
 
 		if(resolved_argstr != NULL && resolved_argstr[0] != 0) {
-			return extract_single_cstring(resolved_argstr, len);
+			return extract_single_cstring(resolved_argstr, len, sanitize_strings, m_strstorage);
 		} else {
-			return extract_single_cstring(argstr, len);
+			return extract_single_cstring(argstr, len, sanitize_strings, m_strstorage);
 		}
 	} break;
 	case TYPE_INFO: {
@@ -1140,7 +1143,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 	case TYPE_ARGS: {
 		if(evt->get_type() == PPME_GENERIC_X) {
 			// Don't print the arguments for generic events: they have only internal use.
-			return extract_single_cstring("", len);
+			return extract_single_cstring("", len, sanitize_strings, m_strstorage);
 		}
 
 		const char* resolved_argstr = NULL;
@@ -1204,7 +1207,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt,
 
 		int64_t res = evt->get_syscall_return_value();
 		if(res >= 0) {
-			return extract_single_cstring("SUCCESS", len);
+			return extract_single_cstring("SUCCESS", len, sanitize_strings, m_strstorage);
 		}
 
 		// todo!: we should check if a failed syscall can return something that is not an errno.

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -514,7 +514,7 @@ uint8_t *sinsp_filter_check_fd::extract_single(sinsp_evt *evt,
 			return NULL;
 		} else {
 			const char *typestr = m_fdinfo->get_typestring();
-			return extract_single_cstring(typestr, len);
+			return extract_single_cstring(typestr, len, sanitize_strings, m_tstr);
 		}
 		break;
 	case TYPE_DIRECTORY:

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -248,7 +248,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		   evt->get_source_name() == sinsp_no_event_source_name) {
 			return NULL;
 		}
-		return extract_single_cstring(evt->get_source_name(), len);
+		return extract_single_cstring(evt->get_source_name(), len, sanitize_strings, m_strstorage);
 	case TYPE_ISASYNC:
 		if(libsinsp::events::is_metaevent((ppm_event_code)evt->get_type())) {
 			m_val.u32 = 1;
@@ -261,11 +261,11 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 			return NULL;
 		}
 		if(evt->get_type() != PPME_ASYNCEVENT_E) {
-			return extract_single_cstring(evt->get_name(), len);
+			return extract_single_cstring(evt->get_name(), len, sanitize_strings, m_strstorage);
 		}
 		const auto name_param = evt->get_param(1);
 		const auto [data, _] = name_param->data_and_len_with_legacy_null_encoding();
-		return extract_single_cstring(data, len);
+		return extract_single_cstring(data, len, sanitize_strings, m_strstorage);
 	}
 
 	case TYPE_HOSTNAME:
@@ -273,7 +273,7 @@ uint8_t* sinsp_filter_check_gen_event::extract_single(sinsp_evt* evt,
 		if(!minfo) {
 			return NULL;
 		}
-		return extract_single_cstring(minfo->hostname, len);
+		return extract_single_cstring(minfo->hostname, len, sanitize_strings, m_strstorage);
 	default:
 		ASSERT(false);
 		return NULL;

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -322,59 +322,80 @@ inline const unsigned char* utf8_first_invalid_seq(const unsigned char* ptr,
 	return end_ptr;
 }
 
-inline void sanitize_string(std::string& str) {
+// Appends a sanitized version of `str` to `storage`. `valid_prefix_len` is the length of the prefix
+// in `str` that is assumed to be valid and copied as is. `valid_prefix_len` must be less than
+// str.size()`, and `storage` and `str` must not alias the same memory region.
+inline void append_sanitized_string(std::string& storage,
+                                    std::string_view str,
+                                    const size_t valid_prefix_len) {
+	ASSERT(valid_prefix_len < str.size());
+	// Assert `storage` and `str` don't alias the same memory region.
+	ASSERT(reinterpret_cast<uintptr_t>(str.data()) + str.size() <=
+	               reinterpret_cast<uintptr_t>(storage.data()) ||
+	       reinterpret_cast<uintptr_t>(storage.data()) + storage.capacity() <=
+	               reinterpret_cast<uintptr_t>(str.data()));
+
 	const auto* const str_ptr = reinterpret_cast<const unsigned char*>(str.data());
 	const auto str_len = str.size();
 	const auto* const str_end_ptr = str_ptr + str_len;
+	auto* str_scan_ptr = str_ptr + valid_prefix_len;
+
+	// Copy the valid prefix in one shot, then process the remainder.
+	storage.append(reinterpret_cast<const char*>(str_ptr), valid_prefix_len);
+
+	// As we scan the string, keep track of the beginning of the last non-yet-copied block of
+	// multiple valid UTF-8 sequences: in this way, we can append the entire block with a single
+	// `storage.append()` call.
+	const auto* block_start = str_scan_ptr;
+	do {
+		// Process the current sequence first (on the first iteration this is the one that must be
+		// replaced).
+		if(const int seq_len = utf8_seq_len(str_scan_ptr, str_end_ptr); seq_len > 0) {
+			str_scan_ptr += seq_len;
+		} else {
+			// Found invalid sequence. Copy the last valid block (if any) and then append the
+			// replacement character.
+			if(str_scan_ptr > block_start) {
+				storage.append(reinterpret_cast<const char*>(block_start),
+				               static_cast<size_t>(str_scan_ptr - block_start));
+			}
+			storage.append("\xEF\xBF\xBD", 3);
+			str_scan_ptr += -seq_len;
+			block_start = str_scan_ptr;
+		}
+		// If `str_scan_ptr` is now 8-byte aligned, try to fast-skip 8-byte printable ASCII blocks.
+		if((reinterpret_cast<uintptr_t>(str_scan_ptr) & 7u) == 0u) {
+			str_scan_ptr = skip_8_byte_printable_ascii_blocks(str_scan_ptr, str_end_ptr);
+		}
+	} while(str_scan_ptr < str_end_ptr);
+
+	// Copy the last valid block (if any).
+	if(str_scan_ptr > block_start) {
+		storage.append(reinterpret_cast<const char*>(block_start),
+		               static_cast<size_t>(str_scan_ptr - block_start));
+	}
+}
+
+inline void sanitize_string(std::string& str) {
+	const auto* const ptr = reinterpret_cast<const unsigned char*>(str.data());
+	const auto len = str.size();
+	const auto* const end_ptr = ptr + len;
 
 	// First pass (note: this must be FAST).
 	// Find the first sequence needing replacement. For valid strings, this is the only pass that
 	// runs (no replacement needed), and the flow immediately returns after it.
-	auto* scan_ptr = utf8_first_invalid_seq(str_ptr, str_end_ptr);
-	if(scan_ptr == str_end_ptr) {
+	const auto* const first_invalid_ptr = utf8_first_invalid_seq(ptr, end_ptr);
+	if(first_invalid_ptr == end_ptr) {
 		return;
 	}
 
-	// Second pass for strings needing replacements (note: unfortunately, this is not as fast as the
-	// first pass).
-	// Copy the already-validated prefix in one shot, then process the remainder.
-	std::string res;
-	res.reserve(str_len);
-	res.append(reinterpret_cast<const char*>(str_ptr), static_cast<size_t>(scan_ptr - str_ptr));
-
-	// As we scan the string, keep track of the beginning of the last non-yet-copied block of
-	// multiple valid UTF-8 sequences: in this way, we can append the entire block with a single
-	// `res.append()` call.
-	const auto* block_start = scan_ptr;
-	do {
-		// Process the current sequence first (on the first iteration this is the one that must be
-		// replaced).
-		if(const int seq_len = utf8_seq_len(scan_ptr, str_end_ptr); seq_len > 0) {
-			scan_ptr += seq_len;
-		} else {
-			// Found invalid sequence. Copy the last valid block (if any) and then append the
-			// replacement character.
-			if(scan_ptr > block_start) {
-				res.append(reinterpret_cast<const char*>(block_start),
-				           static_cast<size_t>(scan_ptr - block_start));
-			}
-			res.append("\xEF\xBF\xBD", 3);
-			scan_ptr += -seq_len;
-			block_start = scan_ptr;
-		}
-		// If `scan_ptr` is now 8-byte aligned, try to fast-skip 8-byte printable ASCII blocks.
-		if((reinterpret_cast<uintptr_t>(scan_ptr) & 7u) == 0u) {
-			scan_ptr = skip_8_byte_printable_ascii_blocks(scan_ptr, str_end_ptr);
-		}
-	} while(scan_ptr < str_end_ptr);
-
-	// Copy the last valid block (if any).
-	if(scan_ptr > block_start) {
-		res.append(reinterpret_cast<const char*>(block_start),
-		           static_cast<size_t>(scan_ptr - block_start));
-	}
-
-	str = std::move(res);
+	// Second pass for strings needing replacements. Unfortunately, this is not as fast as the first
+	// pass.
+	std::string storage;
+	storage.reserve(len);
+	const auto valid_prefix_len = static_cast<size_t>(first_invalid_ptr - ptr);
+	append_sanitized_string(storage, str, valid_prefix_len);
+	str = std::move(storage);
 }
 
 inline void remove_duplicate_path_separators(std::string& str) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR extracts `append_sanitized_string()` from `sanitize_string()` and then leverages it in `sanitize_single_cstring()`, in order to apply sanitization to C strings.

`append_sanitized_string()` appends a sanitized version of a string into a storage passed by the user. The user can pass the length of a `str` prefix which is known to be already sanitized; this prefix is copied as is in storage. Notice that `valid_prefix_len` must be less than `str.size()`, and `storage` and `str` must not alias the same memory region.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix!: honor sanitization request for C strings
```
