### PR TITLE
refactor: build bundled zlib via CMake instead of CONFIGURE_COMMAND

### DIFF
--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -68,8 +68,8 @@ else()
 			DESTDIR=${LIBBPF_BUILD_DIR}/root NO_PKG_CONFIG=1
 			# -Wno-error=discarded-qualifiers can be removed once we update to libbpf 1.7.0 or later
 			"EXTRA_CFLAGS=-fPIC ${LIBELF_COMPILER_STRING} -I${ZLIB_INCLUDE} -Wno-error=discarded-qualifiers"
-			"LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}/lib" -C
-			${LIBBPF_SRC}/libbpf/src install install_uapi_headers
+			"LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}/lib"
+			-C ${LIBBPF_SRC}/libbpf/src install install_uapi_headers
 		INSTALL_COMMAND ""
 		UPDATE_COMMAND ""
 		BUILD_BYPRODUCTS ${LIBBPF_LIB}

--- a/cmake/modules/libbpf.cmake
+++ b/cmake/modules/libbpf.cmake
@@ -68,7 +68,7 @@ else()
 			DESTDIR=${LIBBPF_BUILD_DIR}/root NO_PKG_CONFIG=1
 			# -Wno-error=discarded-qualifiers can be removed once we update to libbpf 1.7.0 or later
 			"EXTRA_CFLAGS=-fPIC ${LIBELF_COMPILER_STRING} -I${ZLIB_INCLUDE} -Wno-error=discarded-qualifiers"
-			"LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}" -C
+			"LDFLAGS=-Wl,-Bstatic" "EXTRA_LDFLAGS=-L${LIBELF_SRC}/libelf/libelf -L${ZLIB_SRC}/lib" -C
 			${LIBBPF_SRC}/libbpf/src install install_uapi_headers
 		INSTALL_COMMAND ""
 		UPDATE_COMMAND ""

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -28,65 +28,110 @@ elseif(NOT USE_BUNDLED_ZLIB)
 		message(FATAL_ERROR "Couldn't find system zlib")
 	endif()
 else()
-	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib")
-	set(ZLIB_INCLUDE "${ZLIB_SRC}")
+	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src")
+	set(ZLIB_SOURCE_DIR "${ZLIB_SRC}/zlib")
+	set(ZLIB_INCLUDE "${ZLIB_SRC}/include")
 	set(ZLIB_HEADERS "")
 	list(
 		APPEND
 		ZLIB_HEADERS
-		"${ZLIB_INCLUDE}/crc32.h"
-		"${ZLIB_INCLUDE}/deflate.h"
-		"${ZLIB_INCLUDE}/gzguts.h"
-		"${ZLIB_INCLUDE}/inffast.h"
-		"${ZLIB_INCLUDE}/inffixed.h"
-		"${ZLIB_INCLUDE}/inflate.h"
-		"${ZLIB_INCLUDE}/inftrees.h"
-		"${ZLIB_INCLUDE}/trees.h"
+		"${ZLIB_SOURCE_DIR}/crc32.h"
+		"${ZLIB_SOURCE_DIR}/deflate.h"
+		"${ZLIB_SOURCE_DIR}/gzguts.h"
+		"${ZLIB_SOURCE_DIR}/inffast.h"
+		"${ZLIB_SOURCE_DIR}/inffixed.h"
+		"${ZLIB_SOURCE_DIR}/inflate.h"
+		"${ZLIB_SOURCE_DIR}/inftrees.h"
+		"${ZLIB_SOURCE_DIR}/trees.h"
 		"${ZLIB_INCLUDE}/zconf.h"
-		"${ZLIB_INCLUDE}/zlib.h"
-		"${ZLIB_INCLUDE}/zutil.h"
+		"${ZLIB_SOURCE_DIR}/zlib.h"
+		"${ZLIB_SOURCE_DIR}/zutil.h"
 	)
 	if(NOT TARGET zlib)
-		# Match both release and relwithdebinfo builds
-		if(CMAKE_BUILD_TYPE MATCHES "[R,r]el*")
-			set(ZLIB_CFLAGS "-O3")
-		else()
-			set(ZLIB_CFLAGS "-g")
-		endif()
-		if(ENABLE_PIC)
-			set(ZLIB_CFLAGS "${ZLIB_CFLAGS} -fPIC")
-		endif()
-		# Propagate toolchain flags (e.g. Zig -target) into ./configure; zlib only sees CFLAGS.
-		if(NOT "${CMAKE_C_FLAGS}" STREQUAL "")
-			string(REPLACE ";" " " _zlib_extra_cflags "${CMAKE_C_FLAGS}")
-			string(STRIP "${_zlib_extra_cflags}" _zlib_extra_cflags)
-			if(NOT "${_zlib_extra_cflags}" STREQUAL "")
-				set(ZLIB_CFLAGS "${ZLIB_CFLAGS} ${_zlib_extra_cflags}")
-			endif()
-		endif()
-
 		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
+		falcosecurity_external_project_cache_args(ZLIB_EXTERNAL_PROJECT_CACHE_ARGS)
 		if(NOT WIN32)
+			# zlib's CMakeLists always defines both the shared ('zlib') and static ('zlibstatic')
+			# targets regardless of BUILD_SHARED_LIBS, so build and install only the one we actually
+			# consume. This mirrors the old './configure --static' behavior and avoids
+			# compiling/linking an unused shared object on static-only (e.g. cross) toolchains. Both
+			# targets are named 'z' via OUTPUT_NAME, so the produced artifact is libz<suffix> in
+			# either case.
 			if(BUILD_SHARED_LIBS)
 				set(ZLIB_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-				set(ZLIB_CONFIGURE_FLAGS)
+				set(ZLIB_BUILD_TARGET zlib)
+				set(ZLIB_LIBRARY_INSTALL_TYPE SHARED_LIBRARY)
 			else()
 				set(ZLIB_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
-				set(ZLIB_CONFIGURE_FLAGS "--static")
+				set(ZLIB_BUILD_TARGET zlibstatic)
+				set(ZLIB_LIBRARY_INSTALL_TYPE STATIC_LIBRARY)
 			endif()
-			set(ZLIB_LIB "${ZLIB_SRC}/libz${ZLIB_LIB_SUFFIX}")
-			falcosecurity_external_project_env(ZLIB_EXTERNAL_PROJECT_ENV)
+			set(ZLIB_BUILD_DIR "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-build")
+			get_property(ZLIB_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+			if(ZLIB_IS_MULTI_CONFIG)
+				set(ZLIB_BUILD_CONFIG_SUBDIR "$<CONFIG>/")
+			else()
+				set(ZLIB_BUILD_CONFIG_SUBDIR "")
+			endif()
+			set(ZLIB_BUILT_LIB
+				"${ZLIB_BUILD_DIR}/${ZLIB_BUILD_CONFIG_SUBDIR}libz${ZLIB_LIB_SUFFIX}"
+			)
+			set(ZLIB_LIB "${ZLIB_SRC}/lib/libz${ZLIB_LIB_SUFFIX}")
+			set(ZLIB_INSTALL_SCRIPT "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-install.cmake")
+			file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/zlib-prefix/src")
+			file(
+				WRITE "${ZLIB_INSTALL_SCRIPT}"
+				[=[
+if(NOT EXISTS "${ZLIB_BUILT_LIB}")
+	message(FATAL_ERROR "Built zlib library not found: ${ZLIB_BUILT_LIB}")
+endif()
+if(NOT EXISTS "${ZLIB_SOURCE_DIR}/zlib.h")
+	message(FATAL_ERROR "zlib.h not found: ${ZLIB_SOURCE_DIR}/zlib.h")
+endif()
+if(NOT EXISTS "${ZLIB_BUILD_DIR}/zconf.h")
+	message(FATAL_ERROR "Generated zconf.h not found: ${ZLIB_BUILD_DIR}/zconf.h")
+endif()
+
+file(MAKE_DIRECTORY "${ZLIB_LIB_DIR}" "${ZLIB_INCLUDE}")
+file(
+	INSTALL DESTINATION "${ZLIB_LIB_DIR}"
+	TYPE "${ZLIB_LIBRARY_INSTALL_TYPE}"
+	FOLLOW_SYMLINK_CHAIN
+	FILES "${ZLIB_BUILT_LIB}"
+)
+file(
+	INSTALL DESTINATION "${ZLIB_INCLUDE}"
+	TYPE FILE
+	FILES "${ZLIB_SOURCE_DIR}/zlib.h" "${ZLIB_BUILD_DIR}/zconf.h"
+)
+]=]
+			)
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
+				SOURCE_DIR "${ZLIB_SOURCE_DIR}"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
-				CONFIGURE_COMMAND ${ZLIB_EXTERNAL_PROJECT_ENV} "CFLAGS=${ZLIB_CFLAGS}" ./configure
-								  --prefix=${ZLIB_SRC} ${ZLIB_CONFIGURE_FLAGS}
-				BUILD_COMMAND ${ZLIB_EXTERNAL_PROJECT_ENV} make
-				BUILD_IN_SOURCE 1
+				CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+						   -DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_PIC}
+						   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+						   "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+						   -DZLIB_BUILD_EXAMPLES=OFF
+						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
+						   -DCMAKE_INSTALL_LIBDIR=lib
+				CMAKE_CACHE_ARGS ${ZLIB_EXTERNAL_PROJECT_CACHE_ARGS}
+				# Build only the target we need so the unused library type is never compiled.
+				BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target
+							  ${ZLIB_BUILD_TARGET}
+				# zlib's own install() installs both targets together, which would fail for the
+				# target we did not build; install just the built library + public headers.
+				INSTALL_COMMAND
+					${CMAKE_COMMAND} "-DZLIB_BUILT_LIB=${ZLIB_BUILT_LIB}"
+					"-DZLIB_LIBRARY_INSTALL_TYPE=${ZLIB_LIBRARY_INSTALL_TYPE}"
+					"-DZLIB_LIB_DIR=${ZLIB_SRC}/lib" "-DZLIB_INCLUDE=${ZLIB_INCLUDE}"
+					"-DZLIB_SOURCE_DIR=${ZLIB_SOURCE_DIR}" "-DZLIB_BUILD_DIR=${ZLIB_BUILD_DIR}" -P
+					"${ZLIB_INSTALL_SCRIPT}"
 				BUILD_BYPRODUCTS ${ZLIB_LIB}
-				INSTALL_COMMAND ""
 			)
 			install(
 				FILES "${ZLIB_LIB}"
@@ -109,6 +154,7 @@ else()
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
+				SOURCE_DIR "${ZLIB_SOURCE_DIR}"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 				BUILD_IN_SOURCE 1
@@ -118,7 +164,11 @@ else()
 						   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 						   -DCMAKE_POSITION_INDEPENDENT_CODE=${ENABLE_PIC}
 						   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+						   "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+						   -DZLIB_BUILD_EXAMPLES=OFF
 						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
+						   -DCMAKE_INSTALL_LIBDIR=lib
+				CMAKE_CACHE_ARGS ${ZLIB_EXTERNAL_PROJECT_CACHE_ARGS}
 			)
 			install(
 				FILES "${ZLIB_LIB}"

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -29,27 +29,27 @@ elseif(NOT USE_BUNDLED_ZLIB)
 	endif()
 else()
 	set(ZLIB_SRC "${PROJECT_BINARY_DIR}/zlib-prefix/src")
-	set(ZLIB_SOURCE_DIR "${ZLIB_SRC}/zlib")
+	set(_zlib_source_dir "${ZLIB_SRC}/zlib")
 	set(ZLIB_INCLUDE "${ZLIB_SRC}/include")
-	set(ZLIB_HEADERS "")
+	set(_zlib_headers "")
 	list(
 		APPEND
-		ZLIB_HEADERS
-		"${ZLIB_SOURCE_DIR}/crc32.h"
-		"${ZLIB_SOURCE_DIR}/deflate.h"
-		"${ZLIB_SOURCE_DIR}/gzguts.h"
-		"${ZLIB_SOURCE_DIR}/inffast.h"
-		"${ZLIB_SOURCE_DIR}/inffixed.h"
-		"${ZLIB_SOURCE_DIR}/inflate.h"
-		"${ZLIB_SOURCE_DIR}/inftrees.h"
-		"${ZLIB_SOURCE_DIR}/trees.h"
+		_zlib_headers
+		"${_zlib_source_dir}/crc32.h"
+		"${_zlib_source_dir}/deflate.h"
+		"${_zlib_source_dir}/gzguts.h"
+		"${_zlib_source_dir}/inffast.h"
+		"${_zlib_source_dir}/inffixed.h"
+		"${_zlib_source_dir}/inflate.h"
+		"${_zlib_source_dir}/inftrees.h"
+		"${_zlib_source_dir}/trees.h"
 		"${ZLIB_INCLUDE}/zconf.h"
-		"${ZLIB_SOURCE_DIR}/zlib.h"
-		"${ZLIB_SOURCE_DIR}/zutil.h"
+		"${_zlib_source_dir}/zlib.h"
+		"${_zlib_source_dir}/zutil.h"
 	)
 	if(NOT TARGET zlib)
 		message(STATUS "Using bundled zlib in '${ZLIB_SRC}'")
-		falcosecurity_external_project_cache_args(ZLIB_EXTERNAL_PROJECT_CACHE_ARGS)
+		falcosecurity_external_project_cache_args(_zlib_external_project_cache_args)
 		if(NOT WIN32)
 			# zlib's CMakeLists always defines both the shared ('zlib') and static ('zlibstatic')
 			# targets regardless of BUILD_SHARED_LIBS, so build and install only the one we actually
@@ -59,57 +59,59 @@ else()
 			# either case.
 			if(BUILD_SHARED_LIBS)
 				set(ZLIB_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-				set(ZLIB_BUILD_TARGET zlib)
-				set(ZLIB_LIBRARY_INSTALL_TYPE SHARED_LIBRARY)
+				set(_zlib_build_target zlib)
+				set(_zlib_library_install_type SHARED_LIBRARY)
 			else()
 				set(ZLIB_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
-				set(ZLIB_BUILD_TARGET zlibstatic)
-				set(ZLIB_LIBRARY_INSTALL_TYPE STATIC_LIBRARY)
+				set(_zlib_build_target zlibstatic)
+				set(_zlib_library_install_type STATIC_LIBRARY)
 			endif()
-			set(ZLIB_BUILD_DIR "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-build")
-			get_property(ZLIB_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-			if(ZLIB_IS_MULTI_CONFIG)
-				set(ZLIB_BUILD_CONFIG_SUBDIR "$<CONFIG>/")
+			set(_zlib_build_dir "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-build")
+			get_property(_zlib_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+			if(_zlib_is_multi_config)
+				set(_zlib_build_config_subdir "$<CONFIG>/")
+				set(_zlib_build_config_args --config $<CONFIG>)
 			else()
-				set(ZLIB_BUILD_CONFIG_SUBDIR "")
+				set(_zlib_build_config_subdir "")
+				set(_zlib_build_config_args)
 			endif()
-			set(ZLIB_BUILT_LIB
-				"${ZLIB_BUILD_DIR}/${ZLIB_BUILD_CONFIG_SUBDIR}libz${ZLIB_LIB_SUFFIX}"
+			set(_zlib_built_lib
+				"${_zlib_build_dir}/${_zlib_build_config_subdir}libz${ZLIB_LIB_SUFFIX}"
 			)
 			set(ZLIB_LIB "${ZLIB_SRC}/lib/libz${ZLIB_LIB_SUFFIX}")
-			set(ZLIB_INSTALL_SCRIPT "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-install.cmake")
+			set(_zlib_install_script "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-install.cmake")
 			file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/zlib-prefix/src")
 			file(
-				WRITE "${ZLIB_INSTALL_SCRIPT}"
+				WRITE "${_zlib_install_script}"
 				[=[
-if(NOT EXISTS "${ZLIB_BUILT_LIB}")
-	message(FATAL_ERROR "Built zlib library not found: ${ZLIB_BUILT_LIB}")
+if(NOT EXISTS "${_zlib_built_lib}")
+	message(FATAL_ERROR "Built zlib library not found: ${_zlib_built_lib}")
 endif()
-if(NOT EXISTS "${ZLIB_SOURCE_DIR}/zlib.h")
-	message(FATAL_ERROR "zlib.h not found: ${ZLIB_SOURCE_DIR}/zlib.h")
+if(NOT EXISTS "${_zlib_source_dir}/zlib.h")
+	message(FATAL_ERROR "zlib.h not found: ${_zlib_source_dir}/zlib.h")
 endif()
-if(NOT EXISTS "${ZLIB_BUILD_DIR}/zconf.h")
-	message(FATAL_ERROR "Generated zconf.h not found: ${ZLIB_BUILD_DIR}/zconf.h")
+if(NOT EXISTS "${_zlib_build_dir}/zconf.h")
+	message(FATAL_ERROR "Generated zconf.h not found: ${_zlib_build_dir}/zconf.h")
 endif()
 
-file(MAKE_DIRECTORY "${ZLIB_LIB_DIR}" "${ZLIB_INCLUDE}")
+file(MAKE_DIRECTORY "${_zlib_lib_dir}" "${ZLIB_INCLUDE}")
 file(
-	INSTALL DESTINATION "${ZLIB_LIB_DIR}"
-	TYPE "${ZLIB_LIBRARY_INSTALL_TYPE}"
+	INSTALL DESTINATION "${_zlib_lib_dir}"
+	TYPE "${_zlib_library_install_type}"
 	FOLLOW_SYMLINK_CHAIN
-	FILES "${ZLIB_BUILT_LIB}"
+	FILES "${_zlib_built_lib}"
 )
 file(
 	INSTALL DESTINATION "${ZLIB_INCLUDE}"
 	TYPE FILE
-	FILES "${ZLIB_SOURCE_DIR}/zlib.h" "${ZLIB_BUILD_DIR}/zconf.h"
+	FILES "${_zlib_source_dir}/zlib.h" "${_zlib_build_dir}/zconf.h"
 )
 ]=]
 			)
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
-				SOURCE_DIR "${ZLIB_SOURCE_DIR}"
+				SOURCE_DIR "${_zlib_source_dir}"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 				CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -119,18 +121,18 @@ file(
 						   -DZLIB_BUILD_EXAMPLES=OFF
 						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
 						   -DCMAKE_INSTALL_LIBDIR=lib
-				CMAKE_CACHE_ARGS ${ZLIB_EXTERNAL_PROJECT_CACHE_ARGS}
+				CMAKE_CACHE_ARGS ${_zlib_external_project_cache_args}
 				# Build only the target we need so the unused library type is never compiled.
-				BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target
-							  ${ZLIB_BUILD_TARGET}
+				BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${_zlib_build_config_args}
+							  --target ${_zlib_build_target}
 				# zlib's own install() installs both targets together, which would fail for the
 				# target we did not build; install just the built library + public headers.
 				INSTALL_COMMAND
-					${CMAKE_COMMAND} "-DZLIB_BUILT_LIB=${ZLIB_BUILT_LIB}"
-					"-DZLIB_LIBRARY_INSTALL_TYPE=${ZLIB_LIBRARY_INSTALL_TYPE}"
-					"-DZLIB_LIB_DIR=${ZLIB_SRC}/lib" "-DZLIB_INCLUDE=${ZLIB_INCLUDE}"
-					"-DZLIB_SOURCE_DIR=${ZLIB_SOURCE_DIR}" "-DZLIB_BUILD_DIR=${ZLIB_BUILD_DIR}" -P
-					"${ZLIB_INSTALL_SCRIPT}"
+					${CMAKE_COMMAND} "-D_zlib_built_lib=${_zlib_built_lib}"
+					"-D_zlib_library_install_type=${_zlib_library_install_type}"
+					"-D_zlib_lib_dir=${ZLIB_SRC}/lib" "-DZLIB_INCLUDE=${ZLIB_INCLUDE}"
+					"-D_zlib_source_dir=${_zlib_source_dir}" "-D_zlib_build_dir=${_zlib_build_dir}"
+					-P "${_zlib_install_script}"
 				BUILD_BYPRODUCTS ${ZLIB_LIB}
 			)
 			install(
@@ -139,7 +141,7 @@ file(
 				COMPONENT "libs-deps"
 			)
 			install(
-				FILES ${ZLIB_HEADERS}
+				FILES ${_zlib_headers}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)
@@ -154,7 +156,7 @@ file(
 			ExternalProject_Add(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
-				SOURCE_DIR "${ZLIB_SOURCE_DIR}"
+				SOURCE_DIR "${_zlib_source_dir}"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 				BUILD_IN_SOURCE 1
@@ -168,7 +170,7 @@ file(
 						   -DZLIB_BUILD_EXAMPLES=OFF
 						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
 						   -DCMAKE_INSTALL_LIBDIR=lib
-				CMAKE_CACHE_ARGS ${ZLIB_EXTERNAL_PROJECT_CACHE_ARGS}
+				CMAKE_CACHE_ARGS ${_zlib_external_project_cache_args}
 			)
 			install(
 				FILES "${ZLIB_LIB}"
@@ -176,7 +178,7 @@ file(
 				COMPONENT "libs-deps"
 			)
 			install(
-				FILES ${ZLIB_HEADERS}
+				FILES ${_zlib_headers}
 				DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/zlib"
 				COMPONENT "libs-deps"
 			)

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -80,7 +80,6 @@ else()
 			)
 			set(ZLIB_LIB "${ZLIB_SRC}/lib/libz${ZLIB_LIB_SUFFIX}")
 			set(_zlib_install_script "${PROJECT_BINARY_DIR}/zlib-prefix/src/zlib-install.cmake")
-			file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/zlib-prefix/src")
 			file(
 				WRITE "${_zlib_install_script}"
 				[=[
@@ -112,6 +111,7 @@ file(
 				zlib
 				PREFIX "${PROJECT_BINARY_DIR}/zlib-prefix"
 				SOURCE_DIR "${_zlib_source_dir}"
+				BINARY_DIR "${_zlib_build_dir}"
 				URL "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
 				URL_HASH "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 				CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -120,7 +120,6 @@ file(
 						   "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
 						   -DZLIB_BUILD_EXAMPLES=OFF
 						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
-						   -DCMAKE_INSTALL_LIBDIR=lib
 				CMAKE_CACHE_ARGS ${_zlib_external_project_cache_args}
 				# Build only the target we need so the unused library type is never compiled.
 				BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${_zlib_build_config_args}
@@ -169,7 +168,6 @@ file(
 						   "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
 						   -DZLIB_BUILD_EXAMPLES=OFF
 						   -DCMAKE_INSTALL_PREFIX=${ZLIB_SRC}
-						   -DCMAKE_INSTALL_LIBDIR=lib
 				CMAKE_CACHE_ARGS ${_zlib_external_project_cache_args}
 			)
 			install(

--- a/cmake/modules/zlib.cmake
+++ b/cmake/modules/zlib.cmake
@@ -93,7 +93,6 @@ if(NOT EXISTS "${_zlib_build_dir}/zconf.h")
 	message(FATAL_ERROR "Generated zconf.h not found: ${_zlib_build_dir}/zconf.h")
 endif()
 
-file(MAKE_DIRECTORY "${_zlib_lib_dir}" "${ZLIB_INCLUDE}")
 file(
 	INSTALL DESTINATION "${_zlib_lib_dir}"
 	TYPE "${_zlib_library_install_type}"


### PR DESCRIPTION
## Summary
Build the bundled `zlib` dependency on non-Windows via zlib's own CMake build instead of
invoking its hand-written `./configure` script through `ExternalProject_Add`'s
`CONFIGURE_COMMAND`. zlib v1.3.1 ships a first-class `CMakeLists.txt`, so the bundled dep is now
configured and built with CMake (mirroring the existing Windows branch and the
`jsoncpp`/`re2`/`tbb` modules), with build settings passed via `CMAKE_ARGS` and the toolchain
forwarded through the shared `falcosecurity_external_project_cache_args` mechanism.

## Why this matters
Issue #2584 tracks this as a build-system maintainability cleanup. Using zlib's own CMake build
drops the bespoke `./configure` + `make` + `CFLAGS` plumbing (`-O3`/`-g`, `-fPIC`, and toolchain
flag accumulation) in favor of standard CMake cache vars (`CMAKE_BUILD_TYPE`,
`CMAKE_POSITION_INDEPENDENT_CODE`, `CMAKE_C_FLAGS`), and unifies how the bundled dependency
toolchain is propagated with the rest of the bundled deps.

## Changes
- `cmake/modules/zlib.cmake` (non-Windows branch): replace `CONFIGURE_COMMAND ./configure` /
  `BUILD_COMMAND make` / `BUILD_IN_SOURCE 1` with a CMake configure+build via `CMAKE_ARGS` and
  `CMAKE_CACHE_ARGS ${ZLIB_EXTERNAL_PROJECT_CACHE_ARGS}`.
- Build only the library type that is actually consumed (`zlibstatic` for static builds, `zlib`
  for shared) so the unused target is never compiled — preserving the old `./configure --static`
  behavior and keeping static-only / cross toolchains working.
- `-DZLIB_BUILD_EXAMPLES=OFF` so the bundled sub-build skips zlib's example/test executables.
- `ZLIB_INCLUDE` / `ZLIB_LIB` / `ZLIB_HEADERS` continue to point at the produced library and
  headers, so downstream consumers (`libscap`, `libsinsp`, `libpman`, `libbpf`) see no interface
  change.

## Testing
The `cmake/modules/zlib.cmake` module is syntactically valid and the `ExternalProject_Add`
arguments are internally consistent (verified by configuring the module in isolation and by
building the bundled zlib sub-project directly for static and shared, single- and multi-config
generators). A full `falcosecurity/libs` build was not run locally as it requires the complete
dependency set; CI exercises the end-to-end bundled build.

Fixes #2584

---
AI was used for assistance.



**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
