### PR TITLE
fix(libscap): wire savefile converter objects into the savefile engine

### DIFF
--- a/userspace/libscap/engine/savefile/CMakeLists.txt
+++ b/userspace/libscap/engine/savefile/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(converter)
 add_library(scap_engine_savefile STATIC scap_savefile.c scap_reader_gzfile.c scap_reader_buffered.c)
 
 add_dependencies(scap_engine_savefile zlib scap_savefile_converter)
+target_sources(scap_engine_savefile PRIVATE $<TARGET_OBJECTS:scap_savefile_converter>)
 target_link_libraries(
-	scap_engine_savefile PRIVATE scap_engine_noop scap_platform_util scap_savefile_converter
-								 ${ZLIB_LIB} scap_error
+	scap_engine_savefile PRIVATE scap_engine_noop scap_platform_util ${ZLIB_LIB} scap_error
 )


### PR DESCRIPTION
/kind bug
/area build
/area libscap-engine-savefile
/area tests

**What this PR does / why we need it**:

This fixes a real build break in the documented `libscap_test` flow.

`scap_engine_savefile` was pulling the converter OBJECT library via `target_link_libraries()`. With Unix Makefiles that leaves `libscap_test` in a bad spot, `make libscap_test` can fail with `No rule to make target ... converter.cpp.o`. Kinda sneaky.

This switches the savefile engine to consume those object files through `target_sources($<TARGET_OBJECTS:...>)`, so the objects are wired into the static archive the right way.

**Which issue(s) this PR fixes**:

None found.

**Special notes for your reviewer**:

Repro:

```bash
cmake -S . -B build-libscap-check \
  -DUSE_BUNDLED_DEPS=ON \
  -DCREATE_TEST_TARGETS=ON \
  -DBUILD_DRIVER=OFF \
  -DENABLE_LIBSCAP_TESTS=ON

cmake --build build-libscap-check --target libscap_test -j2
```

Before this patch, the build can fail with `No rule to make target ... scap_savefile_converter.dir/converter.cpp.o`.
After this patch, `libscap_test` builds ok, `./build-libscap-check/test/libscap/libscap_test` passes, and a clean `scap` build still works.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
