### PR TITLE
ci(drivers_ci): build scap-open with zig to check glibc linked version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
           libsinsp/examples/sinsp-example -s ../test/libsinsp_e2e/resources/captures/curl_google_comments.scap | grep --extended-regexp --invert-match '^(Time spent|Events/ms): ' > /tmp/curl_google_comments.txt
           diff -u /tmp/curl_google.txt /tmp/curl_google_comments.txt
 
-      # On zig, build also sinsp-example and check the glibc linked versions
-      # to make sure we are actually using the correct glibc version.
+      # On zig, check the glibc versions linked to unit-test-libsinsp to make sure we are actually using the correct
+      # glibc version.
       - name: Test zig build glibc version
         if: matrix.name == 'zig'
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Install cmake
         uses: ./.github/actions/install-cmake
 
-      - name: Install bpftool
+      - name: Install bpftool 🐝
         uses: ./.github/actions/install-bpftool
         with:
           arch: 'amd64'

--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -325,6 +325,77 @@ jobs:
         run: |
           cmake --build build --target scap-open --parallel $(nproc)
 
+  build-scap-open-w-zig:
+    name: build-scap-open-w-zig-${{ matrix.arch }} 🎯 (bundled_deps, glibc-check)
+    runs-on: ${{ matrix.runner }}
+    needs: paths-filter
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            zig_target: x86_64-linux-gnu.2.17
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            zig_target: aarch64-linux-gnu.2.17
+      fail-fast: false
+    steps:
+      - name: Checkout Libs ⤵️
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install deps ⛓️
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends ca-certificates build-essential clang-14 llvm-14 git pkg-config autoconf automake libtool libelf-dev libcap-dev linux-headers-$(uname -r)
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
+          sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
+          sudo update-alternatives --install /usr/bin/llc llc /usr/bin/llc-14 90
+
+      - name: Install cmake 🌊
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        uses: ./.github/actions/install-cmake
+
+      - name: Install bpftool 🐝
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        uses: ./.github/actions/install-bpftool
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Install zig
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        uses: ./.github/actions/install-zig
+        with:
+          target: ${{ matrix.zig_target }}
+
+      - name: Build scap-open with zig 🏗️
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        run: |
+          cmake -B build -S . \
+            -DUSE_BUNDLED_DEPS=ON \
+            -DBUILD_DRIVER=Off \
+            -DENABLE_ENGINE_KMOD=ON \
+            -DBUILD_LIBSCAP_MODERN_BPF=ON \
+            -DCREATE_TEST_TARGETS=Off \
+            -DENABLE_LIBSCAP_TESTS=Off \
+            -DCMAKE_TOOLCHAIN_FILE=$ZIG_TOOLCHAIN_FILE
+          cmake --build build --target scap-open --parallel $(nproc)
+
+      # Check the glibc versions linked to scap-open to make sure we are actually using the correct glibc version.
+      - name: Test zig build glibc version
+        if: needs.paths-filter.outputs.driver == 'true' || needs.paths-filter.outputs.libscap == 'true' || needs.paths-filter.outputs.libpman == 'true'
+        run: |
+          cd build
+          objdump -T libscap/examples/01-open/scap-open | grep -Eo 'GLIBC_\S+' | sort -u -t "." -k1,1n -k2,2n -k3,3n
+          linked_glibc=$(objdump -T libscap/examples/01-open/scap-open | grep -Eo 'GLIBC_\S+' | sort -u -t "." -k1,1n -k2,2n -k3,3n | tail -n1 | tr -d ')')
+          if [ "$linked_glibc" != "GLIBC_2.17" ]; then
+            echo "Expected glibc 2.17; found $linked_glibc"
+            exit 1
+          fi
+
   # Only runs on pull request since on master branch it is already triggered by pages CI.
   kernel-tests-dev:
     needs: paths-filter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a CI job `build-scap-open-w-zig` that builds `scap-open` with zig while enabling both kmod and modern eBPF engines to check that the glibc linked versions don't go beyond 2.17. This helps detecting that none of these engines (or any transitive dependency, e.g.: libpman) breaks the glibc ceiling enforced during Falco release building through zig (see `install-zig` action default target).

Notice that we already have a similar check on `unit-test-libsinsp` binary, but that one doesn't build the modern eBPF engine and libpman.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.26.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
