### PR TITLE
fix(userspace/libsinsp/filter): enforce parser recursion depth limit

### DIFF
--- a/userspace/libsinsp/filter/parser.cpp
+++ b/userspace/libsinsp/filter/parser.cpp
@@ -199,7 +199,7 @@ std::unique_ptr<ast::expr> parser::parse() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_field_or_transformer() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 	auto pos = get_pos();
 
 	if(lex_field_name()) {
@@ -216,7 +216,7 @@ std::unique_ptr<ast::expr> parser::parse_field_or_transformer() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_or() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 	auto pos = get_pos();
 
 	std::vector<std::unique_ptr<ast::expr>> children;
@@ -244,7 +244,7 @@ std::unique_ptr<ast::expr> parser::parse_or() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_and() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 	auto pos = get_pos();
 
 	std::unique_ptr<ast::expr> child;
@@ -272,7 +272,7 @@ std::unique_ptr<ast::expr> parser::parse_and() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_not() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 	auto pos = get_pos();
 
 	bool is_not = false;
@@ -293,7 +293,7 @@ std::unique_ptr<ast::expr> parser::parse_not() {
 // this is an internal helper to parse the remainder of a
 // self-embedding expression right after having parsed a "("
 std::unique_ptr<ast::expr> parser::parse_embedded_remainder() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 	std::unique_ptr<ast::expr> child = parse_or();
@@ -305,7 +305,7 @@ std::unique_ptr<ast::expr> parser::parse_embedded_remainder() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_check() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 	auto pos = get_pos();
 
 	lex_blank();
@@ -334,7 +334,7 @@ std::unique_ptr<ast::expr> parser::parse_check() {
 
 std::unique_ptr<ast::expr> parser::parse_field_remainder(std::string fieldname,
                                                          const ast::pos_info& pos) {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	auto field = std::make_unique<ast::field_expr>();
 	field->field = fieldname;
@@ -366,7 +366,7 @@ std::optional<std::string> parser::parse_optional_field_arg() {
 inline std::unique_ptr<ast::expr> parser::parse_field_or_transformer_remainder(
         std::string transformer,
         const ast::pos_info& pos) {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -395,7 +395,7 @@ inline std::unique_ptr<ast::expr> parser::parse_field_or_transformer_remainder(
 
 // FieldTransformerArg ::= FieldTransformer | Field | QuotedStr | NumValue | TransformerList
 inline std::unique_ptr<ast::expr> parser::parse_field_transformer_arg(const ast::pos_info& pos) {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -477,7 +477,7 @@ inline std::unique_ptr<ast::expr> parser::parse_transformer_list_arg(const ast::
 
 std::unique_ptr<ast::expr> parser::parse_condition(std::unique_ptr<ast::expr> left,
                                                    const ast::pos_info& pos) {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 	if(lex_unary_op()) {
@@ -520,7 +520,7 @@ std::unique_ptr<ast::expr> parser::parse_condition(std::unique_ptr<ast::expr> le
 }
 
 std::unique_ptr<ast::expr> parser::parse_num_value_or_transformer() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -539,7 +539,7 @@ std::unique_ptr<ast::expr> parser::parse_num_value_or_transformer() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_str_value_or_transformer(bool no_transformer) {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -605,7 +605,7 @@ std::unique_ptr<ast::expr> parser::try_parse_list_expr() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_list_value() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -623,7 +623,7 @@ std::unique_ptr<ast::expr> parser::parse_list_value() {
 }
 
 std::unique_ptr<ast::expr> parser::parse_list_value_or_transformer() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 
@@ -647,7 +647,7 @@ std::unique_ptr<ast::expr> parser::parse_list_value_or_transformer() {
 
 // note: can return nullptr
 std::unique_ptr<ast::expr> parser::try_parse_transformer_or_val() {
-	depth_guard(m_max_depth, m_depth);
+	depth_guard dg(m_max_depth, m_depth);
 
 	lex_blank();
 

--- a/userspace/libsinsp/test/filter_parser.ut.cpp
+++ b/userspace/libsinsp/test/filter_parser.ut.cpp
@@ -87,6 +87,21 @@ static void test_reject_msg(const std::string& in, const std::string& msg) {
 	}
 }
 
+// Regression test for the unbounded-recursion DoS in the filter parser.
+// Each recursive parse_* function instantiates a depth_guard to cap recursion
+// (default 100). The guard used to be created as an unnamed temporary, so it
+// was destroyed at the end of its own statement and never enforced the limit,
+// letting deeply nested expressions exhaust the stack and crash the process.
+// A crafted input must now be rejected with a clean error instead of crashing.
+TEST(parser, recursion_depth_limit) {
+	// A deeply nested expression must be rejected with a clean error, not
+	// crash the process via stack exhaustion.
+	test_reject_msg(std::string(100000, '('), "exceeded max depth limit of 100");
+
+	// Reasonably nested, valid expressions must still parse.
+	test_accept("((((((((((a))))))))))");
+}
+
 TEST(pos_info, equality_assignments) {
 	pos_info a;
 	pos_info b(5, 1, 3);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

The filter parser is a recursive-descent parser, and it uses a small `depth_guard` RAII helper to cap recursion depth (default `100`, raised to `1000` by Falco for rule conditions) so that deeply nested expressions can't abuse the stack.

However, at every recursive `parse_*` call site, the guard was created as an *unnamed temporary*:

```cpp
  depth_guard(m_max_depth, m_depth);
```

Since a temporary is destroyed at the end of its own statement, the guard incremented `m_depth` and immediately decremented it again in the same statement, so the depth never accumulated across nested calls. As a result, the limit was never actually enforced (since Falco `0.38.0`), and a deeply nested expression - e.g., a rule condition like `((((((...` - could recurse until the stack was exhausted, crashing the process.

This fix names the guard at all call sites:

```cpp
  depth_guard dg(m_max_depth, m_depth);
```

A named local has function-body scope, so its destructor only runs on return/unwind and `m_depth` now tracks the live recursion depth. An over-deep expression is rejected with a clean `exceeded max depth limit of <N>` error instead of crashing.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

- Thanks to Brenno Oliveira (@brennoo) for the report.
- Implemented and validated using https://github.com/leogr/falco-expert

/milestone 0.26.0

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): the filter/rule parser now enforces its recursion depth limit, so deeply nested expressions are rejected with an error
```
