### PR TITLE
fix(libsinsp): sanitize UTF-8 before JSON serialization

### DIFF
--- a/userspace/libsinsp/eventformatter.cpp
+++ b/userspace/libsinsp/eventformatter.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,8 +20,27 @@ limitations under the License.
 #include <libsinsp/filterchecks.h>
 #include <libsinsp/eventformatter.h>
 #include <libsinsp/filter/parser.h>
+#include <libsinsp/utils.h>
 
 static constexpr const char* s_not_available_str = "<NA>";
+
+// Sanitize string values before JsonCpp can consume valid bytes after an invalid UTF-8 sequence.
+static void sanitize_json_strings(Json::Value& value) {
+	const char* begin = nullptr;
+	const char* end = nullptr;
+	if(value.getString(&begin, &end)) {
+		std::string storage;
+		const auto sanitized =
+		        utf8::sanitize(std::string_view(begin, static_cast<size_t>(end - begin)), storage);
+		if(sanitized.data() != begin) {
+			value = Json::Value(sanitized.data(), sanitized.data() + sanitized.size());
+		}
+	} else if(value.isArray() || value.isObject()) {
+		for(auto& child : value) {
+			sanitize_json_strings(child);
+		}
+	}
+}
 
 sinsp_evt_formatter::sinsp_evt_formatter(sinsp* inspector, filter_check_list& available_checks):
         m_inspector(inspector),
@@ -215,7 +234,9 @@ bool sinsp_evt_formatter::tostring_withformat(sinsp_evt* evt,
 				retval = false;
 				break;
 			}
+			// Keep the second extraction: some fields update state on each call.
 			m_root[t.name] = t.token->tojson(evt);
+			sanitize_json_strings(m_root[t.name]);
 		}
 		output = m_writer.write(m_root);
 		output = output.substr(0, output.size() - 1);

--- a/userspace/libsinsp/test/eventformatter.ut.cpp
+++ b/userspace/libsinsp/test/eventformatter.ut.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2024 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -98,6 +98,128 @@ TEST_F(sinsp_formatter_test, field_json) {
 	EXPECT_EQ(m_last_output, "{\"proc.name\":\"init\"}");
 	EXPECT_EQ(m_last_field_values.size(), 1) << pretty_print(m_last_field_values);
 	EXPECT_EQ(m_last_field_values["proc.name"], "init");
+}
+
+TEST_F(sinsp_formatter_test, json_utf8_strings) {
+	struct test_case {
+		const char* name;
+		std::string input;
+		std::string expected;
+	};
+	// Literal expected bytes are independent of the sanitizer under test.
+	const std::vector<test_case> cases = {
+	        {"ascii", "ordinary", "ordinary"},
+	        {"unicode",
+	         "caf\xc3\xa9_\xe2\x98\x83_\xf0\x9f\x98\x80",
+	         "caf\xc3\xa9_\xe2\x98\x83_\xf0\x9f\x98\x80"},
+	        {"invalid_lead", "a\xffz", "a\xef\xbf\xbdz"},
+	        {"continuation", "a\x80z", "a\xef\xbf\xbdz"},
+	        {"truncated", "a\xe2\x82", "a\xef\xbf\xbd"},
+	        {"overlong", "a\xc0\xafz", "a\xef\xbf\xbd\xef\xbf\xbdz"},
+	        {"surrogate", "a\xed\xa0\x80z", "a\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbdz"},
+	        {"out_of_range",
+	         "a\xf4\x90\x80\x80z",
+	         "a\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbdz"},
+	        {"bad_continuation", "a\xe2(\xa1z", "a\xef\xbf\xbd(\xef\xbf\xbdz"},
+	        {"newline", "a\nz", "a\nz"},
+	        {"carriage_return", "a\rz", "a\rz"},
+	        {"tab", "a\tz", "a\tz"},
+	        {"escape", "a\x1b[31mz", "a\x1b[31mz"},
+	        {"other_controls", "a\x01\x07\x08\x0b\x0cz", "a\x01\x07\x08\x0b\x0cz"},
+	        {"quotes_backslash", "a\"\\z", "a\"\\z"},
+	        {"mixed", "a\xff\n\"\\\xe2\x82z", "a\xef\xbf\xbd\n\"\\\xef\xbf\xbdz"},
+	        {"healthy_after", "still_working", "still_working"},
+	};
+	sinsp_evt_formatter formatter(&m_inspector, "%proc.args", m_filter_list);
+	for(const auto& test : cases) {
+		SCOPED_TRACE(test.name);
+		auto evt = generate_getcwd_failed_entry_event();
+		auto tinfo = evt->get_thread_info();
+		ASSERT_NE(tinfo, nullptr);
+		const std::vector<std::string> args = {test.input};
+		tinfo->set_args(args);
+		std::string output;
+		ASSERT_TRUE(formatter.tostring_withformat(evt, output, sinsp_evt_formatter::OF_JSON));
+		Json::Value json;
+		Json::Reader reader;
+		ASSERT_TRUE(reader.parse(output, json)) << output;
+		ASSERT_TRUE(json["proc.args"].isString());
+		EXPECT_EQ(json["proc.args"].asString(), test.expected);
+		// Formatting JSON must not alter normal output or the inspector's argument bytes.
+		ASSERT_TRUE(formatter.tostring_withformat(evt, output, sinsp_evt_formatter::OF_NORMAL));
+		EXPECT_EQ(output, test.input);
+		EXPECT_EQ(tinfo->m_args, args);
+	}
+}
+
+TEST_F(sinsp_formatter_test, json_utf8_string_list) {
+	auto evt = generate_getcwd_failed_entry_event();
+	auto tinfo = evt->get_thread_info();
+	ASSERT_NE(tinfo, nullptr);
+	const std::vector<std::string> args = {"-o", "a\x80z", "-o", "caf\xc3\xa9\n"};
+	tinfo->set_args(args);
+	// getopt emits a string list containing each option followed by its value.
+	const std::string field = "getopt((proc.args[0],proc.args[1],proc.args[2],proc.args[3]),o:)";
+	sinsp_evt_formatter formatter(
+	        &m_inspector,
+	        "%getopt((proc.args[0],proc.args[1],proc.args[2],proc.args[3]),\"o:\")",
+	        m_filter_list);
+	formatter.set_resolve_transformed_fields(true);
+	std::string output;
+	ASSERT_TRUE(formatter.tostring_withformat(evt, output, sinsp_evt_formatter::OF_JSON));
+	Json::Value json;
+	Json::Reader reader;
+	ASSERT_TRUE(reader.parse(output, json)) << output;
+	ASSERT_TRUE(json[field].isArray()) << output;
+	ASSERT_EQ(json[field].size(), 4);
+	EXPECT_EQ(json[field][0].asString(), "o");
+	EXPECT_EQ(json[field][1].asString(), "a\xef\xbf\xbdz");
+	EXPECT_EQ(json[field][2].asString(), "o");
+	EXPECT_EQ(json[field][3].asString(), "caf\xc3\xa9\n");
+	EXPECT_EQ(tinfo->m_args, args);
+}
+
+TEST_F(sinsp_formatter_test, json_utf8_preserves_value_types) {
+	auto evt = generate_getcwd_failed_entry_event();
+	auto tinfo = evt->get_thread_info();
+	ASSERT_NE(tinfo, nullptr);
+	tinfo->set_args(std::vector<std::string>{"a\x80z"});
+	tinfo->m_exe_writable = true;
+	sinsp_evt_formatter formatter(&m_inspector,
+	                              "*%proc.args %thread.tid %proc.is_exe_writable %evt.asynctype",
+	                              m_filter_list);
+	std::string output;
+	ASSERT_TRUE(formatter.tostring_withformat(evt, output, sinsp_evt_formatter::OF_JSON));
+	Json::Value json;
+	Json::Reader reader;
+	ASSERT_TRUE(reader.parse(output, json)) << output;
+	EXPECT_EQ(json["proc.args"].asString(), "a\xef\xbf\xbdz");
+	ASSERT_TRUE(json["thread.tid"].isInt64());
+	EXPECT_EQ(json["thread.tid"].asInt64(), INIT_TID);
+	ASSERT_TRUE(json["proc.is_exe_writable"].isBool());
+	EXPECT_TRUE(json["proc.is_exe_writable"].asBool());
+	EXPECT_TRUE(json.isMember("evt.asynctype"));
+	EXPECT_TRUE(json["evt.asynctype"].isNull());
+}
+
+TEST_F(sinsp_formatter_test, json_preserves_deltatime_behavior) {
+	sinsp_evt_formatter formatter(&m_inspector,
+	                              "%evt.deltatime %evt.deltatime.s %evt.deltatime.ns",
+	                              m_filter_list);
+	const uint64_t first_ts = increasing_ts();
+	for(uint64_t offset : {0ULL, 1000000042ULL, 2000000084ULL}) {
+		SCOPED_TRACE(offset);
+		auto evt = add_event_advance_ts(first_ts + offset,
+		                                INIT_TID,
+		                                PPME_SYSCALL_GETCWD_X,
+		                                2,
+		                                int64_t{-1},
+		                                "/test/dir");
+		std::string output;
+		ASSERT_TRUE(formatter.tostring_withformat(evt, output, sinsp_evt_formatter::OF_JSON));
+		// Preserve the existing second extraction, which observes the same timestamp and returns 0.
+		EXPECT_EQ(output, "{\"evt.deltatime\":0,\"evt.deltatime.ns\":0,\"evt.deltatime.s\":0}");
+	}
 }
 
 TEST_F(sinsp_formatter_test, lenght_shorter) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area libsinsp

**Does this PR require a change in the driver versions?**

No.

**What this PR does / why we need it**:

Malformed UTF-8 can consume valid characters during `JsonCpp` serialization. For example, bytes `61 80 7A` become `a�` instead of `a�z` in `output_fields`.

Sanitize string values before `Json::FastWriter` serializes them, including values inside arrays and objects.

**Which issue(s) this PR fixes**:

Found while testing Falco `0.45.0-rc2`, tracked in:

https://github.com/falcosecurity/falco/issues/3967

**Special notes for your reviewer**:

N.B. Both extraction calls are preserved since fields such as `evt.deltatime` update state on each call.

- `912` unit tests pass, including `17` UTF-8 cases and the `evt.deltatime` compatibility test.
- Tested a `Debug` libs build with `JsonCpp 1.9.5`. Driver and capture-fixture tests were disabled; a full Falco rebuild was not performed.
- Keeping `wip:` until we double-check this.

**Does this PR introduce a user-facing change?**:

```release-note
fix(libsinsp): preserve valid characters around malformed UTF-8 in JSON output
```
