### PR TITLE
ci(bpfcompat): test the v0.4.0 release candidate

### DIFF
--- a/.github/workflows/bpfcompat-compatibility.yml
+++ b/.github/workflows/bpfcompat-compatibility.yml
@@ -80,7 +80,7 @@ jobs:
           file libscap/examples/01-open/scap-open
 
       - name: Validate scap-open across the kernel matrix
-        uses: Kernel-Guard/bpfcompat@f1ba21fd4e098d483961e9e9355a51ae78273422 # v0.3.6
+        uses: Kernel-Guard/bpfcompat@cba1e09537f2e05e4ba7278efdb5c2d044d1889b # v0.4.0-rc.3
         with:
           command: $BPFCOMPAT_BIN --modern_bpf --num_events 10
           command-binary: build/libscap/examples/01-open/scap-open


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Advance the non-blocking bpfcompat compatibility lane from the v0.3.6 release commit to the exact v0.4.0-rc.3 release-candidate commit.

The first scheduled run after #3061 failed in the Action setup step before any VM target ran:
https://github.com/falcosecurity/libs/actions/runs/30792162435

The v0.3.6 Action downloads the amd64 CLI, amd64 validator, and the release SHA256SUMS, then asks sha256sum to validate every entry. Because that checksum file also lists the arm64 CLI, the amd64 job fails with:

    sha256sum: bpfcompat-linux-arm64: No such file or directory

v0.4.0-rc.3 fixes the consumer path by validating only the selected assets and verifying GitHub attestations. Its manual, T+24h, and T+72h canaries all passed against the immutable release commit and image digest.

This one-line exact-SHA update lets the lane reach the real scap-open loader and expanded kernel matrix again. It does not make the scheduled lane blocking.

**Which issue(s) this PR fixes**:

Follow-up to #3023, #3024, and #3061.

**Special notes for your reviewer**:

The next scheduled run is Monday, August 10 at 06:00 UTC. A successful schedule after this merges will provide the external ecosystem evidence for bpfcompat v0.4.0 graduation.

**Does this PR introduce a user-facing change?**:

release-note: NONE
