### PR TITLE
refactor(userspace/libsinsp): modernize `sinsp_evt` code

### DIFF
--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <algorithm>
 #include <unistd.h>
 #else
-#define localtime_r(a, b) (localtime_s(b, a) == 0 ? b : NULL)
+#define localtime_r(a, b) (localtime_s(b, a) == 0 ? b : nullptr)
 #endif
 
 #include <cinttypes>
@@ -62,17 +62,18 @@ extern sinsp_evttables g_infotables;
 // sinsp_evt implementation
 ///////////////////////////////////////////////////////////////////////////////
 sinsp_evt::sinsp_evt():
-        m_inspector(NULL),
-        m_pevt(NULL),
-        m_pevt_storage(NULL),
+        m_inspector(nullptr),
+        m_pevt(nullptr),
+        m_pevt_storage(nullptr),
         m_cpuid(0),
         m_evtnum(0),
         m_flags(EF_NONE),
-        m_info(NULL),
+        m_dump_flags(0),
+        m_info(nullptr),
         m_paramstr_storage(1024),
         m_resolved_paramstr_storage(1024),
-        m_tinfo(NULL),
-        m_fdinfo(NULL),
+        m_tinfo(nullptr),
+        m_fdinfo(nullptr),
         m_fdinfo_name_changed(false),
         m_iosize(0),
         m_errorcode(0),
@@ -80,7 +81,7 @@ sinsp_evt::sinsp_evt():
         m_filtered_out(false),
         m_event_info_table(g_infotables.m_event_info),
         m_source_idx(sinsp_no_event_source_idx),
-        m_source_name(NULL) {}
+        m_source_name(nullptr) {}
 
 sinsp_evt::sinsp_evt(sinsp *inspector): sinsp_evt() {
 	m_inspector = inspector;
@@ -97,14 +98,14 @@ const char *sinsp_evt::get_name() const {
 }
 
 event_direction sinsp_evt::get_direction() const {
-	return (event_direction)(m_pevt->type & PPME_DIRECTION_FLAG);
+	return static_cast<event_direction>(m_pevt->type & PPME_DIRECTION_FLAG);
 }
 
 int64_t sinsp_evt::get_tid() const {
 	return m_pevt->tid;
 }
 
-void sinsp_evt::set_iosize(uint32_t size) {
+void sinsp_evt::set_iosize(const uint32_t size) {
 	m_iosize = size;
 }
 
@@ -113,11 +114,12 @@ uint32_t sinsp_evt::get_iosize() const {
 }
 
 sinsp_threadinfo *sinsp_evt::get_thread_info() {
-	if(NULL != m_tinfo) {
+	if(m_tinfo != nullptr) {
 		return m_tinfo;
-	} else if(m_tinfo_ref) {
-		m_tinfo = m_tinfo_ref.get();
+	}
 
+	if(m_tinfo_ref) {
+		m_tinfo = m_tinfo_ref.get();
 		return m_tinfo;
 	}
 
@@ -133,50 +135,49 @@ int64_t sinsp_evt::get_fd_num() const {
 }
 
 uint32_t sinsp_evt::get_num_params() {
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
-	return (uint32_t)m_params.size();
+	return static_cast<uint32_t>(m_params.size());
 }
 
-const sinsp_evt_param *sinsp_evt::get_param(uint32_t id) {
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+const sinsp_evt_param *sinsp_evt::get_param(const uint32_t id) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
-	return &(m_params.at(id));
+	return &m_params.at(id);
 }
 
 const sinsp_evt_param *sinsp_evt::get_param_by_name(const char *name) {
 	//
 	// Make sure the params are actually loaded
 	//
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
 	//
 	// Locate the parameter given the name
 	//
-	uint32_t np = get_num_params();
-
+	const uint32_t np = get_num_params();
 	for(uint32_t j = 0; j < np; j++) {
 		if(strcmp(name, get_param_name(j)) == 0) {
-			return &(m_params[j]);
+			return &m_params[j];
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
-const char *sinsp_evt::get_param_name(uint32_t id) {
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+const char *sinsp_evt::get_param_name(const uint32_t id) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
 	ASSERT(id < m_info->nparams);
@@ -184,47 +185,45 @@ const char *sinsp_evt::get_param_name(uint32_t id) {
 	return m_info->params[id].name;
 }
 
-const ppm_param_info *sinsp_evt::get_param_info(uint32_t id) {
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+const ppm_param_info *sinsp_evt::get_param_info(const uint32_t id) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
 	ASSERT(id < m_info->nparams);
 
-	return &(m_info->params[id]);
+	return &m_info->params[id];
 }
 
 static uint32_t binary_buffer_to_hex_string(char *dst,
                                             const char *src,
-                                            uint32_t dstlen,
-                                            uint32_t srclen,
-                                            sinsp_evt::param_fmt fmt) {
-	uint32_t j;
-	uint32_t k;
+                                            const uint32_t dstlen,
+                                            const uint32_t srclen,
+                                            const sinsp_evt::param_fmt fmt) {
 	uint32_t l = 0;
-	uint32_t num_chunks;
-	uint32_t row_len;
 	char row[128];
-	const char *ptr;
 	bool truncated = false;
 
-	for(j = 0; j < srclen; j += 8 * sizeof(uint16_t)) {
-		k = 0;
+	for(uint32_t j = 0; j < srclen; j += 8 * sizeof(uint16_t)) {
+		uint32_t k = 0;
 		k += snprintf(row + k, sizeof(row) - k, "\n\t0x%.4x:", j);
 
-		ptr = &src[j];
-		num_chunks = 0;
+		const char *ptr = &src[j];
+		uint32_t num_chunks = 0;
 		while(num_chunks < 8 && ptr < src + srclen) {
-			uint16_t chunk = htons(*(uint16_t *)ptr);
+			uint16_t chunk = htons(*reinterpret_cast<const uint16_t *>(ptr));
 
 			int ret;
 			if(ptr == src + srclen - 1) {
-				ret = snprintf(row + k, sizeof(row) - k, " %.2x", *(((uint8_t *)&chunk) + 1));
+				ret = snprintf(row + k,
+				               sizeof(row) - k,
+				               " %.2x",
+				               *(reinterpret_cast<const uint8_t *>(&chunk) + 1));
 			} else {
 				ret = snprintf(row + k, sizeof(row) - k, " %.4x", chunk);
 			}
-			if(ret < 0 || (unsigned int)ret >= sizeof(row) - k) {
+			if(ret < 0 || static_cast<unsigned int>(ret) >= sizeof(row) - k) {
 				dst[0] = 0;
 				return 0;
 			}
@@ -248,7 +247,7 @@ static uint32_t binary_buffer_to_hex_string(char *dst,
 
 			for(ptr = &src[j]; ptr < src + j + 8 * sizeof(uint16_t) && ptr < src + srclen;
 			    ptr++, k++) {
-				if(isprint((int)(uint8_t)*ptr)) {
+				if(isprint(static_cast<uint8_t>(*ptr))) {
 					row[k] = *ptr;
 				} else {
 					row[k] = '.';
@@ -257,7 +256,7 @@ static uint32_t binary_buffer_to_hex_string(char *dst,
 		}
 		row[k] = 0;
 
-		row_len = (uint32_t)strlen(row);
+		const uint32_t row_len = static_cast<uint32_t>(strlen(row));
 		if(l + row_len >= dstlen - 1) {
 			truncated = true;
 			break;
@@ -270,24 +269,22 @@ static uint32_t binary_buffer_to_hex_string(char *dst,
 
 	if(truncated) {
 		return dstlen;
-	} else {
-		return l;
 	}
+	return l;
 }
 
 static uint32_t binary_buffer_to_asciionly_string(char *dst,
                                                   const char *src,
-                                                  uint32_t dstlen,
-                                                  uint32_t srclen,
-                                                  sinsp_evt::param_fmt fmt) {
-	uint32_t j;
+                                                  const uint32_t dstlen,
+                                                  const uint32_t srclen,
+                                                  const sinsp_evt::param_fmt fmt) {
 	uint32_t k = 0;
 
 	if(fmt != sinsp_evt::PF_EOLS_COMPACT) {
 		dst[k++] = '\n';
 	}
 
-	for(j = 0; j < srclen; j++) {
+	for(uint32_t j = 0; j < srclen; j++) {
 		//
 		// Make sure there's enough space in the target buffer.
 		// Note that we reserve two bytes, because some characters are expanded
@@ -298,7 +295,7 @@ static uint32_t binary_buffer_to_asciionly_string(char *dst,
 			return dstlen;
 		}
 
-		if(isprint((int)(uint8_t)src[j])) {
+		if(isprint(static_cast<uint8_t>(src[j]))) {
 			// switch(src[j])
 			// {
 			// case '"':
@@ -327,13 +324,12 @@ static uint32_t binary_buffer_to_asciionly_string(char *dst,
 
 static uint32_t binary_buffer_to_string_dots(char *dst,
                                              const char *src,
-                                             uint32_t dstlen,
-                                             uint32_t srclen,
-                                             sinsp_evt::param_fmt fmt) {
-	uint32_t j;
+                                             const uint32_t dstlen,
+                                             const uint32_t srclen,
+                                             sinsp_evt::param_fmt /*fmt*/) {
 	uint32_t k = 0;
 
-	for(j = 0; j < srclen; j++) {
+	for(uint32_t j = 0; j < srclen; j++) {
 		//
 		// Make sure there's enough space in the target buffer.
 		// Note that we reserve two bytes, because some characters are expanded
@@ -344,7 +340,7 @@ static uint32_t binary_buffer_to_string_dots(char *dst,
 			return dstlen;
 		}
 
-		if(isprint((int)(uint8_t)src[j])) {
+		if(isprint(static_cast<uint8_t>(src[j]))) {
 			// switch(src[j])
 			// {
 			// case '"':
@@ -368,9 +364,9 @@ static uint32_t binary_buffer_to_string_dots(char *dst,
 
 static uint32_t binary_buffer_to_base64_string(char *dst,
                                                const char *src,
-                                               uint32_t dstlen,
-                                               uint32_t srclen,
-                                               sinsp_evt::param_fmt fmt) {
+                                               const uint32_t dstlen,
+                                               const uint32_t srclen,
+                                               sinsp_evt::param_fmt /*fmt*/) {
 	//
 	// base64 encoder, malloc-free version of:
 	// http://stackoverflow.com/questions/342409/how-do-i-base64-encode-decode-in-c
@@ -382,9 +378,9 @@ static uint32_t binary_buffer_to_base64_string(char *dst,
 	                                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
 	static uint32_t mod_table[] = {0, 2, 1};
 
-	uint32_t j, k, enc_dstlen;
+	uint32_t j, k;
 
-	enc_dstlen = 4 * ((srclen + 2) / 3);
+	const uint32_t enc_dstlen = 4 * ((srclen + 2) / 3);
 	//
 	// Make sure there's enough space in the target buffer.
 	//
@@ -393,11 +389,11 @@ static uint32_t binary_buffer_to_base64_string(char *dst,
 	}
 
 	for(j = 0, k = 0; j < srclen;) {
-		uint32_t octet_a = j < srclen ? (unsigned char)src[j++] : 0;
-		uint32_t octet_b = j < srclen ? (unsigned char)src[j++] : 0;
-		uint32_t octet_c = j < srclen ? (unsigned char)src[j++] : 0;
+		const uint32_t octet_a = j < srclen ? static_cast<unsigned char>(src[j++]) : 0;
+		const uint32_t octet_b = j < srclen ? static_cast<unsigned char>(src[j++]) : 0;
+		const uint32_t octet_c = j < srclen ? static_cast<unsigned char>(src[j++]) : 0;
 
-		uint32_t triple = (octet_a << 0x10) + (octet_b << 0x08) + octet_c;
+		const uint32_t triple = (octet_a << 0x10) + (octet_b << 0x08) + octet_c;
 
 		dst[k++] = encoding_table[(triple >> 3 * 6) & 0x3F];
 		dst[k++] = encoding_table[(triple >> 2 * 6) & 0x3F];
@@ -436,9 +432,9 @@ static uint32_t binary_buffer_to_json_string(char *dst,
 
 uint32_t binary_buffer_to_string(char *dst,
                                  const char *src,
-                                 uint32_t dstlen,
-                                 uint32_t srclen,
-                                 sinsp_evt::param_fmt fmt) {
+                                 const uint32_t dstlen,
+                                 const uint32_t srclen,
+                                 const sinsp_evt::param_fmt fmt) {
 	uint32_t k = 0;
 
 	if(dstlen == 0) {
@@ -550,25 +546,22 @@ static void strcpy_sanitized(std::vector<char> &dst, const std::string_view src)
 }
 
 int sinsp_evt::render_fd_json(Json::Value *ret,
-                              int64_t fd,
-                              const char **resolved_str,
-                              sinsp_evt::param_fmt fmt) {
+                              const int64_t fd,
+                              const char ** /*resolved_str*/,
+                              const param_fmt fmt) {
 	sinsp_threadinfo *tinfo = get_thread_info();
-	if(tinfo == NULL) {
+	if(tinfo == nullptr) {
 		return 0;
 	}
 
 	if(fd >= 0) {
-		sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
-		if(fdinfo) {
-			char tch = fdinfo->get_typechar();
+		if(const auto *fdinfo = tinfo->get_fd(fd)) {
+			const auto tch = fdinfo->get_typechar();
 			char ipprotoch = 0;
 
 			if(fdinfo->m_type == SCAP_FD_IPV4_SOCK || fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
 			   fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK || fdinfo->m_type == SCAP_FD_IPV6_SERVSOCK) {
-				scap_l4_proto l4p = fdinfo->get_l4proto();
-
-				switch(l4p) {
+				switch(fdinfo->get_l4proto()) {
 				case SCAP_L4_TCP:
 					ipprotoch = 't';
 					break;
@@ -586,7 +579,7 @@ int sinsp_evt::render_fd_json(Json::Value *ret,
 				}
 			}
 
-			char typestr[3] = {(fmt & PF_SIMPLE) ? (char)0 : tch, ipprotoch, 0};
+			const char typestr[3] = {fmt & PF_SIMPLE ? static_cast<char>(0) : tch, ipprotoch, 0};
 
 			//
 			// Make sure we remove invalid characters from the resolved name
@@ -606,8 +599,8 @@ int sinsp_evt::render_fd_json(Json::Value *ret,
 		//
 		// Resolve this as an errno
 		//
-		std::string errstr(sinsp_utils::errno_to_str((int32_t)fd));
-		if(errstr != "") {
+		if(const std::string errstr(sinsp_utils::errno_to_str(static_cast<int32_t>(fd)));
+		   errstr != "") {
 			(*ret)["error"] = errstr;
 			return 0;
 		}
@@ -616,14 +609,14 @@ int sinsp_evt::render_fd_json(Json::Value *ret,
 	return 1;
 }
 
-char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::param_fmt fmt) {
+char *sinsp_evt::render_fd(const int64_t fd, const char ** /*resolved_str*/, const param_fmt fmt) {
 	//
 	// Add the fd number
 	//
 	snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "%" PRId64, fd);
 
 	sinsp_threadinfo *tinfo = get_thread_info();
-	if(tinfo == NULL) {
+	if(tinfo == nullptr) {
 		//
 		// no thread. Definitely can't resolve the fd, just return the number
 		//
@@ -631,16 +624,13 @@ char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::par
 	}
 
 	if(fd >= 0) {
-		sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
-		if(fdinfo) {
-			char tch = fdinfo->get_typechar();
+		if(const auto *fdinfo = tinfo->get_fd(fd)) {
+			const auto tch = fdinfo->get_typechar();
 			char ipprotoch = 0;
 
 			if(fdinfo->m_type == SCAP_FD_IPV4_SOCK || fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
 			   fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK || fdinfo->m_type == SCAP_FD_IPV6_SERVSOCK) {
-				scap_l4_proto l4p = fdinfo->get_l4proto();
-
-				switch(l4p) {
+				switch(fdinfo->get_l4proto()) {
 				case SCAP_L4_TCP:
 					ipprotoch = 't';
 					break;
@@ -658,7 +648,7 @@ char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::par
 				}
 			}
 
-			char typestr[3] = {(fmt & PF_SIMPLE) ? (char)0 : tch, ipprotoch, 0};
+			char typestr[3] = {fmt & PF_SIMPLE ? static_cast<char>(0) : tch, ipprotoch, 0};
 
 			//
 			// Make sure we remove invalid characters from the resolved name
@@ -688,7 +678,7 @@ char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::par
 		//
 		// Resolve this as an errno
 		//
-		std::string errstr(sinsp_utils::errno_to_str((int32_t)fd));
+		const std::string errstr(sinsp_utils::errno_to_str(static_cast<int32_t>(fd)));
 		if(errstr != "") {
 			snprintf(&m_resolved_paramstr_storage[0],
 			         m_resolved_paramstr_storage.size(),
@@ -700,7 +690,7 @@ char *sinsp_evt::render_fd(int64_t fd, const char **resolved_str, sinsp_evt::par
 	return &m_paramstr_storage[0];
 }
 
-std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo) {
+std::string sinsp_evt::get_base_dir(const uint32_t id, sinsp_threadinfo *tinfo) {
 	std::string cwd = tinfo->get_cwd();
 
 	const ppm_param_info *param_info = &m_info->params[id];
@@ -711,15 +701,14 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo) {
 		return cwd;
 	}
 
-	uint64_t dirfd_id = (uint64_t)param_info->info;
+	const uint64_t dirfd_id = reinterpret_cast<uint64_t>(param_info->info);
 	if(dirfd_id >= m_info->nparams) {
 		ASSERT(dirfd_id < m_info->nparams);
 		return cwd;
 	}
 
-	const ppm_param_info *dir_param_info = &(m_info->params[dirfd_id]);
 	// Ensure the index points to an actual FD
-	if(dir_param_info->type != PT_FD) {
+	if(const auto *dir_param_info = &m_info->params[dirfd_id]; dir_param_info->type != PT_FD) {
 		return cwd;
 	}
 
@@ -735,22 +724,18 @@ std::string sinsp_evt::get_base_dir(uint32_t id, sinsp_threadinfo *tinfo) {
 	return tinfo->get_path_for_dir_fd(dirfd);
 }
 
-const char *sinsp_evt::get_param_as_str(uint32_t id,
-                                        const char **resolved_str,
-                                        sinsp_evt::param_fmt fmt) {
-	char *prfmt = NULL;
-	const ppm_param_info *param_info = NULL;
-	std::optional<sinsp_evt_param> dyn_param;
+const char *sinsp_evt::get_param_as_str(uint32_t id, const char **resolved_str, param_fmt fmt) {
+	char *prfmt = nullptr;
+	const ppm_param_info *param_info = nullptr;
 	std::string_view s;
 	uint8_t sockfamily;
-	uint32_t j = 0;
 
 	//
 	// Make sure the params are actually loaded
 	//
-	if((m_flags & sinsp_evt::SINSP_EF_PARAMS_LOADED) == 0) {
+	if((m_flags & SINSP_EF_PARAMS_LOADED) == 0) {
 		load_params();
-		m_flags |= (uint32_t)sinsp_evt::SINSP_EF_PARAMS_LOADED;
+		m_flags |= static_cast<uint32_t>(SINSP_EF_PARAMS_LOADED);
 	}
 
 	ASSERT(id < get_num_params());
@@ -793,7 +778,8 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	//
 	// Get the parameter information
 	//
-	if(param_info->type == PT_DYN && param_info->info != NULL) {
+	std::optional<sinsp_evt_param> dyn_param;
+	if(param_info->type == PT_DYN && param_info->info != nullptr) {
 		const auto param_data = param->data();
 		const auto param_len = param->len();
 		uint8_t dyn_idx = 0;
@@ -848,7 +834,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 
 		sinsp_threadinfo *atinfo =
 		        m_inspector->m_thread_manager->find_thread(param->as<int64_t>(), true).get();
-		if(atinfo != NULL) {
+		if(atinfo != nullptr) {
 			std::string &tcomm = atinfo->m_comm;
 
 			//
@@ -890,7 +876,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		std::string errstr;
 
 		if(val < 0) {
-			errstr = sinsp_utils::errno_to_str((int32_t)val);
+			errstr = sinsp_utils::errno_to_str(static_cast<int32_t>(val));
 
 			if(errstr != "") {
 				snprintf(&m_resolved_paramstr_storage[0],
@@ -919,16 +905,14 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		break;
 	case PT_FSPATH:
 	case PT_FSRELPATH: {
-		std::string_view path = param->as<std::string_view>();
+		const auto path = param->as<std::string_view>();
 		if(path.length() + 1 > m_paramstr_storage.size()) {
 			m_paramstr_storage.resize(path.length() + 1);
 		}
 
 		strcpy_sanitized(m_paramstr_storage, path);
 
-		sinsp_threadinfo *tinfo = get_thread_info();
-
-		if(tinfo) {
+		if(auto *tinfo = get_thread_info()) {
 			if(path != "<NA>") {
 				std::string cwd = get_base_dir(id, tinfo);
 
@@ -951,11 +935,12 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		auto param_data = param->data();
 		auto param_len = param->len();
 		while(true) {
-			uint32_t blen = binary_buffer_to_string(&m_paramstr_storage[0],
-			                                        param_data,
-			                                        (uint32_t)m_paramstr_storage.size() - 1,
-			                                        param_len,
-			                                        fmt);
+			uint32_t blen =
+			        binary_buffer_to_string(&m_paramstr_storage[0],
+			                                param_data,
+			                                static_cast<uint32_t>(m_paramstr_storage.size()) - 1,
+			                                param_len,
+			                                fmt);
 
 			if(blen >= m_paramstr_storage.size() - 1) {
 				//
@@ -965,7 +950,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				continue;
 			}
 
-			ASSERT(m_inspector != NULL);
+			ASSERT(m_inspector != nullptr);
 			if(m_inspector->get_max_evt_output_len() != 0 &&
 			   blen > m_inspector->get_max_evt_output_len() && fmt == PF_NORMAL) {
 				uint32_t real_len = std::min(blen, m_inspector->get_max_evt_output_len());
@@ -1005,7 +990,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				ipv4serverinfo addr;
 				memcpy(&addr.m_ip, param_data + 1, sizeof(addr.m_ip));
 				memcpy(&addr.m_port, param_data + 5, sizeof(addr.m_port));
-				addr.m_l4proto = (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
+				addr.m_l4proto = m_fdinfo != nullptr ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 				std::string straddr = ipv4serveraddr_to_string(
 				        addr,
 				        m_inspector->is_hostname_and_port_resolution_enabled());
@@ -1019,7 +1004,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				ipv6serverinfo addr;
 				memcpy(addr.m_ip.m_b, param_data + 1, sizeof(addr.m_ip.m_b));
 				memcpy(&addr.m_port, param_data + 17, sizeof(addr.m_port));
-				addr.m_l4proto = (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
+				addr.m_l4proto = m_fdinfo != nullptr ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 				std::string straddr = ipv6serveraddr_to_string(
 				        addr,
 				        m_inspector->is_hostname_and_port_resolution_enabled());
@@ -1045,7 +1030,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 				memcpy(&addr.m_fields.m_dip, param_data + 7, sizeof(uint32_t));
 				memcpy(&addr.m_fields.m_dport, param_data + 11, sizeof(uint16_t));
 				addr.m_fields.m_l4proto =
-				        (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
+				        m_fdinfo != nullptr ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 				std::string straddr =
 				        ipv4tuple_to_string(addr,
 				                            m_inspector->is_hostname_and_port_resolution_enabled());
@@ -1069,7 +1054,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 					memcpy(&addr.m_fields.m_dip, dip, sizeof(uint32_t));
 					memcpy(&addr.m_fields.m_dport, param_data + 35, sizeof(uint16_t));
 					addr.m_fields.m_l4proto =
-					        (m_fdinfo != NULL) ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
+					        m_fdinfo != nullptr ? m_fdinfo->get_l4proto() : SCAP_L4_UNKNOWN;
 					std::string straddr = ipv4tuple_to_string(
 					        addr,
 					        m_inspector->is_hostname_and_port_resolution_enabled());
@@ -1079,33 +1064,30 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 					         "%s",
 					         straddr.c_str());
 					break;
-				} else {
-					char srcstr[INET6_ADDRSTRLEN];
-					char dststr[INET6_ADDRSTRLEN];
-					if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) &&
-					   inet_ntop(AF_INET6, dip6, dststr, sizeof(dststr))) {
-						uint16_t srcport, dstport;
-						memcpy(&srcport, param_data + 17, sizeof(srcport));
-						memcpy(&dstport, param_data + 35, sizeof(dstport));
-						snprintf(&m_paramstr_storage[0],
-						         m_paramstr_storage.size(),
-						         "%s:%s->%s:%s",
-						         srcstr,
-						         port_to_string(
-						                 srcport,
-						                 (m_fdinfo != NULL) ? m_fdinfo->get_l4proto()
-						                                    : SCAP_L4_UNKNOWN,
-						                 m_inspector->is_hostname_and_port_resolution_enabled())
-						                 .c_str(),
-						         dststr,
-						         port_to_string(
-						                 dstport,
-						                 (m_fdinfo != NULL) ? m_fdinfo->get_l4proto()
-						                                    : SCAP_L4_UNKNOWN,
-						                 m_inspector->is_hostname_and_port_resolution_enabled())
-						                 .c_str());
-						break;
-					}
+				}
+				char srcstr[INET6_ADDRSTRLEN];
+				char dststr[INET6_ADDRSTRLEN];
+				if(inet_ntop(AF_INET6, sip6, srcstr, sizeof(srcstr)) &&
+				   inet_ntop(AF_INET6, dip6, dststr, sizeof(dststr))) {
+					uint16_t srcport, dstport;
+					memcpy(&srcport, param_data + 17, sizeof(srcport));
+					memcpy(&dstport, param_data + 35, sizeof(dstport));
+					snprintf(&m_paramstr_storage[0],
+					         m_paramstr_storage.size(),
+					         "%s:%s->%s:%s",
+					         srcstr,
+					         port_to_string(srcport,
+					                        m_fdinfo != nullptr ? m_fdinfo->get_l4proto()
+					                                            : SCAP_L4_UNKNOWN,
+					                        m_inspector->is_hostname_and_port_resolution_enabled())
+					                 .c_str(),
+					         dststr,
+					         port_to_string(dstport,
+					                        m_fdinfo != nullptr ? m_fdinfo->get_l4proto()
+					                                            : SCAP_L4_UNKNOWN,
+					                        m_inspector->is_hostname_and_port_resolution_enabled())
+					                 .c_str());
+					break;
 				}
 			}
 
@@ -1138,6 +1120,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		break;
 	}
 	case PT_FDLIST: {
+		uint32_t j = 0;
 		sinsp_threadinfo *tinfo = get_thread_info();
 		if(!tinfo) {
 			break;
@@ -1156,8 +1139,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			int64_t fd = 0;
 			memcpy(&fd, param_data + pos, sizeof(uint64_t));
 
-			sinsp_fdinfo *fdinfo = tinfo->get_fd(fd);
-			if(fdinfo) {
+			if(const auto *fdinfo = tinfo->get_fd(fd)) {
 				tch = fdinfo->get_typechar();
 			} else {
 				tch = '?';
@@ -1171,8 +1153,8 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			                 "%" PRIu64 ":%c%x%c",
 			                 fd,
 			                 tch,
-			                 (uint32_t)p8,
-			                 (j < (uint32_t)(nfds - 1)) ? ' ' : '\0');
+			                 static_cast<uint32_t>(p8),
+			                 j < static_cast<uint32_t>(nfds - 1) ? ' ' : '\0');
 
 			if(r < 0 || spos + r >= m_paramstr_storage.size() - 1) {
 				m_paramstr_storage[m_paramstr_storage.size() - 1] = 0;
@@ -1196,7 +1178,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		snprintf(&m_resolved_paramstr_storage[0],
 		         m_resolved_paramstr_storage.size(),
 		         "%s",
-		         scap_get_ppm_sc_name((ppm_sc_code)ppm_sc));
+		         scap_get_ppm_sc_name(static_cast<ppm_sc_code>(ppm_sc)));
 	} break;
 	case PT_SIGTYPE: {
 		const char *sigstr;
@@ -1217,18 +1199,15 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	case PT_RELTIME: {
 		std::string sigstr;
 
-		uint64_t val = param->as<uint64_t>();
-
-		if(val == (uint64_t)(-1)) {
+		if(const auto val = param->as<uint64_t>(); val == static_cast<uint64_t>(-1)) {
 			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "none");
 			m_resolved_paramstr_storage[0] = '\0';
 		} else {
 			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "%" PRIu64, val);
-
 			snprintf(&m_resolved_paramstr_storage[0],
 			         m_resolved_paramstr_storage.size(),
 			         "%lgs",
-			         ((double)val) / 1000000000);
+			         static_cast<double>(val) / 1000000000);
 		}
 	} break;
 	case PT_FLAGS8:
@@ -1256,15 +1235,15 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		}
 		snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "%" PRIu32, val);
 
-		auto flags = (const ppm_name_value *)m_info->params[id].info;
+		auto flags = static_cast<const ppm_name_value *>(m_info->params[id].info);
 		const bool exact_match = param_info->type == PT_ENUMFLAGS8 ||
 		                         param_info->type == PT_ENUMFLAGS16 ||
 		                         param_info->type == PT_ENUMFLAGS32;
-		const char *separator = "";
+		auto separator = "";
 		uint32_t initial_val = val;
 		uint32_t j = 0;
 
-		while(flags != NULL && flags->name != NULL) {
+		while(flags != nullptr && flags->name != nullptr) {
 			bool match = false;
 			if(exact_match) {
 				match = flags->value == initial_val;
@@ -1310,17 +1289,17 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		SET_NUMERIC_FORMAT(prfmt, param_fmt, PRIo32, PRId32, PRIX32);
 		snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), prfmt, val);
 
-		auto mode = (const ppm_name_value *)m_info->params[id].info;
-		const char *separator = "";
+		auto mode = static_cast<const ppm_name_value *>(m_info->params[id].info);
+		auto separator = "";
 		uint32_t initial_val = val;
 		uint32_t j = 0;
 
-		while(mode != NULL && mode->name != NULL && mode->value != initial_val) {
+		while(mode != nullptr && mode->name != nullptr && mode->value != initial_val) {
 			// If mode is 0, then initial_val needs to be 0 for the mode to be resolved
 			if((mode->value == 0 && initial_val == 0) ||
 			   (mode->value != 0 && (val & mode->value) == mode->value && val != 0)) {
-				size_t params_len = j + strlen(separator) + strlen(mode->name);
-				if(m_resolved_paramstr_storage.size() < params_len) {
+				if(size_t params_len = j + strlen(separator) + strlen(mode->name);
+				   m_resolved_paramstr_storage.size() < params_len) {
 					m_resolved_paramstr_storage.resize(params_len + 1);
 				}
 
@@ -1338,7 +1317,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			mode++;
 		}
 
-		if(mode != NULL && mode->name != NULL) {
+		if(mode != nullptr && mode->name != nullptr) {
 			j += snprintf(&m_resolved_paramstr_storage[j],
 			              m_resolved_paramstr_storage.size(),
 			              "%s%s",
@@ -1352,7 +1331,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		uint64_t val = param->as<uint64_t>();
 		time_t sec = val / 1000000000ULL;
 		unsigned long nsec = val % 1000000000ULL;
-		struct tm tm;
+		tm tm;
 		localtime_r(&sec, &tm);
 		strftime(&m_paramstr_storage[0],
 		         m_paramstr_storage.size(),
@@ -1366,8 +1345,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "INVALID DYNAMIC PARAMETER");
 		break;
 	case PT_UID: {
-		uint32_t val = param->as<uint32_t>();
-		if(val < std::numeric_limits<uint32_t>::max()) {
+		if(const auto val = param->as<uint32_t>(); val < std::numeric_limits<uint32_t>::max()) {
 			// Note: we want to resolve user given the uid
 			// from the event.
 			// Eg: for setuid() the requested uid is not
@@ -1375,12 +1353,12 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			// therefore we cannot directly use tinfo->m_user here.
 			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "%d", val);
 			sinsp_threadinfo *tinfo = get_thread_info();
-			scap_userinfo *user_info = NULL;
+			scap_userinfo *user_info = nullptr;
 			if(tinfo) {
 				auto container_id = m_inspector->m_plugin_tables.get_container_id(*tinfo);
 				user_info = m_inspector->m_usergroup_manager->get_user(container_id, val);
 			}
-			if(user_info != NULL && user_info->name[0] != 0) {
+			if(user_info != nullptr && user_info->name[0] != 0) {
 				strcpy_sanitized(m_resolved_paramstr_storage, user_info->name);
 			} else {
 				snprintf(&m_resolved_paramstr_storage[0],
@@ -1394,8 +1372,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		break;
 	}
 	case PT_GID: {
-		uint32_t val = param->as<uint32_t>();
-		if(val < std::numeric_limits<uint32_t>::max()) {
+		if(const auto val = param->as<uint32_t>(); val < std::numeric_limits<uint32_t>::max()) {
 			// Note: we want to resolve group given the gid
 			// from the event.
 			// Eg: for setgid() the requested gid is not
@@ -1403,12 +1380,12 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			// therefore we cannot directly use tinfo->m_group here.
 			snprintf(&m_paramstr_storage[0], m_paramstr_storage.size(), "%d", val);
 			sinsp_threadinfo *tinfo = get_thread_info();
-			scap_groupinfo *group_info = NULL;
+			scap_groupinfo *group_info = nullptr;
 			if(tinfo) {
 				auto container_id = m_inspector->m_plugin_tables.get_container_id(*tinfo);
 				group_info = m_inspector->m_usergroup_manager->get_group(container_id, val);
 			}
-			if(group_info != NULL && group_info->name[0] != 0) {
+			if(group_info != nullptr && group_info->name[0] != 0) {
 				strcpy_sanitized(m_resolved_paramstr_storage, group_info->name);
 			} else {
 				snprintf(&m_resolved_paramstr_storage[0],
@@ -1423,7 +1400,8 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	}
 	case PT_CHARBUFARRAY: {
 		ASSERT(param->len() == sizeof(uint64_t));
-		std::vector<char *> *strvect = (std::vector<char *> *)*(uint64_t *)param->data();
+		auto *strvect = reinterpret_cast<std::vector<char *> *>(
+		        *reinterpret_cast<const uint64_t *>(param->data()));
 
 		m_paramstr_storage[0] = 0;
 
@@ -1472,9 +1450,8 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	} break;
 	case PT_CHARBUF_PAIR_ARRAY: {
 		ASSERT(param->len() == sizeof(uint64_t));
-		std::pair<std::vector<char *> *, std::vector<char *> *> *pairs =
-		        (std::pair<std::vector<char *> *, std::vector<char *> *> *)*(
-		                uint64_t *)param->data();
+		auto *pairs = reinterpret_cast<std::pair<std::vector<char *> *, std::vector<char *> *> *>(
+		        *reinterpret_cast<const uint64_t *>(param->data()));
 
 		m_paramstr_storage[0] = 0;
 
@@ -1487,7 +1464,6 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			std::vector<char *>::iterator it1;
 			std::vector<char *>::iterator itbeg1;
 			std::vector<char *>::iterator it2;
-			std::vector<char *>::iterator itbeg2;
 			bool need_to_resize = false;
 
 			//
@@ -1496,7 +1472,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 			char *dst = &m_paramstr_storage[0];
 			char *dstend = &m_paramstr_storage[0] + m_paramstr_storage.size() - 2;
 
-			for(it1 = itbeg1 = pairs->first->begin(), it2 = itbeg2 = pairs->second->begin();
+			for(it1 = itbeg1 = pairs->first->begin(), it2 = pairs->second->begin();
 			    it1 != pairs->first->end();
 			    ++it1, ++it2) {
 				char *src = *it1;
@@ -1554,13 +1530,12 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 		m_paramstr_storage[0] = '\0';
 
 		char *storage = &m_paramstr_storage[0];
-		int remaining = (int)m_paramstr_storage.size();
+		int remaining = static_cast<int>(m_paramstr_storage.size());
 		bool first = true;
 
 		for(int sig = 0; sig < 32; sig++) {
-			if(val & (1U << sig)) {
-				const char *sigstr = sinsp_utils::signal_to_str(sig + 1);
-				if(sigstr) {
+			if(val & 1U << sig) {
+				if(const auto *sigstr = sinsp_utils::signal_to_str(sig + 1)) {
 					int printed = snprintf(storage, remaining, "%s%s", !first ? " " : "", sigstr);
 					if(printed >= remaining) {
 						storage[remaining - 1] = '\0';
@@ -1586,7 +1561,7 @@ const char *sinsp_evt::get_param_as_str(uint32_t id,
 	return &m_paramstr_storage[0];
 }
 
-std::string sinsp_evt::get_param_value_str(std::string_view name, bool resolved) {
+std::string sinsp_evt::get_param_value_str(const std::string_view name, const bool resolved) {
 	for(uint32_t i = 0; i < get_num_params(); i++) {
 		if(name == get_param_name(i)) {
 			return get_param_value_str(i, resolved);
@@ -1596,32 +1571,29 @@ std::string sinsp_evt::get_param_value_str(std::string_view name, bool resolved)
 	return std::string();
 }
 
-std::string sinsp_evt::get_param_value_str(uint32_t i, bool resolved) {
+std::string sinsp_evt::get_param_value_str(const uint32_t id, const bool resolved) {
 	const char *param_value_str;
-	const char *val_str;
-	val_str = get_param_as_str(i, &param_value_str);
-
+	const char *val_str = get_param_as_str(id, &param_value_str);
 	if(resolved) {
-		return std::string((*param_value_str == '\0') ? val_str : param_value_str);
-	} else {
-		return std::string(val_str);
+		return std::string(*param_value_str == '\0' ? val_str : param_value_str);
 	}
+	return std::string(val_str);
 }
 
 const char *sinsp_evt::get_param_value_str(std::string_view name,
                                            const char **resolved_str,
-                                           param_fmt fmt) {
+                                           const param_fmt fmt) {
 	for(uint32_t i = 0; i < get_num_params(); i++) {
 		if(name == get_param_name(i)) {
 			return get_param_as_str(i, resolved_str, fmt);
 		}
 	}
 
-	*resolved_str = NULL;
-	return NULL;
+	*resolved_str = nullptr;
+	return nullptr;
 }
 
-void sinsp_evt::get_category(sinsp_evt::category *cat) const {
+void sinsp_evt::get_category(category *cat) const {
 	/* We always search the category inside the event table */
 	cat->m_category = get_category();
 
@@ -1636,49 +1608,48 @@ void sinsp_evt::get_category(sinsp_evt::category *cat) const {
 			//
 			cat->m_subcategory = SC_UNKNOWN;
 			return;
-		} else {
-			switch(m_fdinfo->m_type) {
-			case SCAP_FD_FILE:
-			case SCAP_FD_FILE_V2:
-			case SCAP_FD_DIRECTORY:
-				cat->m_subcategory = SC_FILE;
-				break;
-			case SCAP_FD_IPV4_SOCK:
-			case SCAP_FD_IPV6_SOCK:
-				cat->m_subcategory = SC_NET;
-				break;
-			case SCAP_FD_IPV4_SERVSOCK:
-			case SCAP_FD_IPV6_SERVSOCK:
-				cat->m_subcategory = SC_NET;
-				break;
-			case SCAP_FD_FIFO:
-			case SCAP_FD_UNIX_SOCK:
-			case SCAP_FD_EVENT:
-			case SCAP_FD_SIGNALFD:
-			case SCAP_FD_INOTIFY:
-			case SCAP_FD_USERFAULTFD:
-				cat->m_subcategory = SC_IPC;
-				break;
-			case SCAP_FD_UNSUPPORTED:
-			case SCAP_FD_EVENTPOLL:
-			case SCAP_FD_TIMERFD:
-			case SCAP_FD_BPF:
-			case SCAP_FD_IOURING:
-			case SCAP_FD_NETLINK:
-			case SCAP_FD_MEMFD:
-			case SCAP_FD_PIDFD:
-				cat->m_subcategory = SC_OTHER;
-				break;
-			case SCAP_FD_UNKNOWN:
-				cat->m_subcategory = SC_OTHER;
-				break;
-			default:
-				cat->m_subcategory = SC_UNKNOWN;
-				break;
-			}
+		}
+		switch(m_fdinfo->m_type) {
+		case SCAP_FD_FILE:
+		case SCAP_FD_FILE_V2:
+		case SCAP_FD_DIRECTORY:
+			cat->m_subcategory = SC_FILE;
+			break;
+		case SCAP_FD_IPV4_SOCK:
+		case SCAP_FD_IPV6_SOCK:
+			cat->m_subcategory = SC_NET;
+			break;
+		case SCAP_FD_IPV4_SERVSOCK:
+		case SCAP_FD_IPV6_SERVSOCK:
+			cat->m_subcategory = SC_NET;
+			break;
+		case SCAP_FD_FIFO:
+		case SCAP_FD_UNIX_SOCK:
+		case SCAP_FD_EVENT:
+		case SCAP_FD_SIGNALFD:
+		case SCAP_FD_INOTIFY:
+		case SCAP_FD_USERFAULTFD:
+			cat->m_subcategory = SC_IPC;
+			break;
+		case SCAP_FD_UNSUPPORTED:
+		case SCAP_FD_EVENTPOLL:
+		case SCAP_FD_TIMERFD:
+		case SCAP_FD_BPF:
+		case SCAP_FD_IOURING:
+		case SCAP_FD_NETLINK:
+		case SCAP_FD_MEMFD:
+		case SCAP_FD_PIDFD:
+			cat->m_subcategory = SC_OTHER;
+			break;
+		case SCAP_FD_UNKNOWN:
+			cat->m_subcategory = SC_OTHER;
+			break;
+		default:
+			cat->m_subcategory = SC_UNKNOWN;
+			break;
 		}
 	} else {
-		cat->m_subcategory = sinsp_evt::SC_NONE;
+		cat->m_subcategory = SC_NONE;
 	}
 }
 
@@ -1692,9 +1663,7 @@ scap_dump_flags sinsp_evt::get_dump_flags(bool *should_drop) const {
 
 	if(m_filtered_out) {
 		if(m_inspector->is_fatfile_enabled()) {
-			ppm_event_flags eflags = get_info_flags();
-
-			if(eflags & EF_MODIFIES_STATE) {
+			if(const auto eflags = get_info_flags(); eflags & EF_MODIFIES_STATE) {
 				dflags = SCAP_DF_STATE_ONLY;
 			} else {
 				*should_drop = true;
@@ -1704,8 +1673,7 @@ scap_dump_flags sinsp_evt::get_dump_flags(bool *should_drop) const {
 		}
 
 		if(*should_drop) {
-			ppm_event_category ecat = get_category();
-			if(ecat & EC_INTERNAL) {
+			if(const auto ecat = get_category(); ecat & EC_INTERNAL) {
 				*should_drop = false;
 			}
 		}
@@ -1715,25 +1683,24 @@ scap_dump_flags sinsp_evt::get_dump_flags(bool *should_drop) const {
 		dflags |= SCAP_DF_LARGE;
 	}
 
-	return (scap_dump_flags)dflags;
+	return static_cast<scap_dump_flags>(dflags);
 }
 
 bool sinsp_evt::is_syscall_error() const {
-	return (m_errorcode != 0) && (m_errorcode != SE_EINPROGRESS) && (m_errorcode != SE_EAGAIN) &&
-	       (m_errorcode != SE_ETIMEDOUT);
+	return m_errorcode != 0 && m_errorcode != SE_EINPROGRESS && m_errorcode != SE_EAGAIN &&
+	       m_errorcode != SE_ETIMEDOUT;
 }
 
 bool sinsp_evt::is_file_open_error() const {
-	return (m_fdinfo == nullptr) &&
-	       ((m_pevt->type == PPME_SYSCALL_OPEN_X) || (m_pevt->type == PPME_SYSCALL_CREAT_X) ||
-	        (m_pevt->type == PPME_SYSCALL_OPENAT_2_X) || (m_pevt->type == PPME_SYSCALL_OPENAT2_X) ||
-	        (m_pevt->type == PPME_SYSCALL_OPEN_BY_HANDLE_AT_X));
+	return m_fdinfo == nullptr &&
+	       (m_pevt->type == PPME_SYSCALL_OPEN_X || m_pevt->type == PPME_SYSCALL_CREAT_X ||
+	        m_pevt->type == PPME_SYSCALL_OPENAT_2_X || m_pevt->type == PPME_SYSCALL_OPENAT2_X ||
+	        m_pevt->type == PPME_SYSCALL_OPEN_BY_HANDLE_AT_X);
 }
 
 bool sinsp_evt::is_file_error() const {
-	return is_file_open_error() ||
-	       ((m_fdinfo != nullptr) &&
-	        ((m_fdinfo->m_type == SCAP_FD_FILE) || (m_fdinfo->m_type == SCAP_FD_FILE_V2)));
+	return is_file_open_error() || (m_fdinfo != nullptr && (m_fdinfo->m_type == SCAP_FD_FILE ||
+	                                                        m_fdinfo->m_type == SCAP_FD_FILE_V2));
 }
 
 bool sinsp_evt::is_network_error() const {
@@ -1748,7 +1715,7 @@ uint64_t sinsp_evt::get_lastevent_ts() const {
 	return m_tinfo->m_lastevent_ts;
 }
 
-void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const {
+void sinsp_evt_param::throw_invalid_len_error(const size_t requested_len) const {
 	const auto param_data = data();
 	const auto param_len = len();
 	const ppm_param_info *parinfo = get_info();
@@ -1756,10 +1723,9 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const {
 	std::stringstream ss;
 	ss << "could not parse param " << m_idx << " (" << parinfo->name << ") for event "
 	   << m_evt->get_num() << " of type " << m_evt->get_type() << " (" << m_evt->get_name()
-	   << "), for tid " << m_evt->get_tid() << ": expected length " << requested_length
-	   << ", found " << param_len;
-	std::string error_string = ss.str();
-
+	   << "), for tid " << m_evt->get_tid() << ": expected length " << requested_len << ", found "
+	   << param_len;
+	const std::string error_string = ss.str();
 	libsinsp_logger()->log(error_string, sinsp_logger::SEV_ERROR);
 	libsinsp_logger()->log(
 	        "parameter raw data: \n" + buffer_to_multiline_hex(param_data, param_len),
@@ -1769,5 +1735,5 @@ void sinsp_evt_param::throw_invalid_len_error(size_t requested_length) const {
 }
 
 const ppm_param_info *sinsp_evt_param::get_info() const {
-	return &(m_evt->get_info()->params[m_idx]);
+	return &m_evt->get_info()->params[m_idx];
 }

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -54,15 +54,14 @@ class sinsp_evt;
 */
 class SINSP_PUBLIC sinsp_evttables {
 public:
-	struct ppm_event_info
-	        m_event_info[MAX_EVENTINFO_SIZE];  ///< List of events supported by the capture and
-	                                           ///< analysis subsystems. Each entry fully documents
-	                                           ///< an event and its parameters.
-	size_t m_event_size;                       ///< Number of events in the event table.
+	ppm_event_info m_event_info[MAX_EVENTINFO_SIZE];  ///< List of events supported by the capture
+	                                                  ///< and analysis subsystems. Each entry fully
+	                                                  ///< documents an event and its parameters.
+	size_t m_event_size;                              ///< Number of events in the event table.
 };
 
 template<class T>
-inline T get_event_param_as(const class sinsp_evt_param& param);
+T get_event_param_as(const sinsp_evt_param& param);
 
 /*!
   \brief Event parameter wrapper.
@@ -166,11 +165,11 @@ public:
 	  std::vector<std::string>
 	*/
 	template<class T>
-	inline T as() const {
+	T as() const {
 		return get_event_param_as<T>(*this);
 	}
 
-	const struct ppm_param_info* get_info() const;
+	const ppm_param_info* get_info() const;
 
 	// Throws a sinsp_exception detailing why the requested_len is incorrect.
 	// This is only meant to be called by get_event_param_as. This way, this function will not be
@@ -186,7 +185,7 @@ public:
   \param param The parameter.
 */
 template<class T>
-inline T get_event_param_as(const sinsp_evt_param& param) {
+T get_event_param_as(const sinsp_evt_param& param) {
 	static_assert(std::is_fundamental_v<T>,
 	              "event parameter cast (e.g. evt->get_param(N)->as<T>()) unsupported for this "
 	              "type. Implement it or see the available definitions in " __FILE__);
@@ -230,9 +229,8 @@ inline std::string get_event_param_as<std::string>(const sinsp_evt_param& param)
 		return "";
 	}
 
-	size_t string_len = strnlen(param_data, param_len);
 	// We expect the parameter to be exactly one null-terminated string
-	if(param_len != string_len + 1) {
+	if(const auto string_len = strnlen(param_data, param_len); param_len != string_len + 1) {
 		// By moving this error string building operation to a separate function
 		// the compiler is more likely to inline this entire function.
 		param.throw_invalid_len_error(string_len + 1);
@@ -262,7 +260,7 @@ inline std::vector<uint8_t> get_event_param_as<std::vector<uint8_t>>(const sinsp
 	// copy content of the event parameter to a new vector
 	std::vector<uint8_t> res;
 	for(size_t i = 0; i < param_len; ++i) {
-		res.push_back(uint8_t(param_data[i]));
+		res.push_back(static_cast<uint8_t>(param_data[i]));
 	}
 
 	return res;
@@ -281,19 +279,18 @@ public:
 	  \brief How to render an event parameter to string.
 	*/
 	enum param_fmt {
-		PF_NORMAL = (1 << 0),    ///< Normal screen output
-		PF_JSON = (1 << 1),      ///< Json formatting with data in normal screen format
-		PF_SIMPLE = (1 << 2),    ///< Reduced output, e.g. not type character for FDs
-		PF_HEX = (1 << 3),       ///< Hexadecimal output
-		PF_HEXASCII = (1 << 4),  ///< Hexadecimal + ASCII output
-		PF_EOLS = (1 << 5),      ///< Normal + end of lines
-		PF_EOLS_COMPACT =
-		        (1 << 6),        ///< Normal + end of lines but with no force EOL at the beginning
-		PF_BASE64 = (1 << 7),    ///< Base64 output
-		PF_JSONEOLS = (1 << 8),  ///< Json formatting with data in hexadecimal format
-		PF_JSONHEX = (1 << 9),   ///< Json formatting with data in hexadecimal format
-		PF_JSONHEXASCII = (1 << 10),  ///< Json formatting with data in hexadecimal + ASCII format
-		PF_JSONBASE64 = (1 << 11),    ///< Json formatting with data in base64 format
+		PF_NORMAL = 1 << 0,        ///< Normal screen output
+		PF_JSON = 1 << 1,          ///< Json formatting with data in normal screen format
+		PF_SIMPLE = 1 << 2,        ///< Reduced output, e.g. not type character for FDs
+		PF_HEX = 1 << 3,           ///< Hexadecimal output
+		PF_HEXASCII = 1 << 4,      ///< Hexadecimal + ASCII output
+		PF_EOLS = 1 << 5,          ///< Normal + end of lines
+		PF_EOLS_COMPACT = 1 << 6,  ///< Normal + end of lines but with no force EOL at the beginning
+		PF_BASE64 = 1 << 7,        ///< Base64 output
+		PF_JSONEOLS = 1 << 8,      ///< Json formatting with data in hexadecimal format
+		PF_JSONHEX = 1 << 9,       ///< Json formatting with data in hexadecimal format
+		PF_JSONHEXASCII = 1 << 10,  ///< Json formatting with data in hexadecimal + ASCII format
+		PF_JSONBASE64 = 1 << 11,    ///< Json formatting with data in base64 format
 	};
 
 	/*!
@@ -331,65 +328,65 @@ public:
 	/*!
 	  \brief Set the inspector.
 	*/
-	inline void set_inspector(sinsp* value) { m_inspector = value; }
+	void set_inspector(sinsp* value) { m_inspector = value; }
 
-	inline sinsp* get_inspector() { return m_inspector; }
+	sinsp* get_inspector() { return m_inspector; }
 
-	inline const sinsp* get_inspector() const { return m_inspector; }
+	const sinsp* get_inspector() const { return m_inspector; }
 
 	/*!
 	  \brief Get the incremental number of this event.
 	*/
-	inline uint64_t get_num() const { return m_evtnum; }
+	uint64_t get_num() const { return m_evtnum; }
 
 	/*!
 	  \brief Set the number of this event.
 	*/
-	inline void set_num(uint64_t evtnum) { m_evtnum = evtnum; }
+	void set_num(const uint64_t evtnum) { m_evtnum = evtnum; }
 
 	/*!
 	  \brief Get the number of the CPU where this event was captured.
 	*/
-	inline uint16_t get_cpuid() const { return m_cpuid; }
+	uint16_t get_cpuid() const { return m_cpuid; }
 
-	inline void set_cpuid(uint16_t v) { m_cpuid = v; }
+	void set_cpuid(const uint16_t v) { m_cpuid = v; }
 
 	/*!
 	  \brief Get the event type.
 
 	  \note For a list of event types, refer to \ref etypes.
 	*/
-	virtual inline uint16_t get_type() const { return m_pevt->type; }
+	virtual uint16_t get_type() const { return m_pevt->type; }
 
 	/*!
 	  \brief Get the event source index, as in the positional order of
 	  used by the event's inspector event sources.
 	  Returns sinsp_no_event_source_idx if the event source is unknown.
 	*/
-	inline size_t get_source_idx() const { return m_source_idx; }
+	size_t get_source_idx() const { return m_source_idx; }
 
-	inline void set_source_idx(size_t v) { m_source_idx = v; }
+	void set_source_idx(const size_t v) { m_source_idx = v; }
 
 	/*!
 	  \brief Get the event source name, as in the event's inspector
 	  event sources. Returns sinsp_no_event_source_name if
 	  the event source is unknown.
 	*/
-	inline const char* get_source_name() const { return m_source_name; }
+	const char* get_source_name() const { return m_source_name; }
 
-	inline void set_source_name(const char* v) { m_source_name = v; }
+	void set_source_name(const char* v) { m_source_name = v; }
 
 	/*!
 	  \brief Get the event info
 	*/
-	inline const ppm_event_info* get_info() const { return m_info; }
+	const ppm_event_info* get_info() const { return m_info; }
 
-	inline void set_info(const ppm_event_info* v) { m_info = v; }
+	void set_info(const ppm_event_info* v) { m_info = v; }
 
 	/*!
 	  \brief Get the event's flags.
 	*/
-	inline ppm_event_flags get_info_flags() const { return m_info->flags; }
+	ppm_event_flags get_info_flags() const { return m_info->flags; }
 
 	/*!
 	  \brief Return the event direction: in or out.
@@ -401,7 +398,7 @@ public:
 
 	  \return The event timestamp, in nanoseconds from epoch
 	*/
-	virtual inline uint64_t get_ts() const { return m_pevt->ts; }
+	virtual uint64_t get_ts() const { return m_pevt->ts; }
 
 	/*!
 	  \brief Return the event name string, e.g. 'open' or 'socket'.
@@ -412,7 +409,7 @@ public:
 	  \brief Return the event category.
 	*/
 	/// TODO: in the next future we need to rename this into `get_syscall_category_from_event`
-	inline ppm_event_category get_category() const {
+	ppm_event_category get_category() const {
 		/* Every event category is composed of 2 parts:
 		 * 1. The highest bits represent the event category:
 		 *   - `EC_SYSCALL`
@@ -425,7 +422,7 @@ public:
 		 *
 		 * This function removes the highest bits, so we consider only the syscall category.
 		 */
-		const int bitmask = EC_SYSCALL - 1;
+		constexpr int bitmask = EC_SYSCALL - 1;
 		return static_cast<ppm_event_category>(m_info->category & bitmask);
 	}
 
@@ -445,15 +442,15 @@ public:
 
 	  \note For events that are not I/O related, get_fd_info() returns NULL.
 	*/
-	inline const sinsp_fdinfo* get_fd_info() const { return m_fdinfo; }
+	const sinsp_fdinfo* get_fd_info() const { return m_fdinfo; }
 
-	inline sinsp_fdinfo* get_fd_info() { return m_fdinfo; }
+	sinsp_fdinfo* get_fd_info() { return m_fdinfo; }
 
-	inline void set_fd_info(sinsp_fdinfo* v) { m_fdinfo = v; }
+	void set_fd_info(sinsp_fdinfo* v) { m_fdinfo = v; }
 
-	inline bool fdinfo_name_changed() const { return m_fdinfo_name_changed; }
+	bool fdinfo_name_changed() const { return m_fdinfo_name_changed; }
 
-	inline void set_fdinfo_name_changed(bool changed) { m_fdinfo_name_changed = changed; }
+	void set_fdinfo_name_changed(const bool changed) { m_fdinfo_name_changed = changed; }
 
 	/*!
 	  \brief Return the number of the FD associated with this event.
@@ -482,7 +479,7 @@ public:
 	  \note Refer to the g_event_info structure in driver/event_table.c for
 	   a list of event descriptions.
 	*/
-	const struct ppm_param_info* get_param_info(uint32_t id);
+	const ppm_param_info* get_param_info(uint32_t id);
 
 	/*!
 	  \brief Get a parameter in raw format by position.
@@ -514,7 +511,7 @@ public:
 
 	  \param cat [out] the category for the event
 	*/
-	void get_category(sinsp_evt::category* cat) const;
+	void get_category(category* cat) const;
 
 	/*!
 	  \brief Return true if the event has been rejected by the filtering system.
@@ -569,32 +566,34 @@ public:
 	const char* get_param_as_str(uint32_t id, const char** resolved_str, param_fmt fmt = PF_NORMAL);
 
 	/*!
+	  \param name the name of the parameter
 	  \param resolved_str [out] the string representation of the parameter
+	  \param fmt the format specifier
 	*/
 	const char* get_param_value_str(std::string_view name,
 	                                const char** resolved_str,
 	                                param_fmt fmt = PF_NORMAL);
 
-	inline void init() {
+	void init() {
 		m_flags = EF_NONE;
-		m_info = &(m_event_info_table[m_pevt->type]);
+		m_info = &m_event_info_table[m_pevt->type];
 		m_tinfo_ref.reset();
-		m_tinfo = NULL;
+		m_tinfo = nullptr;
 		m_fdinfo_ref.reset();
-		m_fdinfo = NULL;
+		m_fdinfo = nullptr;
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_source_idx = sinsp_no_event_source_idx;
 		m_source_name = sinsp_no_event_source_name;
 	}
-	inline void init_from_raw(uint8_t* evdata, uint16_t cpuid) {
+	void init_from_raw(uint8_t* evdata, const uint16_t cpuid) {
 		m_flags = EF_NONE;
-		m_pevt = (scap_evt*)evdata;
-		m_info = &(m_event_info_table[m_pevt->type]);
+		m_pevt = reinterpret_cast<scap_evt*>(evdata);
+		m_info = &m_event_info_table[m_pevt->type];
 		m_tinfo_ref.reset();
-		m_tinfo = NULL;
+		m_tinfo = nullptr;
 		m_fdinfo_ref.reset();
-		m_fdinfo = NULL;
+		m_fdinfo = nullptr;
 		m_fdinfo_name_changed = false;
 		m_iosize = 0;
 		m_cpuid = cpuid;
@@ -604,19 +603,16 @@ public:
 
 	static std::unique_ptr<sinsp_evt> from_scap_evt(std::unique_ptr<uint8_t[]> scap_event) {
 		auto ret = std::make_unique<sinsp_evt>();
-		auto evdata = scap_event.release();
+		const auto evdata = scap_event.release();
 		ret->init_from_raw(evdata, 0);
-		ret->m_pevt_storage = (char*)evdata;
+		ret->m_pevt_storage = reinterpret_cast<char*>(evdata);
 		return ret;
 	}
 
-	inline void load_params() {
-		struct scap_sized_buffer params[PPM_MAX_EVENT_PARAMS];
-
+	void load_params() {
+		scap_sized_buffer params[PPM_MAX_EVENT_PARAMS];
+		const auto nparams = scap_event_decode_params(m_pevt, params);
 		m_params.clear();
-
-		uint32_t nparams = scap_event_decode_params(m_pevt, params);
-
 		for(uint32_t i = 0; i < nparams; i++) {
 			m_params.emplace_back(this,
 			                      i,
@@ -626,60 +622,60 @@ public:
 	}
 
 	std::string get_param_value_str(uint32_t id, bool resolved);
-	inline uint32_t get_dump_flags() const { return m_dump_flags; }
-	inline void set_dump_flags(uint32_t v) { m_dump_flags = v; }
+	uint32_t get_dump_flags() const { return m_dump_flags; }
+	void set_dump_flags(const uint32_t v) { m_dump_flags = v; }
 	int32_t get_errorcode() const { return m_errorcode; }
-	inline void set_errorcode(int32_t v) { m_errorcode = v; }
+	void set_errorcode(const int32_t v) { m_errorcode = v; }
 
-	inline const scap_evt* get_scap_evt() const { return m_pevt; }
+	const scap_evt* get_scap_evt() const { return m_pevt; }
 
-	inline scap_evt* get_scap_evt() { return m_pevt; }
+	scap_evt* get_scap_evt() { return m_pevt; }
 
-	inline void set_scap_evt(scap_evt* v) { m_pevt = v; }
+	void set_scap_evt(scap_evt* v) { m_pevt = v; }
 
-	inline const char* get_scap_evt_storage() const { return m_pevt_storage; }
+	const char* get_scap_evt_storage() const { return m_pevt_storage; }
 
-	inline char* get_scap_evt_storage() { return m_pevt_storage; }
+	char* get_scap_evt_storage() { return m_pevt_storage; }
 
-	inline void set_scap_evt_storage(char* v) { m_pevt_storage = v; }
+	void set_scap_evt_storage(char* v) { m_pevt_storage = v; }
 
-	inline uint32_t get_flags() const { return m_flags; }
+	uint32_t get_flags() const { return m_flags; }
 
-	inline void set_flags(uint32_t v) { m_flags = v; }
+	void set_flags(const uint32_t v) { m_flags = v; }
 
-	inline int32_t get_rawbuf_str_len() const { return m_rawbuf_str_len; }
+	int32_t get_rawbuf_str_len() const { return m_rawbuf_str_len; }
 
-	inline void set_rawbuf_str_len(int32_t v) { m_rawbuf_str_len = v; }
+	void set_rawbuf_str_len(const int32_t v) { m_rawbuf_str_len = v; }
 
-	inline void set_filtered_out(bool v) { m_filtered_out = v; }
+	void set_filtered_out(const bool v) { m_filtered_out = v; }
 
-	inline std::shared_ptr<const sinsp_threadinfo> get_tinfo_ref() const { return m_tinfo_ref; }
+	std::shared_ptr<const sinsp_threadinfo> get_tinfo_ref() const { return m_tinfo_ref; }
 
-	inline const std::shared_ptr<sinsp_threadinfo>& get_tinfo_ref() { return m_tinfo_ref; }
+	const std::shared_ptr<sinsp_threadinfo>& get_tinfo_ref() { return m_tinfo_ref; }
 
-	inline void set_tinfo_ref(const std::shared_ptr<sinsp_threadinfo>& v) { m_tinfo_ref = v; }
+	void set_tinfo_ref(const std::shared_ptr<sinsp_threadinfo>& v) { m_tinfo_ref = v; }
 
-	inline const sinsp_threadinfo* get_tinfo() const { return m_tinfo; }
+	const sinsp_threadinfo* get_tinfo() const { return m_tinfo; }
 
-	inline sinsp_threadinfo* get_tinfo() { return m_tinfo; }
+	sinsp_threadinfo* get_tinfo() { return m_tinfo; }
 
-	inline void set_tinfo(sinsp_threadinfo* v) { m_tinfo = v; }
+	void set_tinfo(sinsp_threadinfo* v) { m_tinfo = v; }
 
-	inline std::shared_ptr<const sinsp_fdinfo> get_fdinfo_ref() const { return m_fdinfo_ref; }
+	std::shared_ptr<const sinsp_fdinfo> get_fdinfo_ref() const { return m_fdinfo_ref; }
 
-	inline const std::shared_ptr<sinsp_fdinfo>& get_fdinfo_ref() { return m_fdinfo_ref; }
+	const std::shared_ptr<sinsp_fdinfo>& get_fdinfo_ref() { return m_fdinfo_ref; }
 
-	inline void set_fdinfo_ref(const std::shared_ptr<sinsp_fdinfo>& v) { m_fdinfo_ref = v; }
+	void set_fdinfo_ref(const std::shared_ptr<sinsp_fdinfo>& v) { m_fdinfo_ref = v; }
 
-	inline const std::vector<char>& get_paramstr_storage() const { return m_paramstr_storage; }
+	const std::vector<char>& get_paramstr_storage() const { return m_paramstr_storage; }
 
-	inline std::vector<char>& get_paramstr_storage() { return m_paramstr_storage; }
+	std::vector<char>& get_paramstr_storage() { return m_paramstr_storage; }
 
-	inline const std::vector<sinsp_evt_param>& get_params() const { return m_params; }
+	const std::vector<sinsp_evt_param>& get_params() const { return m_params; }
 
-	inline std::vector<sinsp_evt_param>& get_params() { return m_params; }
+	std::vector<sinsp_evt_param>& get_params() { return m_params; }
 
-	inline char extract_typechar() {
+	char extract_typechar() const {
 		switch(PPME_MAKE_EXIT(get_type())) {
 		case PPME_SYSCALL_OPENAT_2_X:
 		case PPME_SYSCALL_OPENAT2_X:
@@ -714,9 +710,9 @@ public:
 		}
 	}
 
-	inline bool is_syscall_event() const { return get_info()->category & EC_SYSCALL; }
+	bool is_syscall_event() const { return get_info()->category & EC_SYSCALL; }
 
-	inline bool has_return_value() {
+	bool has_return_value() {
 		// This event does not have a return value
 		if(get_type() == PPME_GENERIC_X) {
 			return false;
@@ -734,7 +730,7 @@ public:
 		return false;
 	}
 
-	inline int64_t get_syscall_return_value() {
+	int64_t get_syscall_return_value() {
 		if(!has_return_value()) {
 			throw sinsp_exception(
 			        "Called get_syscall_return_value() on an event that does not have a return "
@@ -746,7 +742,7 @@ public:
 		// The return value is always the first parameter of the syscall event
 		// It could have different names depending on the event type `res`,`fd`, etc.
 		const sinsp_evt_param* p = get_param(0);
-		if(p == NULL) {
+		if(p == nullptr) {
 			// We should always have the return value in the syscall
 			ASSERT(false);
 			return 0;
@@ -755,7 +751,7 @@ public:
 		// the only return values should be on 32 or 64 bits
 		switch(p->len()) {
 		case sizeof(int32_t):
-			return (int64_t)p->as<int32_t>();
+			return p->as<int32_t>();
 		case sizeof(int64_t):
 			return p->as<int64_t>();
 		default:
@@ -764,9 +760,9 @@ public:
 		}
 	}
 
-	inline bool uses_fd() const { return get_info_flags() & EF_USES_FD; }
+	bool uses_fd() const { return get_info_flags() & EF_USES_FD; }
 
-	inline bool creates_fd() const { return get_info_flags() & EF_CREATES_FD; }
+	bool creates_fd() const { return get_info_flags() & EF_CREATES_FD; }
 
 private:
 	char* render_fd(int64_t fd, const char** resolved_str, param_fmt fmt);
@@ -780,7 +776,7 @@ private:
 	uint64_t m_evtnum;
 	uint32_t m_flags;
 	uint32_t m_dump_flags;
-	const struct ppm_event_info* m_info;
+	const ppm_event_info* m_info;
 	std::vector<sinsp_evt_param> m_params;
 
 	std::vector<char> m_paramstr_storage;
@@ -800,7 +796,7 @@ private:
 	int32_t m_errorcode;
 	int32_t m_rawbuf_str_len;
 	bool m_filtered_out;
-	const struct ppm_event_info* m_event_info_table;
+	const ppm_event_info* m_event_info_table;
 
 	std::shared_ptr<sinsp_fdinfo> m_fdinfo_ref;
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -626,11 +626,6 @@ public:
 	}
 
 	std::string get_param_value_str(uint32_t id, bool resolved);
-	char* render_fd(int64_t fd, const char** resolved_str, sinsp_evt::param_fmt fmt);
-	int render_fd_json(Json::Value* ret,
-	                   int64_t fd,
-	                   const char** resolved_str,
-	                   sinsp_evt::param_fmt fmt);
 	inline uint32_t get_dump_flags() const { return m_dump_flags; }
 	inline void set_dump_flags(uint32_t v) { m_dump_flags = v; }
 	int32_t get_errorcode() const { return m_errorcode; }
@@ -774,6 +769,9 @@ public:
 	inline bool creates_fd() const { return get_info_flags() & EF_CREATES_FD; }
 
 private:
+	char* render_fd(int64_t fd, const char** resolved_str, param_fmt fmt);
+	int render_fd_json(Json::Value* ret, int64_t fd, const char** resolved_str, param_fmt fmt);
+
 	sinsp* m_inspector;
 	scap_evt* m_pevt;
 	char* m_pevt_storage;  // In some cases an alternate buffer is used to hold m_pevt. This points


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR modernizes `sinsp_evt` code by removing C-style casts, and a bunch of redundancy. Moreover, it makes `sinsp_evt::render_fd{,_json}` private, as they are only used internally.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
chore(userspace)!: `sinsp_evt::render_fd{,_json}` are now private
```
