### PR TITLE
update(userspace/libsinsp): Add a version check macro

### DIFF
--- a/cmake/modules/libsinsp.cmake
+++ b/cmake/modules/libsinsp.cmake
@@ -77,6 +77,11 @@ if(NOT HAVE_LIBSINSP)
 		PATTERN "*test*" EXCLUDE
 	)
 	install(
+		FILES ${CMAKE_BINARY_DIR}/libsinsp/libsinsp/sinsp_config.h
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}/libsinsp"
+		COMPONENT "sinsp"
+	)
+	install(
 		DIRECTORY "${LIBS_DIR}/userspace/async"
 		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBS_PACKAGE_NAME}"
 		COMPONENT "sinsp"

--- a/userspace/libsinsp/CMakeLists.txt
+++ b/userspace/libsinsp/CMakeLists.txt
@@ -34,6 +34,26 @@ include(jsoncpp)
 include(zlib)
 include(tbb)
 
+# The compile-time version macros only carry major.minor.patch, so drop anything the git-derived
+# version appends to them.
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _sinsp_version "${FALCOSECURITY_LIBS_VERSION}")
+
+if(_sinsp_version)
+	set(SINSP_VERSION_MAJOR ${CMAKE_MATCH_1})
+	set(SINSP_VERSION_MINOR ${CMAKE_MATCH_2})
+	set(SINSP_VERSION_PATCH ${CMAKE_MATCH_3})
+else()
+	# Same fallback get_shared_libs_versions() uses for an unparseable version.
+	set(SINSP_VERSION_MAJOR 0)
+	set(SINSP_VERSION_MINOR 0)
+	set(SINSP_VERSION_PATCH 0)
+endif()
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/sinsp_config.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/libsinsp/sinsp_config.h @ONLY
+)
+
 add_library(
 	sinsp
 	filter/ast.cpp
@@ -113,6 +133,7 @@ endif()
 target_include_directories(
 	sinsp
 	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${LIBS_DIR}/userspace>
+		   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 		   $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/${LIBS_PACKAGE_NAME}>
 )
 

--- a/userspace/libsinsp/sinsp_config.h.in
+++ b/userspace/libsinsp/sinsp_config.h.in
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+/*!
+    \brief The libsinsp version, as derived from FALCOSECURITY_LIBS_VERSION at build time.
+
+    Any pre-release or build metadata is dropped: only the major, minor, and patch components are
+    available here. Use SINSP_CHECK_VERSION() in libsinsp/version.h to compare against them.
+*/
+#define SINSP_VERSION_MAJOR @SINSP_VERSION_MAJOR@
+#define SINSP_VERSION_MINOR @SINSP_VERSION_MINOR@
+#define SINSP_VERSION_PATCH @SINSP_VERSION_PATCH@
+
+/*!
+    \brief The full libsinsp version string, including any pre-release or build metadata.
+*/
+#define SINSP_VERSION_STRING "@FALCOSECURITY_LIBS_VERSION@"

--- a/userspace/libsinsp/test/classes/versions.cpp
+++ b/userspace/libsinsp/test/classes/versions.cpp
@@ -70,6 +70,32 @@ TEST(versions, operator_lt) {
 	EXPECT_TRUE(sinsp_version("1.2.3") <= sinsp_version("1.2.3"));
 }
 
+// SINSP_CHECK_VERSION() must be a constant expression, usable by the preprocessor.
+#if !SINSP_CHECK_VERSION(0, 0, 0)
+#error "SINSP_CHECK_VERSION(0, 0, 0) must hold for any libsinsp version"
+#endif
+
+static_assert(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR, SINSP_VERSION_PATCH),
+              "libsinsp must satisfy a check against its own version");
+
+TEST(versions, check_version) {
+	// The current version satisfies a check against itself and against anything older.
+	EXPECT_TRUE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR, SINSP_VERSION_PATCH));
+	EXPECT_TRUE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR, 0));
+	EXPECT_TRUE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, 0, 0));
+	EXPECT_TRUE(SINSP_CHECK_VERSION(0, 0, 0));
+
+	// Bumping any component past the current one must not.
+	EXPECT_FALSE(
+	        SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR, SINSP_VERSION_PATCH + 1));
+	EXPECT_FALSE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR + 1, 0));
+	EXPECT_FALSE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR + 1, 0, 0));
+
+	// A newer minor outweighs an older patch, and a newer major an older minor.
+	EXPECT_FALSE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR, SINSP_VERSION_MINOR + 1, 0));
+	EXPECT_TRUE(SINSP_CHECK_VERSION(SINSP_VERSION_MAJOR - 1, SINSP_VERSION_MINOR + 1, 0));
+}
+
 TEST(versions, compatible_with) {
 	sinsp_version a("1.2.3");
 	EXPECT_FALSE(a.compatible_with(sinsp_version("0.2.3")));

--- a/userspace/libsinsp/version.h
+++ b/userspace/libsinsp/version.h
@@ -23,6 +23,16 @@ limitations under the License.
 #include <inttypes.h>
 
 #include <driver/ppm_api_version.h>
+#include <libsinsp/sinsp_config.h>
+
+/*!
+    \brief Evaluates to true if the libsinsp version is at least major.minor.patch
+*/
+#define SINSP_CHECK_VERSION(major, minor, patch) \
+	(SINSP_VERSION_MAJOR > (major) ||            \
+	 (SINSP_VERSION_MAJOR == (major) &&          \
+	  (SINSP_VERSION_MINOR > (minor) ||          \
+	   (SINSP_VERSION_MINOR == (minor) && SINSP_VERSION_PATCH >= (patch)))))
 
 /*!
     \brief Represents a version number


### PR DESCRIPTION
Add a SINSP_CHECK_VERSION macro which lets you check the library version at compile time, similar to the version check macros that ship with other libraries.

Assisted-by: Claude:claude-opus-4-8

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

/kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

This adds a version check macro similar to GLIB_CHECK_VERSION, QT_VERSION_CHECK, and others, which lets consumers more easily support multiple versions of libs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
