### PR TITLE
cleanup(userspace): Fix some clang warnings on macOS

### DIFF
--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -564,8 +564,7 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 		ppm_sc = libsinsp::events::sinsp_repair_state_sc_set(events_sc_codes);
 		if(!ppm_sc.empty()) {
 			auto events_sc_names = libsinsp::events::sc_set_to_sc_names(ppm_sc);
-			printf("-- Activated (%" PRIu64
-			       ") ppm sc names in kernel using `sinsp_repair_state_sc_set` "
+			printf("-- Activated (%zu) ppm sc names in kernel using `sinsp_repair_state_sc_set` "
 			       "enforcement: %s\n",
 			       events_sc_names.size(),
 			       concat_set_in_order(events_sc_names).c_str());
@@ -582,8 +581,7 @@ void open_engine(sinsp& inspector, libsinsp::events::set<ppm_sc_code> events_sc_
 		ppm_sc = ppm_sc.merge(events_sc_codes);
 		if(!ppm_sc.empty()) {
 			auto events_sc_names = libsinsp::events::sc_set_to_sc_names(ppm_sc);
-			printf("-- Activated (%" PRIu64
-			       ") ppm sc names in kernel using `sinsp_state_sc_set` "
+			printf("-- Activated (%zu) ppm sc names in kernel using `sinsp_state_sc_set` "
 			       "enforcement: %s\n",
 			       events_sc_names.size(),
 			       concat_set_in_order(events_sc_names).c_str());
@@ -758,7 +756,7 @@ int main(int argc, char** argv) {
 	auto events_sc_codes = extract_filter_sc_codes(inspector);
 	if(!events_sc_codes.empty()) {
 		auto events_sc_names = libsinsp::events::sc_set_to_sc_names(events_sc_codes);
-		printf("-- Filter AST (%" PRIu64 ") ppm sc names: %s\n",
+		printf("-- Filter AST (%zu) ppm sc names: %s\n",
 		       events_sc_codes.size(),
 		       concat_set_in_order(events_sc_names).c_str());
 	}

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -547,6 +547,7 @@ void sinsp::mark_ppm_sc_of_interest(ppm_sc_code ppm_sc, bool enable) {
 	}
 }
 
+#if defined(HAS_ENGINE_KMOD) || defined(HAS_ENGINE_MODERN_BPF)
 static void fill_ppm_sc_of_interest(scap_open_args* oargs,
                                     const libsinsp::events::set<ppm_sc_code>& ppm_sc_of_interest) {
 	for(int i = 0; i < PPM_SC_MAX; i++) {
@@ -558,6 +559,7 @@ static void fill_ppm_sc_of_interest(scap_open_args* oargs,
 		}
 	}
 }
+#endif
 
 void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim,
                       const libsinsp::events::set<ppm_sc_code>& ppm_sc_of_interest) {

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -880,25 +880,32 @@ void sinsp_utils::ts_to_string(uint64_t ts, std::string* res, bool date, bool ns
 		Time = (sec + thiszone) - s;
 		tm = gmtime(&Time);
 		if(!tm) {
-			bufsize = sprintf(buf, "<date error> ");
+			bufsize = snprintf(buf, sizeof(buf), "<date error> ");
 		} else {
-			bufsize = sprintf(buf,
-			                  "%04d-%02d-%02d ",
-			                  tm->tm_year + 1900,
-			                  tm->tm_mon + 1,
-			                  tm->tm_mday);
+			bufsize = snprintf(buf,
+			                   sizeof(buf),
+			                   "%04d-%02d-%02d ",
+			                   tm->tm_year + 1900,
+			                   tm->tm_mon + 1,
+			                   tm->tm_mday);
 		}
 	}
 
 	if(ns) {
-		sprintf(buf + bufsize,
-		        "%02d:%02d:%02d.%09u",
-		        s / 3600,
-		        (s % 3600) / 60,
-		        s % 60,
-		        (unsigned)nsec);
+		snprintf(buf + bufsize,
+		         sizeof(buf) - bufsize,
+		         "%02d:%02d:%02d.%09u",
+		         s / 3600,
+		         (s % 3600) / 60,
+		         s % 60,
+		         (unsigned)nsec);
 	} else {
-		sprintf(buf + bufsize, "%02d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60);
+		snprintf(buf + bufsize,
+		         sizeof(buf) - bufsize,
+		         "%02d:%02d:%02d",
+		         s / 3600,
+		         (s % 3600) / 60,
+		         s % 60);
 	}
 
 	*res = buf;
@@ -917,7 +924,7 @@ void sinsp_utils::ts_to_iso_8601(uint64_t ts, std::string* res) {
 	}
 
 	*res = buf;
-	if(sprintf(buf, ".%09u", (unsigned)ns) < 0) {
+	if(snprintf(buf, sizeof(buf), ".%09u", (unsigned)ns) < 0) {
 		*res = fmt;
 		return;
 	}


### PR DESCRIPTION
Fix

    [...]/userspace/libsinsp/utils.cpp:883:14: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
      883 |                         bufsize = sprintf(buf, "<date error> ");
          |                                   ^
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
      278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
          | ^

    [...]/userspace/libsinsp/examples/test.cpp:570:11: warning: format specifies type 'unsigned long long' but the argument has type 'size_type' (aka 'unsigned long') [-Wformat]
      567 |                         printf("-- Activated (%" PRIu64
          |                                               ~~~~~~~~~
      568 |                                ") ppm sc names in kernel using `sinsp_repair_state_sc_set` "
      569 |                                "enforcement: %s\n",
      570 |                                events_sc_names.size(),
          |                                ^~~~~~~~~~~~~~~~~~~~~~

    [...]/userspace/libsinsp/sinsp.cpp:550:13: warning: unused function 'fill_ppm_sc_of_interest' [-Wunused-function]
      550 | static void fill_ppm_sc_of_interest(scap_open_args* oargs,
          |             ^~~~~~~~~~~~~~~~~~~~~~~

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
