### PR TITLE
chore!: move some file system accesses to scap

### DIFF
--- a/userspace/libscap/linux/scap_fds.c
+++ b/userspace/libscap/linux/scap_fds.c
@@ -301,7 +301,7 @@ static uint32_t scap_linux_get_device_by_mount_id_impl(struct scap_linux_platfor
 }
 
 uint32_t scap_linux_get_device_by_mount_id(struct scap_platform *platform,
-                                           const char *procdir,
+                                           const int64_t tid,
                                            unsigned long requested_mount_id) {
 	struct scap_linux_platform *linux_platform = (struct scap_linux_platform *)platform;
 
@@ -311,9 +311,13 @@ uint32_t scap_linux_get_device_by_mount_id(struct scap_platform *platform,
 		return mountinfo->dev;
 	}
 
-	char fd_dir_name[SCAP_MAX_PATH_SIZE];
-	snprintf(fd_dir_name, SCAP_MAX_PATH_SIZE, "%smountinfo", procdir);
-	const int fd = open(fd_dir_name, O_RDONLY, 0);
+	char filename[SCAP_MAX_PATH_SIZE];
+	snprintf(filename,
+	         sizeof(filename),
+	         "%s/proc/%" PRIu64 "/mountinfo",
+	         scap_get_host_root(),
+	         tid);
+	const int fd = open(filename, O_RDONLY, 0);
 	if(fd < 0) {
 		return 0;
 	}

--- a/userspace/libscap/linux/scap_linux_int.h
+++ b/userspace/libscap/linux/scap_linux_int.h
@@ -66,6 +66,13 @@ int32_t scap_linux_get_fdinfo(struct scap_platform* platform,
                               struct scap_threadinfo* tinfo,
                               int fd,
                               char* lasterr);
+int32_t scap_linux_get_file_path(struct scap_platform* platform,
+                                 int64_t pid,
+                                 int64_t fd,
+                                 char* path_buff,
+                                 size_t path_buff_len,
+                                 size_t* path_len,
+                                 char* lasterr);
 
 // read all sockets and add them to the socket table hashed by their ino
 int32_t scap_fd_read_sockets(char* procdir, struct scap_ns_socket_list* sockets, char* error);

--- a/userspace/libscap/linux/scap_linux_int.h
+++ b/userspace/libscap/linux/scap_linux_int.h
@@ -46,7 +46,7 @@ int32_t scap_linux_create_iflist(struct scap_platform* platform);
 int32_t scap_linux_create_userlist(struct scap_platform* platform);
 
 uint32_t scap_linux_get_device_by_mount_id(struct scap_platform* platform,
-                                           const char* procdir,
+                                           int64_t tid,
                                            unsigned long requested_mount_id);
 int32_t scap_linux_proc_get(struct scap_platform* platform, int64_t tid, bool scan_sockets);
 int32_t scap_linux_refresh_proc_table(struct scap_platform* platform,

--- a/userspace/libscap/linux/scap_linux_platform.c
+++ b/userspace/libscap/linux/scap_linux_platform.c
@@ -117,6 +117,7 @@ static const struct scap_platform_vtable scap_linux_platform_vtable = {
         .get_threadlist = scap_linux_get_threadlist,
         .get_fdlist = scap_linux_get_fdlist,
         .get_fdinfo = scap_linux_get_fdinfo,
+        .get_file_path = scap_linux_get_file_path,
         .close_platform = scap_linux_close_platform,
         .free_platform = scap_linux_free_platform,
 };

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1951,26 +1951,11 @@ int32_t scap_linux_get_file_path(struct scap_platform* platform,
                                  const size_t path_buff_len,
                                  size_t* path_len,
                                  char* lasterr) {
-	if(scap_unlikely(pid <= 0)) {
-		ASSERT(false);
-		return scap_errprintf(lasterr, 0, "bug: pid must be positive");
-	}
-	if(scap_unlikely(fd < 0)) {
-		ASSERT(false);
-		return scap_errprintf(lasterr, 0, "bug: fd must be non-negative");
-	}
-	if(scap_unlikely(!path_buff)) {
-		ASSERT(false);
-		return scap_errprintf(lasterr, 0, "bug: path buffer must be non-NULL");
-	}
-	if(scap_unlikely(!path_buff_len)) {
-		ASSERT(false);
-		return scap_errprintf(lasterr, 0, "bug: path buffer len must not be zero");
-	}
-	if(scap_unlikely(!path_len)) {
-		ASSERT(false);
-		return scap_errprintf(lasterr, 0, "bug: path len pointer must non-NULL");
-	}
+	SCAP_ASSERT_OR_RETURN(pid <= 0, lasterr, 0, "bug: pid must be positive");
+	SCAP_ASSERT_OR_RETURN(fd < 0, lasterr, 0, "bug: fd must be non-negative");
+	SCAP_ASSERT_OR_RETURN(!path_buff, lasterr, 0, "bug: path buffer must be non-NULL");
+	SCAP_ASSERT_OR_RETURN(!path_buff_len, lasterr, 0, "bug: path buffer len must not be zero");
+	SCAP_ASSERT_OR_RETURN(!path_len, lasterr, 0, "bug: path len pointer must non-NULL");
 
 	char filename[SCAP_MAX_PATH_SIZE];
 	snprintf(filename,

--- a/userspace/libscap/linux/scap_procs.c
+++ b/userspace/libscap/linux/scap_procs.c
@@ -1943,3 +1943,47 @@ int32_t scap_linux_get_fdinfo(struct scap_platform* platform,
 	}
 	return res;
 }
+
+int32_t scap_linux_get_file_path(struct scap_platform* platform,
+                                 const int64_t pid,
+                                 const int64_t fd,
+                                 char* path_buff,
+                                 const size_t path_buff_len,
+                                 size_t* path_len,
+                                 char* lasterr) {
+	if(scap_unlikely(pid <= 0)) {
+		ASSERT(false);
+		return scap_errprintf(lasterr, 0, "bug: pid must be positive");
+	}
+	if(scap_unlikely(fd < 0)) {
+		ASSERT(false);
+		return scap_errprintf(lasterr, 0, "bug: fd must be non-negative");
+	}
+	if(scap_unlikely(!path_buff)) {
+		ASSERT(false);
+		return scap_errprintf(lasterr, 0, "bug: path buffer must be non-NULL");
+	}
+	if(scap_unlikely(!path_buff_len)) {
+		ASSERT(false);
+		return scap_errprintf(lasterr, 0, "bug: path buffer len must not be zero");
+	}
+	if(scap_unlikely(!path_len)) {
+		ASSERT(false);
+		return scap_errprintf(lasterr, 0, "bug: path len pointer must non-NULL");
+	}
+
+	char filename[SCAP_MAX_PATH_SIZE];
+	snprintf(filename,
+	         sizeof(filename),
+	         "%s/proc/%" PRId64 "/fd/%" PRId64,
+	         scap_get_host_root(),
+	         pid,
+	         fd);
+	const ssize_t bytes_read = readlink(filename, path_buff, path_buff_len - 1);
+	if(bytes_read <= 0) {
+		return scap_errprintf(lasterr, errno, "readlink() failed on %s", filename);
+	}
+	path_buff[bytes_read] = '\0';
+	*path_len = (size_t)bytes_read;
+	return SCAP_SUCCESS;
+}

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -156,3 +156,18 @@ int32_t scap_get_fdinfo(struct scap_platform* platform,
 
 	return scap_err_opnotsup(error);
 }
+
+int32_t scap_get_file_path(struct scap_platform* platform,
+                           const int64_t pid,
+                           const int64_t fd,
+                           char* path_buff,
+                           const size_t path_buff_len,
+                           size_t* path_len,
+                           char* error) {
+	if(platform && platform->m_vtable->get_file_path) {
+		return platform->m_vtable
+		        ->get_file_path(platform, pid, fd, path_buff, path_buff_len, path_len, error);
+	}
+
+	return scap_err_opnotsup(error);
+}

--- a/userspace/libscap/scap_platform_api.c
+++ b/userspace/libscap/scap_platform_api.c
@@ -47,10 +47,10 @@ scap_userlist* scap_get_user_list(struct scap_platform* platform) {
 }
 
 uint32_t scap_get_device_by_mount_id(struct scap_platform* platform,
-                                     const char* procdir,
-                                     unsigned long requested_mount_id) {
+                                     const int64_t tid,
+                                     const unsigned long requested_mount_id) {
 	if(platform && platform->m_vtable->get_device_by_mount_id) {
-		return platform->m_vtable->get_device_by_mount_id(platform, procdir, requested_mount_id);
+		return platform->m_vtable->get_device_by_mount_id(platform, tid, requested_mount_id);
 	}
 
 	return 0;

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 // this header is designed to be useful to scap consumers,
 // using the scap_t wrapper functions
@@ -116,6 +117,27 @@ int32_t scap_get_fdinfo(struct scap_platform* platform,
                         struct scap_threadinfo* tinfo,
                         int fd,
                         char* error);
+
+/*!
+  \brief Get a file path and write it to `path_buff`.
+  \param platform Handle to the platform instance.
+  \param pid Identifier of the process owning the file descriptor.
+  \param fd Identifier of the file.
+  \param path_buff Buffer where the NUL-terminated file path is going to be stored.
+  \param path_buff_len Length of \ref path_buff.
+  \param path_len Pointer where the file path length, on success, is stored. Notice that it doesn't
+  account for the NUL terminator.
+  \param error Pointer to the error buffer where the error reason is stored in case of failure. The
+  buffer must be `SCAP_LASTERR_SIZE` long.
+  \return SCAP_SUCCESS on success, any other SCAP_* failure code otherwise.
+*/
+int32_t scap_get_file_path(struct scap_platform* platform,
+                           int64_t pid,
+                           int64_t fd,
+                           char* path_buff,
+                           size_t path_buff_len,
+                           size_t* path_len,
+                           char* error);
 
 #ifdef __cplusplus
 };

--- a/userspace/libscap/scap_platform_api.h
+++ b/userspace/libscap/scap_platform_api.h
@@ -59,11 +59,11 @@ void scap_refresh_iflist(struct scap_platform* platform);
 */
 struct scap_userlist* scap_get_user_list(struct scap_platform* platform);
 
-// get the device major/minor number for the requested_mount_id, looking in procdir/mountinfo if
-// needed
-// XXX: procdir is Linux-specific
+// get the device major/minor number for the requested_mount_id, looking in
+// `<procfs_mount_path>/<tid>/mountinfo` if needed
+// XXX: this API is Linux-specific
 uint32_t scap_get_device_by_mount_id(struct scap_platform* platform,
-                                     const char* procdir,
+                                     int64_t tid,
                                      unsigned long requested_mount_id);
 
 // Get the information about a thread.

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -55,7 +55,7 @@ struct scap_platform_vtable {
 	// given a mount id, return the device major:minor
 	// XXX this is Linux-specific
 	uint32_t (*get_device_by_mount_id)(struct scap_platform*,
-	                                   const char* procdir,
+	                                   int64_t tid,
 	                                   unsigned long requested_mount_id);
 
 	int32_t (*get_proc)(struct scap_platform*, int64_t tid, bool scan_sockets);

--- a/userspace/libscap/scap_platform_impl.h
+++ b/userspace/libscap/scap_platform_impl.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 // this header is designed to be useful to platform *implementors*
 // i.e. different platforms
@@ -73,6 +74,13 @@ struct scap_platform_vtable {
 	                      struct scap_threadinfo* tinfo,
 	                      int fd,
 	                      char* lasterr);
+	int32_t (*get_file_path)(struct scap_platform* platform,
+	                         int64_t pid,
+	                         int64_t fd,
+	                         char* path_buff,
+	                         size_t path_buff_len,
+	                         size_t* path_len,
+	                         char* lasterr);
 
 	// close the platform structure
 	// clean up all data, make it ready for another call to `init_platform`

--- a/userspace/libscap/strerror.h
+++ b/userspace/libscap/strerror.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include <stdint.h>
 
 #include <libscap/scap_const.h>
+#include <libscap/scap_likely.h>
+#include <libscap/scap_assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +40,14 @@ int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...)
 	((void)sizeof(printf(__VA_ARGS__)), scap_errprintf_unchecked(BUF, ERRNUM, __VA_ARGS__))
 int32_t scap_errprintf_unchecked(char* buf, int errnum, const char* fmt, ...);
 #endif
+
+#define SCAP_ASSERT_OR_RETURN(COND, BUF, ERRNUM, ...)        \
+	do {                                                     \
+		if(scap_unlikely(COND)) {                            \
+			ASSERT(!(#COND));                                \
+			return scap_errprintf(BUF, ERRNUM, __VA_ARGS__); \
+		}                                                    \
+	} while(0)
 
 static inline int32_t scap_err_opnotsup(char* error) {
 	(void)scap_errprintf(error, 0, "operation not supported");

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -160,9 +160,7 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo& fdi) const {
 
 	if(m_tid != 0 && m_tid != static_cast<uint64_t>(-1) && fdi.is_file() && fdi.m_dev == 0 &&
 	   fdi.m_mount_id != 0) {
-		char procdir[SCAP_MAX_PATH_SIZE];
-		snprintf(procdir, sizeof(procdir), "%s/proc/%" PRIu64 "/", scap_get_host_root(), m_tid);
-		fdi.m_dev = scap_get_device_by_mount_id(m_params->m_scap_platform, procdir, fdi.m_mount_id);
+		fdi.m_dev = scap_get_device_by_mount_id(m_params->m_scap_platform, m_tid, fdi.m_mount_id);
 		fdi.m_mount_id = 0;  // don't try again
 	}
 #endif  // _WIN32

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -185,7 +185,9 @@ sinsp::sinsp(bool with_metrics):
                 sinsp_threadinfo::ctor_params{m_network_interfaces,
                                               m_fdinfo_factory,
                                               m_fdtable_factory,
-                                              m_thread_manager_dyn_fields})},
+                                              m_thread_manager_dyn_fields,
+                                              m_platform,
+                                              m_platform_lasterr})},
         m_threadinfo_factory{
                 m_threadinfo_ctor_params,
                 m_external_event_processor,

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include <limits.h>
 #endif
 #include <stdio.h>
+#include <inttypes.h>
 #include <libscap/strl.h>
 #include <libsinsp/sinsp_int.h>
 #include <libscap/scap-int.h>
@@ -872,33 +873,35 @@ std::string sinsp_threadinfo::get_path_for_dir_fd(int64_t dir_fd) {
 #ifdef _WIN32
 	return "";  // We will have to implement this for Windows.
 #else
-	char proc_path[PATH_MAX];
-	char dirfd_path[PATH_MAX + 1];  // +1 accounts for trailing '/' that will be added.
-	snprintf(proc_path,
-	         sizeof(proc_path),
-	         "%s/proc/%lld/fd/%lld",
-	         scap_get_host_root(),
-	         (long long)m_pid,
-	         (long long)dir_fd);
-
-	// Read up to `sizeof(dirfd_path) - 2` to leave room for '/' and '\0'.
-	const ssize_t bytes_read = readlink(proc_path, dirfd_path, sizeof(dirfd_path) - 2);
-	if(bytes_read < 0) {
-		libsinsp_logger()->log("Unable to determine path for file descriptor.",
-		                       sinsp_logger::SEV_INFO);
+	char dir_fd_path[PATH_MAX + 1];  // +1 accounts for trailing '/' that will be added.
+	// Pass `PATH_MAX` to leave room for '/'.
+	size_t dir_fd_path_len = 0;
+	if(scap_get_file_path(m_params->scap_plat,
+	                      m_pid,
+	                      dir_fd,
+	                      dir_fd_path,
+	                      PATH_MAX,
+	                      &dir_fd_path_len,
+	                      m_params->scap_plat_lasterr) != SCAP_SUCCESS) {
+		libsinsp_logger()->format(sinsp_logger::SEV_INFO,
+		                          "Unable to determine path for file descriptor %" PRId64
+		                          " (pid: %" PRId64 "): %s",
+		                          dir_fd,
+		                          m_pid,
+		                          m_params->scap_plat_lasterr);
 		return "";
 	}
-	dirfd_path[bytes_read] = '/';
-	dirfd_path[bytes_read + 1] = '\0';
+	dir_fd_path[dir_fd_path_len] = '/';
+	dir_fd_path[dir_fd_path_len + 1] = '\0';
 
 	// Sanitize the path.
-	const auto path_len = static_cast<size_t>(bytes_read + 1);  // +1 account for trailing '/'
+	dir_fd_path_len++;  // +1 account for trailing '/'
 	std::string sanitized_path_storage;
 	const auto sanitized_path =
-	        sanitize_string(std::string_view{dirfd_path, path_len}, sanitized_path_storage);
-	libsinsp_logger()->log(std::string("Translating to ") + sanitized_path.data());
-	if(sanitized_path.data() == dirfd_path) {
-		return dirfd_path;
+	        sanitize_string(std::string_view{dir_fd_path, dir_fd_path_len}, sanitized_path_storage);
+	libsinsp_logger()->format(sinsp_logger::SEV_INFO, "Translating to %s", sanitized_path.data());
+	if(sanitized_path.data() == dir_fd_path) {
+		return dir_fd_path;
 	}
 	return sanitized_path_storage;
 #endif /* _WIN32 */

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -57,12 +57,15 @@ struct erase_fd_params {
   An instance of this struct is meant to be shared among all sinsp_threadinfo instances.
 */
 struct sinsp_threadinfo_ctor_params {
-	// The following fields are externally provided and access to them is expected to be
-	// read-only.
+	// The following fields are externally provided and access to them is expected to be read-only.
 	const sinsp_network_interfaces& network_interfaces;
 	const sinsp_fdinfo_factory& fdinfo_factory;
 	const sinsp_fdtable_factory& fdtable_factory;
 	const std::shared_ptr<libsinsp::state::dynamic_field_infos>& thread_manager_dyn_fields;
+	scap_platform* const& scap_plat;
+	// The following fields are externally provided and expected to be populated/updated by the
+	// threadinfo logic.
+	char* scap_plat_lasterr;
 };
 
 /*!


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR moves some file system accesses and/or path resolution logic from libsinsp to libscap. Specifically:
- it moves `scap_get_device_by_mount_id()` platform-specific logic to scap
- it moves file path retrieval logic in new `scap_get_file_path()` scap API

Moreover, it adds a new macro `SCAP_ASSERT_OR_RETURN()` that can be used to check pre-requisites that are not supposed to be violated at runtime.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.26.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
chore!: `scap_get_device_by_mount_id()` API signature changed
```
