### PR TITLE
fix(driver/modern_bpf): consolidate capture_settings lookups to fix clang-20 regression

### DIFF
--- a/driver/modern_bpf/helpers/interfaces/toctou_mitigation.h
+++ b/driver/modern_bpf/helpers/interfaces/toctou_mitigation.h
@@ -16,7 +16,12 @@ static __always_inline bool toctou_mitigation__sampling_logic_enter(uint32_t sys
 	 * - false: means don't drop the syscall
 	 * - true: means drop the syscall
 	 */
-	if(!maps__get_dropping_mode()) {
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return false;
+	}
+
+	if(!settings->dropping_mode) {
 		return false;
 	}
 
@@ -31,7 +36,7 @@ static __always_inline bool toctou_mitigation__sampling_logic_enter(uint32_t sys
 	}
 
 	// If we are in the sampling period we drop the event.
-	if((bpf_ktime_get_boot_ns() % SECOND_TO_NS) >= (SECOND_TO_NS / maps__get_sampling_ratio())) {
+	if((bpf_ktime_get_boot_ns() % SECOND_TO_NS) >= (SECOND_TO_NS / settings->sampling_ratio)) {
 		return true;
 	}
 

--- a/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
+++ b/driver/modern_bpf/programs/attached/dispatchers/syscall_exit.bpf.c
@@ -127,7 +127,12 @@ static __always_inline bool sampling_logic_exit(void *ctx, uint32_t id) {
 	 * false: means don't drop the syscall
 	 * true: means drop the syscall
 	 */
-	if(!maps__get_dropping_mode()) {
+	struct capture_settings *settings = maps__get_capture_settings();
+	if(settings == NULL) {
+		return false;
+	}
+
+	if(!settings->dropping_mode) {
 		return false;
 	}
 
@@ -141,7 +146,7 @@ static __always_inline bool sampling_logic_exit(void *ctx, uint32_t id) {
 		return true;
 	}
 
-	if((bpf_ktime_get_boot_ns() % SECOND_TO_NS) >= (SECOND_TO_NS / maps__get_sampling_ratio())) {
+	if((bpf_ktime_get_boot_ns() % SECOND_TO_NS) >= (SECOND_TO_NS / settings->sampling_ratio)) {
 		/* If we are starting the dropping phase we need to notify the userspace, otherwise, we
 		 * simply drop our event.
 		 * PLEASE NOTE: this logic is not per-CPU so it is best effort!


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area drivers

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
Consolidates double `maps__get_capture_settings`() calls in sampling_logic_exit() and toctou_mitigation into a single lookup reused across dropping_mode and sampling_ratio access. **clang-20** **optimizes** away the NULL check on the second bpf_map_lookup_elem call after __always_inline expansion, causing BPF verifier rejection with `R0 invalid mem access 'map_value_or_null' `on all architectures. This fixes Falco modern eBPF probe startup failure when built with clang-20, which is the default compiler on current distributions like **RHEL 9**. Below is detailed error log for reference:

> 42: (07) r2 += -8                     ; R2_w=fp-8
; return bpf_map_lookup_elem(&capture_settings, &key); @ maps_getters.h:22
43: (18) r1 = 0xffffa035857d7200      ; R1_w=map_ptr(map=capture_setting,ks=4,vs=32)
45: (85) call bpf_map_lookup_elem#1   ; R0=map_value_or_null(id=4,map=capture_setting,ks=4,vs=32)
; if(settings == NULL) { @ maps_getters.h:45
46: (15) if r0 == 0x0 goto pc+141     ; R0=map_value(map=capture_setting,ks=4,vs=32)
; return settings->dropping_mode; @ maps_getters.h:49
65: (85) call bpf_map_lookup_elem#1   ; R0=map_value_or_null(id=6,map=capture_setting,ks=4,vs=32)
; return settings->sampling_ratio; @ maps_getters.h:58
66: (61) r1 = *(u32 *)(r0 +16)
R0 invalid mem access 'map_value_or_null'

Confirmed on x86_64 and s390x with clang-20.1.8, RHEL 9.6, kernel 5.14.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
