### PR TITLE
fix(libsinsp): add FL_GENERIC flag to mark source-agnostic field classes

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -840,6 +840,7 @@ sinsp_filter_factory::check_infos_to_fieldclass_infos(
 		cinfo.name = fci->m_name;
 		cinfo.desc = fci->m_desc;
 		cinfo.shortdesc = fci->m_shortdesc;
+		cinfo.is_generic = !!(fci->m_flags & filter_check_info::FL_GENERIC);
 
 		for(auto fld = fci->m_fields; fld != fci->m_fields + fci->m_nfields; ++fld) {
 			// If a field is only used to organize events,

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -146,6 +146,9 @@ public:
 
 		std::list<filter_field_info> fields;
 
+		// True if this field class applies to all event sources (not tied to any specific one).
+		bool is_generic = false;
+
 		// Print a terminal-friendly representation of this
 		// field class, including name, description, supported
 		// event sources, and the name and description of each field.

--- a/userspace/libsinsp/filter_field.h
+++ b/userspace/libsinsp/filter_field.h
@@ -130,6 +130,8 @@ public:
 		FL_NONE = 0,
 		FL_HIDDEN =
 		        (1 << 0),  ///< This filter check class won't be shown by fields/filter listings.
+		FL_GENERIC =
+		        (1 << 1),  ///< This filter check class applies to all event sources (not source-specific).
 	};
 
 	std::string m_name;       ///< Field class name.

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -148,7 +148,7 @@ sinsp_filter_check_gen_event::sinsp_filter_check_gen_event() {
 	        sizeof(sinsp_filter_check_gen_event_fields) /
 	                sizeof(sinsp_filter_check_gen_event_fields[0]),
 	        sinsp_filter_check_gen_event_fields,
-	        filter_check_info::FL_NONE,
+	        filter_check_info::FL_GENERIC,
 	};
 	m_info = &s_field_infos;
 	memset(&m_val, 0, sizeof(m_val));


### PR DESCRIPTION
## What

`sinsp_filter_check_gen_event` provides `evt.*` fields that work on every event source, but its `filter_check_info` had `FL_NONE` for flags - nothing told callers it was source-agnostic. Downstream code (falco's `list_fields()`) collected sources per field class and ended up passing `{"syscall"}` to `as_markdown()`, which then printed `Event Sources: syscall` for a class that should show nothing.

## Changes

- `filter_field.h` - adds `FL_GENERIC = (1 << 1)` to `filter_check_info::flags`
- `filter.h` - adds `bool is_generic = false` to `filter_fieldclass_info`
- `filter.cpp` - propagates `FL_GENERIC` into `is_generic` inside `check_infos_to_fieldclass_infos()`
- `sinsp_filtercheck_gen_event.cpp` - sets `FL_GENERIC` on the static `filter_check_info` (was `FL_NONE`)

## Why not just check the name/shortdesc string

Matching on `"evt"` or `"All event types"` would work today but breaks silently if those strings change. A flag on `filter_check_info` makes the intent explicit and lets any future generic class opt in the same way.

Companion falco PR: falcosecurity/falco#3714