### PR TITLE
ci(bpfcompat): drop source-build deps, add RHEL-family vendor kernels

### DIFF
--- a/.github/workflows/bpfcompat-compatibility.yml
+++ b/.github/workflows/bpfcompat-compatibility.yml
@@ -39,13 +39,17 @@ jobs:
       - name: Install build and VM dependencies
         run: |
           sudo apt-get update
-          # libbpf-dev + zlib1g-dev: the bpfcompat action is pinned by commit
-          # SHA (not a release tag), so it builds its in-guest validator from
-          # source on the runner, which needs libbpf headers + static libs.
+          # Since bpfcompat v0.3.1 a commit-SHA pin that matches a release tag
+          # resolves to prebuilt, checksum-verified release binaries, so the
+          # libbpf/zlib headers previously needed to build its in-guest
+          # validator from source are no longer required. The remaining
+          # packages build scap-open (bundled deps) and run the QEMU guests.
+          # cloud-image-utils provides cloud-localds: RHEL-family guests only
+          # boot from a genuine cidata seed ISO, not the vvfat fallback.
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake clang llvm pkg-config autoconf automake \
-            libtool libelf-dev libbpf-dev zlib1g-dev qemu-system-x86 \
-            qemu-utils jq
+            libtool libelf-dev qemu-system-x86 \
+            qemu-utils cloud-image-utils jq
           # Static bpftool release (needed for skeleton generation): Ubuntu's
           # linux-tools wrapper can't match the runner's Azure kernel.
           curl -fsSL -o /tmp/bpftool.tar.gz \

--- a/test/bpfcompat/kernel-matrix.yaml
+++ b/test/bpfcompat/kernel-matrix.yaml
@@ -11,3 +11,16 @@ profiles:
     required: true
   - id: ubuntu-24.04-6.8
     required: true
+  # RHEL-family kernels, where uname-version heuristics break down: these
+  # boot the real vendor cloud images, so the matrix reflects what modern_bpf
+  # actually does on enterprise backport kernels (the drivers_ci /
+  # kernel-testing images cover upstream kernel versions instead).
+  #
+  # AlmaLinux 8 (RHEL 8 rebuild): 4.18 base with BPF ring buffer and BTF
+  # backported — modern_bpf works here despite 4.18 < the 5.8 upstream
+  # ring-buffer boundary.
+  - id: almalinux-8-4.18
+    required: true
+  # AlmaLinux 9 (RHEL 9 rebuild): 5.14 base with extensive eBPF backports.
+  - id: almalinux-9-5.14
+    required: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Two follow-ups to the bpfcompat compatibility lane (#3024), now that #3057's
dependency-group bump moved the action pin to the v0.3.2 release commit:

1. **Drop `libbpf-dev` and `zlib1g-dev` from the runner deps.** Since
   bpfcompat v0.3.1, a commit-SHA pin that corresponds to a release tag
   resolves to prebuilt, checksum-verified release binaries instead of
   building from source on the runner, so the libbpf headers added in #3055
   are no longer needed. This also shaves ~1.5 min off the job.

2. **Widen the matrix with two RHEL-family vendor kernels**: AlmaLinux 8
   (4.18 base with the BPF ring buffer and BTF backported) and AlmaLinux 9
   (5.14). These are the kernels where uname-version heuristics break down —
   modern_bpf works on Alma 8's "4.18" despite the 5.8 upstream ring-buffer
   boundary, and only booting the real vendor image shows that. This
   complements drivers_ci/kernel-testing, whose images sweep upstream kernel
   versions. RHEL-family guests require a genuine cloud-init seed ISO, so
   this adds `cloud-image-utils` (for `cloud-localds`) to the runner deps —
   the net apt-dependency count goes down by one.

Dress-rehearsed on my fork against current master with exactly this diff:
https://github.com/ErenAri/libs/actions/runs/29778541832 — all 5 kernels pass through the real loader path
(scap-open --modern_bpf, 10 events each), prebuilt binaries resolved and
checksum-verified, no libbpf-dev installed.

**Which issue(s) this PR fixes**:

Follow-up to #3023 / #3024 / #3055.

**Special notes for your reviewer**:

The lane stays non-blocking (schedule + workflow_dispatch only). Happy to
split the dep cleanup and the matrix widening into separate PRs if preferred.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
