### PR TITLE
fix(userspace/libsinsp): recognize statically (un)satisfiable evt.num leaves in ppm_codes

### DIFF
--- a/userspace/libsinsp/filter/ppm_codes.cpp
+++ b/userspace/libsinsp/filter/ppm_codes.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 #include <libsinsp/filter/ppm_codes.h>
+#include <libsinsp/utils.h>
 
 /**
  * NOTE: the following code has been ported from Falco and updated with the
@@ -37,6 +38,11 @@ limitations under the License.
  *   * checks based on evt types (e.g. =xxx, != xxx, in (xxx)) give a clear
  *     definition of the matched event types. The "evt.type exists" check
  *     matches every evt type.
+ *   * checks on fields with a known runtime invariant (e.g. evt.num, whose
+ *     values start at 1) can be statically resolved to either the empty
+ *     set (when the condition is unsatisfiable, like "evt.num=0") or the
+ *     universal set (when the condition is a tautology, like "evt.num>0").
+ *     See evaluate_field_invariant().
  *   * checks non-related to evt types are neutral and match all evt types
  *     (e.g. proc.name=cat).
  *
@@ -57,6 +63,103 @@ limitations under the License.
 
 static bool is_evttype_operator(const std::string& op) {
 	return op == "==" || op == "=" || op == "!=" || op == "in";
+}
+
+// Outcome of a static evaluation of a binary_check_expr against the runtime
+// invariants of the fields it references.
+enum class invariant_result {
+	known_empty,   // condition is provably false; matches no event type
+	known_all,     // condition is provably true; matches every event type
+	indeterminate  // analyzer cannot decide; caller must over-approximate
+};
+
+// Statically evaluates a binary_check_expr against the runtime invariants of
+// known fields. Currently the only field with a documented invariant is
+// `evt.num`, whose values are monotonically increasing and start at 1 for
+// every event delivered through the live/replay event loop (see sinsp::next(),
+// which pre-increments m_nevts before calling sinsp_evt::set_num()). This lets
+// us resolve conditions like "evt.num=0" or "evt.num<1" to known_empty
+// (unsatisfiable), and their duals like "evt.num!=0" or "evt.num>=1" to
+// known_all (tautology), without claiming general satisfiability analysis.
+//
+// Literals are parsed with sinsp_numparser::tryparseu64 - the very same parser
+// libsinsp uses at runtime for PT_UINT64 fields - so the analysis reasons about
+// the exact value the runtime will compare against. In particular, a negative
+// literal wraps around to a large unsigned value (just like at runtime), which
+// the thresholds below correctly treat as indeterminate rather than mistaking
+// it for unsatisfiable.
+//
+// Anything we cannot decide (unknown field, non-numeric literal, unsupported
+// operator, transformer on either side, etc.) yields indeterminate so the
+// caller falls back to the existing over-approximation.
+static invariant_result evaluate_field_invariant(
+        const libsinsp::filter::ast::binary_check_expr* e) {
+	// Only a bare `evt.num` field is recognized. A transformer on the
+	// left, an argument, or any other field name short-circuits to
+	// indeterminate.
+	auto field = dynamic_cast<const libsinsp::filter::ast::field_expr*>(e->left.get());
+	if(field == nullptr || field->field != "evt.num" || field->arg) {
+		return invariant_result::indeterminate;
+	}
+
+	const auto& op = e->op;
+
+	// List operator: "evt.num in (...)". Since evt.num >= 1, the condition
+	// matches nothing iff every listed value is 0 (the only non-positive
+	// value an unsigned literal can take). An empty list never matches either.
+	if(op == "in") {
+		auto list = dynamic_cast<const libsinsp::filter::ast::list_expr*>(e->right.get());
+		if(list == nullptr) {
+			return invariant_result::indeterminate;
+		}
+		if(list->values.empty()) {
+			return invariant_result::known_empty;
+		}
+		for(const auto& v : list->values) {
+			uint64_t n;
+			if(!sinsp_numparser::tryparseu64(v, &n) || n != 0) {
+				return invariant_result::indeterminate;
+			}
+		}
+		return invariant_result::known_empty;
+	}
+
+	// Scalar operators: the right-hand side must be a literal value.
+	auto value = dynamic_cast<const libsinsp::filter::ast::value_expr*>(e->right.get());
+	if(value == nullptr) {
+		return invariant_result::indeterminate;
+	}
+	uint64_t n;
+	if(!sinsp_numparser::tryparseu64(value->value, &n)) {
+		return invariant_result::indeterminate;
+	}
+
+	// Given evt.num >= 1 (with n unsigned):
+	//   evt.num =  N , N == 0  is unsatisfiable
+	//   evt.num != N , N == 0  is a tautology
+	//   evt.num <  N , N <= 1  is unsatisfiable (no value < 1)
+	//   evt.num <= N , N == 0  is unsatisfiable
+	//   evt.num >  N , N == 0  is a tautology
+	//   evt.num >= N , N <= 1  is a tautology
+	if(op == "=" || op == "==") {
+		return n == 0 ? invariant_result::known_empty : invariant_result::indeterminate;
+	}
+	if(op == "!=") {
+		return n == 0 ? invariant_result::known_all : invariant_result::indeterminate;
+	}
+	if(op == "<") {
+		return n <= 1 ? invariant_result::known_empty : invariant_result::indeterminate;
+	}
+	if(op == "<=") {
+		return n == 0 ? invariant_result::known_empty : invariant_result::indeterminate;
+	}
+	if(op == ">") {
+		return n == 0 ? invariant_result::known_all : invariant_result::indeterminate;
+	}
+	if(op == ">=") {
+		return n <= 1 ? invariant_result::known_all : invariant_result::indeterminate;
+	}
+	return invariant_result::indeterminate;
 }
 
 using name_set_t = std::unordered_set<std::string>;
@@ -140,6 +243,28 @@ struct ppm_code_visitor : public libsinsp::filter::ast::const_expr_visitor {
 
 	void visit(const libsinsp::filter::ast::binary_check_expr* e) override {
 		m_last_node_has_codes = false;
+
+		// If a field invariant proves the leaf is statically true or false,
+		// short-circuit with the corresponding set and apply leaf-level
+		// inversion (the visitor pushes negation down to leaves via De
+		// Morgan's laws, so try_inversion must run here too).
+		switch(evaluate_field_invariant(e)) {
+		case invariant_result::known_empty:
+			m_last_node_codes = code_set_t{};
+			m_last_node_has_codes = true;
+			m_last_node_is_evttype_field = false;
+			try_inversion(m_last_node_codes);
+			return;
+		case invariant_result::known_all:
+			m_last_node_codes = all_codes_set();
+			m_last_node_has_codes = true;
+			m_last_node_is_evttype_field = false;
+			try_inversion(m_last_node_codes);
+			return;
+		case invariant_result::indeterminate:
+			break;
+		}
+
 		if(is_evttype_operator(e->op)) {
 			e->left->accept(this);
 			if(m_last_node_is_evttype_field) {

--- a/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
+++ b/userspace/libsinsp/test/filter_ppm_codes.ut.cpp
@@ -323,6 +323,136 @@ TEST_CODES(filter_ppm_codes, check_properties) {
 	                 "not fd.type=file or not proc.name=cat");
 }
 
+// Statically-known leaves: conditions on `evt.num` resolve either to the
+// empty set (unsatisfiable) or the universal set (tautology) under the
+// runtime invariant `evt.num >= 1`. Other patterns must stay indeterminate
+// and over-approximate to all events without being flipped under negation.
+TEST_CODES(filter_ppm_codes, check_evt_num_invariants) {
+	T t;
+	auto all_events = t.all_set();
+	auto no_events = t.all_set();
+	no_events.clear();
+
+	// Unsatisfiable: no event has evt.num < 1.
+	ASSERT_FILTER_SET_EQ(t, "evt.num=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num == 0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<1", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num in (0)", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num in (0, 0)", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num in ()", no_events);
+
+	// Tautology: evt.num is always >= 1.
+	ASSERT_FILTER_SET_EQ(t, "evt.num!=0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>=0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>=1", all_events);
+
+	// Indeterminate: satisfiable but non-narrowing. Must over-approximate
+	// to all events and must NOT be flipped under negation (otherwise
+	// `not evt.num=1` would collapse to the empty set).
+	ASSERT_FILTER_SET_EQ(t, "evt.num=1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=42", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<100", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<=1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>5", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>=2", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num in (1, 2, 3)", all_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num=1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num in (1, 2)", all_events);
+
+	// Indeterminate by design: `evt.num` is unsigned (PT_UINT64), so
+	// negative, hexadecimal, and fractional literals are deliberately not
+	// reasoned about (a negative literal wraps to a huge unsigned value at
+	// runtime). These must fall back to the safe over-approximation rather
+	// than being mistaken for unsatisfiable.
+	ASSERT_FILTER_SET_EQ(t, "evt.num=-1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=-100", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<-5", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num<=-5", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num!=-1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num>-5", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=0x0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=1.5", all_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num in (0, -1, -2)", all_events);
+
+	// Indeterminate: a transformer on the left-hand side is not a bare
+	// `evt.num` field and must not be statically resolved.
+	ASSERT_FILTER_SET_EQ(t, "b64(evt.num)=0", all_events);
+}
+
+// Negation of statically-known leaves must invert at the leaf level (the
+// visitor pushes negation down via De Morgan's laws). Without leaf-level
+// try_inversion, `not evt.num=0` would stay empty instead of becoming
+// the universal set.
+TEST_CODES(filter_ppm_codes, check_evt_num_invariants_negation) {
+	T t;
+	auto all_events = t.all_set();
+	auto no_events = t.all_set();
+	no_events.clear();
+
+	// not(empty) = all
+	ASSERT_FILTER_SET_EQ(t, "not evt.num=0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num<1", all_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num<=0", all_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num in (0)", all_events);
+
+	// not(all) = empty
+	ASSERT_FILTER_SET_EQ(t, "not evt.num!=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num>0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "not evt.num>=1", no_events);
+
+	// Double negation returns to the original set.
+	ASSERT_FILTER_SET_EQ(t, "not not evt.num=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "not not evt.num!=0", all_events);
+
+	// Negation isomorphism via the != operator on evt.num.
+	ASSERT_FILTER_EQ(t, "not evt.num=0", "evt.num!=0");
+	ASSERT_FILTER_EQ(t, "not evt.num!=0", "evt.num=0");
+}
+
+// Composition with other operators: AND/OR over a statically-known leaf
+// must propagate cleanly through the existing set algebra, including the
+// canonical `never_true` idiom (a placeholder macro defined as
+// `(evt.num=0)`) used across the falcosecurity/rules ruleset for tuning.
+TEST_CODES(filter_ppm_codes, check_evt_num_invariants_composition) {
+	T t;
+	auto all_events = t.all_set();
+	auto openat_only = t.openat_set;
+	auto not_openat = t.all_set().diff(openat_only);
+	auto no_events = t.all_set();
+	no_events.clear();
+
+	// A * 0 = 0 (intersection with empty)
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and evt.num=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=0 and evt.type=openat", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and evt.num<=0", no_events);
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and (evt.num=0)", no_events);
+
+	// A + 0 = A (union with empty)
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat or evt.num=0", openat_only);
+	ASSERT_FILTER_SET_EQ(t, "evt.num=0 or evt.type=openat", openat_only);
+
+	// A * 1 = A, A + 1 = 1 (intersection / union with tautology)
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and evt.num!=0", openat_only);
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat or evt.num!=0", all_events);
+
+	// De Morgan: not (A and 0) = not A or not 0 = not A or 1 = 1
+	ASSERT_FILTER_SET_EQ(t, "not (evt.type=openat and evt.num=0)", all_events);
+	// De Morgan: not (A or 0) = not A and not 0 = not A and 1 = not A
+	ASSERT_FILTER_SET_EQ(t, "not (evt.type=openat or evt.num=0)", not_openat);
+
+	// The `never_true` idiom (placeholder for tuning), used as the
+	// right-hand side of `and not (user_known_...)` macros.
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and not (evt.num=0)", openat_only);
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat or not (evt.num=0)", all_events);
+
+	// Indeterminate leaves on evt.num do not narrow the outcome.
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and evt.num=1", openat_only);
+	ASSERT_FILTER_SET_EQ(t, "evt.type=openat and not evt.num=1", openat_only);
+}
+
 TEST_CODES(filter_ppm_codes, field_transformers) {
 	auto parse = [](const std::string& f) {
 		libsinsp::filter::ast::ppm_event_codes(libsinsp::filter::parser(f).parse().get());


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The event code search (`libsinsp::filter::ast::ppm_event_codes` / `ppm_sc_codes`) over-approximates every non-`evt.type` leaf to the full set of event types. That's sound but imprecise: a condition like `evt.num=0` - which can never be true at runtime, since `evt.num` starts at 1 - is reported as matching *all* event types instead of *none*.

This PR teaches the visitor to statically resolve `evt.num` leaves against the `evt.num >= 1` runtime invariant:

- provably unsatisfiable leaves (e.g. `evt.num=0`, `evt.num<1`, `evt.num<=0`, `evt.num in (0)`) now resolve to the empty set
- tautological leaves (e.g. `evt.num!=0`, `evt.num>0`, `evt.num>=1`) resolve to the full set
- anything we cannot decide (other fields, non-decimal literals, transformers, ...) keeps falling back to the previous over-approximation, so the change is conservative by construction

Negation is handled at the leaf level (since the visitor pushes negation down via De Morgan's laws), so `not (evt.num=0)` correctly resolves back to all event types.

We need this since it's the libs half of fixing the `LOAD_NO_EVTTYPE` false positive that Falco emits for the `never_true` idiom (`(evt.num=0)`) - the canonical placeholder used across the default ruleset for tuning. See falcosecurity/falco#3883.

**Which issue(s) this PR fixes**:

Related to falcosecurity/falco#3883

N.B. I'm intentionally not using `Fixes` here, since the user-facing warning lives in Falco. This PR is a prerequisite, and a follow-up Falco PR will complete the fix.

**Special notes for your reviewer**:

This is the same warning family - and the same kind of narrow, targeted visitor improvement - as falcosecurity/falco#3546, which was fixed in libs by https://github.com/falcosecurity/libs/commit/4cd3f9678c24ec86132a4d2c13545eda1fb97e86. 

I deliberately avoided a general satisfiability pass and scoped this to a single field with a documented invariant.

/milestone 0.26.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): `ppm_event_codes`/`ppm_sc_codes` now resolve statically (un)satisfiable `evt.num` conditions (e.g. `evt.num=0`) to the correct event-type set instead of over-approximating to all event types
```
