### PR TITLE
Fix inode timestamp overwide read

### DIFF
--- a/driver/modern_bpf/helpers/extract/extract_from_kernel.h
+++ b/driver/modern_bpf/helpers/extract/extract_from_kernel.h
@@ -350,9 +350,14 @@ static __always_inline void extract__ctime_from_inode(struct inode *f_inode,
 		return;
 	}
 
+	/* `BPF_CORE_READ_INTO()` reads `sizeof(*dst)` bytes, not the size of the field it names, so
+	 * `tv_nsec` cannot be the destination: it is a `long`, and reading 8 bytes at a `u32` field
+	 * takes `i_generation` along with it. */
 	struct inode___v6_11 *f_inode_v6_11 = (void *)f_inode;
+	uint32_t nsec = 0;
 	BPF_CORE_READ_INTO(&time->tv_sec, f_inode_v6_11, i_ctime_sec);
-	BPF_CORE_READ_INTO(&time->tv_nsec, f_inode_v6_11, i_ctime_nsec);
+	BPF_CORE_READ_INTO(&nsec, f_inode_v6_11, i_ctime_nsec);
+	time->tv_nsec = nsec;
 }
 
 /**
@@ -373,9 +378,13 @@ static __always_inline void extract__mtime_from_inode(struct inode *f_inode,
 		return;
 	}
 
+	/* A `u32` destination, for the reason given in extract__ctime_from_inode(): here the eight
+	 * bytes would carry `i_ctime_nsec` into the high half. */
 	struct inode___v6_11 *f_inode_v6_11 = (void *)f_inode;
+	uint32_t nsec = 0;
 	BPF_CORE_READ_INTO(&time->tv_sec, f_inode_v6_11, i_mtime_sec);
-	BPF_CORE_READ_INTO(&time->tv_nsec, f_inode_v6_11, i_mtime_nsec);
+	BPF_CORE_READ_INTO(&nsec, f_inode_v6_11, i_mtime_nsec);
+	time->tv_nsec = nsec;
 }
 
 /**

--- a/test/drivers/event_class/event_class.cpp
+++ b/test/drivers/event_class/event_class.cpp
@@ -1122,6 +1122,18 @@ template void event_test::assert_numeric_param<int16_t>(int, int16_t, assertion_
 template void event_test::assert_numeric_param<int32_t>(int, int32_t, assertion_operators);
 template void event_test::assert_numeric_param<int64_t>(int, int64_t, assertion_operators);
 
+void event_test::assert_abstime_param_in_the_past(int param_num) {
+	struct timespec now = {};
+	ASSERT_EQ(clock_gettime(CLOCK_REALTIME, &now), 0)
+	        << ">>>>> cannot read the current time." << std::endl;
+	const uint64_t now_ns =
+	        static_cast<uint64_t>(now.tv_sec) * 1000000000ULL + static_cast<uint64_t>(now.tv_nsec);
+
+	/* 2001-09-09 in nanoseconds: any real timestamp is above it, a dummy value is not. */
+	assert_numeric_param(param_num, static_cast<uint64_t>(1000000000000000000), GREATER_EQUAL);
+	assert_numeric_param(param_num, now_ns, LESS_EQUAL);
+}
+
 void event_test::assert_charbuf_param(int param_num, const char* param) {
 	assert_param_boundaries(param_num);
 	/* 'strlen()' does not include the terminating null byte while bpf adds it. */

--- a/test/drivers/event_class/event_class.h
+++ b/test/drivers/event_class/event_class.h
@@ -549,6 +549,16 @@ public:
 	void assert_numeric_param(int param_num, T param, enum assertion_operators op = EQUAL);
 
 	/**
+	 * @brief Assert that the parameter is a `PT_ABSTIME` holding a moment that has already
+	 * happened: at least 2001-09-09, so a dummy value fails, and no later than now, so a value
+	 * the kernel got wrong fails too. A lower bound on its own accepts most of the ways such a
+	 * parameter can be corrupted.
+	 *
+	 * @param param_num number of the parameter to assert into the event.
+	 */
+	void assert_abstime_param_in_the_past(int param_num);
+
+	/**
 	 * @brief Assert that the parameter is a `charbuf` and
 	 * compare its value with the expected one.
 	 *

--- a/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
+++ b/test/drivers/test_suites/generic_tracepoints_suite/sched_process_exec.cpp
@@ -110,16 +110,16 @@
 
 #if defined(__NR_execve) || defined(__NR_execveat)
 void assert_ctime_mtime_params(const std::unique_ptr<event_test> &evt_test) {
-	// We make sure that these values are greater than some arbitrary lower bound: this serves to
-	// avoid dummy values (like 0s), to pass checks.
+	// These are absolute times that must already have happened: see
+	// assert_abstime_param_in_the_past().
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, static_cast<uint64_t>(1), GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, static_cast<uint64_t>(1), GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 }
 #endif
 
@@ -512,11 +512,11 @@ TEST(GenericTracepoints, sched_proc_exec_execve_not_upperlayer) {
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modifitrueion time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 
 	/* Parameter 27: euid (type: PT_UID) */
 	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);
@@ -645,11 +645,11 @@ TEST(GenericTracepoints, sched_proc_exec_execve_upperlayer) {
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modifitrueion time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 
 	/* Parameter 27: euid (type: PT_UID) */
 	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);

--- a/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execve_x.cpp
@@ -193,11 +193,11 @@ TEST(SyscallExit, execveX_failure) {
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 
 	/* Parameter 27: euid (type: PT_UID) */
 	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);
@@ -504,11 +504,11 @@ TEST(SyscallExit, execveX_failure_empty_arg) {
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 
 	/* Parameter 27: euid (type: PT_UID) */
 	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);

--- a/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
+++ b/test/drivers/test_suites/syscall_exit_suite/execveat_x.cpp
@@ -196,11 +196,11 @@ TEST(SyscallExit, execveatX_failure) {
 
 	/* Parameter 25: exe_file ctime (last status change time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(25, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(25);
 
 	/* Parameter 26: exe_file mtime (last modification time, epoch value in nanoseconds) (type:
 	 * PT_ABSTIME) */
-	evt_test->assert_numeric_param(26, (uint64_t)1000000000000000000, GREATER_EQUAL);
+	evt_test->assert_abstime_param_in_the_past(26);
 
 	/* Parameter 27: euid (type: PT_UID) */
 	evt_test->assert_numeric_param(27, (uint32_t)geteuid(), EQUAL);


### PR DESCRIPTION
TL;DR proc.exe_ino.[mc]time were broken

    `BPF_CORE_READ_INTO()` takes the read size from its destination, not from the
    field it names:
    
            read_fn((void *)(dst), sizeof(*(dst)), &((src_type)(src))->accessor)
    
    `timespec64.tv_nsec` is a `long`, while `i_ctime_nsec` and `i_mtime_nsec` are
    `u32`, so both reads pulled in the four bytes that follow the field. On the
    inode layout that arrived with 6.11 those are:
    
            u32 i_atime_nsec;  u32 i_mtime_nsec;  u32 i_ctime_nsec;  u32 i_generation;
    
    so ctime came back with `i_generation` in the high half of its nanoseconds and
    mtime with `i_ctime_nsec`. extract__epoch_ns_from_time() then computes
    `tv_sec * 1e9 + tv_nsec`, which makes the exe_file ctime of every execve event
    an essentially uniform 64-bit number on any kernel from 6.11 on -- and
    `proc.exe_ino.ctime`, `proc.exe_ino.mtime` and the two `ctime_duration_*`
    fields are built from these parameters.
    
    It went unnoticed since 2641e573be (2024-08-20) because the drivers tests only
    check that the value is at least 1e18, and the two parameters fail that check
    very differently: ctime's contaminant is a random 32-bit generation, so it is
    below the bound 5.4% of the time, while mtime's is a nanosecond value, which
    for any file with a plausible mtime keeps the total between 1.8e18 and 6.1e18
    and can never fail. A `test-drivers-amd64` run reported
    488986795695061797 for parameter 25 while parameter 26 passed, which is
    exactly this: for a binary built at 1788500000 it needs `i_generation`
    3992400800 and `i_ctime_nsec` 880376613, both in range.
    
    Read into a `uint32_t` and widen afterwards.
    
    The rest of the driver was audited for the same mistake by making
    `___read()` static_assert that `sizeof(*dst)` equals the size of the field,
    then building every program: of the 82 `BPF_CORE_READ_INTO()` call sites in
    175 translation units, these two were the only mismatches.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area automation

> /area drivers

> /area driver-kmod

/area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(driver/modern_bpf): fix wrong exe_file ctime/mtime values (`proc.exe_ino.ctime`, `proc.exe_ino.mtime`) on kernels >= 6.11
```

