### PR TITLE
fix(libsinsp): add FL_GENERIC flag to mark source-agnostic field classes [2/2]

### DIFF
--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -840,6 +840,7 @@ sinsp_filter_factory::check_infos_to_fieldclass_infos(
 		cinfo.name = fci->m_name;
 		cinfo.desc = fci->m_desc;
 		cinfo.shortdesc = fci->m_shortdesc;
+		cinfo.is_generic = static_cast<bool>(fci->m_flags & filter_check_info::FL_GENERIC);
 
 		for(auto fld = fci->m_fields; fld != fci->m_fields + fci->m_nfields; ++fld) {
 			// If a field is only used to organize events,

--- a/userspace/libsinsp/filter.h
+++ b/userspace/libsinsp/filter.h
@@ -146,6 +146,9 @@ public:
 
 		std::list<filter_field_info> fields;
 
+		// True if this field class applies to all event sources (not tied to any specific one).
+		bool is_generic = false;
+
 		// Print a terminal-friendly representation of this
 		// field class, including name, description, supported
 		// event sources, and the name and description of each field.

--- a/userspace/libsinsp/filter_field.h
+++ b/userspace/libsinsp/filter_field.h
@@ -130,6 +130,8 @@ public:
 		FL_NONE = 0,
 		FL_HIDDEN =
 		        (1 << 0),  ///< This filter check class won't be shown by fields/filter listings.
+		FL_GENERIC = (1 << 1),  ///< This filter check class applies to all event sources (not
+		                        ///< source-specific).
 	};
 
 	std::string m_name;       ///< Field class name.

--- a/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_gen_event.cpp
@@ -148,7 +148,7 @@ sinsp_filter_check_gen_event::sinsp_filter_check_gen_event() {
 	        sizeof(sinsp_filter_check_gen_event_fields) /
 	                sizeof(sinsp_filter_check_gen_event_fields[0]),
 	        sinsp_filter_check_gen_event_fields,
-	        filter_check_info::FL_NONE,
+	        filter_check_info::FL_GENERIC,
 	};
 	m_info = &s_field_infos;
 	memset(&m_val, 0, sizeof(m_val));


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
 specific area of the project related to this PR?**
/area libsinsp

**Does this PR require a change in the driver versions?**
No.

**What this PR does / why we need it**:

filter_check_info gains FL_GENERIC (1<<1). sinsp_filter_check_gen_event uses it since its fields apply to all event sources. filter_fieldclass_info exposes is_generic so callers (e.g. falco) can omit the source label when listing fields for generic classes.

**Which issue(s) this PR fixes**:

Fixes falcosecurity/falco#3714

**Special notes for your reviewer**:

```release-note
NONE
```

Companion falco PR: falcosecurity/falco#3936