### PR TITLE
fix(userspace/libsinsp): dedupe async-queue notify fan-out in add_container_group/add_container_user

### DIFF
--- a/userspace/libsinsp/test/user.ut.cpp
+++ b/userspace/libsinsp/test/user.ut.cpp
@@ -385,4 +385,285 @@ TEST_F(usergroup_manager_host_root_parsing_test, short_lines_are_skipped) {
 	mgr.add_group(container_id, -1, 999, std::string_view{});
 	ASSERT_EQ(mgr.get_group(container_id, 999), nullptr);
 }
+
+// Fixture exercising the CONTAINER-pid parsing path (add_container_group/
+// add_container_user), as opposed to the host path (empty container_id)
+// covered above. in_own_ns_mnt()/get_pid_root() only stat() paths built from
+// sinsp's host_root plus a pid, with no real process or mount namespace
+// required, so a fake "/proc/<pid>/root/etc/{group,passwd}" tree under a
+// temp host_root is enough to drive add_container_group/add_container_user
+// directly, with the fake pid's root deliberately a different directory
+// (thus a different inode) than the fake host-init "/proc/1/root".
+class usergroup_manager_container_parsing_test : public sinsp_with_test_input {
+protected:
+	static constexpr int64_t s_container_pid = 12345;
+
+	void SetUp() override {
+		char pwd_buf[SCAP_MAX_PATH_SIZE];
+		auto pwd = getcwd(pwd_buf, SCAP_MAX_PATH_SIZE);
+		ASSERT_NE(pwd, nullptr);
+		m_host_root = pwd_buf;
+		m_host_root += "/host_container_parsing";
+
+		ASSERT_EQ(mkdir(m_host_root.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+		m_inspector.set_host_root(m_host_root);
+
+		const std::string proc = m_host_root + "/proc";
+		ASSERT_EQ(mkdir(proc.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+
+		// Fake host-init root (pid 1), used by ns_helper as the "still in
+		// the host namespace" reference inode. Must be a different
+		// directory than the container pid's root below.
+		const std::string init_proc = proc + "/1";
+		ASSERT_EQ(mkdir(init_proc.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+		m_init_root = init_proc + "/root";
+		ASSERT_EQ(mkdir(m_init_root.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+
+		// Fake container pid root.
+		const std::string container_proc = proc + "/" + std::to_string(s_container_pid);
+		ASSERT_EQ(mkdir(container_proc.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+		m_container_root = container_proc + "/root";
+		ASSERT_EQ(mkdir(m_container_root.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+
+		m_etc = m_container_root + "/etc";
+		ASSERT_EQ(mkdir(m_etc.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH), 0);
+
+		// notify_group_changed/notify_user_changed no-op unless the
+		// inspector is initialized; open_test_input() is the lightweight
+		// way to reach that state without a real capture engine.
+		open_inspector();
+	}
+
+	void TearDown() override {
+		unlink((m_etc + "/passwd").c_str());
+		unlink((m_etc + "/group").c_str());
+		rmdir(m_etc.c_str());
+		rmdir(m_container_root.c_str());
+		rmdir((m_host_root + "/proc/" + std::to_string(s_container_pid)).c_str());
+		rmdir(m_init_root.c_str());
+		rmdir((m_host_root + "/proc/1").c_str());
+		rmdir((m_host_root + "/proc").c_str());
+		rmdir(m_host_root.c_str());
+	}
+
+	void write_passwd(const std::string& content) {
+		std::ofstream ofs(m_etc + "/passwd");
+		ofs << content;
+	}
+
+	void write_group(const std::string& content) {
+		std::ofstream ofs(m_etc + "/group");
+		ofs << content;
+	}
+
+	// Drains and counts every pending push in the inspector's async event
+	// queue (there is no .size() on mpsc_priority_queue, only
+	// empty()/try_pop()/try_pop_if()).
+	int drain_async_events_queue() {
+		int count = 0;
+		sinsp::sinsp_evt_ptr elm;
+		while(m_inspector.m_async_events_queue.try_pop(elm)) {
+			count++;
+		}
+		return count;
+	}
+
+	std::string m_host_root;
+	std::string m_init_root;
+	std::string m_container_root;
+	std::string m_etc;
+};
+
+// Regression test for the notify fan-out fix: the FIRST time a container's
+// /etc/group is parsed, every real entry is genuinely new, so one notify per
+// entry is correct and expected.
+TEST_F(usergroup_manager_container_parsing_test, first_scan_notifies_once_per_entry) {
+	write_group(
+	        "root:x:0:\n"
+	        "adm:x:4:\n"
+	        "app:x:1000:\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	mgr.add_group(container_id, s_container_pid, 1000, std::string_view{}, /*notify=*/true);
+	auto* group = mgr.get_group(container_id, 1000);
+	ASSERT_NE(group, nullptr);
+	ASSERT_STREQ(group->name, "app");
+
+	// 3 real entries in the file, all new on this first scan: 3 notifies.
+	ASSERT_EQ(drain_async_events_queue(), 3);
+}
+
+// The actual bug being fixed: a SECOND cache miss forces add_container_group
+// to re-scan the whole file again (get_group's outer cache-hit check only
+// short-circuits for gids it already resolved, not for a fresh miss on some
+// OTHER, still-absent gid) — every line from the first scan is already
+// cached by the time this happens, so the correct behavior is zero
+// additional notifies. Before the fix, this second miss alone would have
+// re-notified for every previously-cached line, unrelated to the miss.
+TEST_F(usergroup_manager_container_parsing_test, second_scan_does_not_renotify_cached_entries) {
+	write_group(
+	        "root:x:0:\n"
+	        "adm:x:4:\n"
+	        "app:x:1000:\n"
+	        "worker:x:1001:\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	// First miss: gid 1000. Populates the cache for all 4 lines, notifies 4 times.
+	mgr.add_group(container_id, s_container_pid, 1000, std::string_view{}, /*notify=*/true);
+	ASSERT_EQ(drain_async_events_queue(), 4);
+
+	// Second miss: gid 9999 is NOT in the file at all, so get_group's outer
+	// cache-hit check can't short-circuit — this forces genuine re-entry
+	// into add_container_group, which re-scans and re-inserts all 4 lines
+	// (groupinfo_map_insert always overwrites). All 4 were already cached
+	// from the first scan, so the fix must produce zero notifies here.
+	auto* missing =
+	        mgr.add_group(container_id, s_container_pid, 9999, std::string_view{}, /*notify=*/true);
+	ASSERT_EQ(missing, nullptr);
+	ASSERT_EQ(mgr.get_group(container_id, 9999), nullptr);
+	ASSERT_EQ(drain_async_events_queue(), 0);
+}
+
+// Same shape, for add_container_user/notify_user_changed via /etc/passwd.
+TEST_F(usergroup_manager_container_parsing_test,
+       second_user_scan_does_not_renotify_cached_entries) {
+	write_passwd(
+	        "root:x:0:0:root:/root:/bin/sh\n"
+	        "app:x:1000:1000:app:/home/app:/bin/sh\n"
+	        "worker:x:1001:1001:worker:/home/worker:/bin/sh\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	mgr.add_user(container_id, s_container_pid, 1000, 1000, {}, {}, {}, /*notify=*/true);
+	ASSERT_EQ(drain_async_events_queue(), 3);
+
+	// uid 9999 is absent from the file, so this is a genuine second miss
+	// that re-enters add_container_user and re-scans all 3 already-cached
+	// lines; the fix must produce zero additional notifies.
+	auto* missing =
+	        mgr.add_user(container_id, s_container_pid, 9999, 9999, {}, {}, {}, /*notify=*/true);
+	ASSERT_EQ(missing, nullptr);
+	ASSERT_EQ(mgr.get_user(container_id, 9999), nullptr);
+	ASSERT_EQ(drain_async_events_queue(), 0);
+}
+
+// Final cached state must be identical regardless of the notify-dedup
+// change: get_group/get_user still resolve every entry correctly, and
+// repeated scans keep names fresh (groupinfo_map_insert/userinfo_map_insert
+// still unconditionally overwrite on every parse).
+TEST_F(usergroup_manager_container_parsing_test, cache_state_unaffected_by_dedup) {
+	write_group(
+	        "root:x:0:\n"
+	        "app:x:1000:\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	mgr.add_group(container_id, s_container_pid, 1000, std::string_view{});
+	ASSERT_NE(mgr.get_group(container_id, 0), nullptr);
+	ASSERT_NE(mgr.get_group(container_id, 1000), nullptr);
+	ASSERT_EQ(mgr.get_group(container_id, 4242), nullptr);
+
+	// Re-scan (triggered by a miss on a still-unknown gid): previously
+	// cached entries are still present and correct afterward.
+	mgr.add_group(container_id, s_container_pid, 4242, std::string_view{});
+	ASSERT_EQ(mgr.get_group(container_id, 4242), nullptr);  // not in the file
+	auto* root = mgr.get_group(container_id, 0);
+	ASSERT_NE(root, nullptr);
+	ASSERT_STREQ(root->name, "root");
+	auto* app = mgr.get_group(container_id, 1000);
+	ASSERT_NE(app, nullptr);
+	ASSERT_STREQ(app->name, "app");
+}
+
+// A rescan must still notify for an already-cached gid/uid whose underlying
+// value (name, for groups; gid/name/home/shell, for users) changed since it
+// was first cached — e.g. a rename. The cache-presence check alone
+// (was_cached) is not sufficient to gate the notify: it must also compare
+// against the previously cached value, or a legitimate change is silently
+// swallowed even though the in-memory cache itself is updated correctly.
+TEST_F(usergroup_manager_container_parsing_test, rescan_renotifies_on_value_change) {
+	write_group(
+	        "root:x:0:\n"
+	        "app:x:1000:\n");
+	write_passwd(
+	        "root:x:0:0:root:/root:/bin/sh\n"
+	        "app:x:1000:1000:app:/home/app:/bin/sh\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	// First scan: both files have 2 lines each ("root" + "app"), all 4
+	// entries are genuinely new, all 4 notify.
+	mgr.add_group(container_id, s_container_pid, 1000, std::string_view{}, /*notify=*/true);
+	mgr.add_user(container_id, s_container_pid, 1000, 1000, {}, {}, {}, /*notify=*/true);
+	ASSERT_EQ(drain_async_events_queue(), 4);
+
+	// The underlying files change: gid/uid 1000's name is renamed, everything
+	// else about the file (including the still-unrelated "root" line) is the
+	// same. This is a value change on an already-cached key, not a new key.
+	write_group(
+	        "root:x:0:\n"
+	        "appuser:x:1000:\n");
+	write_passwd(
+	        "root:x:0:0:root:/root:/bin/sh\n"
+	        "appuser:x:1000:1000:appuser:/home/appuser:/bin/sh\n");
+
+	// A miss on a still-unknown gid/uid forces add_container_group/
+	// add_container_user to re-scan and re-cache every line, including the
+	// renamed one, exactly the scenario that previously suppressed the
+	// notify solely because gid/uid 1000 had already been seen before.
+	mgr.add_group(container_id, s_container_pid, 4242, std::string_view{}, /*notify=*/true);
+	mgr.add_user(container_id, s_container_pid, 4242, 4242, {}, {}, {}, /*notify=*/true);
+
+	// The cache reflects the new name...
+	auto* renamed_group = mgr.get_group(container_id, 1000);
+	ASSERT_NE(renamed_group, nullptr);
+	ASSERT_STREQ(renamed_group->name, "appuser");
+	auto* renamed_user = mgr.get_user(container_id, 1000);
+	ASSERT_NE(renamed_user, nullptr);
+	ASSERT_STREQ(renamed_user->name, "appuser");
+
+	// ...and the rename must have been notified, not silently swallowed.
+	// "root" (unchanged) must NOT re-notify; only the two renamed entries do.
+	ASSERT_EQ(drain_async_events_queue(), 2);
+}
+
+// sinsp_usergroup_manager::delete_container is otherwise untested. It must
+// purge every cached user/group entry for a container_id, and be a safe
+// no-op for a container_id that was never cached (no crash, no notify).
+TEST_F(usergroup_manager_container_parsing_test, delete_container_purges_cache) {
+	write_group("app:x:1000:\n");
+	write_passwd("app:x:1000:1000:app:/home/app:/bin/sh\n");
+
+	const std::string container_id{"deadbeef"};
+	const timestamper timestamper{0};
+	sinsp_usergroup_manager mgr{&m_inspector, timestamper};
+
+	mgr.add_group(container_id, s_container_pid, 1000, std::string_view{});
+	mgr.add_user(container_id, s_container_pid, 1000, 1000, {}, {}, {});
+	ASSERT_NE(mgr.get_userlist(container_id), nullptr);
+	ASSERT_NE(mgr.get_grouplist(container_id), nullptr);
+
+	mgr.delete_container(container_id);
+
+	ASSERT_EQ(mgr.get_userlist(container_id), nullptr);
+	ASSERT_EQ(mgr.get_grouplist(container_id), nullptr);
+	ASSERT_EQ(mgr.get_user(container_id, 1000), nullptr);
+	ASSERT_EQ(mgr.get_group(container_id, 1000), nullptr);
+
+	// Safe no-op for a container_id with nothing cached.
+	mgr.delete_container("never-seen-container");
+	ASSERT_EQ(mgr.get_userlist("never-seen-container"), nullptr);
+}
 #endif

--- a/userspace/libsinsp/user.cpp
+++ b/userspace/libsinsp/user.cpp
@@ -440,11 +440,22 @@ scap_userinfo *sinsp_usergroup_manager::add_container_user(const std::string &co
 			if(!parse_uint32(fields[2], u_uid) || !parse_uint32(fields[3], u_gid)) {
 				continue;  // skip lines with a non-numeric uid/gid
 			}
-			// Here we cache all container users
+			// Here we cache all container users. Compare against whatever
+			// was previously cached for this uid (if anything) *before*
+			// the insert overwrites it in place, so we can tell a
+			// genuinely new entry or a changed one (e.g. a rename) apart
+			// from a no-op rescan of an already-known, unchanged entry.
+			const auto existing_it = userlist.find(u_uid);
+			const scap_userinfo *previous =
+			        existing_it != userlist.end() ? &existing_it->second : nullptr;
+			const bool changed = !previous || previous->gid != u_gid ||
+			                     fields[0] != previous->name || fields[5] != previous->homedir ||
+			                     fields[6] != previous->shell;
+
 			auto *usr =
 			        userinfo_map_insert(userlist, u_uid, u_gid, fields[0], fields[5], fields[6]);
 
-			if(notify) {
+			if(notify && changed) {
 				notify_user_changed(usr, container_id);
 			}
 
@@ -569,10 +580,19 @@ scap_groupinfo *sinsp_usergroup_manager::add_container_group(const std::string &
 			if(!parse_uint32(fields[2], g_gid)) {
 				continue;  // skip lines with a non-numeric gid
 			}
-			// Here we cache all container groups
+			// Here we cache all container groups. Compare against whatever
+			// was previously cached for this gid (if anything) *before*
+			// the insert overwrites it in place, so we can tell a
+			// genuinely new entry or a changed one (e.g. a rename) apart
+			// from a no-op rescan of an already-known, unchanged entry.
+			const auto existing_it = grouplist.find(g_gid);
+			const scap_groupinfo *previous =
+			        existing_it != grouplist.end() ? &existing_it->second : nullptr;
+			const bool changed = !previous || fields[0] != previous->name;
+
 			auto *gr = groupinfo_map_insert(grouplist, g_gid, fields[0]);
 
-			if(notify) {
+			if(notify && changed) {
 				notify_group_changed(gr, container_id, true);
 			}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**What this PR does / why we need it**:

A single cache miss for one uid/gid re-parses the container's entire `/etc/passwd` or `/etc/group` and fires `notify_user_changed`/`notify_group_changed` for every line, not just the miss. On a container with N entries, one miss now pushes N async-queue events instead of the 1 that changed.

Gate the notify on whether the entry's cached value actually changed: a brand-new uid/gid, or an already-known one whose gid/name/homedir/shell differs from what's currently cached (e.g. a rename). A rescan that only re-confirms already-correct, unchanged entries produces no notify. This is stricter than gating on cache presence alone because presence-only gating would also suppress the notify for a legitimate value change on an already-known key, silently diverging the `PPME_{USER,GROUP}_ADDED` async-event stream (which capture-file replay depends on to rebuild state) from the live cache.

Final cached state is unchanged either way; only the notify call count changes, and only entries whose value truly changed still notify.

**Special notes for your reviewer**:
Added unit tests in `userspace/libsinsp/test/user.ut.cpp` covering: new uid/gid entries, unchanged rescans (no notify), and changed entries (rename of name/gid/homedir/shell) for both `add_container_user` and `add_container_group`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```