### PR TITLE
fix(modern_bpf): reduce BPF instruction count in auxmap__preload_even…

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -92,12 +92,22 @@ static __always_inline struct auxiliary_map *auxmap_iter__get() {
  */
 static __always_inline void auxmap__preload_event_header(struct auxiliary_map *auxmap,
                                                          uint16_t event_type) {
-	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)auxmap->data;
 	uint8_t nparams = maps__get_event_num_params(event_type);
-	hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
-	hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
-	hdr->type = event_type;
-	hdr->nparams = nparams;
+
+	/*
+	 * Avoid byte-by-byte stores from writing packed header fields directly.
+	 * `struct ppm_evt_hdr` is packed, so field assignments can be lowered to
+	 * byte stores. By building the header as a local value and copying it with
+	 * __builtin_memcpy, clang can lower the copy into wider stores at naturally
+	 * aligned destination offsets (ts/tid/len/type).
+	 */
+	struct ppm_evt_hdr hdr = {0};
+	hdr.ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
+	hdr.tid = bpf_get_current_pid_tgid() & 0xffffffff;
+	hdr.type = event_type;
+	hdr.nparams = nparams;
+	__builtin_memcpy(&auxmap->data[0], &hdr, sizeof(struct ppm_evt_hdr));
+
 	auxmap->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	auxmap->lengths_pos = sizeof(struct ppm_evt_hdr);
 	auxmap->event_type = event_type;


### PR DESCRIPTION
## reduce BPF instruction count in auxmap__preload_event_header

**What this PR does / why we need it**:

- In auxmap__preload_event_header, the event header was written by casting `auxmap->data` (`uint8_t[]`) directly to `struct ppm_evt_hdr *`, which is declared with `#pragma pack(1)`. The BPF compiler sees an unaligned pointer and decomposes every field write into individual byte stores:

  `hdr->ts`      (u64) -> 8 byte stores
 ` hdr->tid`     (u64) -> 8 byte stores
  `hdr->type`    (u16) -> 2 byte stores
  `hdr->nparams` (u32) -> 4 byte stores
  Total: 22 byte stores

- Fix by building the header in a naturally-aligned stack struct first, then copying it into `auxmap->data` with `__builtin_memcpy`. The compiler emits full-width stores for the naturally-aligned stack struct:

  `hdr.ts`      -> single *(u64 *) store
  `hdr.tid`     -> single *(u64 *) store
  `hdr.type`    -> single *(u16 *) store
  `hdr.nparams` -> single *(u16 *) store
  Total: 5 stores

This eliminates `~32` BPF instructions per invocation. Since this function is called across all `87 syscall` probe sites in the modern BPF driver, the reduction applies to every syscall event Falco captures.

Before (bpftool prog dump xlated):

```assembly
; return settings->boot_time;
  55: (79) r7 = *(u64 *)(r0 +0)
; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
  56: (85) call bpf_ktime_get_boot_ns#306080
; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
  57: (0f) r0 += r7
; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
  58: (73) *(u8 *)(r8 +0) = r0
  59: (bf) r1 = r0
  60: (77) r1 >>= 56
  61: (73) *(u8 *)(r8 +7) = r1
  62: (bf) r1 = r0
  63: (77) r1 >>= 48
  64: (73) *(u8 *)(r8 +6) = r1
  65: (bf) r1 = r0
  66: (77) r1 >>= 40
  67: (73) *(u8 *)(r8 +5) = r1
  68: (bf) r1 = r0
  69: (77) r1 >>= 32
  70: (73) *(u8 *)(r8 +4) = r1
  71: (bf) r1 = r0
  72: (77) r1 >>= 24
  73: (73) *(u8 *)(r8 +3) = r1
  74: (bf) r1 = r0
  75: (77) r1 >>= 16
  76: (73) *(u8 *)(r8 +2) = r1
  77: (77) r0 >>= 8
  78: (73) *(u8 *)(r8 +1) = r0
; auxmap->event_type = event_type;
  79: (bf) r7 = r8
  80: (07) r7 += 131082
; hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
  81: (85) call bpf_get_current_pid_tgid#305536
  82: (b4) w1 = 293
; auxmap->event_type = event_type;
  83: (6b) *(u16 *)(r7 +0) = r1
  84: (b4) w1 = 0
; hdr->nparams = nparams;
  85: (73) *(u8 *)(r8 +25) = r1
  86: (73) *(u8 *)(r8 +24) = r1
  87: (73) *(u8 *)(r8 +23) = r1
  88: (b4) w1 = 1
; hdr->type = event_type;
  89: (73) *(u8 *)(r8 +21) = r1
  90: (b4) w1 = 37
  91: (73) *(u8 *)(r8 +20) = r1
; hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
  92: (73) *(u8 *)(r8 +15) = r6
  93: (73) *(u8 *)(r8 +14) = r6
  94: (73) *(u8 *)(r8 +13) = r6
  95: (73) *(u8 *)(r8 +12) = r6
  96: (73) *(u8 *)(r8 +8) = r0
  97: (bf) r1 = r0
  98: (77) r1 >>= 24
  99: (73) *(u8 *)(r8 +11) = r1
 100: (bf) r1 = r0
 101: (77) r1 >>= 16
 102: (73) *(u8 *)(r8 +10) = r1
 103: (77) r0 >>= 8
 104: (73) *(u8 *)(r8 +9) = r0
; hdr->nparams = nparams;
 105: (73) *(u8 *)(r8 +22) = r9
```

After (bpftool prog dump xlated):

```assembly
; return settings->boot_time;
  54: (79) r7 = *(u64 *)(r0 +0)
; hdr.ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
  55: (85) call bpf_ktime_get_boot_ns#306080
  56: (bf) r9 = r0
; hdr.ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
  57: (0f) r9 += r7
; auxmap->event_type = event_type;
  58: (bf) r7 = r8
  59: (07) r7 += 131082
; hdr.tid = (uint32_t)bpf_get_current_pid_tgid();
  60: (85) call bpf_get_current_pid_tgid#305536
  61: (b4) w1 = 293
; auxmap->event_type = event_type;
  62: (6b) *(u16 *)(r7 +0) = r1
; __builtin_memcpy(&auxmap->data[0], &hdr, sizeof(struct ppm_evt_hdr));
  63: (6b) *(u16 *)(r8 +20) = r1
  64: (b4) w1 = 0
  65: (6b) *(u16 *)(r8 +24) = r1
  66: (63) *(u32 *)(r8 +16) = r1
  67: (7b) *(u64 *)(r8 +0) = r9
; hdr.tid = (uint32_t)bpf_get_current_pid_tgid();
  68: (67) r0 <<= 32
  69: (77) r0 >>= 32
; __builtin_memcpy(&auxmap->data[0], &hdr, sizeof(struct ppm_evt_hdr));
  70: (7b) *(u64 *)(r8 +8) = r0
  71: (6b) *(u16 *)(r8 +22) = r6
```

**What type of PR is this?**

> /kind bug

**Any specific area of the project related to this PR?**

> /area driver-modern-bpf

> /area libscap-engine-modern-bpf


**Special notes for your reviewer**:

The bytecode optimization significantly shrinks the program size across all 87 probe sites utilizing this helper. Stack usage changes are negligible and safely within eBPF verifier limits.

**Does this PR introduce a user-facing change?**:

No

```release-note
NONE
```
