### PR TITLE
fix(libsinsp): don't create a string_view from a null pointer

### DIFF
--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -125,6 +125,10 @@ static struct group *__getgrgid(uint32_t gid,
 
 using namespace std;
 
+static inline std::string_view sv_or_empty(const char *s) {
+	return s ? std::string_view(s) : std::string_view{};
+}
+
 // clang-format off
 sinsp_usergroup_manager::sinsp_usergroup_manager(sinsp* inspector, const timestamper& timestamper)
 	: m_import_users(true)
@@ -309,9 +313,9 @@ scap_userinfo *sinsp_usergroup_manager::add_host_user(uint32_t uid,
 			retval = userinfo_map_insert(m_userlist[""],
 			                             p->pw_uid,
 			                             p->pw_gid,
-			                             p->pw_name,
-			                             p->pw_dir,
-			                             p->pw_shell);
+			                             sv_or_empty(p->pw_name),
+			                             sv_or_empty(p->pw_dir),
+			                             sv_or_empty(p->pw_shell));
 		}
 #endif
 	}
@@ -353,9 +357,9 @@ scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &co
 			auto *usr = userinfo_map_insert(userlist,
 			                                p->pw_uid,
 			                                p->pw_gid,
-			                                p->pw_name,
-			                                p->pw_dir,
-			                                p->pw_shell);
+			                                sv_or_empty(p->pw_name),
+			                                sv_or_empty(p->pw_dir),
+			                                sv_or_empty(p->pw_shell));
 
 			if(notify) {
 				notify_user_changed(usr, container_id);
@@ -441,7 +445,7 @@ scap_groupinfo *sinsp_usergroup_manager::add_host_group(uint32_t gid,
 		char grp_buf[4096];
 		auto *g = __getgrgid(gid, m_host_root, &grp_entry, grp_buf, sizeof(grp_buf));
 		if(g) {
-			gr = groupinfo_map_insert(m_grouplist[""], g->gr_gid, g->gr_name);
+			gr = groupinfo_map_insert(m_grouplist[""], g->gr_gid, sv_or_empty(g->gr_name));
 		}
 #endif
 	}
@@ -480,7 +484,7 @@ scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &
 				continue;  // skip malformed lines
 			}
 			// Here we cache all container groups
-			auto *gr = groupinfo_map_insert(grouplist, g->gr_gid, g->gr_name);
+			auto *gr = groupinfo_map_insert(grouplist, g->gr_gid, sv_or_empty(g->gr_name));
 
 			if(notify) {
 				notify_group_changed(gr, container_id, true);


### PR DESCRIPTION
Creating a string_view from a null pointer does not create an empty string_view, but is UB.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

sorry :(

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
