### PR TITLE
refactor(userspace/libsinsp): remove default_re2_deleter and ensure_unique_ptr_allocated_deleter

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 #include <cinttypes>
+#include <utility>
 
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
@@ -49,27 +50,18 @@ std::string std::to_string(boolop b) {
 	return "<unset>";
 }
 
-void sinsp_filter_check::default_re2_deleter::operator()(re2::RE2* __ptr) const {
-	std::default_delete<re2::RE2>{}(__ptr);
-}
-
 template<typename Ptr, typename... Params>
-static inline void ensure_unique_ptr_allocated(Ptr& p, Params... args) {
+static inline void ensure_unique_ptr_allocated(Ptr& p, Params&&... args) {
 	if(!p) {
-		p = std::make_unique<typename Ptr::element_type>(args...);
-	}
-}
-
-template<typename Ptr, typename... Params>
-static inline void ensure_unique_ptr_allocated_deleter(Ptr& p, Params... args) {
-	if(!p) {
-		p.reset(new typename Ptr::element_type(args...));
+		p = std::make_unique<typename Ptr::element_type>(std::forward<Params>(args)...);
 	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // sinsp_filter_check implementation
 ///////////////////////////////////////////////////////////////////////////////
+sinsp_filter_check::~sinsp_filter_check() = default;
+
 sinsp_filter_check::sinsp_filter_check() {
 	m_boolop = BO_NONE;
 	m_cmpop = CO_NONE;
@@ -632,9 +624,9 @@ void sinsp_filter_check::add_filter_value(const char* str, uint32_t len, uint32_
 		ensure_unique_ptr_allocated(m_val_storages_paths);
 		m_val_storages_paths->add_search_path(item);
 	} else if(m_cmpop == CO_REGEX) {
-		ensure_unique_ptr_allocated_deleter(m_val_regex,
-		                                    re2::StringPiece((const char*)item.first),
-		                                    re2::RE2::POSIX);
+		ensure_unique_ptr_allocated(m_val_regex,
+		                            re2::StringPiece((const char*)item.first),
+		                            re2::RE2::POSIX);
 		if(scap_unlikely(!m_val_regex->ok())) {
 			throw sinsp_exception("invalid regex pattern: " + m_val_regex->error());
 		}

--- a/userspace/libsinsp/sinsp_filtercheck.h
+++ b/userspace/libsinsp/sinsp_filtercheck.h
@@ -59,7 +59,7 @@ std::string to_string(boolop);
 class sinsp_filter_check {
 public:
 	sinsp_filter_check();
-	virtual ~sinsp_filter_check() = default;
+	virtual ~sinsp_filter_check();
 
 	//
 	// Sets an inspector to be used internally.
@@ -356,10 +356,7 @@ private:
 	uint32_t m_val_storages_min_size;
 	uint32_t m_val_storages_max_size;
 
-	struct default_re2_deleter {
-		void operator()(re2::RE2* __ptr) const;
-	};
-	std::unique_ptr<re2::RE2, default_re2_deleter> m_val_regex;
+	std::unique_ptr<re2::RE2> m_val_regex;
 
 	static constexpr const size_t s_min_filter_value_buf_size = 16;
 	static constexpr const size_t s_max_filter_value_buf_size = 256;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`ensure_unique_ptr_allocated_deleter` and the `default_re2_deleter` custom deleter were hacks to work around the incomplete-type constraint on `std::unique_ptr<re2::RE2>` (the deleter's operator() was defined in the .cpp solely to pin RE2 destruction to that translation unit). This replaces them by moving sinsp_filter_check's destructor definition out of the header into sinsp_filtercheck.cpp, where re2::RE2 is a complete type, allowing a plain `std::unique_ptr<re2::RE2>` with the standard deleter. All lazy-init sites continue to go through the existing `ensure_unique_ptr_allocated` helper, now including the regex case.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
