### PR TITLE
fix(libpman): cache creat/open TOCTOU tracepoint availability

### DIFF
--- a/userspace/libpman/src/sc_set.c
+++ b/userspace/libpman/src/sc_set.c
@@ -127,15 +127,29 @@ int pman_enforce_sc_set(bool* sc_set) {
 	else
 		ret = ret ?: detach_connect_toctou_mitigation_progs();
 
-	if(attach_creat_ttm_progs)
-		ret = ret ?: ignore_and_log_enoent("creat", attach_creat_toctou_mitigation_progs());
-	else
+	if(attach_creat_ttm_progs) {
+		if(!g_state.creat_ttm_unavailable) {
+			const int err = attach_creat_toctou_mitigation_progs();
+			if(err == ENOENT) {
+				g_state.creat_ttm_unavailable = true;
+			}
+			ret = ret ?: ignore_and_log_enoent("creat", err);
+		}
+	} else {
 		ret = ret ?: detach_creat_toctou_mitigation_progs();
+	}
 
-	if(attach_open_ttm_progs)
-		ret = ret ?: ignore_and_log_enoent("open", attach_open_toctou_mitigation_progs());
-	else
+	if(attach_open_ttm_progs) {
+		if(!g_state.open_ttm_unavailable) {
+			const int err = attach_open_toctou_mitigation_progs();
+			if(err == ENOENT) {
+				g_state.open_ttm_unavailable = true;
+			}
+			ret = ret ?: ignore_and_log_enoent("open", err);
+		}
+	} else {
 		ret = ret ?: detach_open_toctou_mitigation_progs();
+	}
 
 	if(attach_openat2_ttm_progs)
 		ret = ret ?: ignore_and_log_enoent("openat2", attach_openat2_toctou_mitigation_progs());

--- a/userspace/libpman/src/sc_set.c
+++ b/userspace/libpman/src/sc_set.c
@@ -128,7 +128,7 @@ int pman_enforce_sc_set(bool* sc_set) {
 		ret = ret ?: detach_connect_toctou_mitigation_progs();
 
 	if(attach_creat_ttm_progs) {
-		if(!g_state.creat_ttm_unavailable) {
+		if(!g_state.creat_ttm_unavailable && ret == 0) {
 			const int err = attach_creat_toctou_mitigation_progs();
 			if(err == ENOENT) {
 				g_state.creat_ttm_unavailable = true;
@@ -140,7 +140,7 @@ int pman_enforce_sc_set(bool* sc_set) {
 	}
 
 	if(attach_open_ttm_progs) {
-		if(!g_state.open_ttm_unavailable) {
+		if(!g_state.open_ttm_unavailable && ret == 0) {
 			const int err = attach_open_toctou_mitigation_progs();
 			if(err == ENOENT) {
 				g_state.open_ttm_unavailable = true;

--- a/userspace/libpman/src/state.h
+++ b/userspace/libpman/src/state.h
@@ -85,6 +85,14 @@ struct internal_state {
 	size_t log_buf_size;      /* size of the log buffer */
 	falcosecurity_log_fn log_fn;
 
+	bool creat_ttm_unavailable; /* If true, the `creat` TOCTOU mitigation tracepoint is not
+	                                  available on this kernel/arch (e.g. ARM64). Set the first time
+	                                  `pman_enforce_sc_set()` sees ENOENT attaching it, so later
+	                               calls skip the doomed attach instead of retrying and re-logging.
+	                             */
+	bool open_ttm_unavailable;  /* Same as `creat_ttm_unavailable`, for the `open` TOCTOU
+	                                  mitigation tracepoint. */
+
 #ifdef BPF_ITERATOR_SUPPORT
 
 	/* BPF iterator section */


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

/area libpman

> /area libsinsp

> /area tests

> /area proposals

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

**What this PR does / why we need it**:

On architectures without the legacy creat/open syscalls (e.g. ARM64), `pman_enforce_sc_set()` re-attempts the doomed tracepoint attach on every call and re-logs the same ENOENT warning via `ignore_and_log_enoent`, since the attach function is idempotent. This caches the unavailability the first time it's detected, the same pattern already used for `is_tasks_dumping_supported` in `state.h`, so the warning is logged once instead of repeating on every call.

**Which issue(s) this PR fixes**:

Related to falcosecurity/falco#3961

**Special notes for your reviewer**:

- Local build verified (bundled_deps).
- Validated the log-spam fix using a temporary GitHub Actions aarch64 workflow on my fork (no physical aarch64 hardware available); real-hardware validation not performed.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libpman): stop repeatedly logging an ENOENT warning for the unsupported creat/open TOCTOU tracepoint on architectures where it doesn't exist (e.g. aarch64)
```