### PR TITLE
cleanup(libsinsp): use lambdas to access dynamic/STL fields

### DIFF
--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -28,7 +28,7 @@ limitations under the License.
 static const auto s_fdtable_static_fields = sinsp_fdinfo::get_static_fields();
 
 sinsp_fdtable::sinsp_fdtable(const std::shared_ptr<ctor_params>& params):
-        extensible_table{"file_descriptors", &s_fdtable_static_fields},
+        extensible_table{type_tag<sinsp_fdinfo>{}, "file_descriptors", &s_fdtable_static_fields},
         m_params{params},
         m_tid{0} {
 	reset_cache();

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -166,8 +166,8 @@ sinsp::sinsp(bool with_metrics):
         m_evt(this),
         m_timestamper{0},
         m_host_root(scap_get_host_root()),
-        m_thread_manager_dyn_fields{std::make_shared<libsinsp::state::dynamic_field_infos>()},
-        m_fdtable_dyn_fields{std::make_shared<libsinsp::state::dynamic_field_infos>()},
+        m_thread_manager_dyn_fields{libsinsp::state::dynamic_field_infos::make<sinsp_threadinfo>()},
+        m_fdtable_dyn_fields{libsinsp::state::dynamic_field_infos::make<sinsp_fdinfo>()},
         m_fdinfo_factory{this, &m_external_event_processor, m_fdtable_dyn_fields},
         m_fdtable_ctor_params{std::make_shared<sinsp_fdtable::ctor_params>(
                 sinsp_fdtable::ctor_params{m_mode,

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -104,7 +104,6 @@ public:
 	inline dynamic_field_info(const std::string& n,
 	                          size_t in,
 	                          ss_plugin_state_type t,
-	                          uintptr_t defsptr,
 	                          bool r,
 	                          accessor::reader_fn reader,
 	                          accessor::writer_fn writer):
@@ -112,23 +111,16 @@ public:
 	        m_index(in),
 	        m_name(n),
 	        m_type_id(t),
-	        m_defs_id(defsptr),
 	        m_reader(reader),
 	        m_writer(writer) {}
 
 	friend inline bool operator==(const dynamic_field_info& a, const dynamic_field_info& b) {
-		return a.type_id() == b.type_id() && a.name() == b.name() && a.m_index == b.m_index &&
-		       a.m_defs_id == b.m_defs_id;
+		return a.type_id() == b.type_id() && a.name() == b.name() && a.m_index == b.m_index;
 	};
 
 	friend inline bool operator!=(const dynamic_field_info& a, const dynamic_field_info& b) {
 		return !(a == b);
 	};
-
-	/**
-	 * @brief Returns the id of the shared definitions this info belongs to.
-	 */
-	inline uintptr_t defs_id() const { return m_defs_id; }
 
 	/**
 	 * @brief Returns true if the field is read only.
@@ -171,7 +163,6 @@ private:
 	size_t m_index;
 	std::string m_name;
 	ss_plugin_state_type m_type_id;
-	uintptr_t m_defs_id;
 	accessor::reader_fn m_reader;
 	accessor::writer_fn m_writer;
 
@@ -204,17 +195,13 @@ void write_dynamic_field(void* obj, size_t index, const libsinsp::state::borrowe
 class dynamic_field_infos {
 public:
 	inline dynamic_field_infos(accessor::reader_fn reader, accessor::writer_fn writer):
-	        m_defs_id((uintptr_t)this),
 	        m_reader(reader),
 	        m_writer(writer) {};
-	inline explicit dynamic_field_infos(uintptr_t defs_id): m_defs_id(defs_id) {};
 	virtual ~dynamic_field_infos() = default;
 	inline dynamic_field_infos(dynamic_field_infos&&) = default;
 	inline dynamic_field_infos& operator=(dynamic_field_infos&&) = default;
 	inline dynamic_field_infos(const dynamic_field_infos& s) = delete;
 	inline dynamic_field_infos& operator=(const dynamic_field_infos& s) = delete;
-
-	inline uintptr_t id() const { return m_defs_id; }
 
 	template<typename T>
 	static std::shared_ptr<dynamic_field_infos> make() {
@@ -231,13 +218,8 @@ public:
 	 */
 	inline const dynamic_field_info& add_field(const std::string& name,
 	                                           ss_plugin_state_type type_id) {
-		auto field = dynamic_field_info(name,
-		                                m_definitions.size(),
-		                                type_id,
-		                                id(),
-		                                false,
-		                                m_reader,
-		                                m_writer);
+		auto field =
+		        dynamic_field_info(name, m_definitions.size(), type_id, false, m_reader, m_writer);
 		return add_field_info(field);
 	}
 
@@ -270,7 +252,6 @@ protected:
 		return def;
 	}
 
-	uintptr_t m_defs_id;
 	std::unordered_map<std::string, dynamic_field_info> m_definitions;
 	std::vector<const dynamic_field_info*> m_definitions_ordered;
 	accessor::reader_fn m_reader;

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -105,12 +105,14 @@ public:
 	                          size_t in,
 	                          ss_plugin_state_type t,
 	                          uintptr_t defsptr,
-	                          bool r):
+	                          bool r,
+	                          accessor::reader_fn reader):
 	        m_readonly(r),
 	        m_index(in),
 	        m_name(n),
 	        m_type_id(t),
-	        m_defs_id(defsptr) {}
+	        m_defs_id(defsptr),
+	        m_reader(reader) {}
 
 	friend inline bool operator==(const dynamic_field_info& a, const dynamic_field_info& b) {
 		return a.type_id() == b.type_id() && a.name() == b.name() && a.m_index == b.m_index &&
@@ -168,9 +170,20 @@ private:
 	std::string m_name;
 	ss_plugin_state_type m_type_id;
 	uintptr_t m_defs_id;
+	accessor::reader_fn m_reader;
 
+	friend class dynamic_field_accessor;
 	friend class extensible_struct;
 };
+
+template<typename T>
+borrowed_state_data read_dynamic_field(const void* obj, size_t index) {
+	auto dstruct = static_cast<const T*>(obj);
+	if(auto ptr = dstruct->_access_dynamic_field_for_read(index)) {
+		return borrowed_state_data(ptr->m_data);
+	}
+	return {};
+}
 
 /**
  * @brief Dynamic fields metadata of a given struct or class
@@ -180,7 +193,9 @@ private:
  */
 class dynamic_field_infos {
 public:
-	inline dynamic_field_infos(): m_defs_id((uintptr_t)this) {};
+	inline dynamic_field_infos(accessor::reader_fn reader):
+	        m_defs_id((uintptr_t)this),
+	        m_reader(reader) {};
 	inline explicit dynamic_field_infos(uintptr_t defs_id): m_defs_id(defs_id) {};
 	virtual ~dynamic_field_infos() = default;
 	inline dynamic_field_infos(dynamic_field_infos&&) = default;
@@ -189,6 +204,11 @@ public:
 	inline dynamic_field_infos& operator=(const dynamic_field_infos& s) = delete;
 
 	inline uintptr_t id() const { return m_defs_id; }
+
+	template<typename T>
+	static std::shared_ptr<dynamic_field_infos> make() {
+		return std::make_shared<dynamic_field_infos>(read_dynamic_field<T>);
+	}
 
 	/**
 	 * @brief Adds metadata for a new field to the list. An exception is
@@ -200,7 +220,7 @@ public:
 	 */
 	inline const dynamic_field_info& add_field(const std::string& name,
 	                                           ss_plugin_state_type type_id) {
-		auto field = dynamic_field_info(name, m_definitions.size(), type_id, id(), false);
+		auto field = dynamic_field_info(name, m_definitions.size(), type_id, id(), false, m_reader);
 		return add_field_info(field);
 	}
 
@@ -236,6 +256,8 @@ protected:
 	uintptr_t m_defs_id;
 	std::unordered_map<std::string, dynamic_field_info> m_definitions;
 	std::vector<const dynamic_field_info*> m_definitions_ordered;
+	accessor::reader_fn m_reader;
+
 	friend class extensible_struct;
 };
 
@@ -252,6 +274,10 @@ public:
 	inline explicit dynamic_field_accessor(const dynamic_field_info& info):
 	        accessor(info.type_id()),
 	        m_info(info) {};
+
+	inline borrowed_state_data read(const void* obj) const {
+		return m_info.m_reader(obj, m_info.index());
+	}
 
 private:
 	dynamic_field_info m_info;

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -106,13 +106,15 @@ public:
 	                          ss_plugin_state_type t,
 	                          uintptr_t defsptr,
 	                          bool r,
-	                          accessor::reader_fn reader):
+	                          accessor::reader_fn reader,
+	                          accessor::writer_fn writer):
 	        m_readonly(r),
 	        m_index(in),
 	        m_name(n),
 	        m_type_id(t),
 	        m_defs_id(defsptr),
-	        m_reader(reader) {}
+	        m_reader(reader),
+	        m_writer(writer) {}
 
 	friend inline bool operator==(const dynamic_field_info& a, const dynamic_field_info& b) {
 		return a.type_id() == b.type_id() && a.name() == b.name() && a.m_index == b.m_index &&
@@ -171,6 +173,7 @@ private:
 	ss_plugin_state_type m_type_id;
 	uintptr_t m_defs_id;
 	accessor::reader_fn m_reader;
+	accessor::writer_fn m_writer;
 
 	friend class dynamic_field_accessor;
 	friend class extensible_struct;
@@ -185,6 +188,13 @@ borrowed_state_data read_dynamic_field(const void* obj, size_t index) {
 	return {};
 }
 
+template<typename T>
+void write_dynamic_field(void* obj, size_t index, const libsinsp::state::borrowed_state_data& in) {
+	auto dstruct = static_cast<T*>(obj);
+	auto ptr = dstruct->_access_dynamic_field_for_write(index);
+	ptr->update(in);
+}
+
 /**
  * @brief Dynamic fields metadata of a given struct or class
  * that are discoverable and accessible dynamically at runtime.
@@ -193,9 +203,10 @@ borrowed_state_data read_dynamic_field(const void* obj, size_t index) {
  */
 class dynamic_field_infos {
 public:
-	inline dynamic_field_infos(accessor::reader_fn reader):
+	inline dynamic_field_infos(accessor::reader_fn reader, accessor::writer_fn writer):
 	        m_defs_id((uintptr_t)this),
-	        m_reader(reader) {};
+	        m_reader(reader),
+	        m_writer(writer) {};
 	inline explicit dynamic_field_infos(uintptr_t defs_id): m_defs_id(defs_id) {};
 	virtual ~dynamic_field_infos() = default;
 	inline dynamic_field_infos(dynamic_field_infos&&) = default;
@@ -207,7 +218,7 @@ public:
 
 	template<typename T>
 	static std::shared_ptr<dynamic_field_infos> make() {
-		return std::make_shared<dynamic_field_infos>(read_dynamic_field<T>);
+		return std::make_shared<dynamic_field_infos>(read_dynamic_field<T>, write_dynamic_field<T>);
 	}
 
 	/**
@@ -220,7 +231,13 @@ public:
 	 */
 	inline const dynamic_field_info& add_field(const std::string& name,
 	                                           ss_plugin_state_type type_id) {
-		auto field = dynamic_field_info(name, m_definitions.size(), type_id, id(), false, m_reader);
+		auto field = dynamic_field_info(name,
+		                                m_definitions.size(),
+		                                type_id,
+		                                id(),
+		                                false,
+		                                m_reader,
+		                                m_writer);
 		return add_field_info(field);
 	}
 
@@ -257,6 +274,7 @@ protected:
 	std::unordered_map<std::string, dynamic_field_info> m_definitions;
 	std::vector<const dynamic_field_info*> m_definitions_ordered;
 	accessor::reader_fn m_reader;
+	accessor::writer_fn m_writer;
 
 	friend class extensible_struct;
 };
@@ -277,6 +295,10 @@ public:
 
 	inline borrowed_state_data read(const void* obj) const {
 		return m_info.m_reader(obj, m_info.index());
+	}
+
+	inline void write(void* obj, const borrowed_state_data& in) const {
+		m_info.m_writer(obj, m_info.index(), in);
 	}
 
 private:

--- a/userspace/libsinsp/state/dynamic_struct.h
+++ b/userspace/libsinsp/state/dynamic_struct.h
@@ -94,7 +94,6 @@ struct dynamic_field_value {
 };
 
 class extensible_struct;
-class dynamic_field_accessor;
 
 /**
  * @brief Info about a given field in a dynamic struct.
@@ -261,32 +260,6 @@ protected:
 };
 
 /**
- * @brief An accessor for accessing a field of a dynamic struct.
- */
-class dynamic_field_accessor : public accessor {
-public:
-	/**
-	 * @brief Returns the info about the field to which this accessor is tied.
-	 */
-	inline const dynamic_field_info& info() const { return m_info; }
-
-	inline explicit dynamic_field_accessor(const dynamic_field_info& info):
-	        accessor(info.type_id()),
-	        m_info(info) {};
-
-	inline borrowed_state_data read(const void* obj) const {
-		return m_info.m_reader(obj, m_info.index());
-	}
-
-	inline void write(void* obj, const borrowed_state_data& in) const {
-		m_info.m_writer(obj, m_info.index(), in);
-	}
-
-private:
-	dynamic_field_info m_info;
-};
-
-/**
  * @brief Returns a strongly-typed accessor for the given field,
  * that can be used to reading and writing the field's value in
  * all instances of structs where it is defined.
@@ -295,7 +268,7 @@ inline accessor::ptr dynamic_field_info::new_accessor() const {
 	if(!valid()) {
 		throw sinsp_exception("can't create dynamic struct field accessor for invalid field");
 	}
-	return accessor::ptr(std::make_unique<dynamic_field_accessor>(*this));
+	return accessor::ptr(std::make_unique<accessor>(type_id(), m_reader, m_writer, m_index));
 }
 
 };  // namespace libsinsp::state

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -129,38 +129,12 @@ private:
 	// end of dynamic_struct interface
 
 	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const override {
-		if(auto static_acc = dynamic_cast<const static_field_accessor*>(&a)) {
-			return static_acc->info().read(this, 0);
-		}
-
-		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
-			return dynamic_acc->read(this);
-		}
-
-#ifdef _MSC_VER
-		_assume(0);
-#else
-		__builtin_unreachable();
-#endif
+		return a.read(this);
 	}
 
 protected:
 	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
-		if(auto static_acc = dynamic_cast<const static_field_accessor*>(&a)) {
-			static_acc->info().write(this, 0, in);
-			return;
-		}
-
-		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
-			dynamic_acc->write(this, in);
-			return;
-		}
-
-#ifdef _MSC_VER
-		_assume(0);
-#else
-		__builtin_unreachable();
-#endif
+		a.write(this, in);
 	}
 
 	template<typename T>

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -128,15 +128,7 @@ private:
 	std::shared_ptr<dynamic_field_infos> m_dynamic_fields;
 	// end of dynamic_struct interface
 
-	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const override {
-		return a.read(this);
-	}
-
 protected:
-	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
-		a.write(this, in);
-	}
-
 	template<typename T>
 	friend borrowed_state_data read_dynamic_field(const void* obj, size_t index);
 

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -147,11 +147,7 @@ private:
 		}
 
 		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
-			_check_defsptr(dynamic_acc->info(), false);
-			if(auto ptr = _access_dynamic_field_for_read(dynamic_acc->info().index())) {
-				return borrowed_state_data(ptr->m_data);
-			}
-			return {};
+			return dynamic_acc->read(this);
 		}
 
 #ifdef _MSC_VER
@@ -180,6 +176,9 @@ protected:
 		__builtin_unreachable();
 #endif
 	}
+
+	template<typename T>
+	friend borrowed_state_data read_dynamic_field(const void* obj, size_t index);
 };
 
 /**

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -68,19 +68,6 @@ protected:
 	}
 
 private:
-	inline void _check_defsptr(const dynamic_field_info& i, bool write) const {
-		if(!i.valid()) {
-			throw sinsp_exception("can't set invalid field in dynamic struct");
-		}
-		if(m_dynamic_fields->id() != i.m_defs_id) {
-			throw sinsp_exception(
-			        "using dynamic field accessor on struct it was not created from: " + i.name());
-		}
-		if(write && i.readonly()) {
-			throw sinsp_exception("can't set a read-only dynamic struct field: " + i.name());
-		}
-	}
-
 	inline dynamic_field_value* _access_dynamic_field_for_write(size_t index) {
 		if(!m_dynamic_fields) {
 			throw sinsp_exception("dynamic struct has no field definitions");

--- a/userspace/libsinsp/state/extensible_struct.h
+++ b/userspace/libsinsp/state/extensible_struct.h
@@ -165,8 +165,7 @@ protected:
 		}
 
 		if(auto dynamic_acc = dynamic_cast<const dynamic_field_accessor*>(&a)) {
-			auto ptr = _access_dynamic_field_for_write(dynamic_acc->info().index());
-			ptr->update(in);
+			dynamic_acc->write(this, in);
 			return;
 		}
 
@@ -179,6 +178,9 @@ protected:
 
 	template<typename T>
 	friend borrowed_state_data read_dynamic_field(const void* obj, size_t index);
+
+	template<typename T>
+	friend void write_dynamic_field(void* obj, size_t index, const borrowed_state_data& in);
 };
 
 /**

--- a/userspace/libsinsp/state/static_struct.h
+++ b/userspace/libsinsp/state/static_struct.h
@@ -27,8 +27,6 @@ limitations under the License.
 namespace libsinsp {
 namespace state {
 
-class static_field_accessor;
-
 /**
  * @brief Info about a given field in a static struct.
  */
@@ -60,13 +58,12 @@ public:
 	/**
 	 * @brief Returns the reader function for this field.
 	 */
-	inline borrowed_state_data read(const void* obj, size_t index) const {
-		return m_reader(obj, index);
-	}
+	inline accessor::reader_fn reader() const { return m_reader; }
 
-	inline void write(void* obj, size_t index, const borrowed_state_data& data) const {
-		m_writer(obj, index, data);
-	}
+	/**
+	 * @brief Returns the writer function for this field.
+	 */
+	inline accessor::writer_fn writer() const { return m_writer; }
 
 	/**
 	 * @brief Returns a strongly-typed accessor for the given field,
@@ -95,25 +92,6 @@ private:
 };
 
 /**
- * @brief An accessor for accessing a field of a static struct.
- * @tparam T Type of the field.
- */
-class static_field_accessor : public accessor {
-public:
-	/**
-	 * @brief Returns the info about the field to which this accessor is tied.
-	 */
-	[[nodiscard]] const static_field_info& info() const { return m_info; }
-
-	explicit static_field_accessor(static_field_info info):
-	        accessor(info.type_id()),
-	        m_info(std::move(info)) {};
-
-private:
-	static_field_info m_info;
-};
-
-/**
  * @brief A group of field infos, describing all the ones available
  * in a static struct.
  */
@@ -125,7 +103,7 @@ using static_field_infos = std::unordered_map<std::string, static_field_info>;
  * all instances of structs where it is defined.
  */
 inline accessor::ptr static_field_info::new_accessor() const {
-	return accessor::ptr(std::make_unique<static_field_accessor>(*this));
+	return accessor::ptr(std::make_unique<accessor>(type_id(), reader(), writer(), 0));
 }
 
 };  // namespace state

--- a/userspace/libsinsp/state/table.h
+++ b/userspace/libsinsp/state/table.h
@@ -334,18 +334,26 @@ private:
 template<typename KeyType>
 class extensible_table : public built_in_table<KeyType> {
 public:
+	template<typename T>
+	struct type_tag {
+		using type = T;
+	};
+
+	template<typename T>
 	inline extensible_table(
+	        type_tag<T>,
 	        const std::string& name,
 	        const static_field_infos* static_fields,
 	        const std::shared_ptr<libsinsp::state::dynamic_field_infos>& dynamic_fields = nullptr):
 	        built_in_table<KeyType>(name),
 	        m_static_fields(static_fields),
 	        m_dynamic_fields(dynamic_fields != nullptr ? dynamic_fields
-	                                                   : std::make_shared<dynamic_field_infos>()) {}
+	                                                   : dynamic_field_infos::make<T>()) {}
 
-	inline extensible_table(const std::string& name):
+	template<typename T>
+	inline extensible_table(type_tag<T>, const std::string& name):
 	        built_in_table<KeyType>(name),
-	        m_dynamic_fields(std::make_shared<dynamic_field_infos>()) {}
+	        m_dynamic_fields(dynamic_field_infos::make<T>()) {}
 
 	/**
 	 * @brief Returns the fields metadata list for the static fields defined

--- a/userspace/libsinsp/state/table_adapters.h
+++ b/userspace/libsinsp/state/table_adapters.h
@@ -21,9 +21,9 @@ namespace state {
 
 class stl_table_entry_accessor : public accessor {
 public:
-	stl_table_entry_accessor(ss_plugin_state_type type_id, int m_index):
-	        accessor(type_id),
-	        m_index(m_index) {}
+	stl_table_entry_accessor(ss_plugin_state_type type_id, int index):
+	        accessor(type_id, nullptr, nullptr, index),
+	        m_index(index) {}
 
 	[[nodiscard]] int index() const { return m_index; }
 

--- a/userspace/libsinsp/state/table_adapters.h
+++ b/userspace/libsinsp/state/table_adapters.h
@@ -19,18 +19,6 @@ limitations under the License.
 namespace libsinsp {
 namespace state {
 
-class stl_table_entry_accessor : public accessor {
-public:
-	stl_table_entry_accessor(ss_plugin_state_type type_id, int index):
-	        accessor(type_id, nullptr, nullptr, index),
-	        m_index(index) {}
-
-	[[nodiscard]] int index() const { return m_index; }
-
-private:
-	const int m_index;
-};
-
 /**
  * @brief An adapter for the libsinsp::state::table_entry interface
  * that wraps a non-owning pointer of arbitrary pair of type T. The underlying pointer
@@ -62,27 +50,25 @@ public:
 				throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 				                      std::string(name));
 			}
-			return accessor::ptr(std::make_unique<stl_table_entry_accessor>(tinfo, 0));
+			return accessor::ptr(std::make_unique<accessor>(tinfo, nullptr, nullptr, 0));
 		} else if(strcmp(name, "second") == 0) {
 			auto tinfo = type_id_of<Tsecond>();
 			if(type_id != tinfo) {
 				throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 				                      std::string(name));
 			}
-			return accessor::ptr(std::make_unique<stl_table_entry_accessor>(tinfo, 1));
+			return accessor::ptr(std::make_unique<accessor>(tinfo, nullptr, nullptr, 1));
 		}
 		throw sinsp_exception(std::string("field ") + name + " not found");
 	}
 
 	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const override {
-		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
-
-		if(acc->index() == 0) {
-			if(acc->type_id() == type_id_of<Tfirst>()) {
+		if(a.index() == 0) {
+			if(a.type_id() == type_id_of<Tfirst>()) {
 				return borrowed_state_data::from<type_id_of<Tfirst>()>(m_value->first);
 			}
 		} else {
-			if(acc->type_id() == type_id_of<Tsecond>()) {
+			if(a.type_id() == type_id_of<Tsecond>()) {
 				return borrowed_state_data::from<type_id_of<Tsecond>()>(m_value->second);
 			}
 		}
@@ -91,8 +77,7 @@ public:
 	}
 
 	void raw_write_field(const accessor& a, const borrowed_state_data& in) override {
-		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
-		if(acc->index() == 0) {
+		if(a.index() == 0) {
 			if(a.type_id() != type_id_of<Tfirst>()) {
 				throw sinsp_exception("incompatible type for pair_table_entry_adapter field: " +
 				                      std::string(type_name(a.type_id())));
@@ -146,7 +131,7 @@ public:
 				throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +
 				                      std::string(name));
 			}
-			return accessor::ptr(std::make_unique<stl_table_entry_accessor>(tinfo, 0));
+			return accessor::ptr(std::make_unique<accessor>(tinfo, nullptr, nullptr, 0));
 		}
 		throw sinsp_exception(std::string("field ") + name + " not found");
 	}
@@ -156,8 +141,7 @@ public:
 			throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +
 			                      std::string(type_name(a.type_id())));
 		}
-		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
-		if(acc->index() != 0) {
+		if(a.index() != 0) {
 			throw sinsp_exception(
 			        "invalid field info passed to value_table_entry_adapter::read_field");
 		}
@@ -170,8 +154,7 @@ protected:
 			throw sinsp_exception("incompatible type for value_table_entry_adapter field: " +
 			                      std::string(type_name(a.type_id())));
 		}
-		auto acc = dynamic_cast<const stl_table_entry_accessor*>(&a);
-		if(acc->index() != 0) {
+		if(a.index() != 0) {
 			throw sinsp_exception(
 			        "invalid field info passed to value_table_entry_adapter::write_field");
 		}

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -176,7 +176,7 @@ public:
 		write_field(a.as_ref(), in);
 	}
 
-	[[nodiscard]] virtual borrowed_state_data raw_read_field(const accessor& a) const {
+	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const {
 		return a.read(this);
 	}
 

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -126,6 +126,8 @@ public:
 		m_writer(obj, m_index, in);
 	}
 
+	size_t index() const { return m_index; }
+
 protected:
 	ss_plugin_state_type m_type_id;
 	reader_fn m_reader;

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -180,9 +180,7 @@ public:
 		return a.read(this);
 	}
 
-	virtual void raw_write_field(const accessor& a, const borrowed_state_data& in) {
-		a.write(this, in);
-	}
+	void raw_write_field(const accessor& a, const borrowed_state_data& in) { a.write(this, in); }
 };
 
 template<>

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -84,7 +84,14 @@ public:
 		std::unique_ptr<const accessor> m_ptr;
 	};
 
-	explicit accessor(ss_plugin_state_type type_id): m_type_id(type_id) {}
+	explicit accessor(ss_plugin_state_type type_id,
+	                  reader_fn reader,
+	                  writer_fn writer,
+	                  size_t index):
+	        m_type_id(type_id),
+	        m_reader(reader),
+	        m_writer(writer),
+	        m_index(index) {}
 	virtual ~accessor() = default;
 
 	[[nodiscard]] ss_plugin_state_type type_id() const { return m_type_id; }
@@ -105,8 +112,25 @@ public:
 		return typed_ref<T>(*this);
 	}
 
+	borrowed_state_data read(const void* obj) const {
+		if(m_reader == nullptr) {
+			throw sinsp_exception("accessor has no reader function");
+		}
+		return m_reader(obj, m_index);
+	}
+
+	void write(void* obj, const borrowed_state_data& in) const {
+		if(m_writer == nullptr) {
+			throw sinsp_exception("accessor has no writer function");
+		}
+		m_writer(obj, m_index, in);
+	}
+
 protected:
 	ss_plugin_state_type m_type_id;
+	reader_fn m_reader;
+	writer_fn m_writer;
+	size_t m_index;
 };
 
 /**

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -176,8 +176,13 @@ public:
 		write_field(a.as_ref(), in);
 	}
 
-	[[nodiscard]] virtual borrowed_state_data raw_read_field(const accessor& a) const = 0;
-	virtual void raw_write_field(const accessor& a, const borrowed_state_data& in) = 0;
+	[[nodiscard]] virtual borrowed_state_data raw_read_field(const accessor& a) const {
+		return a.read(this);
+	}
+
+	virtual void raw_write_field(const accessor& a, const borrowed_state_data& in) {
+		a.write(this, in);
+	}
 };
 
 template<>

--- a/userspace/libsinsp/state/table_entry.h
+++ b/userspace/libsinsp/state/table_entry.h
@@ -145,7 +145,8 @@ public:
 	template<typename T>
 	T read_field(const accessor::typed_ref<T>& a) const {
 		T val{};
-		this->raw_read_field(a).template borrow_to<libsinsp::state::type_id_of<T>(), T>(val);
+		const auto& acc = static_cast<const accessor&>(a);
+		acc.read(this).borrow_to<libsinsp::state::type_id_of<T>(), T>(val);
 		return val;
 	}
 
@@ -168,25 +169,21 @@ public:
 	void write_field(const accessor::typed_ref<T>& a, const Val& in) {
 		borrowed_state_data in_val =
 		        borrowed_state_data::from<libsinsp::state::type_id_of<T>(), Val>(in);
-		this->raw_write_field(a, in_val);
+		const auto& acc = static_cast<const accessor&>(a);
+		acc.write(this, in_val);
 	}
 
 	template<typename T, typename Val = T>
 	void write_field(const accessor::typed_ptr<T>& a, const Val& in) {
 		write_field(a.as_ref(), in);
 	}
-
-	[[nodiscard]] borrowed_state_data raw_read_field(const accessor& a) const {
-		return a.read(this);
-	}
-
-	void raw_write_field(const accessor& a, const borrowed_state_data& in) { a.write(this, in); }
 };
 
 template<>
 inline void table_entry::read_field(const accessor::typed_ref<std::string>& a,
                                     const char*& out) const {
-	const auto val = this->raw_read_field(a);
+	const auto& acc = static_cast<const accessor&>(a);
+	const auto val = acc.read(this);
 	if(val.data().str == nullptr) {
 		out = "";
 	} else {

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -158,19 +158,25 @@ TEST(static_struct, defs_and_access) {
 }
 
 TEST(dynamic_struct, defs_and_access) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 	public:
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
 
+	struct sample_struct2 : public libsinsp::state::extensible_struct {
+	public:
+		sample_struct2(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
+		        extensible_struct(i) {}
+	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
+
 	// struct construction and setting fields definition
 	sample_struct s(fields);
 	ASSERT_ANY_THROW(s.set_dynamic_fields(nullptr));
 	ASSERT_ANY_THROW(
-	        s.set_dynamic_fields(std::make_shared<libsinsp::state::dynamic_field_infos>()));
+	        s.set_dynamic_fields(libsinsp::state::dynamic_field_infos::make<sample_struct>()));
 	// The double paranthesis fixes
 	// Error C2063 'std::shared_ptr<libsinsp::state::dynamic_field_infos>' : not a function
 	// C on the Windows compiler. This should be quirk of the Windows compiler.
@@ -229,12 +235,6 @@ TEST(dynamic_struct, defs_and_access) {
 	ctmpstr = "";
 	s.read_field(acc_str, ctmpstr);
 	ASSERT_EQ(strcmp(ctmpstr, "hello"), 0);
-
-	// illegal access from an accessor created from different definition list
-	auto fields2 = std::make_shared<libsinsp::state::dynamic_field_infos>();
-	auto field_num2 = fields2->add_field("num", SS_PLUGIN_ST_UINT64);
-	auto acc_num2 = field_num2.new_accessor().into<uint64_t>();
-	ASSERT_ANY_THROW(s.read_field(acc_num2, tmp));
 }
 
 TEST(dynamic_struct, mem_ownership) {
@@ -244,7 +244,7 @@ TEST(dynamic_struct, mem_ownership) {
 	};
 
 	std::string tmpstr1, tmpstr2;
-	auto defs1 = std::make_shared<libsinsp::state::dynamic_field_infos>();
+	auto defs1 = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	// construct two entries, test safety checks
 	sample_struct s1(nullptr);
@@ -254,7 +254,7 @@ TEST(dynamic_struct, mem_ownership) {
 	ASSERT_ANY_THROW(s1.set_dynamic_fields(nullptr));
 	ASSERT_NO_THROW(s1.set_dynamic_fields(defs1));
 	ASSERT_ANY_THROW(
-	        s1.set_dynamic_fields(std::make_shared<libsinsp::state::dynamic_field_infos>()));
+	        s1.set_dynamic_fields(libsinsp::state::dynamic_field_infos::make<sample_struct>()));
 
 	// define a string dynamic field
 	auto field_str = defs1->add_field("str", SS_PLUGIN_ST_STRING);
@@ -283,7 +283,7 @@ TEST(dynamic_struct, mem_ownership) {
 	ASSERT_NE(tmpstr1, tmpstr2);
 
 	// deep copy and memory ownership (assignment)
-	sample_struct s4(std::make_shared<libsinsp::state::dynamic_field_infos>());
+	sample_struct s4(libsinsp::state::dynamic_field_infos::make<sample_struct>());
 	s4 = s1;
 	s1.read_field(field_str_acc, tmpstr1);
 	s4.read_field(field_str_acc, tmpstr2);
@@ -308,7 +308,8 @@ TEST(dynamic_struct, mem_ownership) {
 TEST(table_registry, defs_and_access) {
 	class sample_table : public libsinsp::state::extensible_table<uint64_t> {
 	public:
-		sample_table(): extensible_table("sample") {}
+		sample_table():
+		        extensible_table(type_tag<libsinsp::state::extensible_struct>{}, "sample") {}
 
 		size_t entries_count() const override { return m_entries.size(); }
 
@@ -737,12 +738,12 @@ TEST(thread_manager, env_vars_access) {
 //
 // Under ASan/Valgrind this should report a use-after-free / heap-use-after-free.
 TEST(dynamic_struct, thread_local_string_dangling_pointer_regression) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	// Create two string fields
 	auto field_a = fields->add_field("field_a", SS_PLUGIN_ST_STRING);
@@ -794,12 +795,12 @@ TEST(dynamic_struct, thread_local_string_dangling_pointer_regression) {
 // read string fields from two different entries; verify the first pointer
 // survives the second read.
 TEST(dynamic_struct, thread_local_string_cross_entry_dangling_pointer) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	auto field_str = fields->add_field("str", SS_PLUGIN_ST_STRING);
 	auto acc_str = field_str.new_accessor().into<std::string>();
@@ -842,12 +843,12 @@ TEST(dynamic_struct, thread_local_string_cross_entry_dangling_pointer) {
 //
 // This test triggers the read path; the copy path is tested below.
 TEST(dynamic_struct, read_null_string_field_after_lazy_materialization) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	// Define two fields: string at index 0, uint64 at index 1.
 	auto field_str = fields->add_field("str", SS_PLUGIN_ST_STRING);
@@ -874,12 +875,12 @@ TEST(dynamic_struct, read_null_string_field_after_lazy_materialization) {
 // After the above test's scenario, copying the entry invokes
 // strdup(nullptr) in dynamic_field_value's copy path.
 TEST(dynamic_struct, strdup_nullptr_on_copy_with_uninitialized_string_field) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	auto field_str = fields->add_field("str", SS_PLUGIN_ST_STRING);
 	auto field_num = fields->add_field("num", SS_PLUGIN_ST_UINT64);
@@ -928,12 +929,12 @@ TEST(dynamic_struct, strdup_nullptr_on_copy_with_uninitialized_string_field) {
 // (a weaker variant of the nullptr test — ensures the empty-string path
 // also works correctly after the fix).
 TEST(dynamic_struct, copy_entry_with_empty_string_field) {
-	auto fields = std::make_shared<libsinsp::state::dynamic_field_infos>();
-
 	struct sample_struct : public libsinsp::state::extensible_struct {
 		sample_struct(const std::shared_ptr<libsinsp::state::dynamic_field_infos>& i):
 		        extensible_struct(i) {}
 	};
+
+	auto fields = libsinsp::state::dynamic_field_infos::make<sample_struct>();
 
 	auto field_str = fields->add_field("str", SS_PLUGIN_ST_STRING);
 	auto acc_str = field_str.new_accessor().into<std::string>();

--- a/userspace/libsinsp/thread_manager.cpp
+++ b/userspace/libsinsp/thread_manager.cpp
@@ -118,7 +118,8 @@ sinsp_thread_manager::sinsp_thread_manager(
         scap_t* const& scap_handle,
         const std::shared_ptr<libsinsp::state::dynamic_field_infos>& thread_manager_dyn_fields,
         const std::shared_ptr<libsinsp::state::dynamic_field_infos>& fdtable_dyn_fields):
-        extensible_table{s_thread_table_name,
+        extensible_table{type_tag<sinsp_threadinfo>{},
+                         s_thread_table_name,
                          &s_threadinfo_static_fields,
                          thread_manager_dyn_fields},
         m_threadinfo_factory{threadinfo_factory},


### PR DESCRIPTION
This PR continues the table cleanup saga by converting dynamic fields and STL adapter fields to be read/written by lambdas. It reduces the indirection a bit and opens up quite a few cleanups, since we no longer need specific accessor subclasses -- all the per-field data we need now lives in the top-level accessor class.

Note: we do lose the defsptr tag used to distinguish dynamic fields coming from different tables. dynamic_field_infos now takes specializations of read_dynamic_field and write_dynamic_field for specific classes. This makes ASAN catch the wrong casts on read/write time, so we're not completely unprotected.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
