### PR TITLE
fix(libsinsp): generalize big-endian handling beyond s390x

### DIFF
--- a/userspace/libsinsp/filter_compare.cpp
+++ b/userspace/libsinsp/filter_compare.cpp
@@ -627,10 +627,12 @@ static inline toT flt_cast(const void* ptr, uint32_t len) {
 	 * for `evt.rawarg.*` fields.
 	 */
 	uint8_t shift = 0;
-#ifdef __s390x__
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	// NOTE: c++20 has `constexpr (std::endian::native == std::endian::big)`
 	// that would be much better.
-	// To avoid perf hit, only compile this on s390x (our only big-endian supported arch).
+	// Compiled only on big-endian targets, so little-endian builds take no
+	// perf hit. This must cover every big-endian arch, not just s390x:
+	// e.g. big-endian PowerPC hits the same `evt.rawarg.*` edge case.
 	if(len > sizeof(fromT)) {
 		shift = len - sizeof(fromT);
 	}

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -67,9 +67,8 @@ if(NOT WIN32)
 endif()
 
 option(SCAP_FILES_SUITE_ENABLE "Enable scap-file tests in sinsp" "ON")
-# Scap-files on Big Endian systems are not supported. Detect endianness
-# directly instead of matching s390x, so other big-endian targets (e.g.
-# big-endian PowerPC) are covered too.
+# Scap-files on Big Endian systems are not supported. Detect endianness directly instead of matching
+# s390x, so other big-endian targets (e.g. big-endian PowerPC) are covered too.
 if((NOT CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
    AND ${SCAP_FILES_SUITE_ENABLE}
    AND TARGET unit-test-libsinsp

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -67,8 +67,10 @@ if(NOT WIN32)
 endif()
 
 option(SCAP_FILES_SUITE_ENABLE "Enable scap-file tests in sinsp" "ON")
-# Scap-files on Big Endian systems are not supported
-if((NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "s390x")
+# Scap-files on Big Endian systems are not supported. Detect endianness
+# directly instead of matching s390x, so other big-endian targets (e.g.
+# big-endian PowerPC) are covered too.
+if((NOT CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
    AND ${SCAP_FILES_SUITE_ENABLE}
    AND TARGET unit-test-libsinsp
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

While looking at #3002 (big-endian PowerPC), the userspace side still treats `s390x` as a synonym for "big-endian":

- `flt_cast()` in `filter_compare.cpp` applies a byte-shift adjustment for `evt.rawarg.*` fields when `len > sizeof(fromT)` on big-endian systems — but it was compiled only under `#ifdef __s390x__`. On any other big-endian target (e.g. big-endian PowerPC) that adjustment is silently dropped and `evt.rawarg.*` comparisons read the wrong bytes. The guard now keys on endianness (`#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__`) instead of a specific arch. The `defined(__BYTE_ORDER__)` part keeps the Windows/MSVC build path correct (the macro is absent there, and a bare `#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__` would wrongly evaluate true). **The executable block body is unchanged** — only the guard and comment.

- The scap-file test suite in `userspace/libsinsp/test/CMakeLists.txt` was disabled by matching the `s390x` processor string; it now keys off `CMAKE_CXX_BYTE_ORDER` so every big-endian host is covered.

This mirrors how the repo already detects endianness elsewhere (`__BYTE_ORDER__` in `parse_connect.cpp`, `ifinfo.ut.cpp`). The kernel-driver / modern-BPF side of #3002 is larger and out of scope here.

**Which issue(s) this PR fixes**:

Refs #3002

**Special notes for your reviewer**:

Verified: the new guard compiles inactive on x86_64 (little-endian, no perf hit) and active on s390x — cross-compiled and run under `qemu-s390x`. The `flt_cast` block body is byte-identical to the previous `__s390x__`-gated code, so big-endian compile coverage is inherited from the existing s390x build.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): apply the big-endian `evt.rawarg.*` byte adjustment on all big-endian targets, not only s390x
```