### PR TITLE
perf(libsinsp)!: copy-on-write fd tables

### DIFF
--- a/test/libsinsp_e2e/forking.cpp
+++ b/test/libsinsp_e2e/forking.cpp
@@ -414,7 +414,7 @@ TEST_F(sys_call_test, DISABLED_forking_clone_fs) {
 			int64_t res = std::stoll(e->get_param_value_str("res", false));
 
 			if(ti->m_tid == ptid) {
-				sinsp_fdinfo* fdi = ti->get_fd(prfd);
+				const sinsp_fdinfo* fdi = ti->get_fd(prfd);
 				if(fdi && fdi->tostring().find(FILENAME) != std::string::npos) {
 					EXPECT_EQ(parent_res, res) << "filename: " << fdi->tostring() << std::endl
 					                           << "res: " << res << std::endl

--- a/test/libsinsp_e2e/udp_client_server.cpp
+++ b/test/libsinsp_e2e/udp_client_server.cpp
@@ -512,7 +512,7 @@ TEST_F(sys_call_test, udp_client_server) {
 
 				EXPECT_EQ(PAYLOAD, e->get_param_value_str("data"));
 				const auto fd_server_socket = std::stoll(e->get_param_value_str("fd", false));
-				sinsp_fdinfo* fdinfo = e->get_thread_info()->get_fd(fd_server_socket);
+				const sinsp_fdinfo* fdinfo = e->get_thread_info()->get_fd(fd_server_socket);
 				ASSERT_TRUE(fdinfo);
 				EXPECT_EQ(udps.server_ip_address(), fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
 
@@ -537,7 +537,7 @@ TEST_F(sys_call_test, udp_client_server) {
 
 				EXPECT_EQ(PAYLOAD, e->get_param_value_str("data"));
 				const auto fd_server_socket = std::stoll(e->get_param_value_str("fd", false));
-				sinsp_fdinfo* fdinfo = e->get_thread_info()->get_fd(fd_server_socket);
+				const sinsp_fdinfo* fdinfo = e->get_thread_info()->get_fd(fd_server_socket);
 				ASSERT_TRUE(fdinfo);
 				EXPECT_EQ(udps.server_ip_address(), fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip);
 

--- a/userspace/libsinsp/dns_manager.cpp
+++ b/userspace/libsinsp/dns_manager.cpp
@@ -99,7 +99,7 @@ inline sinsp_dns_manager::dns_info sinsp_dns_manager::resolve(const std::string 
 }
 #endif
 
-bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts) {
+bool sinsp_dns_manager::match(const char *name, int af, const void *addr, uint64_t ts) {
 #if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
 	if(!m_resolver) {
 		m_resolver = std::make_unique<std::thread>(sinsp_dns_resolver::refresh,
@@ -136,7 +136,7 @@ bool sinsp_dns_manager::match(const char *name, int af, void *addr, uint64_t ts)
 	return false;
 }
 
-std::string sinsp_dns_manager::name_of(int af, void *addr, uint64_t ts) {
+std::string sinsp_dns_manager::name_of(int af, const void *addr, uint64_t ts) {
 	std::string ret;
 
 #if !defined(_WIN32) && !defined(__EMSCRIPTEN__)

--- a/userspace/libsinsp/dns_manager.h
+++ b/userspace/libsinsp/dns_manager.h
@@ -41,8 +41,8 @@ struct sinsp_dns_resolver {
 
 class sinsp_dns_manager {
 public:
-	bool match(const char *name, int af, void *addr, uint64_t ts);
-	std::string name_of(int af, void *addr, uint64_t ts);
+	bool match(const char *name, int af, const void *addr, uint64_t ts);
+	std::string name_of(int af, const void *addr, uint64_t ts);
 
 	void cleanup();
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -126,6 +126,21 @@ sinsp_threadinfo *sinsp_evt::get_thread_info() {
 	return m_inspector->m_thread_manager->find_thread(m_pevt->tid, false).get();
 }
 
+void sinsp_evt::upgrade_fd_info_writable() {
+	// Re-fetch the event's fd through the writable lookup, which detaches a
+	// private copy if the entry is currently shared with other fd tables. The
+	// clone (if any) is attributed to this event's type. If the thread or fd is
+	// gone we keep the existing (read-only) pointer; callers cope with that the
+	// same way they cope with a null fd info.
+	if(m_tinfo == nullptr || m_fdinfo == nullptr) {
+		return;
+	}
+	sinsp_fdinfo *writable = m_tinfo->get_fd_mut(m_fdinfo->m_fd);
+	if(writable != nullptr) {
+		m_fdinfo = writable;
+	}
+}
+
 int64_t sinsp_evt::get_fd_num() const {
 	if(m_fdinfo) {
 		return m_tinfo->m_lastevent_fd;

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -74,7 +74,7 @@ sinsp_evt::sinsp_evt():
         m_resolved_paramstr_storage(1024),
         m_tinfo(nullptr),
         m_fdinfo(nullptr),
-        m_fdinfo_name_changed(false),
+        m_fdinfo_name_snapshot_valid(false),
         m_iosize(0),
         m_errorcode(0),
         m_rawbuf_str_len(0),

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -444,7 +444,9 @@ public:
 	*/
 	const sinsp_fdinfo* get_fd_info() const { return m_fdinfo; }
 
-	sinsp_fdinfo* get_fd_info() { return m_fdinfo; }
+	// Mutable access to the event's fd entry: the acquisition point where
+	// copy-on-write will detach an entry shared with other fd tables.
+	sinsp_fdinfo* get_fd_info_mut() { return m_fdinfo; }
 
 	void set_fd_info(sinsp_fdinfo* v) { m_fdinfo = v; }
 

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -448,18 +448,36 @@ public:
 	// copy-on-write will detach an entry shared with other fd tables. The
 	// entry's name is snapshotted on the first acquisition per event, so
 	// that fdinfo_name_changed() can detect changes made while parsing.
-	sinsp_fdinfo* get_fd_info_mut() {
+	//
+	// The parse path now stores a *read-only* reference to the fd entry (see
+	// set_fd_info / sinsp_parser::reset), so events that only read the entry
+	// never detach a shared copy. The detach is performed lazily here, the
+	// first time a consumer actually asks for writable access.
+	inline sinsp_fdinfo* get_fd_info_mut() {
+		if(m_fdinfo != nullptr && !m_fdinfo_writable) {
+			// May replace m_fdinfo with a private (copy-on-write-detached)
+			// entry. Out-of-line because it needs the full sinsp_threadinfo
+			// definition, only forward-declared here.
+			upgrade_fd_info_writable();
+			m_fdinfo_writable = true;
+		}
 		if(m_fdinfo != nullptr && !m_fdinfo_name_snapshot_valid) {
 			m_fdinfo_name_snapshot = m_fdinfo->m_name;
 			m_fdinfo_name_snapshot_valid = true;
 		}
-		return m_fdinfo;
+		// Sound: after upgrade_fd_info_writable() m_fdinfo is a private
+		// (copy-on-write-detached) entry, so the write can't reach a shared one.
+		// This is the single point where a mutable fd pointer is handed out.
+		return const_cast<sinsp_fdinfo*>(m_fdinfo);
 	}
 
-	void set_fd_info(sinsp_fdinfo* v) {
+	inline void set_fd_info(const sinsp_fdinfo* v) {
 		if(v != m_fdinfo) {
 			m_fdinfo_name_snapshot_valid = false;
 		}
+		// The stored reference is treated as read-only until the first
+		// get_fd_info_mut() call detaches a private copy.
+		m_fdinfo_writable = false;
 		m_fdinfo = v;
 	}
 
@@ -599,6 +617,7 @@ public:
 		m_fdinfo_ref.reset();
 		m_fdinfo = nullptr;
 		m_fdinfo_name_snapshot_valid = false;
+		m_fdinfo_writable = false;
 		m_iosize = 0;
 		m_source_idx = sinsp_no_event_source_idx;
 		m_source_name = sinsp_no_event_source_name;
@@ -612,6 +631,7 @@ public:
 		m_fdinfo_ref.reset();
 		m_fdinfo = nullptr;
 		m_fdinfo_name_snapshot_valid = false;
+		m_fdinfo_writable = false;
 		m_iosize = 0;
 		m_cpuid = cpuid;
 		m_source_idx = sinsp_no_event_source_idx;
@@ -789,6 +809,10 @@ private:
 	void write_socktuple_param_to_storage(std::vector<char>& storage,
 	                                      const sinsp_evt_param& param) const;
 
+	// Detach a private (copy-on-write) copy of m_fdinfo from the owning fd
+	// table, replacing m_fdinfo with it. Called lazily by get_fd_info_mut.
+	void upgrade_fd_info_writable();
+
 	sinsp* m_inspector;
 	scap_evt* m_pevt;
 	char* m_pevt_storage;  // In some cases an alternate buffer is used to hold m_pevt. This points
@@ -807,7 +831,9 @@ private:
 	// info it should either be null, or point to the same place as m_tinfo
 	std::shared_ptr<sinsp_threadinfo> m_tinfo_ref;
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo* m_fdinfo;
+	// Read-only by default; get_fd_info_mut() detaches a private copy and
+	// re-points this before handing out a mutable pointer.
+	const sinsp_fdinfo* m_fdinfo;
 
 	// If true, then the associated fdinfo changed names as a part
 	// of parsing this event.
@@ -815,6 +841,11 @@ private:
 	// reused across events, validity is tracked separately.
 	std::string m_fdinfo_name_snapshot;
 	bool m_fdinfo_name_snapshot_valid;
+
+	// True once get_fd_info_mut() has detached a private copy of m_fdinfo
+	// for this event; while false, m_fdinfo is a read-only (possibly shared)
+	// reference. Reset whenever m_fdinfo changes.
+	bool m_fdinfo_writable = false;
 
 	uint32_t m_iosize;
 	int32_t m_errorcode;

--- a/userspace/libsinsp/event.h
+++ b/userspace/libsinsp/event.h
@@ -445,14 +445,31 @@ public:
 	const sinsp_fdinfo* get_fd_info() const { return m_fdinfo; }
 
 	// Mutable access to the event's fd entry: the acquisition point where
-	// copy-on-write will detach an entry shared with other fd tables.
-	sinsp_fdinfo* get_fd_info_mut() { return m_fdinfo; }
+	// copy-on-write will detach an entry shared with other fd tables. The
+	// entry's name is snapshotted on the first acquisition per event, so
+	// that fdinfo_name_changed() can detect changes made while parsing.
+	sinsp_fdinfo* get_fd_info_mut() {
+		if(m_fdinfo != nullptr && !m_fdinfo_name_snapshot_valid) {
+			m_fdinfo_name_snapshot = m_fdinfo->m_name;
+			m_fdinfo_name_snapshot_valid = true;
+		}
+		return m_fdinfo;
+	}
 
-	void set_fd_info(sinsp_fdinfo* v) { m_fdinfo = v; }
+	void set_fd_info(sinsp_fdinfo* v) {
+		if(v != m_fdinfo) {
+			m_fdinfo_name_snapshot_valid = false;
+		}
+		m_fdinfo = v;
+	}
 
-	bool fdinfo_name_changed() const { return m_fdinfo_name_changed; }
-
-	void set_fdinfo_name_changed(const bool changed) { m_fdinfo_name_changed = changed; }
+	// True if parsing the current event changed the name of the (pre-existing)
+	// fd the event refers to. Events that never modified their fd, and fds
+	// created by the current event, report false.
+	bool fdinfo_name_changed() const {
+		return m_fdinfo != nullptr && m_fdinfo_name_snapshot_valid &&
+		       m_fdinfo->m_name != m_fdinfo_name_snapshot;
+	}
 
 	/*!
 	  \brief Return the number of the FD associated with this event.
@@ -581,7 +598,7 @@ public:
 		m_tinfo = nullptr;
 		m_fdinfo_ref.reset();
 		m_fdinfo = nullptr;
-		m_fdinfo_name_changed = false;
+		m_fdinfo_name_snapshot_valid = false;
 		m_iosize = 0;
 		m_source_idx = sinsp_no_event_source_idx;
 		m_source_name = sinsp_no_event_source_name;
@@ -594,7 +611,7 @@ public:
 		m_tinfo = nullptr;
 		m_fdinfo_ref.reset();
 		m_fdinfo = nullptr;
-		m_fdinfo_name_changed = false;
+		m_fdinfo_name_snapshot_valid = false;
 		m_iosize = 0;
 		m_cpuid = cpuid;
 		m_source_idx = sinsp_no_event_source_idx;
@@ -794,7 +811,10 @@ private:
 
 	// If true, then the associated fdinfo changed names as a part
 	// of parsing this event.
-	bool m_fdinfo_name_changed;
+	// Name of the event's fd at its first writable acquisition; the string is
+	// reused across events, validity is tracked separately.
+	std::string m_fdinfo_name_snapshot;
+	bool m_fdinfo_name_snapshot_valid;
 
 	uint32_t m_iosize;
 	int32_t m_errorcode;

--- a/userspace/libsinsp/fdinfo.cpp
+++ b/userspace/libsinsp/fdinfo.cpp
@@ -167,7 +167,6 @@ libsinsp::state::static_field_infos sinsp_fdinfo::get_static_fields() {
 	DEFINE_STATIC_FIELD(ret, self, m_openflags, "open_flags");
 	DEFINE_STATIC_FIELD(ret, self, m_name, "name");
 	DEFINE_STATIC_FIELD(ret, self, m_name_raw, "name_raw");
-	DEFINE_STATIC_FIELD(ret, self, m_oldname, "old_name");
 	DEFINE_STATIC_FIELD(ret, self, m_flags, "flags");
 	DEFINE_STATIC_FIELD(ret, self, m_dev, "dev");
 	DEFINE_STATIC_FIELD(ret, self, m_mount_id, "mount_id");

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -371,8 +371,6 @@ public:
 	std::string m_name_raw;  // Human readable rendering of this FD. See m_name, only used if fd is
 	                         // a file path. Path is kept "raw" with limited sanitization and
 	                         // without absolute path derivation.
-	std::string m_oldname;  // The name of this fd at the beginning of event parsing. Used to detect
-	                        // name changes that result from parsing an event.
 	uint32_t m_flags = FLAGS_NONE;
 	uint32_t m_dev = 0;
 	uint32_t m_mount_id = 0;

--- a/userspace/libsinsp/fdinfo.h
+++ b/userspace/libsinsp/fdinfo.h
@@ -95,7 +95,10 @@ public:
 		FLAGS_IN_BASELINE_RW = (1 << 11),
 		FLAGS_IN_BASELINE_OTHER = (1 << 12),
 		FLAGS_SOCKET_CONNECTED = (1 << 13),
-		FLAGS_IS_CLONED = (1 << 14),
+		// FLAGS_IS_CLONED = (1 << 14), // note: retired (fd tables are shared on fork
+		//                              // and copied on write; "still referenced by
+		//                              // another process" is now is_shared() on the
+		//                              // entry's table). Don't reuse the bit.
 		FLAGS_CONNECTION_PENDING = (1 << 15),
 		FLAGS_CONNECTION_FAILED = (1 << 16),
 		FLAGS_OVERLAY_UPPER = (1 << 17),
@@ -257,8 +260,6 @@ public:
 		return (m_flags & FLAGS_CONNECTION_FAILED) == FLAGS_CONNECTION_FAILED;
 	}
 
-	inline bool is_cloned() const { return (m_flags & FLAGS_IS_CLONED) == FLAGS_IS_CLONED; }
-
 	inline bool is_overlay_upper() const {
 		return (m_flags & FLAGS_OVERLAY_UPPER) == FLAGS_OVERLAY_UPPER;
 	}
@@ -341,8 +342,6 @@ public:
 		m_flags &= ~(FLAGS_SOCKET_CONNECTED | FLAGS_CONNECTION_PENDING);
 		m_flags |= FLAGS_CONNECTION_FAILED;
 	}
-
-	inline void set_is_cloned() { m_flags |= FLAGS_IS_CLONED; }
 
 	inline void set_overlay_upper() { m_flags |= FLAGS_OVERLAY_UPPER; }
 

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -158,6 +158,11 @@ void sinsp_fdtable::reset_cache() const {
 	m_last_accessed_fd = -1;
 }
 
+// Lazily resolves the device number of file entries coming from a proc scan.
+// This is the one entry write allowed on the read-only lookup path: it is an
+// idempotent, derived fill (same mount id resolves to the same device no
+// matter which table triggers it), so performing it on an entry shared with
+// other fd tables is safe and does not require copy-on-write.
 void sinsp_fdtable::lookup_device(sinsp_fdinfo& fdi) const {
 #ifndef _WIN32
 	if(m_params->m_sinsp_mode.is_offline() ||

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -34,7 +34,7 @@ sinsp_fdtable::sinsp_fdtable(const std::shared_ptr<ctor_params>& params):
 	reset_cache();
 }
 
-inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd) {
+inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd) const {
 	//
 	// Try looking up in our simple cache
 	//
@@ -148,7 +148,7 @@ size_t sinsp_fdtable::size() const {
 	return m_table.size();
 }
 
-void sinsp_fdtable::reset_cache() {
+void sinsp_fdtable::reset_cache() const {
 	// Only the cache key is cleared here; m_last_accessed_fdinfo is intentionally
 	// left untouched. Cache validity is keyed solely on m_last_accessed_fd (see
 	// find_ref()), so clearing the key is enough to disarm the cache. Do not null
@@ -173,7 +173,7 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo& fdi) const {
 #endif  // _WIN32
 }
 
-const sinsp_fdinfo* sinsp_fdtable::find(const int64_t fd) {
+const sinsp_fdinfo* sinsp_fdtable::find(const int64_t fd) const {
 	return find_ref(fd).get();
 }
 

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -27,9 +27,15 @@ limitations under the License.
 
 static const auto s_fdtable_static_fields = sinsp_fdinfo::get_static_fields();
 
+const std::shared_ptr<sinsp_fdtable::table_t>& sinsp_fdtable::empty_contents() {
+	static const std::shared_ptr<table_t> s_empty = std::make_shared<table_t>();
+	return s_empty;
+}
+
 sinsp_fdtable::sinsp_fdtable(const std::shared_ptr<ctor_params>& params):
         extensible_table{type_tag<sinsp_fdinfo>{}, "file_descriptors", &s_fdtable_static_fields},
         m_params{params},
+        m_table{empty_contents()},
         m_tid{0} {
 	reset_cache();
 }
@@ -48,9 +54,9 @@ inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd) 
 	//
 	// Caching failed, do a real lookup
 	//
-	auto fdit = m_table.find(fd);
+	auto fdit = m_table->find(fd);
 
-	if(fdit == m_table.end()) {
+	if(fdit == m_table->end()) {
 		if(m_params->m_sinsp_stats_v2) {
 			m_params->m_sinsp_stats_v2->m_n_failed_fd_lookups++;
 		}
@@ -67,22 +73,49 @@ inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::find_ref(int64_t fd) 
 	}
 }
 
+void sinsp_fdtable::share_from(const sinsp_fdtable& other) {
+	m_table = other.m_table;
+	reset_cache();
+}
+
+bool sinsp_fdtable::detach_if_shared() {
+	if(!is_shared()) {
+		return false;
+	}
+
+	// Deep detach: clone every entry into a private map. This is the
+	// deferred equivalent of the eager per-fork table copy it replaces.
+	// Deliberately not counted in the m_n_added_fds stat, which tracks fds
+	// added by events.
+	auto detached = std::make_shared<table_t>();
+	detached->reserve(m_table->size());
+	for(const auto& [fd, info] : *m_table) {
+		detached->emplace(fd, info->clone());
+	}
+	m_table = std::move(detached);
+
+	// The cache points into the previously shared contents.
+	reset_cache();
+	return true;
+}
+
 inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::add_ref(
         int64_t fd,
         std::shared_ptr<sinsp_fdinfo>&& fdinfo) {
 	fdinfo->m_fd = fd;
 
-	const auto it = m_table.find(fd);
+	auto it = m_table->find(fd);
 
 	// Three possible exits here:
 	// 1. fd is not on the table
 	//   a. the table size is under the limit so create a new entry
 	//   b. table size is over the limit, discard the fd
 	// 2. fd is already in the table, replace it
-	if(it == m_table.end()) {
-		if(m_table.size() == m_params->m_max_table_size) {
+	if(it == m_table->end()) {
+		if(m_table->size() == m_params->m_max_table_size) {
 			return m_nullptr_ret;
 		}
+		detach_if_shared();
 
 		// No entry in the table, this is the normal case.
 		m_last_accessed_fd = -1;
@@ -90,7 +123,7 @@ inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::add_ref(
 			m_params->m_sinsp_stats_v2->m_n_added_fds++;
 		}
 
-		return m_table.emplace(fd, std::move(fdinfo)).first->second;
+		return m_table->emplace(fd, std::move(fdinfo)).first->second;
 	}
 
 	// the fd is already in the table. This can happen if:
@@ -106,19 +139,22 @@ inline const std::shared_ptr<sinsp_fdinfo>& sinsp_fdtable::add_ref(
 	// ASSERT(false);
 
 	// Replace the fd as a struct copy.
+	if(detach_if_shared()) {
+		it = m_table->find(fd);
+	}
 	m_last_accessed_fd = -1;
 	it->second = std::move(fdinfo);
 	return it->second;
 }
 
 bool sinsp_fdtable::erase(int64_t fd) {
-	auto fdit = m_table.find(fd);
+	auto fdit = m_table->find(fd);
 
 	if(fd == m_last_accessed_fd) {
 		reset_cache();
 	}
 
-	if(fdit == m_table.end()) {
+	if(fdit == m_table->end()) {
 		//
 		// Looks like there's no fd to remove.
 		// Either the fd creation event was dropped or (more likely) our logic doesn't support the
@@ -130,7 +166,10 @@ bool sinsp_fdtable::erase(int64_t fd) {
 		}
 		return false;
 	} else {
-		m_table.erase(fdit);
+		if(detach_if_shared()) {
+			fdit = m_table->find(fd);
+		}
+		m_table->erase(fdit);
 		if(m_params->m_sinsp_stats_v2 != nullptr) {
 			m_params->m_sinsp_stats_v2->m_n_noncached_fd_lookups++;
 			m_params->m_sinsp_stats_v2->m_n_removed_fds++;
@@ -140,12 +179,17 @@ bool sinsp_fdtable::erase(int64_t fd) {
 }
 
 void sinsp_fdtable::clear() {
-	m_table.clear();
+	if(is_shared()) {
+		// No need to copy contents just to drop them.
+		m_table = empty_contents();
+	} else {
+		m_table->clear();
+	}
 	reset_cache();
 }
 
 size_t sinsp_fdtable::size() const {
-	return m_table.size();
+	return m_table->size();
 }
 
 void sinsp_fdtable::reset_cache() const {
@@ -183,6 +227,7 @@ const sinsp_fdinfo* sinsp_fdtable::find(const int64_t fd) const {
 }
 
 sinsp_fdinfo* sinsp_fdtable::find_mut(const int64_t fd) {
+	detach_if_shared();
 	return find_ref(fd).get();
 }
 
@@ -195,5 +240,8 @@ std::unique_ptr<libsinsp::state::table_entry> sinsp_fdtable::new_entry() const {
 };
 
 std::shared_ptr<libsinsp::state::table_entry> sinsp_fdtable::get_entry(const int64_t& key) {
+	// Conservative: entries handed to the plugin API are writable through
+	// write_entry_field, so they must not live in shared contents.
+	detach_if_shared();
 	return find_ref(key);
 }

--- a/userspace/libsinsp/fdtable.cpp
+++ b/userspace/libsinsp/fdtable.cpp
@@ -173,7 +173,11 @@ void sinsp_fdtable::lookup_device(sinsp_fdinfo& fdi) const {
 #endif  // _WIN32
 }
 
-sinsp_fdinfo* sinsp_fdtable::find(const int64_t fd) {
+const sinsp_fdinfo* sinsp_fdtable::find(const int64_t fd) {
+	return find_ref(fd).get();
+}
+
+sinsp_fdinfo* sinsp_fdtable::find_mut(const int64_t fd) {
 	return find_ref(fd).get();
 }
 

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -58,7 +58,7 @@ public:
 
 	// Read-only lookup: the returned entry must not be modified, as it may be
 	// shared with other fd tables.
-	const sinsp_fdinfo* find(int64_t fd);
+	const sinsp_fdinfo* find(int64_t fd) const;
 
 	// Lookup for modification: the single chokepoint through which every
 	// mutable entry is handed out.
@@ -107,7 +107,7 @@ public:
 
 	size_t size() const;
 
-	void reset_cache();
+	void reset_cache() const;
 
 	inline uint64_t get_tid() const { return m_tid; }
 
@@ -155,10 +155,12 @@ private:
 	std::unordered_map<int64_t, std::shared_ptr<sinsp_fdinfo>> m_table;
 
 	//
-	// Simple fd cache
+	// Simple fd cache. This is per-owner memoization, not table content:
+	// it stays mutable so that read-only lookups on a const table can
+	// still maintain it.
 	//
-	int64_t m_last_accessed_fd;
-	std::shared_ptr<sinsp_fdinfo> m_last_accessed_fdinfo;
+	mutable int64_t m_last_accessed_fd;
+	mutable std::shared_ptr<sinsp_fdinfo> m_last_accessed_fdinfo;
 	uint64_t m_tid;
 	std::shared_ptr<sinsp_fdinfo> m_nullptr_ret;  // needed for returning a reference
 
@@ -167,7 +169,7 @@ private:
 	}
 
 	inline void lookup_device(sinsp_fdinfo& fdi) const;
-	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd);
+	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd) const;
 	const std::shared_ptr<sinsp_fdinfo>& add_ref(int64_t fd,
 	                                             std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 };

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -66,8 +66,22 @@ public:
 
 	sinsp_fdinfo* add(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 
+	// Shares table contents with `other` (typically the parent process's
+	// table at fork). Both tables then see the same entries; the first
+	// content modification through either table detaches a private copy
+	// (copy-on-write), leaving the other sharers untouched.
+	void share_from(const sinsp_fdtable& other);
+
+	// True if the contents are currently shared with at least one other fd
+	// table.
+	bool is_shared() const { return m_table.use_count() > 1; }
+
+	// Identity of the current contents: tables sharing contents report the
+	// same value, letting accountants count shared contents once.
+	const void* contents_id() const { return m_table.get(); }
+
 	inline bool const_loop(const fdtable_const_visitor_t callback) const {
-		for(auto it = m_table.begin(); it != m_table.end(); ++it) {
+		for(auto it = m_table->begin(); it != m_table->end(); ++it) {
 			if(!callback(it->first, *it->second)) {
 				return false;
 			}
@@ -76,7 +90,13 @@ public:
 	}
 
 	inline bool loop(const fdtable_visitor_t callback) {
-		for(auto it = m_table.begin(); it != m_table.end(); ++it) {
+		if(m_table->empty()) {
+			// Nothing to visit; in particular, don't detach shared contents
+			// (proc-scan fixups run on freshly created, still-empty tables).
+			return true;
+		}
+		detach_if_shared();
+		for(auto it = m_table->begin(); it != m_table->end(); ++it) {
 			if(!callback(it->first, *it->second)) {
 				return false;
 			}
@@ -85,7 +105,24 @@ public:
 	}
 
 	void retain(const fdtable_const_visitor_t& callback) {
-		for(auto it = m_table.begin(); it != m_table.end();) {
+		if(m_table->empty()) {
+			return;
+		}
+		if(is_shared()) {
+			// Build the private copy directly from the survivors instead of
+			// detaching everything first: the fork→execve path retains only
+			// the non-CLOEXEC subset of the entries.
+			auto retained = std::make_shared<table_t>();
+			for(const auto& [fd, info] : *m_table) {
+				if(callback(fd, *info)) {
+					retained->emplace(fd, info->clone());
+				}
+			}
+			m_table = std::move(retained);
+			reset_cache();
+			return;
+		}
+		for(auto it = m_table->begin(); it != m_table->end();) {
 			if(!callback(it->first, *it->second)) {
 				// Invalidate the cache if we are removing the cached fd, otherwise a
 				// later lookup would return a dangling reference to the removed entry
@@ -93,7 +130,7 @@ public:
 				if(it->first == m_last_accessed_fd) {
 					reset_cache();
 				}
-				it = m_table.erase(it);
+				it = m_table->erase(it);
 			} else {
 				++it;
 			}
@@ -152,7 +189,12 @@ private:
 	// ctor_params object in sinsp constructor.
 	const std::shared_ptr<ctor_params> m_params;
 
-	std::unordered_map<int64_t, std::shared_ptr<sinsp_fdinfo>> m_table;
+	using table_t = std::unordered_map<int64_t, std::shared_ptr<sinsp_fdinfo>>;
+
+	// The table contents. Held through a shared_ptr so that the fd tables of
+	// related processes can share them; a shared map is never modified in
+	// place (see detach_if_shared()).
+	std::shared_ptr<table_t> m_table;
 
 	//
 	// Simple fd cache. This is per-owner memoization, not table content:
@@ -167,6 +209,17 @@ private:
 	bool is_syscall_plugin_enabled() const {
 		return m_params->m_sinsp_mode.is_plugin() && m_params->m_input_plugin->id() == 0;
 	}
+
+	// The shared immutable empty contents that every fd table starts out
+	// referencing: threads that never own fds (all non-main threads) pay no
+	// allocation. The first modification detaches a private map like any
+	// other write to shared contents.
+	static const std::shared_ptr<table_t>& empty_contents();
+
+	// Gives this table private contents before an in-place modification.
+	// Returns true if a detach actually took place (invalidating iterators
+	// and entry pointers previously obtained from this table).
+	bool detach_if_shared();
 
 	inline void lookup_device(sinsp_fdinfo& fdi) const;
 	const std::shared_ptr<sinsp_fdinfo>& find_ref(int64_t fd) const;

--- a/userspace/libsinsp/fdtable.h
+++ b/userspace/libsinsp/fdtable.h
@@ -56,7 +56,13 @@ public:
 
 	explicit sinsp_fdtable(const std::shared_ptr<ctor_params>& params);
 
-	sinsp_fdinfo* find(int64_t fd);
+	// Read-only lookup: the returned entry must not be modified, as it may be
+	// shared with other fd tables.
+	const sinsp_fdinfo* find(int64_t fd);
+
+	// Lookup for modification: the single chokepoint through which every
+	// mutable entry is handed out.
+	sinsp_fdinfo* find_mut(int64_t fd);
 
 	sinsp_fdinfo* add(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo);
 

--- a/userspace/libsinsp/metrics_collector.cpp
+++ b/userspace/libsinsp/metrics_collector.cpp
@@ -257,7 +257,7 @@ libs_state_counters::libs_state_counters(const std::shared_ptr<sinsp_stats_v2>& 
 		threadinfo_map_t* threadtable = thread_manager->get_threads();
 		if(threadtable != nullptr) {
 			threadtable->loop([this](sinsp_threadinfo& tinfo) {
-				sinsp_fdtable* fdtable = tinfo.get_fd_table();
+				const sinsp_fdtable* fdtable = tinfo.get_fd_table();
 				if(fdtable != nullptr) {
 					this->m_n_fds += fdtable->size();
 				}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -307,12 +307,6 @@ void sinsp_parser::process_event(sinsp_evt &evt, sinsp_parser_verdict &verdict) 
 	default:
 		break;
 	}
-
-	// Check to see if the name changed as a side effect of parsing this event. Try to avoid the
-	// overhead of a string compare for every event.
-	if(evt.get_fd_info()) {
-		evt.set_fdinfo_name_changed(evt.get_fd_info()->m_name != evt.get_fd_info()->m_oldname);
-	}
 }
 
 void sinsp_parser::event_cleanup(sinsp_evt &evt) {

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -834,29 +834,20 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt &evt,
 		 * of the main thread.
 		 */
 		if(valid_caller) {
-			/* Copy the fd list:
-			 * XXX this is a gross oversimplification that will need to be fixed.
-			 * What we do is: if the child is NOT a thread, we copy all the parent fds.
-			 * The right thing to do is looking at PPM_CL_CLONE_FILES, but there are
-			 * syscalls like open and pipe2 that can override PPM_CL_CLONE_FILES with the O_CLOEXEC
-			 * flag
+			/* Share the fd table:
+			 * The child sees the same entries as the parent; the first
+			 * modification through either table detaches a private copy
+			 * (copy-on-write), so no per-fork copy is paid here.
+			 * XXX like the eager copy this replaces, sharing for every
+			 * non-thread child is an oversimplification. The right thing to
+			 * do is looking at PPM_CL_CLONE_FILES, but there are syscalls
+			 * like open and pipe2 that can override PPM_CL_CLONE_FILES with
+			 * the O_CLOEXEC flag
 			 */
 			const sinsp_fdtable *fd_table_ptr = caller_tinfo->get_fd_table();
 			if(fd_table_ptr != nullptr) {
-				child_tinfo->get_fdtable().clear();
 				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
-				fd_table_ptr->const_loop([&child_tinfo](int64_t fd, const sinsp_fdinfo &info) {
-					/* Track down that those are cloned fds */
-					auto newinfo = info.clone();
-					newinfo->set_is_cloned();
-					child_tinfo->get_fdtable().add(fd, std::move(newinfo));
-					return true;
-				});
-
-				/* It's important to reset the cache of the child thread, to prevent it from
-				 * referring to an element in the parent's table.
-				 */
-				child_tinfo->get_fdtable().reset_cache();
+				child_tinfo->get_fdtable().share_from(*fd_table_ptr);
 			} else {
 				/* This should never happen */
 				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,
@@ -1276,31 +1267,20 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &
 			 * of the main thread.
 			 */
 
-			/* Copy the fd list:
-			 * XXX this is a gross oversimplification that will need to be fixed.
-			 * What we do is: if the child is NOT a thread, we copy all the parent fds.
-			 * The right thing to do is looking at PPM_CL_CLONE_FILES, but there are
-			 * syscalls like open and pipe2 that can override PPM_CL_CLONE_FILES with the O_CLOEXEC
-			 * flag
+			/* Share the fd table:
+			 * The child sees the same entries as the parent; the first
+			 * modification through either table detaches a private copy
+			 * (copy-on-write), so no per-fork copy is paid here.
+			 * XXX like the eager copy this replaces, sharing for every
+			 * non-thread child is an oversimplification. The right thing to
+			 * do is looking at PPM_CL_CLONE_FILES, but there are syscalls
+			 * like open and pipe2 that can override PPM_CL_CLONE_FILES with
+			 * the O_CLOEXEC flag
 			 */
 			const sinsp_fdtable *fd_table_ptr = lookup_tinfo->get_fd_table();
 			if(fd_table_ptr != nullptr) {
-				child_tinfo->get_fdtable().clear();
 				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
-				fd_table_ptr->const_loop([&child_tinfo](int64_t fd, const sinsp_fdinfo &info) {
-					/* Track down that those are cloned fds.
-					 * This flag `FLAGS_IS_CLONED` seems to be never used...
-					 */
-					auto newinfo = info.clone();
-					newinfo->set_is_cloned();
-					child_tinfo->get_fdtable().add(fd, std::move(newinfo));
-					return true;
-				});
-
-				/* It's important to reset the cache of the child thread, to prevent it from
-				 * referring to an element in the parent's table.
-				 */
-				child_tinfo->get_fdtable().reset_cache();
+				child_tinfo->get_fdtable().share_from(*fd_table_ptr);
 			} else {
 				/* This should never happen */
 				libsinsp_logger()->format(sinsp_logger::SEV_DEBUG,

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -847,7 +847,7 @@ void sinsp_parser::parse_clone_exit_caller(sinsp_evt &evt,
 			 * syscalls like open and pipe2 that can override PPM_CL_CLONE_FILES with the O_CLOEXEC
 			 * flag
 			 */
-			sinsp_fdtable *fd_table_ptr = caller_tinfo->get_fd_table();
+			const sinsp_fdtable *fd_table_ptr = caller_tinfo->get_fd_table();
 			if(fd_table_ptr != nullptr) {
 				child_tinfo->get_fdtable().clear();
 				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
@@ -1289,7 +1289,7 @@ void sinsp_parser::parse_clone_exit_child(sinsp_evt &evt, sinsp_parser_verdict &
 			 * syscalls like open and pipe2 that can override PPM_CL_CLONE_FILES with the O_CLOEXEC
 			 * flag
 			 */
-			sinsp_fdtable *fd_table_ptr = lookup_tinfo->get_fd_table();
+			const sinsp_fdtable *fd_table_ptr = lookup_tinfo->get_fd_table();
 			if(fd_table_ptr != nullptr) {
 				child_tinfo->get_fdtable().clear();
 				child_tinfo->get_fdtable().set_tid(child_tinfo->m_tid);
@@ -1747,7 +1747,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt &evt, sinsp_parser_verdict &verdi
 	//
 	// Purge CLOEXEC FDs on successful execve/execveat
 	//
-	if(auto *fd_table = evt.get_tinfo()->get_fd_table(); fd_table != nullptr) {
+	if(auto *fd_table = evt.get_tinfo()->get_fd_table_mut(); fd_table != nullptr) {
 		fd_table->retain(
 		        [&](int64_t fd, const sinsp_fdinfo &info) { return !info.is_close_on_exec(); });
 	}
@@ -2780,7 +2780,7 @@ void sinsp_parser::parse_close_range_exit(sinsp_evt &evt) const {
 		return;
 	}
 
-	auto *fd_table = evt.get_tinfo()->get_fd_table();
+	auto *fd_table = evt.get_tinfo()->get_fd_table_mut();
 	if(fd_table == nullptr) {
 		return;
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -3260,16 +3260,19 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 		return;
 	}
 
-	// Fd info and type can change during event parsing.
-	auto &fdinfo = *evt.get_fd_info_mut();
-	auto fd_type = evt.get_fd_info()->m_type;
+	// The fd is looked up read-only; a private (copy-on-write) copy is detached
+	// only at the points below that actually modify the entry -- all of which are
+	// socket-only -- so a read on a shared inherited file/pipe fd leaves it
+	// shared.
+	const sinsp_fdinfo *fdinfo = evt.get_fd_info();
+	const auto fd_type = fdinfo->m_type;
 
 	if(evt.get_syscall_return_value() < 0) {
 		if(!m_track_connection_status) {
 			return;
 		}
 		if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-			fdinfo.set_socket_failed();
+			evt.get_fd_info_mut()->set_socket_failed();
 			// If there's a listener, add a callback to later invoke it.
 			if(!m_observer) {
 				return;
@@ -3282,7 +3285,7 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 	}
 
 	if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-		fdinfo.set_socket_connected();
+		evt.get_fd_info_mut()->set_socket_connected();
 	}
 
 	// This should never happen: if it happens, there is a bug in the code.
@@ -3299,32 +3302,38 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 	} else if(etype == PPME_SOCKET_RECVMMSG_X || etype == PPME_SOCKET_RECV_X) {
 		tupleparam = 4;
 	}
-	if(tupleparam != -1 && (fdinfo.m_name.length() == 0 || !fdinfo.is_tcp_socket())) {
+	// Re-fetch read-only: a socket connect above may already have detached a copy.
+	const sinsp_fdinfo *cur_fdinfo = evt.get_fd_info();
+	if(tupleparam != -1 && (cur_fdinfo->m_name.length() == 0 || !cur_fdinfo->is_tcp_socket())) {
 		// recvfrom contains tuple info. If the fd still doesn't contain tuple info (because the
 		// socket is a datagram one or because some event was lost), add it here.
 		if(update_fd(evt, *evt.get_param(tupleparam))) {
-			// update_fd() can change the event's fd type.
-			fd_type = evt.get_fd_info()->m_type;
-			if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-				if(fdinfo.is_role_none()) {
-					fdinfo.set_net_role_by_guessing(*evt.get_tinfo(), true);
+			// update_fd() detached a private writable copy and may have changed the event's fd
+			// type; finish the update on it. This is the first point on a plain (non-socket)
+			// read where a shared inherited entry would be detached, and it is gated on socket
+			// tuple params, so file/pipe reads leave the entry shared.
+			sinsp_fdinfo *wfdinfo = evt.get_fd_info_mut();
+			const auto new_fd_type = wfdinfo->m_type;
+			if(new_fd_type == SCAP_FD_IPV4_SOCK || new_fd_type == SCAP_FD_IPV6_SOCK) {
+				if(wfdinfo->is_role_none()) {
+					wfdinfo->set_net_role_by_guessing(*evt.get_tinfo(), true);
 				}
 
-				if(fdinfo.is_role_client()) {
-					swap_addresses(fdinfo);
+				if(wfdinfo->is_role_client()) {
+					swap_addresses(*wfdinfo);
 				}
 
 				auto *const str_storage_ptr = &evt.get_paramstr_storage()[0];
 				const auto str_storage_len = std::size(evt.get_paramstr_storage());
-				sinsp_utils::sockinfo_to_str(&fdinfo.m_sockinfo,
-				                             fd_type,
+				sinsp_utils::sockinfo_to_str(&wfdinfo->m_sockinfo,
+				                             new_fd_type,
 				                             str_storage_ptr,
 				                             str_storage_len,
 				                             m_hostname_and_port_resolution_enabled);
-				fdinfo.m_name = str_storage_ptr;
+				wfdinfo->m_name = str_storage_ptr;
 			} else {
 				const char *parstr;
-				fdinfo.m_name = evt.get_param_as_str(tupleparam, &parstr, sinsp_evt::PF_SIMPLE);
+				wfdinfo->m_name = evt.get_param_as_str(tupleparam, &parstr, sinsp_evt::PF_SIMPLE);
 			}
 		}
 	}
@@ -3346,10 +3355,12 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 		verdict.add_post_process_cbs([data_ptr, data_len](sinsp_observer *observer,
 		                                                  sinsp_evt *evt) {
 			const auto original_len = static_cast<uint32_t>(evt->get_syscall_return_value());
+			// The observer gets a read-only handle; a listener that needs to
+			// modify the entry re-fetches a writable copy-on-write copy itself.
 			observer->on_read(evt,
 			                  evt->get_tid(),
 			                  evt->get_tinfo()->m_lastevent_fd,
-			                  evt->get_fd_info_mut(),
+			                  evt->get_fd_info(),
 			                  data_ptr,
 			                  original_len,
 			                  data_len);
@@ -3359,8 +3370,8 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 #ifndef _WIN32
 	// For unix sockets, check if recvmsg contains ancillary data. If so, we check for SCM_RIGHTS,
 	// which is used to pass FDs between processes, and update the sinsp state accordingly via
-	// procfs scan.
-	if(fdinfo.is_unix_socket()) {
+	// procfs scan. Re-fetch read-only: the tuple update above may have detached a copy.
+	if(evt.get_fd_info()->is_unix_socket()) {
 		int32_t msgctrl_param_id = -1;
 		if(etype == PPME_SOCKET_RECVMSG_X && evt.get_num_params() >= 5) {
 			msgctrl_param_id = 4;
@@ -3396,16 +3407,19 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 		return;
 	}
 
-	// Fd info and type can change during event parsing.
-	auto &fdinfo = *evt.get_fd_info_mut();
-	auto fd_type = evt.get_fd_info()->m_type;
+	// The fd is looked up read-only; a private (copy-on-write) copy is detached
+	// only at the points below that actually modify the entry -- all of which are
+	// socket-only -- so a write on a shared inherited file/pipe fd leaves it
+	// shared.
+	const sinsp_fdinfo *fdinfo = evt.get_fd_info();
+	const auto fd_type = fdinfo->m_type;
 
 	if(evt.get_syscall_return_value() < 0) {
 		if(!m_track_connection_status) {
 			return;
 		}
 		if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-			fdinfo.set_socket_failed();
+			evt.get_fd_info_mut()->set_socket_failed();
 			// If there's a listener, add a callback to later invoke it.
 			if(!m_observer) {
 				return;
@@ -3418,7 +3432,7 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 	}
 
 	if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-		fdinfo.set_socket_connected();
+		evt.get_fd_info_mut()->set_socket_connected();
 	}
 
 	// This should never happen: if it happens, there is a bug in the code.
@@ -3427,37 +3441,43 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 		return;
 	}
 
+	// Re-fetch read-only: a socket connect above may already have detached a copy.
+	const sinsp_fdinfo *cur_fdinfo = evt.get_fd_info();
 	if((etype == PPME_SOCKET_SEND_X || etype == PPME_SOCKET_SENDTO_X ||
 	    etype == PPME_SOCKET_SENDMSG_X || etype == PPME_SOCKET_SENDMMSG_X) &&
-	   (fdinfo.m_name.length() == 0 || !fdinfo.is_tcp_socket())) {
+	   (cur_fdinfo->m_name.length() == 0 || !cur_fdinfo->is_tcp_socket())) {
 		// send, sendto, sendmsg and sendmmsg contain tuple info in the exit event. If the fd
 		// still doesn't contain tuple info (because the socket is a datagram one or because
 		// some event was lost), add it here.
 		if(constexpr uint32_t SOCKET_TUPLE_PARAM_ID = 4;
 		   update_fd(evt, *evt.get_param(SOCKET_TUPLE_PARAM_ID))) {
-			// update_fd() can change the event's fd type.
-			fd_type = evt.get_fd_info()->m_type;
-			if(fd_type == SCAP_FD_IPV4_SOCK || fd_type == SCAP_FD_IPV6_SOCK) {
-				if(fdinfo.is_role_none()) {
-					fdinfo.set_net_role_by_guessing(*evt.get_tinfo(), false);
+			// update_fd() detached a private writable copy and may have changed the event's fd
+			// type; finish the update on it. This is the first point on a plain (non-socket)
+			// write where a shared inherited entry would be detached, and it is gated on socket
+			// send params, so file/pipe writes leave the entry shared.
+			sinsp_fdinfo *wfdinfo = evt.get_fd_info_mut();
+			const auto new_fd_type = wfdinfo->m_type;
+			if(new_fd_type == SCAP_FD_IPV4_SOCK || new_fd_type == SCAP_FD_IPV6_SOCK) {
+				if(wfdinfo->is_role_none()) {
+					wfdinfo->set_net_role_by_guessing(*evt.get_tinfo(), false);
 				}
 
-				if(fdinfo.is_role_server()) {
-					swap_addresses(fdinfo);
+				if(wfdinfo->is_role_server()) {
+					swap_addresses(*wfdinfo);
 				}
 
 				auto *const str_storage_ptr = &evt.get_paramstr_storage()[0];
 				const auto str_storage_len = std::size(evt.get_paramstr_storage());
-				sinsp_utils::sockinfo_to_str(&fdinfo.m_sockinfo,
-				                             fd_type,
+				sinsp_utils::sockinfo_to_str(&wfdinfo->m_sockinfo,
+				                             new_fd_type,
 				                             str_storage_ptr,
 				                             str_storage_len,
 				                             m_hostname_and_port_resolution_enabled);
 
-				fdinfo.m_name = str_storage_ptr;
+				wfdinfo->m_name = str_storage_ptr;
 			} else {
 				const char *parstr;
-				fdinfo.m_name =
+				wfdinfo->m_name =
 				        evt.get_param_as_str(SOCKET_TUPLE_PARAM_ID, &parstr, sinsp_evt::PF_SIMPLE);
 			}
 		}
@@ -3478,10 +3498,12 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 		verdict.add_post_process_cbs([data_ptr, data_len](sinsp_observer *observer,
 		                                                  sinsp_evt *evt) {
 			const auto original_len = static_cast<uint32_t>(evt->get_syscall_return_value());
+			// The observer gets a read-only handle; a listener that needs to
+			// modify the entry re-fetches a writable copy-on-write copy itself.
 			observer->on_write(evt,
 			                   evt->get_tid(),
 			                   evt->get_tinfo()->m_lastevent_fd,
-			                   evt->get_fd_info_mut(),
+			                   evt->get_fd_info(),
 			                   data_ptr,
 			                   original_len,
 			                   data_len);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2723,7 +2723,10 @@ void sinsp_parser::parse_close_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 
 		erase_fd_params eparams;
 		eparams.m_fd = evt.get_tinfo()->m_lastevent_fd;
-		eparams.m_fdinfo = evt.get_fd_info_mut();
+		// Read-only view: a listener that needs to modify the entry re-fetches a
+		// writable copy itself, so a shared entry is not detached just to
+		// notify-and-delete it.
+		eparams.m_fdinfo = evt.get_fd_info();
 		eparams.m_remove_from_table = true;
 		eparams.m_tinfo = evt.get_tinfo();
 		erase_fd(eparams, verdict);

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2252,6 +2252,8 @@ void sinsp_parser::parse_bind_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 
 	const auto packed_data = reinterpret_cast<const uint8_t *>(addr_param->data());
 
+	sinsp_fdinfo *fdinfo = evt.get_fd_info_mut();
+
 	// Update the FD info with this tuple, assume that if port > 0, means that the socket is used
 	// for listening.
 	if(const auto family = *packed::generic_sockaddr::family(packed_data); family == PPM_AF_INET) {
@@ -2260,12 +2262,12 @@ void sinsp_parser::parse_bind_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 		memcpy(&ip, packed::in_sockaddr::ip(packed_data), sizeof(ip));
 		memcpy(&port, packed::in_sockaddr::port(packed_data), sizeof(port));
 		if(port > 0) {
-			evt.get_fd_info()->m_type = SCAP_FD_IPV4_SERVSOCK;
-			evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_ip = ip;
-			evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_port = port;
-			evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_l4proto =
-			        evt.get_fd_info()->m_sockinfo.m_ipv4info.m_fields.m_l4proto;
-			evt.get_fd_info()->set_role_server();
+			fdinfo->m_type = SCAP_FD_IPV4_SERVSOCK;
+			fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip = ip;
+			fdinfo->m_sockinfo.m_ipv4serverinfo.m_port = port;
+			fdinfo->m_sockinfo.m_ipv4serverinfo.m_l4proto =
+			        fdinfo->m_sockinfo.m_ipv4info.m_fields.m_l4proto;
+			fdinfo->set_role_server();
 		}
 	} else if(family == PPM_AF_INET6) {
 		const auto *const ip = packed::in6_sockaddr::ip(packed_data);
@@ -2273,28 +2275,26 @@ void sinsp_parser::parse_bind_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 		memcpy(&port, packed::in6_sockaddr::port(packed_data), sizeof(uint16_t));
 		if(port > 0) {
 			if(sinsp_utils::is_ipv4_mapped_ipv6(ip)) {
-				evt.get_fd_info()->m_type = SCAP_FD_IPV4_SERVSOCK;
-				evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_l4proto =
-				        evt.get_fd_info()->m_sockinfo.m_ipv6info.m_fields.m_l4proto;
-				memcpy(&evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_ip,
+				fdinfo->m_type = SCAP_FD_IPV4_SERVSOCK;
+				fdinfo->m_sockinfo.m_ipv4serverinfo.m_l4proto =
+				        fdinfo->m_sockinfo.m_ipv6info.m_fields.m_l4proto;
+				memcpy(&fdinfo->m_sockinfo.m_ipv4serverinfo.m_ip,
 				       packed::in6_sockaddr::ipv4_mapped_ip(packed_data),
 				       sizeof(uint32_t));
-				evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_port = port;
+				fdinfo->m_sockinfo.m_ipv4serverinfo.m_port = port;
 			} else {
-				evt.get_fd_info()->m_type = SCAP_FD_IPV6_SERVSOCK;
-				evt.get_fd_info()->m_sockinfo.m_ipv6serverinfo.m_port = port;
-				memcpy(evt.get_fd_info()->m_sockinfo.m_ipv6serverinfo.m_ip.m_b,
-				       ip,
-				       sizeof(ipv6addr));
-				evt.get_fd_info()->m_sockinfo.m_ipv6serverinfo.m_l4proto =
-				        evt.get_fd_info()->m_sockinfo.m_ipv6info.m_fields.m_l4proto;
+				fdinfo->m_type = SCAP_FD_IPV6_SERVSOCK;
+				fdinfo->m_sockinfo.m_ipv6serverinfo.m_port = port;
+				memcpy(fdinfo->m_sockinfo.m_ipv6serverinfo.m_ip.m_b, ip, sizeof(ipv6addr));
+				fdinfo->m_sockinfo.m_ipv6serverinfo.m_l4proto =
+				        fdinfo->m_sockinfo.m_ipv6info.m_fields.m_l4proto;
 			}
-			evt.get_fd_info()->set_role_server();
+			fdinfo->set_role_server();
 		}
 	}
 	// Update the name of this socket.
 	const char *parstr;
-	evt.get_fd_info()->m_name = evt.get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
+	fdinfo->m_name = evt.get_param_as_str(1, &parstr, sinsp_evt::PF_SIMPLE);
 
 	// If there's a listener, add a callback to later invoke it.
 	if(m_observer) {
@@ -2304,7 +2304,7 @@ void sinsp_parser::parse_bind_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 }
 
 void sinsp_parser::fill_client_socket_info_from_addr(sinsp_evt &evt, const uint8_t *packed_data) {
-	const auto fdinfo = evt.get_fd_info();
+	const auto fdinfo = evt.get_fd_info_mut();
 	auto &sockinfo = fdinfo->m_sockinfo;
 	switch(const uint8_t family = *packed::generic_sockaddr::family(packed_data); family) {
 	case PPM_AF_INET: {
@@ -2450,6 +2450,8 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt &evt,
                                                   const uint8_t *exit_addr_data,
                                                   const uint8_t *enter_addr_data,
                                                   const bool can_resolve_hostname_and_port) {
+	sinsp_fdinfo *fdinfo = evt.get_fd_info_mut();
+
 	// Fill the fd with the socket info.
 	if(const uint8_t family = *exit_tuple_data; family == PPM_AF_INET || family == PPM_AF_INET6) {
 		// Always overwrite destination address and port.
@@ -2468,18 +2470,18 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt &evt,
 			// Check to see if it's an IPv4-mapped IPv6 address
 			// (http://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses)
 			if(!(sinsp_utils::is_ipv4_mapped_ipv6(sip) && sinsp_utils::is_ipv4_mapped_ipv6(dip))) {
-				evt.get_fd_info()->m_type = SCAP_FD_IPV6_SOCK;
-				changed = set_ipv6_addresses_and_ports(*evt.get_fd_info(),
+				fdinfo->m_type = SCAP_FD_IPV6_SOCK;
+				changed = set_ipv6_addresses_and_ports(*fdinfo,
 				                                       sip,
 				                                       sport,
 				                                       dip,
 				                                       dport,
 				                                       overwrite_dest);
 			} else {
-				evt.get_fd_info()->m_type = SCAP_FD_IPV4_SOCK;
+				fdinfo->m_type = SCAP_FD_IPV4_SOCK;
 				const auto *const mapped_sip = packed::in6_addr::ipv4_mapped_ip(sip);
 				const auto *const mapped_dip = packed::in6_addr::ipv4_mapped_ip(dip);
-				changed = set_ipv4_mapped_ipv6_addresses_and_ports(*evt.get_fd_info(),
+				changed = set_ipv4_mapped_ipv6_addresses_and_ports(*fdinfo,
 				                                                   mapped_sip,
 				                                                   sport,
 				                                                   mapped_dip,
@@ -2487,7 +2489,7 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt &evt,
 				                                                   overwrite_dest);
 			}
 		} else {
-			evt.get_fd_info()->m_type = SCAP_FD_IPV4_SOCK;
+			fdinfo->m_type = SCAP_FD_IPV4_SOCK;
 			// Update the FD info with this tuple.
 			const auto *const sip = packed::in_socktuple::sip(exit_tuple_data);
 			const auto *const sport = packed::in_socktuple::sport(exit_tuple_data);
@@ -2498,29 +2500,24 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt &evt,
 			                                 enter_addr_data,
 			                                 dip,
 			                                 dport);
-			changed = set_ipv4_addresses_and_ports(*evt.get_fd_info(),
-			                                       sip,
-			                                       sport,
-			                                       dip,
-			                                       dport,
-			                                       overwrite_dest);
+			changed = set_ipv4_addresses_and_ports(*fdinfo, sip, sport, dip, dport, overwrite_dest);
 		}
 
-		if(changed && evt.get_fd_info()->is_role_server() && evt.get_fd_info()->is_udp_socket()) {
+		if(changed && fdinfo->is_role_server() && fdinfo->is_udp_socket()) {
 			// connect done by a udp server, swap the addresses.
-			swap_addresses(*evt.get_fd_info());
+			swap_addresses(*fdinfo);
 		}
 
 		// Add the friendly name to the fd info.
-		sinsp_utils::sockinfo_to_str(&evt.get_fd_info()->m_sockinfo,
-		                             evt.get_fd_info()->m_type,
+		sinsp_utils::sockinfo_to_str(&fdinfo->m_sockinfo,
+		                             fdinfo->m_type,
 		                             &evt.get_paramstr_storage()[0],
 		                             evt.get_paramstr_storage().size(),
 		                             can_resolve_hostname_and_port);
 
-		evt.get_fd_info()->m_name = &evt.get_paramstr_storage()[0];
+		fdinfo->m_name = &evt.get_paramstr_storage()[0];
 	} else {
-		if(!evt.get_fd_info()->is_unix_socket()) {
+		if(!fdinfo->is_unix_socket()) {
 			// This should happen only in case of a bug in our code, because I'm assuming that the
 			// OS causes a connect with the wrong socket type to fail. Assert in debug mode and just
 			// return in release mode.
@@ -2532,15 +2529,15 @@ inline void sinsp_parser::fill_client_socket_info(sinsp_evt &evt,
 		resolve_connect_unix_destination(exit_tuple_data, exit_addr_data, enter_addr_data, dpath);
 
 		// Update tuple info.
-		evt.get_fd_info()->set_unix_info(exit_tuple_data);
-		const auto source = evt.get_fd_info()->m_sockinfo.m_unixinfo.m_fields.m_source;
-		const auto dest = evt.get_fd_info()->m_sockinfo.m_unixinfo.m_fields.m_dest;
-		evt.get_fd_info()->m_name = encode_unix_tuple_fd_name(source, dest, dpath);
+		fdinfo->set_unix_info(exit_tuple_data);
+		const auto source = fdinfo->m_sockinfo.m_unixinfo.m_fields.m_source;
+		const auto dest = fdinfo->m_sockinfo.m_unixinfo.m_fields.m_dest;
+		fdinfo->m_name = encode_unix_tuple_fd_name(source, dest, dpath);
 	}
 
-	if(evt.get_fd_info()->is_role_none()) {
+	if(fdinfo->is_role_none()) {
 		// Mark this fd as a client.
-		evt.get_fd_info()->set_role_client();
+		fdinfo->set_role_client();
 	}
 }
 
@@ -2553,17 +2550,17 @@ void sinsp_parser::parse_connect_exit(sinsp_evt &evt, sinsp_parser_verdict &verd
 
 	if(m_track_connection_status) {
 		if(retval == -SE_EINPROGRESS) {
-			evt.get_fd_info()->set_socket_pending();
+			evt.get_fd_info_mut()->set_socket_pending();
 		} else if(retval < 0) {
-			evt.get_fd_info()->set_socket_failed();
+			evt.get_fd_info_mut()->set_socket_failed();
 		} else {
-			evt.get_fd_info()->set_socket_connected();
+			evt.get_fd_info_mut()->set_socket_connected();
 		}
 	} else {
 		if(retval < 0 && retval != -SE_EINPROGRESS) {
 			return;
 		}
-		evt.get_fd_info()->set_socket_connected();
+		evt.get_fd_info_mut()->set_socket_connected();
 	}
 
 	// Extract enter event address parameter. This is used as a fallback in case the event tuple is
@@ -2705,7 +2702,7 @@ void sinsp_parser::parse_accept_exit(sinsp_evt &evt, sinsp_parser_verdict &verdi
 	if(m_observer) {
 		verdict.add_post_process_cbs(
 		        [fd, packed_data, fdi](sinsp_observer *observer, sinsp_evt *evt) {
-			        auto fd_info = evt->get_fd_info();
+			        auto fd_info = evt->get_fd_info_mut();
 			        if(fd_info == nullptr) {
 				        fd_info = fdi.get();
 			        }
@@ -2752,7 +2749,7 @@ void sinsp_parser::parse_close_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 
 		erase_fd_params eparams;
 		eparams.m_fd = evt.get_tinfo()->m_lastevent_fd;
-		eparams.m_fdinfo = evt.get_fd_info();
+		eparams.m_fdinfo = evt.get_fd_info_mut();
 		eparams.m_remove_from_table = true;
 		eparams.m_tinfo = evt.get_tinfo();
 		erase_fd(eparams, verdict);
@@ -3050,23 +3047,24 @@ bool sinsp_parser::update_fd(sinsp_evt &evt, const sinsp_evt_param &parinfo) con
 	}
 
 	const auto packed_data = reinterpret_cast<const uint8_t *>(parinfo.data());
+	sinsp_fdinfo *fdinfo = evt.get_fd_info_mut();
 	const auto family = *packed::generic_tuple::family(packed_data);
 
 	if(family == PPM_AF_INET) {
-		if(evt.get_fd_info()->m_type == SCAP_FD_IPV4_SERVSOCK) {
+		if(fdinfo->m_type == SCAP_FD_IPV4_SERVSOCK) {
 			//
 			// If this was previously a server socket, propagate the L4 protocol
 			//
-			evt.get_fd_info()->m_sockinfo.m_ipv4info.m_fields.m_l4proto =
-			        evt.get_fd_info()->m_sockinfo.m_ipv4serverinfo.m_l4proto;
+			fdinfo->m_sockinfo.m_ipv4info.m_fields.m_l4proto =
+			        fdinfo->m_sockinfo.m_ipv4serverinfo.m_l4proto;
 		}
 
-		evt.get_fd_info()->m_type = SCAP_FD_IPV4_SOCK;
+		fdinfo->m_type = SCAP_FD_IPV4_SOCK;
 		const auto *const sip = packed::in_socktuple::sip(packed_data);
 		const auto *const sport = packed::in_socktuple::sport(packed_data);
 		const auto *const dip = packed::in_socktuple::dip(packed_data);
 		const auto *const dport = packed::in_socktuple::dport(packed_data);
-		if(set_ipv4_addresses_and_ports(*evt.get_fd_info(), sip, sport, dip, dport) == false) {
+		if(set_ipv4_addresses_and_ports(*fdinfo, sip, sport, dip, dport) == false) {
 			return false;
 		}
 	} else if(family == PPM_AF_INET6) {
@@ -3079,10 +3077,10 @@ bool sinsp_parser::update_fd(sinsp_evt &evt, const sinsp_evt_param &parinfo) con
 		// (http://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses)
 		//
 		if(sinsp_utils::is_ipv4_mapped_ipv6(sip) && sinsp_utils::is_ipv4_mapped_ipv6(dip)) {
-			evt.get_fd_info()->m_type = SCAP_FD_IPV4_SOCK;
+			fdinfo->m_type = SCAP_FD_IPV4_SOCK;
 			const auto *const mapped_sip = packed::in6_socktuple::ipv4_mapped_sip(packed_data);
 			const auto *const mapped_dip = packed::in6_socktuple::ipv4_mapped_dip(packed_data);
-			if(set_ipv4_mapped_ipv6_addresses_and_ports(*evt.get_fd_info(),
+			if(set_ipv4_mapped_ipv6_addresses_and_ports(*fdinfo,
 			                                            mapped_sip,
 			                                            sport,
 			                                            mapped_dip,
@@ -3091,14 +3089,14 @@ bool sinsp_parser::update_fd(sinsp_evt &evt, const sinsp_evt_param &parinfo) con
 			}
 		} else {
 			// It's not an ipv4-mapped ipv6 address. Extract it as a normal address.
-			if(set_ipv6_addresses_and_ports(*evt.get_fd_info(), sip, sport, dip, dport) == false) {
+			if(set_ipv6_addresses_and_ports(*fdinfo, sip, sport, dip, dport) == false) {
 				return false;
 			}
 		}
 	} else if(family == PPM_AF_UNIX) {
-		evt.get_fd_info()->m_type = SCAP_FD_UNIX_SOCK;
-		evt.get_fd_info()->set_unix_info(packed_data);
-		evt.get_fd_info()->m_name = packed::un_socktuple::dpath(packed_data);
+		fdinfo->m_type = SCAP_FD_UNIX_SOCK;
+		fdinfo->set_unix_info(packed_data);
+		fdinfo->m_name = packed::un_socktuple::dpath(packed_data);
 		return true;
 	}
 
@@ -3107,20 +3105,20 @@ bool sinsp_parser::update_fd(sinsp_evt &evt, const sinsp_evt_param &parinfo) con
 	// connection is UDP, because TCP would fail if the address is changed in
 	// the middle of a connection.
 	//
-	if(evt.get_fd_info()->m_type == SCAP_FD_IPV4_SOCK) {
-		if(evt.get_fd_info()->m_sockinfo.m_ipv4info.m_fields.m_l4proto == SCAP_L4_UNKNOWN) {
-			evt.get_fd_info()->m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_UDP;
+	if(fdinfo->m_type == SCAP_FD_IPV4_SOCK) {
+		if(fdinfo->m_sockinfo.m_ipv4info.m_fields.m_l4proto == SCAP_L4_UNKNOWN) {
+			fdinfo->m_sockinfo.m_ipv4info.m_fields.m_l4proto = SCAP_L4_UDP;
 		}
-	} else if(evt.get_fd_info()->m_type == SCAP_FD_IPV6_SOCK) {
-		if(evt.get_fd_info()->m_sockinfo.m_ipv6info.m_fields.m_l4proto == SCAP_L4_UNKNOWN) {
-			evt.get_fd_info()->m_sockinfo.m_ipv6info.m_fields.m_l4proto = SCAP_L4_UDP;
+	} else if(fdinfo->m_type == SCAP_FD_IPV6_SOCK) {
+		if(fdinfo->m_sockinfo.m_ipv6info.m_fields.m_l4proto == SCAP_L4_UNKNOWN) {
+			fdinfo->m_sockinfo.m_ipv6info.m_fields.m_l4proto = SCAP_L4_UDP;
 		}
 	}
 
 	//
 	// If this is an incomplete tuple, patch it using interface info
 	//
-	m_network_interfaces.update_fd(*evt.get_fd_info());
+	m_network_interfaces.update_fd(*fdinfo);
 
 	return true;
 }
@@ -3286,7 +3284,7 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 	}
 
 	// Fd info and type can change during event parsing.
-	auto &fdinfo = *evt.get_fd_info();
+	auto &fdinfo = *evt.get_fd_info_mut();
 	auto fd_type = evt.get_fd_info()->m_type;
 
 	if(evt.get_syscall_return_value() < 0) {
@@ -3374,7 +3372,7 @@ void sinsp_parser::parse_read_exit(sinsp_evt &evt, sinsp_parser_verdict &verdict
 			observer->on_read(evt,
 			                  evt->get_tid(),
 			                  evt->get_tinfo()->m_lastevent_fd,
-			                  evt->get_fd_info(),
+			                  evt->get_fd_info_mut(),
 			                  data_ptr,
 			                  original_len,
 			                  data_len);
@@ -3422,7 +3420,7 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 	}
 
 	// Fd info and type can change during event parsing.
-	auto &fdinfo = *evt.get_fd_info();
+	auto &fdinfo = *evt.get_fd_info_mut();
 	auto fd_type = evt.get_fd_info()->m_type;
 
 	if(evt.get_syscall_return_value() < 0) {
@@ -3468,7 +3466,7 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 				}
 
 				if(fdinfo.is_role_server()) {
-					swap_addresses(*evt.get_fd_info());
+					swap_addresses(fdinfo);
 				}
 
 				auto *const str_storage_ptr = &evt.get_paramstr_storage()[0];
@@ -3506,7 +3504,7 @@ void sinsp_parser::parse_write_exit(sinsp_evt &evt, sinsp_parser_verdict &verdic
 			observer->on_write(evt,
 			                   evt->get_tid(),
 			                   evt->get_tinfo()->m_lastevent_fd,
-			                   evt->get_fd_info(),
+			                   evt->get_fd_info_mut(),
 			                   data_ptr,
 			                   original_len,
 			                   data_len);
@@ -3793,10 +3791,10 @@ void sinsp_parser::parse_fcntl_exit(sinsp_evt &evt) {
 
 #ifdef FD_CLOEXEC
 	if(cmd == PPM_FCNTL_F_SETFD) {
-		evt.get_fd_info()->clear_close_on_exec_bits();
+		evt.get_fd_info_mut()->clear_close_on_exec_bits();
 		const auto arg = evt.get_param(3)->as<uint64_t>();
 		if((arg & FD_CLOEXEC) != 0) {
-			evt.get_fd_info()->m_openflags |= PPM_O_CLOEXEC;
+			evt.get_fd_info_mut()->m_openflags |= PPM_O_CLOEXEC;
 		}
 		return;
 	}
@@ -4037,9 +4035,9 @@ void sinsp_parser::parse_getsockopt_exit(sinsp_evt &evt, sinsp_parser_verdict &v
 
 	evt.set_errorcode(static_cast<int32_t>(err));
 	if(err < 0) {
-		evt.get_fd_info()->set_socket_failed();
+		evt.get_fd_info_mut()->set_socket_failed();
 	} else {
-		evt.get_fd_info()->set_socket_connected();
+		evt.get_fd_info_mut()->set_socket_connected();
 	}
 
 	// If there's a listener, add a callback to later invoke it.

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -1268,7 +1268,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt, uint32_t* len)
 
 		ppm_event_flags eflags = evt->get_info_flags();
 		if(eflags & EF_WRITES_TO_FD) {
-			sinsp_fdinfo* fdinfo = evt->get_fd_info();
+			const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 
 			if(fdinfo != NULL && fdinfo->is_syslog()) {
 				m_val.u32 = 1;
@@ -1284,7 +1284,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt, uint32_t* len)
 	case TYPE_COUNT_ERROR:
 		return extract_error_count(evt, len);
 	case TYPE_COUNT_ERROR_FILE: {
-		sinsp_fdinfo* fdinfo = evt->get_fd_info();
+		const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 
 		if(fdinfo != NULL) {
 			if(fdinfo->m_type == SCAP_FD_FILE || fdinfo->m_type == SCAP_FD_FILE_V2 ||
@@ -1303,7 +1303,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt, uint32_t* len)
 		return NULL;
 	}
 	case TYPE_COUNT_ERROR_NET: {
-		sinsp_fdinfo* fdinfo = evt->get_fd_info();
+		const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 
 		if(fdinfo != NULL) {
 			if(fdinfo->m_type == SCAP_FD_IPV4_SOCK || fdinfo->m_type == SCAP_FD_IPV6_SOCK ||
@@ -1330,7 +1330,7 @@ uint8_t* sinsp_filter_check_event::extract_single(sinsp_evt* evt, uint32_t* len)
 		}
 	}
 	case TYPE_COUNT_ERROR_OTHER: {
-		sinsp_fdinfo* fdinfo = evt->get_fd_info();
+		const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 
 		if(fdinfo != NULL) {
 			if(!(fdinfo->m_type == SCAP_FD_FILE || fdinfo->m_type == SCAP_FD_FILE_V2 ||

--- a/userspace/libsinsp/sinsp_filtercheck_fd.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.cpp
@@ -1377,8 +1377,8 @@ bool sinsp_filter_check_fd::compare_port(sinsp_evt *evt) {
 			return true;
 		}
 
-		uint16_t *sport;
-		uint16_t *dport;
+		const uint16_t *sport;
+		const uint16_t *dport;
 		scap_fd_type evt_type = m_fdinfo->m_type;
 
 		if(evt_type == SCAP_FD_IPV4_SOCK) {
@@ -1462,7 +1462,7 @@ bool sinsp_filter_check_fd::compare_domain(sinsp_evt *evt) {
 			return false;
 		}
 
-		uint32_t *addr;
+		const uint32_t *addr;
 		if(m_field_id == TYPE_CLIENTIP_NAME) {
 			if(evt_type == SCAP_FD_IPV4_SOCK) {
 				addr = &m_fdinfo->m_sockinfo.m_ipv4info.m_fields.m_sip;

--- a/userspace/libsinsp/sinsp_filtercheck_fd.h
+++ b/userspace/libsinsp/sinsp_filtercheck_fd.h
@@ -97,7 +97,7 @@ private:
 	bool compare_domain(sinsp_evt* evt);
 
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo* m_fdinfo;
+	const sinsp_fdinfo* m_fdinfo;
 	std::string m_tstr;
 	uint8_t m_tcstr[2];
 	int64_t m_argid;

--- a/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fdlist.cpp
@@ -111,7 +111,7 @@ uint8_t *sinsp_filter_check_fdlist::extract_single(sinsp_evt *evt, uint32_t *len
 		bool add_comma = true;
 		int64_t fd = *(int64_t *)(payload + pos);
 
-		sinsp_fdinfo *fdinfo = tinfo ? tinfo->get_fd(fd) : NULL;
+		const sinsp_fdinfo *fdinfo = tinfo ? tinfo->get_fd(fd) : NULL;
 
 		switch(m_field_id) {
 		case TYPE_FDNUMS: {

--- a/userspace/libsinsp/sinsp_observer.h
+++ b/userspace/libsinsp/sinsp_observer.h
@@ -27,14 +27,14 @@ public:
 	virtual void on_read(sinsp_evt* evt,
 	                     int64_t tid,
 	                     int64_t fd,
-	                     sinsp_fdinfo* fdinfo,
+	                     const sinsp_fdinfo* fdinfo,
 	                     const char* data,
 	                     uint32_t original_len,
 	                     uint32_t len) = 0;
 	virtual void on_write(sinsp_evt* evt,
 	                      int64_t tid,
 	                      int64_t fd,
-	                      sinsp_fdinfo* fdinfo,
+	                      const sinsp_fdinfo* fdinfo,
 	                      const char* data,
 	                      uint32_t original_len,
 	                      uint32_t len) = 0;

--- a/userspace/libsinsp/test/CMakeLists.txt
+++ b/userspace/libsinsp/test/CMakeLists.txt
@@ -111,6 +111,7 @@ set(LIBSINSP_UNIT_TESTS_SOURCES
 	filter_eval_test.cpp
 	events_evt.ut.cpp
 	events_file.ut.cpp
+	fdtable_sharing.ut.cpp
 	events_fspath.ut.cpp
 	events_injection.ut.cpp
 	events_net.ut.cpp

--- a/userspace/libsinsp/test/classes/sinsp_observer.cpp
+++ b/userspace/libsinsp/test/classes/sinsp_observer.cpp
@@ -31,7 +31,7 @@ public:
 	void on_read(sinsp_evt* evt,
 	             int64_t tid,
 	             int64_t fd,
-	             sinsp_fdinfo* fdinfo,
+	             const sinsp_fdinfo* fdinfo,
 	             const char* data,
 	             uint32_t original_len,
 	             uint32_t len) override {
@@ -44,7 +44,7 @@ public:
 	void on_write(sinsp_evt* evt,
 	              int64_t tid,
 	              int64_t fd,
-	              sinsp_fdinfo* fdinfo,
+	              const sinsp_fdinfo* fdinfo,
 	              const char* data,
 	              uint32_t original_len,
 	              uint32_t len) override {}

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -387,7 +387,7 @@ TEST_F(sinsp_with_test_input, umount) {
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.res"), std::to_string(res));
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), name);
 
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_EQ(fdinfo, nullptr);
 }
 
@@ -406,7 +406,7 @@ TEST_F(sinsp_with_test_input, umount2) {
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.res"), std::to_string(res));
 	ASSERT_EQ(get_field_as_string(evt, "evt.arg.name"), name);
 
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_EQ(fdinfo, nullptr);
 }
 
@@ -437,7 +437,7 @@ TEST_F(sinsp_with_test_input, pipe) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check the `openflags` field of the fdinfo2, it should be 0 since pipe has no flags */
-	sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
 	ASSERT_NE(fdinfo2, nullptr);
 	ASSERT_EQ(fdinfo2->m_openflags, 0);
 	ASSERT_FD_GETTERS_NOT_FILE(fdinfo2)
@@ -493,7 +493,7 @@ TEST_F(sinsp_with_test_input, pipe2) {
 
 	/* Here we check the `openflags` field of the fdinfo2, it should be 17 since pipe2 has flags
 	 * field */
-	sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo2 = evt->get_fd_info();
 	ASSERT_NE(fdinfo2, nullptr);
 	ASSERT_EQ(fdinfo2->m_openflags, flags);
 	ASSERT_FD_GETTERS_NOT_FILE(fdinfo2)
@@ -528,7 +528,7 @@ TEST_F(sinsp_with_test_input, inotify_init) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "inotify");
 	ASSERT_EQ(fdinfo->get_typechar(), 'i');
@@ -555,7 +555,7 @@ TEST_F(sinsp_with_test_input, inotify_init1) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "inotify");
 	ASSERT_EQ(fdinfo->get_typechar(), 'i');
@@ -582,7 +582,7 @@ TEST_F(sinsp_with_test_input, eventfd) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "event");
 	ASSERT_EQ(fdinfo->get_typechar(), 'e');
@@ -610,7 +610,7 @@ TEST_F(sinsp_with_test_input, eventfd2) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "event");
 	ASSERT_EQ(fdinfo->get_typechar(), 'e');
@@ -645,7 +645,7 @@ TEST_F(sinsp_with_test_input, signalfd) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "signalfd");
 	ASSERT_EQ(fdinfo->get_typechar(), 's');
@@ -680,7 +680,7 @@ TEST_F(sinsp_with_test_input, signalfd4) {
 	ASSERT_FD_FILTER_CHECK_NOT_FILE()
 
 	/* Here we check fields of the fdinfo directly with getter methods */
-	sinsp_fdinfo* fdinfo = evt->get_fd_info();
+	const sinsp_fdinfo* fdinfo = evt->get_fd_info();
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_STREQ(fdinfo->get_typestring(), "signalfd");
 	ASSERT_EQ(fdinfo->get_typechar(), 's');

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -447,7 +447,7 @@ TEST_F(sinsp_with_test_input, pipe) {
 	 * `fdinfo` pointer. */
 
 	ASSERT_NE(evt->get_thread_info(), nullptr);
-	sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
+	const sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
 	ASSERT_NE(fdinfo1, nullptr);
 	ASSERT_STREQ(fdinfo1->get_typestring(), "pipe");
 	ASSERT_EQ(fdinfo1->get_typechar(), 'p');
@@ -502,7 +502,7 @@ TEST_F(sinsp_with_test_input, pipe2) {
 	/* Now we get the first file descriptor (`3`) and we assert some fields directly through the
 	 * `fdinfo` pointer. */
 	ASSERT_NE(evt->get_thread_info(), nullptr);
-	sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
+	const sinsp_fdinfo* fdinfo1 = evt->get_thread_info()->get_fd(fd1);
 	ASSERT_NE(fdinfo1, nullptr);
 	ASSERT_STREQ(fdinfo1->get_typestring(), "pipe");
 	ASSERT_EQ(fdinfo1->get_typechar(), 'p');

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -38,7 +38,6 @@ limitations under the License.
 #define ASSERT_FD_GETTERS_NOT_FILE(x)    \
 	ASSERT_EQ(x->m_name, "");            \
 	ASSERT_EQ(x->m_name_raw, "");        \
-	ASSERT_EQ(x->m_oldname, "");         \
 	ASSERT_EQ(x->get_device(), 0);       \
 	ASSERT_EQ(x->tostring(), "");        \
 	ASSERT_EQ(x->get_device_major(), 0); \
@@ -73,6 +72,8 @@ TEST_F(sinsp_with_test_input, file_open) {
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "/tmp/the_file");
 	ASSERT_EQ(get_field_as_string(evt, "fd.directory"), "/tmp");
 	ASSERT_EQ(get_field_as_string(evt, "fd.filename"), "the_file");
+	// An fd created by the current event is not a name *change*.
+	ASSERT_EQ(get_field_as_string(evt, "fd.name_changed"), "false");
 }
 
 TEST_F(sinsp_with_test_input, file_open_invalid_utf8) {

--- a/userspace/libsinsp/test/events_net.ut.cpp
+++ b/userspace/libsinsp/test/events_net.ut.cpp
@@ -91,7 +91,7 @@ TEST_F(sinsp_with_test_input, net_ipv4_connect) {
 	 * added the fdinfo into the thread. See `reset` logic, the fdinfo is recovered from the
 	 * `client_fd` (first parameter).
 	 */
-	auto* fdinfo = tinfo->get_fd(sinsp_test_input::socket_params::default_fd);
+	const auto* fdinfo = tinfo->get_fd(sinsp_test_input::socket_params::default_fd);
 	ASSERT_NE(fdinfo, nullptr);
 	ASSERT_TRUE(fdinfo->is_ipv4_socket()); /* in `parse_connect_enter` we set `SCAP_FD_IPV4_SOCK` as
 	                                          type */
@@ -309,7 +309,7 @@ TEST_F(sinsp_with_test_input, net_bind_listen_accept_ipv4) {
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo* fdinfo = NULL;
+	const sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 
 	generate_socket_exit_event();
@@ -467,7 +467,7 @@ TEST_F(sinsp_with_test_input, net_connect_exit_event_fails) {
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo* fdinfo = NULL;
+	const sinsp_fdinfo* fdinfo = NULL;
 
 	generate_socket_exit_event();
 
@@ -653,7 +653,7 @@ TEST_F(sinsp_with_test_input, net_connect_enter_event_is_missing) {
 	add_default_init_thread();
 	open_inspector();
 	sinsp_evt* evt = NULL;
-	sinsp_fdinfo* fdinfo = NULL;
+	const sinsp_fdinfo* fdinfo = NULL;
 	char ipv4_string[DEFAULT_IP_STRING_SIZE];
 
 	generate_socket_exit_event(sinsp_test_input::socket_params(PPM_AF_INET, SOCK_DGRAM));

--- a/userspace/libsinsp/test/fdtable_sharing.ut.cpp
+++ b/userspace/libsinsp/test/fdtable_sharing.ut.cpp
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <gtest/gtest.h>
+
+#include <sinsp_with_test_input.h>
+
+// Tests for the fd-table contents-sharing primitives (share_from /
+// detach-on-write). These exercise sinsp_fdtable directly; nothing in the
+// event parsers shares tables yet.
+class fdtable_sharing : public sinsp_with_test_input {
+protected:
+	// Creates a child process of init and returns its threadinfo. The parser
+	// currently populates the child's fd table with a deep copy of the
+	// parent's; tests overwrite that state via share_from().
+	sinsp_threadinfo* spawn_child(int64_t tid) {
+		generate_clone_x_event(0, tid, tid, INIT_TID);
+		auto child = m_inspector.m_thread_manager->find_thread(tid, true).get();
+		EXPECT_NE(child, nullptr);
+		return child;
+	}
+
+	static constexpr int64_t s_fd = sinsp_test_input::open_params::default_fd;
+};
+
+TEST_F(fdtable_sharing, untouched_tables_reference_the_shared_empty_contents) {
+	add_default_init_thread();
+	open_inspector();
+
+	// Secondary threads never own fds (they use their leader's table), so
+	// their own tables keep referencing the shared empty contents.
+	generate_clone_x_event(0, 21, INIT_PID, INIT_PTID, PPM_CL_CLONE_THREAD | PPM_CL_CLONE_FILES);
+	generate_clone_x_event(0, 22, INIT_PID, INIT_PTID, PPM_CL_CLONE_THREAD | PPM_CL_CLONE_FILES);
+	auto* t1 = m_inspector.m_thread_manager->find_thread(21, true).get();
+	auto* t2 = m_inspector.m_thread_manager->find_thread(22, true).get();
+	ASSERT_NE(t1, nullptr);
+	ASSERT_NE(t2, nullptr);
+	ASSERT_FALSE(t1->is_main_thread());
+
+	auto& tt1 = t1->get_fdtable();
+	auto& tt2 = t2->get_fdtable();
+	ASSERT_EQ(tt1.size(), 0);
+	ASSERT_TRUE(tt1.is_shared());
+	// Same contents object for every untouched table: no per-table map.
+	ASSERT_EQ(tt1.contents_id(), tt2.contents_id());
+
+	// The leader's table, which does own an fd, has private contents.
+	auto* leader = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	ASSERT_NE(leader->get_fdtable().contents_id(), tt1.contents_id());
+}
+
+TEST_F(fdtable_sharing, share_and_lookup) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+
+	ASSERT_FALSE(pt.is_shared());
+	ct.share_from(pt);
+
+	ASSERT_TRUE(pt.is_shared());
+	ASSERT_TRUE(ct.is_shared());
+	ASSERT_EQ(ct.size(), pt.size());
+	// Same contents means the same entry objects.
+	ASSERT_EQ(ct.find(s_fd), pt.find(s_fd));
+	ASSERT_EQ(pt.find(s_fd)->m_name, sinsp_test_input::open_params::default_path);
+}
+
+TEST_F(fdtable_sharing, writable_lookup_detaches) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	sinsp_fdinfo* w = ct.find_mut(s_fd);
+	ASSERT_NE(w, nullptr);
+	w->m_name = "/changed";
+
+	// The write detached the child's copy; the parent is untouched.
+	ASSERT_FALSE(pt.is_shared());
+	ASSERT_FALSE(ct.is_shared());
+	ASSERT_NE(ct.find(s_fd), pt.find(s_fd));
+	ASSERT_EQ(ct.find(s_fd)->m_name, "/changed");
+	ASSERT_EQ(pt.find(s_fd)->m_name, sinsp_test_input::open_params::default_path);
+}
+
+TEST_F(fdtable_sharing, const_lookup_does_not_detach) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	ASSERT_NE(ct.find(s_fd), nullptr);
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ASSERT_TRUE(ct.is_shared());
+	ASSERT_TRUE(pt.is_shared());
+}
+
+TEST_F(fdtable_sharing, add_detaches) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	auto fdi = m_inspector.get_fdinfo_factory().create();
+	fdi->m_type = SCAP_FD_FILE_V2;
+	fdi->m_name = "/child-only";
+	ASSERT_NE(ct.add(100, std::move(fdi)), nullptr);
+
+	ASSERT_FALSE(ct.is_shared());
+	ASSERT_NE(ct.find(100), nullptr);
+	ASSERT_EQ(pt.find(100), nullptr);
+	ASSERT_NE(pt.find(s_fd), nullptr);
+}
+
+TEST_F(fdtable_sharing, erase_detaches) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	ASSERT_TRUE(ct.erase(s_fd));
+
+	ASSERT_EQ(ct.find(s_fd), nullptr);
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ASSERT_FALSE(pt.is_shared());
+}
+
+TEST_F(fdtable_sharing, retain_builds_private_copy_from_survivors) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+	sinsp_test_input::open_params second_open;
+	second_open.fd = 5;
+	second_open.path = "/second";
+	generate_open_x_event(second_open);
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	ct.retain([](int64_t fd, const sinsp_fdinfo&) { return fd == 5; });
+
+	ASSERT_FALSE(ct.is_shared());
+	ASSERT_EQ(ct.size(), 1);
+	ASSERT_EQ(ct.find(s_fd), nullptr);
+	ASSERT_NE(ct.find(5), nullptr);
+	// Parent keeps everything.
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ASSERT_NE(pt.find(5), nullptr);
+}
+
+TEST_F(fdtable_sharing, clear_leaves_other_sharers_intact) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ct.share_from(pt);
+
+	ct.clear();
+
+	ASSERT_EQ(ct.size(), 0);
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ASSERT_FALSE(pt.is_shared());
+}
+
+TEST_F(fdtable_sharing, chains_detach_independently) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* grandparent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* parent = spawn_child(20);
+	auto* child = spawn_child(30);
+
+	auto& gt = grandparent->get_fdtable();
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+
+	// G -> P -> C all share one map, no matter through whom they got it.
+	pt.share_from(gt);
+	ct.share_from(pt);
+	ASSERT_TRUE(gt.is_shared());
+	ASSERT_TRUE(pt.is_shared());
+	ASSERT_TRUE(ct.is_shared());
+
+	// The middle of the chain detaching leaves the other two still sharing.
+	ASSERT_NE(pt.find_mut(s_fd), nullptr);
+	ASSERT_FALSE(pt.is_shared());
+	ASSERT_TRUE(gt.is_shared());
+	ASSERT_TRUE(ct.is_shared());
+	ASSERT_EQ(gt.find(s_fd), ct.find(s_fd));
+	ASSERT_NE(gt.find(s_fd), pt.find(s_fd));
+
+	// The last write unshares everything.
+	ASSERT_NE(ct.find_mut(s_fd), nullptr);
+	ASSERT_FALSE(gt.is_shared());
+	ASSERT_FALSE(ct.is_shared());
+}
+
+TEST_F(fdtable_sharing, lookup_cache_survives_share_and_detach) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+
+	// Warm the parent's cache, then share and detach through the child.
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ct.share_from(pt);
+	ASSERT_NE(ct.find(s_fd), nullptr);  // warms the child's cache on the shared map
+	sinsp_fdinfo* w = ct.find_mut(s_fd);
+	w->m_name = "/changed";
+
+	// Both caches resolve to their own table's current entry.
+	ASSERT_EQ(pt.find(s_fd)->m_name, sinsp_test_input::open_params::default_path);
+	ASSERT_EQ(ct.find(s_fd)->m_name, "/changed");
+}

--- a/userspace/libsinsp/test/fdtable_sharing.ut.cpp
+++ b/userspace/libsinsp/test/fdtable_sharing.ut.cpp
@@ -20,16 +20,15 @@ limitations under the License.
 
 #include <sinsp_with_test_input.h>
 
-// Tests for the fd-table contents-sharing primitives (share_from /
-// detach-on-write). These exercise sinsp_fdtable directly; nothing in the
-// event parsers shares tables yet.
+// Tests for fd-table contents sharing: the clone parser shares the parent's
+// table with the child, and the first modification through either table
+// detaches a private copy (copy-on-write).
 class fdtable_sharing : public sinsp_with_test_input {
 protected:
-	// Creates a child process of init and returns its threadinfo. The parser
-	// currently populates the child's fd table with a deep copy of the
-	// parent's; tests overwrite that state via share_from().
-	sinsp_threadinfo* spawn_child(int64_t tid) {
-		generate_clone_x_event(0, tid, tid, INIT_TID);
+	// Creates a child process and returns its threadinfo. The clone parser
+	// shares the parent's fd-table contents with the child (copy-on-write).
+	sinsp_threadinfo* spawn_child(int64_t tid, int64_t parent_tid = INIT_TID) {
+		generate_clone_x_event(0, tid, tid, parent_tid);
 		auto child = m_inspector.m_thread_manager->find_thread(tid, true).get();
 		EXPECT_NE(child, nullptr);
 		return child;
@@ -64,19 +63,17 @@ TEST_F(fdtable_sharing, untouched_tables_reference_the_shared_empty_contents) {
 	ASSERT_NE(leader->get_fdtable().contents_id(), tt1.contents_id());
 }
 
-TEST_F(fdtable_sharing, share_and_lookup) {
+TEST_F(fdtable_sharing, fork_shares_the_parent_table) {
 	add_default_init_thread();
 	open_inspector();
 	generate_open_x_event();
 
 	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
-	auto* child = spawn_child(20);
-
 	auto& pt = parent->get_fdtable();
-	auto& ct = child->get_fdtable();
-
 	ASSERT_FALSE(pt.is_shared());
-	ct.share_from(pt);
+
+	auto* child = spawn_child(20);
+	auto& ct = child->get_fdtable();
 
 	ASSERT_TRUE(pt.is_shared());
 	ASSERT_TRUE(ct.is_shared());
@@ -95,7 +92,6 @@ TEST_F(fdtable_sharing, writable_lookup_detaches) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	sinsp_fdinfo* w = ct.find_mut(s_fd);
 	ASSERT_NE(w, nullptr);
@@ -118,7 +114,6 @@ TEST_F(fdtable_sharing, const_lookup_does_not_detach) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	ASSERT_NE(ct.find(s_fd), nullptr);
 	ASSERT_NE(pt.find(s_fd), nullptr);
@@ -135,7 +130,6 @@ TEST_F(fdtable_sharing, add_detaches) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	auto fdi = m_inspector.get_fdinfo_factory().create();
 	fdi->m_type = SCAP_FD_FILE_V2;
@@ -157,7 +151,6 @@ TEST_F(fdtable_sharing, erase_detaches) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	ASSERT_TRUE(ct.erase(s_fd));
 
@@ -179,7 +172,6 @@ TEST_F(fdtable_sharing, retain_builds_private_copy_from_survivors) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	ct.retain([](int64_t fd, const sinsp_fdinfo&) { return fd == 5; });
 
@@ -201,7 +193,6 @@ TEST_F(fdtable_sharing, clear_leaves_other_sharers_intact) {
 	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
-	ct.share_from(pt);
 
 	ct.clear();
 
@@ -217,15 +208,13 @@ TEST_F(fdtable_sharing, chains_detach_independently) {
 
 	auto* grandparent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
 	auto* parent = spawn_child(20);
-	auto* child = spawn_child(30);
+	auto* child = spawn_child(30, 20);
 
 	auto& gt = grandparent->get_fdtable();
 	auto& pt = parent->get_fdtable();
 	auto& ct = child->get_fdtable();
 
-	// G -> P -> C all share one map, no matter through whom they got it.
-	pt.share_from(gt);
-	ct.share_from(pt);
+	// G -> P -> C all share one map, inherited fork by fork.
 	ASSERT_TRUE(gt.is_shared());
 	ASSERT_TRUE(pt.is_shared());
 	ASSERT_TRUE(ct.is_shared());
@@ -244,19 +233,46 @@ TEST_F(fdtable_sharing, chains_detach_independently) {
 	ASSERT_FALSE(ct.is_shared());
 }
 
+TEST_F(fdtable_sharing, execve_purges_cloexec_without_touching_the_parent) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+	sinsp_test_input::open_params cloexec_open;
+	cloexec_open.fd = 5;
+	cloexec_open.path = "/cloexec";
+	cloexec_open.flags = PPM_O_CLOEXEC;
+	generate_open_x_event(cloexec_open);
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto& pt = parent->get_fdtable();
+	spawn_child(20);
+	generate_execve_enter_and_exit_event(0, 20, 20, 20, INIT_TID);
+
+	auto* child = m_inspector.m_thread_manager->find_thread(20, true).get();
+	auto& ct = child->get_fdtable();
+
+	// The purge kept only the non-CLOEXEC entry, without copying the rest.
+	ASSERT_FALSE(ct.is_shared());
+	ASSERT_NE(ct.find(s_fd), nullptr);
+	ASSERT_EQ(ct.find(5), nullptr);
+	// The parent still owns both.
+	ASSERT_FALSE(pt.is_shared());
+	ASSERT_NE(pt.find(s_fd), nullptr);
+	ASSERT_NE(pt.find(5), nullptr);
+}
+
 TEST_F(fdtable_sharing, lookup_cache_survives_share_and_detach) {
 	add_default_init_thread();
 	open_inspector();
 	generate_open_x_event();
 
 	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
-	auto* child = spawn_child(20);
 	auto& pt = parent->get_fdtable();
-	auto& ct = child->get_fdtable();
 
-	// Warm the parent's cache, then share and detach through the child.
+	// Warm the parent's cache, then fork and detach through the child.
 	ASSERT_NE(pt.find(s_fd), nullptr);
-	ct.share_from(pt);
+	auto* child = spawn_child(20);
+	auto& ct = child->get_fdtable();
 	ASSERT_NE(ct.find(s_fd), nullptr);  // warms the child's cache on the shared map
 	sinsp_fdinfo* w = ct.find_mut(s_fd);
 	w->m_name = "/changed";

--- a/userspace/libsinsp/test/fdtable_sharing.ut.cpp
+++ b/userspace/libsinsp/test/fdtable_sharing.ut.cpp
@@ -121,6 +121,43 @@ TEST_F(fdtable_sharing, const_lookup_does_not_detach) {
 	ASSERT_TRUE(pt.is_shared());
 }
 
+// A plain read on an inherited file fd is a read-only event. Driven through the
+// full parser pipeline it must leave the child's table shared with the parent:
+// reset() populates the event fd via the const lookup, and get_fd_info_mut() --
+// the only writable acquisition -- is never reached because the read modifies
+// nothing. Regression guard: if reset() or an eager acquisition takes a writable
+// handle, the child detaches on this first fd event and the entry pointers diverge.
+TEST_F(fdtable_sharing, read_only_fd_event_keeps_tables_shared) {
+	add_default_init_thread();
+	open_inspector();
+	generate_open_x_event();
+
+	auto* parent = m_inspector.m_thread_manager->find_thread(INIT_TID, true).get();
+	auto* child = spawn_child(20);
+	auto& pt = parent->get_fdtable();
+	auto& ct = child->get_fdtable();
+	ASSERT_TRUE(pt.is_shared());
+	ASSERT_TRUE(ct.is_shared());
+
+	// Successful read on the child's inherited file fd, through the pipeline.
+	uint8_t read_buf[] = {'x'};
+	uint32_t read_size = sizeof(read_buf);
+	add_event_advance_ts(increasing_ts(), 20, PPME_SYSCALL_READ_E, 2, s_fd, read_size);
+	add_event_advance_ts(increasing_ts(),
+	                     20,
+	                     PPME_SYSCALL_READ_X,
+	                     4,
+	                     (int64_t)read_size,
+	                     scap_const_sized_buffer{read_buf, read_size},
+	                     s_fd,
+	                     read_size);
+
+	// The read modified nothing, so both tables still share the same entry.
+	ASSERT_TRUE(pt.is_shared());
+	ASSERT_TRUE(ct.is_shared());
+	ASSERT_EQ(ct.find(s_fd), pt.find(s_fd));
+}
+
 TEST_F(fdtable_sharing, add_detaches) {
 	add_default_init_thread();
 	open_inspector();

--- a/userspace/libsinsp/test/state.ut.cpp
+++ b/userspace/libsinsp/test/state.ut.cpp
@@ -470,7 +470,7 @@ TEST(built_in_table, get_field_type_mismatch_on_cached_accessor) {
 
 TEST(thread_manager, fdtable_access) {
 	// note: used for regression checks, keep this updated as we make new fields available
-	static const int s_fdinfo_static_fields_count = 32;
+	static const int s_fdinfo_static_fields_count = 31;
 
 	sinsp inspector;
 	auto& reg = inspector.get_table_registry();

--- a/userspace/libsinsp/thread_manager.cpp
+++ b/userspace/libsinsp/thread_manager.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <stdio.h>
 #include <algorithm>
 #include <cinttypes>
+#include <vector>
 #include <libscap/strl.h>
 #include <libsinsp/sinsp.h>
 #include <libsinsp/sinsp_int.h>
@@ -378,8 +379,6 @@ void sinsp_thread_manager::remove_main_thread_fdtable(sinsp_threadinfo* main_thr
 		return;
 	}
 
-	// Writable: the fd_listener may mutate the entries handed to it during
-	// the erase notifications below.
 	sinsp_fdtable* fd_table_ptr = main_thread->get_fd_table_mut();
 	if(fd_table_ptr == nullptr) {
 		return;
@@ -389,15 +388,35 @@ void sinsp_thread_manager::remove_main_thread_fdtable(sinsp_threadinfo* main_thr
 	eparams.m_remove_from_table = false;
 	eparams.m_tinfo = main_thread;
 
-	fd_table_ptr->loop([&](int64_t fd, sinsp_fdinfo& fdinfo) {
+	// Iterate read-only: on_erase_fd only reads the entry unless it has a live
+	// transaction to finalize, in which case it re-fetches a writable
+	// copy-on-write copy itself. This avoids cloning an entire fd table — which
+	// may be shared with other processes' tables via fork inheritance — every
+	// time a process exits, just to notify and then destroy it (historically
+	// the single largest source of cow detaches).
+	//
+	// The fd numbers are snapshotted up front because on_erase_fd's writable
+	// re-fetch may detach the underlying map, which must not happen while the
+	// table is being iterated.
+	std::vector<int64_t> fds;
+	fds.reserve(fd_table_ptr->size());
+	fd_table_ptr->const_loop([&fds](int64_t fd, const sinsp_fdinfo&) {
+		fds.push_back(fd);
+		return true;
+	});
+
+	for(const int64_t fd : fds) {
+		const sinsp_fdinfo* fdinfo = fd_table_ptr->find(fd);
+		if(fdinfo == nullptr) {
+			continue;
+		}
 		// The canceled fd should always be deleted immediately, so if it appears here it means we
 		// have a problem. Note: it looks like that the canceled FD may appear here in case of high
 		// drop, and we need to recover. This was an assertion failure, now removed.
 		eparams.m_fd = fd;
-		eparams.m_fdinfo = &fdinfo;
+		eparams.m_fdinfo = fdinfo;
 		m_observer->on_erase_fd(&eparams);
-		return true;
-	});
+	}
 }
 
 void sinsp_thread_manager::remove_thread(int64_t tid) {

--- a/userspace/libsinsp/thread_manager.cpp
+++ b/userspace/libsinsp/thread_manager.cpp
@@ -378,7 +378,9 @@ void sinsp_thread_manager::remove_main_thread_fdtable(sinsp_threadinfo* main_thr
 		return;
 	}
 
-	sinsp_fdtable* fd_table_ptr = main_thread->get_fd_table();
+	// Writable: the fd_listener may mutate the entries handed to it during
+	// the erase notifications below.
+	sinsp_fdtable* fd_table_ptr = main_thread->get_fd_table_mut();
 	if(fd_table_ptr == nullptr) {
 		return;
 	}
@@ -531,7 +533,7 @@ void sinsp_thread_manager::fix_sockets_coming_from_proc(const bool resolve_hostn
 }
 
 void sinsp_thread_manager::clear_thread_pointers(sinsp_threadinfo& tinfo) {
-	sinsp_fdtable* fdt = tinfo.get_fd_table();
+	const sinsp_fdtable* fdt = tinfo.get_fd_table();
 	if(fdt != NULL) {
 		fdt->reset_cache();
 	}
@@ -830,13 +832,13 @@ void sinsp_thread_manager::dump_threads_to_file(scap_dumper_t* dumper) {
 			//
 			// Add the FDs
 			//
-			sinsp_fdtable* fd_table_ptr = tinfo.get_fd_table();
+			const sinsp_fdtable* fd_table_ptr = tinfo.get_fd_table();
 			if(fd_table_ptr == NULL) {
 				return false;
 			}
 
 			bool should_exit = false;
-			fd_table_ptr->loop([&](int64_t fd, sinsp_fdinfo& info) {
+			fd_table_ptr->const_loop([&](int64_t fd, const sinsp_fdinfo& info) {
 				//
 				// Allocate the scap fd info
 				//

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -581,7 +581,7 @@ void sinsp_threadinfo::set_cgroups(const cgroups_t& cgroups) {
 }
 
 sinsp_fdinfo* sinsp_threadinfo::add_fd(int64_t fd, std::shared_ptr<sinsp_fdinfo>&& fdinfo) {
-	sinsp_fdtable* fd_table_ptr = get_fd_table();
+	sinsp_fdtable* fd_table_ptr = get_fd_table_mut();
 	if(fd_table_ptr == NULL) {
 		return NULL;
 	}
@@ -596,7 +596,7 @@ sinsp_fdinfo* sinsp_threadinfo::add_fd(int64_t fd, std::shared_ptr<sinsp_fdinfo>
 }
 
 void sinsp_threadinfo::remove_fd(int64_t fd) {
-	sinsp_fdtable* fd_table_ptr = get_fd_table();
+	sinsp_fdtable* fd_table_ptr = get_fd_table_mut();
 	if(fd_table_ptr == NULL) {
 		return;
 	}
@@ -604,7 +604,7 @@ void sinsp_threadinfo::remove_fd(int64_t fd) {
 }
 
 bool sinsp_threadinfo::loop_fds(sinsp_fdtable::fdtable_const_visitor_t visitor) {
-	sinsp_fdtable* fdt = get_fd_table();
+	const sinsp_fdtable* fdt = get_fd_table();
 	if(fdt == NULL) {
 		return false;
 	}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -45,7 +45,10 @@ struct erase_fd_params {
 	bool m_remove_from_table;
 	int64_t m_fd;
 	sinsp_threadinfo* m_tinfo;
-	sinsp_fdinfo* m_fdinfo;
+	// Read-only view of the fd being erased. A consumer that needs to modify
+	// the entry (e.g. finalizing a transaction on a socket) re-fetches a
+	// writable copy-on-write copy via m_tinfo->get_fd_mut(m_fd).
+	const sinsp_fdinfo* m_fdinfo;
 };
 
 /** @defgroup state State management
@@ -242,7 +245,22 @@ public:
 	  \return Pointer to the FD information, or NULL if the given FD doesn't
 	   exist
 	*/
-	inline sinsp_fdinfo* get_fd(int64_t fd) {
+	// Read-only fd lookup: never detaches a copy-on-write-shared entry. This is
+	// the default; a caller that will modify the entry must use
+	// get_fd_mut() (or sinsp_evt::get_fd_info_mut()). Writing through
+	// a pointer obtained here would corrupt entries still shared with other fd
+	// tables.
+	inline const sinsp_fdinfo* get_fd(int64_t fd) const {
+		if(fd < 0) {
+			return nullptr;
+		}
+		const sinsp_fdtable* fdt = get_fd_table();
+		return (fdt != nullptr) ? fdt->find(fd) : nullptr;
+	}
+
+	// Writable fd lookup: detaches a private copy-on-write copy of a shared
+	// entry so the caller may modify it in place.
+	inline sinsp_fdinfo* get_fd_mut(int64_t fd) {
 		if(fd < 0) {
 			return NULL;
 		}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -250,7 +250,7 @@ public:
 		sinsp_fdtable* fdt = get_fd_table();
 
 		if(fdt) {
-			sinsp_fdinfo* fdinfo = fdt->find(fd);
+			sinsp_fdinfo* fdinfo = fdt->find_mut(fd);
 			if(fdinfo) {
 				// Its current name is now its old
 				// name. The name might change as a

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -252,10 +252,6 @@ public:
 		if(fdt) {
 			sinsp_fdinfo* fdinfo = fdt->find_mut(fd);
 			if(fdinfo) {
-				// Its current name is now its old
-				// name. The name might change as a
-				// result of parsing.
-				fdinfo->m_oldname = fdinfo->m_name;
 				return fdinfo;
 			}
 		}

--- a/userspace/libsinsp/threadinfo.h
+++ b/userspace/libsinsp/threadinfo.h
@@ -247,7 +247,7 @@ public:
 			return NULL;
 		}
 
-		sinsp_fdtable* fdt = get_fd_table();
+		sinsp_fdtable* fdt = get_fd_table_mut();
 
 		if(fdt) {
 			sinsp_fdinfo* fdinfo = fdt->find_mut(fd);
@@ -436,18 +436,18 @@ public:
 	/* Note that `fd_table` should be shared with the main thread only if `PPM_CL_CLONE_FILES`
 	 * is specified. Today we always specify `PPM_CL_CLONE_FILES` for all threads.
 	 */
-	inline sinsp_fdtable* get_fd_table() {
+	inline const sinsp_fdtable* get_fd_table() const {
 		if(!(m_flags & PPM_CL_CLONE_FILES)) {
 			return &m_fdtable;
-		} else {
-			sinsp_threadinfo* root = get_main_thread();
-			return (root == nullptr) ? nullptr : &(root->get_fdtable());
 		}
+		const sinsp_threadinfo* root = get_main_thread();
+		return (root == nullptr) ? nullptr : &(root->get_fdtable());
 	}
 
-	inline const sinsp_fdtable* get_fd_table() const {
-		return const_cast<sinsp_threadinfo*>(this)->get_fd_table();
-	}
+	// Table access for modification: the chokepoint where copy-on-write
+	// will detach state shared with other processes' fd tables. Same
+	// CLONE_FILES routing as the const accessor, so delegate to it.
+	inline sinsp_fdtable* get_fd_table_mut() { return const_cast<sinsp_fdtable*>(get_fd_table()); }
 
 	void init();
 	void init(const scap_threadinfo& pinfo, bool can_load_env_from_proc);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In large fleets a single capture can carry tens of thousands of threads and                                                                                                                                                             
close to a million `sinsp_fdinfo`s, the vast majority of which are fork                                                                                                                                                                 
duplicates: a child's fd table is a near-exact copy of its parent's. Today                                                                                                                                                             
that copy is made eagerly at every clone/fork exit.                                                                                                                                                                                     
                                                                                                                                                                                                                                          
This PR makes an fd table's contents shareable and copy-on-write **as a                                                                                                                                                                 
whole**: a fork points the child at the parent's contents instead of copying                                                                                                                                                            
them, and the first in-place modification through either table detaches a                                                                                                                                                               
private copy. Untouched inherited tables are never copied.   

## Breaking changes

- **`fd.name_changed`** now means, deliberately, "parsing this event changed
  the name of a *pre-existing* fd." It is `false` on fd-creating events
  (open/openat/accept), where it was previously `true` by accident of
  empty-string comparison. Known consumers (inbound/outbound-style macros) only
  read it on `recv*`/`send*` over existing fds, where behavior is unchanged.
- The fd table's **`old_name` state-table field is removed** (it existed only to
  compute the above; it cost every fdinfo 32 bytes and every lookup a string
  copy).
- **`sinsp_fdinfo::is_cloned()` / `set_is_cloned()` / `FLAGS_IS_CLONED`** are
  removed outright (bit `1 << 14` stays reserved). Out-of-tree consumers should
  migrate to `is_shared()`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
action required: review rules using `fd.name_changed` on fd-creating events (there shouldn't be any but still)
action required: `is_cloned()` is removed, switch to `is_shared()`
```
