### PR TITLE
fix(libsinsp): evt.abspath no longer overwrites the event's fd

### DIFF
--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -760,16 +760,21 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 	} else if(dirfd == PPM_AT_FDCWD) {
 		sdir = evt->get_tinfo()->get_cwd();
 	} else {
-		evt->set_fd_info(evt->get_tinfo()->get_fd(dirfd));
+		// Resolve the dirfd locally: extraction must not write to the event. Note that
+		// this is *not* necessarily the event's own fd. For the `*at` events that carry
+		// the dirfd in their fd parameter (see get_exit_event_fd_location()) the two
+		// coincide, but on openat the event's fd is the newly opened file, and on
+		// linkat/renameat the event has no fd at all.
+		const sinsp_fdinfo* dir_fdinfo = evt->get_tinfo()->get_fd(dirfd);
 
-		if(evt->get_fd_info() == nullptr) {
+		if(dir_fdinfo == nullptr) {
 			ASSERT(false);
 			sdir = "<UNKNOWN>/";
 		} else {
-			if(evt->get_fd_info()->m_name[evt->get_fd_info()->m_name.length()] == '/') {
-				sdir = evt->get_fd_info()->m_name;
+			if(dir_fdinfo->m_name[dir_fdinfo->m_name.length()] == '/') {
+				sdir = dir_fdinfo->m_name;
 			} else {
-				sdir = evt->get_fd_info()->m_name + '/';
+				sdir = dir_fdinfo->m_name + '/';
 			}
 		}
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <libsinsp/sinsp_int.h>
 #include <libsinsp/plugin.h>
 #include <libsinsp/plugin_manager.h>
+#include <libsinsp/parsers.h>
 #include <libsinsp/value_parser.h>
 
 using namespace std;
@@ -747,35 +748,13 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 	const auto dirfd = dirfd_param->as<int64_t>();
 	const auto path = path_param->as<std::string_view>();
 
-	string sdir;
-
-	bool is_absolute = (path[0] == '/');
-	if(is_absolute) {
-		//
-		// The path is absolute.
-		// Some processes (e.g. irqbalance) actually do this: they pass an invalid fd and
-		// and absolute path, and openat succeeds.
-		//
-		sdir = ".";
-	} else if(dirfd == PPM_AT_FDCWD) {
-		sdir = evt->get_tinfo()->get_cwd();
-	} else {
-		// Resolve the dirfd locally: extraction must not write to the event. Note that
-		// this is *not* necessarily the event's own fd. For the `*at` events that carry
-		// the dirfd in their fd parameter (see get_exit_event_fd_location()) the two
-		// coincide, but on openat the event's fd is the newly opened file, and on
-		// linkat/renameat the event has no fd at all.
-		const sinsp_fdinfo* dir_fdinfo = evt->get_tinfo()->get_fd(dirfd);
-
-		if(dir_fdinfo == nullptr) {
-			ASSERT(false);
-			sdir = "<UNKNOWN>/";
-		} else {
-			sdir = dir_fdinfo->m_name;
-			if(sdir.empty() || sdir.back() != '/') {
-				sdir += '/';
-			}
-		}
+	// The same dirfd resolution the parser and the fspath check use. Its result is a
+	// prefix for concatenate_paths(), which inserts no separator of its own, so make
+	// sure it ends with one: parse_dirfd() omits it for its "<UNKNOWN>" answer, and
+	// every other answer already carries it.
+	std::string sdir = sinsp_parser::parse_dirfd(*evt, path, dirfd);
+	if(!sdir.empty() && sdir.back() != '/') {
+		sdir += '/';
 	}
 
 	m_strstorage = sinsp_utils::concatenate_paths(sdir, path);

--- a/userspace/libsinsp/sinsp_filtercheck_event.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_event.cpp
@@ -771,10 +771,9 @@ uint8_t* sinsp_filter_check_event::extract_abspath(sinsp_evt* evt, uint32_t* len
 			ASSERT(false);
 			sdir = "<UNKNOWN>/";
 		} else {
-			if(dir_fdinfo->m_name[dir_fdinfo->m_name.length()] == '/') {
-				sdir = dir_fdinfo->m_name;
-			} else {
-				sdir = dir_fdinfo->m_name + '/';
+			sdir = dir_fdinfo->m_name;
+			if(sdir.empty() || sdir.back() != '/') {
+				sdir += '/';
 			}
 		}
 	}

--- a/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
+++ b/userspace/libsinsp/sinsp_filtercheck_fspath.cpp
@@ -338,8 +338,9 @@ uint8_t* sinsp_filter_check_fspath::extract_single(sinsp_evt* evt, uint32_t* len
 				}
 				break;
 			}
-			// For the following syscalls, the event fdinfo is set to their dirfd.
-			// Set `sdir` to the dirfd info path.
+			// For the following syscalls the event fdinfo is set to their dirfd:
+			// their fd parameter *is* the dirfd (see get_exit_event_fd_location()),
+			// so sinsp_parser::reset() installs it. Set `sdir` to that dirfd's path.
 			case PPME_SYSCALL_NEWFSTATAT_X:
 			case PPME_SYSCALL_FCHOWNAT_X:
 			case PPME_SYSCALL_FCHMODAT_X:

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -854,3 +854,66 @@ TEST_F(sinsp_with_test_input, test_pidfd) {
 	ASSERT_EQ(get_field_as_string(evt, "fd.typechar"), "f");
 	ASSERT_EQ(get_field_as_string(evt, "fd.type"), "file");
 }
+
+// `evt.abspath` resolves the path against the event's dirfd. That lookup must not
+// disturb the event's own fd: on openat the event's fdinfo is the newly opened file,
+// so an extraction that installed the dirfd there left every field extracted
+// afterwards describing the directory instead of the file.
+TEST_F(sinsp_with_test_input, abspath_extraction_leaves_event_fd_alone) {
+	add_default_init_thread();
+	open_inspector();
+
+	constexpr int64_t dirfd = 5;
+	constexpr int64_t fd = 6;
+	const std::string dir_name = "/tmp/dir";
+	const std::string file_name = dir_name + "/file.txt";
+
+	// A directory fd for the relative path to resolve against.
+	add_event_advance_ts(increasing_ts(),
+	                     1,
+	                     PPME_SYSCALL_OPENAT2_X,
+	                     8,
+	                     dirfd,
+	                     (int64_t)PPM_AT_FDCWD,
+	                     dir_name.c_str(),
+	                     (uint32_t)(PPM_O_RDONLY | PPM_O_DIRECTORY),
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint64_t)0);
+
+	// openat(dirfd, "file.txt"): the event's fd is the file it just created.
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPENAT_2_X,
+	                                7,
+	                                fd,
+	                                dirfd,
+	                                "file.txt",
+	                                (uint32_t)PPM_O_RDWR,
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), file_name);
+
+	// abspath resolves the relative name through the dirfd...
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), file_name);
+
+	// ...and the fields extracted after it still describe the file, not the directory.
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), file_name);
+	ASSERT_EQ(get_field_as_string(evt, "fs.path.name"), file_name);
+
+	// For the `*at` events that carry the dirfd in their fd parameter, the event's fd
+	// *is* the directory (see get_exit_event_fd_location()); abspath leaves it that way.
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_UNLINKAT_2_X,
+	                           4,
+	                           (int64_t)0,
+	                           dirfd,
+	                           "file.txt",
+	                           (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), file_name);
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), dir_name);
+	ASSERT_EQ(get_field_as_string(evt, "fs.path.name"), file_name);
+}

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -967,3 +967,93 @@ TEST_F(sinsp_with_test_input, abspath_root_dirfd_single_separator) {
 	                           (uint32_t)0);
 	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/etc/passwd");
 }
+
+// Characterization test for how evt.abspath resolves its dirfd, pinning the cases
+// where extract_abspath() and sinsp_parser::parse_dirfd() -- which computes the same
+// thing for the parser and the fspath check -- must agree, so that replacing the
+// former's open-coded copy with a call to the latter is provably behavior-preserving.
+//
+// Mind the separator when reading the unknown-dirfd expectations below.
+// concatenate_paths() does not insert one -- it copies the second path at the end of
+// the first verbatim -- so the prefix has to carry it. parse_dirfd() omits it for its
+// "<UNKNOWN>" answer, which is why fd.name and fs.path.name, which take that route
+// directly, report "<UNKNOWN>etc/passwd", while evt.abspath adds the separator and
+// reports "<UNKNOWN>/etc/passwd".
+TEST_F(sinsp_with_test_input, abspath_dirfd_resolution_cases) {
+	add_default_init_thread();
+	open_inspector();
+
+	constexpr int64_t unknown_dirfd = 99;
+	constexpr int64_t file_dirfd = 7;
+	int64_t fd = 10;
+
+	// An absolute path wins over the dirfd, which is not even looked up.
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPENAT_2_X,
+	                                7,
+	                                fd++,
+	                                unknown_dirfd,
+	                                "/etc/passwd",
+	                                (uint32_t)PPM_O_RDONLY,
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/etc/passwd");
+
+	// AT_FDCWD resolves against the thread's cwd.
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_OPENAT_2_X,
+	                           7,
+	                           fd++,
+	                           (int64_t)PPM_AT_FDCWD,
+	                           "etc/passwd",
+	                           (uint32_t)PPM_O_RDONLY,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/root/etc/passwd");
+
+	// A dirfd that is a plain file, not a directory: neither resolver checks, both
+	// concatenate against its name.
+	add_event_advance_ts(increasing_ts(),
+	                     1,
+	                     PPME_SYSCALL_OPEN_X,
+	                     6,
+	                     file_dirfd,
+	                     "/tmp/afile",
+	                     (uint32_t)PPM_O_RDONLY,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint64_t)0);
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_OPENAT_2_X,
+	                           7,
+	                           fd++,
+	                           file_dirfd,
+	                           "etc/passwd",
+	                           (uint32_t)PPM_O_RDONLY,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/tmp/afile/etc/passwd");
+
+	// An unknown dirfd, as reported by the fields that already go through
+	// parse_dirfd()/format_dirfd(): no separator is inserted after "<UNKNOWN>".
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_OPENAT_2_X,
+	                           7,
+	                           fd++,
+	                           unknown_dirfd,
+	                           "etc/passwd",
+	                           (uint32_t)PPM_O_RDONLY,
+	                           (uint32_t)0,
+	                           (uint32_t)0,
+	                           (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "fd.name"), "<UNKNOWN>etc/passwd");
+	ASSERT_EQ(get_field_as_string(evt, "fs.path.name"), "<UNKNOWN>etc/passwd");
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "<UNKNOWN>/etc/passwd");
+}

--- a/userspace/libsinsp/test/events_file.ut.cpp
+++ b/userspace/libsinsp/test/events_file.ut.cpp
@@ -917,3 +917,53 @@ TEST_F(sinsp_with_test_input, abspath_extraction_leaves_event_fd_alone) {
 	ASSERT_EQ(get_field_as_string(evt, "fd.name"), dir_name);
 	ASSERT_EQ(get_field_as_string(evt, "fs.path.name"), file_name);
 }
+
+// A dirfd that is already the root directory must not yield a doubled separator.
+// The trailing-slash check used to index the string terminator, so a '/' was
+// appended unconditionally and abspath reported "//etc/passwd" for this case;
+// concatenate_paths() keeps the leading "//" rather than collapsing it.
+TEST_F(sinsp_with_test_input, abspath_root_dirfd_single_separator) {
+	add_default_init_thread();
+	open_inspector();
+
+	constexpr int64_t dirfd = 5;
+	constexpr int64_t fd = 6;
+
+	// A directory fd for "/".
+	add_event_advance_ts(increasing_ts(),
+	                     1,
+	                     PPME_SYSCALL_OPENAT2_X,
+	                     8,
+	                     dirfd,
+	                     (int64_t)PPM_AT_FDCWD,
+	                     "/",
+	                     (uint32_t)(PPM_O_RDONLY | PPM_O_DIRECTORY),
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint32_t)0,
+	                     (uint64_t)0);
+
+	auto evt = add_event_advance_ts(increasing_ts(),
+	                                1,
+	                                PPME_SYSCALL_OPENAT_2_X,
+	                                7,
+	                                fd,
+	                                dirfd,
+	                                "etc/passwd",
+	                                (uint32_t)PPM_O_RDONLY,
+	                                (uint32_t)0,
+	                                (uint32_t)0,
+	                                (uint64_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/etc/passwd");
+
+	// unlinkat carries the dirfd in its fd parameter; same requirement.
+	evt = add_event_advance_ts(increasing_ts(),
+	                           1,
+	                           PPME_SYSCALL_UNLINKAT_2_X,
+	                           4,
+	                           (int64_t)0,
+	                           dirfd,
+	                           "etc/passwd",
+	                           (uint32_t)0);
+	ASSERT_EQ(get_field_as_string(evt, "evt.abspath"), "/etc/passwd");
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area libsinsp

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
extract_abspath() resolved the dirfd by installing it into the event with
sinsp_evt::set_fd_info() and reading it straight back out on the next
line, a habit inherited from the days when filterchecks assigned
evt->m_fdinfo directly.
    
The event's fd slot is not scratch space. For the `*at` events that carry
their dirfd in the fd parameter (see get_exit_event_fd_location()) the
event's fd and the dirfd happen to coincide, so the assignment was inert.
But openat is EF_CREATES_FD: its event fd is the file that was just
opened, and linkat/renameat carry no fd at all. Extracting evt.abspath on
those events replaced the event's fd with the directory, so every field
extracted afterwards -- fd.name, fd.directory, fs.path.name, whose openat
branch explicitly assumes the event fdinfo is "already correctly expanded
by parsers" -- described the directory instead of the file. Which fields
were affected depended on the order they happened to be extracted in.
    
Resolve the dirfd into a local instead, leaving the event alone. The
extraction phase no longer writes to fd state at all.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Includes some minor drive-by fixes (a double slash and a slightly improved comment), so probably works best commit by commit.

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: using evt.abspath no longer overwrites fd.name and fs.path.name with the name of the dirfd
```
