### PR TITLE
fix(userspace/libsinsp): fix `sinsp_threadinfo::get_path_for_dir_fd()`

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -732,15 +732,9 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo) {
 		return cwd;
 	}
 
-	// If the previous param is a fd with a value other than AT_FDCWD,
-	// get the path to that fd and use it in place of CWD
-	std::string rel_path_base = tinfo->get_path_for_dir_fd(dirfd);
-	if(rel_path_base.empty()) {
-		return rel_path_base;
-	}
-	sanitize_string(rel_path_base);
-	rel_path_base.append("/");
-	return rel_path_base;
+	// If the previous param is a fd with a value other than AT_FDCWD, get the path to that fd and
+	// use it in place of CWD
+	return tinfo->get_path_for_dir_fd(dirfd);
 }
 
 const char *sinsp_evt::get_param_as_str(uint32_t id,

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -825,35 +825,48 @@ void sinsp_threadinfo::populate_args(std::string& args, const sinsp_threadinfo* 
 
 std::string sinsp_threadinfo::get_path_for_dir_fd(int64_t dir_fd) {
 	sinsp_fdinfo* dir_fdinfo = get_fd(dir_fd);
-	if(!dir_fdinfo || dir_fdinfo->m_name.empty()) {
-#ifndef _WIN32  // we will have to implement this for Windows
-		// Sad day; we don't have the directory in the tinfo's fd cache.
-		// Must manually look it up so we can resolve filenames correctly.
-		char proc_path[PATH_MAX];
-		char dirfd_path[PATH_MAX];
-		int ret;
-		snprintf(proc_path,
-		         sizeof(proc_path),
-		         "%s/proc/%lld/fd/%lld",
-		         scap_get_host_root(),
-		         (long long)m_pid,
-		         (long long)dir_fd);
-
-		ret = readlink(proc_path, dirfd_path, sizeof(dirfd_path) - 1);
-		if(ret < 0) {
-			libsinsp_logger()->log("Unable to determine path for file descriptor.",
-			                       sinsp_logger::SEV_INFO);
-			return "";
+	if(dir_fdinfo && !dir_fdinfo->m_name.empty()) {
+		const auto& name = dir_fdinfo->m_name;
+		std::string sanitized_name;
+		if(name.back() == '/') {
+			sanitized_name.reserve(name.size());
+			sanitized_name.append(name);
+		} else {
+			sanitized_name.reserve(name.size() + 1);  // +1 account for the trailing '/'.
+			sanitized_name.append(name);
+			sanitized_name.append("/");
 		}
-		dirfd_path[ret] = '\0';
-		std::string rel_path_base = dirfd_path;
-		sanitize_string(rel_path_base);
-		rel_path_base.append("/");
-		libsinsp_logger()->log(std::string("Translating to ") + rel_path_base);
-		return rel_path_base;
-#endif  // _WIN32
+		sanitize_string(sanitized_name);
+		return sanitized_name;
 	}
-	return dir_fdinfo->m_name;
+#ifdef _WIN32
+	return "";  // We will have to implement this for Windows.
+#else
+	// Sad day; we don't have the directory in the tinfo's fd cache.
+	// Must manually look it up so we can resolve filenames correctly.
+	char proc_path[PATH_MAX];
+	char dirfd_path[PATH_MAX];
+	int ret;
+	snprintf(proc_path,
+	         sizeof(proc_path),
+	         "%s/proc/%lld/fd/%lld",
+	         scap_get_host_root(),
+	         (long long)m_pid,
+	         (long long)dir_fd);
+
+	ret = readlink(proc_path, dirfd_path, sizeof(dirfd_path) - 1);
+	if(ret < 0) {
+		libsinsp_logger()->log("Unable to determine path for file descriptor.",
+		                       sinsp_logger::SEV_INFO);
+		return "";
+	}
+	dirfd_path[ret] = '\0';
+	std::string rel_path_base = dirfd_path;
+	sanitize_string(rel_path_base);
+	rel_path_base.append("/");
+	libsinsp_logger()->log(std::string("Translating to ") + rel_path_base);
+	return rel_path_base;
+#endif
 }
 
 size_t sinsp_threadinfo::args_len() const {

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -339,7 +339,9 @@ public:
 	static void populate_args(std::string& args, const sinsp_threadinfo* tinfo);
 
 	/*!
-	  \brief Translate a directory's file descriptor into its path
+	  \brief Translate a directory's file descriptor into its path.
+
+	  The returned path is sanitized and terminated with a trailing slash.
 	  \param dir_fd  A file descriptor for a directory
 	  \return  A path (or "" if failure)
 	 */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR ensures that the path returned by `sinsp_threadinfo::get_path_for_dir_fd()`, when the dir_fd fdinfo is there, has a trailing slash and is sanitized. This allows to streamline the call site. Moreover, it fixes the value returned on Windows: it returns "" instead of trying to return `m_name` field starting from a possibly-null fdinfo pointer.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
