### PR TITLE
fix(userspace/libsinsp): invalidate fd cache in fdtable retain() and clear()

### DIFF
--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -141,6 +141,7 @@ bool sinsp_fdtable::erase(int64_t fd) {
 
 void sinsp_fdtable::clear() {
 	m_table.clear();
+	reset_cache();
 }
 
 size_t sinsp_fdtable::size() const {
@@ -148,6 +149,12 @@ size_t sinsp_fdtable::size() const {
 }
 
 void sinsp_fdtable::reset_cache() {
+	// Only the cache key is cleared here; m_last_accessed_fdinfo is intentionally
+	// left untouched. Cache validity is keyed solely on m_last_accessed_fd (see
+	// find_ref()), so clearing the key is enough to disarm the cache. Do not null
+	// the shared_ptr to "tidy up": besides being unnecessary, it could free an
+	// fdinfo that a raw pointer (e.g. sinsp_evt::m_fdinfo) obtained earlier in the
+	// same event still points at, which is why erase() leaves it untouched too.
 	m_last_accessed_fd = -1;
 }
 

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -115,7 +115,7 @@ bool sinsp_fdtable::erase(int64_t fd) {
 	auto fdit = m_table.find(fd);
 
 	if(fd == m_last_accessed_fd) {
-		m_last_accessed_fd = -1;
+		reset_cache();
 	}
 
 	if(fdit == m_table.end()) {

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -81,6 +81,12 @@ public:
 	void retain(const fdtable_const_visitor_t& callback) {
 		for(auto it = m_table.begin(); it != m_table.end();) {
 			if(!callback(it->first, *it->second)) {
+				// Invalidate the cache if we are removing the cached fd, otherwise a
+				// later lookup would return a dangling reference to the removed entry
+				// (the same hazard erase() guards against).
+				if(it->first == m_last_accessed_fd) {
+					reset_cache();
+				}
 				it = m_table.erase(it);
 			} else {
 				++it;

--- a/userspace/libsinsp/test/parsers/parse_close_range.cpp
+++ b/userspace/libsinsp/test/parsers/parse_close_range.cpp
@@ -1,0 +1,125 @@
+
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <sinsp_with_test_input.h>
+
+// Regression guard for a use-after-free in sinsp_fdtable's single-entry LRU cache.
+//
+// sinsp_fdtable caches the last accessed fd as an OWNING std::shared_ptr
+// (m_last_accessed_fdinfo). close_range() reaches sinsp_fdtable::retain() (via
+// parse_close_range_exit) to drop fds in a range. retain() used to erase entries
+// from the map WITHOUT invalidating that cache, unlike erase()/clear(). As a
+// result, after close_range removed the cached fd, the cache still held the only
+// owning reference to the freed map entry, and a subsequent get_fd() of the same
+// fd returned a stale cache hit pointing at an entry no longer in the table.
+//
+// The dup2 exit parser is where this turns into a heap-use-after-free: it resolves
+// evt.m_fdinfo (a raw, non-owning pointer) from the stale cache, then calls
+// get_fd(newfd) which is a cache-miss + map-hit that OVERWRITES
+// m_last_accessed_fdinfo, dropping the last owning shared_ptr and freeing the
+// fdinfo that evt.m_fdinfo still points at. The next deref
+// (evt.get_fd_info()->clone(), a virtual call) reads freed memory.
+//
+// The exact sequence below reproduces the original crash:
+//   OPEN fd 40 -> OPEN fd 30 -> FSTAT_X(res=0, fd=30) [seeds the cache with fd 30]
+//   -> CLOSE_RANGE_X(res=0, first=30, last=30, flags=0) [retain() removes fd 30]
+//   -> DUP2_X(res=40, oldfd=30, newfd=40)
+//
+// With the retain() cache-invalidation fix in place:
+//   - after close_range, get_fd(30) is a cache-miss + map-miss -> nullptr,
+//   - dup2 exit takes the graceful early-return (evt.get_fd_info() == nullptr) and
+//     never dereferences a dangling pointer.
+//
+// Without the fix, this test fails in two ways: the EXPECT_EQ below fails
+// deterministically (close_range leaves the cache stale, so get_fd(30) returns
+// a non-null dangling entry instead of nullptr), and the dup2 event below then
+// dereferences the freed fdinfo. That dereference is caught reliably only under
+// AddressSanitizer, which reports a heap-use-after-free READ; CI runs the
+// libsinsp unit tests with -DUSE_ASAN=On (.github/workflows/ci.yml).
+TEST_F(sinsp_with_test_input, CLOSE_RANGE_cached_fd_no_use_after_free) {
+	add_default_init_thread();
+	open_inspector();
+
+	const auto tinfo = m_inspector.m_thread_manager->find_thread(INIT_TID, true);
+	ASSERT_NE(tinfo, nullptr);
+
+	// fd 40 must exist in the fd table so that the dup2 exit's get_fd(40) is a
+	// map-HIT. That map-hit is what overwrites the LRU cache and frees fd 30's
+	// fdinfo in the buggy path.
+	constexpr int64_t newfd = 40;
+	sinsp_test_input::open_params open_newfd{};
+	open_newfd.fd = newfd;
+	open_newfd.path = "/tmp/newfd.txt";
+	ASSERT_TRUE(generate_open_x_event(open_newfd)->get_fd_info());
+	ASSERT_TRUE(tinfo->get_fd(newfd));
+
+	// fd 30 must exist in the fd table; it is the fd we close via close_range and
+	// the one that must be the cached entry right before the close_range event.
+	constexpr int64_t oldfd = 30;
+	sinsp_test_input::open_params open_oldfd{};
+	open_oldfd.fd = oldfd;
+	open_oldfd.path = "/tmp/oldfd.txt";
+	ASSERT_TRUE(generate_open_x_event(open_oldfd)->get_fd_info());
+	ASSERT_TRUE(tinfo->get_fd(oldfd));
+
+	// Seed the single-entry LRU cache with fd 30. Processing FSTAT_X(res=0, fd=30)
+	// resolves fd 30 via a map-hit, which populates m_last_accessed_fd = 30 and
+	// makes m_last_accessed_fdinfo the owning reference to fd 30's fdinfo.
+	add_event_advance_ts(increasing_ts(),
+	                     INIT_TID,
+	                     PPME_SYSCALL_FSTAT_X,
+	                     2,
+	                     static_cast<int64_t>(0),  // res
+	                     oldfd);                   // fd
+
+	// close_range over [30, 30] reaches sinsp_fdtable::retain(), which removes fd
+	// 30 from the map. Without the fix, the cache is left pointing at the removed
+	// entry (m_last_accessed_fd stays 30).
+	add_event_advance_ts(increasing_ts(),
+	                     INIT_TID,
+	                     PPME_SYSCALL_CLOSE_RANGE_X,
+	                     4,
+	                     static_cast<int64_t>(0),       // res
+	                     static_cast<uint32_t>(oldfd),  // first
+	                     static_cast<uint32_t>(oldfd),  // last
+	                     static_cast<uint32_t>(0));     // flags
+
+	// With the fix, fd 30 is gone AND the cache was invalidated, so get_fd(30) now
+	// misses both the cache and the map and returns nullptr.
+	//
+	// This is a non-fatal EXPECT (not ASSERT) on purpose: without the fix, get_fd(30)
+	// returns a stale (map-detached but not-yet-freed) cache pointer instead of
+	// nullptr. We must NOT abort the test here, otherwise the dup2 event below (which
+	// is what actually frees the fdinfo and triggers the use-after-free) would never
+	// be processed and the regression would go undetected under AddressSanitizer.
+	EXPECT_EQ(tinfo->get_fd(oldfd), nullptr);
+
+	// dup2(oldfd=30 -> newfd=40), res = newfd = 40. This is the event that
+	// triggers the heap-use-after-free in the buggy build (deref at the dup exit
+	// parser's evt.get_fd_info()->clone()). With the fix it processes cleanly
+	// because the dup exit parser sees evt.get_fd_info() == nullptr and returns
+	// early.
+	const auto dup2_evt = add_event_advance_ts(increasing_ts(),
+	                                           INIT_TID,
+	                                           PPME_SYSCALL_DUP2_X,
+	                                           3,
+	                                           newfd,   // res (return value == newfd)
+	                                           oldfd,   // oldfd
+	                                           newfd);  // newfd
+	ASSERT_NE(dup2_evt, nullptr);
+
+	// fd 40 is still present after the (no-op for the old fd) dup2 handling.
+	ASSERT_TRUE(tinfo->get_fd(newfd));
+}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

`sinsp_fdtable` keeps a single-entry LRU cache that holds the cached `fdinfo` via an **owning** `shared_ptr`, while `sinsp_evt::m_fdinfo` is a raw, non-owning pointer.

  `retain()` - used by the `close_range` parser to drop a range of fds - removed entries from the table without invalidating that cache (unlike `erase()`). So, after `close_range` removed the cached
  fd, the cache still held the only reference to it, and a following `dup2`/`dup3` exit could resolve `evt.m_fdinfo` from the stale cache, free it via `get_fd(newfd)`, and then dereference the dangling
  pointer in `parse_dup_exit` (`evt.get_fd_info()->clone()`) - a **use-after-free** reachable via ordinary `close_range` + `dup2` syscalls, which can crash the process.

  The fix invalidates the cache on removal, the same way `erase()` already does:

  - `retain()` clears the cache key when it removes the cached fd, so the next lookup misses and `parse_dup_exit` takes its existing `nullptr` early-return instead of dereferencing freed memory.
  - `clear()` now calls `reset_cache()` too - no live path was found through it, but it had the same latent gap.

  Since the fix sits at the `retain()`/`clear()` definitions, all their callers are covered

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.26.0

Reviewed with https://github.com/leogr/falco-expert

Thanks to [Brenno Oliveira](https://github.com/brennoo) for the report 🙏

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(libsinsp): use-after-free in the fd table cache triggered by close_range + dup2/dup3
```
