### PR TITLE
perf(modern_bpf): reduce BPF instruction count in ringbuf__store_event_header

### DIFF
--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -139,13 +139,33 @@ static __always_inline uint32_t ringbuf__reserve_space(struct ringbuf_struct *ri
  * @param ringbuf pointer to the `ringbuf_struct`.
  */
 static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf) {
-	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)ringbuf->data;
-	uint8_t nparams = maps__get_event_num_params(ringbuf->event_type);
-	hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
-	hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
-	hdr->type = ringbuf->event_type;
-	hdr->nparams = nparams;
-	hdr->len = ringbuf->reserved_event_size;
+	/*
+	 * Avoid byte-by-byte stores when writing packed header fields into
+	 * ringbuf memory. Unlike auxmap->data (an inline array), ringbuf->data
+	 * is a pointer returned by bpf_ringbuf_reserve(), which the BPF verifier
+	 * tracks specially. __builtin_memcpy into ringbuf pointers is still
+	 * decomposed into byte stores, so we use explicit u32/u16 stores via
+	 * offsetof instead. The verifier permits these wider stores and they
+	 * emit single-instruction writes rather than byte-by-byte decomposition.
+	 */
+	uint64_t ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
+	uint32_t ts_lo = (uint32_t)(ts & 0xffffffff);
+	uint32_t ts_hi = (uint32_t)(ts >> 32);
+	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, ts)) = ts_lo;
+	*(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, ts) + 4)) = ts_hi;
+
+	uint32_t tid = (uint32_t)(bpf_get_current_pid_tgid() & 0xffffffff);
+	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, tid)) = tid;
+	*(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, tid) + 4)) = 0;
+
+	uint32_t len = ringbuf->reserved_event_size;
+	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, len)) = len;
+
+	uint16_t type = ringbuf->event_type;
+	*(uint16_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, type)) = type;
+
+	uint32_t nparams = maps__get_event_num_params(ringbuf->event_type);
+	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, nparams)) = nparams;
 
 	ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	ringbuf->lengths_pos = sizeof(struct ppm_evt_hdr);

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -134,53 +134,29 @@ static __always_inline uint32_t ringbuf__reserve_space(struct ringbuf_struct *ri
 ////////////////////////////////
 
 /**
- * @brief Write a 64-bit header field into ringbuf-reserved memory.
- *
- * The value is written as two 32-bit stores.
- */
-static __always_inline void ringbuf__store_header_u64(uint8_t *data, size_t offset, uint64_t val) {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	*(volatile uint32_t *)(data + offset) = (uint32_t)(val & 0xffffffff);
-	*(volatile uint32_t *)(data + offset + 4) = (uint32_t)(val >> 32);
-#else
-	*(volatile uint32_t *)(data + offset) = (uint32_t)(val >> 32);
-	*(volatile uint32_t *)(data + offset + 4) = (uint32_t)(val & 0xffffffff);
-#endif
-}
-
-/**
- * @brief Write a 32-bit header field into ringbuf-reserved memory.
- */
-static __always_inline void ringbuf__store_header_u32(uint8_t *data, size_t offset, uint32_t val) {
-	*(volatile uint32_t *)(data + offset) = val;
-}
-
-/**
- * @brief Write a 16-bit header field into ringbuf-reserved memory.
- */
-static __always_inline void ringbuf__store_header_u16(uint8_t *data, size_t offset, uint16_t val) {
-	*(volatile uint16_t *)(data + offset) = val;
-}
-
-/**
  * @brief Push the event header inside the ringbuf space.
  *
  * @param ringbuf pointer to the `ringbuf_struct`.
  */
 static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf) {
-	uint64_t ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
-	uint64_t tid = bpf_get_current_pid_tgid() & 0xffffffff;
-	uint32_t len = ringbuf->reserved_event_size;
 	uint8_t nparams = maps__get_event_num_params(ringbuf->event_type);
-	uint16_t type = ringbuf->event_type;
 
-	ringbuf__store_header_u64(ringbuf->data, offsetof(struct ppm_evt_hdr, ts), ts);
-	ringbuf__store_header_u64(ringbuf->data, offsetof(struct ppm_evt_hdr, tid), tid);
-	ringbuf__store_header_u32(ringbuf->data, offsetof(struct ppm_evt_hdr, len), len);
-	ringbuf__store_header_u16(ringbuf->data, offsetof(struct ppm_evt_hdr, type), type);
-	ringbuf__store_header_u32(ringbuf->data,
-	                          offsetof(struct ppm_evt_hdr, nparams),
-	                          (uint32_t)nparams);
+	/*
+	 * Avoid byte-by-byte stores when writing packed header fields directly.
+	 *
+	 * The ringbuf data pointer is expected to be naturally aligned.
+	 * Inform the compiler about 8-byte alignment so clang can emit
+	 * full-width stores (u64/u32/u16) instead of byte-by-byte stores,
+	 * without changing the packed ABI layout.
+	 */
+	void *aligned_ptr = __builtin_assume_aligned(ringbuf->data, 8);
+	struct ppm_evt_hdr *hdr = (struct ppm_evt_hdr *)aligned_ptr;
+
+	hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
+	hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
+	hdr->len = ringbuf->reserved_event_size;
+	hdr->type = ringbuf->event_type;
+	hdr->nparams = nparams;
 
 	ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	ringbuf->lengths_pos = sizeof(struct ppm_evt_hdr);

--- a/driver/modern_bpf/helpers/store/ringbuf_store_params.h
+++ b/driver/modern_bpf/helpers/store/ringbuf_store_params.h
@@ -134,38 +134,53 @@ static __always_inline uint32_t ringbuf__reserve_space(struct ringbuf_struct *ri
 ////////////////////////////////
 
 /**
+ * @brief Write a 64-bit header field into ringbuf-reserved memory.
+ *
+ * The value is written as two 32-bit stores.
+ */
+static __always_inline void ringbuf__store_header_u64(uint8_t *data, size_t offset, uint64_t val) {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	*(volatile uint32_t *)(data + offset) = (uint32_t)(val & 0xffffffff);
+	*(volatile uint32_t *)(data + offset + 4) = (uint32_t)(val >> 32);
+#else
+	*(volatile uint32_t *)(data + offset) = (uint32_t)(val >> 32);
+	*(volatile uint32_t *)(data + offset + 4) = (uint32_t)(val & 0xffffffff);
+#endif
+}
+
+/**
+ * @brief Write a 32-bit header field into ringbuf-reserved memory.
+ */
+static __always_inline void ringbuf__store_header_u32(uint8_t *data, size_t offset, uint32_t val) {
+	*(volatile uint32_t *)(data + offset) = val;
+}
+
+/**
+ * @brief Write a 16-bit header field into ringbuf-reserved memory.
+ */
+static __always_inline void ringbuf__store_header_u16(uint8_t *data, size_t offset, uint16_t val) {
+	*(volatile uint16_t *)(data + offset) = val;
+}
+
+/**
  * @brief Push the event header inside the ringbuf space.
  *
  * @param ringbuf pointer to the `ringbuf_struct`.
  */
 static __always_inline void ringbuf__store_event_header(struct ringbuf_struct *ringbuf) {
-	/*
-	 * Avoid byte-by-byte stores when writing packed header fields into
-	 * ringbuf memory. Unlike auxmap->data (an inline array), ringbuf->data
-	 * is a pointer returned by bpf_ringbuf_reserve(), which the BPF verifier
-	 * tracks specially. __builtin_memcpy into ringbuf pointers is still
-	 * decomposed into byte stores, so we use explicit u32/u16 stores via
-	 * offsetof instead. The verifier permits these wider stores and they
-	 * emit single-instruction writes rather than byte-by-byte decomposition.
-	 */
 	uint64_t ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
-	uint32_t ts_lo = (uint32_t)(ts & 0xffffffff);
-	uint32_t ts_hi = (uint32_t)(ts >> 32);
-	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, ts)) = ts_lo;
-	*(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, ts) + 4)) = ts_hi;
-
-	uint32_t tid = (uint32_t)(bpf_get_current_pid_tgid() & 0xffffffff);
-	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, tid)) = tid;
-	*(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, tid) + 4)) = 0;
-
+	uint64_t tid = bpf_get_current_pid_tgid() & 0xffffffff;
 	uint32_t len = ringbuf->reserved_event_size;
-	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, len)) = len;
-
+	uint8_t nparams = maps__get_event_num_params(ringbuf->event_type);
 	uint16_t type = ringbuf->event_type;
-	*(uint16_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, type)) = type;
 
-	uint32_t nparams = maps__get_event_num_params(ringbuf->event_type);
-	*(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, nparams)) = nparams;
+	ringbuf__store_header_u64(ringbuf->data, offsetof(struct ppm_evt_hdr, ts), ts);
+	ringbuf__store_header_u64(ringbuf->data, offsetof(struct ppm_evt_hdr, tid), tid);
+	ringbuf__store_header_u32(ringbuf->data, offsetof(struct ppm_evt_hdr, len), len);
+	ringbuf__store_header_u16(ringbuf->data, offsetof(struct ppm_evt_hdr, type), type);
+	ringbuf__store_header_u32(ringbuf->data,
+	                          offsetof(struct ppm_evt_hdr, nparams),
+	                          (uint32_t)nparams);
 
 	ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 	ringbuf->lengths_pos = sizeof(struct ppm_evt_hdr);


### PR DESCRIPTION
## Reduce BPF instruction count in ringbuf__store_event_header

**What this PR does / why we need it**:

`ringbuf__store_event_header` wrote event header fields by casting
`ringbuf->data` (`uint8_t *`) directly to `struct ppm_evt_hdr *`,
which is declared with `#pragma pack(1)`. The BPF compiler sees an
unaligned pointer and decomposes every field write into individual
byte stores:

- `hdr->ts`      (u64) → 8 byte stores
- `hdr->tid`     (u64) → 8 byte stores
- `hdr->len`     (u32) → 4 byte stores
- `hdr->type`    (u16) → 2 byte stores
- `hdr->nparams` (u32) → 4 byte stores
- Total: ~51 byte stores

This function is called across all **92 syscall probe sites** in the
modern BPF driver, so the overhead applies to every syscall event
Falco captures.

### Why a different approach from #3022

The same issue was fixed in `auxmap__preload_event_header` in #3022
using a stack struct + `__builtin_memcpy`. That approach cannot be
applied here because `ringbuf->data` is a **ringbuf-reserved pointer**
(returned by `bpf_ringbuf_reserve()`), not an inline byte array like
`auxmap->data`. The BPF verifier tracks ringbuf pointers specially and
does not allow wide stores via `__builtin_memcpy` into them.

Instead, this fix uses explicit u32/u16 pointer stores with `offsetof`
to write each field at its correct offset directly. The verifier allows
u32 and u16 wide stores into ringbuf memory, reducing the instruction
count significantly.

### Results

~44 fewer BPF instructions per invocation across 92 probe sites.

**additional details**

- Header write instructions saved:  ~40 direct byte stores eliminated
- Compiler reorganization bonus:     ~4 additional instructions cleaned up
- Total program reduction:           44

Before (bpftool prog dump xlated):

```assembly
; return settings->boot_time;
 216: (79) r9 = *(u64 *)(r0 +0)
 217: (79) r1 = *(u64 *)(r10 -56)
; ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 218: (bf) r7 = r1
 219: (67) r7 <<= 1
; ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 220: (bf) r8 = r7
 221: (07) r8 += 26

[instructions 222-224 are unrelated to this change — omitted for clarity]

; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 225: (7b) *(u64 *)(r10 -64) = r2
 226: (85) call bpf_ktime_get_boot_ns#306080
; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 227: (0f) r0 += r9
; hdr->ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 228: (73) *(u8 *)(r6 +0) = r0
 229: (bf) r1 = r0
 230: (77) r1 >>= 56
 231: (73) *(u8 *)(r6 +7) = r1
 232: (bf) r1 = r0
 233: (77) r1 >>= 48
 234: (73) *(u8 *)(r6 +6) = r1
 235: (bf) r1 = r0
 236: (77) r1 >>= 40
 237: (73) *(u8 *)(r6 +5) = r1
 238: (bf) r1 = r0
 239: (77) r1 >>= 32
 240: (73) *(u8 *)(r6 +4) = r1
 241: (bf) r1 = r0
 242: (77) r1 >>= 24
 243: (73) *(u8 *)(r6 +3) = r1
 244: (bf) r1 = r0
 245: (77) r1 >>= 16
 246: (73) *(u8 *)(r6 +2) = r1
 247: (77) r0 >>= 8
 248: (73) *(u8 *)(r6 +1) = r0
; hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
 249: (85) call bpf_get_current_pid_tgid#305536
; hdr->nparams = nparams;
 250: (79) r1 = *(u64 *)(r10 -56)
 251: (73) *(u8 *)(r6 +22) = r1
 252: (b4) w1 = 37
; hdr->type = ringbuf->event_type;
 253: (73) *(u8 *)(r6 +20) = r1
 254: (b7) r1 = 0
; hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
 255: (73) *(u8 *)(r6 +15) = r1
 256: (73) *(u8 *)(r6 +14) = r1
 257: (73) *(u8 *)(r6 +13) = r1
 258: (73) *(u8 *)(r6 +12) = r1
 259: (b4) w1 = 49
; hdr->len = ringbuf->reserved_event_size;
 260: (73) *(u8 *)(r6 +16) = r1
; hdr->tid = bpf_get_current_pid_tgid() & 0xffffffff;
 261: (73) *(u8 *)(r6 +8) = r0
 262: (bf) r1 = r0
 263: (77) r1 >>= 24
 264: (73) *(u8 *)(r6 +11) = r1
 265: (bf) r1 = r0
 266: (77) r1 >>= 16
 267: (73) *(u8 *)(r6 +10) = r1
 268: (77) r0 >>= 8
 269: (73) *(u8 *)(r6 +9) = r0
 270: (b4) w1 = 0
; hdr->nparams = nparams;
 271: (73) *(u8 *)(r6 +25) = r1
 272: (73) *(u8 *)(r6 +24) = r1
 273: (73) *(u8 *)(r6 +23) = r1
; hdr->type = ringbuf->event_type;
 274: (73) *(u8 *)(r6 +21) = r1
; hdr->len = ringbuf->reserved_event_size;
 275: (73) *(u8 *)(r6 +19) = r1
 276: (73) *(u8 *)(r6 +18) = r1
 277: (73) *(u8 *)(r6 +17) = r1
```

After (bpftool prog dump xlated):

```assembly
; return settings->boot_time;
 212: (79) r8 = *(u64 *)(r0 +0)
; uint64_t ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 213: (85) call bpf_ktime_get_boot_ns#306080
; uint64_t ts = maps__get_boot_time() + bpf_ktime_get_boot_ns();
 214: (0f) r0 += r8
; *(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, ts)) = ts_lo;
 215: (63) *(u32 *)(r6 +0) = r0
; uint32_t ts_hi = (uint32_t)(ts >> 32);
 216: (77) r0 >>= 32
; *(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, ts) + 4)) = ts_hi;
 217: (63) *(u32 *)(r6 +4) = r0
; uint32_t tid = (uint32_t)(bpf_get_current_pid_tgid() & 0xffffffff);
 218: (85) call bpf_get_current_pid_tgid#305536
 219: (b4) w1 = 37
; *(uint16_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, type)) = type;
 220: (6b) *(u16 *)(r6 +20) = r1
 221: (b4) w1 = 49
; *(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, len)) = len;
 222: (63) *(u32 *)(r6 +16) = r1
; *(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, tid)) = tid;
 223: (63) *(u32 *)(r6 +8) = r0
; *(uint32_t *)(ringbuf->data + (offsetof(struct ppm_evt_hdr, tid) + 4)) = 0;
 224: (63) *(u32 *)(r6 +12) = r7
 225: (79) r0 = *(u64 *)(r10 -88)

[instructions 226-230 are unrelated to this change — omitted for clarity]

; *(uint32_t *)(ringbuf->data + offsetof(struct ppm_evt_hdr, nparams)) = nparams;
 231: (63) *(u32 *)(r6 +22) = r2
; ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 232: (bf) r1 = r2
 233: (67) r1 <<= 1
; ringbuf->payload_pos = sizeof(struct ppm_evt_hdr) + nparams * sizeof(uint16_t);
 234: (bf) r5 = r1
 235: (07) r5 += 26
```

**What type of PR is this?**

> /kind cleanup

**Any specific area of the project related to this PR?**

> /area driver-modern-bpf

> /area libscap-engine-modern-bpf


**Special notes for your reviewer**:

This is a follow-up to #3022 which fixed the same byte-store pattern
in `auxmap__preload_event_header`. The fix approach differs due to
fundamental differences in pointer provenance between map value arrays
(`auxmap->data`) and ringbuf-reserved memory (`ringbuf->data`).

The `offsetof` macro is used throughout to correctly handle both
standard and `PPM_ENABLE_SENTINEL` builds without additional `#ifdef`
guards.

Stack usage changes are negligible and safely within eBPF verifier
limits.

**Does this PR introduce a user-facing change?**:

No

```release-note
NONE
```
