### PR TITLE
fix(libscap): reject malformed savefile events

### DIFF
--- a/test/libscap/test_suites/engines/savefile/convert_event_test.h
+++ b/test/libscap/test_suites/engines/savefile/convert_event_test.h
@@ -83,7 +83,11 @@ protected:
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, expected_evt->len));
 		// First we check the conversion result matches the expected result
-		ASSERT_EQ(scap_convert_event(m_converter_buf, storage.get(), evt_to_convert.get(), error),
+		ASSERT_EQ(scap_convert_event(m_converter_buf,
+		                             storage.get(),
+		                             evt_to_convert.get(),
+		                             expected_evt->len,
+		                             error),
 		          expected_res)
 		        << "Different conversion results: " << error;
 
@@ -101,7 +105,11 @@ protected:
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, evt_to_convert->len));
 		// First we check the conversion result matches the expected result
-		ASSERT_EQ(scap_convert_event(m_converter_buf, storage.get(), evt_to_convert.get(), error),
+		ASSERT_EQ(scap_convert_event(m_converter_buf,
+		                             storage.get(),
+		                             evt_to_convert.get(),
+		                             evt_to_convert->len,
+		                             error),
 		          CONVERSION_ERROR)
 		        << "The conversion is not failed: " << error;
 	}
@@ -111,7 +119,11 @@ protected:
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, evt_to_convert->len));
 		// First we check the conversion result matches the expected result
-		ASSERT_EQ(scap_convert_event(m_converter_buf, storage.get(), evt_to_convert.get(), error),
+		ASSERT_EQ(scap_convert_event(m_converter_buf,
+		                             storage.get(),
+		                             evt_to_convert.get(),
+		                             evt_to_convert->len,
+		                             error),
 		          CONVERSION_PASS)
 		        << "Event is not allowed to pass: " << error;
 	}
@@ -121,7 +133,11 @@ protected:
 		// We assume it's okay to create a new event with the same size as the expected event
 		auto storage = new_safe_scap_evt((scap_evt *)calloc(1, evt_to_convert->len));
 		// First we check the conversion result matches the expected result
-		ASSERT_EQ(scap_convert_event(m_converter_buf, storage.get(), evt_to_convert.get(), error),
+		ASSERT_EQ(scap_convert_event(m_converter_buf,
+		                             storage.get(),
+		                             evt_to_convert.get(),
+		                             evt_to_convert->len,
+		                             error),
 		          CONVERSION_DROP)
 		        << "Event is not dropped: " << error;
 	}
@@ -159,6 +175,7 @@ protected:
 			conv_res = scap_convert_event(m_converter_buf,
 			                              (scap_evt *)new_evt.get(),
 			                              (scap_evt *)to_convert_evt.get(),
+			                              expected_evt->len + convert_event_test::safe_margin,
 			                              error);
 		}
 		switch(conv_res) {

--- a/test/libscap/test_suites/engines/savefile/oob_read_write.cpp
+++ b/test/libscap/test_suites/engines/savefile/oob_read_write.cpp
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Regression tests for a heap out-of-bounds read/write in the savefile parser.
+//
+// For EV_BLOCK_TYPE_V2 / EV_BLOCK_TYPE_V2_LARGE blocks the event header `len` is taken
+// verbatim from the capture file. The conversion path used to memcpy `len` bytes into the
+// fixed-size (MAX_EVENT_SIZE = 64 KiB) staging buffer without validating it, so a crafted
+// `.scap` file could:
+//   * Bug 1 (EV_BLOCK_TYPE_V2):       set `len` far beyond the bytes actually read, causing a
+//                                     large heap OOB read and write.
+//   * Bug 2 (EV_BLOCK_TYPE_V2_LARGE): set `len = MAX_EVENT_SIZE + N` with all bytes present in
+//                                     the (reallocated) reader buffer, causing a controlled
+//                                     N-byte heap OOB write past the staging buffer.
+//
+// The fix bounds `len` against the bytes available in the block (next_event_from_file) and
+// validates the V2 length table before conversion. The conversion loop also rejects events larger
+// than MAX_EVENT_SIZE before copying them into fixed-size staging buffers. These tests build such
+// files in memory, read them through the savefile engine, and assert the crafted event is rejected
+// with a clean SCAP_FAILURE instead of corrupting memory (the OOB is also caught by ASan).
+
+#include <gtest/gtest.h>
+#include <libscap/scap.h>
+#include <libscap/scap_engines.h>
+#include <libscap/scap_procs.h>
+#include <libscap/scap_platform.h>
+#include <libscap/scap_savefile.h>
+#include <libscap/engine/savefile/savefile_public.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+namespace {
+
+// MAX_EVENT_SIZE is private to scap_savefile.c; keep a local copy in sync. The savefile
+// reader buffer (READER_BUF_SIZE) is intentionally the same size, which is why Bug 2 works.
+constexpr uint32_t MAX_EVENT_SIZE = 64 * 1024;
+// ppm_evt_hdr = ts(8) + tid(8) + len(4) + type(2) + nparams(4).
+constexpr uint32_t PPM_EVT_HDR_SIZE = 26;
+
+// Append the native-order bytes of an integer. The Section Header Block magic is written in
+// native order too, so the reader treats the whole capture as host byte order (no swap).
+template<typename T>
+void append(std::vector<uint8_t>& buf, T value) {
+	const auto* p = reinterpret_cast<const uint8_t*>(&value);
+	buf.insert(buf.end(), p, p + sizeof(T));
+}
+
+// Minimal Section Header Block: enough preamble for the engine to reach the event block.
+std::vector<uint8_t> build_shb() {
+	std::vector<uint8_t> body;
+	append<uint32_t>(body, SHB_MAGIC);              // byte_order_magic
+	append<uint16_t>(body, CURRENT_MAJOR_VERSION);  // major_version
+	append<uint16_t>(body, CURRENT_MINOR_VERSION);  // minor_version
+	append<uint64_t>(body, UINT64_MAX);             // section_length (unspecified)
+
+	const uint32_t total = sizeof(block_header) + static_cast<uint32_t>(body.size()) + 4;
+	std::vector<uint8_t> out;
+	append<uint32_t>(out, SHB_BLOCK_TYPE);
+	append<uint32_t>(out, total);
+	out.insert(out.end(), body.begin(), body.end());
+	append<uint32_t>(out, total);  // trailing block_total_length
+	return out;
+}
+
+// Build a single event block carrying an attacker-chosen `evt_len`/`nparams`.
+std::vector<uint8_t> event_block(uint32_t block_type,
+                                 uint16_t cpuid,
+                                 uint32_t evt_len,
+                                 uint16_t evt_type,
+                                 uint32_t nparams,
+                                 const std::vector<uint8_t>& payload,
+                                 bool pad_to_4) {
+	std::vector<uint8_t> body;
+	append<uint16_t>(body, cpuid);
+	append<uint64_t>(body, /*ts*/ 1);
+	append<uint64_t>(body, /*tid*/ 0);
+	append<uint32_t>(body, evt_len);
+	append<uint16_t>(body, evt_type);
+	append<uint32_t>(body, nparams);
+	body.insert(body.end(), payload.begin(), payload.end());
+
+	uint32_t total = sizeof(block_header) + static_cast<uint32_t>(body.size()) + 4;
+	if(pad_to_4) {
+		const uint32_t pad = (4 - (total % 4)) % 4;
+		body.insert(body.end(), pad, 0u);
+		total += pad;
+	}
+
+	std::vector<uint8_t> out;
+	append<uint32_t>(out, block_type);
+	append<uint32_t>(out, total);
+	out.insert(out.end(), body.begin(), body.end());
+	append<uint32_t>(out, total);  // trailing block_total_length
+	return out;
+}
+
+// Write the bytes to a throwaway file and return its path.
+std::string write_temp_capture(const std::vector<uint8_t>& bytes) {
+	char path[] = "/tmp/scap_oob_XXXXXX";
+	const int fd = mkstemp(path);
+	EXPECT_GE(fd, 0) << "cannot create temp capture";
+	if(fd < 0) {
+		return {};
+	}
+	const ssize_t written = write(fd, bytes.data(), bytes.size());
+	EXPECT_EQ(static_cast<size_t>(written), bytes.size());
+	close(fd);
+	return path;
+}
+
+// Open the crafted capture through the savefile engine and return the result of reading the
+// first event, along with the last error string. The crafted event is the first (and only)
+// event, so a correct parser must reject it here rather than crash.
+int32_t read_first_event(const std::vector<uint8_t>& capture, std::string& lasterr) {
+	const std::string path = write_temp_capture(capture);
+	if(path.empty()) {
+		return SCAP_FAILURE;
+	}
+
+	scap_proc_callbacks callbacks{};
+	callbacks.m_refresh_start_cb = default_refresh_start_end_callback;
+	callbacks.m_refresh_end_cb = default_refresh_start_end_callback;
+	callbacks.m_proc_entry_cb = default_proc_entry_callback;
+	callbacks.m_callback_context = nullptr;
+
+	scap_savefile_engine_params params{};
+	params.fname = path.c_str();
+	params.platform = scap_savefile_alloc_platform(callbacks);
+
+	scap_open_args oargs{};
+	oargs.engine_params = &params;
+
+	char error[SCAP_LASTERR_SIZE] = {};
+	int32_t rc = SCAP_FAILURE;
+	scap_t* h = scap_open(&oargs, &scap_savefile_engine, error, &rc);
+	// The SHB + event preamble is well-formed, so opening must succeed; the crafted event is
+	// only inspected on the first scap_next().
+	EXPECT_NE(h, nullptr) << "scap_open failed: " << error;
+
+	int32_t res = rc;
+	if(h != nullptr) {
+		scap_evt* evt = nullptr;
+		uint16_t devid = 0;
+		uint32_t flags = 0;
+		res = scap_next(h, &evt, &devid, &flags);
+		lasterr = scap_getlasterr(h);
+	}
+
+	// The caller owns the platform allocated above; free it as libsinsp does on close.
+	scap_platform_close(params.platform);
+	scap_platform_free(params.platform);
+	if(h != nullptr) {
+		scap_close(h);
+	}
+	remove(path.c_str());
+	return res;
+}
+
+}  // namespace
+
+// Bug 1: EV_BLOCK_TYPE_V2 with `len` far larger than the bytes read for the block.
+// Rejected by the in-buffer bound in next_event_from_file().
+TEST(savefile_oob, ev_v2_len_exceeds_block) {
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2,
+	                               /*cpuid*/ 0,
+	                               /*evt_len*/ 5'832'704,  // ~5.8 MiB, block holds < 64 bytes
+	                               /*evt_type*/ PPME_SYSCALL_OPEN_E,
+	                               /*nparams*/ 524'288,
+	                               /*payload*/ {},
+	                               /*pad_to_4*/ true);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "oversized V2 event should be rejected";
+	EXPECT_NE(lasterr.find("invalid event"), std::string::npos) << "unexpected error: " << lasterr;
+}
+
+// Bug 2 (crash variant): EV_BLOCK_TYPE_V2_LARGE whose `len` exceeds the bytes actually read.
+// Also rejected by the in-buffer bound in next_event_from_file().
+TEST(savefile_oob, ev_v2_large_len_exceeds_block) {
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2_LARGE,
+	                               /*cpuid*/ 0,
+	                               /*evt_len*/ 196'608,  // 0x30000, block holds < 64 bytes
+	                               /*evt_type*/ PPME_GENERIC_E,
+	                               /*nparams*/ 2'490'368,
+	                               /*payload*/ {},
+	                               /*pad_to_4*/ false);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "oversized V2_LARGE event should be rejected";
+	EXPECT_NE(lasterr.find("invalid event"), std::string::npos) << "unexpected error: " << lasterr;
+}
+
+// Bug 2 (controlled-write variant): EV_BLOCK_TYPE_V2_LARGE where every byte of `len` is present
+// in the (reallocated) reader buffer, but `len > MAX_EVENT_SIZE`. This passes the in-buffer
+// bound and must be stopped by the MAX_EVENT_SIZE bound on the conversion path before the
+// memcpy into the fixed-size staging buffer. A converter-managed enter event (PPME_GENERIC_E)
+// forces the conversion (CONVERSION_CONTINUE) that reaches the memcpy.
+TEST(savefile_oob, ev_v2_large_len_exceeds_max_event_size) {
+	constexpr uint32_t overflow = 64;
+	const uint32_t evt_len = MAX_EVENT_SIZE + overflow;
+	constexpr uint16_t first_param_len = 32785;
+	constexpr uint16_t second_param_len = 32785;
+
+	// Make the block carry exactly `evt_len` event bytes so the in-buffer bound passes and the
+	// event reaches the conversion path. 0x42 marks the bytes that would overflow.
+	std::vector<uint8_t> payload;
+	payload.reserve(sizeof(uint16_t) * 2 + first_param_len + second_param_len);
+	append<uint16_t>(payload, first_param_len);
+	append<uint16_t>(payload, second_param_len);
+	for(uint32_t i = 0; i < first_param_len + second_param_len; i++) {
+		payload.push_back(i < first_param_len + second_param_len - overflow ? 0x41 : 0x42);
+	}
+
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2_LARGE,
+	                               /*cpuid*/ 0,
+	                               evt_len,
+	                               /*evt_type*/ PPME_GENERIC_E,
+	                               /*nparams*/ 2,
+	                               payload,
+	                               /*pad_to_4*/ false);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "V2_LARGE event over MAX_EVENT_SIZE should be rejected";
+	EXPECT_NE(lasterr.find("invalid event"), std::string::npos) << "unexpected error: " << lasterr;
+}
+
+// A valid-size event can still overflow the conversion output buffer if conversion adds parameters
+// and shifts the existing parameter blob forward.
+TEST(savefile_oob, ev_v2_large_conversion_expansion_exceeds_max_event_size) {
+	constexpr uint32_t param_len = MAX_EVENT_SIZE - PPM_EVT_HDR_SIZE - sizeof(uint16_t);
+
+	std::vector<uint8_t> payload;
+	payload.reserve(sizeof(uint16_t) + param_len);
+	append<uint16_t>(payload, param_len);
+	for(uint32_t i = 0; i < param_len; i++) {
+		payload.push_back(0x41);
+	}
+
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2_LARGE,
+	                               /*cpuid*/ 0,
+	                               MAX_EVENT_SIZE,
+	                               /*evt_type*/ PPME_GENERIC_X,
+	                               /*nparams*/ 1,
+	                               payload,
+	                               /*pad_to_4*/ false);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "conversion expansion past MAX_EVENT_SIZE should be rejected";
+	EXPECT_NE(lasterr.find("conversion buffer"), std::string::npos)
+	        << "unexpected error: " << lasterr;
+}
+
+// The V2 `nparams` field is attacker-controlled too. If the declared length table cannot fit
+// inside `len`, conversion must reject the event before using `nparams` in offset calculations.
+TEST(savefile_oob, ev_v2_nparams_exceeds_event_len) {
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2,
+	                               /*cpuid*/ 0,
+	                               PPM_EVT_HDR_SIZE,
+	                               /*evt_type*/ PPME_GENERIC_X,
+	                               /*nparams*/ 257,
+	                               /*payload*/ {},
+	                               /*pad_to_4*/ true);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "V2 event with impossible nparams should be rejected";
+	EXPECT_NE(lasterr.find("invalid event"), std::string::npos) << "unexpected error: " << lasterr;
+}
+
+// Even when the length table fits, individual parameter lengths must stay inside event->len.
+TEST(savefile_oob, ev_v2_param_len_exceeds_event_len) {
+	std::vector<uint8_t> payload;
+	append<uint16_t>(payload, UINT16_MAX);
+
+	auto capture = build_shb();
+	const auto block = event_block(EV_BLOCK_TYPE_V2,
+	                               /*cpuid*/ 0,
+	                               PPM_EVT_HDR_SIZE + static_cast<uint32_t>(payload.size()),
+	                               /*evt_type*/ PPME_GENERIC_X,
+	                               /*nparams*/ 1,
+	                               payload,
+	                               /*pad_to_4*/ true);
+	capture.insert(capture.end(), block.begin(), block.end());
+
+	std::string lasterr;
+	const int32_t res = read_first_event(capture, lasterr);
+	EXPECT_EQ(res, SCAP_FAILURE) << "V2 event with oversized param len should be rejected";
+	EXPECT_NE(lasterr.find("invalid event"), std::string::npos) << "unexpected error: " << lasterr;
+}

--- a/userspace/libscap/engine/savefile/converter/converter.cpp
+++ b/userspace/libscap/engine/savefile/converter/converter.cpp
@@ -226,14 +226,42 @@ static uint64_t get_default_value_from_type(const ppm_param_type t) {
 	}
 }
 
+static int ensure_evt_space(size_t offset, size_t len, size_t evt_size, char *error) {
+	if(offset > evt_size || len > evt_size - offset) {
+		scap_errprintf(error,
+		               0,
+		               "converted event length would exceed conversion buffer size %zu",
+		               evt_size);
+		return -1;
+	}
+	return 0;
+}
+
+static int ensure_param_len_slot(const scap_evt *evt,
+                                 const uint8_t param_num,
+                                 const size_t evt_size,
+                                 char *error) {
+	const auto len_size = get_param_len_size(evt);
+	const size_t len_offset = sizeof(scap_evt) + (size_t)param_num * len_size;
+	return ensure_evt_space(len_offset, len_size, evt_size, error);
+}
+
 // Writes parameter length and value and update the provided parameter offsets accordingly to the
 // written length.
-static void push_default_parameter(scap_evt *evt, size_t *params_offset, const uint8_t param_num) {
+static int push_default_parameter(scap_evt *evt,
+                                  size_t *params_offset,
+                                  const uint8_t param_num,
+                                  size_t evt_size,
+                                  char *error) {
 	// Please ensure that `evt->type` is already the final type you want to obtain.
 	// Otherwise, we will access the wrong entry in the event table.
 	const auto param_type = get_param_type(evt, param_num);
 	const auto len = get_default_value_size_bytes_from_type(param_type);
 	const auto len_size = get_param_len_size(evt);
+	if(ensure_param_len_slot(evt, param_num, evt_size, error) != 0 ||
+	   ensure_evt_space(*params_offset, len, evt_size, error) != 0) {
+		return -1;
+	}
 
 	PRINT_MESSAGE(
 	        "Push default parameter - (evt_type: %d, param_num: %d, param_type: %d, param_len: %d, "
@@ -250,12 +278,19 @@ static void push_default_parameter(scap_evt *evt, size_t *params_offset, const u
 	*params_offset += len;
 	set_param_len_unchecked(evt, param_num, len, len_size);
 	evt->len += len;
+	return 0;
 }
 
 // Writes parameter length and value and update the provided parameter offsets accordingly to the
 // written length.
-static void push_empty_parameter(scap_evt *evt, const uint8_t param_num) {
+static int push_empty_parameter(scap_evt *evt,
+                                const uint8_t param_num,
+                                size_t evt_size,
+                                char *error) {
 	const auto len_size = get_param_len_size(evt);
+	if(ensure_param_len_slot(evt, param_num, evt_size, error) != 0) {
+		return -1;
+	}
 
 	PRINT_MESSAGE(
 	        "Push empty parameter - (evt_type: %d, param_num: %d, param_type: %d, param_len: 0, "
@@ -267,6 +302,7 @@ static void push_empty_parameter(scap_evt *evt, const uint8_t param_num) {
 
 	// Just set the parameter length to 0.
 	set_param_len_unchecked(evt, param_num, 0, len_size);
+	return 0;
 }
 
 // Cap the provided parameter length to the maximum value allowed for the event parameter
@@ -283,11 +319,13 @@ static uint32_t cap_param_len(const scap_evt *evt,
 
 // Writes parameter length and value and update the provided parameter offsets accordingly to the
 // written length.
-static void push_parameter(scap_evt *new_evt,
-                           const scap_evt *tmp_evt,
-                           size_t *new_evt_params_offset,
-                           const uint8_t new_evt_param_num,
-                           const uint8_t tmp_evt_param_num) {
+static int push_parameter(scap_evt *new_evt,
+                          const scap_evt *tmp_evt,
+                          size_t *new_evt_params_offset,
+                          const uint8_t new_evt_param_num,
+                          const uint8_t tmp_evt_param_num,
+                          size_t new_evt_size,
+                          char *error) {
 	const auto new_evt_len_size = get_param_len_size(new_evt);
 	const auto tmp_evt_len_size = get_param_len_size(tmp_evt);
 	const auto tmp_evt_param_len = get_param_len(tmp_evt, tmp_evt_param_num, tmp_evt_len_size);
@@ -295,6 +333,10 @@ static void push_parameter(scap_evt *new_evt,
 	        get_param_ptr(tmp_evt, tmp_evt_param_num, tmp_evt_len_size);
 	const auto new_evt_param_len =
 	        cap_param_len(new_evt, new_evt_param_num, tmp_evt_param_len, new_evt_len_size);
+	if(ensure_param_len_slot(new_evt, new_evt_param_num, new_evt_size, error) != 0 ||
+	   ensure_evt_space(*new_evt_params_offset, new_evt_param_len, new_evt_size, error) != 0) {
+		return -1;
+	}
 	auto *const new_evt_param_ptr = reinterpret_cast<char *>(new_evt) + *new_evt_params_offset;
 
 	PRINT_MESSAGE(
@@ -320,15 +362,38 @@ static void push_parameter(scap_evt *new_evt,
 	*new_evt_params_offset += new_evt_param_len;
 	set_param_len_unchecked(new_evt, new_evt_param_num, new_evt_param_len, new_evt_len_size);
 	new_evt->len += new_evt_param_len;
+	return 0;
 }
 
-static size_t copy_old_params(scap_evt *new_evt, const scap_evt *evt_to_convert) {
+static int copy_old_params(scap_evt *new_evt,
+                           const scap_evt *evt_to_convert,
+                           size_t new_evt_size,
+                           size_t *new_evt_params_offset,
+                           char *error) {
 	auto *const new_evt_ptr = reinterpret_cast<char *>(new_evt);
 	const auto *const old_evt_ptr = reinterpret_cast<const char *>(evt_to_convert);
 	size_t new_evt_offset = sizeof(scap_evt);
 	size_t old_evt_offset = sizeof(scap_evt);
 	const auto new_evt_len_size = get_param_len_size(new_evt);
 	const auto old_evt_len_size = get_param_len_size(evt_to_convert);
+	const uint64_t old_evt_params_offset =
+	        sizeof(scap_evt) + (uint64_t)evt_to_convert->nparams * old_evt_len_size;
+	if(old_evt_params_offset > evt_to_convert->len) {
+		scap_errprintf(error,
+		               0,
+		               "event length %u is smaller than its parameter length table",
+		               evt_to_convert->len);
+		return -1;
+	}
+	const uint64_t new_evt_params_offset_u64 =
+	        sizeof(scap_evt) + (uint64_t)new_evt->nparams * new_evt_len_size;
+	if(new_evt_params_offset_u64 > new_evt_size) {
+		scap_errprintf(error,
+		               0,
+		               "converted event length would exceed conversion buffer size %zu",
+		               new_evt_size);
+		return -1;
+	}
 
 	// Copy the lengths array.
 	if(new_evt_len_size == old_evt_len_size) {
@@ -354,10 +419,13 @@ static size_t copy_old_params(scap_evt *new_evt, const scap_evt *evt_to_convert)
 	        evt_to_convert->nparams * old_evt_len_size);
 
 	// Copy the parameters (we left some space for the missing lengths)
-	new_evt_offset += new_evt->nparams * new_evt_len_size;
-	old_evt_offset += evt_to_convert->nparams * old_evt_len_size;
+	new_evt_offset = (size_t)new_evt_params_offset_u64;
+	old_evt_offset = (size_t)old_evt_params_offset;
 	const uint32_t params_len =
 	        evt_to_convert->len - (sizeof(scap_evt) + evt_to_convert->nparams * old_evt_len_size);
+	if(ensure_evt_space(new_evt_offset, params_len, new_evt_size, error) != 0) {
+		return -1;
+	}
 	memcpy(new_evt_ptr + new_evt_offset, old_evt_ptr + old_evt_offset, params_len);
 
 	PRINT_MESSAGE(
@@ -370,7 +438,9 @@ static size_t copy_old_params(scap_evt *new_evt, const scap_evt *evt_to_convert)
 	        old_evt_offset,
 	        params_len);
 
-	return new_evt_offset + params_len;
+	*new_evt_params_offset = new_evt_offset + params_len;
+	new_evt->len = *new_evt_params_offset;
+	return 0;
 }
 
 // note: the control flow of this function must always be kept in sync with the converter
@@ -422,7 +492,15 @@ extern "C" conversion_result test_event_convertibility(const scap_evt *evt_to_co
 	// If we are a new event type we need to check the number of parameters.
 	const uint32_t evt_params_num = evt_to_convert->nparams;
 	const uint32_t expected_params_num = evt_info->nparams;
-	assert(evt_params_num <= expected_params_num);
+	if(evt_params_num > expected_params_num) {
+		scap_errprintf(error,
+		               0,
+		               "Event (type: %d) has more parameters (%d) than expected (%d).",
+		               evt_type,
+		               evt_params_num,
+		               expected_params_num);
+		return CONVERSION_ERROR;
+	}
 
 	// If the number of parameters is different from the one in the event table we need a
 	// conversion.
@@ -474,6 +552,7 @@ int push_parameter_from_callback(scap_evt *new_evt,
                                  const uint8_t new_evt_param_num,
                                  const conversion_instruction_callback callback,
                                  const conversion_instruction_flags instr_flags,
+                                 size_t new_evt_size,
                                  char *error) {
 	if(callback == nullptr) {
 		scap_errprintf(error,
@@ -496,11 +575,13 @@ int push_parameter_from_callback(scap_evt *new_evt,
 	} catch(...) {
 		// todo: log info about exception.
 		if(instr_flags & CIF_FALLBACK_TO_EMPTY) {
-			push_empty_parameter(new_evt, new_evt_param_num);
-		} else {
-			push_default_parameter(new_evt, new_evt_params_offset, new_evt_param_num);
+			return push_empty_parameter(new_evt, new_evt_param_num, new_evt_size, error);
 		}
-		return 0;
+		return push_default_parameter(new_evt,
+		                              new_evt_params_offset,
+		                              new_evt_param_num,
+		                              new_evt_size,
+		                              error);
 	}
 
 	const auto *buffer_ptr = std::data(buffer);
@@ -516,6 +597,10 @@ int push_parameter_from_callback(scap_evt *new_evt,
 		               min_param_len,
 		               max_param_len,
 		               buffer_len);
+		return -1;
+	}
+	if(ensure_param_len_slot(new_evt, new_evt_param_num, new_evt_size, error) != 0 ||
+	   ensure_evt_space(*new_evt_params_offset, buffer_len, new_evt_size, error) != 0) {
 		return -1;
 	}
 
@@ -544,6 +629,7 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
                                        scap_evt *new_evt,
                                        scap_evt *evt_to_convert,
                                        const conversion_info &ci,
+                                       size_t new_evt_size,
                                        char *error) {
 	/////////////////////////////
 	// Dispatch the action
@@ -554,6 +640,14 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 
 	// We copy the entire event in any case so that we are ready to handle `CONVERSION_PASS` cases
 	// without further actions.
+	if(evt_to_convert->len > new_evt_size) {
+		scap_errprintf(error,
+		               0,
+		               "event length %u is larger than conversion buffer size %zu",
+		               evt_to_convert->len,
+		               new_evt_size);
+		return CONVERSION_ERROR;
+	}
 	memcpy(new_evt, evt_to_convert, evt_to_convert->len);
 
 	switch(ci.m_action) {
@@ -570,20 +664,41 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 
 	case C_ACTION_ADD_PARAMS:
 		// The new number of params is the previous one plus the number of conversion instructions.
+		if(ci.m_instrs.size() >
+		   (size_t)std::numeric_limits<uint32_t>::max() - evt_to_convert->nparams) {
+			scap_errprintf(error, 0, "converted event would have too many parameters");
+			return CONVERSION_ERROR;
+		}
 		new_evt->nparams = evt_to_convert->nparams + ci.m_instrs.size();
 		// Initial `new_evt->len` value set in `copy_old_params()`.
-		params_offset = copy_old_params(new_evt, evt_to_convert);
+		if(copy_old_params(new_evt, evt_to_convert, new_evt_size, &params_offset, error) != 0) {
+			return CONVERSION_ERROR;
+		}
 		param_to_populate = evt_to_convert->nparams;
 		break;
 
-	case C_ACTION_CHANGE_TYPE:
+	case C_ACTION_CHANGE_TYPE: {
 		// The new number of params is the number of conversion instructions.
+		if(ci.m_instrs.size() > (size_t)std::numeric_limits<uint32_t>::max()) {
+			scap_errprintf(error, 0, "converted event would have too many parameters");
+			return CONVERSION_ERROR;
+		}
 		new_evt->nparams = ci.m_instrs.size();
 		new_evt->type = ci.m_desired_type;
-		new_evt->len = 0;
-		params_offset = sizeof(scap_evt) + new_evt->nparams * get_param_len_size(new_evt);
+		const uint64_t params_offset_u64 =
+		        sizeof(scap_evt) + (uint64_t)new_evt->nparams * get_param_len_size(new_evt);
+		if(params_offset_u64 > new_evt_size) {
+			scap_errprintf(error,
+			               0,
+			               "converted event length would exceed conversion buffer size %zu",
+			               new_evt_size);
+			return CONVERSION_ERROR;
+		}
+		params_offset = (size_t)params_offset_u64;
+		new_evt->len = params_offset;
 		param_to_populate = 0;
 		break;
+	}
 
 	default:
 		scap_errprintf(error, 0, "Unhandled conversion action '%d'.", ci.m_action);
@@ -619,10 +734,18 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 
 		switch(instr.code) {
 		case C_INSTR_FROM_EMPTY:
-			push_empty_parameter(new_evt, param_to_populate);
+			if(push_empty_parameter(new_evt, param_to_populate, new_evt_size, error) != 0) {
+				return CONVERSION_ERROR;
+			}
 			continue;
 		case C_INSTR_FROM_DEFAULT:
-			push_default_parameter(new_evt, &params_offset, param_to_populate);
+			if(push_default_parameter(new_evt,
+			                          &params_offset,
+			                          param_to_populate,
+			                          new_evt_size,
+			                          error) != 0) {
+				return CONVERSION_ERROR;
+			}
 			continue;
 
 		case C_INSTR_FROM_ENTER:
@@ -688,6 +811,7 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 			                                param_to_populate,
 			                                instr.callback,
 			                                instr.flags,
+			                                new_evt_size,
 			                                error) != 0) {
 				return CONVERSION_ERROR;
 			}
@@ -704,14 +828,30 @@ static conversion_result convert_event(std::unordered_map<uint64_t, safe_scap_ev
 
 		if(!tmp_evt) {
 			if(instr.flags & CIF_FALLBACK_TO_EMPTY) {
-				push_empty_parameter(new_evt, param_to_populate);
+				if(push_empty_parameter(new_evt, param_to_populate, new_evt_size, error) != 0) {
+					return CONVERSION_ERROR;
+				}
 			} else {
-				push_default_parameter(new_evt, &params_offset, param_to_populate);
+				if(push_default_parameter(new_evt,
+				                          &params_offset,
+				                          param_to_populate,
+				                          new_evt_size,
+				                          error) != 0) {
+					return CONVERSION_ERROR;
+				}
 			}
 			continue;
 		}
 
-		push_parameter(new_evt, tmp_evt, &params_offset, param_to_populate, instr.param_num);
+		if(push_parameter(new_evt,
+		                  tmp_evt,
+		                  &params_offset,
+		                  param_to_populate,
+		                  instr.param_num,
+		                  new_evt_size,
+		                  error) != 0) {
+			return CONVERSION_ERROR;
+		}
 	}
 
 	if(used_enter_event) {
@@ -732,6 +872,7 @@ extern "C" struct scap_convert_buffer *scap_convert_alloc_buffer() {
 extern "C" conversion_result scap_convert_event(struct scap_convert_buffer *buf,
                                                 scap_evt *new_evt,
                                                 scap_evt *evt_to_convert,
+                                                size_t new_evt_size,
                                                 char *error) {
 	// This should be checked by the caller but just double check here.
 	switch(const auto conv_res = test_event_convertibility(evt_to_convert, error)) {
@@ -765,11 +906,8 @@ extern "C" conversion_result scap_convert_event(struct scap_convert_buffer *buf,
 	}
 
 	// If we reached this point we have for sure an entry in the conversion table.
-	return convert_event(buf->evt_storage,
-	                     new_evt,
-	                     evt_to_convert,
-	                     g_conversion_table.at(conv_key),
-	                     error);
+	const auto conv_info = g_conversion_table.at(conv_key);
+	return convert_event(buf->evt_storage, new_evt, evt_to_convert, conv_info, new_evt_size, error);
 }
 
 extern "C" void scap_convert_free_buffer(struct scap_convert_buffer *buf) {

--- a/userspace/libscap/engine/savefile/converter/converter.h
+++ b/userspace/libscap/engine/savefile/converter/converter.h
@@ -22,6 +22,7 @@ limitations under the License.
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <libscap/engine/savefile/converter/results.h>
 
 typedef struct ppm_evt_hdr scap_evt;
@@ -35,6 +36,7 @@ struct scap_convert_buffer* scap_convert_alloc_buffer();
 conversion_result scap_convert_event(struct scap_convert_buffer* buf,
                                      scap_evt* new_evt,
                                      scap_evt* evt_to_convert,
+                                     size_t new_evt_size,
                                      char* error);
 void scap_convert_free_buffer(struct scap_convert_buffer* buf);
 

--- a/userspace/libscap/engine/savefile/scap_savefile.c
+++ b/userspace/libscap/engine/savefile/scap_savefile.c
@@ -60,6 +60,63 @@ inline static int read_block_header(struct savefile_engine *handle,
 	return res;
 }
 
+static int32_t validate_v2_event(struct savefile_engine *handle,
+                                 const scap_evt *event,
+                                 uint32_t avail) {
+	if(event->len < sizeof(struct ppm_evt_hdr)) {
+		return scap_errprintf(handle->m_lasterr,
+		                      0,
+		                      "invalid event: len %u is smaller than the event header size %zu",
+		                      event->len,
+		                      sizeof(struct ppm_evt_hdr));
+	}
+
+	if(event->len > avail) {
+		return scap_errprintf(handle->m_lasterr,
+		                      0,
+		                      "invalid event: len %u is larger than the %u bytes "
+		                      "available in the block",
+		                      event->len,
+		                      avail);
+	}
+
+	const uint32_t len_size = (g_event_info[event->type].flags & EF_LARGE_PAYLOAD)
+	                                  ? sizeof(uint32_t)
+	                                  : sizeof(uint16_t);
+	uint64_t param_offset = sizeof(struct ppm_evt_hdr) + (uint64_t)event->nparams * len_size;
+	if(param_offset > event->len) {
+		return scap_errprintf(handle->m_lasterr,
+		                      0,
+		                      "invalid event: nparams %u does not fit in event len %u",
+		                      event->nparams,
+		                      event->len);
+	}
+
+	const char *lens = (const char *)event + sizeof(struct ppm_evt_hdr);
+	for(uint32_t i = 0; i < event->nparams; i++) {
+		uint32_t param_len;
+		if(len_size == sizeof(uint32_t)) {
+			memcpy(&param_len, lens + i * len_size, sizeof(uint32_t));
+		} else {
+			uint16_t param_len16;
+			memcpy(&param_len16, lens + i * len_size, sizeof(uint16_t));
+			param_len = param_len16;
+		}
+
+		if(param_len > event->len - param_offset) {
+			return scap_errprintf(handle->m_lasterr,
+			                      0,
+			                      "invalid event: param %u len %u exceeds event len %u",
+			                      i,
+			                      param_len,
+			                      event->len);
+		}
+		param_offset += param_len;
+	}
+
+	return SCAP_SUCCESS;
+}
+
 //
 // Load the machine info block
 //
@@ -1903,6 +1960,8 @@ static int32_t next_event_from_file(struct savefile_engine *handle,
 		// Read the event
 		//
 		readlen = bh.block_total_length - sizeof(bh);
+		const uint32_t block_body_len =
+		        readlen >= sizeof(uint32_t) ? readlen - sizeof(uint32_t) : 0;
 		// Non-large block types have an uint16_max maximum size
 		if(bh.block_type != EV_BLOCK_TYPE_V2_LARGE && bh.block_type != EVF_BLOCK_TYPE_V2_LARGE) {
 			if(readlen > READER_BUF_SIZE) {
@@ -1945,6 +2004,23 @@ static int32_t next_event_from_file(struct savefile_engine *handle,
 		} else {
 			*pflags = 0;
 			*pevent = (struct ppm_evt_hdr *)(handle->m_reader_evt_buf + sizeof(uint16_t));
+		}
+
+		// Number of block-body bytes that follow *pevent in the reader buffer, excluding the
+		// trailing block_total_length. Compute it with a guarded subtraction: readlen and evt_off
+		// both derive from the attacker-controlled block length, so avoid unsigned underflow.
+		uint32_t evt_off = (uint32_t)((char *)*pevent - handle->m_reader_evt_buf);
+		uint32_t avail = evt_off <= block_body_len ? block_body_len - evt_off : 0;
+		if(avail < hdr_len) {
+			return scap_errprintf(
+			        handle->m_lasterr,
+			        0,
+			        "event header exceeds block payload: block length %u, event offset %u, "
+			        "available %u, header size %u",
+			        (uint32_t)bh.block_total_length,
+			        evt_off,
+			        avail,
+			        (uint32_t)hdr_len);
 		}
 
 		if((*pevent)->type >= PPM_EVENT_MAX) {
@@ -2029,6 +2105,17 @@ static int32_t next_event_from_file(struct savefile_engine *handle,
 			// the event. To do so we'd have to check to see if the block data len exceeds
 			// (*pevent)->len and parse the excess as block options.
 			//
+		} else {
+			//
+			// For V2/V2_LARGE blocks the event header `len` (and `nparams`) are taken
+			// verbatim from the file and, unlike the old-format path above, are never
+			// recomputed. Validate the event shape before the event reaches conversion or
+			// downstream consumers.
+			//
+			int32_t res = validate_v2_event(handle, *pevent, avail);
+			if(res != SCAP_SUCCESS) {
+				return res;
+			}
 		}
 
 		break;
@@ -2086,11 +2173,25 @@ static int32_t next(struct scap_engine_handle engine,
 	conv_res = CONVERSION_CONTINUE;
 	for(conv_num = 0; conv_num < MAX_CONVERSION_BOUNDARY && conv_res == CONVERSION_CONTINUE;
 	    conv_num++) {
+		// The conversion staging buffers (m_to_convert_evt / m_new_evt) are MAX_EVENT_SIZE
+		// bytes. Refuse to convert any event whose len would overflow them. This guards
+		// against a crafted V2_LARGE block whose len exceeds MAX_EVENT_SIZE while all its
+		// bytes are present in the (reallocated) reader buffer: such an event passes the
+		// in-buffer bound checked in next_event_from_file() but would still overflow the
+		// fixed-size conversion storage here.
+		if((*pevent)->len > MAX_EVENT_SIZE) {
+			return scap_errprintf(handle->m_lasterr,
+			                      0,
+			                      "invalid event: len %u is larger than the maximum event size %u",
+			                      (*pevent)->len,
+			                      MAX_EVENT_SIZE);
+		}
 		// Before each conversion we move the current event into the storage.
 		memcpy(handle->m_to_convert_evt, *pevent, (*pevent)->len);
 		conv_res = scap_convert_event(handle->m_converter_buf,
 		                              (scap_evt *)handle->m_new_evt,
 		                              (scap_evt *)handle->m_to_convert_evt,
+		                              MAX_EVENT_SIZE,
 		                              handle->m_lasterr);
 		// At the end of the conversion in any case we switch to the new event pointer.
 		*pevent = (scap_evt *)handle->m_new_evt;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR hardens the libscap savefile engine against malformed V2/V2_LARGE event blocks.

For these block types, the event `len` and `nparams` fields come from the capture file. Before this change, malformed values could reach the event conversion path and be used to copy or rebuild events into fixed-size conversion buffers without enough validation.

The fix adds validation before V2/V2_LARGE events are exposed to downstream code, checking that:

  - the event header fits in the block payload
  - the declared event length fits in the bytes available from the block
  - the parameter length table and parameter payload fit within the declared event
  - conversion output cannot exceed the destination buffer

The converter now performs capacity checks in the actual write path, instead of relying on a separate sizing pass.

Regression tests cover the reported malformed savefile cases, including conversion expansion beyond `MAX_EVENT_SIZE`.

**Special notes for your reviewer**:

- Reported responsibly via the Falco security mailing list. Thanks to Brenno Oliveira (@brennoo) for the report.
- Implemented and validated using https://github.com/leogr/falco-expert

/milestone 0.26.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libscap): validate malformed savefile events to prevent out-of-bounds memory access during replay/conversion
```

