### PR TITLE
docs(proc.cmdline): clarify behavior for pre-execve events

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -149,8 +149,8 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] = {
          "proc.cmdline",
          "Command Line",
          "The concatenation of `proc.name + proc.args` (truncated after 4096 bytes) when starting "
-"the process generating the event. For events occurring before an execve() call completes, "
-"this value may differ from the command line later observed through tools such as ps or pstree."},
+         "the process generating the event. For events occurring before an execve() call completes, "
+         "this value may differ from the command line later observed through tools such as ps or pstree."},
         {PT_CHARBUF,
          EPF_NONE,
          PF_NA,

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -149,7 +149,8 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] = {
          "proc.cmdline",
          "Command Line",
          "The concatenation of `proc.name + proc.args` (truncated after 4096 bytes) when starting "
-         "the process generating the event."},
+"the process generating the event. For events occurring before an execve() call completes, "
+"this value may differ from the command line later observed through tools such as ps or pstree."},
         {PT_CHARBUF,
          EPF_NONE,
          PF_NA,

--- a/userspace/libsinsp/sinsp_filtercheck_thread.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_thread.cpp
@@ -149,7 +149,9 @@ static const filtercheck_field_info sinsp_filter_check_thread_fields[] = {
          "proc.cmdline",
          "Command Line",
          "The concatenation of `proc.name + proc.args` (truncated after 4096 bytes) when starting "
-         "the process generating the event."},
+         "the process generating the event. For events occurring before an execve() call "
+         "completes, this value may differ from the command line later observed through tools "
+         "such as ps or pstree."},
         {PT_CHARBUF,
          EPF_NONE,
          PF_NA,


### PR DESCRIPTION
What type of PR is this?

/kind documentation

What this PR does / why we need it:

Clarifies that proc.cmdline may differ from the command line later observed
through tools such as ps or pstree for events generated before an execve()
call completes.

Related to falcosecurity/falco#3842