### PR TITLE
fix(libsinsp): normalize long paths before checking the output limit

### DIFF
--- a/benchmark/libsinsp/utils.cpp
+++ b/benchmark/libsinsp/utils.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2024 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -200,3 +200,40 @@ static void BM_sinsp_utf8_sanitize_slow_path_all_invalid_long_noalloc(benchmark:
 	}
 }
 BENCHMARK(BM_sinsp_utf8_sanitize_slow_path_all_invalid_long_noalloc);
+
+// Long path that normalizes back under the limit, so it takes the new branch.
+// Built once, outside the loop, so the measurement is the concatenation and not
+// the construction of a 1KB-plus string.
+static void BM_sinsp_concatenate_paths_long_normalizing_path(benchmark::State& state) {
+	std::string path2;
+	for(int i = 0; i < 520; i++) {
+		path2 += "./";
+	}
+	path2 += "foo/bar";
+	const std::string path1 = "/tmp/";
+	for(auto _ : state) {
+		benchmark::DoNotOptimize(sinsp_utils::concatenate_paths(path1, path2));
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_long_normalizing_path);
+
+// Long path that is still over the limit after normalizing, so it reaches the
+// marker by the longer route.
+static void BM_sinsp_concatenate_paths_too_long_path(benchmark::State& state) {
+	const std::string path1 = "/tmp/";
+	const std::string path2(2048, 'a');
+	for(auto _ : state) {
+		benchmark::DoNotOptimize(sinsp_utils::concatenate_paths(path1, path2));
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_too_long_path);
+
+// Past the scratch entirely, rejected on length without any copying.
+static void BM_sinsp_concatenate_paths_beyond_scratch(benchmark::State& state) {
+	const std::string path1 = "/tmp/";
+	const std::string path2(16384, 'a');
+	for(auto _ : state) {
+		benchmark::DoNotOptimize(sinsp_utils::concatenate_paths(path1, path2));
+	}
+}
+BENCHMARK(BM_sinsp_concatenate_paths_beyond_scratch);

--- a/userspace/libscap/scap_limits.h
+++ b/userspace/libscap/scap_limits.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ limitations under the License.
 #pragma once
 
 #define SCAP_MAX_PATH_SIZE 1024
+// Per-path capture width. Keep this independent of the host's PATH_MAX so that
+// replaying the same capture on different platforms uses the same bound.
+#define SCAP_MAX_CAPTURED_PATH_SIZE 4096
+#define SCAP_MAX_PATH_CONCAT_SIZE (2 * SCAP_MAX_CAPTURED_PATH_SIZE + 1)
 #define SCAP_MAX_ARGS_SIZE 4096
 #define SCAP_MAX_ENV_SIZE 4096
 #define SCAP_MAX_CGROUPS_SIZE 4096

--- a/userspace/libsinsp/test/scap_files/converter_tests.cpp
+++ b/userspace/libsinsp/test/scap_files/converter_tests.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-Copyright (C) 2024 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -532,8 +532,10 @@ TEST_F(scap_file_test, fcntl_x_check_final_converted_event) {
 	constexpr int64_t res = 0;
 	constexpr int64_t fd = 19;
 	constexpr uint8_t cmd = 5;
+	constexpr uint64_t arg = 0;  // Older events receive the converter's default value.
 
-	assert_event_presence(create_safe_scap_event(ts, tid, PPME_SYSCALL_FCNTL_X, 3, res, fd, cmd));
+	assert_event_presence(
+	        create_safe_scap_event(ts, tid, PPME_SYSCALL_FCNTL_X, 4, res, fd, cmd, arg));
 }
 
 ////////////////////////////

--- a/userspace/libsinsp/test/sinsp_utils.ut.cpp
+++ b/userspace/libsinsp/test/sinsp_utils.ut.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -399,4 +399,94 @@ TEST(sinsp_utils_test, sinsp_split) {
 	EXPECT_EQ(split.size(), 2);
 	EXPECT_EQ(split[0], "");
 	EXPECT_EQ(split[1], "B");
+}
+
+TEST(sinsp_utils_test, concatenate_paths_under_the_gate_is_unaffected) {
+	std::string padded;
+	for(int i = 0; i < 100; i++) {
+		padded += "./";
+	}
+	padded += "foo/bar";
+	ASSERT_LT(1 + padded.length() + 1, SCAP_MAX_PATH_SIZE);
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths("/", padded));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_recovers_normalizing_long_paths) {
+	std::string padded;
+	for(int i = 0; i < 520; i++) {
+		padded += "./";
+	}
+	padded += "foo/bar";
+	ASSERT_GT(padded.length() + 1, SCAP_MAX_PATH_SIZE);
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths("/", padded));
+	EXPECT_EQ("/tmp/foo/bar", sinsp_utils::concatenate_paths("/tmp/", padded));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_still_rejects_genuinely_long_paths) {
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG",
+	          sinsp_utils::concatenate_paths("/", std::string(2048, 'a')));
+	// Inputs exceeding the scratch capacity are rejected before copying.
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG",
+	          sinsp_utils::concatenate_paths("/", std::string(16384, 'a')));
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG",
+	          sinsp_utils::concatenate_paths(std::string(9000, 'y') + "/", "foo/bar"));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_normalizes_long_absolute_paths) {
+	std::string padded = "/";
+	for(int i = 0; i < 520; i++) {
+		padded += "./";
+	}
+	padded += "foo/bar";
+	ASSERT_GT(padded.length() + 1, SCAP_MAX_PATH_SIZE);
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths("/ignored/", padded));
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths("", padded));
+	// An absolute second path also ignores a long first path.
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths(std::string(2048, 'a'), "/foo/bar"));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_normalized_length_boundaries) {
+	for(size_t length : {SCAP_MAX_PATH_SIZE - 1, SCAP_MAX_PATH_SIZE}) {
+		SCOPED_TRACE(length);
+		const std::string filename(length - 1, 'a');
+		const std::string expected =
+		        length < SCAP_MAX_PATH_SIZE ? "/" + filename : "/DIR_TOO_LONG/FILENAME_TOO_LONG";
+		// Include both sides of the fast-path gate, then force normalization
+		// through the slow branch for relative and absolute second paths.
+		EXPECT_EQ(expected, sinsp_utils::concatenate_paths("/", filename));
+		EXPECT_EQ(expected, sinsp_utils::concatenate_paths("/", "./" + filename));
+		EXPECT_EQ(expected, sinsp_utils::concatenate_paths("/ignored/", "/./" + filename));
+	}
+}
+
+TEST(sinsp_utils_test, concatenate_paths_raw_length_boundaries) {
+	const std::string path1 = "/";
+	std::string path2 = "foo/";
+	path2 += std::string(SCAP_MAX_PATH_CONCAT_SIZE - 1 - path1.size() - path2.size() - 3, '/');
+	path2 += "bar";
+	ASSERT_EQ(8192, path1.size() + path2.size());
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths(path1, path2));
+	// The absolute branch accepts the same total raw length.
+	EXPECT_EQ("/foo/bar", sinsp_utils::concatenate_paths("", path1 + path2));
+	path2 += '/';
+	ASSERT_EQ(8193, path1.size() + path2.size());
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG", sinsp_utils::concatenate_paths(path1, path2));
+	EXPECT_EQ("/DIR_TOO_LONG/FILENAME_TOO_LONG", sinsp_utils::concatenate_paths("", path1 + path2));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_long_parent_rewinds) {
+	// A long intermediate component can be removed before applying the limit.
+	const std::string component(2048, 'a');
+	EXPECT_EQ("/tmp/foo", sinsp_utils::concatenate_paths("/tmp/", component + "/../foo"));
+	EXPECT_EQ("/foo", sinsp_utils::concatenate_paths("/" + component + "/", "../foo"));
+	EXPECT_EQ("/foo", sinsp_utils::concatenate_paths("/ignored/", "/" + component + "/../foo"));
+	// Preserve the first path's raw spelling, just as the fast path does.
+	EXPECT_EQ("/tmp////foo",
+	          sinsp_utils::concatenate_paths("/tmp////" + component + "/", "../foo"));
+}
+
+TEST(sinsp_utils_test, concatenate_paths_long_base_empty_second_path) {
+	const std::string path1(2048, 'a');
+	EXPECT_EQ("", sinsp_utils::concatenate_paths(path1, ""));
+	EXPECT_EQ("", sinsp_utils::concatenate_paths(path1, std::string_view{}));
 }

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -701,13 +701,50 @@ static inline void copy_and_normalize_path(char* target,
 	}
 }
 
+// Normalize longer inputs before applying the output limit. Normalization only
+// removes bytes, so a raw path that exceeds SCAP_MAX_PATH_SIZE can still fit.
+// Keep the larger scratch buffer out of concatenate_paths' fast-path frame.
+#if defined(__GNUC__)
+[[gnu::noinline]]
+#endif
+static std::string concatenate_paths_normalized(const char* path1_data,
+                                                const size_t path1_len,
+                                                const char* path2_data,
+                                                const size_t path2_len) {
+	// Bound the raw copy of path1 and the normalization work.
+	if(path1_len + path2_len + 1 > SCAP_MAX_PATH_CONCAT_SIZE) {
+		return "/DIR_TOO_LONG/FILENAME_TOO_LONG";
+	}
+
+	char target[SCAP_MAX_PATH_CONCAT_SIZE];
+	char* target_end = target + SCAP_MAX_PATH_CONCAT_SIZE;
+
+	// Preserve the fast path's behavior: path1 is copied without normalization.
+	if(path2_len != 0 && path2_data[0] != '/') {
+		memcpy(target, path1_data, path1_len);
+		copy_and_normalize_path(target + path1_len, target, target_end, path2_data, '/');
+	} else {
+		target[0] = 0;
+		if(path2_len != 0) {
+			copy_and_normalize_path(target, target, target_end, path2_data, '/');
+		}
+	}
+
+	// Apply the limit to the normalized result, including its terminator.
+	if(strlen(target) + 1 > SCAP_MAX_PATH_SIZE) {
+		return "/DIR_TOO_LONG/FILENAME_TOO_LONG";
+	}
+
+	return target;
+}
+
 std::string sinsp_utils::concatenate_paths(const std::string_view path1,
                                            const std::string_view path2) {
 	char target[SCAP_MAX_PATH_SIZE];
 	const auto path1_len = path1.length();
 	const auto path2_len = path2.length();
 	if(path1_len + path2_len + 1 > SCAP_MAX_PATH_SIZE) {
-		return "/DIR_TOO_LONG/FILENAME_TOO_LONG";
+		return concatenate_paths_normalized(path1.data(), path1_len, path2.data(), path2_len);
 	}
 
 	const auto path1_data = path1.data();


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp
/area tests

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

`concatenate_paths` can return the length marker for a path with repeated `./` components even when the normalized result fits. This change normalizes longer inputs in a bounded stack buffer before checking the output limit.

The existing fast path is preserved. Paths that remain too long, or exceed the scratch capacity, still return the marker. Tests cover absolute paths, length boundaries, parent-directory traversal, and empty second paths.

Based on Arpit Jain's original patch, tests, and benchmarks. Thanks for the contribution 🙏

**Special notes for your reviewer**:

A separate test commit updates the converted `fcntl` event expectation to include its fourth parameter, which defaults to zero for older captures. This fixes a pre-existing failure found while running the capture-file tests.

Validation on Linux with GCC 13.3:

- All 980 libsinsp unit tests pass in Release and with ASan/UBSan, including the 55 capture-file tests. Leak detection is enabled.
- A sanitizer-enabled differential check passes 407,790 cases, including the existing corpus, length sweeps, and padded path shapes.
- The three existing path benchmarks stay within about 2% of the baseline in alternating before/after runs, pinned to one CPU. Median CPU times over 14 samples per version:

| Case | Before | After | Change |
|---|---:|---:|---:|
| Relative path | 23.127 ns | 23.462 ns | +1.45% |
| Empty path | 11.892 ns | 11.969 ns | +0.65% |
| Absolute path | 22.149 ns | 22.592 ns | +2.00% |

The added benchmarks measure 482.961 ns for a long path that normalizes to a short one, 953.211 ns for a path that remains too long, and 14.688 ns for an input exceeding the scratch limit.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): normalize long paths with redundant components before applying the path length limit.
```
