### PR TITLE
fix(driver): initialize acrret to avoid using uninitialized dev in scap_init() error path

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -2622,7 +2622,7 @@ static int scap_init(void) {
 	unsigned int cpu;
 	unsigned int num_cpus;
 	int ret;
-	int acrret = 0;
+	int acrret = -1;
 	int j;
 	int n_created_devices = 0;
 	struct device *device = NULL;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area driver-kmod

**Does this PR require a change in the driver versions?**

**What this PR does / why we need it**:

In `scap_init()`'s error path (`driver/main.c`), `acrret` was initialized to `0`, which is also the success value returned by `alloc_chrdev_region()`. When `get_tracepoint_handles()` fails early, execution jumps to `init_module_err` before `alloc_chrdev_region()` ever runs, so `dev` is never assigned — yet the `acrret == 0` guard still passed and called `unregister_chrdev_region()` with an uninitialized `dev`.

This initializes `acrret = -1` so the cleanup path only unregisters the chrdev region after `alloc_chrdev_region()` has actually succeeded.

**Which issue(s) this PR fixes**:

Fixes #3049

**Special notes for your reviewer**:

The fix matches exactly what @leogr suggested and confirmed in the issue discussion.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
