### PR TITLE
fix(libraries): The shared library soversion also has to include the second number

### DIFF
--- a/cmake/modules/versions.cmake
+++ b/cmake/modules/versions.cmake
@@ -48,8 +48,7 @@ function(get_shared_libs_versions _var _sovar)
 		${sl_ver}
 		PARENT_SCOPE
 	)
-	string(REPLACE "." ";" sl_ver_list ${sl_ver})
-	list(GET sl_ver_list 0 so_ver)
+	string(REGEX MATCH "^[0-9]+\\.[0-9]+" so_ver ${sl_ver})
 	set(${_sovar}
 		${so_ver}
 		PARENT_SCOPE


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind test

> /kind feature

> /kind sync

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

/area build

> /area automation

> /area drivers

> /area driver-kmod

> /area driver-modern-bpf

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

/area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

My understanding is that a change in the second number indicates possible breaking changes.
E.g. 0.25 -> 0.25.1 does not breaking changes, but 0.25 -> 0.26 might change the library ABI.

Shared libraries with this PR:
```
$ objdump -p ./libscap/libscap.so | grep SONAME
  SONAME               libscap.so.0.26
$
```

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix(cmake)!: the SOVERSION of the shared libraries (libscap, its engine libraries, and libsinsp) now includes the minor version, e.g. `libscap.so.0.26` instead of `libscap.so.0`; downstream packagers of the shared libraries must rebuild dependents and rename runtime packages accordingly
```
