### PR TITLE
fix(ci): install libbpf build deps for the bpfcompat lane

### DIFF
--- a/.github/workflows/bpfcompat-compatibility.yml
+++ b/.github/workflows/bpfcompat-compatibility.yml
@@ -39,9 +39,13 @@ jobs:
       - name: Install build and VM dependencies
         run: |
           sudo apt-get update
+          # libbpf-dev + zlib1g-dev: the bpfcompat action is pinned by commit
+          # SHA (not a release tag), so it builds its in-guest validator from
+          # source on the runner, which needs libbpf headers + static libs.
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake clang llvm pkg-config autoconf automake \
-            libtool libelf-dev qemu-system-x86 qemu-utils jq
+            libtool libelf-dev libbpf-dev zlib1g-dev qemu-system-x86 \
+            qemu-utils jq
           # Static bpftool release (needed for skeleton generation): Ubuntu's
           # linux-tools wrapper can't match the runner's Azure kernel.
           curl -fsSL -o /tmp/bpftool.tar.gz \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it:**

Fast follow-up to #3024, before the lane's first scheduled run (Monday 06:00 UTC).

I dress-rehearsed the merged workflow on a fork (`workflow_dispatch` runs the exact file) and it fails before booting any VM: the bpfcompat action is pinned by commit SHA (as required for third-party actions), and the action only uses its prebuilt release binaries for `v*` tag refs — with a SHA ref it builds its in-guest validator from source on the runner, which needs libbpf headers and static libs the runner image doesn't ship:

```
src/main.c:3:10: fatal error: bpf/bpf.h: No such file or directory
```

- Failing run (workflow exactly as merged): https://github.com/ErenAri/libs/actions/runs/29421614293
- Green run with this one-line dep fix: https://github.com/ErenAri/libs/actions/runs/29422004424 — scap-open static build + all three matrix kernels pass (`ubuntu-22.04-5.15` / `debian-12-6.1` / `ubuntu-24.04-6.8`), under 10 minutes total.

Side note: I'll also fix this properly on the bpfcompat side (resolve a SHA ref to its release tag so SHA-pinned consumers get prebuilt binaries); once that ships in a release, these extra packages can be dropped when the pin is next bumped.

**Which issue(s) this PR fixes:**

Follow-up to #3023 / #3024.

**Special notes for your reviewer:**

Workflow-file-only change; adds `libbpf-dev` and `zlib1g-dev` to the existing apt install step.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```