### PR TITLE
perf(userspace/libsinsp)!: make `sanitize_string()` more efficient

### DIFF
--- a/benchmark/libsinsp/utils.cpp
+++ b/benchmark/libsinsp/utils.cpp
@@ -56,10 +56,10 @@ BENCHMARK(BM_sinsp_concatenate_paths_absolute_path);
 
 // Fast path for short valid ASCII string. No 8-byte aligned block skipping. No replacement needed.
 static void BM_sinsp_sanitize_string_fast_path_ascii_short(benchmark::State& state) {
-	std::string str = "/foo/";
+	const std::string str = "/foo/";
+	std::string unused_storage;
 	for(auto _ : state) {
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, unused_storage));
 	}
 }
 BENCHMARK(BM_sinsp_sanitize_string_fast_path_ascii_short);
@@ -67,10 +67,10 @@ BENCHMARK(BM_sinsp_sanitize_string_fast_path_ascii_short);
 // Fast path for long valid ASCII string. Exercises 8-byte aligned block skipping. No replacement
 // needed.
 static void BM_sinsp_sanitize_string_fast_path_ascii_long(benchmark::State& state) {
-	std::string str(1024, 'a');
+	const std::string str(1024, 'a');
+	std::string unused_storage;
 	for(auto _ : state) {
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, unused_storage));
 	}
 }
 BENCHMARK(BM_sinsp_sanitize_string_fast_path_ascii_long);
@@ -78,10 +78,10 @@ BENCHMARK(BM_sinsp_sanitize_string_fast_path_ascii_long);
 // Fast path for short valid multibyte UTF-8 string. No 8-byte aligned block skipping. No
 // replacement needed.
 static void BM_sinsp_sanitize_string_fast_path_multibyte_short(benchmark::State& state) {
-	std::string str{"😀😀"};
+	const std::string str{"😀😀"};
+	std::string unused_storage;
 	for(auto _ : state) {
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, unused_storage));
 	}
 }
 BENCHMARK(BM_sinsp_sanitize_string_fast_path_multibyte_short);
@@ -95,9 +95,9 @@ static void BM_sinsp_sanitize_string_fast_path_multibyte_long(benchmark::State& 
 	for(int i = 0; i < 1024; i++) {
 		str.append(emoji.data(), emoji.size());
 	}
+	std::string unused_storage;
 	for(auto _ : state) {
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, unused_storage));
 	}
 }
 BENCHMARK(BM_sinsp_sanitize_string_fast_path_multibyte_long);
@@ -113,53 +113,91 @@ static void BM_sinsp_sanitize_string_fast_path_mixed_long(benchmark::State& stat
 		str.append(ascii.data(), ascii.size());
 		str.append(emoji.data(), emoji.size());
 	}
+	std::string unused_storage;
 	for(auto _ : state) {
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, unused_storage));
 	}
 }
 BENCHMARK(BM_sinsp_sanitize_string_fast_path_mixed_long);
 
 // Slow path for long valid multibyte UTF-8 composed of 2-byte non-printable characters (C1 control
-// characters). Replacement needed for all characters.
-static void BM_sinsp_sanitize_string_slow_path_c1_controls_long(benchmark::State& state) {
+// characters). Replacement needed for all characters. Storage needs allocation.
+static void BM_sinsp_sanitize_string_slow_path_c1_controls_long_alloc(benchmark::State& state) {
+	const std::string c1{"\xC2\x80"};
+	std::string str;
+	str.reserve(512 * c1.size());
+	for(int i = 0; i < 512; i++) {
+		str.append(c1.data(), c1.size());
+	}
 	for(auto _ : state) {
-		state.PauseTiming();
-		std::string c1{"\xC2\x80"};
-		std::string str;
-		str.reserve(512 * c1.size());
-		for(int i = 0; i < 512; i++) {
-			str.append(c1.data(), c1.size());
-		}
-		state.ResumeTiming();
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		std::string storage;
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
 	}
 }
-BENCHMARK(BM_sinsp_sanitize_string_slow_path_c1_controls_long);
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_c1_controls_long_alloc);
+
+// Slow path for long valid multibyte UTF-8 composed of 2-byte non-printable characters (C1 control
+// characters). Replacement needed for all characters. Storage has enough capacity.
+static void BM_sinsp_sanitize_string_slow_path_c1_controls_long_noalloc(benchmark::State& state) {
+	const std::string c1{"\xC2\x80"};
+	std::string str;
+	str.reserve(512 * c1.size());
+	for(int i = 0; i < 512; i++) {
+		str.append(c1.data(), c1.size());
+	}
+	std::string storage;
+	storage.reserve(3 * str.size() / 2);  // Each 2 bytes are replaced with 3 bytes.
+	for(auto _ : state) {
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
+	}
+}
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_c1_controls_long_noalloc);
 
 // Slow path for long string with a single, invalid byte in the middle. Triggers second pass but
-// only a single replacement takes place.
-static void BM_sinsp_sanitize_string_slow_path_sparse_invalid_long(benchmark::State& state) {
+// only a single replacement takes place. Storage needs allocation.
+static void BM_sinsp_sanitize_string_slow_path_sparse_invalid_long_alloc(benchmark::State& state) {
+	std::string str(1024, 'a');
+	str[512] = '\x80';
 	for(auto _ : state) {
-		state.PauseTiming();
-		std::string str(1024, 'a');
-		str[512] = '\x80';
-		state.ResumeTiming();
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		std::string storage;
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
 	}
 }
-BENCHMARK(BM_sinsp_sanitize_string_slow_path_sparse_invalid_long);
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_sparse_invalid_long_alloc);
 
-// Slow path for long string with all bytes invalid. Worst scenario for replacement logic.
-static void BM_sinsp_sanitize_string_slow_path_all_invalid_long(benchmark::State& state) {
+// Slow path for long string with a single, invalid byte in the middle. Triggers second pass but
+// only a single replacement takes place. Storage has enough capacity.
+static void BM_sinsp_sanitize_string_slow_path_sparse_invalid_long_noalloc(
+        benchmark::State& state) {
+	std::string str(1024, 'a');
+	str[512] = '\x80';
+	std::string storage;
+	storage.reserve(str.size() + 2);  // +2 accounts for 1 byte replaced by 3.
 	for(auto _ : state) {
-		state.PauseTiming();
-		std::string str(1024, '\x80');
-		state.ResumeTiming();
-		sanitize_string(str);
-		benchmark::DoNotOptimize(str);
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
 	}
 }
-BENCHMARK(BM_sinsp_sanitize_string_slow_path_all_invalid_long);
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_sparse_invalid_long_noalloc);
+
+// Slow path for long string with all bytes invalid. Worst scenario for replacement logic. Storage
+// needs allocation.
+static void BM_sinsp_sanitize_string_slow_path_all_invalid_long_alloc(benchmark::State& state) {
+	const std::string str(1024, '\x80');
+	for(auto _ : state) {
+		std::string storage;
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
+	}
+}
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_all_invalid_long_alloc);
+
+// Slow path for long string with all bytes invalid. Worst scenario for replacement logic. Storage
+// has enough capacity.
+static void BM_sinsp_sanitize_string_slow_path_all_invalid_long_noalloc(benchmark::State& state) {
+	const std::string str(1024, '\x80');
+	std::string storage;
+	storage.reserve(str.size() * 3);  // Each byte needs 3 replacement bytes.
+	for(auto _ : state) {
+		benchmark::DoNotOptimize(sanitize_string(str, storage));
+	}
+}
+BENCHMARK(BM_sinsp_sanitize_string_slow_path_all_invalid_long_noalloc);

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -591,12 +591,11 @@ int sinsp_evt::render_fd_json(Json::Value *ret,
 			//
 			// Make sure we remove invalid characters from the resolved name
 			//
-			std::string sanitized_str = fdinfo->m_name;
-
-			sanitize_string(sanitized_str);
+			std::string sanitized_name_storage;
+			const auto sanitized_name = sanitize_string(fdinfo->m_name, sanitized_name_storage);
 
 			(*ret)["typechar"] = typestr;
-			(*ret)["name"] = sanitized_str;
+			(*ret)["name"] = sanitized_name.data();
 		}
 	} else if(fd == PPM_AT_FDCWD) {
 		//
@@ -664,22 +663,21 @@ char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::par
 			//
 			// Make sure we remove invalid characters from the resolved name
 			//
-			std::string sanitized_str = fdinfo->m_name;
-
-			sanitize_string(sanitized_str);
+			std::string sanitized_name_storage;
+			const auto sanitized_name = sanitize_string(fdinfo->m_name, sanitized_name_storage);
 
 			//
 			// Make sure the string will fit
 			//
-			if(sanitized_str.size() >= m_resolved_paramstr_storage.size()) {
-				m_resolved_paramstr_storage.resize(sanitized_str.size() + 1);
+			if(sanitized_name.size() >= m_resolved_paramstr_storage.size()) {
+				m_resolved_paramstr_storage.resize(sanitized_name.size() + 1);
 			}
 
 			snprintf(&m_resolved_paramstr_storage[0],
 			         m_resolved_paramstr_storage.size(),
 			         "<%s>%s",
 			         typestr,
-			         sanitized_str.c_str());
+			         sanitized_name.data());
 		}
 	} else if(fd == PPM_AT_FDCWD) {
 		//
@@ -996,13 +994,12 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			//
 			// Sanitize the file string.
 			//
-			std::string sanitized_str = param_data + 1;
-			sanitize_string(sanitized_str);
-
+			std::string sanitized_path_storage;
+			const auto sanitized_path = sanitize_string(param_data + 1, sanitized_path_storage);
 			snprintf(&m_paramstr_storage[0],
 			         m_paramstr_storage.size(),
 			         "%s",
-			         sanitized_str.c_str());
+			         sanitized_path.data());
 		} else if(sockfamily == PPM_AF_INET) {
 			if(param_len == 1 + 4 + 2) {
 				ipv4serverinfo addr;
@@ -1120,8 +1117,10 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			//
 			// Sanitize the file string.
 			//
-			std::string sanitized_str = reinterpret_cast<const char *>(param_data) + 17;
-			sanitize_string(sanitized_str);
+			std::string sanitized_path_storage;
+			const auto sanitized_path =
+			        sanitize_string(reinterpret_cast<const char *>(param_data) + 17,
+			                        sanitized_path_storage);
 
 			uint64_t src, dst;
 			memcpy(&src, param_data + 1, sizeof(uint64_t));
@@ -1132,7 +1131,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			         "%" PRIx64 "->%" PRIx64 " %s",
 			         src,
 			         dst,
-			         sanitized_str.c_str());
+			         sanitized_path.data());
 		} else {
 			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "family %d", sockfamily);
 		}

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -214,10 +214,12 @@ sinsp_fdinfo::get_static_fields() {
 }
 
 std::string sinsp_fdinfo::tostring_clean() const {
-	std::string tstr = m_name;
-	sanitize_string(tstr);
-
-	return tstr;
+	std::string sanitized_name_storage;
+	const auto sanitized_name = sanitize_string(m_name, sanitized_name_storage);
+	if(sanitized_name.data() == m_name.data()) {
+		return m_name;
+	}
+	return sanitized_name_storage;
 }
 
 void sinsp_fdinfo::add_filename_raw(std::string_view rawpath) {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2429,8 +2429,8 @@ const char *sinsp_parser::encode_unix_tuple_fd_name(sinsp_evt &evt,
                                                     const uint64_t dst,
                                                     const char *path) {
 	// Sanitize the file string.
-	std::string sanitized_str = path;
-	sanitize_string(sanitized_str);
+	std::string sanitized_path_storage;
+	const auto sanitized_path = sanitize_string(path, sanitized_path_storage);
 
 	auto &storage = evt.get_paramstr_storage();
 
@@ -2440,7 +2440,7 @@ const char *sinsp_parser::encode_unix_tuple_fd_name(sinsp_evt &evt,
 	         "%" PRIx64 "->%" PRIx64 " %s",
 	         src,
 	         dst,
-	         sanitized_str.c_str());
+	         sanitized_path.data());
 
 	return &storage[0];
 }

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -280,117 +280,119 @@ TEST(sinsp_utils_test, concatenate_paths) {
 
 TEST(sinsp_utils_test, sanitize_string) {
 	std::string str;
+	std::string storage;
+	std::string_view res;
 
 	// Empty string passes through unchanged.
 	str = "";
-	sanitize_string(str);
-	EXPECT_EQ("", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("", res);
 
 	// Valid pure ASCII passes through unchanged.
 	str = "hello world";
-	sanitize_string(str);
-	EXPECT_EQ("hello world", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("hello world", res);
 
 	// Valid multibyte UTF-8 passes through unchanged.
 	str = "😀";  // U+1F600, 4-byte sequence
-	sanitize_string(str);
-	EXPECT_EQ("😀", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("😀", res);
 
 	str = "诶比西";  // 3-byte sequences
-	sanitize_string(str);
-	EXPECT_EQ("诶比西", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("诶比西", res);
 
 	str = "АБВЙЛж";  // 2-byte sequences (Cyrillic)
-	sanitize_string(str);
-	EXPECT_EQ("АБВЙЛж", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("АБВЙЛж", res);
 
 	// Mixed valid ASCII and valid multibyte UTF-8 passes through unchanged.
 	str = "hello 😀 world";
-	sanitize_string(str);
-	EXPECT_EQ("hello 😀 world", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("hello 😀 world", res);
 
 	// Non-printable ASCII control characters (0x00-0x1F) are replaced with U+FFFD.
 	str = "foo\x01\x1Fxyz";
-	sanitize_string(str);
-	EXPECT_EQ("foo\xEF\xBF\xBD\xEF\xBF\xBDxyz", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("foo\xEF\xBF\xBD\xEF\xBF\xBDxyz", res);
 
 	// DEL (0x7F) is replaced with U+FFFD.
 	str = "foo\x7Fxyz";
-	sanitize_string(str);
-	EXPECT_EQ("foo\xEF\xBF\xBDxyz", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("foo\xEF\xBF\xBDxyz", res);
 
 	// C1 control character encoded as valid-but-non-printable UTF-8 (U+0085, NEL = C2 85) is
 	// replaced with U+FFFD.
 	str = "foo\xC2\x85xyz";
-	sanitize_string(str);
-	EXPECT_EQ("foo\xEF\xBF\xBDxyz", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("foo\xEF\xBF\xBDxyz", res);
 
 	// Invalid UTF-8 bytes are replaced with U+FFFD (EF BF BD).
 	str = "foo\xFF\xFExyz";
-	sanitize_string(str);
-	EXPECT_EQ("foo\xEF\xBF\xBD\xEF\xBF\xBDxyz", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("foo\xEF\xBF\xBD\xEF\xBF\xBDxyz", res);
 
 	// Mix of valid UTF-8 (é = C3 A9) and an invalid byte (FF).
 	str = "\xC3\xA9\xFF";
-	sanitize_string(str);
-	EXPECT_EQ("\xC3\xA9\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xC3\xA9\xEF\xBF\xBD", res);
 
 	// Invalid byte at the start of the string.
 	str = "\x80xyz";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBDxyz", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBDxyz", res);
 
 	// Invalid byte at the end of the string.
 	str = "foo\xFF";
-	sanitize_string(str);
-	EXPECT_EQ("foo\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("foo\xEF\xBF\xBD", res);
 
 	// All bytes invalid.
 	str = "\x80\xFF\xFE";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", res);
 
 	// Unicode non-characters are replaced with U+FFFD.
 	// U+FDD0 (EF B7 90) - non-character in the range U+FDD0..U+FDEF.
 	str = "\xEF\xB7\x90";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD", res);
 
 	// U+FFFF (EF BF BF) - non-character U+FFFF.
 	str = "\xEF\xBF\xBF";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD", res);
 
 	// U+1FFFE (F0 9F BF BE) - end-of-plane non-character in plane 1.
 	str = "\xF0\x9F\xBF\xBE";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD", res);
 
 	// Maximal-subpart: 3-byte lead (E1) + valid first continuation (80) + bad second continuation
 	// (61 = 'a'). The maximal subpart is 2 bytes, so the pair is replaced with one U+FFFD.
 	str = "\xE1\x80x";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBDx", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBDx", res);
 
 	// Maximal-subpart: truncated 3-byte sequence at end of string. Lead (E1) + valid first
 	// continuation (80), missing second continuation. Replaced with one U+FFFD.
 	str = "hello\xE1\x80";
-	sanitize_string(str);
-	EXPECT_EQ("hello\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("hello\xEF\xBF\xBD", res);
 
 	// Maximal-subpart: surrogate bytes (ED A0 80). The first continuation A0 is outside the valid
 	// range 80-9F for lead ED, so the maximal subpart is just ED, and the entire sequence is
 	// replaced with three individual U+FFFDs.
 	str = "\xED\xA0\x80";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", res);
 
 	// Maximal-subpart: overlong 3-byte (E0 9F BF). The first continuation 9F is outside the valid
 	// range A0-BF for lead E0, so the maximal subpart is just E0, and the entire sequence is
 	// replaced with three individual U+FFFDs.
 	str = "\xE0\x9F\xBF";
-	sanitize_string(str);
-	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", str);
+	res = sanitize_string(str, storage);
+	EXPECT_EQ("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", res);
 }
 
 TEST(sinsp_utils_test, sinsp_split) {

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -824,29 +824,37 @@ void sinsp_threadinfo::populate_args(std::string& args, const sinsp_threadinfo* 
 }
 
 std::string sinsp_threadinfo::get_path_for_dir_fd(int64_t dir_fd) {
-	sinsp_fdinfo* dir_fdinfo = get_fd(dir_fd);
-	if(dir_fdinfo && !dir_fdinfo->m_name.empty()) {
+	if(const auto* dir_fdinfo = get_fd(dir_fd); dir_fdinfo && !dir_fdinfo->m_name.empty()) {
 		const auto& name = dir_fdinfo->m_name;
-		std::string sanitized_name;
 		if(name.back() == '/') {
-			sanitized_name.reserve(name.size());
-			sanitized_name.append(name);
-		} else {
-			sanitized_name.reserve(name.size() + 1);  // +1 account for the trailing '/'.
-			sanitized_name.append(name);
-			sanitized_name.append("/");
+			std::string sanitized_name_storage;
+			const auto sanitized_name = sanitize_string(name, sanitized_name_storage);
+			if(sanitized_name.data() == name.data()) {
+				return name;
+			}
+			return sanitized_name_storage;
 		}
-		sanitize_string(sanitized_name);
-		return sanitized_name;
+
+		// We need to copy the name as we must append '/'.
+		std::string copied_name;
+		copied_name.reserve(name.size() + 1);  // +1 accounts for the trailing '/'.
+		copied_name.append(name);
+		copied_name.append("/");
+		std::string sanitized_name_storage;
+		const auto sanitized_name = sanitize_string(copied_name, sanitized_name_storage);
+		if(sanitized_name.data() == copied_name.data()) {
+			return copied_name;
+		}
+		return sanitized_name_storage;
 	}
+
+	// Sad day; we don't have the directory in the tinfo's fd cache.
+	// Must manually look it up so we can resolve filenames correctly.
 #ifdef _WIN32
 	return "";  // We will have to implement this for Windows.
 #else
-	// Sad day; we don't have the directory in the tinfo's fd cache.
-	// Must manually look it up so we can resolve filenames correctly.
 	char proc_path[PATH_MAX];
-	char dirfd_path[PATH_MAX];
-	int ret;
+	char dirfd_path[PATH_MAX + 1];  // +1 accounts for trailing '/' that will be added.
 	snprintf(proc_path,
 	         sizeof(proc_path),
 	         "%s/proc/%lld/fd/%lld",
@@ -854,19 +862,27 @@ std::string sinsp_threadinfo::get_path_for_dir_fd(int64_t dir_fd) {
 	         (long long)m_pid,
 	         (long long)dir_fd);
 
-	ret = readlink(proc_path, dirfd_path, sizeof(dirfd_path) - 1);
-	if(ret < 0) {
+	// Read up to `sizeof(dirfd_path) - 2` to leave room for '/' and '\0'.
+	const ssize_t bytes_read = readlink(proc_path, dirfd_path, sizeof(dirfd_path) - 2);
+	if(bytes_read < 0) {
 		libsinsp_logger()->log("Unable to determine path for file descriptor.",
 		                       sinsp_logger::SEV_INFO);
 		return "";
 	}
-	dirfd_path[ret] = '\0';
-	std::string rel_path_base = dirfd_path;
-	sanitize_string(rel_path_base);
-	rel_path_base.append("/");
-	libsinsp_logger()->log(std::string("Translating to ") + rel_path_base);
-	return rel_path_base;
-#endif
+	dirfd_path[bytes_read] = '/';
+	dirfd_path[bytes_read + 1] = '\0';
+
+	// Sanitize the path.
+	const auto path_len = static_cast<size_t>(bytes_read + 1);  // +1 account for trailing '/'
+	std::string sanitized_path_storage;
+	const auto sanitized_path =
+	        sanitize_string(std::string_view{dirfd_path, path_len}, sanitized_path_storage);
+	libsinsp_logger()->log(std::string("Translating to ") + sanitized_path.data());
+	if(sanitized_path.data() == dirfd_path) {
+		return dirfd_path;
+	}
+	return sanitized_path_storage;
+#endif /* _WIN32 */
 }
 
 size_t sinsp_threadinfo::args_len() const {

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -381,8 +381,7 @@ inline void append_sanitized_string(std::string& storage,
 // - a string view of `storage`, if `str` needs sanitization. In this case a sanitized version of
 // `str` is written into `storage`, reusing its capacity.
 // `storage` and `str` must not alias the same memory region.
-[[nodiscard]] inline std::string_view sanitize_string_with_storage(std::string_view str,
-                                                                   std::string& storage) {
+[[nodiscard]] inline std::string_view sanitize_string(std::string_view str, std::string& storage) {
 	// Assert `storage` and `str` don't alias the same memory region.
 	ASSERT(reinterpret_cast<uintptr_t>(str.data()) + str.size() <=
 	               reinterpret_cast<uintptr_t>(storage.data()) ||
@@ -407,14 +406,6 @@ inline void append_sanitized_string(std::string& storage,
 	const auto valid_prefix_len = static_cast<size_t>(first_invalid_ptr - ptr);
 	append_sanitized_string(storage, str, valid_prefix_len);
 	return storage;
-}
-
-inline void sanitize_string(std::string& str) {
-	std::string storage;
-	const auto sanitized_str = sanitize_string_with_storage(str, storage);
-	if(sanitized_str.data() != str.data()) {
-		str = std::move(storage);
-	}
 }
 
 inline void remove_duplicate_path_separators(std::string& str) {

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -376,26 +376,45 @@ inline void append_sanitized_string(std::string& storage,
 	}
 }
 
-inline void sanitize_string(std::string& str) {
+// Sanitizes `str`, returning a string view of its sanitized version. It returns:
+// - `str` itself, if already sanitized
+// - a string view of `storage`, if `str` needs sanitization. In this case a sanitized version of
+// `str` is written into `storage`, reusing its capacity.
+// `storage` and `str` must not alias the same memory region.
+[[nodiscard]] inline std::string_view sanitize_string_with_storage(std::string_view str,
+                                                                   std::string& storage) {
+	// Assert `storage` and `str` don't alias the same memory region.
+	ASSERT(reinterpret_cast<uintptr_t>(str.data()) + str.size() <=
+	               reinterpret_cast<uintptr_t>(storage.data()) ||
+	       reinterpret_cast<uintptr_t>(storage.data()) + storage.capacity() <=
+	               reinterpret_cast<uintptr_t>(str.data()));
+
 	const auto* const ptr = reinterpret_cast<const unsigned char*>(str.data());
-	const auto len = str.size();
-	const auto* const end_ptr = ptr + len;
+	const auto* const end_ptr = ptr + str.size();
 
 	// First pass (note: this must be FAST).
 	// Find the first sequence needing replacement. For valid strings, this is the only pass that
 	// runs (no replacement needed), and the flow immediately returns after it.
 	const auto* const first_invalid_ptr = utf8_first_invalid_seq(ptr, end_ptr);
 	if(first_invalid_ptr == end_ptr) {
-		return;
+		return str;  // CLion false positive: no address escapes here.
 	}
 
 	// Second pass for strings needing replacements. Unfortunately, this is not as fast as the first
 	// pass.
-	std::string storage;
-	storage.reserve(len);
+	storage.clear();  // Reset to empty while preserving allocated capacity.
+	storage.reserve(str.size());
 	const auto valid_prefix_len = static_cast<size_t>(first_invalid_ptr - ptr);
 	append_sanitized_string(storage, str, valid_prefix_len);
-	str = std::move(storage);
+	return storage;
+}
+
+inline void sanitize_string(std::string& str) {
+	std::string storage;
+	const auto sanitized_str = sanitize_string_with_storage(str, storage);
+	if(sanitized_str.data() != str.data()) {
+		str = std::move(storage);
+	}
 }
 
 inline void remove_duplicate_path_separators(std::string& str) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR replace the old `sanitize_string()` with a new one allowing to reuse the capacity of the passed storage to avoid new heap allocations.

The new helper accepts a view of the string to be sanitized and the aforementioned storage. It returns the string view as is if the underlying string is already sanitized; returns a string view pointing to the storage otherwise. Accepting a string view enables avoiding allocations in case the original string is a C string.

The new implementation is strictly better as it *can* completely avoid new allocations both for valid and invalid string cases. This latter advantage materializes for the unhappy path if the call site can provide a long-lived storage.

Notice that the passed string view and the storage must not alias the same memory region.

Additional work is required for passing long-lived storage in all call sites. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR is part of the effort for fixing https://github.com/falcosecurity/libs/issues/2965.

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
perf(userspace/libsinsp)!: change `sanitize_string()` API signature
```
