### PR TITLE
refactor(sinsp): make parse/extract inputs class members

### DIFF
--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -211,6 +211,12 @@ bool sinsp_plugin::init(const std::string& config, std::string& errstr) {
 	clear_accessed_entries();
 	clear_created_entries();
 
+	// set up extract inputs just once
+	m_extract_input.owner = (ss_plugin_owner_t*)this;
+	m_extract_input.get_owner_last_error = sinsp_plugin::get_owner_last_error;
+	m_extract_input.table_reader_ext = &m_tables_reader_ext;
+	m_extract_input.table_reader = m_tables_reader;
+
 	return true;
 }
 
@@ -1065,15 +1071,10 @@ bool sinsp_plugin::extract_fields_and_offsets(sinsp_evt* evt,
 	ev.evtnum = evt->get_num();
 	ev.evtsrc = evt->get_source_name();
 
-	ss_plugin_field_extract_input in;
-	in.num_fields = num_fields;
-	in.fields = fields;
-	in.owner = (ss_plugin_owner_t*)this;
-	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &m_tables_reader_ext;
-	in.table_reader = m_tables_reader;
-	in.value_offsets = value_offsets;
-	auto res = m_handle->api.extract_fields(m_state, &ev, &in) == SS_PLUGIN_SUCCESS;
+	m_extract_input.num_fields = num_fields;
+	m_extract_input.fields = fields;
+	m_extract_input.value_offsets = value_offsets;
+	auto res = m_handle->api.extract_fields(m_state, &ev, &m_extract_input) == SS_PLUGIN_SUCCESS;
 
 	// do some defensive garbage collection
 	clear_ephemeral_tables();

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -217,6 +217,14 @@ bool sinsp_plugin::init(const std::string& config, std::string& errstr) {
 	m_extract_input.table_reader_ext = &m_tables_reader_ext;
 	m_extract_input.table_reader = m_tables_reader;
 
+	// set up parse inputs just once
+	m_parse_input.owner = (ss_plugin_owner_t*)this;
+	m_parse_input.get_owner_last_error = sinsp_plugin::get_owner_last_error;
+	m_parse_input.table_reader_ext = &m_tables_reader_ext;
+	m_parse_input.table_reader = m_tables_reader;
+	m_parse_input.table_writer_ext = &m_tables_writer_ext;
+	m_parse_input.table_writer = m_tables_writer;
+
 	return true;
 }
 
@@ -1103,15 +1111,7 @@ bool sinsp_plugin::parse_event(sinsp_evt* evt) {
 	ev.evt = (const ss_plugin_event*)evt->get_scap_evt();
 	ev.evtnum = evt->get_num();
 	ev.evtsrc = evt->get_source_name();
-
-	ss_plugin_event_parse_input in;
-	in.owner = (ss_plugin_owner_t*)this;
-	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &m_tables_reader_ext;
-	in.table_reader = m_tables_reader;
-	in.table_writer_ext = &m_tables_writer_ext;
-	in.table_writer = m_tables_writer;
-	auto res = m_handle->api.parse_event(m_state, &ev, &in) == SS_PLUGIN_SUCCESS;
+	auto res = m_handle->api.parse_event(m_state, &ev, &m_parse_input) == SS_PLUGIN_SUCCESS;
 
 	// do some defensive garbage collection
 	clear_ephemeral_tables();

--- a/userspace/libsinsp/plugin.cpp
+++ b/userspace/libsinsp/plugin.cpp
@@ -161,24 +161,20 @@ bool sinsp_plugin::init(const std::string& config, std::string& errstr) {
 	in.config = conf.c_str();
 	in.log_fn = &plugin_log_fn;
 
-	ss_plugin_init_tables_input tables_in = {};
-	ss_plugin_table_fields_vtable_ext table_fields_ext = {};
-	ss_plugin_table_reader_vtable reader_deprecated = {};  // unused
-	ss_plugin_table_reader_vtable_ext table_reader_ext = {};
-	ss_plugin_table_writer_vtable writer_deprecated = {};  // unused
-	ss_plugin_table_writer_vtable_ext table_writer_ext = {};
+	// Fill the member vtables (see plugin.h: stable storage the adapter can
+	// park pointers to), regardless of caps -- they are cheap static tables.
+	sinsp_plugin::table_field_api(m_tables_input.fields, m_tables_fields_ext);
+	sinsp_plugin::table_read_api(m_tables_reader, m_tables_reader_ext);
+	sinsp_plugin::table_write_api(m_tables_writer, m_tables_writer_ext);
+	m_tables_input.fields_ext = &m_tables_fields_ext;
+	m_tables_input.reader_ext = &m_tables_reader_ext;
+	m_tables_input.writer_ext = &m_tables_writer_ext;
+	m_tables_input.list_tables = sinsp_plugin::table_api_list_tables;
+	m_tables_input.get_table = sinsp_plugin::table_api_get_table;
+	m_tables_input.add_table = sinsp_plugin::table_api_add_table;
 
 	if(m_caps & (CAP_PARSING | CAP_EXTRACTION)) {
-		tables_in.fields_ext = &table_fields_ext;
-		tables_in.reader_ext = &table_reader_ext;
-		tables_in.writer_ext = &table_writer_ext;
-		sinsp_plugin::table_field_api(tables_in.fields, table_fields_ext);
-		sinsp_plugin::table_read_api(reader_deprecated, table_reader_ext);
-		sinsp_plugin::table_write_api(writer_deprecated, table_writer_ext);
-		tables_in.list_tables = sinsp_plugin::table_api_list_tables;
-		tables_in.get_table = sinsp_plugin::table_api_get_table;
-		tables_in.add_table = sinsp_plugin::table_api_add_table;
-		in.tables = &tables_in;
+		in.tables = &m_tables_input;
 	}
 	ss_plugin_t* state = m_handle->api.init(&in, &rc);
 	if(state != NULL) {
@@ -896,19 +892,11 @@ bool sinsp_plugin::capture_open() {
 	routine_vtable.unsubscribe = &plugin_unsubscribe_routine;
 
 	ss_plugin_capture_listen_input in;
-	ss_plugin_table_reader_vtable_ext table_reader_ext;
-	ss_plugin_table_writer_vtable_ext table_writer_ext;
-	ss_plugin_table_reader_vtable table_reader;
-	ss_plugin_table_writer_vtable table_writer;
-
 	in.owner = (ss_plugin_owner_t*)this;
 	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &table_reader_ext;
-	in.table_writer_ext = &table_writer_ext;
+	in.table_reader_ext = &m_tables_reader_ext;
+	in.table_writer_ext = &m_tables_writer_ext;
 	in.routine = &routine_vtable;
-
-	sinsp_plugin::table_read_api(table_reader, table_reader_ext);
-	sinsp_plugin::table_write_api(table_writer, table_writer_ext);
 
 	return m_handle->api.capture_open(m_state, &in) == SS_PLUGIN_SUCCESS;
 }
@@ -927,19 +915,11 @@ bool sinsp_plugin::capture_close() {
 	routine_vtable.unsubscribe = &plugin_unsubscribe_routine;
 
 	ss_plugin_capture_listen_input in;
-	ss_plugin_table_reader_vtable_ext table_reader_ext;
-	ss_plugin_table_writer_vtable_ext table_writer_ext;
-	ss_plugin_table_reader_vtable table_reader;
-	ss_plugin_table_writer_vtable table_writer;
-
 	in.owner = (ss_plugin_owner_t*)this;
 	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &table_reader_ext;
-	in.table_writer_ext = &table_writer_ext;
+	in.table_reader_ext = &m_tables_reader_ext;
+	in.table_writer_ext = &m_tables_writer_ext;
 	in.routine = &routine_vtable;
-
-	sinsp_plugin::table_read_api(table_reader, table_reader_ext);
-	sinsp_plugin::table_write_api(table_writer, table_writer_ext);
 
 	return m_handle->api.capture_close(m_state, &in) == SS_PLUGIN_SUCCESS;
 }
@@ -1086,14 +1066,13 @@ bool sinsp_plugin::extract_fields_and_offsets(sinsp_evt* evt,
 	ev.evtsrc = evt->get_source_name();
 
 	ss_plugin_field_extract_input in;
-	ss_plugin_table_reader_vtable_ext table_reader_ext;
 	in.num_fields = num_fields;
 	in.fields = fields;
 	in.owner = (ss_plugin_owner_t*)this;
 	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &table_reader_ext;
+	in.table_reader_ext = &m_tables_reader_ext;
+	in.table_reader = m_tables_reader;
 	in.value_offsets = value_offsets;
-	sinsp_plugin::table_read_api(in.table_reader, table_reader_ext);
 	auto res = m_handle->api.extract_fields(m_state, &ev, &in) == SS_PLUGIN_SUCCESS;
 
 	// do some defensive garbage collection
@@ -1125,14 +1104,12 @@ bool sinsp_plugin::parse_event(sinsp_evt* evt) {
 	ev.evtsrc = evt->get_source_name();
 
 	ss_plugin_event_parse_input in;
-	ss_plugin_table_reader_vtable_ext table_reader_ext;
-	ss_plugin_table_writer_vtable_ext table_writer_ext;
 	in.owner = (ss_plugin_owner_t*)this;
 	in.get_owner_last_error = sinsp_plugin::get_owner_last_error;
-	in.table_reader_ext = &table_reader_ext;
-	in.table_writer_ext = &table_writer_ext;
-	sinsp_plugin::table_read_api(in.table_reader, table_reader_ext);
-	sinsp_plugin::table_write_api(in.table_writer, table_writer_ext);
+	in.table_reader_ext = &m_tables_reader_ext;
+	in.table_reader = m_tables_reader;
+	in.table_writer_ext = &m_tables_writer_ext;
+	in.table_writer = m_tables_writer;
 	auto res = m_handle->api.parse_event(m_state, &ev, &in) == SS_PLUGIN_SUCCESS;
 
 	// do some defensive garbage collection

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -242,6 +242,12 @@ private:
 	bool m_inited;
 	ss_plugin_t* m_state;
 	plugin_handle_t* m_handle;
+	ss_plugin_init_tables_input m_tables_input = {};
+	ss_plugin_table_fields_vtable_ext m_tables_fields_ext = {};
+	ss_plugin_table_reader_vtable m_tables_reader = {};
+	ss_plugin_table_reader_vtable_ext m_tables_reader_ext = {};
+	ss_plugin_table_writer_vtable m_tables_writer = {};
+	ss_plugin_table_writer_vtable_ext m_tables_writer_ext = {};
 
 	/** Event Sourcing **/
 	scap_source_plugin m_scap_source_plugin;

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -251,6 +251,7 @@ private:
 	ss_plugin_table_writer_vtable m_tables_writer = {};
 	ss_plugin_table_writer_vtable_ext m_tables_writer_ext = {};
 	ss_plugin_field_extract_input m_extract_input = {};
+	ss_plugin_event_parse_input m_parse_input = {};
 
 	/** Event Sourcing **/
 	scap_source_plugin m_scap_source_plugin;

--- a/userspace/libsinsp/plugin.h
+++ b/userspace/libsinsp/plugin.h
@@ -134,6 +134,8 @@ public:
 	virtual ~sinsp_plugin();
 	sinsp_plugin(const sinsp_plugin& s) = delete;
 	sinsp_plugin& operator=(const sinsp_plugin& s) = delete;
+	sinsp_plugin(sinsp_plugin&& s) = delete;
+	sinsp_plugin& operator=(sinsp_plugin&& s) = delete;
 
 	/** Common API **/
 	inline plugin_caps_t caps() const { return m_caps; }
@@ -248,6 +250,7 @@ private:
 	ss_plugin_table_reader_vtable_ext m_tables_reader_ext = {};
 	ss_plugin_table_writer_vtable m_tables_writer = {};
 	ss_plugin_table_writer_vtable_ext m_tables_writer_ext = {};
+	ss_plugin_field_extract_input m_extract_input = {};
 
 	/** Event Sourcing **/
 	scap_source_plugin m_scap_source_plugin;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes a heavy initialization of parse/extract input structs every time from scratch from the hot path. Instead, we initialize them in sinsp_plugin::init and only update the needed fields at extraction time.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
