### PR TITLE
ci(libscap): Run libscap fuzzer in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,55 @@ jobs:
         if: matrix.name == 'zig'
         run: .github/check-glibc-version.sh build/libsinsp/test/unit-test-libsinsp
 
+  libscap-fuzz-smoke:
+    name: libscap-fuzz-smoke
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Libs
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install deps
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends ca-certificates build-essential git clang llvm libclang-rt-18-dev pkg-config autoconf automake libtool libelf-dev wget python3
+
+      - name: Install cmake
+        uses: ./.github/actions/install-cmake
+
+      - name: Git safe directory
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Generate synthetic fuzz corpus
+        run: |
+          mkdir -p /tmp/falco-libs-fuzz-corpus
+          python3 ./test/libscap/fuzz/tools/recreate_seed_corpus.py \
+            --synthetic-only . /tmp/falco-libs-fuzz-corpus
+
+      - name: Build fuzz target
+        run: |
+          cmake -B build-fuzz -S . \
+            -DUSE_BUNDLED_DEPS=ON \
+            -DUSE_BUNDLED_DRIVER=OFF \
+            -DENABLE_ENGINE_KMOD=OFF \
+            -DCREATE_TEST_TARGETS=ON \
+            -DENABLE_LIBSCAP_TESTS=OFF \
+            -DENABLE_LIBSCAP_FUZZERS=ON \
+            -DUSE_ASAN=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++
+          cmake --build build-fuzz --target fuzz_scap_event_decode --parallel 1
+
+      - name: Run fuzz smoke test
+        run: |
+          ./build-fuzz/test/libscap/fuzz/fuzz_scap_event_decode \
+            /tmp/falco-libs-fuzz-corpus \
+            -dict=./test/libscap/fuzz/fuzz_scap_event_decode.dict \
+            -max_len=4096 \
+            -max_total_time=15
+
   build-libs-linux-amd64-cross-arm64:
     name: build-libs-linux-amd64-cross-arm64 (bundled_deps)
     runs-on: ubuntu-24.04

--- a/test/libscap/fuzz/tools/recreate_seed_corpus.py
+++ b/test/libscap/fuzz/tools/recreate_seed_corpus.py
@@ -15,10 +15,10 @@
 # the License.
 #
 
-from pathlib import Path
+import argparse
 import re
 import struct
-import sys
+from pathlib import Path
 
 
 # Build the deterministic seed corpus used by fuzz_scap_event_decode.
@@ -214,15 +214,26 @@ def write_synthetic_events(corpus_dir, event_codes):
     return len(synthetic_events)
 
 
-def main():
-    if len(sys.argv) != 4:
-        raise SystemExit(
-            f"usage: {Path(sys.argv[0]).name} <repo-root> <corpus-dir> <extracted-events-dir>"
-        )
+def parse_args():
+    parser = argparse.ArgumentParser(description="Build the deterministic libscap fuzz seed corpus.")
+    parser.add_argument(
+        "--synthetic-only",
+        action="store_true",
+        help="skip real capture events and generate only synthetic seeds",
+    )
+    parser.add_argument("repo_root", type=Path)
+    parser.add_argument("corpus_dir", type=Path)
+    parser.add_argument("extracted_events_dir", type=Path, nargs="?")
+    args = parser.parse_args()
+    if not args.synthetic_only and args.extracted_events_dir is None:
+        parser.error("extracted_events_dir is required unless --synthetic-only is used")
+    return args
 
-    root_dir = Path(sys.argv[1])
-    corpus_dir = Path(sys.argv[2])
-    extracted_root = Path(sys.argv[3])
+
+def main():
+    args = parse_args()
+    root_dir = args.repo_root
+    corpus_dir = args.corpus_dir
 
     corpus_dir.mkdir(parents=True, exist_ok=True)
 
@@ -231,10 +242,13 @@ def main():
         set(REGULAR_EVENT_NAMES + LARGE_PAYLOAD_EVENT_NAMES),
     )
 
-    copy_real_events(corpus_dir, extracted_root)
+    real_event_count = 0
+    if not args.synthetic_only:
+        copy_real_events(corpus_dir, args.extracted_events_dir)
+        real_event_count = len(REAL_EVENT_SELECTIONS)
     synthetic_count = write_synthetic_events(corpus_dir, event_codes)
 
-    print(f"recreated {len(REAL_EVENT_SELECTIONS) + synthetic_count} files in {corpus_dir}")
+    print(f"recreated {real_event_count + synthetic_count} files in {corpus_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**Any specific area of the project related to this PR?**

/area libscap
/area tests

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

This follows up on #2857 by running the libscap fuzzer using the synthetic corpus only for 15 seconds for simplicity. 

The idea would be that a long running fuzz job would be added to [oss-fuzz ](https://github.com/google/oss-fuzz)and this would just validate functionality and severe regressions. 

I was able to test this CI stage using act locally to try to validate it works as close as I could to actual GitHub actions but can make any changes required once it's actually run here. 

```
act pull_request -j libscap-fuzz-smoke \
  --container-architecture linux/amd64 \
  -P ubuntu-24.04=catthehacker/ubuntu:act-24.04
  ```
  
  **Does this PR introduce a user-facing change?**:

```release-note
NONE
```