### PR TITLE
perf(driver/modern_bpf): skip dynamic snaplen when it cannot change the outcome

### DIFF
--- a/driver/modern_bpf/helpers/store/auxmap_store_params.h
+++ b/driver/modern_bpf/helpers/store/auxmap_store_params.h
@@ -2006,6 +2006,35 @@ static __always_inline void apply_dynamic_snaplen(struct pt_regs *regs,
 	}
 }
 
+/**
+ * @brief Apply the dynamic snaplen logic only when it can actually change the outcome.
+ *
+ * `apply_dynamic_snaplen()` can only ever raise `*snaplen`: every assignment it performs is a
+ * `max()` against one of the `SNAPLEN_*` constants, so the value never goes down (note the
+ * constants are not necessarily above the configured snaplen - the `max()` is what makes the
+ * logic monotonic, not their magnitude). Callers then clamp the result back down to the number
+ * of bytes they are going to capture. So whenever that number already fits within the current
+ * snaplen, the final value is that number no matter what the dynamic snaplen logic computes, and
+ * the whole computation - a `fd -> file -> socket` walk plus a lookahead read of the user buffer
+ * - is dead work.
+ *
+ * @param regs pointer to the struct where we find the syscall arguments
+ * @param snaplen pointer to the current snaplen value (may be raised)
+ * @param input_args see `apply_dynamic_snaplen()`
+ * @param bytes_to_capture number of bytes the caller is going to capture, or a negative value when
+ * the caller cannot know it upfront (in that case the logic is always applied)
+ */
+static __always_inline void apply_dynamic_snaplen_if_relevant(
+        struct pt_regs *regs,
+        uint16_t *snaplen,
+        const dynamic_snaplen_args *input_args,
+        int64_t bytes_to_capture) {
+	if(bytes_to_capture >= 0 && bytes_to_capture <= (int64_t)*snaplen) {
+		return;
+	}
+	apply_dynamic_snaplen(regs, snaplen, input_args);
+}
+
 /* __noinline wrappers for use inside bpf_loop() callbacks.
  *
  * Kernel 6.19 commit f597664 introduced aggressive SCC analysis for implicit
@@ -2106,6 +2135,30 @@ static __noinline void apply_dynamic_snaplen_port_range(uint16_t *snaplen,
 		*snaplen = *snaplen > SNAPLEN_DNS_UDP ? *snaplen : SNAPLEN_DNS_UDP;
 		return;
 	}
+}
+
+/**
+ * @brief `apply_dynamic_snaplen_if_relevant()` for the port-range-only variant.
+ *
+ * Note the guard is kept here, at the caller side, rather than inside the `__noinline`
+ * `apply_dynamic_snaplen_port_range()`: this way a skipped message avoids the BPF subprogram call
+ * altogether. This matters for the sendmmsg/recvmmsg `bpf_loop()` callbacks, which would otherwise
+ * repeat the `fd -> file -> socket` walk once per message in the batch.
+ *
+ * @param snaplen pointer to the current snaplen value (may be raised)
+ * @param socket_fd the socket file descriptor (first syscall arg)
+ * @param sockaddr userspace sockaddr from the message header (may be NULL)
+ * @param bytes_to_capture number of bytes the caller is going to capture, or a negative value when
+ * the caller cannot know it upfront (in that case the logic is always applied)
+ */
+static __always_inline void apply_dynamic_snaplen_port_range_if_relevant(uint16_t *snaplen,
+                                                                         int32_t socket_fd,
+                                                                         struct sockaddr *sockaddr,
+                                                                         int64_t bytes_to_capture) {
+	if(bytes_to_capture >= 0 && bytes_to_capture <= (int64_t)*snaplen) {
+		return;
+	}
+	apply_dynamic_snaplen_port_range(snaplen, socket_fd, sockaddr);
 }
 
 /* We must always leave at least 4096 bytes free in our tmp scratch space

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pread64.bpf.c
@@ -34,7 +34,7 @@ int BPF_PROG(pread64_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_PREAD_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/preadv.bpf.c
@@ -37,7 +37,7 @@ int BPF_PROG(preadv_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_PREADV_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/process_vm_readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/process_vm_readv.bpf.c
@@ -38,7 +38,7 @@ int BPF_PROG(process_vm_readv_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_PROCESS_VM_READV_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/process_vm_writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/process_vm_writev.bpf.c
@@ -38,7 +38,7 @@ int BPF_PROG(process_vm_writev_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_PROCESS_VM_WRITEV_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwrite64.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(pwrite64_x, struct pt_regs *regs, long ret) {
 	size_t size = extract__syscall_argument(regs, 2);
 	int64_t bytes_to_read = ret > 0 ? ret : size;
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, bytes_to_read);
 	if((int64_t)snaplen > bytes_to_read) {
 		snaplen = bytes_to_read;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/pwritev.bpf.c
@@ -35,7 +35,9 @@ int BPF_PROG(pwritev_x, struct pt_regs *regs, long ret) {
 	        .evt_type = PPME_SYSCALL_PWRITEV_X,
 	};
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+	/* When `ret <= 0` the snaplen is not clamped below, so the dynamic snaplen logic
+	 * can still change what we capture: pass -1 to always apply it in that case. */
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret > 0 ? ret : -1);
 	if(ret > 0 && snaplen > ret) {
 		snaplen = ret;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/read.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(read_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_READ_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/readv.bpf.c
@@ -37,7 +37,7 @@ int BPF_PROG(readv_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SYSCALL_READV_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recv.bpf.c
@@ -39,7 +39,7 @@ int BPF_PROG(recv_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SOCKET_RECV_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvfrom.bpf.c
@@ -40,7 +40,7 @@ int BPF_PROG(recvfrom_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SOCKET_RECVFROM_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmmsg.bpf.c
@@ -67,7 +67,7 @@ static __always_inline long handle_exit(uint32_t index, void *ctx) {
 	auxmap__store_u32_param(auxmap, (uint32_t)msg_len);
 
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen_port_range(&snaplen, (int32_t)data->fd, msg_name);
+	apply_dynamic_snaplen_port_range_if_relevant(&snaplen, (int32_t)data->fd, msg_name, msg_len);
 	if(snaplen > msg_len) {
 		snaplen = msg_len;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/recvmsg.bpf.c
@@ -44,7 +44,7 @@ int BPF_PROG(recvmsg_x, struct pt_regs *regs, long ret) {
 		        .evt_type = PPME_SOCKET_RECVMSG_X,
 		};
 		uint16_t snaplen = maps__get_snaplen();
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret);
 		if(snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/send.bpf.c
@@ -34,7 +34,6 @@ int BPF_PROG(send_x, struct pt_regs *regs, long ret) {
 	        .evt_type = PPME_SOCKET_SEND_X,
 	};
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
 
 	/* Extract size syscall parameter */
 	uint32_t size = (uint32_t)args[2];
@@ -43,6 +42,7 @@ int BPF_PROG(send_x, struct pt_regs *regs, long ret) {
 	 * otherwise we need to rely on the syscall parameter provided by the user */
 	int64_t bytes_to_read = ret > 0 ? ret : (int64_t)size;
 
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, bytes_to_read);
 	if((int64_t)snaplen > bytes_to_read) {
 		snaplen = bytes_to_read;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmmsg.bpf.c
@@ -61,7 +61,12 @@ static __always_inline long handle_exit(uint32_t index, void *ctx) {
 	auxmap__store_iovec_size_param(auxmap, msg_iov, msg_iovlen);
 
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen_port_range(&snaplen, (int32_t)data->fd, msg_name);
+	/* `msg_len == 0` skips the clamp below, so the dynamic snaplen logic can still change what
+	 * we capture: pass -1 to always apply it in that case. */
+	apply_dynamic_snaplen_port_range_if_relevant(&snaplen,
+	                                             (int32_t)data->fd,
+	                                             msg_name,
+	                                             msg_len > 0 ? (int64_t)msg_len : -1);
 	if(msg_len > 0 && snaplen > msg_len) {
 		snaplen = msg_len;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendmsg.bpf.c
@@ -57,7 +57,9 @@ int BPF_PROG(sendmsg_x, struct pt_regs *regs, long ret) {
 		        .only_port_range = true,
 		        .evt_type = PPME_SOCKET_SENDMSG_X,
 		};
-		apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+		/* When `ret <= 0` the snaplen is not clamped below, so the dynamic snaplen logic
+		 * can still change what we capture: pass -1 to always apply it in that case. */
+		apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret > 0 ? ret : -1);
 		if(ret > 0 && snaplen > ret) {
 			snaplen = ret;
 		}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/sendto.bpf.c
@@ -33,7 +33,6 @@ int BPF_PROG(sendto_x, struct pt_regs *regs, long ret) {
 	        .evt_type = PPME_SOCKET_SENDTO_X,
 	};
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
 
 	/* Extract size syscall parameter */
 	uint32_t size = (uint32_t)args[2];
@@ -42,6 +41,7 @@ int BPF_PROG(sendto_x, struct pt_regs *regs, long ret) {
 	 * otherwise we need to rely on the syscall parameter provided by the user.  */
 	int64_t bytes_to_read = ret > 0 ? ret : (int64_t)size;
 
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, bytes_to_read);
 	if((int64_t)snaplen > bytes_to_read) {
 		snaplen = bytes_to_read;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/write.bpf.c
@@ -35,7 +35,7 @@ int BPF_PROG(write_x, struct pt_regs *regs, long ret) {
 	size_t size = extract__syscall_argument(regs, 2);
 	int64_t bytes_to_read = ret > 0 ? ret : size;
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, bytes_to_read);
 	if((int64_t)snaplen > bytes_to_read) {
 		snaplen = bytes_to_read;
 	}

--- a/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
+++ b/driver/modern_bpf/programs/tail_called/events/syscall_dispatched_events/writev.bpf.c
@@ -35,7 +35,9 @@ int BPF_PROG(writev_x, struct pt_regs *regs, long ret) {
 	        .evt_type = PPME_SYSCALL_WRITEV_X,
 	};
 	uint16_t snaplen = maps__get_snaplen();
-	apply_dynamic_snaplen(regs, &snaplen, &snaplen_args);
+	/* When `ret <= 0` the snaplen is not clamped below, so the dynamic snaplen logic
+	 * can still change what we capture: pass -1 to always apply it in that case. */
+	apply_dynamic_snaplen_if_relevant(regs, &snaplen, &snaplen_args, ret > 0 ? ret : -1);
 	if(ret > 0 && snaplen > ret) {
 		snaplen = ret;
 	}

--- a/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
+++ b/test/drivers/test_suites/actions_suite/dynamic_snaplen.cpp
@@ -1311,5 +1311,263 @@ TEST(Actions, dynamic_snaplen_no_statsd_port) {
 
 	evt_test->assert_num_params_pushed(5);
 }
+
+/* The dynamic snaplen logic is skipped whenever the data already fits within the configured
+ * snaplen, since it can only ever widen it and the caller clamps the result back down. Here the
+ * message is shorter than the snaplen, so the HTTP heuristic cannot change what we capture: we
+ * must still collect exactly the message, no more and no less.
+ */
+TEST(Actions, dynamic_snaplen_HTTP_below_snaplen) {
+	auto evt_test = get_syscall_event_test(__NR_sendto, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd,
+	                                        &client_addr,
+	                                        &server_socket_fd,
+	                                        &server_addr);
+
+	/* The payload looks like HTTP traffic but is shorter than the snaplen. */
+	const unsigned data_len = DEFAULT_SNAPLEN / 2;
+	char buf[data_len] = "HTTP/\0";
+	uint32_t sendto_flags = 0;
+
+	assert_syscall_state(SYSCALL_SUCCESS,
+	                     "sendto",
+	                     syscall(__NR_sendto,
+	                             client_socket_fd,
+	                             buf,
+	                             data_len,
+	                             sendto_flags,
+	                             (sockaddr *)&server_addr,
+	                             sizeof(server_addr)),
+	                     NOT_EQUAL,
+	                     -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)data_len);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(2, buf, data_len);
+
+	/* Parameter 4: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, data_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+#ifdef __NR_writev
+/* `writev` only applies the port-range part of the dynamic snaplen logic. The message is longer
+ * than the snaplen, so the logic must run and the fullcapture port must widen the snaplen enough
+ * to collect the whole iovec instead of truncating it to DEFAULT_SNAPLEN.
+ */
+TEST(Actions, dynamic_snaplen_writev_fullcapture_port) {
+	auto evt_test = get_syscall_event_test(__NR_writev, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd,
+	                                        &client_addr,
+	                                        &server_socket_fd,
+	                                        &server_addr);
+
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char sent_data[data_len] = "some-data";
+	struct iovec iov[1];
+	memset(iov, 0, sizeof(iov));
+	iov[0].iov_base = sent_data;
+	iov[0].iov_len = sizeof(sent_data);
+
+	assert_syscall_state(SYSCALL_SUCCESS,
+	                     "writev",
+	                     syscall(__NR_writev, client_socket_fd, iov, 1),
+	                     NOT_EQUAL,
+	                     -1);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_shutdown, client_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)data_len);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	/* Not truncated to DEFAULT_SNAPLEN: the dynamic snaplen logic must have run. */
+	evt_test->assert_bytebuf_param(2, sent_data, data_len);
+
+	/* Parameter 3: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)client_socket_fd);
+
+	/* Parameter 4: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)data_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+
+/* `writev` only clamps the snaplen down to `ret` when the syscall succeeded. When it failed we
+ * cannot know upfront how many bytes will be collected from the iovec, so the dynamic snaplen
+ * logic must run unconditionally: skipping it here would silently truncate the captured data to
+ * DEFAULT_SNAPLEN even though the fullcapture port asked for everything.
+ */
+TEST(Actions, dynamic_snaplen_writev_fullcapture_port_failed_syscall) {
+	auto evt_test = get_syscall_event_test(__NR_writev, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_socket_fd = 0;
+	int32_t server_socket_fd = 0;
+	sockaddr_in client_addr = {};
+	sockaddr_in server_addr = {};
+	evt_test->connect_ipv4_client_to_server(&client_socket_fd,
+	                                        &client_addr,
+	                                        &server_socket_fd,
+	                                        &server_addr);
+
+	const unsigned data_len = DEFAULT_SNAPLEN * 2;
+	char sent_data[data_len] = "some-data";
+	struct iovec iov[1];
+	memset(iov, 0, sizeof(iov));
+	iov[0].iov_base = sent_data;
+	iov[0].iov_len = sizeof(sent_data);
+
+	/* Shutting down the write side makes the `writev` below fail with `EPIPE` while keeping the fd
+	 * open, so the driver can still walk fd -> file -> socket and see the fullcapture port.
+	 */
+	assert_syscall_state(SYSCALL_SUCCESS,
+	                     "shutdown",
+	                     syscall(__NR_shutdown, client_socket_fd, SHUT_WR),
+	                     NOT_EQUAL,
+	                     -1);
+	auto previous_handler = signal(SIGPIPE, SIG_IGN);
+
+	assert_syscall_state(SYSCALL_FAILURE, "writev", syscall(__NR_writev, client_socket_fd, iov, 1));
+	int64_t errno_value = -errno;
+
+	signal(SIGPIPE, previous_handler);
+
+	/* Cleaning phase */
+	syscall(__NR_shutdown, server_socket_fd, 2);
+	syscall(__NR_close, server_socket_fd);
+	syscall(__NR_close, client_socket_fd);
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)errno_value);
+
+	/* Parameter 2: data (type: PT_BYTEBUF) */
+	/* The syscall failed, so the snaplen was never clamped down to `ret`: we still expect the
+	 * whole iovec thanks to the fullcapture port, not a DEFAULT_SNAPLEN truncation. */
+	evt_test->assert_bytebuf_param(2, sent_data, data_len);
+
+	/* Parameter 3: fd (type: PT_FD) */
+	evt_test->assert_numeric_param(3, (int64_t)client_socket_fd);
+
+	/* Parameter 4: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(4, (uint32_t)data_len);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(4);
+}
+#endif /* __NR_writev */
 #endif
 #endif

--- a/test/drivers/test_suites/syscall_exit_suite/recvmmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/recvmmsg_x.cpp
@@ -154,6 +154,174 @@ TEST(SyscallExit, recvmmsgX_ipv4_tcp_truncated) {
 	evt_test->assert_num_params_pushed(6);
 }
 
+/* The dynamic snaplen logic runs once per message inside the `bpf_loop()` callback and is skipped
+ * whenever the message already fits within the configured snaplen. These two tests pin both sides
+ * of that boundary. Here the received message (MAX_RECV_BUF_SIZE) is longer than the snaplen, so
+ * the logic must run and the fullcapture port must widen the snaplen: we expect the whole message
+ * instead of the DEFAULT_SNAPLEN truncation asserted by the test above.
+ */
+TEST(SyscallExit, recvmmsgX_ipv4_tcp_fullcapture_port_not_truncated) {
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_fd, server_fd;
+	evt_test->client_to_server_ipv4_tcp(&client_fd,
+	                                    &server_fd,
+	                                    send_data{
+	                                            .syscall_num = __NR_sendto,
+	                                            .greater_snaplen = true,
+	                                    },
+	                                    recv_data{
+	                                            .syscall_num = __NR_recvmmsg,
+	                                    });
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)MAX_RECV_BUF_SIZE);
+
+	/* Parameter 2: fd (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (int64_t)server_fd);
+
+	/* Parameter 3: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)MAX_RECV_BUF_SIZE);
+
+	/* Parameter 4: data (type: PT_BYTEBUF) */
+	/* Not truncated to DEFAULT_SNAPLEN: the dynamic snaplen logic must have run. */
+	evt_test->assert_bytebuf_param(4, LONG_MESSAGE, MAX_RECV_BUF_SIZE);
+
+	if(evt_test->is_modern_bpf_engine()) {
+		/* Parameter 5: tuple (type: PT_SOCKTUPLE) */
+		evt_test->assert_tuple_inet_param(5,
+		                                  PPM_AF_INET,
+		                                  IPV4_CLIENT,
+		                                  IPV4_SERVER,
+		                                  IPV4_PORT_CLIENT_STRING,
+		                                  IPV4_PORT_SERVER_STRING);
+	} else {
+		evt_test->assert_empty_param(5);
+		evt_test->assert_num_params_pushed(6);
+		GTEST_SKIP() << "[RECVMSG_X]: we receive an empty tuple but we have all the data in the "
+		                "kernel to obtain the correct tuple"
+		             << std::endl;
+	}
+
+	/* Parameter 5: msg_control (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(6);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
+/* Same setup as above, but the message already fits within the snaplen. Whether or not the dynamic
+ * snaplen logic runs, the captured data must be exactly the message.
+ */
+TEST(SyscallExit, recvmmsgX_ipv4_tcp_fullcapture_port_below_snaplen) {
+	auto evt_test = get_syscall_event_test(__NR_recvmmsg, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_fd, server_fd;
+	evt_test->client_to_server_ipv4_tcp(&client_fd,
+	                                    &server_fd,
+	                                    send_data{
+	                                            .syscall_num = __NR_sendto,
+	                                    },
+	                                    recv_data{
+	                                            .syscall_num = __NR_recvmmsg,
+	                                    });
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)SHORT_MESSAGE_LEN);
+
+	/* Parameter 2: fd (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (int64_t)server_fd);
+
+	/* Parameter 3: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)SHORT_MESSAGE_LEN);
+
+	/* Parameter 4: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(4, SHORT_MESSAGE, SHORT_MESSAGE_LEN);
+
+	if(evt_test->is_modern_bpf_engine()) {
+		/* Parameter 5: tuple (type: PT_SOCKTUPLE) */
+		evt_test->assert_tuple_inet_param(5,
+		                                  PPM_AF_INET,
+		                                  IPV4_CLIENT,
+		                                  IPV4_SERVER,
+		                                  IPV4_PORT_CLIENT_STRING,
+		                                  IPV4_PORT_SERVER_STRING);
+	} else {
+		evt_test->assert_empty_param(5);
+		evt_test->assert_num_params_pushed(6);
+		GTEST_SKIP() << "[RECVMSG_X]: we receive an empty tuple but we have all the data in the "
+		                "kernel to obtain the correct tuple"
+		             << std::endl;
+	}
+
+	/* Parameter 5: msg_control (type: PT_BYTEBUF) */
+	evt_test->assert_empty_param(6);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(6);
+}
+
 TEST(SyscallExit, recvmmsgX_ipv6_tcp_no_snaplen) {
 	auto evt_test = get_syscall_event_test(__NR_recvmmsg, EXIT_EVENT);
 

--- a/test/drivers/test_suites/syscall_exit_suite/sendmmsg_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/sendmmsg_x.cpp
@@ -114,6 +114,144 @@ TEST(SyscallExit, sendmmsgX_ipv4_tcp_truncated) {
 	evt_test->assert_num_params_pushed(5);
 }
 
+/* The dynamic snaplen logic runs once per message inside the `bpf_loop()` callback and is skipped
+ * whenever the message already fits within the configured snaplen. These two tests pin both sides
+ * of that boundary: the message here is longer than the snaplen, so the logic must run and the
+ * fullcapture port must widen the snaplen to capture the whole message.
+ */
+TEST(SyscallExit, sendmmsgX_ipv4_tcp_fullcapture_port_not_truncated) {
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	/* The client port is in the fullcapture range, so we expect the whole message. */
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_fd, server_fd;
+	evt_test->client_to_server_ipv4_tcp(&client_fd,
+	                                    &server_fd,
+	                                    send_data{
+	                                            .syscall_num = __NR_sendmmsg,
+	                                            .greater_snaplen = true,
+	                                    });
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	/* we need to clean the values after we read our event because the kernel module
+	 * flushes the ring buffers when we change this config.
+	 */
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)LONG_MESSAGE_LEN);
+
+	/* Parameter 2: fd (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (int64_t)client_fd);
+
+	/* Parameter 3: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)LONG_MESSAGE_LEN);
+
+	/* Parameter 4: data (type: PT_BYTEBUF) */
+	/* Not truncated to DEFAULT_SNAPLEN: the dynamic snaplen logic must have run. */
+	evt_test->assert_bytebuf_param(4, LONG_MESSAGE, LONG_MESSAGE_LEN);
+
+	/* Parameter 5: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_tuple_inet_param(5,
+	                                  PPM_AF_INET,
+	                                  IPV4_CLIENT,
+	                                  IPV4_SERVER,
+	                                  IPV4_PORT_CLIENT_STRING,
+	                                  IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
+/* Same setup as above, but the message already fits within the snaplen. Whether or not the dynamic
+ * snaplen logic runs, the captured data must be exactly the message.
+ */
+TEST(SyscallExit, sendmmsgX_ipv4_tcp_fullcapture_port_below_snaplen) {
+	auto evt_test = get_syscall_event_test(__NR_sendmmsg, EXIT_EVENT);
+
+	evt_test->set_do_dynamic_snaplen(true);
+
+	evt_test->set_fullcapture_port_range(IPV4_PORT_CLIENT, IPV4_PORT_CLIENT);
+
+	evt_test->enable_capture();
+
+	/*=============================== TRIGGER SYSCALL  ===========================*/
+
+	int32_t client_fd, server_fd;
+	evt_test->client_to_server_ipv4_tcp(&client_fd,
+	                                    &server_fd,
+	                                    send_data{.syscall_num = __NR_sendmmsg});
+
+	/*=============================== TRIGGER SYSCALL ===========================*/
+
+	evt_test->disable_capture();
+
+	evt_test->set_do_dynamic_snaplen(false);
+
+	evt_test->assert_event_presence();
+
+	evt_test->set_fullcapture_port_range(0, 0);
+
+	if(HasFatalFailure()) {
+		return;
+	}
+
+	evt_test->parse_event();
+
+	evt_test->assert_header();
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	/* Parameter 1: res (type: PT_ERRNO) */
+	evt_test->assert_numeric_param(1, (int64_t)SHORT_MESSAGE_LEN);
+
+	/* Parameter 2: fd (type: PT_UINT32) */
+	evt_test->assert_numeric_param(2, (int64_t)client_fd);
+
+	/* Parameter 3: size (type: PT_UINT32) */
+	evt_test->assert_numeric_param(3, (uint32_t)SHORT_MESSAGE_LEN);
+
+	/* Parameter 4: data (type: PT_BYTEBUF) */
+	evt_test->assert_bytebuf_param(4, SHORT_MESSAGE, SHORT_MESSAGE_LEN);
+
+	/* Parameter 5: tuple (type: PT_SOCKTUPLE) */
+	evt_test->assert_tuple_inet_param(5,
+	                                  PPM_AF_INET,
+	                                  IPV4_CLIENT,
+	                                  IPV4_SERVER,
+	                                  IPV4_PORT_CLIENT_STRING,
+	                                  IPV4_PORT_SERVER_STRING);
+
+	/*=============================== ASSERT PARAMETERS  ===========================*/
+
+	evt_test->assert_num_params_pushed(5);
+}
+
 TEST(SyscallExit, sendmmsgX_ipv6_tcp_message_no_snaplen) {
 	auto evt_test = get_syscall_event_test(__NR_sendmmsg, EXIT_EVENT);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

perf(driver/modern_bpf): skip dynamic snaplen when it cannot change the outcome

`apply_dynamic_snaplen()` can only ever raise the snaplen: every assignment it
performs is a `max()` against one of the `SNAPLEN_*` constants, so the value
never goes down. (The constants are not necessarily above the configured
snaplen - it is user-settable with no cap, while `SNAPLEN_DNS_UDP` is 512 - but
the `max()` is what makes the logic monotonic, not their magnitude.) Callers
then clamp the result back down to the number of bytes they are actually going
to capture.

So whenever that number already fits within the configured snaplen, the final
value is that number regardless of what the dynamic snaplen logic computes, and
the whole computation is dead work: an `fd -> file -> socket` walk (several
kernel reads) plus a `DPI_LOOKAHEAD_SIZE` read of the user buffer. For the
sendmmsg/recvmmsg `bpf_loop()` callbacks this was repeated once per message in
the batch.

Introduce `apply_dynamic_snaplen_if_relevant()` (and the matching
`_port_range_if_relevant()` for the `__noinline` variant used inside the
`bpf_loop()` callbacks) which takes the number of bytes the caller will capture
and skips the call when it cannot affect the result. Callers that cannot know
that number upfront pass a negative value and always apply the logic:
`writev`/`pwritev`/`sendmsg`/`sendmmsg` do not clamp when `ret <= 0`
(resp. `msg_len == 0`), so a raised snaplen still matters there.

`send`/`sendto` only needed `bytes_to_read` to be computed before the call
instead of after it; the call has no side effects beyond writing `*snaplen`.

Measured with `scap-open --modern_bpf --ppm_sc 3`, 5M 64-byte reads pinned to
one CPU, reading `run_time_ns` off the `sys_exit` dispatcher (which includes the
tail-called handler) via `kernel.bpf_stats_enabled`, min of 8 runs:

  dynamic snaplen enabled:   477.6 -> 349.7 ns/read  (-26.8%)
  dynamic snaplen disabled:  357.3 -> 355.6 ns/read  (unchanged, within noise)

Event output was verified byte-identical against the unpatched probe across
read, write, sendto, writev, sendmsg, sendmmsg, recvmmsg and recvmsg, covering
payloads below and above the snaplen, regular-file and UDP-socket fds, failing
syscalls, and a payload that trips the HTTP heuristic so the dynamic snaplen is
genuinely raised.

Static instruction counts are flat (-6 to +15 out of 950-2830), and the probe
loads with no verifier issues.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
