### PR TITLE
test(libsinsp): guard setrlimit expectations

### DIFF
--- a/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
+++ b/userspace/libsinsp/test/public_sinsp_API/ppm_sc_codes.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
+#include <driver/syscall_compat.h>
 #include <libsinsp/sinsp.h>
 #include "../test_utils.h"
 
@@ -140,8 +141,10 @@ const libsinsp::events::set<ppm_event_code> expected_sinsp_state_event_set = {
         PPME_SYSCALL_SETRESGID_X,
         PPME_SYSCALL_SETRESUID_E,
         PPME_SYSCALL_SETRESUID_X,
+#ifdef __NR_setrlimit
         PPME_SYSCALL_SETRLIMIT_E,
         PPME_SYSCALL_SETRLIMIT_X,
+#endif
         PPME_SYSCALL_SETSID_E,
         PPME_SYSCALL_SETSID_X,
         PPME_SYSCALL_SETUID_E,
@@ -268,7 +271,9 @@ const libsinsp::events::set<ppm_sc_code> expected_sinsp_state_sc_set = {
         PPM_SC_SETRESGID32,
         PPM_SC_SETRESUID,
         PPM_SC_SETRESUID32,
+#ifdef __NR_setrlimit
         PPM_SC_SETRLIMIT,
+#endif
         PPM_SC_SETSID,
         PPM_SC_SETUID,
         PPM_SC_SETUID32,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

/area libsinsp

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:
The sinsp state tests currently expect SETRLIMIT events and syscall codes unconditionally. However, driver/syscall_table.c only registers those entries when __NR_setrlimit is defined.

LoongArch exposes prlimit64 but not the legacy setrlimit syscall, so the generated state set does not contain PPME_SYSCALL_SETRLIMIT_{E,X} or PPM_SC_SETRLIMIT. This makes the test fail even though the syscall table matches the architecture.

Include driver/syscall_compat.h in the test and guard the SETRLIMIT expectations with __NR_setrlimit, matching the syscall table behavior.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
