### PR TITLE
chore(ci): serialize the ppc64le driver tests on the shared node

### DIFF
--- a/.github/workflows/drivers_ci.yml
+++ b/.github/workflows/drivers_ci.yml
@@ -174,6 +174,11 @@ jobs:
   test-drivers-ppc64le:
     name: test-drivers-ppc64le 😁 (system_deps,custom node)
     runs-on: ubuntu-24.04
+    # The job runs on a single shared ppc64le machine: serialize the runs so that
+    # concurrent clones and builds cannot delete each other's source tree.
+    concurrency:
+      group: ${{ github.workflow }}-ppc64le-node
+      cancel-in-progress: false
     # Avoid running on forks since this job uses a private secret
     # not available on forks, leading to failures.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'falcosecurity/libs'


### PR DESCRIPTION
The `test-drivers-ppc64le` job runs over ssh on a single shared ppc64le machine, always in the same `libs` directory, and the workflow-level concurrency group is per run on pushes. So two pushes close to each other run it concurrently: the second `rm -rf libs` deletes the tree the first job is still compiling, and both fail with spurious errors 👇
- https://github.com/falcosecurity/libs/actions/runs/34338872420/job/102424698239
- https://github.com/falcosecurity/libs/actions/runs/34338999166/job/102425102319

This adds a job-level concurrency group, so the runs queue instead of racing.

/kind cleanup
/area automation

```release-note
NONE
```
