### PR TITLE
fix(libpman): only append errno to error logs

### DIFF
--- a/test/libscap/test_suites/engines/modern_bpf/libpman_log.cpp
+++ b/test/libscap/test_suites/engines/modern_bpf/libpman_log.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+#include <libscap/scap_log.h>
+#include <cerrno>
+#include <string>
+
+// These are internal libpman symbols (declared in libpman's private `state.h`, which we can't
+// include here because it drags in the generated BPF skeleton header). They are exported by the
+// `scap` library that this test binary links against, so we declare them directly.
+extern "C" {
+void log_errorf(const char* fmt, ...);
+void log_msgf(enum falcosecurity_log_severity level, const char* fmt, ...);
+int pman_init_state(falcosecurity_log_fn log_fn,
+                    unsigned long buf_bytes_dim,
+                    uint16_t cpus_for_each_buffer,
+                    bool allocate_online_only,
+                    bool disable_iterators);
+}
+
+namespace {
+std::string g_last_msg;
+
+void capture_log_fn(const char* /*component*/, const char* msg, falcosecurity_log_severity /*sev*/) {
+	g_last_msg = msg != nullptr ? msg : "";
+}
+
+// Installs `capture_log_fn` as libpman's log callback. `pman_init_state()` sets the log callback
+// before any of its own failure paths, so this works without root and regardless of its return
+// value (which we intentionally ignore).
+void install_capture_log_fn() {
+	pman_init_state(capture_log_fn, 4 * 4096, 1, true, false);
+}
+}  // namespace
+
+// A stale errno (as libbpf feature probes leave behind, e.g. EACCES from the verifier) must NOT
+// leak into non-error log lines: those results are signalled via return values, not errno.
+TEST(libpman_log, no_errno_appended_to_debug_log) {
+	install_capture_log_fn();
+	g_last_msg.clear();
+	errno = EACCES;
+	log_msgf(FALCOSECURITY_LOG_SEV_DEBUG, "BPF program 'foo' satisfied required feature [1]");
+	EXPECT_EQ(g_last_msg.find("errno:"), std::string::npos)
+	        << "stale errno leaked into a debug log: " << g_last_msg;
+}
+
+TEST(libpman_log, no_errno_appended_to_info_or_warning_log) {
+	install_capture_log_fn();
+	errno = EACCES;
+	log_msgf(FALCOSECURITY_LOG_SEV_INFO, "info line");
+	EXPECT_EQ(g_last_msg.find("errno:"), std::string::npos)
+	        << "stale errno leaked into an info log: " << g_last_msg;
+
+	errno = EACCES;
+	log_msgf(FALCOSECURITY_LOG_SEV_WARNING, "warning line");
+	EXPECT_EQ(g_last_msg.find("errno:"), std::string::npos)
+	        << "stale errno leaked into a warning log: " << g_last_msg;
+}
+
+// Error logs, where errno is meaningful, must still carry the errno detail.
+TEST(libpman_log, errno_appended_to_error_log) {
+	install_capture_log_fn();
+	g_last_msg.clear();
+	errno = EACCES;
+	log_errorf("something failed");
+	EXPECT_NE(g_last_msg.find("errno: 13"), std::string::npos)
+	        << "error log should carry the errno detail: " << g_last_msg;
+}
+
+// With errno cleared, even an error log must not append a bogus errno detail.
+TEST(libpman_log, no_errno_appended_when_errno_is_zero) {
+	install_capture_log_fn();
+	g_last_msg.clear();
+	errno = 0;
+	log_errorf("something failed");
+	EXPECT_EQ(g_last_msg.find("errno:"), std::string::npos)
+	        << "no errno detail expected when errno is 0: " << g_last_msg;
+}

--- a/userspace/libpman/src/lifecycle.c
+++ b/userspace/libpman/src/lifecycle.c
@@ -132,8 +132,8 @@ int pman_prepare_progs_before_loading() {
 		// In case we couldn't find any program satisfying required features, give an error.
 		// As of today, this will never happen, but better safe than sorry.
 		if(chosen_idx == -1 && progs[0].name != NULL) {
-			log_errorf("no program satisfies required features for event %d", ev);
 			errno = ENXIO;
+			log_errorf("no program satisfies required features for event %d", ev);
 			return errno;
 		}
 

--- a/userspace/libpman/src/state.c
+++ b/userspace/libpman/src/state.c
@@ -34,8 +34,12 @@ static void log_msg_v(const enum falcosecurity_log_severity level, const char* f
 	// infinitely large, not the amount of written bytes. That's why we must cap it (see below).
 	char buf[MAX_ERROR_MESSAGE_LEN];
 	const int writable_bytes = vsnprintf(buf, sizeof(buf), fmt, args);
-	// Append errno details if set.
-	if(errno != 0 && writable_bytes >= 0) {
+	// Append errno details if set, but only for error logs where errno is meaningful. Lower
+	// severities (debug/info/warning) may run right after a libbpf/syscall probe that leaves a
+	// stale errno behind (e.g. ENOENT for a missing symbol, EACCES from the verifier rejecting a
+	// probe program); those results are signalled through return values, not errno, so appending it
+	// there would be misleading.
+	if(level == FALCOSECURITY_LOG_SEV_ERROR && errno != 0 && writable_bytes >= 0) {
 		// See above why we cap to `sizeof(buf) - 1`.
 		const size_t offset = writable_bytes < sizeof(buf) ? writable_bytes : sizeof(buf) - 1;
 		// libbpf uses -ESRCH to indicate that something could not be found, e.g. vmlinux or btf id.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libpman

/area libscap-engine-modern-bpf

/area tests


**What this PR does / why we need it**:

`libpman`'s `log_msg_v()` appends the current `errno` to every log message it formats, regardless of severity. But several libpman code paths run libbpf feature probes right before logging a non-error line:

- `libbpf_probe_bpf_helper()` in `pman_prepare_progs_before_loading()`
- `libbpf_find_vmlinux_btf_id()` in `is_kernel_symbol_available()`

These probes signal their result through the return value and leave a stale `errno` behind (e.g. `EACCES` when the verifier rejects the probe program, `ENOENT` for a missing kernel symbol). The subsequent `FALCOSECURITY_LOG_SEV_DEBUG` "satisfied required feature" success line then wrongly rendered as:

```
BPF program 'foo' satisfied required feature [1] (errno: 13 | message: Permission denied)
```

which is confusing: nothing failed, the feature is supported.

This PR fixes the leak at its root instead of clearing `errno` at each probe call site:

- `log_msg_v()` now appends the `errno` detail only for `FALCOSECURITY_LOG_SEV_ERROR`, where `errno` is meaningful. Lower severities (debug/info/warning) report their result via return values, not `errno`.
- The `errno = ENXIO` in `pman_prepare_progs_before_loading()` is now set *before* its `log_errorf()`, so the error line carries the right code.

**Special notes for your reviewer**:

Adds a `libpman_log` unit suite (`test/libscap/test_suites/engines/modern_bpf/libpman_log.cpp`) that exercises the gate directly, without root or a loaded BPF probe: it installs a capturing log callback via `pman_init_state()` and asserts that a stale `errno` is not appended to debug/info/warning lines, that error lines still carry it, and that no bogus `errno` is appended when `errno` is 0. Reverting the gate turns the debug/info/warning assertions red while the error-log assertions stay green.

The bug only reproduces on a kernel where a feature probe actually fails (leaving `EACCES`/`ENOENT` in `errno`); on a fully-supported kernel every probe passes clean, so the unit suite — which injects `errno` deterministically — is the reliable regression guard.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libpman): stop appending a stale errno to non-error log messages emitted after libbpf feature probing
```
