### PR TITLE
fix(driver): replace removed task_euid helper

### DIFF
--- a/driver/ppm_fillers.c
+++ b/driver/ppm_fillers.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only OR MIT
 /*
 
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 This file is dual licensed under either the MIT or GPL 2. See MIT.txt
 or GPL2.txt for full copies of the license.
@@ -7941,7 +7941,7 @@ int f_sched_prog_fork(struct event_filler_arguments *args) {
 	long swap = 0;
 	int available = STR_STORAGE_SIZE;
 	uint32_t flags = 0;
-	uint32_t euid = from_kuid(&init_user_ns, task_euid(child));
+	uint32_t euid = from_kuid(&init_user_ns, task_cred_xxx(child, euid));
 	uint32_t egid = from_kgid(&init_user_ns, child->cred->egid);
 	struct pid_namespace *pidns = task_active_pid_ns(child);
 	uint64_t pidns_init_start_time = 0;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

No. This only fixes a kernel-specific build issue, as described in the [driver versioning policy](https://github.com/falcosecurity/libs/blob/38496fa35601f2d3adc4ad8fe8ad7fa6f92372c0/driver/README.VERSION.md#L7).

**What this PR does / why we need it**:

Linux `7.3-rc1` removed `task_euid()`, breaking the ARM64 mainline kernel build:

```text
error: implicit declaration of function 'task_euid'
```

Replace `task_euid(child)` with `task_cred_xxx(child, euid)` in the fork filler. This is the same expansion used by the removed macro, so it preserves the credential lookup and RCU protection.

The helper is already available in Linux `3.10`, so no kernel-version guard is needed. See the [upstream removal](https://github.com/torvalds/linux/commit/15c1f17979712407a4a71f2129f89ecd625ccbe8) and the [older definition](https://github.com/torvalds/linux/blob/v3.10/include/linux/cred.h#L314-L324).

N.B. An x86 build alone does not exercise this change, since the kernel module enables this filler only on ARM64, S390, RISC-V, and LoongArch.

**Which issue(s) this PR fixes**:

Addresses the [ARM64 mainline build failure](https://github.com/falcosecurity/libs/actions/runs/34020972132/job/101453392506).

**Special notes for your reviewer**:

- `pre-commit run --all-files`: passed
- `git diff --check`: passed
- ARM64 / Linux `7.3-rc1`: reproduced the `task_euid()` build error on unmodified `master`; the patched module builds successfully
- ARM64 / Linux `6.6`: both unmodified `master` and the patched module build successfully

Cross-compiled locally with GCC `16.1.0`, using ARM64 `defconfig` and `modules_prepare`. These are compile/link checks, not runtime tests. As in the mainline Driverkit build, `KBUILD_MODPOST_WARN=1` allows the missing `Module.symvers` warnings. No kernel module was loaded.

**Does this PR introduce a user-facing change?**:

```release-note
fix(driver): restore kernel module builds on Linux 7.3 for architectures using the fork tracepoint
```
